### PR TITLE
remove setTxCounter and setCreatorAccountId from Transaction

### DIFF
--- a/irohad/model/transaction.hpp
+++ b/irohad/model/transaction.hpp
@@ -33,15 +33,6 @@ namespace iroha {
      * Transaction can be divided to {Header, Meta, Body}.
      */
     struct Transaction {
-      Transaction& setTxCounter(uint64_t tx_counter) {
-        this->tx_counter = tx_counter;
-        return *this;
-      }
-
-      Transaction& setCreatorAccountId(std::string creator_account_id) {
-        this->creator_account_id = creator_account_id;
-        return *this;
-      }
       /**
        * List of signatories that sign transaction
        * HEADER field

--- a/test/module/irohad/model/converters/pb_query_responses_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_responses_test.cpp
@@ -125,9 +125,15 @@ TEST(QueryResponseTest, TransactionsResponseTest) {
   model::TransactionsResponse txs_response{};
 
   txs_response.transactions =
-      rxcpp::observable<>::from(model::Transaction().setTxCounter(0),
-                                model::Transaction().setTxCounter(1),
-                                model::Transaction().setTxCounter(2));
+          rxcpp::observable<>::iterate([] {
+              std::vector<model::Transaction> result;
+              for (size_t i = 0; i < 3; ++i) {
+                model::Transaction current;
+                current.tx_counter = i;
+                result.push_back(current);
+              }
+              return result;
+          }());
 
   auto shrd_tr = std::make_shared<decltype(txs_response)>(txs_response);
   auto query_response = *pb_factory.serialize(shrd_tr);

--- a/test/module/irohad/model/converters/pb_query_responses_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_responses_test.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <responses.pb.h>
 #include "model/converters/pb_query_response_factory.hpp"
 
 using namespace iroha;

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -372,13 +372,17 @@ TEST_F(ToriiServiceTest, FindTransactionsWhenValid) {
   iroha::model::Account account;
   account.account_id = "accountA";
 
-  auto txs_observable = rxcpp::observable<>::from(
-      iroha::model::Transaction().setTxCounter(0).setCreatorAccountId(
-          account.account_id),
-      iroha::model::Transaction().setTxCounter(1).setCreatorAccountId(
-          account.account_id),
-      iroha::model::Transaction().setTxCounter(2).setCreatorAccountId(
-          account.account_id));
+  auto txs_observable  =
+          rxcpp::observable<>::iterate([account] {
+              std::vector<iroha::model::Transaction> result;
+              for (size_t i = 0; i < 3; ++i) {
+                iroha::model::Transaction current;
+                current.creator_account_id = account.account_id;
+                current.tx_counter = i;
+                result.push_back(current);
+              }
+              return result;
+          }());
 
   EXPECT_CALL(*wsv_query, getAccount(_)).WillOnce(Return(account));
   EXPECT_CALL(*block_query, getAccountTransactions(account.account_id))


### PR DESCRIPTION
This pull request removes redundant methods (setTxCounter and setCreatorAccountId) and removes their references from tests.