### PR TITLE
Fix dependency of peer orderer implementation

### DIFF
--- a/irohad/consensus/yac/impl/peer_orderer_impl.cpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.cpp
@@ -22,11 +22,12 @@ namespace iroha {
     namespace yac {
 
       PeerOrdererImpl::PeerOrdererImpl(
-          std::shared_ptr<ametsuchi::WsvQuery> query)
-          : query_(std::move(query)) {}
+          std::shared_ptr<ametsuchi::PeerQuery> peer_query)
+          : query_(std::move(peer_query)) {
+      }
 
       nonstd::optional<ClusterOrdering> PeerOrdererImpl::getInitialOrdering() {
-        auto peers = query_->getPeers();
+        auto peers = query_->getLedgerPeers();
         if (peers.has_value()) {
           return ClusterOrdering(peers.value());
         }
@@ -36,7 +37,7 @@ namespace iroha {
 
       nonstd::optional<ClusterOrdering> PeerOrdererImpl::getOrdering(
           YacHash hash) {
-        auto peers = query_->getPeers();
+        auto peers = query_->getLedgerPeers();
         if (peers.has_value()) {
           // todo implement effective ordering based on hash value
           return ClusterOrdering(peers.value());

--- a/irohad/consensus/yac/impl/peer_orderer_impl.hpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_PEER_ORDERER_IMPL_HPP
 #define IROHA_PEER_ORDERER_IMPL_HPP
 
-#include "ametsuchi/wsv_query.hpp"
+#include "ametsuchi/peer_query.hpp"
 #include "consensus/yac/yac_peer_orderer.hpp"
 
 namespace iroha {
@@ -27,15 +27,14 @@ namespace iroha {
 
       class PeerOrdererImpl : public YacPeerOrderer {
        public:
-        explicit PeerOrdererImpl(std::shared_ptr<ametsuchi::WsvQuery> query);
+        explicit PeerOrdererImpl(std::shared_ptr<ametsuchi::PeerQuery> peer_query);
 
         nonstd::optional<ClusterOrdering> getInitialOrdering() override;
 
         nonstd::optional<ClusterOrdering> getOrdering(YacHash hash) override;
 
        private:
-        std::shared_ptr<ametsuchi::WsvQuery> query_;
-        std::shared_ptr<YacHashProvider> hash_provider_;
+        std::shared_ptr<ametsuchi::PeerQuery> query_;
       };
 
     }  // namespace yac

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -112,10 +112,11 @@ void Irohad::run() {
   auto chain_validator = std::make_shared<ChainValidatorImpl>(crypto_verifier);
   log_->info("[Init] => validators");
 
-  auto orderer = std::make_shared<PeerOrdererImpl>(storage);
+  auto wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage);
+
+  auto orderer = std::make_shared<PeerOrdererImpl>(wsv);
   log_->info("[Init] => peer orderer");
 
-  auto wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage);
   auto peer_address = wsv->getLedgerPeers().value().at(peer_number_).address;
 
   // Ordering gate


### PR DESCRIPTION
## What is this pull request?
This pr provides fix of responsibility in dependency of `PeerOrdererImpl`.
Current implementation use only subset of wsv queries - peer queries.