### PR TITLE
Remove redundant capture

### DIFF
--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -38,7 +38,7 @@ class ToriiServiceTest : public testing::Test {
  public:
   virtual void SetUp() {
     runner = new ServerRunner(Ip, Port);
-    th = std::thread([ this, runner = runner ] {
+    th = std::thread([this] {
       // ----------- Command Service --------------
 
       auto tx_processor =

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -48,7 +48,7 @@ class ToriiServiceTest : public testing::Test {
  public:
   virtual void SetUp() {
     runner = new ServerRunner(Ip, Port);
-    th = std::thread([this, runner = runner] {
+    th = std::thread([this] {
       // ----------- Command Service --------------
 
       auto tx_processor =


### PR DESCRIPTION
## What is this pull request?
Small refactor torii test.

## Why do you implement it? Why do we need this pull request?
To remove redundant capture.
`[this, runner = runner]` -> `[this]`