### PR TITLE
Fix Nodes pointer type

### DIFF
--- a/core/service/peer_service.cpp
+++ b/core/service/peer_service.cpp
@@ -100,7 +100,7 @@ Nodes getPeerList() {
   Nodes nodes;
   for (const auto &node : peerList) {
     if (node->isok) {
-      nodes.push_back(std::make_unique<peer::Node>(
+      nodes.push_back(std::make_shared<peer::Node>(
           node->ip, node->publicKey, node->trustScore));
     }
   }


### PR DESCRIPTION
Nodes is a vector of shared_ptrs, therefore should be initialized with shared_ptr objects, right?
(this modification fixed a memory corruption I encountered when testing Iroha)