### PR TITLE
Feature/update iroha cli

### DIFF
--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(cli_client
     endpoint)
 
 add_executable(cli-main main.cpp)
-target_link_libraries(cli-main gflags ed25519 logger)
+target_link_libraries(cli-main gflags ed25519 cli_client)

--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.0)
 PROJECT(iroha C CXX)
 
+add_library(cli_client
+    client.cpp
+    )
+
+target_link_libraries(cli_client
+    endpoint)
+
 add_executable(cli-main main.cpp)
-target_link_libraries(cli-main gflags ed25519)
+target_link_libraries(cli-main gflags ed25519 logger)

--- a/iroha-cli/client.cpp
+++ b/iroha-cli/client.cpp
@@ -29,36 +29,34 @@
 
 namespace iroha_cli {
 
-    CliClient::CliClient(std::string targetIp,int port):
+  CliClient::CliClient(std::string targetIp, int port):
       targetIp(targetIp),
       port(port)
-    {}
+  {}
 
-    std::string CliClient::sendTx(
-          const Transaction &tx
-    ) {
-       auto channel = grpc::CreateChannel(
-         targetIp + ":" + std::to_string(port),
-         grpc::InsecureChannelCredentials()
-       );
+  std::string CliClient::sendTx(const Transaction &tx) {
+    auto channel = grpc::CreateChannel(
+      targetIp + ":" + std::to_string(port),
+      grpc::InsecureChannelCredentials()
+    );
 
-       auto stub = iroha::protocol::CommandService::NewStub(channel);
+    auto stub = iroha::protocol::CommandService::NewStub(channel);
 
-       iroha::protocol::ToriiResponse response;
-       grpc::ClientContext context;
+    iroha::protocol::ToriiResponse response;
+    grpc::ClientContext context;
 
-       // ToDo model::transaction -> protocol::transaction
-       iroha::protocol::Transaction transaction;
-       grpc::Status status = stub->Torii(&context, transaction, &response);
-        if (status.ok()) {
-          return response.message();
-        } else {
-          std::cout <<
-            status.error_code() << ": " <<
-            status.error_message()
-            << std::endl;
-          return response.message();
-        }
+    // ToDo model::transaction -> protocol::transaction
+    iroha::protocol::Transaction transaction;
+    grpc::Status status = stub->Torii(&context, transaction, &response);
+    
+    if (status.ok()) {
+      return response.message();
+    } else {
+      std::cout <<
+        status.error_code() << ": " <<
+        status.error_message()
+        << std::endl;
+      return response.message();
     }
-
+  }
 };

--- a/iroha-cli/client.cpp
+++ b/iroha-cli/client.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// In iroha-cli only, " is used.
+#include "client.hpp"
+
+#include <grpc/grpc.h>
+#include <grpc++/channel.h>
+#include <grpc++/client_context.h>
+#include <grpc++/create_channel.h>
+#include <grpc++/security/credentials.h>
+
+#include <endpoint.grpc.pb.h>
+#include <endpoint.pb.h>
+
+namespace iroha_cli {
+
+    CliClient::CliClient(std::string targetIp,int port):
+      targetIp(targetIp),
+      port(port)
+    {}
+
+    std::string CliClient::sendTx(
+          const Transaction &tx
+    ) {
+       auto channel = grpc::CreateChannel(
+         targetIp + ":" + std::to_string(port),
+         grpc::InsecureChannelCredentials()
+       );
+
+       auto stub = iroha::protocol::CommandService::NewStub(channel);
+
+       iroha::protocol::ToriiResponse response;
+       grpc::ClientContext context;
+
+       // ToDo model::transaction -> protocol::transaction
+       iroha::protocol::Transaction transaction;
+       grpc::Status status = stub->Torii(&context, transaction, &response);
+        if (status.ok()) {
+          return response.message();
+        } else {
+          std::cout <<
+            status.error_code() << ": " <<
+            status.error_message()
+            << std::endl;
+          return response.message();
+        }
+    }
+
+};

--- a/iroha-cli/client.hpp
+++ b/iroha-cli/client.hpp
@@ -27,9 +27,9 @@ namespace iroha_cli {
 
   using iroha::model::Transaction;
 
-  class CliClient{
+  class CliClient {
     public:
-      CliClient(std::string targetIp,int port);
+      CliClient(std::string targetIp, int port);
 
       std::string sendTx(
         const Transaction &tx
@@ -39,7 +39,6 @@ namespace iroha_cli {
       std::string targetIp;
       int port;
   };
-
 };
 
 #endif //IROHA_CLIENT_CPP_HPP

--- a/iroha-cli/client.hpp
+++ b/iroha-cli/client.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IROHA_CLIENT_HPP
+#define IROHA_CLIENT_HPP
+
+#include <string>
+#include <model/transaction.hpp>
+
+
+namespace iroha_cli {
+
+  using iroha::model::Transaction;
+
+  class CliClient{
+    public:
+      CliClient(std::string targetIp,int port);
+
+      std::string sendTx(
+        const Transaction &tx
+      );
+
+    private:
+      std::string targetIp;
+      int port;
+  };
+
+};
+
+#endif //IROHA_CLIENT_CPP_HPP

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iostream>
 
+
 DEFINE_bool(new_account, false, "Choose if account does not exist");
 DEFINE_string(name, "", "Name of the account");
 

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -21,14 +21,16 @@
 #include <fstream>
 #include <iostream>
 
+#include "client.hpp"
+
 
 DEFINE_bool(new_account, false, "Choose if account does not exist");
 DEFINE_string(name, "", "Name of the account");
 
-static bool not_empty_name(const char* flagname, const std::string& value) {
-  return value[0] != '\0';
-}
-DEFINE_validator(name, &not_empty_name);
+
+DEFINE_bool(grpc, false, "send sample transaction to IrohaNetwork");
+DEFINE_string(address, "127.0.0.1", "Where is Iroha network");
+DEFINE_int32(port, 50051, "What port to access iroha's Torii");
 
 void create_account(std::string name);
 
@@ -43,6 +45,18 @@ int main(int argc, char* argv[]) {
       return -1;
     }
     create_account(FLAGS_name);
+
+  // Send test tx to Iroha
+  }else if(FLAGS_grpc){
+    if(FLAGS_port > 0 && FLAGS_port < 65535){
+      std::cout<< "Send transaction to "<< FLAGS_address <<":" << FLAGS_port << std::endl;
+      auto client = iroha_cli::CliClient(FLAGS_address,FLAGS_port);
+      // ToDo more variables transaction
+      client.sendTx(iroha::model::Transaction{});
+    }else{
+      std::cout<< "Invalid port number " << FLAGS_port << std::endl;
+      iroha_cli::CliClient(FLAGS_address,FLAGS_port);
+    }
   }
 }
 

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -47,13 +47,13 @@ int main(int argc, char* argv[]) {
     create_account(FLAGS_name);
 
   // Send test tx to Iroha
-  }else if(FLAGS_grpc){
-    if(FLAGS_port > 0 && FLAGS_port < 65535){
+  } else if (FLAGS_grpc) {
+    if (FLAGS_port > 0 && FLAGS_port < 65535) {
       std::cout<< "Send transaction to "<< FLAGS_address <<":" << FLAGS_port << std::endl;
       auto client = iroha_cli::CliClient(FLAGS_address,FLAGS_port);
       // ToDo more variables transaction
       client.sendTx(iroha::model::Transaction{});
-    }else{
+    } else {
       std::cout<< "Invalid port number " << FLAGS_port << std::endl;
       iroha_cli::CliClient(FLAGS_address,FLAGS_port);
     }
@@ -71,6 +71,9 @@ std::string hex_str(unsigned char* data, int len) {
   return s;
 }
 
+/**
+ * Command to create a new account using the interactive console.
+ */
 void create_account(std::string name) {
   unsigned char public_key[32], private_key[64], seed[32];
 


### PR DESCRIPTION

## What is this pull request?
We can iroha-cli to send sample tx to Iroha! like this
```sh
$ ./iroha-cli/cli-main  --grpc --address example.com --port 50051
```
   
## Why do you implement it? Why do we need this pull request?
We want to touch Iroha network more simply,
Of course, we can use for test
  
## Details/Features
- update iroha-cli
- send tx to any domain, port

## WIP
- [ ] cannot any transaction, only empty tx.
- [ ] Not interactive
- [ ] add logger
