### PR TITLE
Hotfix/missing on completed

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -226,6 +226,7 @@ namespace iroha {
                 s.on_completed();
               }
               s.on_next(block.value());
+              s.on_completed();
             });
       });
     }

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -57,7 +57,7 @@ namespace framework {
 
       /**
        * Handler which is called after target subscriber call
-       * @param ep
+       * @param ep - pointer to exception thrown in observable
        */
       virtual void on_error(std::exception_ptr ep) {}
 
@@ -125,14 +125,12 @@ namespace framework {
               // invoke subscriber
               error(ep);
 
-              // verify
               this->strategy_->on_error(ep);
             },
             [this, completed]() {
               // invoke subscriber
               completed();
 
-              // verify
               this->strategy_->on_completed();
             });
 
@@ -217,7 +215,7 @@ namespace framework {
 
     /**
      * Checks that on_completed was called by observable
-     * @tparam T
+     * @tparam T - observable parameter
      */
     template <typename T>
     class IsCompleted : public VerificationStrategy<T> {

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -105,11 +105,6 @@ namespace iroha {
                           const auto &top_hash) { return true; });
       storage->commit(std::move(ms));
 
-      auto times_wrapper =
-          make_test_subscriber<CallExact>(storage->getBlocks(1, 1), 1);
-      times_wrapper.subscribe();
-      ASSERT_TRUE(times_wrapper.validate());
-
       auto completed_wrapper =
           make_test_subscriber<IsCompleted>(storage->getBlocks(1, 1));
       completed_wrapper.subscribe();

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -28,6 +28,10 @@
 #include "model/commands/transfer_asset.hpp"
 #include "model/model_hash_provider_impl.hpp"
 #include "ametsuchi_test_common.hpp"
+#include "framework/test_subscriber.hpp"
+
+using namespace iroha::model;
+using namespace framework::test_subscriber;
 
 namespace iroha {
   namespace ametsuchi {
@@ -86,6 +90,31 @@ namespace iroha {
 
       std::string block_store_path = "/tmp/block_store";
     };
+
+    TEST_F(AmetsuchiTest, GetBlocksCompletedWhenCalled) {
+      // Commit block => get block => observable completed
+      auto storage =
+          StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+      ASSERT_TRUE(storage);
+
+      model::Block block;
+      block.height = 1;
+
+      auto ms = storage->createMutableStorage();
+      ms->apply(block, [](const auto &blk, auto &executor, auto &query,
+                          const auto &top_hash) { return true; });
+      storage->commit(std::move(ms));
+
+      auto times_wrapper =
+          make_test_subscriber<CallExact>(storage->getBlocks(1, 1), 1);
+      times_wrapper.subscribe();
+      ASSERT_TRUE(times_wrapper.validate());
+
+      auto completed_wrapper =
+          make_test_subscriber<IsCompleted>(storage->getBlocks(1, 1));
+      completed_wrapper.subscribe();
+      ASSERT_TRUE(completed_wrapper.validate());
+    }
 
     TEST_F(AmetsuchiTest, SampleTest) {
       model::HashProviderImpl hashProvider;


### PR DESCRIPTION
## What is this pull request?
`on_completed()` call was missing in `StorageImpl::getBlocks()`, causing execution to hang in `Simulator::process_proposal` method

To avoid such errors, a new `TestSubscriber` `ValidationStrategy` is added: `IsCompleted`, which checks that `on_completed()` was called in observable
   
## Details/Features
List of features / major commits
- Add test for `BlockQuery::getBlocks()`
- Add `IsCompleted` `ValidationStrategy` for `TestSubscriber`