### PR TITLE
Hotfix/torii test

### DIFF
--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -37,9 +37,11 @@ namespace torii {
     /**
      * requests tx to a torii server and returns response (blocking, sync)
      * @param tx
-     * @return ToriiResponse
+     * @param response - returns ToriiResponse if succeeded
+     * @return grpc::Status - returns connection is success or not.
      */
-    iroha::protocol::ToriiResponse Torii(const iroha::protocol::Transaction& tx);
+    grpc::Status Torii(const iroha::protocol::Transaction& tx,
+                       iroha::protocol::ToriiResponse& response);
 
   private:
     grpc::ClientContext context_;
@@ -68,9 +70,9 @@ namespace torii {
      * Async Torii rpc
      * @param tx
      * @param callback
+     * @return grpc::Status
      */
-    void Torii(const iroha::protocol::Transaction& tx,
-               const Callback& callback);
+    grpc::Status Torii(const iroha::protocol::Transaction& tx, const Callback& callback);
 
   private:
     /**

--- a/irohad/torii/query_service.hpp
+++ b/irohad/torii/query_service.hpp
@@ -32,13 +32,11 @@ namespace torii {
      * actual implementation of async Find in QueryService
      * @param request - Query
      * @param response - QueryResponse
-     * @return grpc::Status - Status::OK if succeeded. TODO(motxx): grpc::CANCELLED is not supported.
      */
-    static grpc::Status FindAsync(
+    static void FindAsync(
       iroha::protocol::Query const& request, iroha::protocol::QueryResponse& response) {
       response.set_code(iroha::protocol::ResponseCode::OK);
       response.set_message("Find async response");
-      return grpc::Status::OK;
     }
   };
 

--- a/irohad/torii/torii_service_handler.cpp
+++ b/irohad/torii/torii_service_handler.cpp
@@ -98,7 +98,7 @@ namespace torii {
     CommandServiceCall<prot::Transaction, prot::ToriiResponse>* call) {
 
     CommandService::ToriiAsync(call->request(), call->response());
-    call->sendResponse(grpc::Status::OK); // TODO(motxx) currently, grpc::Status::CANCELLED is not supported.
+    call->sendResponse(grpc::Status::OK);
 
     // Spawn a new Call instance to serve an another client.
     enqueueRequest<prot::CommandService::AsyncService, prot::Transaction, prot::ToriiResponse>(
@@ -111,8 +111,9 @@ namespace torii {
   void ToriiServiceHandler::QueryFindHandler(
     QueryServiceCall<
       iroha::protocol::Query, iroha::protocol::QueryResponse>* call) {
-    auto stat = QueryService::FindAsync(call->request(), call->response());
-    call->sendResponse(stat);
+
+    QueryService::FindAsync(call->request(), call->response());
+    call->sendResponse(grpc::Status::OK);
 
     // Spawn a new Call instance to serve an another client.
     enqueueRequest<prot::QueryService::AsyncService, prot::Query, prot::QueryResponse>(

--- a/libs/torii_utils/query_client.cpp
+++ b/libs/torii_utils/query_client.cpp
@@ -19,9 +19,7 @@ limitations under the License.
 #include <thread>
 
 namespace torii_utils {
-
-  const char* FailureMessage = "RPC failed";
-
+  
   using iroha::protocol::Query;
   using iroha::protocol::QueryResponse;
 
@@ -35,12 +33,12 @@ namespace torii_utils {
   }
 
   /**
-   * requests tx to a torii server and returns response (blocking, sync)
-   * @param tx
-   * @return ToriiResponse
+   * requests query to a torii server and returns response (blocking, sync)
+   * @param query
+   * @param response
+   * @return grpc::Status
    */
-  QueryResponse QuerySyncClient::Find(const iroha::protocol::Query &query) {
-    QueryResponse response;
+  grpc::Status QuerySyncClient::Find(const iroha::protocol::Query &query, QueryResponse &response) {
 
     std::unique_ptr<grpc::ClientAsyncResponseReader<iroha::protocol::QueryResponse>> rpc(
       stub_->AsyncFind(&context_, query, &completionQueue_)
@@ -63,13 +61,7 @@ namespace torii_utils {
     assert(got_tag == (void *)static_cast<int>(State::ResponseSent));
     assert(ok);
 
-    if (status_.ok()) {
-      return response;
-    }
-
-    response.set_code(iroha::protocol::ResponseCode::FAIL);
-    response.set_message(FailureMessage);
-    return response;
+    return status_;
   }
 
 }  // namespace torii

--- a/libs/torii_utils/query_client.hpp
+++ b/libs/torii_utils/query_client.hpp
@@ -26,8 +26,6 @@ limitations under the License.
 
 namespace torii_utils {
 
-  extern const char* FailureMessage;
-
   /**
    * CommandSyncClient
    */
@@ -38,10 +36,11 @@ namespace torii_utils {
 
     /**
      * requests query to a torii server and returns response (blocking, sync)
-     * @param query
-     * @return QueryResponse
+     * @param query - contains Query what clients request.
+     * @param response - QueryResponse that contains what clients want to get.
+     * @return grpc::Status
      */
-    iroha::protocol::QueryResponse Find(const iroha::protocol::Query& query);
+    grpc::Status Find(const iroha::protocol::Query &query, iroha::protocol::QueryResponse &response);
 
   private:
     grpc::ClientContext context_;


### PR DESCRIPTION
## What is this pull request?
Make Torii test more appropriate.

## Why do you implement it? Why do we need this pull request?
Torii test should check `grpc::Status`, not depending on scheme response.

## Details/Features
List of features / major commits
- `FindAsync()` returns void.
- Torii clients returns `grpc::Status` and responses.