### PR TITLE
Feature/quick build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 	rm -fr build external docker/tiny/release
 
 run:
-	docker run -d --name iroha -p 1204:1204 -p 50051:50051 hyperledger/iroha
+	docker run -d --name iroha -p 50051:50051 hyperledger/iroha
 
 logs:
 	docker logs -f iroha

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Copyright 2017 Soramitsu Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: all pwd build scripts
+
+IROHA_HOME := $(if $(IROHA_HOME),$(IROHA_HOME),$(shell pwd))
+
+DUMMY = .dummy
+
+all: pwd build scripts iroha-dev iroha-build iroha
+
+pwd:
+	@echo "IROHA_HOME=$(IROHA_HOME)"
+
+build:
+	mkdir -p $@
+
+scripts:
+	rsync -av scripts build
+
+iroha-dev:
+	docker build -t hyperledger/iroha-dev docker/dev
+
+iroha-build:
+	docker run -t --rm --name iroha-build \
+	  -v $(IROHA_HOME):/opt/iroha \
+	  hyperledger/iroha-dev /opt/iroha/build/scripts/iroha-build.sh
+
+iroha:
+	rm -fr docker/tiny/release
+	rsync -av ${IROHA_HOME}/build/release docker/tiny
+	docker build --rm -t hyperledger/iroha docker/tiny
+
+clean:
+	rm -fr build external docker/tiny/release
+
+run:
+	docker run -d --name iroha -p 1204:1204 -p 50051:50051 hyperledger/iroha
+
+logs:
+	docker logs -f iroha
+
+stop:
+	docker stop iroha
+	docker rm iroha

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,11 +11,11 @@ Build depends on the environment variable `IROHA_HOME` so you need to set it:
 
 `export IROHA_HOME=$(pwd)`
 
-Build on docker container for develop environment `warchantua/iroha-dev` so you need to build it:
+Build on docker container for develop environment `hyperledger/iroha-dev` so you need to build it:
 
 ```
 cd docker/dev
-docker build -t warchantua/iroha-dev .
+docker build -t hyperledger/iroha-dev .
 ```
 
 Run build script and wait for completion. 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -3,65 +3,36 @@
 #
 # build : docker build -t hyperledger/iroha-dev .
 #
-# Copyright (c) 2016 Soramitsu,Co.,Ltd.
+# Copyright (c) 2016, 2017 Soramitsu,Co.,Ltd.
 # All Rights Reserved.
 #-----------------------------------------------------------------------
-FROM ubuntu
-
-MAINTAINER Takeshi Yonezu <yonezu@soramitsu.co.jp> / Bogdan Vaneev <bogdan@soramitsu.co.jp>
-
-LABEL BUILD="docker build -t hyperledger/iroha-dev ."
-LABEL RUN="docker run -it --rm hyperledger/iroha-dev bash"
-
-USER root
+FROM ubuntu:16.04
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-ENV IROHA_HOME /opt/iroha
-ENV IROHA_BUILD /tmp/build
-ENV IROHA_RELEASE /iroha
+ENV IROHA_HOME /usr/local/iroha
+ENV IROHA_BUILD ${IROHA_HOME}/build
+ENV IROHA_RELEASE ${IROHA_BUILD}/release
 
-# install dependencies
-RUN apt-get update && apt-get -y upgrade; \
-    apt-get -yqq install \
-        sudo \
+RUN apt update && apt -y upgrade && \
+    apt -y install \
         software-properties-common \
         python-software-properties \
