### PR TITLE
Feature/sonar for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             # sonarqube is at /opt/sonar-scanner in warchantua/iroha-dev
             /opt/sonar-scanner/bin/sonar-scanner \
               -Dsonar.sourceEncoding=UTF-8 \
-              -Dsonar.sources=benchmark,core,peer,smart_contract,test,tools \
+              -Dsonar.sources=benchmark,core,peer,test,tools \
               -Dsonar.host.url=https://sonar.innoctf.com \
               -Dsonar.projectKey=hyperledger:iroha \
               -Dsonar.projectName="Iroha" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
         environment:
           IROHA_HOME: /opt/iroha
           IROHA_BUILD: /tmp/build
-      - image: ubuntu:16.04
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
               -Dsonar.projectKey=hyperledger:iroha \
               -Dsonar.projectName="Iroha" \
               -Dsonar.projectVersion="$CIRCLE_BUILD_NUM" \
+              -Dsonar.login=$SONAR_TOKEN \
               -Dsonar.cxx.cppcheck.reportPath=/tmp/cppcheck.xml || true
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,6 @@ jobs:
           IROHA_BUILD: /tmp/build
       - image: ubuntu:16.04
     steps:
-      - run:
-          name: build and install grpc (WIP) I want to move it to dependencies.cmake
-          command: |
-            apt-get -qq update; apt-get -y install golang
-            cd /tmp; rm -rf grpc; git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
-            cd grpc && git submodule update --init && make && make install
-            cd
       - checkout
 
       - run:
@@ -45,6 +38,23 @@ jobs:
                 total=$((total + $?)) 
             done
             exit $total
+
+      - run:
+          name: analyze source code with cppcheck and sonarqube
+          command: |
+            cd $IROHA_HOME
+            cppcheck --enable=all --inconclusive --xml --xml-version=2 core/ peer/ smart_contract/ test/ tools/ 2>/tmp/cppcheck.xml || true
+            
+            # sonarqube is at /opt/sonar-scanner in warchantua/iroha-dev
+            /opt/sonar-scanner/bin/sonar-scanner \
+              -Dsonar.sourceEncoding=UTF-8 \
+              -Dsonar.sources=benchmark,core,peer,smart_contract,test,tools \
+              -Dsonar.host.url=https://sonar.innoctf.com \
+              -Dsonar.projectKey=hyperledger:iroha \
+              -Dsonar.projectName="Iroha" \
+              -Dsonar.projectVersion="$CIRCLE_BUILD_NUM" \
+              -Dsonar.cxx.cppcheck.reportPath=/tmp/cppcheck.xml || true
+
 
       # integrated into circle 2.0
       - setup_docker_engine

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cmake-build-debug/*
 external/*
 core/infra/protobuf
 docker/tiny/iroha/
+.scannerwork/


### PR DESCRIPTION
## Changelog:
- there is no need in installing grpc in that image, because circle 2.0 runs build in `warchantua/iroha-dev` image. I installed all required dependencies there, including grpc.
- removed unnecessary ubuntu image 
- added sonarqube and cppcheck analyzers. Reports automatically parsed and pushed to https://sonar.innoctf.com (you can be authorized via github). I own domain innoctf.com only, I hope @takemiyamakoto will create A record for `sonar.soramitsu.co.jp` and receive a certificate (https is mandatory!) for this domain. P.S.: you can do it via `letsencrypt`.

## Future work:
- Soon I will add `valgrind` analyzer for iroha-main and other binaries (+all tests). Its results will be displayed in sonarqube interface. It looks really nice there :)