### PR TITLE
Fix1 circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,13 +21,7 @@ dependencies:
   override:
     # one way to cache iroha-dev container is to save it to tar image. 2 mins vs 10 mins without caching.
     - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; else docker build --rm=false -t hyperledger/iroha-dev ${IROHA_HOME}/docker/dev; fi
-    # build iroha-dev (if it is in cache, this step will be skipped) and iroha-docker (production) images
-    - docker run -it -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh << COMMANDS
-          cd /opt/iroha
-          /build-iroha.sh || (echo "[-] Can't build iroha" && exit 1)
-          /mktar-iroha.sh || (echo "[-] Can't make tarball" && exit 1)
-          (cp /tmp/iroha.tar /build/iroha.tar || (echo "[-] FAILED!"" && exit 1))
-      COMMANDS
+    - docker run -it -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh "cd /opt/iroha; /build-iroha.sh || exit 2; /mktar-iroha.sh || exit 3; cp /tmp/iroha.tar /build/iroha.tar || exit 4"
     - docker build --rm=false -t hyperledger/iroha-docker ${IROHA_HOME}/docker/build
     # cache iroha-dev image. takes 30 sec to save into file
     - mkdir -p ~/docker; docker save hyperledger/iroha-dev > ~/docker/iroha-dev.tar

--- a/circle.yml
+++ b/circle.yml
@@ -20,9 +20,15 @@ dependencies:
     - ~/docker
   override:
     # one way to cache iroha-dev container is to save it to tar image. 2 mins vs 10 mins without caching.
-    - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; fi
+    - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; else docker build --rm=false -t hyperledger/iroha-dev ${IROHA_HOME}/docker/dev fi
     # build iroha-dev (if it is in cache, this step will be skipped) and iroha-docker (production) images
-    - ${IROHA_HOME}/docker/build.sh
+    - docker run -it -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh << COMMANDS
+          cd /opt/iroha
+          /build-iroha.sh || (echo "[-] Can't build iroha" && exit 1)
+          /mktar-iroha.sh || (echo "[-] Can't make tarball" && exit 1)
+          (cp /tmp/iroha.tar /build/iroha.tar || (echo "[-] FAILED!"" && exit 1))
+      COMMANDS
+    - docker build --rm=false -t hyperledger/iroha-docker ${IROHA_HOME}/docker/build
     # cache iroha-dev image. takes 30 sec to save into file
     - mkdir -p ~/docker; docker save hyperledger/iroha-dev > ~/docker/iroha-dev.tar
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ machine:
   java:
       version: 'oraclejdk8'
 
-
 checkout:
   post:
     - git submodule sync
@@ -21,7 +20,9 @@ dependencies:
   override:
     # one way to cache iroha-dev container is to save it to tar image. 2 mins vs 10 mins without caching.
     - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; else docker build --rm=false -t hyperledger/iroha-dev ${IROHA_HOME}/docker/dev; fi
-    - docker run -it -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh "cd /opt/iroha; /build-iroha.sh || exit 2; /mktar-iroha.sh || exit 3; cp /tmp/iroha.tar /build/iroha.tar || exit 4"
+    # build iroha. Result of this instruction is ${IROHA_HOME}/docker/build/iroha.tar
+    - docker run -i -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh <<< "cd /opt/iroha; /build-iroha.sh || exit 2; /mktar-iroha.sh || exit 3; cp /tmp/iroha.tar /build/iroha.tar || exit 4"
+    # build iroha-docker image
     - docker build --rm=false -t hyperledger/iroha-docker ${IROHA_HOME}/docker/build
     # cache iroha-dev image. takes 30 sec to save into file
     - mkdir -p ~/docker; docker save hyperledger/iroha-dev > ~/docker/iroha-dev.tar

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
     - ~/docker
   override:
     # one way to cache iroha-dev container is to save it to tar image. 2 mins vs 10 mins without caching.
-    - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; else docker build --rm=false -t hyperledger/iroha-dev ${IROHA_HOME}/docker/dev fi
+    - if [[ -e ~/docker/iroha-dev.tar ]]; then docker load -i ~/docker/iroha-dev.tar; else docker build --rm=false -t hyperledger/iroha-dev ${IROHA_HOME}/docker/dev; fi
     # build iroha-dev (if it is in cache, this step will be skipped) and iroha-docker (production) images
     - docker run -it -v ${IROHA_HOME}/docker/build:/build -v ${IROHA_HOME}:/opt/iroha hyperledger/iroha-dev sh << COMMANDS
           cd /opt/iroha


### PR DESCRIPTION
For some reason build process doesn't use cached `hyperledger/iroha-dev` while it executes `build.sh`. Fixing.