-        curl \
-        expect \
-        git \
-        make \
-        build-essential \
-        wget \
-        cmake \
-        g++-5 \
-        gcc-5 \
-        default-jdk \
-        libhdf5-serial-dev \
-        libleveldb-dev \
-        libsnappy-dev\
-        liblmdb-dev \
-        libssl-dev \
-        snappy \
-        unzip \
-        xsltproc \
-        zlib1g-dev \
-        autoconf \
-        automake \
-        libtool \
-        jq \
-        pkg-config \
-        cppcheck \
-        valgrind \
-        clang-tidy
+        curl git wget make g++-5 gcc-5 default-jdk \
+        libhdf5-serial-dev libleveldb-dev libsnappy-dev \
+        liblmdb-dev libssl-dev unzip xsltproc zlib1g-dev \
+        autoconf automake libtool jq pkg-config cppcheck \
+        valgrind clang-tidy
     
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test; \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20; \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-5 20; \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20; \
-    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-5 20; \
-    curl -sSL https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz | tar -xzC /opt; \
-    ln -s /opt/cmake*/bin/c* /usr/local/bin; \
-    mkdir -p ${IROHA_RELEASE}; \
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-5 20 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-5 20 && \
+    curl -sSL https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz | \
+      tar -xzC /opt && \
+    ln -s /opt/cmake*/bin/c* /usr/local/bin
+
+RUN mkdir -p ${IROHA_RELEASE}; \
     mkdir -p ${IROHA_BUILD}; \
     mkdir -p ${IROHA_HOME}
 
@@ -72,19 +43,18 @@ RUN cd /tmp; \
     (git cherry-pick 1760feb621a913189b90fe8595fffb74bce84598; echo Force continue) && \
     ./autogen.sh && \
     ./configure --prefix=/usr && \
-    make -j4 && make install; \
+    make -j4 && make install
 
 # install grpc
 RUN cd /tmp; \
     git clone --recursive -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc; \
     cd grpc; \
-    make -j4 && make install; \
+    make -j4 && make install
 
 # install sonar-scanner
-RUN cd /tmp; \ 
+RUN cd /tmp; \
     wget -O /tmp/sonar.zip https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.1.733-linux.zip; \
     unzip -d /opt /tmp/sonar.zip; \
     mv /opt/sonar-scanner* /opt/sonar-scanner
 
-# clean up
-RUN rm -rf /tmp/*
+CMD ["/bin/bash"]

--- a/docker/tiny/.gitignore
+++ b/docker/tiny/.gitignore
@@ -1,0 +1,1 @@
+release

--- a/docker/tiny/Dockerfile
+++ b/docker/tiny/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:16.04
 
-COPY iroha /iroha
+ENV IROHA_HOME=/usr/local/iroha
+ENV LD_LIBRARY_PATH=${IROHA_HOME}/lib
 
-ENV IROHA_HOME=/iroha
-ENV LD_LIBRARY_PATH=/iroha/lib
+COPY release ${IROHA_HOME}
 
-WORKDIR /iroha
-
-RUN useradd -ms /bin/bash iroha; \
-	chown -R iroha:iroha $IROHA_HOME
-
+RUN apt update && apt upgrade -y; \
+    useradd -ms /bin/bash iroha; \
+    chown -R iroha:iroha $IROHA_HOME
 
 USER iroha
 
-CMD /iroha/scripts/run.sh
+WORKDIR ${IROHA_HOME}
+
+CMD ["/usr/local/iroha/bin/iroha-main"]

--- a/scripts/iroha-build.sh
+++ b/scripts/iroha-build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export IROHA_HOME=/opt/iroha
+
+rm -fr ${IROHA_HOME}/external
+
+cd ${IROHA_HOME}/build
+
+cmake ${IROHA_HOME} -DCMAKE_BUILD_TYPE=Release
+make -j 10
+
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
+LIBS=$(ldd ${IROHA_HOME}/build/bin/iroha-main | cut -f 2 | cut -d " " -f 3)
+rm -fr ${IROHA_HOME}/build/release
+mkdir -p ${IROHA_HOME}/build/release/lib
+cp -H $LIBS ${IROHA_HOME}/build/release/lib
+
+mkdir -p ${IROHA_HOME}/build/release/config
+cp ${IROHA_HOME}/config/sumeragi.json ${IROHA_HOME}/build/release/config/sumeragi.json
+cp ${IROHA_HOME}/config/config.json   ${IROHA_HOME}/build/release/config/config.json
+
+rsync -avr ${IROHA_HOME}/build/bin      ${IROHA_HOME}/build/release
+rsync -avr ${IROHA_HOME}/build/test_bin ${IROHA_HOME}/build/release


### PR DESCRIPTION
This is Makefile version for Iroha quick building. 
You can build Iroha simply with typing 'make'. And you can run Iroha with 'make run' to running single Iroha container. You can view logs by 'make logs' and so on...