### PR TITLE
Fix cmake file for MacOS. Add target link libraries.

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -238,14 +238,18 @@ add_library(jni SHARED IMPORTED)
 if (DEFINED ENV{JAVA_HOME})
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(_JVM_INCLUDE_PATH "$ENV{JAVA_HOME}/include/darwin")
+    set_target_properties(jni PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${_JVM_INCLUDE_PATH};$ENV{JAVA_HOME}/include"
+            IMPORTED_LOCATION "$ENV{JAVA_HOME}/jre/lib/server/libjvm.dylib"
+            )
   else()
     set(_JVM_INCLUDE_PATH "$ENV{JAVA_HOME}/include/linux")
+    set_target_properties(jni PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${_JVM_INCLUDE_PATH};$ENV{JAVA_HOME}/include"
+            IMPORTED_LOCATION "$ENV{JAVA_HOME}/jre/lib/amd64/server/libjvm.so"
+            )
   endif()
 
-  set_target_properties(jni PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${_JVM_INCLUDE_PATH};$ENV{JAVA_HOME}/include"
-    IMPORTED_LOCATION "$ENV{JAVA_HOME}/jre/lib/amd64/server/libjvm.so"
-  )
 else()
   find_package(JNI)
   if (!JNI_FOUND)

--- a/smart_contract/repository/CMakeLists.txt
+++ b/smart_contract/repository/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(Repository SHARED
 target_link_libraries(Repository
   core_repository
   jni
+  create_objects_helper
+  java_data_structure
 )
 
 add_custom_command(TARGET Repository


### PR DESCRIPTION
Added following link libraries:
- create_objects_helper
- java_data_structure

Change libjvm from "so" to "dylib".

I tested on MacOS 10.11.6.