### PR TITLE
Hotfix/torii async non blocking fix

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(irohad
   ordering_service
   consensus_service
   chain_validator
-  stateful_validator
   hash
   stateless_validator
   client_processor

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -33,9 +33,7 @@ void ServerRunner::run() {
 
   commandServiceHandler_ = std::make_unique<torii::CommandServiceHandler>(builder);
 
-  waitForServer_.lock();
   serverInstance_ = builder.BuildAndStart();
-  waitForServer_.unlock();
   serverInstanceCV_.notify_one();
 
   Log.info("Server listening on {}", serverAddress_);

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -26,6 +26,10 @@ logger::Logger Log("ServerRunner");
 ServerRunner::ServerRunner(const std::string &ip, int port)
     : serverAddress_(ip + ":" + std::to_string(port)) {}
 
+ServerRunner::~ServerRunner() {
+  commandServiceHandler_->shutdown();
+}
+
 void ServerRunner::run() {
   grpc::ServerBuilder builder;
 

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -47,10 +47,11 @@ void ServerRunner::run() {
 }
 
 void ServerRunner::shutdown() {
-  commandServiceHandler_->shutdown();
+  serverInstance_->Shutdown();
+
   while (!commandServiceHandler_->isShutdownCompletionQueue())
     usleep(1); // wait for shutting down completion queue
-  serverInstance_->Shutdown();
+  commandServiceHandler_->shutdown();
 }
 
 bool ServerRunner::waitForServersReady() {

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -48,7 +48,6 @@ void ServerRunner::run() {
 
 void ServerRunner::shutdown() {
   serverInstance_->Shutdown();
-
   while (!commandServiceHandler_->isShutdownCompletionQueue())
     usleep(1); // wait for shutting down completion queue
   commandServiceHandler_->shutdown();

--- a/irohad/main/server_runner.hpp
+++ b/irohad/main/server_runner.hpp
@@ -24,6 +24,7 @@ limitations under the License.
 class ServerRunner {
 public:
   ServerRunner(const std::string &ip, int port);
+  ~ServerRunner();
   void run();
   void shutdown();
   bool waitForServersReady();

--- a/irohad/network/grpc_call.hpp
+++ b/irohad/network/grpc_call.hpp
@@ -47,6 +47,7 @@ namespace network {
 
     /**
      * owns concrete Call type and executes derived functions.
+     * container for vtable to work if casts UntypedCall<> from void*
      */
     class CallOwner {
     public:
@@ -72,17 +73,17 @@ namespace network {
       }
 
     private:
-      UntypedCall* call_; // owns concrete Call type.
+      UntypedCall* call_; // owns concrete Call type, works vtable.
       const UntypedCall::State state_;
     };
   };
 
   /**
    * to manage the state of one rpc.
-   * @tparam ServiceHandler
-   * @tparam AsyncService
-   * @tparam RequestType
-   * @tparam ResponseType
+   * @tparam ServiceHandler - class that has interface GrpcAsyncService.
+   * @tparam AsyncService - [SomeService]::AsyncService in *.grpc.pb.h
+   * @tparam RequestType - type of a request from client
+   * @tparam ResponseType - type of a response to client
    */
   template <typename ServiceHandler, typename AsyncService, typename RequestType, typename ResponseType>
   class Call : public UntypedCall<ServiceHandler> {

--- a/irohad/torii/CMakeLists.txt
+++ b/irohad/torii/CMakeLists.txt
@@ -17,7 +17,6 @@ add_library(command_client
   command_client.cpp
 )
 target_link_libraries(command_client
-  thread_pool
   endpoint
 )
 

--- a/irohad/torii/command_client.cpp
+++ b/irohad/torii/command_client.cpp
@@ -88,9 +88,9 @@ namespace torii {
     const std::function<void(ToriiResponse& response)>& callback)
   {
     auto call = new ToriiAsyncClientCall;
+    call->callback = callback;
     call->response_reader = stub_->AsyncTorii(&call->context, tx, &cq_);
     call->response_reader->Finish(&call->response, &call->status, (void*)call);
-    call->callback = callback;
   }
 
   /**
@@ -107,6 +107,7 @@ namespace torii {
 
   CommandAsyncClient::~CommandAsyncClient() {
     cq_.Shutdown();
+    listener_.join();
   }
 
   /**

--- a/irohad/torii/command_client.cpp
+++ b/irohad/torii/command_client.cpp
@@ -40,7 +40,7 @@ namespace torii {
     std::unique_ptr<grpc::ClientAsyncResponseReader<iroha::protocol::ToriiResponse>> response_reader;
   };
 
-  CommandClient::CommandClient(const std::string& ip, int port)
+  CommandClient::CommandClient(const std::string& ip, const int port)
     : stub_(iroha::protocol::CommandService::NewStub(
     grpc::CreateChannel(ip + ":" + std::to_string(port), grpc::InsecureChannelCredentials()))),
       listenerPool_(new ThreadContainer)

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -44,7 +44,7 @@ namespace torii {
   private:
     grpc::ClientContext context_;
     std::unique_ptr<iroha::protocol::CommandService::Stub> stub_;
-    grpc::CompletionQueue cq_;
+    grpc::CompletionQueue completionQueue_;
     grpc::Status status_;
   };
 
@@ -81,7 +81,7 @@ namespace torii {
   private:
     grpc::ClientContext context_;
     std::unique_ptr<iroha::protocol::CommandService::Stub> stub_;
-    grpc::CompletionQueue cq_;
+    grpc::CompletionQueue completionQueue_;
     grpc::Status status_;
     std::thread listener_; // listens rpcs' responses and executes callbacks.
   };

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -37,7 +37,7 @@ namespace torii {
    */
   class CommandClient {
   public:
-    CommandClient(const std::string& ip, int port);
+    CommandClient(const std::string& ip, const int port);
     ~CommandClient();
 
     /**

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -83,7 +83,7 @@ namespace torii {
     std::unique_ptr<iroha::protocol::CommandService::Stub> stub_;
     grpc::CompletionQueue cq_;
     grpc::Status status_;
-    std::thread listener_;
+    std::thread listener_; // listens rpcs' responses and executes callbacks.
   };
 
 }  // namespace torii

--- a/irohad/torii/command_service_handler.cpp
+++ b/irohad/torii/command_service_handler.cpp
@@ -35,18 +35,13 @@ namespace torii {
     cq_ = builder.AddCompletionQueue();
   }
 
-  CommandServiceHandler::~CommandServiceHandler() {
-    //while (cq_->AsyncNext(&tag, &ok, gpr_time_from_seconds(1, GPR_CLOCK_MONOTONIC)) == 1) ;
-    //delete shutdownAlarm_;
-  }
+  CommandServiceHandler::~CommandServiceHandler() {}
 
   /**
    * shuts down service handler.
    * specifically, enqueues a special event that causes the completion queue to be shut down.
    */
   void CommandServiceHandler::shutdown() {
-    //void* tag;
-    //bool ok;
     cq_->Shutdown();
   }
 
@@ -67,7 +62,7 @@ namespace torii {
       if (ok && callbackTag) {
         callbackTag->onCompleted(this);
       } else {
-         isShutdownCompletionQueue_ = true;
+        isShutdownCompletionQueue_ = true;
         break;
       }
     }

--- a/irohad/torii/command_service_handler.cpp
+++ b/irohad/torii/command_service_handler.cpp
@@ -36,11 +36,8 @@ namespace torii {
   }
 
   CommandServiceHandler::~CommandServiceHandler() {
-    void* tag;
-    bool ok;
-    while (cq_->AsyncNext(&tag, &ok, gpr_time_from_seconds(1, GPR_CLOCK_MONOTONIC)) == 1) ;
-    cq_->Shutdown();
-    delete shutdownAlarm_;
+    //while (cq_->AsyncNext(&tag, &ok, gpr_time_from_seconds(1, GPR_CLOCK_MONOTONIC)) == 1) ;
+    //delete shutdownAlarm_;
   }
 
   /**
@@ -48,20 +45,9 @@ namespace torii {
    * specifically, enqueues a special event that causes the completion queue to be shut down.
    */
   void CommandServiceHandler::shutdown() {
-    bool didShutdown = false;
-    {
-      std::unique_lock<std::mutex> lock(mtx_);
-      if (!isShutdown_) {
-        isShutdown_ = true;
-        didShutdown = true;
-      }
-    }
-
-    if (didShutdown) {
-      // enqueue a special event that causes the completion queue to be shut down.
-      // tag is nullptr in order to determine no Call instance allocated when static_cast.
-      shutdownAlarm_ = new ::grpc::Alarm(cq_.get(), gpr_now(GPR_CLOCK_MONOTONIC), nullptr);
-    }
+    //void* tag;
+    //bool ok;
+    cq_->Shutdown();
   }
 
   /**

--- a/irohad/torii/command_service_handler.cpp
+++ b/irohad/torii/command_service_handler.cpp
@@ -32,7 +32,7 @@ namespace torii {
    */
   CommandServiceHandler::CommandServiceHandler(::grpc::ServerBuilder& builder) {
     builder.RegisterService(&asyncService_);
-    cq_ = builder.AddCompletionQueue();
+    completionQueue_ = builder.AddCompletionQueue();
   }
 
   CommandServiceHandler::~CommandServiceHandler() {}
@@ -41,7 +41,7 @@ namespace torii {
    * shuts down service handler. (actually, shuts down completion queue only)
    */
   void CommandServiceHandler::shutdown() {
-    cq_->Shutdown();
+    completionQueue_->Shutdown();
   }
 
   /**
@@ -61,11 +61,11 @@ namespace torii {
     bool ok;
 
     /**
-     * pulls a state of a new client's rpc request from completion queue (cq_)
+     * pulls a state of a new client's rpc request from completion queue.
      * If no request, CompletionQueue::Next() waits a new request (blocks this thread).
-     * CompletionQueue::Next() returns false if cq_->Shutdown() is executed.
+     * CompletionQueue::Next() returns false if completionQueue_->Shutdown() is executed.
      */
-    while (cq_->Next(&tag, &ok)) {
+    while (completionQueue_->Next(&tag, &ok)) {
       auto callbackTag =
           static_cast<network::UntypedCall<CommandServiceHandler>::CallOwner*>(tag);
       if (ok && callbackTag) {

--- a/irohad/torii/command_service_handler.cpp
+++ b/irohad/torii/command_service_handler.cpp
@@ -38,8 +38,7 @@ namespace torii {
   CommandServiceHandler::~CommandServiceHandler() {}
 
   /**
-   * shuts down service handler.
-   * specifically, enqueues a special event that causes the completion queue to be shut down.
+   * shuts down service handler. (actually, shuts down completion queue only)
    */
   void CommandServiceHandler::shutdown() {
     cq_->Shutdown();

--- a/irohad/torii/command_service_handler.cpp
+++ b/irohad/torii/command_service_handler.cpp
@@ -54,12 +54,23 @@ namespace torii {
         &CommandServiceHandler::ToriiHandler
     );
 
+    /**
+     * tag is a state corresponding to one rpc connection.
+     * ok is true if read a regular event, false otherwise (e.g. grpc::Alarm is not a regular event).
+     */
     void* tag;
     bool ok;
+
+    /**
+     * pulls a state of a new client's rpc request from completion queue (cq_)
+     * If no request, CompletionQueue::Next() waits a new request (blocks this thread).
+     * CompletionQueue::Next() returns false if cq_->Shutdown() is executed.
+     */
     while (cq_->Next(&tag, &ok)) {
       auto callbackTag =
           static_cast<network::UntypedCall<CommandServiceHandler>::CallOwner*>(tag);
       if (ok && callbackTag) {
+        /*assert(callbackTag);*/
         callbackTag->onCompleted(this);
       } else {
         isShutdownCompletionQueue_ = true;

--- a/irohad/torii/command_service_handler.hpp
+++ b/irohad/torii/command_service_handler.hpp
@@ -21,7 +21,6 @@ limitations under the License.
 #include <network/grpc_call.hpp>
 #include <endpoint.grpc.pb.h>
 #include <endpoint.pb.h>
-#include <grpc++/alarm.h>
 
 namespace torii {
   /**
@@ -81,7 +80,7 @@ namespace torii {
       std::unique_lock<std::mutex> lock(mtx_);
       if (!isShutdown_) {
         CommandServiceCall<iroha::protocol::Transaction, iroha::protocol::ToriiResponse>::enqueueRequest(
-          &asyncService_, cq_.get(), requester, rpcHandler
+          &asyncService_, completionQueue_.get(), requester, rpcHandler
         );
       }
     }
@@ -96,7 +95,7 @@ namespace torii {
 
   private:
     iroha::protocol::CommandService::AsyncService asyncService_;
-    std::unique_ptr<grpc::ServerCompletionQueue> cq_;
+    std::unique_ptr<grpc::ServerCompletionQueue> completionQueue_;
     std::mutex mtx_;
     bool isShutdown_ = false; // called shutdown()
     bool isShutdownCompletionQueue_ = false; // called cq_->Shutdown()

--- a/irohad/torii/command_service_handler.hpp
+++ b/irohad/torii/command_service_handler.hpp
@@ -100,7 +100,6 @@ namespace torii {
     std::mutex mtx_;
     bool isShutdown_ = false; // called shutdown()
     bool isShutdownCompletionQueue_ = false; // called cq_->Shutdown()
-    ::grpc::Alarm* shutdownAlarm_ = nullptr;
   };
 }  // namespace torii
 

--- a/test/module/irohad/torii/torii_async_test.cpp
+++ b/test/module/irohad/torii/torii_async_test.cpp
@@ -28,6 +28,9 @@ limitations under the License.
 constexpr const char* Ip = "0.0.0.0";
 constexpr int Port = 50051;
 
+constexpr size_t TimesToriiBlocking = 100;
+constexpr size_t TimesToriiNonBlocking = 3;
+
 class ToriiAsyncTest : public testing::Test {
 public:
   virtual void SetUp() {
@@ -52,7 +55,7 @@ public:
 TEST_F(ToriiAsyncTest, ToriiWhenBlocking) {
   EXPECT_GT(static_cast<int>(iroha::protocol::ResponseCode::OK), 0); // to guarantee ASSERT_EQ works TODO(motxx): More reasonable way.
 
-  for (int i = 0; i < 5; ++i) {
+  for (int i = 0; i < TimesToriiBlocking; ++i) {
     std::cout << i << std::endl;
     auto response = torii::CommandSyncClient(Ip, Port)
       .Torii(iroha::protocol::Transaction {});
@@ -67,7 +70,7 @@ TEST_F(ToriiAsyncTest, ToriiWhenNonBlocking) {
   torii::CommandAsyncClient client(Ip, Port);
   std::atomic_int count {0};
 
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < TimesToriiNonBlocking; ++i) {
     std::cout << i << std::endl;
     client.Torii(iroha::protocol::Transaction {},
                  [&count](iroha::protocol::ToriiResponse response){
@@ -77,6 +80,6 @@ TEST_F(ToriiAsyncTest, ToriiWhenNonBlocking) {
                  });
   }
 
-  while (count < 3);
-  ASSERT_EQ(count, 3);
+  while (count < TimesToriiNonBlocking);
+  ASSERT_EQ(count, TimesToriiNonBlocking);
 }


### PR DESCRIPTION
## What is this pull request?
Implement `CommandAsyncClient::Torii()` and its test.
Change interface of `ToriiBlocking()` -> `CommandSyncClient::Torii()`

## Why do you implement it? Why do we need this pull request?
enables Iroha (peer service) to send a transaction with async (non-blocking).

## How to use the features provided in the pull request?
https://github.com/hyperledger/iroha/blob/179a7811f5457fa524396c47da0a963533a16f2d/test/module/irohad/torii/torii_async_test.cpp

## Details/Features
- CommandAsyncClient::ToriI()

## P.S. (optional)
### TODO in another PR
- To test much more sending tx in for-loop with non-blocking, we need to implement the feature of **resending** (maybe in an another PR).
- Rename class, rearrangement files and directories of grpc async files.