### PR TITLE
use 1M instead of 1G for recv buff

### DIFF
--- a/docker/config-discovery/config-server.py
+++ b/docker/config-discovery/config-server.py
@@ -57,8 +57,9 @@ class ThreadedServer(object):
 
 
     def listenToClient(self, tid, client, address):
-        data = client.recv(2**30) # 1 MB at max
+        data = client.recv(2**20) # 1 MB at max
         if data: # we received something
+            print(data)
             try:
                 self.LOCK.acquire()
                 self.network[tid] = json.loads(data.decode('utf-8'))


### PR DESCRIPTION
2**30 equals to 1G for a socket recv buff.
This value causes the script throw MemErorr exception on some machine that has not enough memory space.