### PR TITLE
Update deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,4 +21,10 @@ if [[ ! -e ~/.docker/config.json ]]; then
 	expect eof' 1>/dev/null || exit 1
 fi
 
+# dirty fix: we build hyperledger/iroha-docker from master branch, but 
+# now also we build hyperledger/iroha-docker-develop from develop
+if [ "$1" == "hyperledger/iroha-docker-develop" ]; then
+	docker tag hyperledger/iroha-docker hyperledger/iroha-docker-develop
+fi
+
 docker push $1


### PR DESCRIPTION
Fix, which allows to deploy 
- master branch under tag `hyperledger/iroha-docker`
- develop branch under tag `hyperledger/iroha-docker-develop`