### PR TITLE
Feature/pb factories pure

### DIFF
--- a/irohad/ametsuchi/impl/block_serializer.cpp
+++ b/irohad/ametsuchi/impl/block_serializer.cpp
@@ -213,12 +213,13 @@ namespace iroha {
       writer.String(add_asset_quantity.asset_id.c_str());
 
       writer.String("amount");
-      writer.StartArray();
+      writer.StartObject();
+
       writer.String("int_part");
       writer.Uint64(add_asset_quantity.amount.int_part);
       writer.String("frac_part");
       writer.Uint64(add_asset_quantity.amount.frac_part);
-      writer.EndArray();
+      writer.EndObject();
 
       writer.EndObject();
     }
@@ -408,12 +409,12 @@ namespace iroha {
       writer.String(transfer_asset.asset_id.c_str());
 
       writer.String("amount");
-      writer.StartArray();
+      writer.StartObject();
       writer.String("int_part");
       writer.Uint64(transfer_asset.amount.int_part);
       writer.String("frac_part");
       writer.Uint64(transfer_asset.amount.frac_part);
-      writer.EndArray();
+      writer.EndObject();
 
       writer.EndObject();
     }

--- a/irohad/ametsuchi/impl/block_serializer.cpp
+++ b/irohad/ametsuchi/impl/block_serializer.cpp
@@ -629,7 +629,7 @@ namespace iroha {
     BlockSerializer::deserialize_add_asset_quantity(
         GenericValue<rapidjson::UTF8<char>>::Object& json_command) {
       // TODO: make this function return nullopt when some field is missed
-      model::AddAssetQuantity add_asset_quantity{};
+      model::AddAssetQuantity add_asset_quantity;
 
       // account_id
       add_asset_quantity.account_id = json_command["account_id"].GetString();

--- a/irohad/ametsuchi/impl/block_serializer.cpp
+++ b/irohad/ametsuchi/impl/block_serializer.cpp
@@ -213,9 +213,12 @@ namespace iroha {
       writer.String(add_asset_quantity.asset_id.c_str());
 
       writer.String("amount");
-
-      writer.Double(
-          std::decimal::decimal64_to_double(add_asset_quantity.amount));
+      writer.StartArray();
+      writer.String("int_part");
+      writer.Uint64(add_asset_quantity.amount.int_part);
+      writer.String("frac_part");
+      writer.Uint64(add_asset_quantity.amount.frac_part);
+      writer.EndArray();
 
       writer.EndObject();
     }
@@ -405,7 +408,12 @@ namespace iroha {
       writer.String(transfer_asset.asset_id.c_str());
 
       writer.String("amount");
-      writer.Double(std::decimal::decimal64_to_double(transfer_asset.amount));
+      writer.StartArray();
+      writer.String("int_part");
+      writer.Uint64(transfer_asset.amount.int_part);
+      writer.String("frac_part");
+      writer.Uint64(transfer_asset.amount.frac_part);
+      writer.EndArray();
 
       writer.EndObject();
     }
@@ -574,14 +582,16 @@ namespace iroha {
                 std::make_shared<model::CreateDomain>(create_domain.value()));
           }
         } else if (command_type == "RemoveSignatory") {
-          if (auto remove_signatory = deserialize_remove_signatory(json_command)) {
-            commands.push_back(
-                std::make_shared<model::RemoveSignatory>(remove_signatory.value()));
+          if (auto remove_signatory =
+                  deserialize_remove_signatory(json_command)) {
+            commands.push_back(std::make_shared<model::RemoveSignatory>(
+                remove_signatory.value()));
           }
         } else if (command_type == "SetAccountPermissions") {
-          if (auto set_account_permissions = deserialize_set_account_permissions(json_command)) {
-            commands.push_back(
-                std::make_shared<model::SetAccountPermissions>(set_account_permissions.value()));
+          if (auto set_account_permissions =
+                  deserialize_set_account_permissions(json_command)) {
+            commands.push_back(std::make_shared<model::SetAccountPermissions>(
+                set_account_permissions.value()));
           }
         } else if (command_type == "SetQuorum") {
           if (auto set_quorum = deserialize_set_quorum(json_command)) {
@@ -627,7 +637,10 @@ namespace iroha {
       add_asset_quantity.asset_id = json_command["asset_id"].GetString();
 
       // amount
-      auto amount = std::decimal::decimal64(json_command["amount"].GetDouble());
+      auto json_amount = json_command["amount"].GetObject();
+      Amount amount;
+      amount.int_part = json_amount["int_part"].GetUint64();
+      amount.frac_part = json_amount["frac_part"].GetUint64();
       add_asset_quantity.amount = amount;
 
       return add_asset_quantity;
@@ -802,8 +815,11 @@ namespace iroha {
       transferAsset.asset_id = json_command["asset_id"].GetString();
 
       // amount
-      transferAsset.amount =
-          std::decimal::decimal64(json_command["amount"].GetDouble());
+      auto json_amount = json_command["amount"].GetObject();
+      Amount amount;
+      amount.int_part = json_amount["int_part"].GetUint64();
+      amount.frac_part = json_amount["frac_part"].GetUint64();
+      transferAsset.amount = amount;
 
       return transferAsset;
     }

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -3,6 +3,9 @@ add_library(model
     model_hash_provider_impl.cpp
     impl/stateful_command_validation.cpp
     impl/command_execution.cpp
+    converters/impl/pb_block_factory.cpp
+    converters/impl/pb_transaction_factory.cpp
+    converters/impl/pb_command_factory.cpp
     )
 
 target_link_libraries(model

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(model
     model_hash_provider_impl.cpp
     impl/stateful_command_validation.cpp
     impl/command_execution.cpp
+    impl/model_operators.cpp
     converters/impl/pb_block_factory.cpp
     converters/impl/pb_transaction_factory.cpp
     converters/impl/pb_command_factory.cpp

--- a/irohad/model/account.hpp
+++ b/irohad/model/account.hpp
@@ -82,6 +82,9 @@ namespace iroha {
          * User's account permission
          */
         bool can_transfer;
+
+        bool operator==(const Permissions& rhs) const;
+        bool operator!=(const Permissions& rhs) const;
       };
 
       /**

--- a/irohad/model/account.hpp
+++ b/irohad/model/account.hpp
@@ -27,6 +27,19 @@ namespace iroha {
      */
     struct Account {
       struct Permissions {
+        Permissions() {
+          issue_assets = false;
+          create_assets = false;
+          create_accounts = false;
+          create_domains = false;
+          read_all_accounts = false;
+          add_signatory = false;
+          remove_signatory = false;
+          set_permissions = false;
+          set_quorum = false;
+          can_transfer = false;
+        }
+
         /**
          * Can account add assets to own account;
          * Dangerous operation - require high number of quorum;
@@ -83,8 +96,8 @@ namespace iroha {
          */
         bool can_transfer;
 
-        bool operator==(const Permissions& rhs) const;
-        bool operator!=(const Permissions& rhs) const;
+        bool operator==(const Permissions &rhs) const;
+        bool operator!=(const Permissions &rhs) const;
       };
 
       /**

--- a/irohad/model/block.hpp
+++ b/irohad/model/block.hpp
@@ -81,6 +81,9 @@ namespace iroha {
        * BODY field
        */
       std::vector<Transaction> transactions;
+
+      bool operator==(const Block& rhs) const;
+      bool operator!=(const Block& rhs) const;
     };
   }
 }

--- a/irohad/model/command.hpp
+++ b/irohad/model/command.hpp
@@ -34,6 +34,8 @@ namespace iroha {
                             const Account& creator) = 0;
       virtual bool execute(ametsuchi::WsvQuery& queries,
                            ametsuchi::WsvCommand& commands) = 0;
+      virtual bool operator==(const Command& rhs) const = 0;
+      virtual bool operator!=(const Command& rhs) const = 0;
     };
   }
 }

--- a/irohad/model/commands/add_asset_quantity.hpp
+++ b/irohad/model/commands/add_asset_quantity.hpp
@@ -20,6 +20,7 @@
 
 #include <model/command.hpp>
 #include <string>
+#include "common/types.hpp"
 
 namespace iroha {
   namespace model {
@@ -42,7 +43,7 @@ namespace iroha {
       /**
        * Amount to add to account asset
        */
-      std::string amount;
+      Amount amount;
 
       bool validate(ametsuchi::WsvQuery& queries,
                     const Account& creator) override;

--- a/irohad/model/commands/add_asset_quantity.hpp
+++ b/irohad/model/commands/add_asset_quantity.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_ADD_ASSET_QUANTITY_HPP
 #define IROHA_ADD_ASSET_QUANTITY_HPP
 
+#include <decimal/decimal>
 #include <model/command.hpp>
 #include <string>
 
@@ -42,7 +43,7 @@ namespace iroha {
       /**
        * Amount to add to account asset
        */
-      std::string amount;
+      std::decimal::decimal64 amount;
 
       bool validate(ametsuchi::WsvQuery& queries,
                     const Account& creator) override;

--- a/irohad/model/commands/add_asset_quantity.hpp
+++ b/irohad/model/commands/add_asset_quantity.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_ADD_ASSET_QUANTITY_HPP
 #define IROHA_ADD_ASSET_QUANTITY_HPP
 
-#include <decimal/decimal>
 #include <model/command.hpp>
 #include <string>
 
@@ -43,7 +42,7 @@ namespace iroha {
       /**
        * Amount to add to account asset
        */
-      std::decimal::decimal64 amount;
+      std::string amount;
 
       bool validate(ametsuchi::WsvQuery& queries,
                     const Account& creator) override;

--- a/irohad/model/commands/add_asset_quantity.hpp
+++ b/irohad/model/commands/add_asset_quantity.hpp
@@ -49,6 +49,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/add_peer.hpp
+++ b/irohad/model/commands/add_peer.hpp
@@ -37,6 +37,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/add_signatory.hpp
+++ b/irohad/model/commands/add_signatory.hpp
@@ -43,6 +43,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/assign_master_key.hpp
+++ b/irohad/model/commands/assign_master_key.hpp
@@ -43,6 +43,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/create_account.hpp
+++ b/irohad/model/commands/create_account.hpp
@@ -46,6 +46,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/create_asset.hpp
+++ b/irohad/model/commands/create_asset.hpp
@@ -48,6 +48,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/create_domain.hpp
+++ b/irohad/model/commands/create_domain.hpp
@@ -36,6 +36,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }

--- a/irohad/model/commands/remove_signatory.hpp
+++ b/irohad/model/commands/remove_signatory.hpp
@@ -44,6 +44,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/set_permissions.hpp
+++ b/irohad/model/commands/set_permissions.hpp
@@ -42,6 +42,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/set_quorum.hpp
+++ b/irohad/model/commands/set_quorum.hpp
@@ -42,6 +42,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/transfer_asset.hpp
+++ b/irohad/model/commands/transfer_asset.hpp
@@ -20,6 +20,7 @@
 
 #include <model/command.hpp>
 #include <string>
+#include "common/types.hpp"
 
 namespace iroha {
   namespace model {
@@ -45,7 +46,7 @@ namespace iroha {
       /**
        * Amount of transferred asset
        */
-      std::string amount;
+      Amount amount;
 
       bool validate(ametsuchi::WsvQuery& queries,
                     const Account& creator) override;

--- a/irohad/model/commands/transfer_asset.hpp
+++ b/irohad/model/commands/transfer_asset.hpp
@@ -52,6 +52,9 @@ namespace iroha {
                     const Account& creator) override;
       bool execute(ametsuchi::WsvQuery& queries,
                    ametsuchi::WsvCommand& commands) override;
+
+      bool operator==(const Command& command) const override;
+      bool operator!=(const Command& command) const override;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/commands/transfer_asset.hpp
+++ b/irohad/model/commands/transfer_asset.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_TRANSFER_ASSET_HPP
 #define IROHA_TRANSFER_ASSET_HPP
 
-#include <decimal/decimal>
 #include <model/command.hpp>
 #include <string>
 
@@ -46,7 +45,7 @@ namespace iroha {
       /**
        * Amount of transferred asset
        */
-      std::decimal::decimal64 amount;
+      std::string amount;
 
       bool validate(ametsuchi::WsvQuery& queries,
                     const Account& creator) override;

--- a/irohad/model/converters/impl/pb_block_factory.cpp
+++ b/irohad/model/converters/impl/pb_block_factory.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <model/model_hash_provider_impl.hpp>
 #include "model/converters/pb_block_factory.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
 
@@ -83,6 +84,9 @@ namespace iroha {
         for (auto pb_tx: body.transactions()){
           block.transactions.push_back(tx_factory.deserialize(pb_tx));
         }
+
+        iroha::model::HashProviderImpl hash_provider;
+        block.hash = hash_provider.get_hash(block);
 
         return block;
       }

--- a/irohad/model/converters/impl/pb_block_factory.cpp
+++ b/irohad/model/converters/impl/pb_block_factory.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "model/converters/pb_block_factory.hpp"
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      protocol::Block PbBlockFactory::serialize(model::Block &block) {
+        protocol::Block pb_block;
+
+        // -----|Header|-----
+        auto header = pb_block.mutable_header();
+        header->set_created_time(block.created_ts);
+        // todo set signatures
+
+        // -----|Meta|-----
+        auto meta = pb_block.mutable_meta();
+        meta->set_tx_number(block.txs_number);
+        meta->set_height(block.height);
+        meta->set_merkle_root(block.merkle_root.data(),
+                              block.merkle_root.size());
+        meta->set_prev_block_hash(block.prev_hash.data(),
+                                  block.prev_hash.size());
+
+        // -----|Body|-----
+        auto body = pb_block.mutable_body();
+        // todo set transactions
+
+        return pb_block;
+      }
+
+      model::Block PbBlockFactory::deserialize(protocol::Block &pb_block) {
+        model::Block block;
+
+        // -----|Header|-----
+        block.created_ts = pb_block.header().created_time();
+        // todo set signatures
+
+        // -----|Meta|-----
+        auto meta = pb_block.meta();
+        // potential dangerous cast
+        block.txs_number = (uint16_t) meta.tx_number();
+        block.height = meta.height();
+        std::copy(meta.merkle_root().begin(), meta.merkle_root().end(),
+                  block.merkle_root.begin());
+        std::copy(meta.prev_block_hash().begin(), meta.prev_block_hash().end(),
+                  block.prev_hash.begin());
+
+        // -----|Body|-----
+        auto body = pb_block.body();
+        // todo set transactions
+
+        return block;
+      }
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -267,7 +267,7 @@ namespace iroha {
         return transfer_asset;
       }
 
-      protocol::Command &&
+      protocol::Command
       PbCommandFactory::serializeAbstractCommand(const model::Command &command) {
         PbCommandFactory commandFactory;
         auto cmd = protocol::Command();
@@ -365,7 +365,7 @@ namespace iroha {
               serialized));
         }
 
-        return std::forward<protocol::Command>(cmd);
+        return cmd;
       }
 
       std::shared_ptr<model::Command>

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -33,6 +33,7 @@ namespace iroha {
         auto amount = pb_add_asset_quantity.mutable_amount();
         amount->set_integer_part(add_asset_quantity.amount.int_part);
         amount->set_fractial_part(add_asset_quantity.amount.frac_part);
+        return pb_add_asset_quantity;
       }
 
       model::AddAssetQuantity
@@ -41,10 +42,11 @@ namespace iroha {
         model::AddAssetQuantity add_asset_quantity;
         add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
         add_asset_quantity.asset_id = pb_add_asset_quantity.asset_id();
-        add_asset_quantity.amount.int_part =
-            pb_add_asset_quantity.amount().integer_part();
-        add_asset_quantity.amount.frac_part =
-            pb_add_asset_quantity.amount().fractial_part();
+        Amount amount;
+        amount.int_part = pb_add_asset_quantity.amount().integer_part();
+        amount.frac_part = pb_add_asset_quantity.amount().fractial_part();
+        add_asset_quantity.amount = amount;
+
         return add_asset_quantity;
       }
 

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -30,7 +30,7 @@ namespace iroha {
         protocol::AddAssetQuantity pb_add_asset_quantity;
         pb_add_asset_quantity.set_account_id(add_asset_quantity.account_id);
         pb_add_asset_quantity.set_asset_id(add_asset_quantity.asset_id);
-        // todo set amount
+        pb_add_asset_quantity.set_amount(add_asset_quantity.amount);
       }
 
       model::AddAssetQuantity
@@ -39,7 +39,7 @@ namespace iroha {
         model::AddAssetQuantity add_asset_quantity;
         add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
         add_asset_quantity.asset_id = pb_add_asset_quantity.asset_id();
-        // todo set amount
+        add_asset_quantity.amount = pb_add_asset_quantity.amount();
         return add_asset_quantity;
       }
 
@@ -63,50 +63,194 @@ namespace iroha {
 
       // add signatory
       protocol::AddSignatory
-      PbCommandFactory::serializeAddSignatory(model::AddSignatory &addSignatory) {
-        protocol::AddSignatory add_signatory;
-
-        return add_signatory;
+      PbCommandFactory::serializeAddSignatory(model::AddSignatory &add_signatory) {
+        protocol::AddSignatory pb_add_signatory;
+        pb_add_signatory.set_account_id(add_signatory.account_id);
+        pb_add_signatory.set_public_key(add_signatory.pubkey.data(),
+                                        add_signatory.pubkey.size());
+        return pb_add_signatory;
       }
-      model::AddSignatory PbCommandFactory::deserializeAddSignatory(protocol::AddSignatory &addSignatory) {
-
+      model::AddSignatory PbCommandFactory::deserializeAddSignatory(protocol::AddSignatory &pb_add_signatory) {
+        model::AddSignatory add_signatory;
+        add_signatory.account_id = pb_add_signatory.account_id();
+        std::copy(pb_add_signatory.public_key().begin(),
+                  pb_add_signatory.public_key().end(),
+                  add_signatory.pubkey.begin());
+        return add_signatory;
       }
 
       // assign master key
-      protocol::AssignMasterKey PbCommandFactory::serializeAssignMasterKey(model::AssignMasterKey &assignMasterKey) {}
+      protocol::AssignMasterKey
+      PbCommandFactory::serializeAssignMasterKey(model::AssignMasterKey &assign_master_key) {
+        protocol::AssignMasterKey pb_assign_master_key;
+        pb_assign_master_key.set_account_id(assign_master_key.account_id);
+        pb_assign_master_key.set_public_key(assign_master_key.pubkey.data(),
+                                            assign_master_key.pubkey.size());
+        return pb_assign_master_key;
+      }
+
       model::AssignMasterKey PbCommandFactory::deserializeAssignMasterKey(
-          protocol::AssignMasterKey &assignMasterKey) {}
+          protocol::AssignMasterKey &pb_assign_master_key) {
+        model::AssignMasterKey assign_master_key;
+        assign_master_key.account_id = pb_assign_master_key.account_id();
+        std::copy(pb_assign_master_key.public_key().begin(),
+                  pb_assign_master_key.public_key().end(),
+                  assign_master_key.pubkey.begin());
+        return assign_master_key;
+      }
 
       // create asset
-      protocol::CreateAsset PbCommandFactory::serializeCreateAsset(model::CreateAsset &createAsset) {}
-      model::CreateAsset PbCommandFactory::deserializeCreateAsset(protocol::CreateAsset &createAsset) {}
+      protocol::CreateAsset
+      PbCommandFactory::serializeCreateAsset(model::CreateAsset &create_asset) {
+        protocol::CreateAsset pb_create_asset;
+        pb_create_asset.set_asset_name(create_asset.asset_name);
+        pb_create_asset.set_domain_id(create_asset.domain_id);
+        pb_create_asset.set_precision(create_asset.precision);
+        return pb_create_asset;
+      }
+
+      model::CreateAsset
+      PbCommandFactory::deserializeCreateAsset(protocol::CreateAsset &pb_create_asset) {
+        model::CreateAsset create_asset;
+        create_asset.asset_name = pb_create_asset.asset_name();
+        create_asset.domain_id = pb_create_asset.domain_id();
+        create_asset.precision =
+            static_cast<uint8_t>(pb_create_asset.precision());
+        return create_asset;
+      }
 
       // create account
-      protocol::CreateAccount PbCommandFactory::serializeCreateAccount(model::CreateAccount &createAccount) {}
-      model::CreateAccount PbCommandFactory::deserializeCreateAccount(protocol::CreateAccount &createAccount) {}
+      protocol::CreateAccount
+      PbCommandFactory::serializeCreateAccount(model::CreateAccount &create_account) {
+        protocol::CreateAccount pb_create_account;
+        pb_create_account.set_account_name(create_account.account_name);
+        pb_create_account.set_domain_id(create_account.domain_id);
+        pb_create_account.set_main_pubkey(create_account.pubkey.data(),
+                                          create_account.pubkey.size());
+        return pb_create_account;
+      }
+      model::CreateAccount PbCommandFactory::deserializeCreateAccount(protocol::CreateAccount &pb_create_account) {
+        model::CreateAccount create_account;
+        create_account.account_name = pb_create_account.account_name();
+        create_account.domain_id = pb_create_account.domain_id();
+        std::copy(pb_create_account.main_pubkey().begin(),
+                  pb_create_account.main_pubkey().end(),
+                  create_account.pubkey.begin());
+        return create_account;
+      }
 
       // create domain
-      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(model::CreateDomain &createDomain) {}
-      model::CreateDomain PbCommandFactory::deserializeCreateDomain(protocol::CreateDomain &createDomain) {}
+      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(model::CreateDomain &create_domain) {
+        protocol::CreateDomain pb_create_domain;
+        pb_create_domain.set_domain_name(create_domain.domain_name);
+        return pb_create_domain;
+      }
+
+      model::CreateDomain PbCommandFactory::deserializeCreateDomain(protocol::CreateDomain &pb_create_domain) {
+        model::CreateDomain create_domain;
+        create_domain.domain_name = pb_create_domain.domain_name();
+        return create_domain;
+      }
 
       // remove signatory
-      protocol::RemoveSignatory PbCommandFactory::serializeRemoveSignatory(model::RemoveSignatory &removeSignatory) {}
+      protocol::RemoveSignatory
+      PbCommandFactory::serializeRemoveSignatory(model::RemoveSignatory &remove_signatory) {
+        protocol::RemoveSignatory pb_remove_signatory;
+        pb_remove_signatory.set_account_id(remove_signatory.account_id);
+        pb_remove_signatory.set_public_key(remove_signatory.pubkey.data(),
+                                           remove_signatory.pubkey.size());
+        return pb_remove_signatory;
+      }
+
       model::RemoveSignatory PbCommandFactory::deserializeRemoveSignatory(
-          protocol::RemoveSignatory &removeSignatory) {}
+          protocol::RemoveSignatory &pb_remove_signatory) {
+        model::RemoveSignatory remove_signatory;
+        remove_signatory.account_id = pb_remove_signatory.account_id();
+        return remove_signatory;
+      }
 
       // set account permissions
       protocol::SetAccountPermissions PbCommandFactory::serializeSetAccountPermissions(
-          model::SetAccountPermissions &setAccountPermissions) {}
-      model::SetAccountPermissions PbCommandFactory::deserializeSetAccountPermissions(
-          protocol::SetAccountPermissions &setAccountPermissions) {}
+          model::SetAccountPermissions &set_account_permissions) {
+        protocol::SetAccountPermissions pb_set_account_permissions;
+        pb_set_account_permissions.set_account_id(set_account_permissions.account_id);
+        auto permissions = pb_set_account_permissions.mutable_permissions();
+        permissions->set_issue_assets(set_account_permissions.new_permissions.issue_assets);
+        permissions->set_create_assets(set_account_permissions.new_permissions.create_assets);
+        permissions->set_create_accounts(set_account_permissions.new_permissions.create_accounts);
+        permissions->set_create_domains(set_account_permissions.new_permissions.create_domains);
+        permissions->set_read_all_accounts(set_account_permissions.new_permissions.read_all_accounts);
+        permissions->set_add_signatory(set_account_permissions.new_permissions.add_signatory);
+        permissions->set_remove_signatory(set_account_permissions.new_permissions.remove_signatory);
+        permissions->set_set_quorum(set_account_permissions.new_permissions.set_quorum);
+        permissions->set_can_transfer(set_account_permissions.new_permissions.can_transfer);
+        return pb_set_account_permissions;
+      }
+
+      model::SetAccountPermissions
+      PbCommandFactory::deserializeSetAccountPermissions(
+          protocol::SetAccountPermissions &pb_set_account_permissions) {
+        model::SetAccountPermissions set_account_permissions;
+        set_account_permissions.account_id =
+            pb_set_account_permissions.account_id();
+        set_account_permissions.new_permissions.issue_assets =
+            pb_set_account_permissions.permissions().issue_assets();
+        set_account_permissions.new_permissions.create_assets =
+            pb_set_account_permissions.permissions().create_assets();
+        set_account_permissions.new_permissions.create_accounts =
+            pb_set_account_permissions.permissions().create_accounts();
+        set_account_permissions.new_permissions.create_domains =
+            pb_set_account_permissions.permissions().create_domains();
+        set_account_permissions.new_permissions.read_all_accounts =
+            pb_set_account_permissions.permissions().read_all_accounts();
+        set_account_permissions.new_permissions.add_signatory =
+            pb_set_account_permissions.permissions().add_signatory();
+        set_account_permissions.new_permissions.remove_signatory =
+            pb_set_account_permissions.permissions().remove_signatory();
+        set_account_permissions.new_permissions.set_permissions =
+            pb_set_account_permissions.permissions().set_permissions();
+        set_account_permissions.new_permissions.set_quorum =
+            pb_set_account_permissions.permissions().set_quorum();
+        set_account_permissions.new_permissions.can_transfer =
+            pb_set_account_permissions.permissions().can_transfer();
+        return set_account_permissions;
+      }
 
       // set account quorum
-      protocol::SetAccountQuorum PbCommandFactory::serializeSetQuorum(model::SetQuorum &setAccountQuorum) {}
-      model::SetQuorum PbCommandFactory::deserializeSetQuorum(protocol::SetAccountQuorum &setAccountQuorum) {}
+      protocol::SetAccountQuorum
+      PbCommandFactory::serializeSetQuorum(model::SetQuorum &set_account_quorum) {
+        protocol::SetAccountQuorum pb_set_account_quorum;
+        pb_set_account_quorum.set_account_id(set_account_quorum.account_id);
+        pb_set_account_quorum.set_quorum(set_account_quorum.new_quorum);
+        return pb_set_account_quorum;
+      }
+      model::SetQuorum
+      PbCommandFactory::deserializeSetQuorum(protocol::SetAccountQuorum &pb_set_account_quorum) {
+        model::SetQuorum set_quorum;
+        set_quorum.account_id = pb_set_account_quorum.account_id();
+        set_quorum.new_quorum = pb_set_account_quorum.quorum();
+        return set_quorum;
+      }
 
       // transfer asset
-      protocol::TransferAsset PbCommandFactory::serializeTransferAsset(model::TransferAsset &subtractAssetQuantity) {}
-      model::TransferAsset PbCommandFactory::deserializeTransferAsset(protocol::TransferAsset &subtractAssetQuantity) {}
+      protocol::TransferAsset
+      PbCommandFactory::serializeTransferAsset(model::TransferAsset &transfer_asset) {
+        protocol::TransferAsset pb_transfer_asset;
+        pb_transfer_asset.set_src_account_id(transfer_asset.src_account_id);
+        pb_transfer_asset.set_dest_account_id(transfer_asset.dest_account_id);
+        pb_transfer_asset.set_asset_id(transfer_asset.asset_id);
+        pb_transfer_asset.set_ammount(transfer_asset.amount);
+        return pb_transfer_asset;
+      }
+      model::TransferAsset
+      PbCommandFactory::deserializeTransferAsset(protocol::TransferAsset &pb_subtract_asset_quantity) {
+        model::TransferAsset transfer_asset;
+        transfer_asset.src_account_id = pb_subtract_asset_quantity.src_account_id();
+        transfer_asset.dest_account_id = pb_subtract_asset_quantity.dest_account_id();
+        transfer_asset.asset_id = pb_subtract_asset_quantity.asset_id();
+        transfer_asset.amount = pb_subtract_asset_quantity.asset_id();
+        return transfer_asset;
+      }
 
     } // namespace converters
   }  // namespace model

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -173,12 +173,15 @@ namespace iroha {
           const protocol::RemoveSignatory &pb_remove_signatory) {
         model::RemoveSignatory remove_signatory;
         remove_signatory.account_id = pb_remove_signatory.account_id();
+        std::copy(pb_remove_signatory.public_key().begin(),
+                  pb_remove_signatory.public_key().end(),
+                  remove_signatory.pubkey.begin());
         return remove_signatory;
       }
 
       // set account permissions
       protocol::SetAccountPermissions PbCommandFactory::serializeSetAccountPermissions(
-          const  model::SetAccountPermissions &set_account_permissions) {
+          const model::SetAccountPermissions &set_account_permissions) {
         protocol::SetAccountPermissions pb_set_account_permissions;
         pb_set_account_permissions.set_account_id(set_account_permissions.account_id);
         auto permissions = pb_set_account_permissions.mutable_permissions();
@@ -196,7 +199,7 @@ namespace iroha {
 
       model::SetAccountPermissions
       PbCommandFactory::deserializeSetAccountPermissions(
-          const  protocol::SetAccountPermissions &pb_set_account_permissions) {
+          const protocol::SetAccountPermissions &pb_set_account_permissions) {
         model::SetAccountPermissions set_account_permissions;
         set_account_permissions.account_id =
             pb_set_account_permissions.account_id();

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -26,7 +26,7 @@ namespace iroha {
       // asset quantity
       protocol::AddAssetQuantity
       PbCommandFactory::serializeAddAssetQuantity(
-          model::AddAssetQuantity &add_asset_quantity) {
+          const model::AddAssetQuantity &add_asset_quantity) {
         protocol::AddAssetQuantity pb_add_asset_quantity;
         pb_add_asset_quantity.set_account_id(add_asset_quantity.account_id);
         pb_add_asset_quantity.set_asset_id(add_asset_quantity.asset_id);
@@ -38,7 +38,7 @@ namespace iroha {
 
       model::AddAssetQuantity
       PbCommandFactory::deserializeAddAssetQuantity(
-          protocol::AddAssetQuantity &pb_add_asset_quantity) {
+          const protocol::AddAssetQuantity &pb_add_asset_quantity) {
         model::AddAssetQuantity add_asset_quantity;
         add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
         add_asset_quantity.asset_id = pb_add_asset_quantity.asset_id();
@@ -52,7 +52,7 @@ namespace iroha {
 
       // add peer
       protocol::AddPeer
-      PbCommandFactory::serializeAddPeer(model::AddPeer &add_peer) {
+      PbCommandFactory::serializeAddPeer(const model::AddPeer &add_peer) {
         protocol::AddPeer pb_add_peer;
         pb_add_peer.set_address(add_peer.address);
         pb_add_peer.set_peer_key(add_peer.peer_key.data(),
@@ -60,7 +60,7 @@ namespace iroha {
         return pb_add_peer;
       }
       model::AddPeer
-      PbCommandFactory::deserializeAddPeer(protocol::AddPeer &pb_add_peer) {
+      PbCommandFactory::deserializeAddPeer(const protocol::AddPeer &pb_add_peer) {
         model::AddPeer add_peer;
         add_peer.address = pb_add_peer.address();
         std::copy(pb_add_peer.peer_key().begin(), pb_add_peer.peer_key().end(),
@@ -70,14 +70,14 @@ namespace iroha {
 
       // add signatory
       protocol::AddSignatory
-      PbCommandFactory::serializeAddSignatory(model::AddSignatory &add_signatory) {
+      PbCommandFactory::serializeAddSignatory(const model::AddSignatory &add_signatory) {
         protocol::AddSignatory pb_add_signatory;
         pb_add_signatory.set_account_id(add_signatory.account_id);
         pb_add_signatory.set_public_key(add_signatory.pubkey.data(),
                                         add_signatory.pubkey.size());
         return pb_add_signatory;
       }
-      model::AddSignatory PbCommandFactory::deserializeAddSignatory(protocol::AddSignatory &pb_add_signatory) {
+      model::AddSignatory PbCommandFactory::deserializeAddSignatory(const protocol::AddSignatory &pb_add_signatory) {
         model::AddSignatory add_signatory;
         add_signatory.account_id = pb_add_signatory.account_id();
         std::copy(pb_add_signatory.public_key().begin(),
@@ -88,7 +88,7 @@ namespace iroha {
 
       // assign master key
       protocol::AssignMasterKey
-      PbCommandFactory::serializeAssignMasterKey(model::AssignMasterKey &assign_master_key) {
+      PbCommandFactory::serializeAssignMasterKey(const model::AssignMasterKey &assign_master_key) {
         protocol::AssignMasterKey pb_assign_master_key;
         pb_assign_master_key.set_account_id(assign_master_key.account_id);
         pb_assign_master_key.set_public_key(assign_master_key.pubkey.data(),
@@ -97,7 +97,7 @@ namespace iroha {
       }
 
       model::AssignMasterKey PbCommandFactory::deserializeAssignMasterKey(
-          protocol::AssignMasterKey &pb_assign_master_key) {
+          const protocol::AssignMasterKey &pb_assign_master_key) {
         model::AssignMasterKey assign_master_key;
         assign_master_key.account_id = pb_assign_master_key.account_id();
         std::copy(pb_assign_master_key.public_key().begin(),
@@ -108,7 +108,7 @@ namespace iroha {
 
       // create asset
       protocol::CreateAsset
-      PbCommandFactory::serializeCreateAsset(model::CreateAsset &create_asset) {
+      PbCommandFactory::serializeCreateAsset(const model::CreateAsset &create_asset) {
         protocol::CreateAsset pb_create_asset;
         pb_create_asset.set_asset_name(create_asset.asset_name);
         pb_create_asset.set_domain_id(create_asset.domain_id);
@@ -117,7 +117,7 @@ namespace iroha {
       }
 
       model::CreateAsset
-      PbCommandFactory::deserializeCreateAsset(protocol::CreateAsset &pb_create_asset) {
+      PbCommandFactory::deserializeCreateAsset(const protocol::CreateAsset &pb_create_asset) {
         model::CreateAsset create_asset;
         create_asset.asset_name = pb_create_asset.asset_name();
         create_asset.domain_id = pb_create_asset.domain_id();
@@ -128,7 +128,7 @@ namespace iroha {
 
       // create account
       protocol::CreateAccount
-      PbCommandFactory::serializeCreateAccount(model::CreateAccount &create_account) {
+      PbCommandFactory::serializeCreateAccount(const model::CreateAccount &create_account) {
         protocol::CreateAccount pb_create_account;
         pb_create_account.set_account_name(create_account.account_name);
         pb_create_account.set_domain_id(create_account.domain_id);
@@ -136,7 +136,7 @@ namespace iroha {
                                           create_account.pubkey.size());
         return pb_create_account;
       }
-      model::CreateAccount PbCommandFactory::deserializeCreateAccount(protocol::CreateAccount &pb_create_account) {
+      model::CreateAccount PbCommandFactory::deserializeCreateAccount(const protocol::CreateAccount &pb_create_account) {
         model::CreateAccount create_account;
         create_account.account_name = pb_create_account.account_name();
         create_account.domain_id = pb_create_account.domain_id();
@@ -147,13 +147,13 @@ namespace iroha {
       }
 
       // create domain
-      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(model::CreateDomain &create_domain) {
+      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(const model::CreateDomain &create_domain) {
         protocol::CreateDomain pb_create_domain;
         pb_create_domain.set_domain_name(create_domain.domain_name);
         return pb_create_domain;
       }
 
-      model::CreateDomain PbCommandFactory::deserializeCreateDomain(protocol::CreateDomain &pb_create_domain) {
+      model::CreateDomain PbCommandFactory::deserializeCreateDomain(const protocol::CreateDomain &pb_create_domain) {
         model::CreateDomain create_domain;
         create_domain.domain_name = pb_create_domain.domain_name();
         return create_domain;
@@ -161,7 +161,7 @@ namespace iroha {
 
       // remove signatory
       protocol::RemoveSignatory
-      PbCommandFactory::serializeRemoveSignatory(model::RemoveSignatory &remove_signatory) {
+      PbCommandFactory::serializeRemoveSignatory(const model::RemoveSignatory &remove_signatory) {
         protocol::RemoveSignatory pb_remove_signatory;
         pb_remove_signatory.set_account_id(remove_signatory.account_id);
         pb_remove_signatory.set_public_key(remove_signatory.pubkey.data(),
@@ -170,7 +170,7 @@ namespace iroha {
       }
 
       model::RemoveSignatory PbCommandFactory::deserializeRemoveSignatory(
-          protocol::RemoveSignatory &pb_remove_signatory) {
+          const protocol::RemoveSignatory &pb_remove_signatory) {
         model::RemoveSignatory remove_signatory;
         remove_signatory.account_id = pb_remove_signatory.account_id();
         return remove_signatory;
@@ -178,7 +178,7 @@ namespace iroha {
 
       // set account permissions
       protocol::SetAccountPermissions PbCommandFactory::serializeSetAccountPermissions(
-          model::SetAccountPermissions &set_account_permissions) {
+          const  model::SetAccountPermissions &set_account_permissions) {
         protocol::SetAccountPermissions pb_set_account_permissions;
         pb_set_account_permissions.set_account_id(set_account_permissions.account_id);
         auto permissions = pb_set_account_permissions.mutable_permissions();
@@ -196,7 +196,7 @@ namespace iroha {
 
       model::SetAccountPermissions
       PbCommandFactory::deserializeSetAccountPermissions(
-          protocol::SetAccountPermissions &pb_set_account_permissions) {
+          const  protocol::SetAccountPermissions &pb_set_account_permissions) {
         model::SetAccountPermissions set_account_permissions;
         set_account_permissions.account_id =
             pb_set_account_permissions.account_id();
@@ -225,14 +225,14 @@ namespace iroha {
 
       // set account quorum
       protocol::SetAccountQuorum
-      PbCommandFactory::serializeSetQuorum(model::SetQuorum &set_account_quorum) {
+      PbCommandFactory::serializeSetQuorum(const model::SetQuorum &set_account_quorum) {
         protocol::SetAccountQuorum pb_set_account_quorum;
         pb_set_account_quorum.set_account_id(set_account_quorum.account_id);
         pb_set_account_quorum.set_quorum(set_account_quorum.new_quorum);
         return pb_set_account_quorum;
       }
       model::SetQuorum
-      PbCommandFactory::deserializeSetQuorum(protocol::SetAccountQuorum &pb_set_account_quorum) {
+      PbCommandFactory::deserializeSetQuorum(const protocol::SetAccountQuorum &pb_set_account_quorum) {
         model::SetQuorum set_quorum;
         set_quorum.account_id = pb_set_account_quorum.account_id();
         set_quorum.new_quorum = pb_set_account_quorum.quorum();
@@ -241,7 +241,7 @@ namespace iroha {
 
       // transfer asset
       protocol::TransferAsset
-      PbCommandFactory::serializeTransferAsset(model::TransferAsset &transfer_asset) {
+      PbCommandFactory::serializeTransferAsset(const model::TransferAsset &transfer_asset) {
         protocol::TransferAsset pb_transfer_asset;
         pb_transfer_asset.set_src_account_id(transfer_asset.src_account_id);
         pb_transfer_asset.set_dest_account_id(transfer_asset.dest_account_id);
@@ -251,8 +251,9 @@ namespace iroha {
         amount->set_fractial_part(transfer_asset.amount.frac_part);
         return pb_transfer_asset;
       }
+
       model::TransferAsset
-      PbCommandFactory::deserializeTransferAsset(protocol::TransferAsset &pb_subtract_asset_quantity) {
+      PbCommandFactory::deserializeTransferAsset(const protocol::TransferAsset &pb_subtract_asset_quantity) {
         model::TransferAsset transfer_asset;
         transfer_asset.src_account_id =
             pb_subtract_asset_quantity.src_account_id();
@@ -264,6 +265,193 @@ namespace iroha {
         transfer_asset.amount.frac_part =
             pb_subtract_asset_quantity.amount().fractial_part();
         return transfer_asset;
+      }
+
+      protocol::Command &&
+      PbCommandFactory::serializeAbstractCommand(const model::Command &command) {
+        PbCommandFactory commandFactory;
+        auto cmd = protocol::Command();
+
+        // -----|AddAssetQuantity|-----
+        if (instanceof<model::AddAssetQuantity>(command)) {
+          auto serialized = commandFactory
+              .serializeAddAssetQuantity(
+                  static_cast<const model::AddAssetQuantity &>(command));
+          cmd.set_allocated_add_asset_quantity(new protocol::AddAssetQuantity(
+              serialized));
+        }
+
+        // -----|AddPeer|-----
+        if (instanceof<model::AddPeer>(command)) {
+          auto serialized = commandFactory
+              .serializeAddPeer(
+                  static_cast<const model::AddPeer &>(command));
+          cmd.set_allocated_add_peer(new protocol::AddPeer(serialized));
+        }
+
+        // -----|AddSignatory|-----
+        if (instanceof<model::AddSignatory>(command)) {
+          auto serialized = commandFactory
+              .serializeAddSignatory(
+                  static_cast<const model::AddSignatory &>(command));
+          cmd.set_allocated_add_signatory(new protocol::AddSignatory(serialized));
+        }
+
+        // -----|AssignMasterKey|-----
+        if (instanceof<model::AssignMasterKey>(command)) {
+          auto serialized = commandFactory
+              .serializeAssignMasterKey(
+                  static_cast<const model::AssignMasterKey &>(command));
+          cmd.set_allocated_account_assign_mk(new protocol::AssignMasterKey(
+              serialized));
+        }
+
+        // -----|AssignMasterKey|-----
+        if (instanceof<model::CreateAsset>(command)) {
+          auto serialized = commandFactory
+              .serializeCreateAsset(
+                  static_cast<const model::CreateAsset &>(command));
+          cmd.set_allocated_create_asset(new protocol::CreateAsset(serialized));
+        }
+
+        // -----|CreateAccount|-----
+        if (instanceof<model::CreateAccount>(command)) {
+          auto serialized = commandFactory
+              .serializeCreateAccount(
+                  static_cast<const model::CreateAccount &>(command));
+          cmd.set_allocated_create_account(new protocol::CreateAccount(
+              serialized));
+        }
+
+        // -----|CreateDomain|-----
+        if (instanceof<model::CreateDomain>(command)) {
+          auto serialized = commandFactory
+              .serializeCreateDomain(
+                  static_cast<const model::CreateDomain &>(command));
+          cmd.set_allocated_create_domain(new protocol::CreateDomain(serialized));
+        }
+
+        // -----|RemoveSignatory|-----
+        if (instanceof<model::RemoveSignatory>(command)) {
+          auto serialized = commandFactory
+              .serializeRemoveSignatory(
+                  static_cast<const model::RemoveSignatory &>(command));
+          cmd.set_allocated_remove_sign(new protocol::RemoveSignatory(serialized));
+        }
+
+        // -----|SetAccountPermissions|-----
+        if (instanceof<model::SetAccountPermissions>(command)) {
+          auto serialized = commandFactory
+              .serializeSetAccountPermissions(
+                  static_cast<const model::SetAccountPermissions &>(command));
+          cmd.set_allocated_set_permission(new protocol::SetAccountPermissions(
+              serialized));
+        }
+
+        // -----|SetAccountQuorum|-----
+        if (instanceof<model::SetQuorum>(command)) {
+          auto serialized = commandFactory
+              .serializeSetQuorum(
+                  static_cast<const model::SetQuorum &>(command));
+          cmd.set_allocated_set_quorum(new protocol::SetAccountQuorum(serialized));
+        }
+
+        // -----|TransferAsset|-----
+        if (instanceof<model::TransferAsset>(command)) {
+          auto serialized = commandFactory
+              .serializeTransferAsset(
+                  static_cast<const model::TransferAsset &>(command));
+          cmd.set_allocated_transfer_asset(new protocol::TransferAsset(
+              serialized));
+        }
+
+        return std::forward<protocol::Command>(cmd);
+      }
+
+      std::shared_ptr<model::Command>
+      PbCommandFactory::deserializeAbstractCommand(const protocol::Command &command) {
+        PbCommandFactory commandFactory;
+        std::shared_ptr<model::Command> val;
+
+        // -----|AddAssetQuantity|-----
+        if (command.has_add_asset_quantity()) {
+          auto pb_command = command.add_asset_quantity();
+          auto cmd = commandFactory.deserializeAddAssetQuantity(pb_command);
+          val = std::make_shared<model::AddAssetQuantity>(cmd);
+        }
+
+        // -----|AddPeer|-----
+        if (command.has_add_peer()) {
+          auto pb_command = command.add_peer();
+          auto cmd = commandFactory.deserializeAddPeer(pb_command);
+          val = std::make_shared<model::AddPeer>(cmd);
+        }
+
+        // -----|AddSignatory|-----
+        if (command.has_add_signatory()) {
+          auto pb_command = command.add_signatory();
+          auto cmd = commandFactory.deserializeAddSignatory(pb_command);
+          val = std::make_shared<model::AddSignatory>(cmd);
+        }
+
+        // -----|AssignMasterKey|-----
+        if (command.has_account_assign_mk()) {
+          auto pb_command = command.account_assign_mk();
+          auto cmd = commandFactory.deserializeAssignMasterKey(pb_command);
+          val = std::make_shared<model::AssignMasterKey>(cmd);
+        }
+
+        // -----|CreateAsset|-----
+        if (command.has_create_asset()) {
+          auto pb_command = command.create_asset();
+          auto cmd = commandFactory.deserializeCreateAsset(pb_command);
+          val = std::make_shared<model::CreateAsset>(cmd);
+        }
+
+        // -----|CreateAccount|-----
+        if (command.has_create_account()) {
+          auto pb_command = command.create_account();
+          auto cmd = commandFactory.deserializeCreateAccount(pb_command);
+          val = std::make_shared<model::CreateAccount>(cmd);
+        }
+
+        // -----|CreateDomain|-----
+        if (command.has_create_domain()) {
+          auto pb_command = command.create_domain();
+          auto cmd = commandFactory.deserializeCreateDomain(pb_command);
+          val = std::make_shared<model::CreateDomain>(cmd);
+        }
+
+        // -----|RemoveSignatory|-----
+        if (command.has_remove_sign()) {
+          auto pb_command = command.remove_sign();
+          auto cmd = commandFactory.deserializeRemoveSignatory(pb_command);
+          val = std::make_shared<model::RemoveSignatory>(cmd);
+        }
+
+        // -----|SetAccountPermissions|-----
+        if (command.has_set_permission()) {
+          auto pb_command = command.set_permission();
+          auto
+              cmd = commandFactory.deserializeSetAccountPermissions(pb_command);
+          val = std::make_shared<model::SetAccountPermissions>(cmd);
+        }
+
+        // -----|SetAccountQuorum|-----
+        if (command.has_set_quorum()) {
+          auto pb_command = command.set_quorum();
+          auto cmd = commandFactory.deserializeSetQuorum(pb_command);
+          val = std::make_shared<model::SetQuorum>(cmd);
+        }
+
+        // -----|TransferAsset|-----
+        if (command.has_transfer_asset()) {
+          auto pb_command = command.transfer_asset();
+          auto cmd = commandFactory.deserializeTransferAsset(pb_command);
+          val = std::make_shared<model::TransferAsset>(cmd);
+        }
+
+        return val;
       }
 
     } // namespace converters

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -30,7 +30,9 @@ namespace iroha {
         protocol::AddAssetQuantity pb_add_asset_quantity;
         pb_add_asset_quantity.set_account_id(add_asset_quantity.account_id);
         pb_add_asset_quantity.set_asset_id(add_asset_quantity.asset_id);
-        pb_add_asset_quantity.set_amount(add_asset_quantity.amount);
+        auto amount = pb_add_asset_quantity.mutable_amount();
+        amount->set_integer_part(add_asset_quantity.amount.int_part);
+        amount->set_fractial_part(add_asset_quantity.amount.frac_part);
       }
 
       model::AddAssetQuantity
@@ -39,7 +41,10 @@ namespace iroha {
         model::AddAssetQuantity add_asset_quantity;
         add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
         add_asset_quantity.asset_id = pb_add_asset_quantity.asset_id();
-        add_asset_quantity.amount = pb_add_asset_quantity.amount();
+        add_asset_quantity.amount.int_part =
+            pb_add_asset_quantity.amount().integer_part();
+        add_asset_quantity.amount.frac_part =
+            pb_add_asset_quantity.amount().fractial_part();
         return add_asset_quantity;
       }
 
@@ -239,16 +244,23 @@ namespace iroha {
         pb_transfer_asset.set_src_account_id(transfer_asset.src_account_id);
         pb_transfer_asset.set_dest_account_id(transfer_asset.dest_account_id);
         pb_transfer_asset.set_asset_id(transfer_asset.asset_id);
-        pb_transfer_asset.set_ammount(transfer_asset.amount);
+        auto amount = pb_transfer_asset.mutable_amount();
+        amount->set_integer_part(transfer_asset.amount.int_part);
+        amount->set_fractial_part(transfer_asset.amount.frac_part);
         return pb_transfer_asset;
       }
       model::TransferAsset
       PbCommandFactory::deserializeTransferAsset(protocol::TransferAsset &pb_subtract_asset_quantity) {
         model::TransferAsset transfer_asset;
-        transfer_asset.src_account_id = pb_subtract_asset_quantity.src_account_id();
-        transfer_asset.dest_account_id = pb_subtract_asset_quantity.dest_account_id();
+        transfer_asset.src_account_id =
+            pb_subtract_asset_quantity.src_account_id();
+        transfer_asset.dest_account_id =
+            pb_subtract_asset_quantity.dest_account_id();
         transfer_asset.asset_id = pb_subtract_asset_quantity.asset_id();
-        transfer_asset.amount = pb_subtract_asset_quantity.asset_id();
+        transfer_asset.amount.int_part =
+            pb_subtract_asset_quantity.amount().integer_part();
+        transfer_asset.amount.frac_part =
+            pb_subtract_asset_quantity.amount().fractial_part();
         return transfer_asset;
       }
 

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -1,0 +1,113 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "model/converters/pb_command_factory.hpp"
+
+#include <string>
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      // asset quantity
+      protocol::AddAssetQuantity
+      PbCommandFactory::serializeAddAssetQuantity(
+          model::AddAssetQuantity &add_asset_quantity) {
+        protocol::AddAssetQuantity pb_add_asset_quantity;
+        pb_add_asset_quantity.set_account_id(add_asset_quantity.account_id);
+        pb_add_asset_quantity.set_asset_id(add_asset_quantity.asset_id);
+        // todo set amount
+      }
+
+      model::AddAssetQuantity
+      PbCommandFactory::deserializeAddAssetQuantity(
+          protocol::AddAssetQuantity &pb_add_asset_quantity) {
+        model::AddAssetQuantity add_asset_quantity;
+        add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
+        add_asset_quantity.asset_id = pb_add_asset_quantity.asset_id();
+        // todo set amount
+        return add_asset_quantity;
+      }
+
+      // add peer
+      protocol::AddPeer
+      PbCommandFactory::serializeAddPeer(model::AddPeer &add_peer) {
+        protocol::AddPeer pb_add_peer;
+        pb_add_peer.set_address(add_peer.address);
+        pb_add_peer.set_peer_key(add_peer.peer_key.data(),
+                                 add_peer.peer_key.size());
+        return pb_add_peer;
+      }
+      model::AddPeer
+      PbCommandFactory::deserializeAddPeer(protocol::AddPeer &pb_add_peer) {
+        model::AddPeer add_peer;
+        add_peer.address = pb_add_peer.address();
+        std::copy(pb_add_peer.peer_key().begin(), pb_add_peer.peer_key().end(),
+                  add_peer.peer_key.begin());
+        return add_peer;
+      }
+
+      // add signatory
+      protocol::AddSignatory
+      PbCommandFactory::serializeAddSignatory(model::AddSignatory &addSignatory) {
+        protocol::AddSignatory add_signatory;
+
+        return add_signatory;
+      }
+      model::AddSignatory PbCommandFactory::deserializeAddSignatory(protocol::AddSignatory &addSignatory) {
+
+      }
+
+      // assign master key
+      protocol::AssignMasterKey PbCommandFactory::serializeAssignMasterKey(model::AssignMasterKey &assignMasterKey) {}
+      model::AssignMasterKey PbCommandFactory::deserializeAssignMasterKey(
+          protocol::AssignMasterKey &assignMasterKey) {}
+
+      // create asset
+      protocol::CreateAsset PbCommandFactory::serializeCreateAsset(model::CreateAsset &createAsset) {}
+      model::CreateAsset PbCommandFactory::deserializeCreateAsset(protocol::CreateAsset &createAsset) {}
+
+      // create account
+      protocol::CreateAccount PbCommandFactory::serializeCreateAccount(model::CreateAccount &createAccount) {}
+      model::CreateAccount PbCommandFactory::deserializeCreateAccount(protocol::CreateAccount &createAccount) {}
+
+      // create domain
+      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(model::CreateDomain &createDomain) {}
+      model::CreateDomain PbCommandFactory::deserializeCreateDomain(protocol::CreateDomain &createDomain) {}
+
+      // remove signatory
+      protocol::RemoveSignatory PbCommandFactory::serializeRemoveSignatory(model::RemoveSignatory &removeSignatory) {}
+      model::RemoveSignatory PbCommandFactory::deserializeRemoveSignatory(
+          protocol::RemoveSignatory &removeSignatory) {}
+
+      // set account permissions
+      protocol::SetAccountPermissions PbCommandFactory::serializeSetAccountPermissions(
+          model::SetAccountPermissions &setAccountPermissions) {}
+      model::SetAccountPermissions PbCommandFactory::deserializeSetAccountPermissions(
+          protocol::SetAccountPermissions &setAccountPermissions) {}
+
+      // set account quorum
+      protocol::SetAccountQuorum PbCommandFactory::serializeSetQuorum(model::SetQuorum &setAccountQuorum) {}
+      model::SetQuorum PbCommandFactory::deserializeSetQuorum(protocol::SetAccountQuorum &setAccountQuorum) {}
+
+      // transfer asset
+      protocol::TransferAsset PbCommandFactory::serializeTransferAsset(model::TransferAsset &subtractAssetQuantity) {}
+      model::TransferAsset PbCommandFactory::deserializeTransferAsset(protocol::TransferAsset &subtractAssetQuantity) {}
+
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "model/converters/pb_transaction_factory.hpp"
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      protocol::Transaction PbTransactionFactory::serialize(model::Transaction &tx) {
+        protocol::Transaction pb_tx;
+
+        // -----|Header|-----
+        auto header = pb_tx.mutable_header();
+        header->set_created_time(tx.created_ts);
+        // todo set signatures
+
+        // -----|Meta|-----
+        auto meta = pb_tx.mutable_meta();
+        meta->set_creator_account_id(tx.creator_account_id);
+        meta->set_tx_counter(tx.tx_counter);
+
+        // -----|Body|-----
+        auto body = pb_tx.mutable_body();
+        // todo set commands
+        return pb_tx;
+      }
+
+      model::Transaction PbTransactionFactory::deserialize(protocol::Transaction &pb_tx) {
+
+      }
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -15,19 +15,30 @@
  * limitations under the License.
  */
 
+#include <model/commands/add_asset_quantity.hpp>
 #include "model/converters/pb_transaction_factory.hpp"
+#include "model/converters/pb_command_factory.hpp"
+#include "common/types.hpp"
 
 namespace iroha {
   namespace model {
     namespace converters {
 
       protocol::Transaction PbTransactionFactory::serialize(model::Transaction &tx) {
+        model::converters::PbCommandFactory factory;
         protocol::Transaction pb_tx;
 
         // -----|Header|-----
         auto header = pb_tx.mutable_header();
         header->set_created_time(tx.created_ts);
-        // todo set signatures
+        for (auto &signature: tx.signatures) {
+
+          auto proto_signature = pb_tx.mutable_header()->add_signatures();
+          proto_signature->set_pubkey(signature.pubkey.data(),
+                                      signature.pubkey.size());
+          proto_signature->set_signature(signature.signature.data(),
+                                         signature.signature.size());
+        }
 
         // -----|Meta|-----
         auto meta = pb_tx.mutable_meta();
@@ -35,14 +46,40 @@ namespace iroha {
         meta->set_tx_counter(tx.tx_counter);
 
         // -----|Body|-----
-        auto body = pb_tx.mutable_body();
-        // todo set commands
+        for (auto &command: tx.commands) {
+          auto cmd = pb_tx.mutable_body()->add_commands();
+          new(cmd) protocol::Command(factory.serializeAbstractCommand(*command));
+        }
         return pb_tx;
       }
 
       model::Transaction PbTransactionFactory::deserialize(protocol::Transaction &pb_tx) {
+        model::converters::PbCommandFactory commandFactory;
+        model::Transaction tx;
 
+        // -----|Header|-----
+        tx.created_ts = pb_tx.header().created_time();
+        for (auto &pb_sign: pb_tx.header().signatures()) {
+          model::Signature sign;
+          std::copy(pb_sign.pubkey().begin(), pb_sign.pubkey().end(),
+                    sign.pubkey.begin());
+          std::copy(pb_sign.signature().begin(), pb_sign.signature().end(),
+                    sign.signature.begin());
+          tx.signatures.push_back(sign);
+        }
+
+        // -----|Meta|-----
+        tx.creator_account_id = pb_tx.meta().creator_account_id();
+        tx.tx_counter = pb_tx.meta().tx_counter();
+
+        // -----|Body|-----
+        for (const auto &pb_command: pb_tx.body().commands()) {
+          tx.commands.push_back(commandFactory.deserializeAbstractCommand(pb_command));
+        }
+
+        return tx;
       }
+
     } // namespace converters
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/converters/pb_block_factory.hpp
+++ b/irohad/model/converters/pb_block_factory.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_PBFACTORY_HPP
+#define IROHA_PBFACTORY_HPP
+
+#include "block.pb.h"
+#include "model/block.hpp"
+
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      /**
+       * Converting business objects to protobuf and vice versa
+       */
+      class PbBlockFactory {
+       public:
+        /**
+         * Convert block to proto block
+         * @param block - reference to block
+         * @return proto block
+         */
+        protocol::Block serialize(model::Block &block);
+
+        /**
+         * Convert proto block to model block
+         * @param pb_block - reference to proto block
+         * @return model block
+         */
+        model::Block deserialize(protocol::Block &pb_block);
+      };
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha
+#endif //IROHA_PBFACTORY_HPP

--- a/irohad/model/converters/pb_command_factory.hpp
+++ b/irohad/model/converters/pb_command_factory.hpp
@@ -41,48 +41,52 @@ namespace iroha {
       class PbCommandFactory {
        public:
         // asset quantity
-        protocol::AddAssetQuantity serializeAddAssetQuantity(model::AddAssetQuantity &addAssetQuantity);
-        model::AddAssetQuantity deserializeAddAssetQuantity(protocol::AddAssetQuantity &addAssetQuantity);
+        protocol::AddAssetQuantity serializeAddAssetQuantity(const model::AddAssetQuantity &addAssetQuantity);
+        model::AddAssetQuantity deserializeAddAssetQuantity(const protocol::AddAssetQuantity &addAssetQuantity);
 
         // add peer
-        protocol::AddPeer serializeAddPeer(model::AddPeer &addPeer);
-        model::AddPeer deserializeAddPeer(protocol::AddPeer &addPeer);
+        protocol::AddPeer serializeAddPeer(const model::AddPeer &addPeer);
+        model::AddPeer deserializeAddPeer(const protocol::AddPeer &addPeer);
 
         // add signatory
-        protocol::AddSignatory serializeAddSignatory(model::AddSignatory &addSignatory);
-        model::AddSignatory deserializeAddSignatory(protocol::AddSignatory &addSignatory);
+        protocol::AddSignatory serializeAddSignatory(const model::AddSignatory &addSignatory);
+        model::AddSignatory deserializeAddSignatory(const protocol::AddSignatory &addSignatory);
 
         // assign master key
-        protocol::AssignMasterKey serializeAssignMasterKey(model::AssignMasterKey &assignMasterKey);
-        model::AssignMasterKey deserializeAssignMasterKey(protocol::AssignMasterKey &assignMasterKey);
+        protocol::AssignMasterKey serializeAssignMasterKey(const model::AssignMasterKey &assignMasterKey);
+        model::AssignMasterKey deserializeAssignMasterKey(const protocol::AssignMasterKey &assignMasterKey);
 
         // create asset
-        protocol::CreateAsset serializeCreateAsset(model::CreateAsset &createAsset);
-        model::CreateAsset deserializeCreateAsset(protocol::CreateAsset &createAsset);
+        protocol::CreateAsset serializeCreateAsset(const model::CreateAsset &createAsset);
+        model::CreateAsset deserializeCreateAsset(const protocol::CreateAsset &createAsset);
 
         // create account
-        protocol::CreateAccount serializeCreateAccount(model::CreateAccount &createAccount);
-        model::CreateAccount deserializeCreateAccount(protocol::CreateAccount &createAccount);
+        protocol::CreateAccount serializeCreateAccount(const model::CreateAccount &createAccount);
+        model::CreateAccount deserializeCreateAccount(const protocol::CreateAccount &createAccount);
 
         // create domain
-        protocol::CreateDomain serializeCreateDomain(model::CreateDomain &createDomain);
-        model::CreateDomain deserializeCreateDomain(protocol::CreateDomain &createDomain);
+        protocol::CreateDomain serializeCreateDomain(const model::CreateDomain &createDomain);
+        model::CreateDomain deserializeCreateDomain(const protocol::CreateDomain &createDomain);
 
         // remove signatory
-        protocol::RemoveSignatory serializeRemoveSignatory(model::RemoveSignatory &removeSignatory);
-        model::RemoveSignatory deserializeRemoveSignatory(protocol::RemoveSignatory &removeSignatory);
+        protocol::RemoveSignatory serializeRemoveSignatory(const model::RemoveSignatory &removeSignatory);
+        model::RemoveSignatory deserializeRemoveSignatory(const protocol::RemoveSignatory &removeSignatory);
 
         // set account permissions
-        protocol::SetAccountPermissions serializeSetAccountPermissions(model::SetAccountPermissions &setAccountPermissions);
-        model::SetAccountPermissions deserializeSetAccountPermissions(protocol::SetAccountPermissions &setAccountPermissions);
+        protocol::SetAccountPermissions serializeSetAccountPermissions(const model::SetAccountPermissions &setAccountPermissions);
+        model::SetAccountPermissions deserializeSetAccountPermissions(const protocol::SetAccountPermissions &setAccountPermissions);
 
         // set account quorum
-        protocol::SetAccountQuorum serializeSetQuorum(model::SetQuorum &setAccountQuorum);
-        model::SetQuorum deserializeSetQuorum(protocol::SetAccountQuorum &setAccountQuorum);
+        protocol::SetAccountQuorum serializeSetQuorum(const model::SetQuorum &setAccountQuorum);
+        model::SetQuorum deserializeSetQuorum(const protocol::SetAccountQuorum &setAccountQuorum);
 
         // transfer asset
-        protocol::TransferAsset serializeTransferAsset(model::TransferAsset &subtractAssetQuantity);
-        model::TransferAsset deserializeTransferAsset(protocol::TransferAsset &subtractAssetQuantity);
+        protocol::TransferAsset serializeTransferAsset(const model::TransferAsset &subtractAssetQuantity);
+        model::TransferAsset deserializeTransferAsset(const protocol::TransferAsset &subtractAssetQuantity);
+
+        // abstract
+        protocol::Command &&serializeAbstractCommand(const model::Command &command);
+        std::shared_ptr<model::Command> deserializeAbstractCommand(const protocol::Command &command);
       };
     } // namespace converters
   }  // namespace model

--- a/irohad/model/converters/pb_command_factory.hpp
+++ b/irohad/model/converters/pb_command_factory.hpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_PB_COMMAND_FACTORY_HPP
+#define IROHA_PB_COMMAND_FACTORY_HPP
+
+#include "commands.pb.h"
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/add_peer.hpp"
+#include "model/commands/add_signatory.hpp"
+#include "model/commands/assign_master_key.hpp"
+#include "model/commands/create_account.hpp"
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/remove_signatory.hpp"
+#include "model/commands/set_permissions.hpp"
+#include "model/commands/set_quorum.hpp"
+#include "model/commands/transfer_asset.hpp"
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      /**
+       * Converting commands and proto commands
+       */
+      class PbCommandFactory {
+       public:
+        // asset quantity
+        protocol::AddAssetQuantity serializeAddAssetQuantity(model::AddAssetQuantity &addAssetQuantity);
+        model::AddAssetQuantity deserializeAddAssetQuantity(protocol::AddAssetQuantity &addAssetQuantity);
+
+        // add peer
+        protocol::AddPeer serializeAddPeer(model::AddPeer &addPeer);
+        model::AddPeer deserializeAddPeer(protocol::AddPeer &addPeer);
+
+        // add signatory
+        protocol::AddSignatory serializeAddSignatory(model::AddSignatory &addSignatory);
+        model::AddSignatory deserializeAddSignatory(protocol::AddSignatory &addSignatory);
+
+        // assign master key
+        protocol::AssignMasterKey serializeAssignMasterKey(model::AssignMasterKey &assignMasterKey);
+        model::AssignMasterKey deserializeAssignMasterKey(protocol::AssignMasterKey &assignMasterKey);
+
+        // create asset
+        protocol::CreateAsset serializeCreateAsset(model::CreateAsset &createAsset);
+        model::CreateAsset deserializeCreateAsset(protocol::CreateAsset &createAsset);
+
+        // create account
+        protocol::CreateAccount serializeCreateAccount(model::CreateAccount &createAccount);
+        model::CreateAccount deserializeCreateAccount(protocol::CreateAccount &createAccount);
+
+        // create domain
+        protocol::CreateDomain serializeCreateDomain(model::CreateDomain &createDomain);
+        model::CreateDomain deserializeCreateDomain(protocol::CreateDomain &createDomain);
+
+        // remove signatory
+        protocol::RemoveSignatory serializeRemoveSignatory(model::RemoveSignatory &removeSignatory);
+        model::RemoveSignatory deserializeRemoveSignatory(protocol::RemoveSignatory &removeSignatory);
+
+        // set account permissions
+        protocol::SetAccountPermissions serializeSetAccountPermissions(model::SetAccountPermissions &setAccountPermissions);
+        model::SetAccountPermissions deserializeSetAccountPermissions(protocol::SetAccountPermissions &setAccountPermissions);
+
+        // set account quorum
+        protocol::SetAccountQuorum serializeSetQuorum(model::SetQuorum &setAccountQuorum);
+        model::SetQuorum deserializeSetQuorum(protocol::SetAccountQuorum &setAccountQuorum);
+
+        // transfer asset
+        protocol::TransferAsset serializeTransferAsset(model::TransferAsset &subtractAssetQuantity);
+        model::TransferAsset deserializeTransferAsset(protocol::TransferAsset &subtractAssetQuantity);
+      };
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha
+#endif //IROHA_PB_COMMAND_FACTORY_HPP

--- a/irohad/model/converters/pb_command_factory.hpp
+++ b/irohad/model/converters/pb_command_factory.hpp
@@ -85,7 +85,7 @@ namespace iroha {
         model::TransferAsset deserializeTransferAsset(const protocol::TransferAsset &subtractAssetQuantity);
 
         // abstract
-        protocol::Command &&serializeAbstractCommand(const model::Command &command);
+        protocol::Command serializeAbstractCommand(const model::Command &command);
         std::shared_ptr<model::Command> deserializeAbstractCommand(const protocol::Command &command);
       };
     } // namespace converters

--- a/irohad/model/converters/pb_transaction_factory.hpp
+++ b/irohad/model/converters/pb_transaction_factory.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_PB_TRANSACTION_FACTORY_HPP
+#define IROHA_PB_TRANSACTION_FACTORY_HPP
+
+#include "block.pb.h"
+#include "model/transaction.hpp"
+
+namespace iroha {
+  namespace model {
+    namespace converters {
+
+      /**
+       * Converting business objects to protobuf and vice versa
+       */
+      class PbTransactionFactory {
+       public:
+        /**
+         * Convert block to proto block
+         * @param block - reference to block
+         * @return proto block
+         */
+        protocol::Transaction serialize(model::Transaction &tx);
+
+        /**
+         * Convert proto block to model block
+         * @param pb_block - reference to proto block
+         * @return model block
+         */
+        model::Transaction deserialize(protocol::Transaction &pb_tx);
+      };
+    } // namespace converters
+  }  // namespace model
+}  // namespace iroha
+#endif //IROHA_PB_TRANSACTION_FACTORY_HPP

--- a/irohad/model/converters/pb_transaction_factory.hpp
+++ b/irohad/model/converters/pb_transaction_factory.hpp
@@ -20,6 +20,7 @@
 
 #include "block.pb.h"
 #include "model/transaction.hpp"
+#include <memory>
 
 namespace iroha {
   namespace model {
@@ -43,6 +44,9 @@ namespace iroha {
          * @return model block
          */
         model::Transaction deserialize(protocol::Transaction &pb_tx);
+       private:
+//        std::shared_ptr<protocol::Command> serializeAbstractCommand(model::Command &command);
+//        std::shared_ptr<model::Command> deserializeAbstractCommand(protocol::Command &command);
       };
     } // namespace converters
   }  // namespace model

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <model/block.hpp>
 #include <model/commands/add_asset_quantity.hpp>
 #include <model/commands/add_peer.hpp>
 #include <model/commands/add_signatory.hpp>
@@ -26,6 +27,7 @@
 #include <model/commands/set_permissions.hpp>
 #include <model/commands/set_quorum.hpp>
 #include <model/commands/transfer_asset.hpp>
+#include <model/transaction.hpp>
 namespace iroha {
   namespace model {
 
@@ -140,7 +142,7 @@ namespace iroha {
     }
 
     bool Account::Permissions::operator!=(const Permissions &rhs) const {
-      return !rhs.operator==(rhs);
+      return !operator==(rhs);
     }
 
     /* Set permissions */
@@ -180,5 +182,35 @@ namespace iroha {
     bool TransferAsset::operator!=(const Command &command) const {
       return !operator==(command);
     }
+
+    /* Signature */
+    bool Signature::operator==(const Signature &rhs) const {
+      return rhs.pubkey == pubkey && rhs.signature == signature;
+    }
+
+    bool Signature::operator!=(const Signature &rhs) const {
+      return !operator==(rhs);
+    }
+
+    /* Transaction */
+    bool Transaction::operator==(const Transaction &rhs) const {
+      return rhs.tx_counter == tx_counter && rhs.signatures == signatures &&
+             rhs.created_ts == created_ts && rhs.commands == commands;
+    }
+
+    bool Transaction::operator!=(const Transaction &rhs) const {
+      return !operator==(rhs);
+    }
+
+    /* Block */
+    bool Block::operator==(const Block &rhs) const {
+      return rhs.hash == hash && rhs.height == height &&
+             rhs.prev_hash == prev_hash && rhs.txs_number == txs_number &&
+             rhs.merkle_root == merkle_root && rhs.sigs == sigs &&
+             rhs.transactions == transactions && rhs.created_ts == created_ts &&
+             rhs.hash == hash;
+    }
+
+    bool Block::operator!=(const Block &rhs) const { return !operator==(rhs); }
   }
 }

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -195,7 +195,9 @@ namespace iroha {
     /* Transaction */
     bool Transaction::operator==(const Transaction &rhs) const {
       if (rhs.commands.size() != commands.size()) return false;
-      for (uint i = 0; i < rhs.commands.size(); i++){
+
+      // todo change for cycle to comparison with predicate
+      for (auto i = 0; i < rhs.commands.size(); i++){
         if (*rhs.commands.at(i) != *commands.at(i)) return false;
       }
       return rhs.tx_counter == tx_counter && rhs.signatures == signatures &&

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -194,8 +194,12 @@ namespace iroha {
 
     /* Transaction */
     bool Transaction::operator==(const Transaction &rhs) const {
+      if (rhs.commands.size() != commands.size()) return false;
+      for (uint i = 0; i < rhs.commands.size(); i++){
+        if (*rhs.commands.at(i) != *commands.at(i)) return false;
+      }
       return rhs.tx_counter == tx_counter && rhs.signatures == signatures &&
-             rhs.created_ts == created_ts && rhs.commands == commands;
+             rhs.created_ts == created_ts;
     }
 
     bool Transaction::operator!=(const Transaction &rhs) const {

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -1,0 +1,184 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <model/commands/add_asset_quantity.hpp>
+#include <model/commands/add_peer.hpp>
+#include <model/commands/add_signatory.hpp>
+#include <model/commands/assign_master_key.hpp>
+#include <model/commands/create_account.hpp>
+#include <model/commands/create_asset.hpp>
+#include <model/commands/create_domain.hpp>
+#include <model/commands/remove_signatory.hpp>
+#include <model/commands/set_permissions.hpp>
+#include <model/commands/set_quorum.hpp>
+#include <model/commands/transfer_asset.hpp>
+namespace iroha {
+  namespace model {
+
+    /* AddAssetQuantity */
+    bool AddAssetQuantity::operator==(const Command &command) const {
+      if (! instanceof <AddAssetQuantity>(&command)) return false;
+      auto add_asset_quantity = static_cast<const AddAssetQuantity &>(command);
+      return add_asset_quantity.account_id == account_id &&
+             add_asset_quantity.asset_id == asset_id &&
+             add_asset_quantity.amount == amount;
+    }
+
+    bool AddAssetQuantity::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* AddPeer */
+    bool AddPeer::operator==(const Command &command) const {
+      if (! instanceof <AddPeer>(&command)) return false;
+      auto add_peer = static_cast<const AddPeer &>(command);
+      return add_peer.peer_key == peer_key && add_peer.address == address;
+    }
+
+    bool AddPeer::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* AddSignatory */
+    bool AddSignatory::operator==(const Command &command) const {
+      if (! instanceof <AddSignatory>(&command)) return false;
+      auto add_signatory = static_cast<const AddSignatory &>(command);
+      return add_signatory.account_id == account_id &&
+             add_signatory.pubkey == pubkey;
+    }
+
+    bool AddSignatory::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* Assign master key */
+    bool AssignMasterKey::operator==(const Command &command) const {
+      if (! instanceof <AssignMasterKey>(&command)) return false;
+      auto assign_master_key = static_cast<const AssignMasterKey &>(command);
+      return assign_master_key.account_id == account_id &&
+             assign_master_key.pubkey == pubkey;
+    }
+
+    bool AssignMasterKey::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* CreateAccount */
+    bool CreateAccount::operator==(const Command &command) const {
+      if (! instanceof <CreateAccount>(&command)) return false;
+      auto create_account = static_cast<const CreateAccount &>(command);
+      return create_account.pubkey == pubkey &&
+             create_account.domain_id == domain_id &&
+             create_account.account_name == account_name;
+    }
+
+    bool CreateAccount::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* CreateAsset */
+    bool CreateAsset::operator==(const Command &command) const {
+      if (! instanceof <CreateAsset>(&command)) return false;
+      auto create_asset = static_cast<const CreateAsset &>(command);
+      return create_asset.domain_id == domain_id &&
+             create_asset.precision == precision &&
+             create_asset.asset_name == asset_name;
+    }
+
+    bool CreateAsset::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* Create domain */
+    bool CreateDomain::operator==(const Command &command) const {
+      if (! instanceof <CreateDomain>(&command)) return false;
+      auto create_domain = static_cast<const CreateDomain &>(command);
+      return create_domain.domain_name == domain_name;
+    }
+
+    bool CreateDomain::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* Remove signatory */
+    bool RemoveSignatory::operator==(const Command &command) const {
+      if (! instanceof <RemoveSignatory>(&command)) return false;
+      auto remove_signatory = static_cast<const RemoveSignatory &>(command);
+      return remove_signatory.pubkey == pubkey &&
+             remove_signatory.account_id == account_id;
+    }
+
+    bool RemoveSignatory::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    bool Account::Permissions::operator==(const Permissions &rhs) const {
+      return rhs.add_signatory == add_signatory &&
+             rhs.can_transfer == can_transfer &&
+             rhs.create_accounts == create_accounts &&
+             rhs.create_assets == create_assets &&
+             rhs.create_domains == create_domains &&
+             rhs.issue_assets == issue_assets &&
+             rhs.read_all_accounts == read_all_accounts &&
+             rhs.remove_signatory == remove_signatory &&
+             rhs.set_permissions == set_permissions &&
+             rhs.set_quorum == set_quorum;
+    }
+
+    bool Account::Permissions::operator!=(const Permissions &rhs) const {
+      return !rhs.operator==(rhs);
+    }
+
+    /* Set permissions */
+    bool SetAccountPermissions::operator==(const Command &command) const {
+      if (! instanceof <SetAccountPermissions>(&command)) return false;
+      auto set_account_permissions =
+          static_cast<const SetAccountPermissions &>(command);
+      return set_account_permissions.account_id == account_id &&
+             set_account_permissions.new_permissions == new_permissions;
+    }
+
+    bool SetAccountPermissions::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* Set Quorum*/
+    bool SetQuorum::operator==(const Command &command) const {
+      if (! instanceof <SetQuorum>(&command)) return false;
+      auto set_quorum = static_cast<const SetQuorum &>(command);
+      return set_quorum.account_id == account_id &&
+             set_quorum.new_quorum == new_quorum;
+    }
+
+    bool SetQuorum::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+
+    /* Transfer Asset */
+    bool TransferAsset::operator==(const Command &command) const {
+      if (! instanceof <TransferAsset>(&command)) return false;
+      auto transfer_asset = static_cast<const TransferAsset &>(command);
+      return transfer_asset.asset_id == asset_id &&
+             transfer_asset.amount == amount &&
+             transfer_asset.src_account_id == src_account_id &&
+             transfer_asset.dest_account_id == dest_account_id;
+    }
+    bool TransferAsset::operator!=(const Command &command) const {
+      return !operator==(command);
+    }
+  }
+}

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -33,7 +33,7 @@ namespace iroha {
 
     /* AddAssetQuantity */
     bool AddAssetQuantity::operator==(const Command &command) const {
-      if (! instanceof <AddAssetQuantity>(&command)) return false;
+      if (! instanceof <AddAssetQuantity>(command)) return false;
       auto add_asset_quantity = static_cast<const AddAssetQuantity &>(command);
       return add_asset_quantity.account_id == account_id &&
              add_asset_quantity.asset_id == asset_id &&
@@ -46,7 +46,7 @@ namespace iroha {
 
     /* AddPeer */
     bool AddPeer::operator==(const Command &command) const {
-      if (! instanceof <AddPeer>(&command)) return false;
+      if (! instanceof <AddPeer>(command)) return false;
       auto add_peer = static_cast<const AddPeer &>(command);
       return add_peer.peer_key == peer_key && add_peer.address == address;
     }
@@ -57,7 +57,7 @@ namespace iroha {
 
     /* AddSignatory */
     bool AddSignatory::operator==(const Command &command) const {
-      if (! instanceof <AddSignatory>(&command)) return false;
+      if (! instanceof <AddSignatory>(command)) return false;
       auto add_signatory = static_cast<const AddSignatory &>(command);
       return add_signatory.account_id == account_id &&
              add_signatory.pubkey == pubkey;
@@ -69,7 +69,7 @@ namespace iroha {
 
     /* Assign master key */
     bool AssignMasterKey::operator==(const Command &command) const {
-      if (! instanceof <AssignMasterKey>(&command)) return false;
+      if (! instanceof <AssignMasterKey>(command)) return false;
       auto assign_master_key = static_cast<const AssignMasterKey &>(command);
       return assign_master_key.account_id == account_id &&
              assign_master_key.pubkey == pubkey;
@@ -81,7 +81,7 @@ namespace iroha {
 
     /* CreateAccount */
     bool CreateAccount::operator==(const Command &command) const {
-      if (! instanceof <CreateAccount>(&command)) return false;
+      if (! instanceof <CreateAccount>(command)) return false;
       auto create_account = static_cast<const CreateAccount &>(command);
       return create_account.pubkey == pubkey &&
              create_account.domain_id == domain_id &&
@@ -94,7 +94,7 @@ namespace iroha {
 
     /* CreateAsset */
     bool CreateAsset::operator==(const Command &command) const {
-      if (! instanceof <CreateAsset>(&command)) return false;
+      if (! instanceof <CreateAsset>(command)) return false;
       auto create_asset = static_cast<const CreateAsset &>(command);
       return create_asset.domain_id == domain_id &&
              create_asset.precision == precision &&
@@ -107,7 +107,7 @@ namespace iroha {
 
     /* Create domain */
     bool CreateDomain::operator==(const Command &command) const {
-      if (! instanceof <CreateDomain>(&command)) return false;
+      if (! instanceof <CreateDomain>(command)) return false;
       auto create_domain = static_cast<const CreateDomain &>(command);
       return create_domain.domain_name == domain_name;
     }
@@ -118,7 +118,7 @@ namespace iroha {
 
     /* Remove signatory */
     bool RemoveSignatory::operator==(const Command &command) const {
-      if (! instanceof <RemoveSignatory>(&command)) return false;
+      if (! instanceof <RemoveSignatory>(command)) return false;
       auto remove_signatory = static_cast<const RemoveSignatory &>(command);
       return remove_signatory.pubkey == pubkey &&
              remove_signatory.account_id == account_id;
@@ -147,7 +147,7 @@ namespace iroha {
 
     /* Set permissions */
     bool SetAccountPermissions::operator==(const Command &command) const {
-      if (! instanceof <SetAccountPermissions>(&command)) return false;
+      if (! instanceof <SetAccountPermissions>(command)) return false;
       auto set_account_permissions =
           static_cast<const SetAccountPermissions &>(command);
       return set_account_permissions.account_id == account_id &&
@@ -160,7 +160,7 @@ namespace iroha {
 
     /* Set Quorum*/
     bool SetQuorum::operator==(const Command &command) const {
-      if (! instanceof <SetQuorum>(&command)) return false;
+      if (! instanceof <SetQuorum>(command)) return false;
       auto set_quorum = static_cast<const SetQuorum &>(command);
       return set_quorum.account_id == account_id &&
              set_quorum.new_quorum == new_quorum;
@@ -172,7 +172,7 @@ namespace iroha {
 
     /* Transfer Asset */
     bool TransferAsset::operator==(const Command &command) const {
-      if (! instanceof <TransferAsset>(&command)) return false;
+      if (! instanceof <TransferAsset>(command)) return false;
       auto transfer_asset = static_cast<const TransferAsset &>(command);
       return transfer_asset.asset_id == asset_id &&
              transfer_asset.amount == amount &&

--- a/irohad/model/impl/stateful_command_validation.cpp
+++ b/irohad/model/impl/stateful_command_validation.cpp
@@ -207,18 +207,17 @@ namespace iroha {
       if (!account_asset || !asset) return false;
       // Amount is formed wrong
       if (amount.get_frac_number() > asset.value().precision) return false;
-      auto precision = asset.value().precision;
-      amount.get_joint_amount(precision);
 
-      return std::decimal::make_decimal64(
-                 (unsigned long long int)account_asset.value().balance,
-                 -asset.value().precision) < amount &&
-             // Check if src_account exist
-             queries.getAccount(src_account_id) &&
-             // Can account transfer assets
-             creator.permissions.can_transfer &&
-             // Creator can transfer only from their account
-             creator.account_id == src_account_id;
+      return
+          // Check if src_account exist
+          queries.getAccount(src_account_id) &&
+          // Can account transfer assets
+          creator.permissions.can_transfer &&
+          // Creator can transfer only from their account
+          creator.account_id == src_account_id &&
+          // Balance in your wallet should be at least amount of transfer
+          account_asset.value().balance >=
+              amount.get_joint_amount(asset.value().precision);
     }
 
   }  // namespace model

--- a/irohad/model/signature.hpp
+++ b/irohad/model/signature.hpp
@@ -28,6 +28,9 @@ namespace iroha {
     struct Signature {
       ed25519::sig_t signature;
       ed25519::pubkey_t pubkey;
+
+      bool operator==(const Signature& rhs) const;
+      bool operator!=(const Signature& rhs) const;
     };
   } // namespace model
 } // namespace iroha

--- a/irohad/model/transaction.hpp
+++ b/irohad/model/transaction.hpp
@@ -68,6 +68,9 @@ namespace iroha {
        * BODY field
        */
       std::vector<std::shared_ptr<Command>> commands;
+
+      bool operator==(const Transaction& rhs) const;
+      bool operator!=(const Transaction& rhs) const;
     };
   }
 }

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -42,7 +42,7 @@ namespace iroha {
   /**
    * Base type which represents blob of fixed size.
    */
-  template<size_t size_>
+  template <size_t size_>
   class blob_t : public std::array<byte_t, size_> {
     /**
      * Dark magic of C++, do not touch pls :)
@@ -76,8 +76,8 @@ namespace iroha {
       uint8_t front, back;
       auto ptr = this->data();
       for (uint32_t i = 0, k = 0; i < size_; i++) {
-        front = (uint8_t) (ptr[i] & 0xF0) >> 4;
-        back = (uint8_t) (ptr[i] & 0xF);
+        front = (uint8_t)(ptr[i] & 0xF0) >> 4;
+        back = (uint8_t)(ptr[i] & 0xF);
         res[k++] = code[front];
         res[k++] = code[back];
       }
@@ -85,7 +85,7 @@ namespace iroha {
     }
   };
 
-  template<size_t size>
+  template <size_t size>
   using hash_t = blob_t<size>;
 
   // fixed-size hashes
@@ -120,9 +120,8 @@ namespace iroha {
       return int_part * coef + frac_part;
     }
 
-    bool operator==(const Amount &rhs) {
-      return this->int_part == rhs.int_part &&
-          this->frac_part == rhs.frac_part;
+    bool operator==(const Amount &rhs) const {
+      return this->int_part == rhs.int_part && this->frac_part == rhs.frac_part;
     }
 
    private:
@@ -139,8 +138,8 @@ namespace iroha {
   };
 
   // check the type of the derived class
-  template<typename Base, typename T>
-  inline bool instanceof(const T *ptr) {
+  template <typename Base, typename T>
+  inline bool instanceof (const T *ptr) {
     return typeid(Base) == typeid(*ptr);
   }
 

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -22,6 +22,7 @@
 #include <crypto/base64.hpp>
 #include <cstdio>
 #include <string>
+#include <typeinfo>
 
 /**
  * This file defines common types used in iroha.
@@ -131,6 +132,12 @@ namespace iroha {
       return result;
     }
   };
+
+  // check the type of the derived class
+  template<typename Base, typename T>
+  inline bool instanceof(const T *ptr) {
+    return typeid(Base) == typeid(*ptr);
+  }
 
 }  // namespace iroha
 #endif  // IROHA_COMMON_HPP

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -42,7 +42,7 @@ namespace iroha {
   /**
    * Base type which represents blob of fixed size.
    */
-  template <size_t size_>
+  template<size_t size_>
   class blob_t : public std::array<byte_t, size_> {
     /**
      * Dark magic of C++, do not touch pls :)
@@ -76,8 +76,8 @@ namespace iroha {
       uint8_t front, back;
       auto ptr = this->data();
       for (uint32_t i = 0, k = 0; i < size_; i++) {
-        front = (uint8_t)(ptr[i] & 0xF0) >> 4;
-        back = (uint8_t)(ptr[i] & 0xF);
+        front = (uint8_t) (ptr[i] & 0xF0) >> 4;
+        back = (uint8_t) (ptr[i] & 0xF);
         res[k++] = code[front];
         res[k++] = code[back];
       }
@@ -85,7 +85,7 @@ namespace iroha {
     }
   };
 
-  template <size_t size>
+  template<size_t size>
   using hash_t = blob_t<size>;
 
   // fixed-size hashes
@@ -118,6 +118,11 @@ namespace iroha {
     uint64_t get_joint_amount(uint32_t precision) {
       auto coef = ipow(10, precision);
       return int_part * coef + frac_part;
+    }
+
+    bool operator==(const Amount &rhs) {
+      return this->int_part == rhs.int_part &&
+          this->frac_part == rhs.frac_part;
     }
 
    private:

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <crypto/base64.hpp>
 #include <cstdio>
+#include <string>
 
 /**
  * This file defines common types used in iroha.
@@ -106,6 +107,30 @@ namespace iroha {
   // timestamps
   using ts64_t = uint64_t;
   using ts32_t = uint32_t;
+
+  struct Amount {
+    uint64_t int_part;
+    uint64_t frac_part;
+
+    uint32_t get_frac_number() { return std::to_string(frac_part).length(); }
+
+    uint64_t get_joint_amount(uint32_t precision) {
+      auto coef = ipow(10, precision);
+      return int_part * coef + frac_part;
+    }
+
+   private:
+    int ipow(int base, int exp) {
+      int result = 1;
+      while (exp) {
+        if (exp & 1) result *= base;
+        exp >>= 1;
+        base *= base;
+      }
+
+      return result;
+    }
+  };
 
 }  // namespace iroha
 #endif  // IROHA_COMMON_HPP

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -134,6 +134,10 @@ namespace iroha {
       return this->int_part == rhs.int_part && this->frac_part == rhs.frac_part;
     }
 
+    bool operator!=(const Amount &rhs) const {
+      return !operator==(rhs);
+    }
+
    private:
     int ipow(int base, int exp) {
       int result = 1;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -76,8 +76,8 @@ namespace iroha {
       uint8_t front, back;
       auto ptr = this->data();
       for (uint32_t i = 0, k = 0; i < size_; i++) {
-        front = (uint8_t)(ptr[i] & 0xF0) >> 4;
-        back = (uint8_t)(ptr[i] & 0xF);
+        front = (uint8_t) (ptr[i] & 0xF0) >> 4;
+        back = (uint8_t) (ptr[i] & 0xF);
         res[k++] = code[front];
         res[k++] = code[back];
       }
@@ -85,7 +85,7 @@ namespace iroha {
     }
   };
 
-  template <size_t size>
+  template<size_t size>
   using hash_t = blob_t<size>;
 
   // fixed-size hashes
@@ -113,6 +113,16 @@ namespace iroha {
     uint64_t int_part;
     uint64_t frac_part;
 
+    Amount(uint64_t integer_part, uint64_t fractional_part) {
+      int_part = integer_part;
+      frac_part = fractional_part;
+    }
+
+    Amount() {
+      int_part = 0;
+      frac_part = 0;
+    }
+
     uint32_t get_frac_number() { return std::to_string(frac_part).length(); }
 
     uint64_t get_joint_amount(uint32_t precision) {
@@ -138,13 +148,13 @@ namespace iroha {
   };
 
   // check the type of the derived class
-  template <typename Base, typename T>
-  inline bool instanceof (const T *ptr) {
+  template<typename Base, typename T>
+  inline bool instanceof(const T *ptr) {
     return typeid(Base) == typeid(*ptr);
   }
 
-  template <typename Base, typename T>
-  inline bool instanceof (const T &ptr) {
+  template<typename Base, typename T>
+  inline bool instanceof(const T &ptr) {
     return typeid(Base) == typeid(ptr);
   }
 

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -143,5 +143,10 @@ namespace iroha {
     return typeid(Base) == typeid(*ptr);
   }
 
+  template <typename Base, typename T>
+  inline bool instanceof (const T &ptr) {
+    return typeid(Base) == typeid(ptr);
+  }
+
 }  // namespace iroha
 #endif  // IROHA_COMMON_HPP

--- a/schema/block.proto
+++ b/schema/block.proto
@@ -11,7 +11,7 @@ message Header {
 message Transaction {
 
   message Meta {
-    bytes creator_pubkey = 1;
+    string creator_account_id = 1;
     // used to prevent replay attacks.
     uint64  tx_counter = 2;
   }
@@ -30,7 +30,7 @@ message Block {
 
   message Meta {
     uint32             tx_number      = 1;  // the number of transactions inside. Maximum 16384 or 2^14
-    uint32             height         = 2;  // the current block number in a ledger
+    uint64             height         = 2;  // the current block number in a ledger
     bytes              merkle_root    = 3;  // global merkle root
     bytes              prev_block_hash      = 4; // Previous block hash
   }

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -1,10 +1,15 @@
 syntax = "proto3";
 package iroha.protocol;
 
+message Amount {
+    uint64 integer_part = 1;
+    uint64 fractial_part = 2;
+}
+
 message AddAssetQuantity {
     string account_id = 1;
     string asset_id = 2;
-    string amount = 3;
+    Amount amount = 3;
 }
 
 message AddPeer {
@@ -71,7 +76,7 @@ message TransferAsset {
     string src_account_id = 1;
     string dest_account_id = 2;
     string asset_id = 3;
-    string ammount = 4;
+    Amount amount = 4;
 }
 
 message Command {

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -29,7 +29,7 @@ message CreateAsset {
 }
 
 message CreateAccount {
-    string user_name = 1;
+    string account_name = 1;
     string domain_id = 2;
     bytes main_pubkey = 3;
 }
@@ -44,8 +44,22 @@ message RemoveSignatory {
 }
 
 message SetAccountPermissions {
+
+    message Permissions {
+        bool issue_assets = 1;
+        bool create_assets = 2;
+        bool create_accounts = 3;
+        bool create_domains = 4;
+        bool read_all_accounts = 5;
+        bool add_signatory = 6;
+        bool remove_signatory = 7;
+        bool set_permissions = 8;
+        bool set_quorum = 9;
+        bool can_transfer = 10;
+    }
+
     string account_id = 1;
-    uint32 permissions = 2;
+    Permissions permissions = 2;
 }
 
 message SetAccountQuorum {
@@ -71,7 +85,7 @@ message Command {
         CreateDomain create_domain = 7;
         RemoveSignatory remove_sign = 8;
         SetAccountPermissions set_permission = 9;
-        SetAccountQuorum    set_quorum = 10;
-        TransferAsset   transfer_asset = 11;
+        SetAccountQuorum set_quorum = 10;
+        TransferAsset transfer_asset = 11;
     }
 }

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -9,7 +9,7 @@ message AddAssetQuantity {
 
 message AddPeer {
     string address = 1;
-    string account_id = 2;
+    bytes peer_key = 2;
 }
 
 message AddSignatory {
@@ -53,12 +53,6 @@ message SetAccountQuorum {
     uint32 quorum = 2;
 }
 
-message SubtractAssetQuantity {
-    string account_id = 1;
-    string asset_id = 2;
-    string amount = 3;
-}
-
 message TransferAsset {
     string src_account_id = 1;
     string dest_account_id = 2;
@@ -76,9 +70,8 @@ message Command {
         CreateAccount create_account = 6;
         CreateDomain create_domain = 7;
         RemoveSignatory remove_sign = 8;
-        SubtractAssetQuantity subtract_asset_quantity = 9;
-        SetAccountPermissions set_permission = 10;
-        SetAccountQuorum    set_quorum = 11;
-        TransferAsset   transfer_asset = 12;
+        SetAccountPermissions set_permission = 9;
+        SetAccountQuorum    set_quorum = 10;
+        TransferAsset   transfer_asset = 11;
     }
 }

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -160,14 +160,20 @@ namespace iroha {
       model::AddAssetQuantity addAssetQuantity;
       addAssetQuantity.asset_id = "RUB#ru";
       addAssetQuantity.account_id = "user1@ru";
-      addAssetQuantity.amount = std::decimal::make_decimal64(150ull, -2);
+      iroha::Amount asset_amount;
+      asset_amount.int_part = 1;
+      asset_amount.frac_part = 50;
+      addAssetQuantity.amount = asset_amount;
       txn.commands.push_back(
           std::make_shared<model::AddAssetQuantity>(addAssetQuantity));
       model::TransferAsset transferAsset;
       transferAsset.src_account_id = "user1@ru";
       transferAsset.dest_account_id = "user2@ru";
       transferAsset.asset_id = "RUB#ru";
-      transferAsset.amount = std::decimal::make_decimal64(100ull, -2);
+      iroha::Amount transfer_amount;
+      transfer_amount.int_part = 1;
+      transfer_amount.frac_part = 0;
+      transferAsset.amount = transfer_amount;
       txn.commands.push_back(
           std::make_shared<model::TransferAsset>(transferAsset));
 
@@ -210,21 +216,18 @@ namespace iroha {
       }
 
       // Block store tests
-      storage->getBlocks(1, 2).subscribe([block1hash, block2hash](auto block){
-        if (block.height == 1){
+      storage->getBlocks(1, 2).subscribe([block1hash, block2hash](auto block) {
+        if (block.height == 1) {
           EXPECT_EQ(block.hash, block1hash);
-        }
-        else if (block.height == 2){
+        } else if (block.height == 2) {
           EXPECT_EQ(block.hash, block2hash);
         }
       });
 
-      storage->getAccountTransactions("admin1").subscribe([](auto tx){
-        EXPECT_EQ(tx.commands.size(), 2);
-      });
-      storage->getAccountTransactions("admin2").subscribe([](auto tx){
-        EXPECT_EQ(tx.commands.size(), 4);
-      });
+      storage->getAccountTransactions("admin1").subscribe(
+          [](auto tx) { EXPECT_EQ(tx.commands.size(), 2); });
+      storage->getAccountTransactions("admin2").subscribe(
+          [](auto tx) { EXPECT_EQ(tx.commands.size(), 4); });
     }
 
     TEST_F(AmetsuchiTest, PeerTest) {

--- a/test/module/irohad/ametsuchi/block_serializer_test.cpp
+++ b/test/module/irohad/ametsuchi/block_serializer_test.cpp
@@ -16,7 +16,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <ametsuchi/block_serializer.hpp>
+#include "ametsuchi/block_serializer.hpp"
+#include "common/types.hpp"
 
 iroha::model::Signature create_signature();
 iroha::model::Transaction create_transaction();
@@ -52,7 +53,10 @@ iroha::model::Transaction create_transaction() {
   iroha::model::AddAssetQuantity add_asset_qty;
   add_asset_qty.account_id = "123";
   add_asset_qty.asset_id = "123";
-  add_asset_qty.amount = std::decimal::make_decimal64(1010LL, -2);
+  iroha::Amount amount;
+  amount.int_part = 10;
+  amount.frac_part = 10;
+  add_asset_qty.amount = amount;
   tx.commands.push_back(std::make_shared<iroha::model::AddAssetQuantity>(add_asset_qty));
 
   // AddSignatory
@@ -108,7 +112,7 @@ iroha::model::Transaction create_transaction() {
   iroha::model::TransferAsset transfer_asset;
   transfer_asset.src_account_id = "123";
   transfer_asset.dest_account_id = "321";
-  transfer_asset.amount = std::decimal::make_decimal64(1010ll, -2);
+  transfer_asset.amount = amount;
   transfer_asset.asset_id = "123";
   tx.commands.push_back(std::make_shared<iroha::model::TransferAsset>(transfer_asset));
   return tx;
@@ -196,6 +200,7 @@ TEST(block_serialize, block_serialize_test){
         else if (instanceof<iroha::model::AddAssetQuantity>(tx.commands[j].get())){
           auto add_asset_quantity = static_cast<const iroha::model::AddAssetQuantity&>(*tx.commands[j].get());
           auto des_add_asset_quantity = static_cast<const iroha::model::AddAssetQuantity&>(*des_tx.commands[j].get());
+
           ASSERT_EQ(add_asset_quantity.amount, des_add_asset_quantity.amount);
           ASSERT_EQ(add_asset_quantity.asset_id, des_add_asset_quantity.asset_id);
           ASSERT_EQ(add_asset_quantity.account_id, des_add_asset_quantity.account_id);

--- a/test/module/irohad/model/CMakeLists.txt
+++ b/test/module/irohad/model/CMakeLists.txt
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(CMAKE_BUILD_TYPE Debug)
-
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test_bin)
-
 addtest(command_converter_test converters/pb_commands_test.cpp)
 target_link_libraries(command_converter_test
+    model
+    )
+
+addtest(transaction_converter_test converters/pb_transaction_test.cpp)
+target_link_libraries(transaction_converter_test
+    model
+    )
+
+addtest(block_converter_test converters/pb_block_test.cpp)
+target_link_libraries(block_converter_test
     model
     )

--- a/test/module/irohad/model/CMakeLists.txt
+++ b/test/module/irohad/model/CMakeLists.txt
@@ -14,14 +14,9 @@
 
 set(CMAKE_BUILD_TYPE Debug)
 
-SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test_bin)
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test_bin)
 
-# Reusable tests
-add_subdirectory(ametsuchi)
-#add_subdirectory(api)
-add_subdirectory(consensus)
-add_subdirectory(logger)
-add_subdirectory(peer_service)
-add_subdirectory(validation)
-add_subdirectory(torii)
-add_subdirectory(model)
+addtest(command_converter_test converters/pb_commands_test.cpp)
+target_link_libraries(command_converter_test
+    model
+    )

--- a/test/module/irohad/model/CMakeLists.txt
+++ b/test/module/irohad/model/CMakeLists.txt
@@ -26,3 +26,8 @@ addtest(block_converter_test converters/pb_block_test.cpp)
 target_link_libraries(block_converter_test
     model
     )
+
+addtest(model_operators_test operators/model_operators_test.cpp)
+target_link_libraries(model_operators_test
+    model
+    )

--- a/test/module/irohad/model/converters/pb_block_test.cpp
+++ b/test/module/irohad/model/converters/pb_block_test.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "commands.pb.h"
+#include "model/block.hpp"
+#include "model/converters/pb_block_factory.hpp"
+
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/add_peer.hpp"
+#include "model/commands/add_signatory.hpp"
+#include "model/commands/assign_master_key.hpp"
+#include "model/commands/create_account.hpp"
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/remove_signatory.hpp"
+#include "model/commands/set_permissions.hpp"
+#include "model/commands/set_quorum.hpp"
+#include "model/commands/transfer_asset.hpp"
+
+TEST(BlockTest, bl_test) {
+  auto orig_tx = iroha::model::Transaction();
+  orig_tx.creator_account_id = "andr@kek";
+  auto siga = iroha::model::Signature();
+  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
+  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
+  orig_tx.signatures = {siga};
+
+  orig_tx.created_ts = 2;
+  orig_tx.tx_counter = 1;
+
+  auto c1 = iroha::model::CreateDomain();
+  c1.domain_name = "keker";
+  auto c2 = iroha::model::CreateAsset();
+  c2.domain_id = "keker";
+  c2.precision = 2;
+  c2.asset_name = "fedor-coin";
+
+  auto c3 = iroha::model::SetAccountPermissions();
+  c3.account_id = "fedor";
+  c3.new_permissions.can_transfer = true;
+  c3.new_permissions.create_assets = true;
+
+  orig_tx.commands = {
+      std::make_shared<iroha::model::CreateDomain>(c1),
+      std::make_shared<iroha::model::CreateAsset>(c2),
+      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
+
+  auto orig_block = iroha::model::Block();
+  orig_block.created_ts = 1;
+  std::fill(orig_block.hash.begin(), orig_block.hash.end(), 0x7);
+
+  std::fill(orig_block.prev_hash.begin(), orig_block.prev_hash.end(), 0x3);
+  orig_block.sigs = {siga};
+
+  std::fill(orig_block.merkle_root.begin(), orig_block.merkle_root.end(), 0x14);
+  orig_block.height = 3;
+  orig_block.txs_number = 1;
+  orig_block.transactions = {orig_tx};
+
+  auto factory = iroha::model::converters::PbBlockFactory();
+  auto proto_block = factory.serialize(orig_block);
+  auto serial_block = factory.deserialize(proto_block);
+  ASSERT_EQ(orig_block, serial_block);
+}

--- a/test/module/irohad/model/converters/pb_block_test.cpp
+++ b/test/module/irohad/model/converters/pb_block_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <model/model_hash_provider_impl.hpp>
 #include "commands.pb.h"
 #include "model/block.hpp"
 #include "model/converters/pb_block_factory.hpp"
@@ -62,7 +63,6 @@ TEST(BlockTest, bl_test) {
 
   auto orig_block = iroha::model::Block();
   orig_block.created_ts = 1;
-  std::fill(orig_block.hash.begin(), orig_block.hash.end(), 0x7);
 
   std::fill(orig_block.prev_hash.begin(), orig_block.prev_hash.end(), 0x3);
   orig_block.sigs = {siga};
@@ -72,8 +72,18 @@ TEST(BlockTest, bl_test) {
   orig_block.txs_number = 1;
   orig_block.transactions = {orig_tx};
 
+  iroha::model::HashProviderImpl hash_provider;
+  orig_block.hash = hash_provider.get_hash(orig_block);
+
   auto factory = iroha::model::converters::PbBlockFactory();
   auto proto_block = factory.serialize(orig_block);
   auto serial_block = factory.deserialize(proto_block);
+  ASSERT_EQ(orig_block.created_ts, serial_block.created_ts);
+  ASSERT_EQ(orig_block.transactions, serial_block.transactions);
+  ASSERT_EQ(orig_block.sigs, serial_block.sigs);
+  ASSERT_EQ(orig_block.hash, serial_block.hash);
+  ASSERT_EQ(orig_block.merkle_root, serial_block.merkle_root);
+  ASSERT_EQ(orig_block.prev_hash, serial_block.prev_hash);
+  ASSERT_EQ(orig_block.txs_number, serial_block.txs_number);
   ASSERT_EQ(orig_block, serial_block);
 }

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -31,10 +31,15 @@
 
 #include "model/converters/pb_command_factory.hpp"
 
+void command_converter_test(iroha::model::Command &abstract_command) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto pb_repr = factory.serializeAbstractCommand(abstract_command);
+  auto model_repr = factory.deserializeAbstractCommand(pb_repr);
+  ASSERT_EQ(abstract_command, *model_repr);
+}
 
 TEST(CommandTest, add_peer) {
   auto orig_addPeer = iroha::model::AddPeer();
-  // addPeer.peer_key =
   orig_addPeer.address = "10.90.129.23";
 
   auto factory = iroha::model::converters::PbCommandFactory();
@@ -43,10 +48,12 @@ TEST(CommandTest, add_peer) {
   auto serial_addPeer = factory.deserializeAddPeer(proto_add_peer);
 
   ASSERT_EQ(orig_addPeer, serial_addPeer);
+  command_converter_test(orig_addPeer);
 
   orig_addPeer.address = "134";
   ASSERT_NE(serial_addPeer, orig_addPeer);
 }
+
 
 TEST(CommandTest, add_signatory) {
   auto orig_command = iroha::model::AddSignatory();
@@ -57,7 +64,19 @@ TEST(CommandTest, add_signatory) {
   auto serial_command = factory.deserializeAddSignatory(proto_command);
 
   ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
+
+  orig_command.account_id = "100500";
+  ASSERT_NE(orig_command, serial_command);
 }
+
+TEST(CommandTest, add_signatory_abstract_factory) {
+  auto orig_command = iroha::model::AddSignatory();
+  orig_command.account_id = "23";
+
+  command_converter_test(orig_command);
+}
+
 
 TEST(CommandTest, add_asset_quantity) {
   auto orig_command = iroha::model::AddAssetQuantity();
@@ -74,6 +93,7 @@ TEST(CommandTest, add_asset_quantity) {
   auto serial_command = factory.deserializeAddAssetQuantity(proto_command);
 
   ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
 }
 
 TEST(CommandTest, assign_master_key) {
@@ -84,6 +104,7 @@ TEST(CommandTest, assign_master_key) {
   auto serial_command = factory.deserializeAssignMasterKey(proto_command);
 
   ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
 }
 
 TEST(CommandTest, create_account) {
@@ -94,5 +115,6 @@ TEST(CommandTest, create_account) {
   auto proto_command = factory.serializeCreateAccount(orig_command);
   auto serial_command = factory.deserializeCreateAccount(proto_command);
   ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
 }
 

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -1,0 +1,105 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "commands.pb.h"
+#include "model/commands/add_peer.hpp"
+#include "model/commands/add_signatory.hpp"
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/assign_master_key.hpp"
+#include "model/commands/create_account.hpp"
+
+
+#include "model/converters/pb_command_factory.hpp"
+
+TEST(CommandTest, add_peer) {
+  auto orig_addPeer = iroha::model::AddPeer();
+  // addPeer.peer_key =
+  orig_addPeer.address = "10.90.129.23";
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto proto_add_peer = factory.serializeAddPeer(orig_addPeer);
+  auto serial_addPeer = factory.deserializeAddPeer(proto_add_peer);
+
+  // ASSERT_EQ(add_peer.peer_key, addPeer.peer_key);
+
+  orig_addPeer.address = "134";
+  //ASSERT_NE(serial_addPeer, orig_addPeer);
+}
+
+TEST(CommandTest, add_signatory) {
+  auto orig_command = iroha::model::AddSignatory();
+  orig_command.account_id = "23";
+
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAddSignatory(orig_command);
+  auto serial_command = factory.deserializeAddSignatory(proto_command);
+
+  //ASSERT_EQ(orig_command, serial_command);
+}
+
+TEST(CommandTest, add_asset_quantity) {
+  auto orig_command = iroha::model::AddAssetQuantity();
+  orig_command.account_id = "23";
+  orig_command.amount = "1.50";
+  orig_command.asset_id = "23";
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAddAssetQuantity(orig_command);
+  auto serial_command = factory.deserializeAddAssetQuantity(proto_command);
+
+  //ASSERT_EQ(orig_command, serial_command);
+}
+
+
+TEST(CommandTest, assign_master_key) {
+  auto orig_command = iroha::model::AssignMasterKey();
+  orig_command.account_id = "23";
+
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAssignMasterKey(orig_command);
+  auto serial_command = factory.deserializeAssignMasterKey(proto_command);
+
+  //ASSERT_EQ(orig_command, serial_command);
+}
+
+TEST(CommandTest, AddSignatory) {
+  auto orig_command = iroha::model::AddSignatory();
+  orig_command.account_id = "23";
+
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAddSignatory(orig_command);
+  auto serial_command = factory.deserializeAddSignatory(proto_command);
+
+  //ASSERT_EQ(orig_command, serial_command);
+}
+
+TEST(CommandTest, AddSignatory) {
+  auto orig_command = iroha::model::AddSignatory();
+  orig_command.account_id = "23";
+
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAddSignatory(orig_command);
+  auto serial_command = factory.deserializeAddSignatory(proto_command);
+
+  //ASSERT_EQ(orig_command, serial_command);
+}

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -17,14 +17,25 @@
 
 #include <gtest/gtest.h>
 #include "commands.pb.h"
+#include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/add_peer.hpp"
 #include "model/commands/add_signatory.hpp"
-#include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/assign_master_key.hpp"
 #include "model/commands/create_account.hpp"
 
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/remove_signatory.hpp"
+#include "model/commands/set_permissions.hpp"
+#include "model/commands/set_quorum.hpp"
+#include "model/commands/transfer_asset.hpp"
 
+#include "model/block.hpp"
+#include "model/transaction.hpp"
+
+#include "model/converters/pb_block_factory.hpp"
 #include "model/converters/pb_command_factory.hpp"
+#include "model/converters/pb_transaction_factory.hpp"
 
 TEST(CommandTest, add_peer) {
   auto orig_addPeer = iroha::model::AddPeer();
@@ -36,59 +47,136 @@ TEST(CommandTest, add_peer) {
   auto proto_add_peer = factory.serializeAddPeer(orig_addPeer);
   auto serial_addPeer = factory.deserializeAddPeer(proto_add_peer);
 
-  // ASSERT_EQ(add_peer.peer_key, addPeer.peer_key);
+  ASSERT_EQ(orig_addPeer, serial_addPeer);
 
   orig_addPeer.address = "134";
-  //ASSERT_NE(serial_addPeer, orig_addPeer);
+  ASSERT_NE(serial_addPeer, orig_addPeer);
 }
 
 TEST(CommandTest, add_signatory) {
   auto orig_command = iroha::model::AddSignatory();
   orig_command.account_id = "23";
 
-
   auto factory = iroha::model::converters::PbCommandFactory();
   auto proto_command = factory.serializeAddSignatory(orig_command);
   auto serial_command = factory.deserializeAddSignatory(proto_command);
 
-  //ASSERT_EQ(orig_command, serial_command);
+  ASSERT_EQ(orig_command, serial_command);
 }
 
 TEST(CommandTest, add_asset_quantity) {
   auto orig_command = iroha::model::AddAssetQuantity();
   orig_command.account_id = "23";
-  orig_command.amount.int_part = 1;
-  orig_command.amount.frac_part = 50;
+  iroha::Amount amount;
+  amount.frac_part = 50;
+  amount.int_part = 1;
+
+  orig_command.amount = amount;
   orig_command.asset_id = "23";
 
   auto factory = iroha::model::converters::PbCommandFactory();
   auto proto_command = factory.serializeAddAssetQuantity(orig_command);
   auto serial_command = factory.deserializeAddAssetQuantity(proto_command);
 
-  //ASSERT_EQ(orig_command, serial_command);
+  ASSERT_EQ(orig_command, serial_command);
 }
-
 
 TEST(CommandTest, assign_master_key) {
   auto orig_command = iroha::model::AssignMasterKey();
   orig_command.account_id = "23";
-
-
   auto factory = iroha::model::converters::PbCommandFactory();
   auto proto_command = factory.serializeAssignMasterKey(orig_command);
   auto serial_command = factory.deserializeAssignMasterKey(proto_command);
 
-  //ASSERT_EQ(orig_command, serial_command);
+  ASSERT_EQ(orig_command, serial_command);
 }
 
-TEST(CommandTest, AddSignatory) {
-  auto orig_command = iroha::model::AddSignatory();
-  orig_command.account_id = "23";
-
-
+TEST(CommandTest, create_account) {
+  auto orig_command = iroha::model::CreateAccount();
+  orig_command.account_name = "keker";
+  orig_command.domain_id = "cheburek";
   auto factory = iroha::model::converters::PbCommandFactory();
-  auto proto_command = factory.serializeAddSignatory(orig_command);
-  auto serial_command = factory.deserializeAddSignatory(proto_command);
+  auto proto_command = factory.serializeCreateAccount(orig_command);
+  auto serial_command = factory.deserializeCreateAccount(proto_command);
+  ASSERT_EQ(orig_command, serial_command);
+}
 
-  //ASSERT_EQ(orig_command, serial_command);
+TEST(TransactionTest, tx_test) {
+  auto orig_tx = iroha::model::Transaction();
+  orig_tx.creator_account_id = "andr@kek";
+  auto siga = iroha::model::Signature();
+  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
+  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
+  orig_tx.signatures = {siga};
+
+  orig_tx.created_ts = 2;
+  orig_tx.tx_counter = 1;
+
+  auto c1 = iroha::model::CreateDomain();
+  c1.domain_name = "keker";
+  auto c2 = iroha::model::CreateAsset();
+  c2.domain_id = "keker";
+  c2.precision = 2;
+  c2.asset_name = "fedor-coin";
+
+  auto c3 = iroha::model::SetAccountPermissions();
+  c3.account_id = "fedor";
+  c3.new_permissions.can_transfer = true;
+  c3.new_permissions.create_assets = true;
+
+  orig_tx.commands = {
+      std::make_shared<iroha::model::CreateDomain>(c1),
+      std::make_shared<iroha::model::CreateAsset>(c2),
+      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
+
+  auto factory = iroha::model::converters::PbTransactionFactory();
+  auto proto_tx = factory.serialize(orig_tx);
+  auto serial_tx = factory.deserialize(proto_tx);
+  ASSERT_EQ(orig_tx, serial_tx);
+}
+
+TEST(BlockTest, bl_test) {
+  auto orig_tx = iroha::model::Transaction();
+  orig_tx.creator_account_id = "andr@kek";
+  auto siga = iroha::model::Signature();
+  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
+  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
+  orig_tx.signatures = {siga};
+
+  orig_tx.created_ts = 2;
+  orig_tx.tx_counter = 1;
+
+  auto c1 = iroha::model::CreateDomain();
+  c1.domain_name = "keker";
+  auto c2 = iroha::model::CreateAsset();
+  c2.domain_id = "keker";
+  c2.precision = 2;
+  c2.asset_name = "fedor-coin";
+
+  auto c3 = iroha::model::SetAccountPermissions();
+  c3.account_id = "fedor";
+  c3.new_permissions.can_transfer = true;
+  c3.new_permissions.create_assets = true;
+
+  orig_tx.commands = {
+      std::make_shared<iroha::model::CreateDomain>(c1),
+      std::make_shared<iroha::model::CreateAsset>(c2),
+      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
+
+  auto orig_block = iroha::model::Block();
+  orig_block.created_ts = 1;
+  std::fill(orig_block.hash.begin(), orig_block.hash.end(), 0x7);
+
+  std::fill(orig_block.prev_hash.begin(), orig_block.prev_hash.end(), 0x3);
+  orig_block.sigs = {siga};
+
+  std::fill(orig_block.merkle_root.begin(), orig_block.merkle_root.end(), 0x14);
+  orig_block.height = 3;
+  orig_block.txs_number = 1;
+  orig_block.transactions = {orig_tx};
+
+  auto factory = iroha::model::converters::PbBlockFactory();
+  auto proto_block = factory.serialize(orig_block);
+  auto serial_block = factory.deserialize(proto_block);
+  ASSERT_EQ(orig_block, serial_block);
 }

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -57,7 +57,8 @@ TEST(CommandTest, add_signatory) {
 TEST(CommandTest, add_asset_quantity) {
   auto orig_command = iroha::model::AddAssetQuantity();
   orig_command.account_id = "23";
-  orig_command.amount = "1.50";
+  orig_command.amount.int_part = 1;
+  orig_command.amount.frac_part = 50;
   orig_command.asset_id = "23";
 
   auto factory = iroha::model::converters::PbCommandFactory();
@@ -76,18 +77,6 @@ TEST(CommandTest, assign_master_key) {
   auto factory = iroha::model::converters::PbCommandFactory();
   auto proto_command = factory.serializeAssignMasterKey(orig_command);
   auto serial_command = factory.deserializeAssignMasterKey(proto_command);
-
-  //ASSERT_EQ(orig_command, serial_command);
-}
-
-TEST(CommandTest, AddSignatory) {
-  auto orig_command = iroha::model::AddSignatory();
-  orig_command.account_id = "23";
-
-
-  auto factory = iroha::model::converters::PbCommandFactory();
-  auto proto_command = factory.serializeAddSignatory(orig_command);
-  auto serial_command = factory.deserializeAddSignatory(proto_command);
 
   //ASSERT_EQ(orig_command, serial_command);
 }

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -22,7 +22,6 @@
 #include "model/commands/add_signatory.hpp"
 #include "model/commands/assign_master_key.hpp"
 #include "model/commands/create_account.hpp"
-
 #include "model/commands/create_asset.hpp"
 #include "model/commands/create_domain.hpp"
 #include "model/commands/remove_signatory.hpp"
@@ -30,12 +29,8 @@
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/transfer_asset.hpp"
 
-#include "model/block.hpp"
-#include "model/transaction.hpp"
-
-#include "model/converters/pb_block_factory.hpp"
 #include "model/converters/pb_command_factory.hpp"
-#include "model/converters/pb_transaction_factory.hpp"
+
 
 TEST(CommandTest, add_peer) {
   auto orig_addPeer = iroha::model::AddPeer();
@@ -101,82 +96,3 @@ TEST(CommandTest, create_account) {
   ASSERT_EQ(orig_command, serial_command);
 }
 
-TEST(TransactionTest, tx_test) {
-  auto orig_tx = iroha::model::Transaction();
-  orig_tx.creator_account_id = "andr@kek";
-  auto siga = iroha::model::Signature();
-  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
-  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
-  orig_tx.signatures = {siga};
-
-  orig_tx.created_ts = 2;
-  orig_tx.tx_counter = 1;
-
-  auto c1 = iroha::model::CreateDomain();
-  c1.domain_name = "keker";
-  auto c2 = iroha::model::CreateAsset();
-  c2.domain_id = "keker";
-  c2.precision = 2;
-  c2.asset_name = "fedor-coin";
-
-  auto c3 = iroha::model::SetAccountPermissions();
-  c3.account_id = "fedor";
-  c3.new_permissions.can_transfer = true;
-  c3.new_permissions.create_assets = true;
-
-  orig_tx.commands = {
-      std::make_shared<iroha::model::CreateDomain>(c1),
-      std::make_shared<iroha::model::CreateAsset>(c2),
-      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
-
-  auto factory = iroha::model::converters::PbTransactionFactory();
-  auto proto_tx = factory.serialize(orig_tx);
-  auto serial_tx = factory.deserialize(proto_tx);
-  ASSERT_EQ(orig_tx, serial_tx);
-}
-
-TEST(BlockTest, bl_test) {
-  auto orig_tx = iroha::model::Transaction();
-  orig_tx.creator_account_id = "andr@kek";
-  auto siga = iroha::model::Signature();
-  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
-  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
-  orig_tx.signatures = {siga};
-
-  orig_tx.created_ts = 2;
-  orig_tx.tx_counter = 1;
-
-  auto c1 = iroha::model::CreateDomain();
-  c1.domain_name = "keker";
-  auto c2 = iroha::model::CreateAsset();
-  c2.domain_id = "keker";
-  c2.precision = 2;
-  c2.asset_name = "fedor-coin";
-
-  auto c3 = iroha::model::SetAccountPermissions();
-  c3.account_id = "fedor";
-  c3.new_permissions.can_transfer = true;
-  c3.new_permissions.create_assets = true;
-
-  orig_tx.commands = {
-      std::make_shared<iroha::model::CreateDomain>(c1),
-      std::make_shared<iroha::model::CreateAsset>(c2),
-      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
-
-  auto orig_block = iroha::model::Block();
-  orig_block.created_ts = 1;
-  std::fill(orig_block.hash.begin(), orig_block.hash.end(), 0x7);
-
-  std::fill(orig_block.prev_hash.begin(), orig_block.prev_hash.end(), 0x3);
-  orig_block.sigs = {siga};
-
-  std::fill(orig_block.merkle_root.begin(), orig_block.merkle_root.end(), 0x14);
-  orig_block.height = 3;
-  orig_block.txs_number = 1;
-  orig_block.transactions = {orig_tx};
-
-  auto factory = iroha::model::converters::PbBlockFactory();
-  auto proto_block = factory.serialize(orig_block);
-  auto serial_block = factory.deserialize(proto_block);
-  ASSERT_EQ(orig_block, serial_block);
-}

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -31,11 +31,31 @@
 
 #include "model/converters/pb_command_factory.hpp"
 
+#include <algorithm>
+
 void command_converter_test(iroha::model::Command &abstract_command) {
   auto factory = iroha::model::converters::PbCommandFactory();
   auto pb_repr = factory.serializeAbstractCommand(abstract_command);
   auto model_repr = factory.deserializeAbstractCommand(pb_repr);
   ASSERT_EQ(abstract_command, *model_repr);
+}
+
+TEST(CommandTest, add_asset_quantity) {
+  auto orig_command = iroha::model::AddAssetQuantity();
+  orig_command.account_id = "23";
+  iroha::Amount amount;
+  amount.frac_part = 50;
+  amount.int_part = 1;
+
+  orig_command.amount = amount;
+  orig_command.asset_id = "23";
+
+  auto factory = iroha::model::converters::PbCommandFactory();
+  auto proto_command = factory.serializeAddAssetQuantity(orig_command);
+  auto serial_command = factory.deserializeAddAssetQuantity(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
 }
 
 TEST(CommandTest, add_peer) {
@@ -53,7 +73,6 @@ TEST(CommandTest, add_peer) {
   orig_addPeer.address = "134";
   ASSERT_NE(serial_addPeer, orig_addPeer);
 }
-
 
 TEST(CommandTest, add_signatory) {
   auto orig_command = iroha::model::AddSignatory();
@@ -77,25 +96,6 @@ TEST(CommandTest, add_signatory_abstract_factory) {
   command_converter_test(orig_command);
 }
 
-
-TEST(CommandTest, add_asset_quantity) {
-  auto orig_command = iroha::model::AddAssetQuantity();
-  orig_command.account_id = "23";
-  iroha::Amount amount;
-  amount.frac_part = 50;
-  amount.int_part = 1;
-
-  orig_command.amount = amount;
-  orig_command.asset_id = "23";
-
-  auto factory = iroha::model::converters::PbCommandFactory();
-  auto proto_command = factory.serializeAddAssetQuantity(orig_command);
-  auto serial_command = factory.deserializeAddAssetQuantity(proto_command);
-
-  ASSERT_EQ(orig_command, serial_command);
-  command_converter_test(orig_command);
-}
-
 TEST(CommandTest, assign_master_key) {
   auto orig_command = iroha::model::AssignMasterKey();
   orig_command.account_id = "23";
@@ -107,6 +107,22 @@ TEST(CommandTest, assign_master_key) {
   command_converter_test(orig_command);
 }
 
+TEST(CommandTest, create_asset) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = iroha::model::CreateAsset();
+  orig_command.domain_id = "kek_cheburek";
+  orig_command.precision = 1;
+  orig_command.asset_name = "test_asset";
+
+  auto proto_command = factory.serializeCreateAsset(orig_command);
+  auto serial_command = factory.deserializeCreateAsset(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+
+  command_converter_test(orig_command);
+}
+
 TEST(CommandTest, create_account) {
   auto orig_command = iroha::model::CreateAccount();
   orig_command.account_name = "keker";
@@ -115,6 +131,72 @@ TEST(CommandTest, create_account) {
   auto proto_command = factory.serializeCreateAccount(orig_command);
   auto serial_command = factory.deserializeCreateAccount(proto_command);
   ASSERT_EQ(orig_command, serial_command);
+  command_converter_test(orig_command);
+}
+
+TEST(CommandTest, remove_signatory) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = iroha::model::RemoveSignatory();
+  orig_command.account_id = "Vasya";
+  std::fill(orig_command.pubkey.begin(), orig_command.pubkey.end(), 0xF);
+
+  auto proto_command = factory.serializeRemoveSignatory(orig_command);
+  auto serial_command = factory.deserializeRemoveSignatory(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+
+  command_converter_test(orig_command);
+}
+
+TEST(CommandTest, set_acount_permissions) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = iroha::model::SetAccountPermissions();
+  orig_command.account_id = "Vasya";
+  iroha::model::Account::Permissions perm;
+  perm.can_transfer = true;
+  perm.add_signatory = true;
+  perm.issue_assets = true;
+  orig_command.new_permissions = perm;
+
+  auto proto_command = factory.serializeSetAccountPermissions(orig_command);
+  auto serial_command = factory.deserializeSetAccountPermissions(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+
+  command_converter_test(orig_command);
+}
+
+TEST(CommandTest, set_account_quorum) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = iroha::model::SetQuorum();
+  orig_command.new_quorum = 11;
+  orig_command.account_id = "Vasya";
+
+  auto proto_command = factory.serializeSetQuorum(orig_command);
+  auto serial_command = factory.deserializeSetQuorum(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+
+  command_converter_test(orig_command);
+}
+
+TEST(CommandTest, set_transfer_asset) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = iroha::model::TransferAsset();
+  orig_command.amount = {1, 20};
+  orig_command.asset_id = "tugrik";
+  orig_command.src_account_id = "Vasya";
+  orig_command.dest_account_id = "Petya";
+
+  auto proto_command = factory.serializeTransferAsset(orig_command);
+  auto serial_command = factory.deserializeTransferAsset(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+
   command_converter_test(orig_command);
 }
 

--- a/test/module/irohad/model/converters/pb_transaction_test.cpp
+++ b/test/module/irohad/model/converters/pb_transaction_test.cpp
@@ -62,6 +62,21 @@ TEST(TransactionTest, tx_test) {
 
   auto factory = iroha::model::converters::PbTransactionFactory();
   auto proto_tx = factory.serialize(orig_tx);
+  switch (proto_tx.body().commands().Get(0).command_case()){
+
+    case iroha::protocol::Command::kAddAssetQuantity:break;
+    case iroha::protocol::Command::kAddPeer:break;
+    case iroha::protocol::Command::kAddSignatory:break;
+    case iroha::protocol::Command::kAccountAssignMk:break;
+    case iroha::protocol::Command::kCreateAsset:break;
+    case iroha::protocol::Command::kCreateAccount:break;
+    case iroha::protocol::Command::kCreateDomain:break;
+    case iroha::protocol::Command::kRemoveSign:break;
+    case iroha::protocol::Command::kSetPermission:break;
+    case iroha::protocol::Command::kSetQuorum:break;
+    case iroha::protocol::Command::kTransferAsset:break;
+    case iroha::protocol::Command::COMMAND_NOT_SET:break;
+  }
   auto serial_tx = factory.deserialize(proto_tx);
   ASSERT_EQ(orig_tx, serial_tx);
 }

--- a/test/module/irohad/model/converters/pb_transaction_test.cpp
+++ b/test/module/irohad/model/converters/pb_transaction_test.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "commands.pb.h"
+#include "model/converters/pb_transaction_factory.hpp"
+#include "model/transaction.hpp"
+
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/add_peer.hpp"
+#include "model/commands/add_signatory.hpp"
+#include "model/commands/assign_master_key.hpp"
+#include "model/commands/create_account.hpp"
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/remove_signatory.hpp"
+#include "model/commands/set_permissions.hpp"
+#include "model/commands/set_quorum.hpp"
+#include "model/commands/transfer_asset.hpp"
+
+TEST(TransactionTest, tx_test) {
+  auto orig_tx = iroha::model::Transaction();
+  orig_tx.creator_account_id = "andr@kek";
+  auto siga = iroha::model::Signature();
+  std::fill(siga.pubkey.begin(), siga.pubkey.end(), 0x22);
+  std::fill(siga.signature.begin(), siga.signature.end(), 0x10);
+  orig_tx.signatures = {siga};
+
+  orig_tx.created_ts = 2;
+  orig_tx.tx_counter = 1;
+
+  auto c1 = iroha::model::CreateDomain();
+  c1.domain_name = "keker";
+  auto c2 = iroha::model::CreateAsset();
+  c2.domain_id = "keker";
+  c2.precision = 2;
+  c2.asset_name = "fedor-coin";
+
+  auto c3 = iroha::model::SetAccountPermissions();
+  c3.account_id = "fedor";
+  c3.new_permissions.can_transfer = true;
+  c3.new_permissions.create_assets = true;
+
+  orig_tx.commands = {
+      std::make_shared<iroha::model::CreateDomain>(c1),
+      std::make_shared<iroha::model::CreateAsset>(c2),
+      std::make_shared<iroha::model::SetAccountPermissions>(c3)};
+
+  auto factory = iroha::model::converters::PbTransactionFactory();
+  auto proto_tx = factory.serialize(orig_tx);
+  auto serial_tx = factory.deserialize(proto_tx);
+  ASSERT_EQ(orig_tx, serial_tx);
+}

--- a/test/module/irohad/model/operators/model_operators_test.cpp
+++ b/test/module/irohad/model/operators/model_operators_test.cpp
@@ -1,0 +1,337 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <model/model_hash_provider_impl.hpp>
+#include "model/block.hpp"
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/add_peer.hpp"
+#include "model/commands/add_signatory.hpp"
+#include "model/commands/assign_master_key.hpp"
+#include "model/commands/create_account.hpp"
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/remove_signatory.hpp"
+#include "model/commands/set_permissions.hpp"
+#include "model/commands/set_quorum.hpp"
+#include "model/commands/transfer_asset.hpp"
+#include "model/transaction.hpp"
+
+using namespace iroha::model;
+
+// -----|AddPeer|-----
+
+AddPeer createAddPeer() {
+  AddPeer addPeer;
+  addPeer.address = "localhost";
+  std::fill(addPeer.peer_key.begin(), addPeer.peer_key.end(), 0x1);
+  return addPeer;
+}
+
+TEST(ModelOperatorTest, AddPeerTest) {
+  AddPeer first = createAddPeer();
+  AddPeer second = createAddPeer();
+  ASSERT_EQ(first, second);
+  second.address = "127.0.0.1";
+  ASSERT_NE(first, second);
+}
+
+// -----|AddAssetQuantity|-----
+
+AddAssetQuantity createAddAssetQuantity() {
+  AddAssetQuantity aaq;
+  aaq.account_id = "123";
+  aaq.amount.int_part = 10;
+  aaq.amount.frac_part = 10;
+  aaq.asset_id = "123";
+  return aaq;
+}
+
+TEST(ModelOperatorTest, AddAssetQuantityTest) {
+  auto first = createAddAssetQuantity();
+  auto second = createAddAssetQuantity();
+
+  ASSERT_EQ(first, second);
+  second.asset_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|AddSignatory|-----
+
+AddSignatory createAddSignatory() {
+  AddSignatory add_signatory;
+  add_signatory.account_id = "123";
+  std::fill(add_signatory.pubkey.begin(), add_signatory.pubkey.end(), 0x23);
+  return add_signatory;
+}
+
+TEST(ModelOperatorTest, AddSignatoryTest) {
+  auto first = createAddSignatory();
+  auto second = createAddSignatory();
+
+  ASSERT_EQ(first, second);
+  second.account_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|AssignMasterKey|-----
+
+AssignMasterKey createAssignMasterKey() {
+  AssignMasterKey assignMasterKey;
+  assignMasterKey.account_id = "123";
+  std::fill(assignMasterKey.pubkey.begin(), assignMasterKey.pubkey.end(), 0x23);
+  return assignMasterKey;
+}
+
+TEST(ModelOperatorTest, AssignMasterKeyTest) {
+  auto first = createAssignMasterKey();
+  auto second = createAssignMasterKey();
+
+  ASSERT_EQ(first, second);
+  second.account_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|CreateAccount|-----
+
+CreateAccount createCreateAccount() {
+  CreateAccount createAccount;
+  createAccount.domain_id = "123";
+  createAccount.account_name = "kek";
+  std::fill(createAccount.pubkey.begin(), createAccount.pubkey.end(), 0x23);
+  return createAccount;
+}
+
+TEST(ModelOperatorTest, CreateAccountTest) {
+  auto first = createCreateAccount();
+  auto second = createCreateAccount();
+
+  ASSERT_EQ(first, second);
+  second.account_name = "cheburek";
+  ASSERT_NE(first, second);
+}
+
+// -----|CreateAsset|-----
+
+CreateAsset createCreateAsset() {
+  CreateAsset createAsset;
+  createAsset.domain_id = "localhost";
+  createAsset.asset_name = "rub";
+  createAsset.precision = 2;
+  return createAsset;
+}
+
+TEST(ModelOperatorTest, CreateAssetTest) {
+  auto first = createCreateAsset();
+  auto second = createCreateAsset();
+
+  ASSERT_EQ(first, second);
+  second.asset_name = "usd";
+  ASSERT_NE(first, second);
+}
+
+// -----|CreateDomain|-----
+
+CreateDomain createCreateDomain() {
+  CreateDomain createDomain;
+  createDomain.domain_name = "rus";
+  return createDomain;
+}
+
+TEST(ModelOperatorTest, CreateDomainTest) {
+  auto first = createCreateDomain();
+  auto second = createCreateDomain();
+
+  ASSERT_EQ(first, second);
+  second.domain_name = "jp";
+  ASSERT_NE(first, second);
+}
+
+// -----|RemoveSignatory|-----
+
+RemoveSignatory createRemoveSignatory() {
+  RemoveSignatory removeSignatory;
+  removeSignatory.account_id = "123";
+  std::fill(removeSignatory.pubkey.begin(), removeSignatory.pubkey.end(), 0x23);
+  return removeSignatory;
+}
+
+TEST(ModelOperatorTest, RemoveSignatoryTest) {
+  auto first = createRemoveSignatory();
+  auto second = createRemoveSignatory();
+
+  ASSERT_EQ(first, second);
+  second.account_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|SetAccountPermissions|-----
+
+SetAccountPermissions createSetAccountPermissions() {
+  SetAccountPermissions setAccountPermissions;
+  setAccountPermissions.account_id = "123";
+  setAccountPermissions.new_permissions.set_quorum = true;
+  return setAccountPermissions;
+}
+
+TEST(ModelOperatorTest, SetAccountPermissionsTest) {
+  auto first = createSetAccountPermissions();
+  auto second = createSetAccountPermissions();
+  ASSERT_EQ(first, second);
+  second.account_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|SetQuorum|-----
+
+SetQuorum createSetQuorum() {
+  SetQuorum setQuorum;
+  setQuorum.account_id = "123";
+  setQuorum.new_quorum = 23;
+  return setQuorum;
+}
+
+TEST(ModelOperatorTest, SetQuorumTest) {
+  auto first = createSetQuorum();
+  auto second = createSetQuorum();
+
+  ASSERT_EQ(first, second);
+  second.account_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|TransferAsset|-----
+
+TransferAsset createTransferAsset() {
+  TransferAsset transferAsset;
+  transferAsset.asset_id = "123";
+  transferAsset.amount.int_part = 10;
+  transferAsset.amount.frac_part = 10;
+  transferAsset.src_account_id = "1";
+  transferAsset.dest_account_id = "2";
+  return transferAsset;
+}
+
+TEST(ModelOperatorTest, TransferAssetTest) {
+  auto first = createTransferAsset();
+  auto second = createTransferAsset();
+
+  ASSERT_EQ(first, second);
+  second.asset_id = "22";
+  ASSERT_NE(first, second);
+}
+
+// -----|Amount|-----
+
+TEST(ModelOperatorTest, AmountTest) {
+  iroha::Amount amount1;
+  amount1.int_part = 10;
+  amount1.frac_part = 10;
+
+  iroha::Amount amount2;
+  amount2.int_part = 10;
+  amount2.frac_part = 10;
+
+  ASSERT_EQ(amount1, amount2);
+  amount2.frac_part = 11;
+  ASSERT_NE(amount1, amount2);
+}
+
+// -----|Signature|-----
+
+Signature createSignature() {
+  Signature sig{};
+  std::fill(sig.pubkey.begin(), sig.pubkey.end(), 0x1);
+  std::fill(sig.signature.begin(), sig.signature.end(), 0x1);
+  return sig;
+}
+
+TEST(ModelOperatorTest, SignatureTest) {
+  auto sig1 = createSignature();
+  auto sig2 = createSignature();
+
+  ASSERT_EQ(sig1, sig2);
+  sig1.signature[0] = 0x23;
+  ASSERT_NE(sig1, sig2);
+}
+
+// -----|Transaction|-----
+
+Transaction createTransaction() {
+  Transaction transaction;
+  transaction.created_ts = 1;
+  transaction.creator_account_id = "132";
+  transaction.tx_counter = 5;
+  transaction.signatures.push_back(createSignature());
+
+  // commands
+  transaction.commands.push_back(
+      std::make_shared<AddAssetQuantity>(createAddAssetQuantity()));
+  transaction.commands.push_back(std::make_shared<AddPeer>(createAddPeer()));
+  transaction.commands.push_back(
+      std::make_shared<AddSignatory>(createAddSignatory()));
+  transaction.commands.push_back(
+      std::make_shared<AssignMasterKey>(createAssignMasterKey()));
+  transaction.commands.push_back(
+      std::make_shared<CreateAccount>(createCreateAccount()));
+  transaction.commands.push_back(
+      std::make_shared<CreateAsset>(createCreateAsset()));
+  transaction.commands.push_back(
+      std::make_shared<CreateDomain>(createCreateDomain()));
+  transaction.commands.push_back(
+      std::make_shared<RemoveSignatory>(createRemoveSignatory()));
+  transaction.commands.push_back(
+      std::make_shared<SetAccountPermissions>(createSetAccountPermissions()));
+  transaction.commands.push_back(
+      std::make_shared<TransferAsset>(createTransferAsset()));
+  return transaction;
+}
+
+TEST(ModelOperatorTest, TransactionTest) {
+  auto tx1 = createTransaction();
+  auto tx2 = createTransaction();
+
+  ASSERT_EQ(tx1, tx2);
+  tx1.signatures.push_back(createSignature());
+  ASSERT_NE(tx1, tx2);
+}
+
+// -----|Block|-----
+
+Block createBlock(){
+  Block block;
+  block.created_ts = 1;
+  block.txs_number = 2;
+  std::fill(block.prev_hash.begin(), block.prev_hash.end(), 0x23);
+  std::fill(block.merkle_root.begin(), block.merkle_root.end(), 0x23);
+  block.sigs.push_back(createSignature());
+  block.transactions.push_back(createTransaction());
+  block.height = 123;
+
+  HashProviderImpl hashProvider;
+  block.hash = hashProvider.get_hash(block);
+  return block;
+}
+
+TEST(ModelOperatorTest, BlockTest) {
+  auto first = createBlock();
+  auto second = createBlock();
+
+  ASSERT_EQ(first, second);
+  second.height += 1;
+  ASSERT_NE(first, second);
+}


### PR DESCRIPTION
## What is this pull request?
Providing converters for model and protobuf objects
   
## Why do you implement it? Why do we need this pull request?
Pb use in transport layer for support it we should convert business object to pb and vice versa.
  
## How to use the features provided in the pull request?
`C++
auto factory = iroha::model::converters::PbBlockFactory();
 auto proto_block = factory.serialize(model_block);
 auto serial_block = factory.deserialize(proto_block);
`
More usages see in tests: `test/irohad/model/converters/*`

## Details/Features
- Supported converters for blocks and transactions. 
- Written tests for it. Looks them for getting example.
