### PR TITLE
Fix build error for 8 threads

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm schema/*.{cc,h}
+rm -rf external
+rm -rf build

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(endpoint
 target_link_libraries(endpoint
     protobuf
     grpc++
+    schema
     )
 
 add_library(peer_service_grpc


### PR DESCRIPTION
Whenever you try to perform a clean build with 8 or more threads, it will fail because `endpoint` requires `block.pb.h` but has no linkage dependency on `schema` target. I fixed this in this PR.