### PR TITLE
[WIP] IR279 - Add convenient initializers for blob_t

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -93,8 +93,7 @@ namespace iroha {
       std::vector<ed25519::pubkey_t> signatories;
       for (const auto &row : result) {
         pqxx::binarystring public_key_str(row.at("public_key"));
-        ed25519::pubkey_t pubkey =
-            std::string{public_key_str.begin(), public_key_str.end()};
+        ed25519::pubkey_t pubkey = public_key_str.str();
         signatories.push_back(pubkey);
       }
       return signatories;
@@ -174,7 +173,7 @@ namespace iroha {
       for (const auto &row : result) {
         model::Peer peer;
         pqxx::binarystring public_key_str(row.at("public_key"));
-        ed25519::pubkey_t pubkey = std::string{public_key_str.begin(), public_key_str.end()};
+        ed25519::pubkey_t pubkey = public_key_str.str();
         peer.pubkey = pubkey;
         row.at("address") >> peer.address;
         peers.push_back(peer);

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -55,7 +55,7 @@ namespace iroha {
       row.at("account_id") >> account.account_id;
       row.at("domain_id") >> account.domain_name;
       pqxx::binarystring master_key(row.at("master_key"));
-      account.master_key = std::string{master_key.begin(), master_key.end()};
+      account.master_key = master_key.str();
       row.at("quorum") >> account.quorum;
       //      row.at("status") >> ?
       //      row.at("transaction_count") >> ?

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -55,8 +55,7 @@ namespace iroha {
       row.at("account_id") >> account.account_id;
       row.at("domain_id") >> account.domain_name;
       pqxx::binarystring master_key(row.at("master_key"));
-      std::copy(master_key.begin(), master_key.end(),
-                account.master_key.begin());
+      account.master_key = std::string{master_key.begin(), master_key.end()};
       row.at("quorum") >> account.quorum;
       //      row.at("status") >> ?
       //      row.at("transaction_count") >> ?
@@ -94,8 +93,8 @@ namespace iroha {
       std::vector<ed25519::pubkey_t> signatories;
       for (const auto &row : result) {
         pqxx::binarystring public_key_str(row.at("public_key"));
-        ed25519::pubkey_t pubkey;
-        std::copy(public_key_str.begin(), public_key_str.end(), pubkey.begin());
+        ed25519::pubkey_t pubkey =
+            std::string{public_key_str.begin(), public_key_str.end()};
         signatories.push_back(pubkey);
       }
       return signatories;
@@ -175,8 +174,7 @@ namespace iroha {
       for (const auto &row : result) {
         model::Peer peer;
         pqxx::binarystring public_key_str(row.at("public_key"));
-        ed25519::pubkey_t pubkey;
-        std::copy(public_key_str.begin(), public_key_str.end(), pubkey.begin());
+        ed25519::pubkey_t pubkey = std::string{public_key_str.begin(), public_key_str.end()};
         peer.pubkey = pubkey;
         row.at("address") >> peer.address;
         peers.push_back(peer);

--- a/irohad/consensus/yac/impl/network_impl.cpp
+++ b/irohad/consensus/yac/impl/network_impl.cpp
@@ -123,13 +123,8 @@ namespace iroha {
         VoteMessage vote;
         vote.hash.proposal_hash = request->hash().proposal();
         vote.hash.block_hash = request->hash().block();
-        std::copy(request->signature().signature().begin(),
-                  request->signature().signature().end(),
-                  vote.signature.signature.begin());
-        std::copy(request->signature().pubkey().begin(),
-                  request->signature().pubkey().end(),
-                  vote.signature.pubkey.begin());
-
+        vote.signature.signature = request->signature().signature();
+        vote.signature.pubkey = request->signature().pubkey();
         handler_.lock()->on_vote(peer, vote);
         return grpc::Status::OK;
       }
@@ -150,12 +145,8 @@ namespace iroha {
           VoteMessage vote;
           vote.hash.proposal_hash = pb_vote.hash().proposal();
           vote.hash.block_hash = pb_vote.hash().block();
-          std::copy(pb_vote.signature().signature().begin(),
-                    pb_vote.signature().signature().end(),
-                    vote.signature.signature.begin());
-          std::copy(pb_vote.signature().pubkey().begin(),
-                    pb_vote.signature().pubkey().end(),
-                    vote.signature.pubkey.begin());
+          vote.signature.signature = pb_vote.signature().signature();
+          vote.signature.pubkey = pb_vote.signature().pubkey();
           commit.votes.push_back(vote);
         }
 
@@ -179,12 +170,8 @@ namespace iroha {
           VoteMessage vote;
           vote.hash.proposal_hash = pb_vote.hash().proposal();
           vote.hash.block_hash = pb_vote.hash().block();
-          std::copy(pb_vote.signature().signature().begin(),
-                    pb_vote.signature().signature().end(),
-                    vote.signature.signature.begin());
-          std::copy(pb_vote.signature().pubkey().begin(),
-                    pb_vote.signature().pubkey().end(),
-                    vote.signature.pubkey.begin());
+          vote.signature.signature = pb_vote.signature().signature();
+          vote.signature.pubkey = pb_vote.signature().pubkey();
           reject.votes.push_back(vote);
         }
 

--- a/irohad/consensus/yac/impl/yac_hash_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_hash_provider_impl.cpp
@@ -25,14 +25,8 @@ namespace iroha {
       YacHash YacHashProviderImpl::makeHash(model::Block &block) {
         YacHash hash;
         // todo add proposal hash from block.proposal_hash
-        hash.proposal_hash = std::string(block.hash.size(), 0);
-        std::copy(block.hash.begin(),
-                  block.hash.end(),
-                  hash.proposal_hash.begin());
-        hash.block_hash = std::string(block.hash.size(), 0);
-        std::copy(block.hash.begin(),
-                  block.hash.end(),
-                  hash.block_hash.begin());
+        hash.proposal_hash = block.hash.to_string();
+        hash.block_hash = block.hash.to_string();
         return hash;
       }
     }  // namespace yac

--- a/irohad/model/converters/impl/pb_block_factory.cpp
+++ b/irohad/model/converters/impl/pb_block_factory.cpp
@@ -23,7 +23,7 @@ namespace iroha {
   namespace model {
     namespace converters {
 
-      protocol::Block PbBlockFactory::serialize(model::Block const&block) {
+      protocol::Block PbBlockFactory::serialize(model::Block const& block) {
         protocol::Block pb_block;
 
         // -----|Header|-----
@@ -55,7 +55,8 @@ namespace iroha {
         return pb_block;
       }
 
-      model::Block PbBlockFactory::deserialize(protocol::Block const&pb_block) {
+      model::Block PbBlockFactory::deserialize(
+          protocol::Block const& pb_block) {
         model::Block block;
 
         // -----|Header|-----
@@ -63,10 +64,8 @@ namespace iroha {
         auto header = pb_block.header();
         for (auto pb_sig : header.signatures()) {
           Signature sig{};
-          std::copy(pb_sig.pubkey().begin(), pb_sig.pubkey().end(),
-                    sig.pubkey.begin());
-          std::copy(pb_sig.signature().begin(), pb_sig.signature().end(),
-                    sig.signature.begin());
+          sig.pubkey = pb_sig.pubkey();
+          sig.signature = pb_sig.signature();
           block.sigs.push_back(sig);
         }
 
@@ -75,10 +74,8 @@ namespace iroha {
         // potential dangerous cast
         block.txs_number = (uint16_t)meta.tx_number();
         block.height = meta.height();
-        std::copy(meta.merkle_root().begin(), meta.merkle_root().end(),
-                  block.merkle_root.begin());
-        std::copy(meta.prev_block_hash().begin(), meta.prev_block_hash().end(),
-                  block.prev_hash.begin());
+        block.merkle_root = meta.merkle_root();
+        block.prev_hash = meta.prev_block_hash();
 
         // -----|Body|-----
         auto body = pb_block.body();

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -63,8 +63,7 @@ namespace iroha {
       PbCommandFactory::deserializeAddPeer(const protocol::AddPeer &pb_add_peer) {
         model::AddPeer add_peer;
         add_peer.address = pb_add_peer.address();
-        std::copy(pb_add_peer.peer_key().begin(), pb_add_peer.peer_key().end(),
-                  add_peer.peer_key.begin());
+        add_peer.peer_key = pb_add_peer.peer_key();
         return add_peer;
       }
 
@@ -80,9 +79,7 @@ namespace iroha {
       model::AddSignatory PbCommandFactory::deserializeAddSignatory(const protocol::AddSignatory &pb_add_signatory) {
         model::AddSignatory add_signatory;
         add_signatory.account_id = pb_add_signatory.account_id();
-        std::copy(pb_add_signatory.public_key().begin(),
-                  pb_add_signatory.public_key().end(),
-                  add_signatory.pubkey.begin());
+        add_signatory.pubkey = pb_add_signatory.public_key();
         return add_signatory;
       }
 
@@ -100,9 +97,7 @@ namespace iroha {
           const protocol::AssignMasterKey &pb_assign_master_key) {
         model::AssignMasterKey assign_master_key;
         assign_master_key.account_id = pb_assign_master_key.account_id();
-        std::copy(pb_assign_master_key.public_key().begin(),
-                  pb_assign_master_key.public_key().end(),
-                  assign_master_key.pubkey.begin());
+        assign_master_key.pubkey = pb_assign_master_key.public_key();
         return assign_master_key;
       }
 
@@ -140,9 +135,7 @@ namespace iroha {
         model::CreateAccount create_account;
         create_account.account_name = pb_create_account.account_name();
         create_account.domain_id = pb_create_account.domain_id();
-        std::copy(pb_create_account.main_pubkey().begin(),
-                  pb_create_account.main_pubkey().end(),
-                  create_account.pubkey.begin());
+        create_account.pubkey = pb_create_account.main_pubkey();
         return create_account;
       }
 
@@ -173,9 +166,7 @@ namespace iroha {
           const protocol::RemoveSignatory &pb_remove_signatory) {
         model::RemoveSignatory remove_signatory;
         remove_signatory.account_id = pb_remove_signatory.account_id();
-        std::copy(pb_remove_signatory.public_key().begin(),
-                  pb_remove_signatory.public_key().end(),
-                  remove_signatory.pubkey.begin());
+        remove_signatory.pubkey = pb_remove_signatory.public_key();
         return remove_signatory;
       }
 

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include <model/model_hash_provider_impl.hpp>
 #include "model/converters/pb_query_factory.hpp"
+#include <model/model_hash_provider_impl.hpp>
 #include "model/queries/get_account.hpp"
 #include "model/queries/get_account_assets.hpp"
 #include "model/queries/get_signatories.hpp"
@@ -27,7 +27,7 @@ namespace iroha {
     namespace converters {
 
       std::shared_ptr<model::Query> PbQueryFactory::deserialize(
-           const protocol::Query &pb_query) {
+          const protocol::Query &pb_query) {
         std::shared_ptr<model::Query> val;
 
         if (pb_query.has_get_account()) {
@@ -67,16 +67,14 @@ namespace iroha {
         }
         Signature sign;
         auto pb_sign = pb_query.header().signature();
-        std::copy(pb_sign.pubkey().begin(), pb_sign.pubkey().end(),
-                  sign.pubkey.begin());
-
-        std::copy(pb_sign.signature().begin(), pb_sign.signature().end(),
-                  sign.signature.begin());
+        sign.pubkey = pb_sign.pubkey();
+        sign.signature = pb_sign.signature();
         val->query_counter = pb_query.query_counter();
         val->signature = sign;
         val->created_ts = pb_query.header().created_time();
         val->creator_account_id = pb_query.creator_account_id();
-        model::HashProviderImpl hashProvider; // TODO: get rid off unnecessary object initialization
+        model::HashProviderImpl hashProvider;  // TODO: get rid off unnecessary
+                                               // object initialization
         val->query_hash = hashProvider.get_hash(val);
         return val;
       }

--- a/irohad/model/converters/impl/pb_query_response_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_response_factory.cpp
@@ -109,8 +109,7 @@ namespace iroha {
             pb_account.permissions().set_permissions();
         res.permissions.set_quorum = pb_account.permissions().set_quorum();
 
-        std::copy(pb_account.master_key().begin(),
-                  pb_account.master_key().end(), res.master_key.begin());
+        res.master_key = pb_account.master_key();
         return res;
       }
 
@@ -190,9 +189,8 @@ namespace iroha {
           const protocol::SignatoriesResponse &signatoriesResponse) const {
         model::SignatoriesResponse res{};
         for (const auto &key : signatoriesResponse.keys()) {
-          ed25519::pubkey_t pubkey;
-          std::copy(key.begin(), key.end(), pubkey.begin());
-          res.keys.push_back(pubkey);
+          ed25519::pubkey_t pubkey = key;
+          res.keys.push_back(std::move(pubkey));
         }
         return res;
       }

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -64,11 +64,9 @@ namespace iroha {
         tx.created_ts = pb_tx.header().created_time();
         for (auto &pb_sign : pb_tx.header().signatures()) {
           model::Signature sign;
-          std::copy(pb_sign.pubkey().begin(), pb_sign.pubkey().end(),
-                    sign.pubkey.begin());
-          std::copy(pb_sign.signature().begin(), pb_sign.signature().end(),
-                    sign.signature.begin());
-          tx.signatures.push_back(sign);
+          sign.pubkey = pb_sign.pubkey();
+          sign.signature = pb_sign.signature();
+          tx.signatures.push_back(std::move(sign));
         }
 
         // -----|Meta|-----

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <string>
 #include <typeinfo>
+#include <algorithm>
 
 /**
  * This file defines common types used in iroha.
@@ -52,6 +53,13 @@ namespace iroha {
         throw std::invalid_argument("input string has wrong size");
 
       std::copy(s.begin(), s.end(), this->begin());
+    }
+
+    blob_t(std::vector<uint8_t> b) {
+      if (b.size() != size_)
+        throw std::invalid_argument("input string has wrong size");
+
+      std::copy(b.begin(), b.end(), this->begin());
     }
 
     blob_t &operator=(std::string s) {

--- a/libs/crypto/ed25519_impl.cpp
+++ b/libs/crypto/ed25519_impl.cpp
@@ -16,11 +16,18 @@
  */
 
 #include <ed25519.h>
+#include <algorithm>
+#include <functional>
+#include <random>
 #include <string>
 #include "crypto.hpp"
 #include "hash.hpp"
 
 namespace iroha {
+
+  static auto random =
+      std::bind(std::uniform_int_distribution<int32_t>{0x00, 0xFF},
+                std::mt19937(std::random_device{}()));
 
   using sig_t = ed25519::sig_t;
   using pubkey_t = ed25519::pubkey_t;
@@ -49,7 +56,7 @@ namespace iroha {
    */
   blob_t<32> create_seed() {
     blob_t<32> seed;
-    ed25519_create_seed(seed.data());
+    std::generate_n(seed.begin(), seed.size(), random);
     return seed;
   }
 

--- a/libs/crypto/hash.cpp
+++ b/libs/crypto/hash.cpp
@@ -20,13 +20,11 @@ extern "C" {
 #include <sha3.h>
 }
 namespace sha3 {
-  void sha3_256_(const unsigned char *message,
-                 size_t message_len,
+  void sha3_256_(const unsigned char *message, size_t message_len,
                  unsigned char *out) {
     sha3_256(message, message_len, out);
   }
-  void sha3_512_(const unsigned char *message,
-                 size_t message_len,
+  void sha3_512_(const unsigned char *message, size_t message_len,
                  unsigned char *out) {
     sha3_512(message, message_len, out);
   }
@@ -34,13 +32,11 @@ namespace sha3 {
 
 namespace iroha {
 
-  void sha3_256(unsigned char *output, unsigned char *input,
-                size_t in_size) {
+  void sha3_256(unsigned char *output, unsigned char *input, size_t in_size) {
     sha3::sha3_256_(input, in_size, output);
   }
 
-  void sha3_512(unsigned char *output, unsigned char *input,
-                size_t in_size) {
+  void sha3_512(unsigned char *output, unsigned char *input, size_t in_size) {
     sha3::sha3_512_(input, in_size, output);
   }
 
@@ -53,6 +49,18 @@ namespace iroha {
   hash512_t sha3_512(const uint8_t *input, size_t in_size) {
     hash512_t h;
     sha3::sha3_512_(input, in_size, h.data());
+    return h;
+  }
+
+  hash256_t sha3_256(const std::string &s) {
+    hash256_t h;
+    sha3::sha3_256_((unsigned char *)s.data(), s.size(), h.data());
+    return h;
+  }
+
+  hash512_t sha3_512(const std::string &s) {
+    hash512_t h;
+    sha3::sha3_512_((unsigned char *)s.data(), s.size(), h.data());
     return h;
   }
 

--- a/libs/crypto/hash.hpp
+++ b/libs/crypto/hash.hpp
@@ -32,6 +32,10 @@ namespace iroha {
 
   hash512_t sha3_512(const uint8_t *input, size_t in_size);
 
+  hash256_t sha3_256(const std::string &s);
+
+  hash512_t sha3_512(const std::string &s);
+
 }  // namespace iroha
 
 #endif  // IROHA_HASH_H

--- a/test/module/irohad/common/block_insertion_test.cpp
+++ b/test/module/irohad/common/block_insertion_test.cpp
@@ -55,7 +55,7 @@ Transaction getAddPeerTransaction(uint64_t create_time, std::string address) {
 
   auto add_peer = std::make_shared<AddPeer>();
   add_peer->address = address;
-  add_peer->peer_key = {};
+  add_peer->peer_key = std::string(add_peer->peer_key.size(), '\0');
 
   transaction.commands = {add_peer};
   return transaction;

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -26,7 +26,7 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::model::Block block;
   std::string test_hash = std::string(block.hash.size(), 'f');
-  std::copy(test_hash.begin(), test_hash.end(), block.hash.begin());
+  block.hash = test_hash;
 
   auto yac_hash = hash_provider.makeHash(block);
 

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -39,7 +39,7 @@ namespace iroha {
       VoteMessage create_vote(YacHash hash, std::string sign) {
         VoteMessage vote;
         vote.hash = hash;
-        std::copy(sign.begin(), sign.end(), vote.signature.pubkey.begin());
+        vote.signature.pubkey = sign;
         return vote;
       }
 

--- a/test/module/irohad/consensus/yac/yac_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_storage_test.cpp
@@ -25,6 +25,8 @@ using namespace std;
 
 using namespace iroha::consensus::yac;
 
+using pub_t = iroha::ed25519::pubkey_t;
+
 TEST(YacStorageTest, SupermajorityFunctionForAllCases2) {
   cout << "-----------| F(x, 2), x in {0..3} -----------" << endl;
 
@@ -54,23 +56,27 @@ TEST(YacStorageTest, YacBlockStorageWhenNormalDataInput) {
   int N = 4;
   YacBlockStorage storage(hash, N);
 
-  auto insert_1 = storage.insert(create_vote(hash, "one"));
+  auto insert_1 = storage.insert(
+      create_vote(hash, pub_t::from_string_var("one").to_string()));
   ASSERT_EQ(CommitState::not_committed, insert_1.state);
   ASSERT_EQ(nonstd::nullopt, insert_1.answer.commit);
   ASSERT_EQ(nonstd::nullopt, insert_1.answer.reject);
 
-  auto insert_2 = storage.insert(create_vote(hash, "two"));
+  auto insert_2 = storage.insert(
+      create_vote(hash, pub_t::from_string_var("two").to_string()));
   ASSERT_EQ(CommitState::not_committed, insert_2.state);
   ASSERT_EQ(nonstd::nullopt, insert_2.answer.commit);
   ASSERT_EQ(nonstd::nullopt, insert_2.answer.reject);
 
-  auto insert_3 = storage.insert(create_vote(hash, "three"));
+  auto insert_3 = storage.insert(
+      create_vote(hash, pub_t::from_string_var("three").to_string()));
   ASSERT_EQ(CommitState::committed, insert_3.state);
   ASSERT_NE(nonstd::nullopt, insert_3.answer.commit);
   ASSERT_EQ(3, insert_3.answer.commit->votes.size());
   ASSERT_EQ(nonstd::nullopt, insert_3.answer.reject);
 
-  auto insert_4 = storage.insert(create_vote(hash, "four"));
+  auto insert_4 = storage.insert(
+      create_vote(hash, pub_t::from_string_var("four").to_string()));
   ASSERT_EQ(CommitState::committed_before, insert_4.state);
   ASSERT_EQ(4, insert_4.answer.commit->votes.size());
   ASSERT_EQ(nonstd::nullopt, insert_4.answer.reject);
@@ -83,15 +89,16 @@ TEST(YacStorageTest, YacBlockStorageWhenNotCommittedAndCommitAcheive) {
   int N = 4;
   YacBlockStorage storage(hash, N);
 
-  auto insert_1 = storage.insert(create_vote(hash, "one"));
+  auto insert_1 = storage.insert(
+      create_vote(hash, pub_t::from_string_var("one").to_string()));
   ASSERT_EQ(CommitState::not_committed, insert_1.state);
   ASSERT_EQ(nonstd::nullopt, insert_1.answer.commit);
   ASSERT_EQ(nonstd::nullopt, insert_1.answer.reject);
 
-  auto insert_commit = storage.insert(CommitMessage({create_vote(hash, "two"),
-                                                     create_vote(hash, "three"),
-                                                     create_vote(hash, "four")})
-  );
+  auto insert_commit = storage.insert(CommitMessage(
+      {create_vote(hash, pub_t::from_string_var("two").to_string()),
+       create_vote(hash, pub_t::from_string_var("three").to_string()),
+       create_vote(hash, pub_t::from_string_var("four").to_string())}));
   ASSERT_EQ(CommitState::committed, insert_commit.state);
   ASSERT_EQ(4, insert_commit.answer.commit->votes.size());
   ASSERT_EQ(nonstd::nullopt, insert_1.answer.reject);

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -112,6 +112,10 @@ TEST_F(ToriiServiceTest, FindWhenResponseInvalid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account()->set_account_id("accountB");
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Must return Error Response
@@ -141,7 +145,10 @@ TEST_F(ToriiServiceTest, FindAccountWhenStatefulInvalid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account()->set_account_id("accountB");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
@@ -175,7 +182,10 @@ TEST_F(ToriiServiceTest, FindAccountWhenHasReadPermissions) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account()->set_account_id("accountB");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
@@ -201,7 +211,10 @@ TEST_F(ToriiServiceTest, FindAccountWhenValid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account()->set_account_id("accountA");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
@@ -241,7 +254,10 @@ TEST_F(ToriiServiceTest, FindAccountAssetWhenStatefulInvalid) {
   query.set_creator_account_id("accountA");
   query.mutable_get_account_assets()->set_account_id("accountB");
   query.mutable_get_account_assets()->set_asset_id("usd");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
@@ -278,7 +294,10 @@ TEST_F(ToriiServiceTest, FindAccountAssetWhenValid) {
   query.set_creator_account_id("accountA");
   query.mutable_get_account_assets()->set_account_id("accountA");
   query.mutable_get_account_assets()->set_asset_id("usd");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
@@ -318,7 +337,10 @@ TEST_F(ToriiServiceTest, FindSignatoriesWhenStatefulInvalid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account_signatories()->set_account_id("accountB");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
@@ -348,7 +370,10 @@ TEST_F(ToriiServiceTest, FindSignatoriesWhenValid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id("accountA");
   query.mutable_get_account_signatories()->set_account_id("accountA");
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   /// Should not return Error Response because tx is stateless and stateful
@@ -395,7 +420,10 @@ TEST_F(ToriiServiceTest, FindTransactionsWhenValid) {
   auto query = iroha::protocol::Query();
   query.set_creator_account_id(account.account_id);
   query.mutable_get_account_transactions()->set_account_id(account.account_id);
-
+  query.mutable_header()->mutable_signature()->set_signature(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  query.mutable_header()->mutable_signature()->set_pubkey(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
@@ -424,7 +452,10 @@ TEST_F(ToriiServiceTest, FindManyTimesWhereQueryServiceSync) {
     query.set_creator_account_id("accountA");
     query.mutable_get_account()->set_account_id("accountB");
     query.set_query_counter(i);
-
+    query.mutable_header()->mutable_signature()->set_signature(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    query.mutable_header()->mutable_signature()->set_pubkey(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
     ASSERT_TRUE(stat.ok());
     // Must return Error Response

--- a/test/module/libs/CMakeLists.txt
+++ b/test/module/libs/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_BUILD_TYPE Debug)
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test_bin)
 
 # Reusable tests
+add_subdirectory(common)
 add_subdirectory(crypto)
 add_subdirectory(datetime)
 add_subdirectory(map_queue)

--- a/test/module/libs/common/CMakeLists.txt
+++ b/test/module/libs/common/CMakeLists.txt
@@ -1,0 +1,1 @@
+AddTest(types_test types_test.cpp)

--- a/test/module/libs/common/types_test.cpp
+++ b/test/module/libs/common/types_test.cpp
@@ -1,0 +1,93 @@
+/*
+Copyright Soramitsu Co., Ltd. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <common/types.hpp>
+
+using namespace iroha;
+
+// len(PUB32) = 32 + \0, total = 33
+#define PUB32 "11111111111111111111111111111111"
+
+TEST(Blob, Construction) {
+  using pub_t = blob_t<32>;
+
+  ASSERT_NO_THROW(pub_t _p(PUB32)) << "constructor throws with correct length";
+
+  ASSERT_THROW(pub_t _p(std::string("1")), std::invalid_argument)
+      << "constructor does not throw with incorrect length";
+
+  ASSERT_THROW(pub_t _p("1"), std::invalid_argument)
+      << "constructor does not throw with incorrect length";
+
+  ASSERT_NO_THROW(pub_t _p) << "default constructor throws";
+
+  ASSERT_NO_THROW(auto p = pub_t::from_string(PUB32))
+      << "from_string throws, but shouldn't";
+
+  ASSERT_THROW(auto p = pub_t::from_string("1"), std::invalid_argument)
+      << "from_string should throw, but does not";
+
+  ASSERT_NO_THROW(auto p = pub_t::from_string_var("1"))
+      << "from_string_var should not throw, but throws";
+
+  {
+    pub_t p = pub_t::from_string_var("2");
+    std::string _s(pub_t::size(), '\0');
+    _s[0] = '2';  // 2000000...00
+
+    ASSERT_EQ(p, _s) << "from_string_var is wrong";
+  }
+
+  ASSERT_NO_THROW(pub_t p = std::string(PUB32))
+      << "operator = throws, but should not";
+
+  // with prefix 0x
+  ASSERT_NO_THROW(
+      pub_t p = pub_t::from_hexstring(
+          "0x1212121212121212121212121212121212121212121212121212121212121212"))
+      << "from_hexstring throws, but should not";
+
+  // with prefix 0X
+  ASSERT_NO_THROW(
+      pub_t p = pub_t::from_hexstring(
+          "0X1212121212121212121212121212121212121212121212121212121212121212"))
+      << "from_hexstring throws, but should not";
+
+  // without prefix 0x
+  ASSERT_NO_THROW(
+      pub_t p = pub_t::from_hexstring(
+          "1212121212121212121212121212121212121212121212121212121212121212"))
+      << "from_hexstring throws, but should not";
+
+  // bad length (34)
+  ASSERT_THROW(
+      pub_t p = pub_t::from_hexstring(
+          "121212121212121212121212121212121212121212121212121212121212121234"),
+      std::invalid_argument)
+      << "from_hexstring does not throw, but should.";
+
+  // bad characters but good length
+  ASSERT_THROW(
+      pub_t p = pub_t::from_hexstring(
+          "12121212121212121212121212121212121212121212121212121212121212zz"),
+      std::invalid_argument)
+      << "from_hexstring does not throw, but should.";
+
+  // incorrect length
+  ASSERT_THROW(pub_t p = pub_t::from_hexstring("123"), std::invalid_argument)
+      << "from_hexstring does not throw, but should.";
+}

--- a/test/module/libs/crypto/signature_test.cpp
+++ b/test/module/libs/crypto/signature_test.cpp
@@ -61,15 +61,8 @@ TEST(Signature, generatedByAndroid) {
       "b75def7379be0e808392922cb8c43d5dd5d5039828ed7ade7e1c6c81";
   std::vector<uint8_t> message(message_.begin(), message_.end());
 
-  auto pubkey_ = base64_decode(public_key_b64);
-  auto pubkey = to_blob<ed25519::pubkey_t::size()>(
-      std::string{pubkey_.begin(), pubkey_.end()});
-
-  ed25519::sig_t signature;
-  std::vector<uint8_t> signature_v = base64_decode(signature_b64);
-  ASSERT_EQ(signature.size(), signature_v.size());
-  std::copy(signature_v.begin(), signature_v.end(), signature.begin());
-
+  ed25519::pubkey_t pubkey = base64_decode(public_key_b64);
+  ed25519::sig_t signature = base64_decode(signature_b64);
   ASSERT_TRUE(verify(message.data(), message.size(), pubkey, signature));
 }
 
@@ -82,15 +75,8 @@ TEST(Signature, generatedByiOS) {
       "46ed8c250356759f68930a94996faaa8f8c98ecbe0dcc58c479c8fad71e30096";
   std::vector<uint8_t> message(message_.begin(), message_.end());
 
-  auto pubkey_ = base64_decode(public_key_b64);
-  auto pubkey = to_blob<ed25519::pubkey_t::size()>(
-      std::string{pubkey_.begin(), pubkey_.end()});
-
-  ed25519::sig_t signature;
-  std::vector<uint8_t> signature_v = base64_decode(signature_b64);
-  ASSERT_EQ(signature.size(), signature_v.size());
-  std::copy(signature_v.begin(), signature_v.end(), signature.begin());
-
+  ed25519::pubkey_t pubkey = base64_decode(public_key_b64);
+  ed25519::sig_t signature = base64_decode(signature_b64);
   ASSERT_TRUE(verify(message.data(), message.size(), pubkey, signature));
 }
 
@@ -105,14 +91,7 @@ TEST(Signature, generatedByGO) {
       "b75def7379be0e808392922cb8c43d5dd5d5039828ed7ade7e1c6c81";
   std::vector<uint8_t> message(message_.begin(), message_.end());
 
-  auto pubkey_ = base64_decode(public_key_b64);
-  auto pubkey = to_blob<ed25519::pubkey_t::size()>(
-      std::string{pubkey_.begin(), pubkey_.end()});
-
-  ed25519::sig_t signature;
-  std::vector<uint8_t> signature_v = base64_decode(signature_b64);
-  ASSERT_EQ(signature.size(), signature_v.size());
-  std::copy(signature_v.begin(), signature_v.end(), signature.begin());
-
+  ed25519::pubkey_t pubkey = base64_decode(public_key_b64);
+  ed25519::sig_t signature = base64_decode(signature_b64);
   ASSERT_TRUE(verify(message.data(), message.size(), pubkey, signature));
 }


### PR DESCRIPTION
## What is this pull request?
- [x] add `blob_t<N>::from_string(std::string s);` which creates blob_t of size N from strings
- [x] add `blob_t<N>::from_hexstring(std::string s);` which creates blob_t of size N from string encoded in hex (like 0x1234567890abcdef)
- [x] add `blob_t<N>::from_string_var(std::string s);` which creates blob_t of size N from strings of variable size. Example `blob_t<32>::from_string_var("1"); // result is 1000...00 (32 bytes)`
- [x] add tests for each of method and constructor
- [x] fixed few bugs in tests related to "bad format" for pubkey and signature
- [x] refactored the code, to get rid of `std::copy`

Anything else?