### PR TITLE
Refactor simulator and synchronizer interface

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -193,15 +193,9 @@ std::shared_ptr<Simulator> Irohad::createSimulator(
     std::shared_ptr<BlockQuery> block_query,
     std::shared_ptr<TemporaryFactory> temporary_factory,
     std::shared_ptr<HashProviderImpl> hash_provider) {
-  auto simulator = std::make_shared<Simulator>(
-      stateful_validator, temporary_factory, block_query, hash_provider);
-
-  ordering_gate->on_proposal().subscribe(
-      [simulator](auto proposal) {
-        simulator->process_proposal(proposal);
-      });
-
-  return simulator;
+  return std::make_shared<Simulator>(ordering_gate, stateful_validator,
+                                     temporary_factory, block_query,
+                                     hash_provider);
 }
 
 std::shared_ptr<PeerCommunicationService>
@@ -217,14 +211,8 @@ std::shared_ptr<Synchronizer> Irohad::createSynchronizer(
     std::shared_ptr<ChainValidator> validator,
     std::shared_ptr<MutableFactory> mutableFactory,
     std::shared_ptr<BlockLoader> blockLoader) {
-  auto synchronizer = std::make_shared<SynchronizerImpl>(
-      std::move(validator), mutableFactory, blockLoader);
-
-  consensus_gate->on_commit().subscribe([synchronizer](auto block) {
-    synchronizer->process_commit(block);
-  });
-
-  return synchronizer;
+  return std::make_shared<SynchronizerImpl>(consensus_gate, validator,
+                                            mutableFactory, blockLoader);
 }
 
 std::unique_ptr<::torii::CommandService> Irohad::createCommandService(

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -40,7 +40,7 @@ namespace iroha {
        * Note: committed block may be not satisfy for top block in ledger
        * because synchronization reasons
        */
-      virtual rxcpp::observable <model::Block> on_commit() = 0;
+      virtual rxcpp::observable<model::Block> on_commit() = 0;
 
       virtual ~ConsensusGate() = default;
     };

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -21,6 +21,7 @@ namespace iroha {
   namespace simulator {
 
     Simulator::Simulator(
+        std::shared_ptr<network::OrderingGate> ordering_gate,
         std::shared_ptr<validation::StatefulValidator> statefulValidator,
         std::shared_ptr<ametsuchi::TemporaryFactory> factory,
         std::shared_ptr<ametsuchi::BlockQuery> blockQuery,
@@ -30,6 +31,9 @@ namespace iroha {
           block_queries_(std::move(blockQuery)),
           hash_provider_(std::move(hash_provider)) {
       log_ = logger::log("Simulator");
+      ordering_gate->on_proposal().subscribe(
+          [this](auto proposal) { this->process_proposal(proposal); });
+
       notifier_.get_observable().subscribe([this](auto verified_proposal) {
         this->process_verified_proposal(verified_proposal);
       });

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -21,6 +21,7 @@
 #include "ametsuchi/block_query.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "model/model_hash_provider_impl.hpp"
+#include "network/ordering_gate.hpp"
 #include "simulator/block_creator.hpp"
 #include "simulator/verified_proposal_creator.hpp"
 #include "validation/stateful_validator.hpp"
@@ -33,6 +34,7 @@ namespace iroha {
     class Simulator : public VerifiedProposalCreator, public BlockCreator {
      public:
       Simulator(
+          std::shared_ptr<network::OrderingGate> ordering_gate,
           std::shared_ptr<validation::StatefulValidator> statefulValidator,
           std::shared_ptr<ametsuchi::TemporaryFactory> factory,
           std::shared_ptr<ametsuchi::BlockQuery> blockQuery,

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -23,6 +23,7 @@ namespace iroha {
   namespace synchronizer {
 
     SynchronizerImpl::SynchronizerImpl(
+        std::shared_ptr<network::ConsensusGate> consensus_gate,
         std::shared_ptr<validation::ChainValidator> validator,
         std::shared_ptr<ametsuchi::MutableFactory> mutableFactory,
         std::shared_ptr<network::BlockLoader> blockLoader)
@@ -30,6 +31,9 @@ namespace iroha {
           mutableFactory_(std::move(mutableFactory)),
           blockLoader_(std::move(blockLoader)) {
       log_ = logger::log("synchronizer");
+      consensus_gate->on_commit().subscribe([this](auto block) {
+        this->process_commit(block);
+      });
     }
 
     void SynchronizerImpl::process_commit(iroha::model::Block commit_message) {

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -19,6 +19,7 @@
 
 #include "ametsuchi/mutable_factory.hpp"
 #include "network/block_loader.hpp"
+#include "network/consensus_gate.hpp"
 #include "synchronizer/synchronizer.hpp"
 #include "validation/chain_validator.hpp"
 
@@ -28,9 +29,11 @@ namespace iroha {
   namespace synchronizer {
     class SynchronizerImpl : public Synchronizer {
      public:
-      SynchronizerImpl(std::shared_ptr<validation::ChainValidator> validator,
-                       std::shared_ptr<ametsuchi::MutableFactory> mutableFactory,
-                       std::shared_ptr<network::BlockLoader> blockLoader);
+      SynchronizerImpl(
+          std::shared_ptr<network::ConsensusGate> consensus_gate,
+          std::shared_ptr<validation::ChainValidator> validator,
+          std::shared_ptr<ametsuchi::MutableFactory> mutableFactory,
+          std::shared_ptr<network::BlockLoader> blockLoader);
 
       void process_commit(iroha::model::Block commit_message) override;
 

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -20,8 +20,9 @@
 
 #include <gmock/gmock.h>
 #include "network/block_loader.hpp"
-#include "network/peer_communication_service.hpp"
+#include "network/consensus_gate.hpp"
 #include "network/ordering_gate.hpp"
+#include "network/peer_communication_service.hpp"
 
 namespace iroha {
   namespace network {
@@ -48,6 +49,13 @@ namespace iroha {
                    void(std::shared_ptr<const model::Transaction> transaction));
 
       MOCK_METHOD0(on_proposal, rxcpp::observable<model::Proposal>());
+    };
+
+    class MockConsensusGate : public ConsensusGate {
+     public:
+      MOCK_METHOD1(vote, void(model::Block));
+
+      MOCK_METHOD0(on_commit, rxcpp::observable<model::Block>());
     };
   }  // namespace network
 }  // namespace iroha

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -58,6 +58,7 @@ class SimulatorTest : public ::testing::Test {
 };
 
 TEST_F(SimulatorTest, ValidWhenInitialized) {
+  // simulator constructor => on_proposal subscription called
   EXPECT_CALL(*ordering_gate, on_proposal())
       .WillOnce(Return(rxcpp::observable<>::empty<Proposal>()));
 
@@ -65,6 +66,7 @@ TEST_F(SimulatorTest, ValidWhenInitialized) {
 }
 
 TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
+  // proposal with height 2 => height 1 block present => new block generated
   auto txs = std::vector<model::Transaction>(2);
   auto proposal = model::Proposal(txs);
   proposal.height = 2;
@@ -104,6 +106,7 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
 }
 
 TEST_F(SimulatorTest, FailWhenNoBlock) {
+  // height 2 proposal => height 1 block not present => no validated proposal
   auto txs = std::vector<model::Transaction>(2);
   auto proposal = model::Proposal(txs);
   proposal.height = 2;
@@ -134,6 +137,7 @@ TEST_F(SimulatorTest, FailWhenNoBlock) {
 }
 
 TEST_F(SimulatorTest, FailWhenSameAsProposalHeight) {
+  // proposal with height 2 => height 2 block present => no validated proposal
   auto txs = std::vector<model::Transaction>(2);
   auto proposal = model::Proposal(txs);
   proposal.height = 2;

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -58,6 +58,7 @@ class SynchronizerTest : public ::testing::Test {
 };
 
 TEST_F(SynchronizerTest, ValidWhenInitialized) {
+  // synchronizer constructor => on_commit subscription called
   EXPECT_CALL(*consensus_gate, on_commit())
       .WillOnce(Return(rxcpp::observable<>::empty<Block>()));
 
@@ -65,6 +66,7 @@ TEST_F(SynchronizerTest, ValidWhenInitialized) {
 }
 
 TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
+  // commit from consensus => chain validation passed => commit successful
   Block test_block;
   test_block.height = 5;
 
@@ -101,6 +103,7 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
 }
 
 TEST_F(SynchronizerTest, ValidWhenBadStorage) {
+  // commit from consensus => storage not created => no commit
   Block test_block;
 
   DefaultValue<std::unique_ptr<MutableStorage>>::Clear();
@@ -127,6 +130,7 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
 }
 
 TEST_F(SynchronizerTest, ValidWhenBlockValidationFailure) {
+  // commit from consensus => chain validation failed => commit successful
   Block test_block;
   test_block.height = 5;
   test_block.sigs.emplace_back();


### PR DESCRIPTION
## What is this pull request?
Change `Simulator` and `Synchronizer` interface for explicit subscription to `OrderingGate` and `ConsensusGate`
   
## Why do you implement it? Why do we need this pull request?
Explicit dependency in constructor makes the usage less error prone
  
## How to use the features provided in the pull request?
`shared_ptr`s to `OrderingGate` and `ConsensusGate` should be passed to constructors of `Simulator` and `Synchronizer`

## Details/Features
- Subscription to ordering and consensus gates is in constructors
- Add fixture to synchronizer test
- Add mock consensus gate