### PR TITLE
Fixed warnings during make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/*
 .vscode/*
 .idea/*
 *xcworkspace*
+.vscode/*

--- a/core/consensus/consensus_event.hpp
+++ b/core/consensus/consensus_event.hpp
@@ -89,7 +89,7 @@ public:
         return T::getHash();
     }
 
-    int getNumValidSignatures() {
+    unsigned int getNumValidSignatures() {
         return std::count_if(
                 _eventSignatures.begin(), _eventSignatures.end(),
             [hash = getHash()](eventSignature sig){

--- a/core/consensus/event.hpp
+++ b/core/consensus/event.hpp
@@ -29,7 +29,7 @@ class Event {
 public:
   int order = 0;
   virtual void addSignature(const std::string& publicKey, const std::string& signature) = 0;
-  virtual int getNumValidSignatures() = 0;
+  virtual unsigned int getNumValidSignatures() = 0;
   virtual bool eventSignatureIsEmpty() = 0;
   virtual std::vector<std::tuple<std::string,std::string>> eventSignatures() = 0;
   virtual std::string getHash() = 0;

--- a/core/model/transaction.cpp
+++ b/core/model/transaction.cpp
@@ -13,8 +13,8 @@ namespace transaction{
         Transfer(
             obj.dictSub["command"]
         ),
-        senderPubkey(obj.dictSub["senderPublicKey"].str),
-        hash(obj.dictSub["hash"].str)
+        hash(obj.dictSub["hash"].str),
+        senderPubkey(obj.dictSub["senderPublicKey"].str)
     {
         
         std::vector<Object> txSigs = obj.dictSub["txSignatures"].listSub;
@@ -62,13 +62,13 @@ namespace transaction{
         const std::string& name,
         const int& value
     ):
-        senderPubkey(senderPubkey),
         Transfer(
             senderPubkey,
             receiverPubkey,
             name,
             value
-        )
+        ),
+        senderPubkey(senderPubkey)
     {}
 
     template <>
@@ -79,13 +79,13 @@ namespace transaction{
         const unsigned long long& value,
         const unsigned int& precision
     ):
-        senderPubkey(senderPubkey),
         Add(
             domain,
             name,
             value,
             precision
-        )    
+        ),
+        senderPubkey(senderPubkey)
     {}
 
     template <>
@@ -94,11 +94,11 @@ namespace transaction{
         const std::string& ownerPublicKey,
         const std::string& name
     ):
-        senderPubkey(senderPubkey),
         Add(
             ownerPublicKey,
             name
-        )    
+        ),
+        senderPubkey(senderPubkey)
     {}
 
 }

--- a/core/repository/consensus/merkle_transaction_repository.hpp
+++ b/core/repository/consensus/merkle_transaction_repository.hpp
@@ -83,15 +83,15 @@ struct MerkleNode {
 
 //TODO: change bool to throw an exception instead
 bool commit(const std::unique_ptr<event::Event>& event){
-
+    return false; // TODO: fill this function
 };
 
 bool leafExists(const std::string& hash){
-
+    return false; // TODO: fill this function
 }
 
 std::string getLeaf(const std::string& hash){
-
+    return ""; // TODO: fill this function
 }
 
 template <typename T>


### PR DESCRIPTION
Fixed following warnings:
 - wrong initialization order in constructors (http://stackoverflow.com/questions/1564937/gcc-warning-will-be-initialized-after)
 - comparison between signed and unsigned integer expressions
 - no return statement in function returning non-void

**Not fixed** (I believe they will disappear after further developing): 
 - unused parameter ‘from’
 - /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64: linker input file unused because linking not done
 - defined but not used

Warnings may lead to errors. It is better to fix them now, without risk of getting errors in future.
