### PR TITLE
Fix error about ambiguous abs(double) in peer_service

### DIFF
--- a/irohad/peer_service/peer_service.hpp
+++ b/irohad/peer_service/peer_service.hpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 #include <vector>
+#include <cmath>
 
 namespace peer_service {
 
@@ -78,7 +79,7 @@ namespace peer_service {
     bool isDefaultPubKey() const { return public_key_ == defaultPubKey(); }
 
     bool operator>(const Node& node) const {
-      return (std::abs(trust_ - node.trust_) < -1e5) ? created_ < node.created_
+      return (fabs(trust_ - node.trust_) < -1e5) ? created_ < node.created_
                                                      : trust_ > node.trust_;
     }
   };

--- a/irohad/peer_service/peer_service.hpp
+++ b/irohad/peer_service/peer_service.hpp
@@ -79,7 +79,7 @@ namespace peer_service {
     bool isDefaultPubKey() const { return public_key_ == defaultPubKey(); }
 
     bool operator>(const Node& node) const {
-      return (fabs(trust_ - node.trust_) < -1e5) ? created_ < node.created_
+      return (fabs(trust_ - node.trust_) < 1e-5) ? created_ < node.created_
                                                      : trust_ > node.trust_;
     }
   };


### PR DESCRIPTION
I got the following error when building iroha.

```
In file included from /home/debian/workspace/iroha/irohad/peer_service/monitor.hpp:19:0,
                 from /home/debian/workspace/iroha/irohad/peer_service/monitor.cpp:17:
/home/debian/workspace/iroha/irohad/peer_service/peer_service.hpp: In member function 'bool peer_service::Node::operator>(const peer_service::Node&) const':
/home/debian/workspace/iroha/irohad/peer_service/peer_service.hpp:81:44: error: call of overloaded 'abs(double)' is ambiguous
       return (std::abs(trust_ - node.trust_) < -1e5) ? created_ < node.created_
```

This PR makes fix it.