### PR TITLE
Feature/ametsuchi refactoring, chain validator extension

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(ametsuchi
     impl/postgres_wsv_query.cpp
     impl/postgres_wsv_command.cpp
     impl/peer_query_wsv.cpp
+
+    impl/flat_file_block_query.cpp
     )
 
 target_link_libraries(ametsuchi

--- a/irohad/ametsuchi/impl/flat_file_block_query.cpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.cpp
@@ -1,0 +1,105 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ametsuchi/impl/flat_file_block_query.hpp"
+
+#include "model/converters/json_common.hpp"
+#include "model/commands/transfer_asset.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+    FlatFileBlockQuery::FlatFileBlockQuery(FlatFile &block_store)
+        : block_store_(block_store) {}
+
+    rxcpp::observable<model::Transaction>
+    FlatFileBlockQuery::getAccountTransactions(std::string account_id) {
+      return getBlocksFrom(1)
+          .flat_map([](auto block) {
+            return rxcpp::observable<>::iterate(block.transactions);
+          })
+          .filter([account_id](auto tx) {
+            return tx.creator_account_id == account_id;
+          });
+    }
+
+    rxcpp::observable<model::Block> FlatFileBlockQuery::getBlocks(
+        uint32_t height, uint32_t count) {
+      auto to = height + count;
+      auto last_id = block_store_.last_id();
+      if (to > last_id) {
+        to = last_id;
+      }
+      if (height > to) {
+        return rxcpp::observable<>::empty<model::Block>();
+      }
+      return rxcpp::observable<>::range(height, to).flat_map([this](auto i) {
+        auto bytes = block_store_.get(i);
+        return rxcpp::observable<>::create<model::Block>([this, bytes](auto s) {
+          if (not bytes.has_value()) {
+            s.on_completed();
+            return;
+          }
+          auto document = model::converters::vectorToJson(bytes.value());
+          if (not document.has_value()) {
+            s.on_completed();
+            return;
+          }
+          auto block = serializer_.deserialize(document.value());
+          if (not block.has_value()) {
+            s.on_completed();
+            return;
+          }
+          s.on_next(block.value());
+          s.on_completed();
+        });
+      });
+    }
+
+    rxcpp::observable<model::Block> FlatFileBlockQuery::getBlocksFrom(
+        uint32_t height) {
+      return getBlocks(height, block_store_.last_id());
+    }
+
+    rxcpp::observable<model::Block> FlatFileBlockQuery::getTopBlocks(
+        uint32_t count) {
+      auto last_id = block_store_.last_id();
+      if (count > last_id) {
+        count = last_id;
+      }
+      return getBlocks(last_id - count + 1, count);
+    }
+
+    rxcpp::observable<model::Transaction>
+    FlatFileBlockQuery::getAccountAssetTransactions(std::string account_id,
+                                                    std::string asset_id) {
+      return getAccountTransactions(account_id)
+          .filter([account_id, asset_id](auto tx) {
+            return std::any_of(
+                tx.commands.begin(), tx.commands.end(),
+                [account_id, asset_id](auto command) {
+                  if (instanceof <model::TransferAsset>(*command)) {
+                    auto transferAsset = (model::TransferAsset *)command.get();
+                    return (transferAsset->src_account_id == account_id or
+                            transferAsset->dest_account_id == account_id) and
+                           transferAsset->asset_id == asset_id;
+                  }
+                  return false;
+                });
+          });
+    }
+  }  // namespace ametsuchi
+}  // namespace iroha

--- a/irohad/ametsuchi/impl/flat_file_block_query.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.hpp
@@ -27,7 +27,7 @@ namespace iroha {
   namespace ametsuchi {
     class FlatFileBlockQuery : public BlockQuery {
      public:
-      FlatFileBlockQuery(FlatFile &block_store);
+      explicit FlatFileBlockQuery(FlatFile &block_store);
 
       rxcpp::observable<model::Transaction> getAccountTransactions(
           std::string account_id) override;

--- a/irohad/ametsuchi/impl/flat_file_block_query.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_FLAT_FILE_BLOCK_QUERY_HPP
+#define IROHA_FLAT_FILE_BLOCK_QUERY_HPP
+
+#include "ametsuchi/block_query.hpp"
+
+#include "ametsuchi/impl/flat_file/flat_file.hpp"
+#include "model/converters/json_block_factory.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+    class FlatFileBlockQuery : public BlockQuery {
+     public:
+      FlatFileBlockQuery(FlatFile &block_store);
+
+      rxcpp::observable<model::Transaction> getAccountTransactions(
+          std::string account_id) override;
+
+      rxcpp::observable<model::Block> getBlocks(uint32_t height,
+                                                uint32_t count) override;
+
+      rxcpp::observable<model::Block> getBlocksFrom(uint32_t height) override;
+
+      rxcpp::observable<model::Block> getTopBlocks(uint32_t count) override;
+
+      rxcpp::observable<model::Transaction> getAccountAssetTransactions(
+          std::string account_id, std::string asset_id) override;
+
+     private:
+      FlatFile &block_store_;
+
+      model::converters::JsonBlockFactory serializer_;
+    };
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif  // IROHA_FLAT_FILE_BLOCK_QUERY_HPP

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -38,20 +38,13 @@ namespace iroha {
           std::unique_ptr<pqxx::nontransaction> transaction,
           std::unique_ptr<WsvQuery> wsv, std::unique_ptr<WsvCommand> executor,
           std::shared_ptr<model::CommandExecutorFactory> command_executors);
+
       bool apply(const model::Block &block,
                  std::function<bool(const model::Block &,
                                     WsvQuery &, const hash256_t &)>
-                     function) override;
+                 function) override;
+
       ~MutableStorageImpl() override;
-      nonstd::optional<model::Account> getAccount(
-          const std::string &account_id) override;
-      nonstd::optional<std::vector<ed25519::pubkey_t>> getSignatories(
-          const std::string &account_id) override;
-      nonstd::optional<model::Asset> getAsset(
-          const std::string &asset_id) override;
-      nonstd::optional<model::AccountAsset> getAccountAsset(
-          const std::string &account_id, const std::string &asset_id) override;
-      nonstd::optional<std::vector<model::Peer>> getPeers() override;
 
      private:
       hash256_t top_hash_;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -36,7 +36,6 @@ namespace iroha {
           hash256_t top_hash, std::unique_ptr<cpp_redis::redis_client> index,
           std::unique_ptr<pqxx::lazyconnection> connection,
           std::unique_ptr<pqxx::nontransaction> transaction,
-          std::unique_ptr<WsvQuery> wsv, std::unique_ptr<WsvCommand> executor,
           std::shared_ptr<model::CommandExecutorFactory> command_executors);
 
       bool apply(const model::Block &block,

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -18,24 +18,21 @@
 #include "ametsuchi/impl/storage_impl.hpp"
 
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
-#include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/impl/temporary_wsv_impl.hpp"
-#include "model/commands/transfer_asset.hpp"
+#include "ametsuchi/impl/flat_file_block_query.hpp"
 #include "model/converters/json_common.hpp"
 
 namespace iroha {
   namespace ametsuchi {
 
-    StorageImpl::StorageImpl(std::string block_store_dir,
-                             std::string redis_host,
-                             std::size_t redis_port,
-                             std::string postgres_options,
-                             std::unique_ptr<FlatFile> block_store,
-                             std::unique_ptr<cpp_redis::redis_client> index,
-                             std::unique_ptr<pqxx::lazyconnection> wsv_connection,
-                             std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                             std::shared_ptr<WsvQuery> wsv)
+    StorageImpl::StorageImpl(
+        std::string block_store_dir, std::string redis_host,
+        std::size_t redis_port, std::string postgres_options,
+        std::unique_ptr<FlatFile> block_store,
+        std::unique_ptr<cpp_redis::redis_client> index,
+        std::unique_ptr<pqxx::lazyconnection> wsv_connection,
+        std::unique_ptr<pqxx::nontransaction> wsv_transaction)
         : block_store_dir_(std::move(block_store_dir)),
           redis_host_(std::move(redis_host)),
           redis_port_(redis_port),
@@ -44,7 +41,8 @@ namespace iroha {
           index_(std::move(index)),
           wsv_connection_(std::move(wsv_connection)),
           wsv_transaction_(std::move(wsv_transaction)),
-          wsv_(std::move(wsv)) {
+          wsv_(std::make_shared<PostgresWsvQuery>(*wsv_transaction_)),
+          blocks_(std::make_shared<FlatFileBlockQuery>(*block_store_)) {
       log_ = logger::log("StorageImpl");
 
       wsv_transaction_->exec(init_);
@@ -69,14 +67,9 @@ namespace iroha {
       }
       auto wsv_transaction = std::make_unique<pqxx::nontransaction>(
           *postgres_connection, "TemporaryWsv");
-      std::unique_ptr<WsvQuery> wsv =
-          std::make_unique<PostgresWsvQuery>(*wsv_transaction);
-      std::unique_ptr<WsvCommand> executor =
-          std::make_unique<PostgresWsvCommand>(*wsv_transaction);
 
       return std::make_unique<TemporaryWsvImpl>(
           std::move(postgres_connection), std::move(wsv_transaction),
-          std::move(wsv), std::move(executor),
           std::move(command_executors.value()));
     }
 
@@ -97,10 +90,6 @@ namespace iroha {
       }
       auto wsv_transaction = std::make_unique<pqxx::nontransaction>(
           *postgres_connection, "TemporaryWsv");
-      std::unique_ptr<WsvQuery> wsv =
-          std::make_unique<PostgresWsvQuery>(*wsv_transaction);
-      std::unique_ptr<WsvCommand> executor =
-          std::make_unique<PostgresWsvCommand>(*wsv_transaction);
 
       auto index = std::make_unique<cpp_redis::redis_client>();
       try {
@@ -110,41 +99,22 @@ namespace iroha {
         return nullptr;
       }
 
-      hash256_t top_hash;
+      nonstd::optional<hash256_t> top_hash;
 
-      if (block_store_->last_id() > 0) {
-        auto blob = block_store_->get(block_store_->last_id());
-        if (not blob.has_value()) {
-          log_->error("Fetching of blob failed");
-          return nullptr;
-        }
-
-        auto document = model::converters::vectorToJson(blob.value());
-        if (not document.has_value()) {
-          log_->error("Blob parsing failed");
-          return nullptr;
-        }
-
-        auto block = serializer_.deserialize(document.value());
-        if (not block.has_value()) {
-          log_->error("Deserialization of block failed");
-          return nullptr;
-        }
-        top_hash = block->hash;
-      } else {
-        top_hash.fill(0);
-      }
+      blocks_->getTopBlocks(1).as_blocking().subscribe(
+          [&top_hash](auto block) { top_hash = block.hash; });
 
       return std::make_unique<MutableStorageImpl>(
-          top_hash, std::move(index), std::move(postgres_connection),
-          std::move(wsv_transaction), std::move(wsv), std::move(executor),
+          top_hash.value_or(hash256_t{}),
+          std::move(index),
+          std::move(postgres_connection),
+          std::move(wsv_transaction),
           std::move(command_executors.value()));
     }
 
-    nonstd::optional<ConnectionContext> StorageImpl::initConnections(std::string block_store_dir,
-                                                                     std::string redis_host,
-                                                                     std::size_t redis_port,
-                                                                     std::string postgres_options) {
+    nonstd::optional<ConnectionContext> StorageImpl::initConnections(
+        std::string block_store_dir, std::string redis_host,
+        std::size_t redis_port, std::string postgres_options) {
       auto log_ = logger::log("StorageImpl:initConnection");
       log_->info("Start storage creation");
 
@@ -178,26 +148,18 @@ namespace iroha {
 
       auto wsv_transaction = std::make_unique<pqxx::nontransaction>(
           *postgres_connection, "Storage");
-      std::shared_ptr<WsvQuery> wsv =
-          std::make_shared<PostgresWsvQuery>(*wsv_transaction);
       log_->info("transaction to PostgreSQL initialized");
 
-      return nonstd::make_optional<ConnectionContext>(std::move(block_store),
-                                                      std::move(index),
-                                                      std::move(
-                                                          postgres_connection),
-                                                      std::move(wsv_transaction),
-                                                      std::move(wsv));
-
+      return nonstd::make_optional<ConnectionContext>(
+          std::move(block_store), std::move(index),
+          std::move(postgres_connection), std::move(wsv_transaction));
     }
 
     std::shared_ptr<StorageImpl> StorageImpl::create(
         std::string block_store_dir, std::string redis_host,
         std::size_t redis_port, std::string postgres_options) {
-
       auto ctx = initConnections(block_store_dir,
-                                 redis_host,
-                                 redis_port,
+                                 redis_host, redis_port,
                                  postgres_options);
       if (not ctx.has_value()) {
         return nullptr;
@@ -209,9 +171,7 @@ namespace iroha {
                           postgres_options,
                           std::move(ctx->block_store),
                           std::move(ctx->index),
-                          std::move(ctx->pg_lazy),
-                          std::move(ctx->pg_nontx),
-                          std::move(ctx->wsv)));
+                          std::move(ctx->pg_lazy), std::move(ctx->pg_nontx)));
     }
 
     void StorageImpl::commit(std::unique_ptr<MutableStorage> mutableStorage) {
@@ -232,77 +192,8 @@ namespace iroha {
       return wsv_;
     }
 
-    rxcpp::observable<model::Transaction> StorageImpl::getAccountTransactions(
-        std::string account_id) {
-      std::shared_lock<std::shared_timed_mutex> write(rw_lock_);
-      return getBlocksFrom(1)
-          .flat_map([](auto block) {
-            return rxcpp::observable<>::iterate(block.transactions);
-          })
-          .filter([account_id](auto tx) {
-            return tx.creator_account_id == account_id;
-          });
-    }
-
-    rxcpp::observable<model::Transaction> StorageImpl::getAccountAssetTransactions(
-        std::string account_id, std::string asset_id) {
-      return getAccountTransactions(account_id).filter([account_id, asset_id](auto tx) {
-          return std::any_of(tx.commands.begin(), tx.commands.end(), [account_id, asset_id](auto command) {
-            if (instanceof <model::TransferAsset>(*command)) {
-              auto transferAsset = (model::TransferAsset*) command.get();
-              return (transferAsset->src_account_id == account_id || transferAsset->dest_account_id == account_id) && transferAsset->asset_id == asset_id;
-            }
-            return false;
-          });
-      });
-    }
-
-    rxcpp::observable<model::Block> StorageImpl::getBlocks(uint32_t height,
-                                                           uint32_t count) {
-      std::shared_lock<std::shared_timed_mutex> write(rw_lock_);
-      auto to = height - 1 + count;
-      auto last_id = block_store_->last_id();
-      if (to > last_id) {
-        to = last_id;
-      }
-      return rxcpp::observable<>::range(height, to).flat_map([this](auto i) {
-        auto bytes = block_store_->get(i);
-        return rxcpp::observable<>::create<model::Block>(
-            [this, bytes](auto s) {
-              if (not bytes.has_value()) {
-                s.on_completed();
-                return;
-              }
-              auto document = model::converters::vectorToJson(bytes.value());
-              if (not document.has_value()) {
-                s.on_completed();
-                return;
-              }
-              auto block = serializer_.deserialize(document.value());
-              if (not block.has_value()) {
-                s.on_completed();
-                return;
-              }
-              s.on_next(block.value());
-              s.on_completed();
-            });
-      });
-    }
-
-    rxcpp::observable<model::Block> StorageImpl::getBlocksFrom(uint32_t height) {
-      auto last_id = block_store_->last_id();
-      if (height > last_id) {
-        height = last_id;
-      }
-      return getBlocks(height, block_store_->last_id() - height + 1);
-    }
-
-    rxcpp::observable<model::Block> StorageImpl::getTopBlocks(uint32_t count) {
-      auto last_id = block_store_->last_id();
-      if (count > last_id) {
-        count = last_id;
-      }
-      return getBlocks(last_id - count + 1, count);
+    std::shared_ptr<BlockQuery> StorageImpl::getBlockQuery() const {
+      return blocks_;
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -36,7 +36,7 @@ namespace iroha {
                         std::unique_ptr<cpp_redis::redis_client> index,
                         std::unique_ptr<pqxx::lazyconnection> pg_lazy,
                         std::unique_ptr<pqxx::nontransaction> pg_nontx,
-                        std::unique_ptr<WsvQuery> wsv)
+                        std::shared_ptr<WsvQuery> wsv)
           : block_store(std::move(block_store)),
             index(std::move(index)),
             pg_lazy(std::move(pg_lazy)),
@@ -48,7 +48,7 @@ namespace iroha {
       std::unique_ptr<cpp_redis::redis_client> index;
       std::unique_ptr<pqxx::lazyconnection> pg_lazy;
       std::unique_ptr<pqxx::nontransaction> pg_nontx;
-      std::unique_ptr<WsvQuery> wsv;
+      std::shared_ptr<WsvQuery> wsv;
     };
 
     class StorageImpl : public Storage {
@@ -68,6 +68,8 @@ namespace iroha {
       std::unique_ptr<MutableStorage> createMutableStorage() override;
       void commit(std::unique_ptr<MutableStorage> mutableStorage) override;
 
+      std::shared_ptr<WsvQuery> getWsvQuery() const override;
+
       rxcpp::observable<model::Transaction> getAccountTransactions(
           std::string account_id) override;
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
@@ -76,16 +78,6 @@ namespace iroha {
                                                 uint32_t count) override;
       rxcpp::observable<model::Block> getBlocksFrom(uint32_t height) override;
       rxcpp::observable<model::Block> getTopBlocks(uint32_t count) override;
-
-      nonstd::optional<model::Account> getAccount(
-          const std::string &account_id) override;
-      nonstd::optional<std::vector<ed25519::pubkey_t>> getSignatories(
-          const std::string &account_id) override;
-      nonstd::optional<model::Asset> getAsset(
-          const std::string &asset_id) override;
-      nonstd::optional<model::AccountAsset> getAccountAsset(
-          const std::string &account_id, const std::string &asset_id) override;
-      nonstd::optional<std::vector<model::Peer>> getPeers() override;
 
      protected:
 
@@ -97,7 +89,7 @@ namespace iroha {
                   std::unique_ptr<cpp_redis::redis_client> index,
                   std::unique_ptr<pqxx::lazyconnection> wsv_connection,
                   std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                  std::unique_ptr<WsvQuery> wsv);
+                  std::shared_ptr<WsvQuery> wsv);
 
       /**
        * Folder with raw blocks
@@ -124,7 +116,7 @@ namespace iroha {
 
       std::unique_ptr<pqxx::nontransaction> wsv_transaction_;
 
-      std::unique_ptr<WsvQuery> wsv_;
+      std::shared_ptr<WsvQuery> wsv_;
 
       model::converters::JsonBlockFactory serializer_;
 

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -31,7 +31,6 @@ namespace iroha {
       TemporaryWsvImpl(
           std::unique_ptr<pqxx::lazyconnection> connection,
           std::unique_ptr<pqxx::nontransaction> transaction,
-          std::unique_ptr<WsvQuery> wsv, std::unique_ptr<WsvCommand> executor,
           std::shared_ptr<model::CommandExecutorFactory> command_executors);
 
       bool apply(const model::Transaction &transaction,

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -28,24 +28,17 @@ namespace iroha {
   namespace ametsuchi {
     class TemporaryWsvImpl : public TemporaryWsv {
      public:
-      TemporaryWsvImpl(std::unique_ptr<pqxx::lazyconnection> connection,
-                       std::unique_ptr<pqxx::nontransaction> transaction,
-                       std::unique_ptr<WsvQuery> wsv,
-                       std::unique_ptr<WsvCommand> executor,
-                       std::shared_ptr<model::CommandExecutorFactory> command_executors);
+      TemporaryWsvImpl(
+          std::unique_ptr<pqxx::lazyconnection> connection,
+          std::unique_ptr<pqxx::nontransaction> transaction,
+          std::unique_ptr<WsvQuery> wsv, std::unique_ptr<WsvCommand> executor,
+          std::shared_ptr<model::CommandExecutorFactory> command_executors);
+
       bool apply(const model::Transaction &transaction,
                  std::function<bool(const model::Transaction &,
                                     WsvQuery &)>
-                     function) override;
-      nonstd::optional<model::Account> getAccount(
-          const std::string &account_id) override;
-      nonstd::optional<std::vector<ed25519::pubkey_t>> getSignatories(
-          const std::string &account_id) override;
-      nonstd::optional<model::Asset> getAsset(
-          const std::string &asset_id) override;
-      nonstd::optional<model::AccountAsset> getAccountAsset(
-          const std::string &account_id, const std::string &asset_id) override;
-      nonstd::optional<std::vector<model::Peer>> getPeers() override;
+                 function) override;
+
       ~TemporaryWsvImpl() override;
 
      private:

--- a/irohad/ametsuchi/impl/test_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/test_storage_impl.cpp
@@ -40,28 +40,18 @@ namespace iroha {
                               std::move(ctx->block_store),
                               std::move(ctx->index),
                               std::move(ctx->pg_lazy),
-                              std::move(ctx->pg_nontx),
-                              std::move(ctx->wsv)));
+                              std::move(ctx->pg_nontx)));
     }
 
-    TestStorageImpl::TestStorageImpl(std::string block_store_dir,
-                                     std::string redis_host,
-                                     size_t redis_port,
-                                     std::string postgres_options,
-                                     std::unique_ptr<FlatFile> block_store,
-                                     std::unique_ptr<cpp_redis::redis_client> index,
-                                     std::unique_ptr<pqxx::lazyconnection> wsv_connection,
-                                     std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                                     std::shared_ptr<WsvQuery> wsv)
-        : StorageImpl(block_store_dir,
-                      redis_host,
-                      redis_port,
-                      postgres_options,
-                      std::move(block_store),
-                      std::move(index),
-                      std::move(wsv_connection),
-                      std::move(wsv_transaction),
-                      std::move(wsv)) {
+    TestStorageImpl::TestStorageImpl(
+        std::string block_store_dir, std::string redis_host, size_t redis_port,
+        std::string postgres_options, std::unique_ptr<FlatFile> block_store,
+        std::unique_ptr<cpp_redis::redis_client> index,
+        std::unique_ptr<pqxx::lazyconnection> wsv_connection,
+        std::unique_ptr<pqxx::nontransaction> wsv_transaction)
+        : StorageImpl(block_store_dir, redis_host, redis_port, postgres_options,
+                      std::move(block_store), std::move(index),
+                      std::move(wsv_connection), std::move(wsv_transaction)) {
       log_ = logger::log("TestStorage");
     }
 
@@ -130,27 +120,8 @@ namespace iroha {
       return StorageImpl::getWsvQuery();
     }
 
-    rxcpp::observable<model::Transaction> TestStorageImpl::getAccountTransactions(
-        std::string account_id) {
-      return StorageImpl::getAccountTransactions(account_id);
-    }
-
-    rxcpp::observable<model::Transaction> TestStorageImpl::getAccountAssetTransactions(
-        std::string account_id, std::string asset_id) {
-      return StorageImpl::getAccountAssetTransactions(account_id, asset_id);
-    }
-
-    rxcpp::observable<model::Block> TestStorageImpl::getBlocks(uint32_t height,
-                                                               uint32_t count) {
-      return StorageImpl::getBlocks(height, count);
-    };
-
-    rxcpp::observable<model::Block> TestStorageImpl::getBlocksFrom(uint32_t height) {
-      return StorageImpl::getBlocksFrom(height);
-    };
-
-    rxcpp::observable<model::Block> TestStorageImpl::getTopBlocks(uint32_t count) {
-      return StorageImpl::getTopBlocks(count);
+    std::shared_ptr<BlockQuery> TestStorageImpl::getBlockQuery() const {
+      return StorageImpl::getBlockQuery();
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/test_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/test_storage_impl.cpp
@@ -52,7 +52,7 @@ namespace iroha {
                                      std::unique_ptr<cpp_redis::redis_client> index,
                                      std::unique_ptr<pqxx::lazyconnection> wsv_connection,
                                      std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                                     std::unique_ptr<WsvQuery> wsv)
+                                     std::shared_ptr<WsvQuery> wsv)
         : StorageImpl(block_store_dir,
                       redis_host,
                       redis_port,
@@ -126,6 +126,10 @@ namespace iroha {
       return StorageImpl::commit(std::move(mutableStorage));
     }
 
+    std::shared_ptr<WsvQuery> TestStorageImpl::getWsvQuery() const {
+      return StorageImpl::getWsvQuery();
+    }
+
     rxcpp::observable<model::Transaction> TestStorageImpl::getAccountTransactions(
         std::string account_id) {
       return StorageImpl::getAccountTransactions(account_id);
@@ -147,31 +151,6 @@ namespace iroha {
 
     rxcpp::observable<model::Block> TestStorageImpl::getTopBlocks(uint32_t count) {
       return StorageImpl::getTopBlocks(count);
-    };
-
-    nonstd::optional<model::Account> TestStorageImpl::getAccount(
-        const std::string &account_id) {
-      return StorageImpl::getAccount(account_id);
     }
-
-    nonstd::optional<std::vector<ed25519::pubkey_t>> TestStorageImpl::getSignatories(
-        const std::string &account_id) {
-      return StorageImpl::getSignatories(account_id);
-    }
-
-    nonstd::optional<model::Asset> TestStorageImpl::getAsset(
-        const std::string &asset_id) {
-      return StorageImpl::getAsset(asset_id);
-    }
-
-    nonstd::optional<model::AccountAsset> TestStorageImpl::getAccountAsset(
-        const std::string &account_id, const std::string &asset_id) {
-      return StorageImpl::getAccountAsset(account_id, asset_id);
-    }
-
-    nonstd::optional<std::vector<model::Peer>> TestStorageImpl::getPeers() {
-      return StorageImpl::getPeers();
-    }
-
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/test_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/test_storage_impl.hpp
@@ -45,7 +45,7 @@ namespace iroha {
                       std::unique_ptr<cpp_redis::redis_client> index,
                       std::unique_ptr<pqxx::lazyconnection> wsv_connection,
                       std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                      std::unique_ptr<WsvQuery> wsv);
+                      std::shared_ptr<WsvQuery> wsv);
      private:
       logger::Logger log_;
 
@@ -56,6 +56,8 @@ namespace iroha {
       std::unique_ptr<MutableStorage> createMutableStorage() override;
 
       void commit(std::unique_ptr<MutableStorage> mutableStorage) override;
+
+      std::shared_ptr<WsvQuery> getWsvQuery() const override;
 
       rxcpp::observable<model::Transaction>
       getAccountTransactions(std::string account_id) override;
@@ -71,21 +73,6 @@ namespace iroha {
 
       rxcpp::observable<model::Block>
       getTopBlocks(uint32_t count) override;
-
-      nonstd::optional<model::Account>
-      getAccount(const std::string &account_id) override;
-
-      nonstd::optional<std::vector<ed25519::pubkey_t>>
-      getSignatories(const std::string &account_id) override;
-
-      nonstd::optional<model::Asset>
-      getAsset(const std::string &asset_id) override;
-
-      nonstd::optional<model::AccountAsset>
-      getAccountAsset(const std::string &account_id,
-                      const std::string &asset_id) override;
-
-      nonstd::optional<std::vector<model::Peer>> getPeers() override ;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/test_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/test_storage_impl.hpp
@@ -44,8 +44,7 @@ namespace iroha {
                       std::unique_ptr<FlatFile> block_store,
                       std::unique_ptr<cpp_redis::redis_client> index,
                       std::unique_ptr<pqxx::lazyconnection> wsv_connection,
-                      std::unique_ptr<pqxx::nontransaction> wsv_transaction,
-                      std::shared_ptr<WsvQuery> wsv);
+                      std::unique_ptr<pqxx::nontransaction> wsv_transaction);
      private:
       logger::Logger log_;
 
@@ -59,20 +58,7 @@ namespace iroha {
 
       std::shared_ptr<WsvQuery> getWsvQuery() const override;
 
-      rxcpp::observable<model::Transaction>
-      getAccountTransactions(std::string account_id) override;
-
-      rxcpp::observable<model::Transaction>
-      getAccountAssetTransactions(std::string account_id, std::string asset_id) override;
-
-      rxcpp::observable<model::Block>
-      getBlocks(uint32_t height, uint32_t count) override;
-
-      rxcpp::observable<model::Block>
-      getBlocksFrom(uint32_t height) override;
-
-      rxcpp::observable<model::Block>
-      getTopBlocks(uint32_t count) override;
+      std::shared_ptr<BlockQuery> getBlockQuery() const override;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -28,9 +28,9 @@ namespace iroha {
      * Mutable storage is used apply blocks to the storage.
      * Allows to query the world state view, transactions, and blocks.
      */
-    class MutableStorage : public WsvQuery {
+    class MutableStorage {
      public:
-      virtual ~MutableStorage() = default;
+
       /**
        * Applies a block to current mutable state
        * using logic specified in function
@@ -45,11 +45,12 @@ namespace iroha {
        * otherwise.
        * @return True if block was successfully applied, false otherwise.
        */
-      virtual bool apply(
-          const model::Block &block,
-          std::function<bool(const model::Block &, WsvQuery &,
-                             const hash256_t &)>
-              function) = 0;
+      virtual bool apply(const model::Block &block,
+                         std::function<bool(const model::Block &, WsvQuery &,
+                                            const hash256_t &)>
+                             function) = 0;
+
+      virtual ~MutableStorage() = default;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -31,10 +31,12 @@ namespace iroha {
      * Storage interface, which allows queries on current committed state, and
      * creation of state which can be mutated with blocks and transactions
      */
-    class Storage : public BlockQuery, public TemporaryFactory,
-                    public MutableFactory {
+    class Storage : public TemporaryFactory, public MutableFactory {
      public:
+
       virtual std::shared_ptr<WsvQuery> getWsvQuery() const = 0;
+
+      virtual std::shared_ptr<BlockQuery> getBlockQuery() const = 0;
 
       virtual ~Storage() = default;
     };

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -31,9 +31,11 @@ namespace iroha {
      * Storage interface, which allows queries on current committed state, and
      * creation of state which can be mutated with blocks and transactions
      */
-    class Storage : public WsvQuery, public BlockQuery, public TemporaryFactory,
+    class Storage : public BlockQuery, public TemporaryFactory,
                     public MutableFactory {
      public:
+      virtual std::shared_ptr<WsvQuery> getWsvQuery() const = 0;
+
       virtual ~Storage() = default;
     };
 

--- a/irohad/ametsuchi/temporary_wsv.hpp
+++ b/irohad/ametsuchi/temporary_wsv.hpp
@@ -25,16 +25,15 @@
 #include <model/transaction.hpp>
 
 namespace iroha {
-
   namespace ametsuchi {
 
     /**
      * Temporary world state view
      * Allows to query the temporary world state view
      */
-    class TemporaryWsv : public WsvQuery {
+    class TemporaryWsv {
      public:
-      virtual ~TemporaryWsv() = default;
+
       /**
        * Applies a transaction to current state
        * using logic specified in function
@@ -48,14 +47,14 @@ namespace iroha {
        * otherwise.
        * @return True if transaction was successfully applied, false otherwise
        */
-      virtual bool apply(const model::Transaction &transaction,
-                         std::function<bool(const model::Transaction &,
-                                            WsvQuery &)>
-                             function) = 0;
+      virtual bool apply(
+          const model::Transaction &transaction,
+          std::function<bool(const model::Transaction &, WsvQuery &)>
+              function) = 0;
+
+      virtual ~TemporaryWsv() = default;
     };
-
   }  // namespace ametsuchi
-
 }  // namespace iroha
 
 #endif  // IROHA_TEMPORARYWSV_HPP

--- a/irohad/consensus/consensus_common.hpp
+++ b/irohad/consensus/consensus_common.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_CONSENSUS_COMMON_HPP
+#define IROHA_CONSENSUS_COMMON_HPP
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "model/peer.hpp"
+#include "model/signature.hpp"
+
+namespace iroha {
+  namespace consensus {
+    /**
+     * Check that current number >= supermajority.
+     * @param current - current number for validation
+     * @param all - whole number (N)
+     * @return true if belong supermajority
+     */
+    inline bool hasSupermajority(uint64_t current, uint64_t all) {
+      if (current > all) {
+        return false;
+      }
+      auto f = (all - 1) / 3.0;
+      return current >= 2 * f + 1;
+    }
+
+    /**
+     * Checks if public keys of signatures are present in peers collection
+     * @param signatures - collection of signatures
+     * @param peers - collection of peers
+     * @return true, if all public keys of signatures are present in peers
+     * collection, false otherwise
+     */
+    inline bool peersSubset(std::vector<model::Signature> signatures,
+                            std::vector<model::Peer> peers) {
+      return std::all_of(
+          signatures.begin(), signatures.end(), [peers](auto signature) {
+            return std::find_if(peers.begin(), peers.end(),
+                                [signature](auto peer) {
+                                  return signature.pubkey == peer.pubkey;
+                                }) != peers.end();
+          });
+    }
+  }  // namespace consensus
+}  // namespace iroha
+
+#endif  // IROHA_CONSENSUS_COMMON_HPP

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
+#include "consensus/yac/storage/yac_block_storage.hpp"
+
 #include <utility>
 #include <algorithm>
-#include "consensus/yac/storage/yac_block_storage.hpp"
+
+#include "consensus/consensus_common.hpp"
 
 using namespace logger;
 

--- a/irohad/consensus/yac/storage/impl/yac_common.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_common.cpp
@@ -17,18 +17,11 @@
 
 #include <algorithm>
 #include "consensus/yac/storage/yac_common.hpp"
+#include "consensus/consensus_common.hpp"
 
 namespace iroha {
   namespace consensus {
     namespace yac {
-
-      bool hasSupermajority(uint64_t current, uint64_t all) {
-        if (current > all)
-          return false;
-        auto f = (all - 1) / 3.0;
-        return current >= 2 * f + 1;
-      }
-
       bool hasReject(uint64_t frequent, uint64_t voted, uint64_t all) {
         auto not_voted = all - voted;
         return not hasSupermajority(frequent + not_voted, all);

--- a/irohad/consensus/yac/storage/yac_common.hpp
+++ b/irohad/consensus/yac/storage/yac_common.hpp
@@ -29,14 +29,6 @@ namespace iroha {
       using BlockHash = decltype(YacHash::block_hash);
 
       /**
-       * Check that current number >= supermajority.
-       * @param current - current number for validation
-       * @param all - whole number (N)
-       * @return true if belong supermajority
-       */
-      bool hasSupermajority(uint64_t current, uint64_t all);
-
-      /**
        * Check if there is available reject proof.
        * Reject proof is proof that in current round
        * no one hash doesn't achieve supermajority.
@@ -59,8 +51,8 @@ namespace iroha {
        * @param votes - collection with votes
        * @return hash, if collection has same proposal hash, otherwise nullopt
        */
-      nonstd::optional<ProposalHash>
-      getProposalHash(const std::vector<VoteMessage> &votes);
+      nonstd::optional<ProposalHash> getProposalHash(
+          const std::vector<VoteMessage> &votes);
 
       /**
        * Get common hash from collection
@@ -68,7 +60,7 @@ namespace iroha {
        * @return hash, if collection elements have same hash, otherwise nullopt
        */
       nonstd::optional<YacHash> getHash(const std::vector<VoteMessage> &votes);
-    } // namespace yac
-  } // namespace consensus
-} // namespace iroha
-#endif //IROHA_YAC_COMMON_HPP
+    }  // namespace yac
+  }    // namespace consensus
+}  // namespace iroha
+#endif  // IROHA_YAC_COMMON_HPP

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -60,11 +60,9 @@ Irohad::~Irohad() {
 
 class MockCryptoProvider : public ModelCryptoProvider {
  public:
-  MOCK_CONST_METHOD1(verify, bool(
-      const Transaction &));
+  MOCK_CONST_METHOD1(verify, bool(const Transaction &));
   MOCK_CONST_METHOD1(verify, bool(std::shared_ptr<const Query>));
-  MOCK_CONST_METHOD1(verify, bool(
-      const Block &));
+  MOCK_CONST_METHOD1(verify, bool(const Block &));
 };
 
 void Irohad::run() {
@@ -101,7 +99,7 @@ void Irohad::run() {
   auto chain_validator = std::make_shared<ChainValidatorImpl>();
   log_->info("[Init] => validators");
 
-  auto wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage);
+  auto wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery());
 
   auto orderer = std::make_shared<PeerOrdererImpl>(wsv);
   log_->info("[Init] => peer orderer");
@@ -150,7 +148,7 @@ void Irohad::run() {
 
   // --- Queries
   auto query_proccessing_factory =
-      createQueryProcessingFactory(storage, storage);
+      createQueryProcessingFactory(storage->getWsvQuery(), storage);
 
   auto query_processor = createQueryProcessor(
       std::move(query_proccessing_factory), stateless_validator);

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -112,11 +112,13 @@ void Irohad::run() {
              logger::logBool(ordering_gate));
 
   // Simulator
-  auto simulator = createSimulator(ordering_gate, stateful_validator, storage,
-                                   storage, hash_provider);
+  auto simulator =
+      createSimulator(ordering_gate, stateful_validator,
+                      storage->getBlockQuery(), storage, hash_provider);
 
   // Block loader
-  auto block_loader = loader_init.initBlockLoader(wsv, storage, crypto_verifier);
+  auto block_loader = loader_init.initBlockLoader(wsv, storage->getBlockQuery(),
+                                                  crypto_verifier);
 
   // Consensus gate
   auto consensus_gate = yac_init.initConsensusGate(peer_address,
@@ -147,8 +149,8 @@ void Irohad::run() {
   command_service = createCommandService(pb_tx_factory, tx_processor);
 
   // --- Queries
-  auto query_proccessing_factory =
-      createQueryProcessingFactory(storage->getWsvQuery(), storage);
+  auto query_proccessing_factory = createQueryProcessingFactory(
+      storage->getWsvQuery(), storage->getBlockQuery());
 
   auto query_processor = createQueryProcessor(
       std::move(query_proccessing_factory), stateless_validator);

--- a/irohad/model/peer.hpp
+++ b/irohad/model/peer.hpp
@@ -34,8 +34,8 @@ namespace iroha {
       /**
        * Public key of peer
        */
-      iroha::ed25519::pubkey_t pubkey;
-      
+      ed25519::pubkey_t pubkey;
+
       using KeyType = decltype(pubkey);
 
       bool operator==(const Peer &obj) const {

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -34,9 +34,9 @@ namespace iroha {
         if (not peers.has_value()) {
           return false;
         }
-        return block.prev_hash == top_hash &&
+        return block.prev_hash == top_hash and
             this->hasSupermajority(block.sigs.size(),
-                                   peers.value().size()) &&
+                                   peers.value().size()) and
             this->peersSubset(block.sigs, peers.value());
       };
 

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -35,24 +35,6 @@ namespace iroha {
 
      private:
 
-      /**
-       * Check that current number >= supermajority.
-       * @param current - current number for validation
-       * @param all - whole number (N)
-       * @return true if belong supermajority
-       */
-      bool hasSupermajority(uint64_t current, uint64_t all);
-
-      /**
-       * Checks if public keys of signatures are present in peers collection
-       * @param signatures - collection of signatures
-       * @param peers - collection of peers
-       * @return true, if all public keys of signatures are present in peers
-       * collection, false otherwise
-       */
-      bool peersSubset(std::vector<model::Signature> signatures,
-                       std::vector<model::Peer> peers);
-
       logger::Logger log_;
 
     };

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -35,6 +35,12 @@ namespace iroha {
 
      private:
 
+      /**
+       * Check that current number >= supermajority.
+       * @param current - current number for validation
+       * @param all - whole number (N)
+       * @return true if belong supermajority
+       */
       bool hasSupermajority(uint64_t current, uint64_t all);
 
       /**

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -35,8 +35,17 @@ namespace iroha {
 
      private:
 
-      bool checkSupermajority(ametsuchi::MutableStorage &storage,
-                              uint64_t signs_num);
+      bool hasSupermajority(uint64_t current, uint64_t all);
+
+      /**
+       * Checks if public keys of signatures are present in peers collection
+       * @param signatures - collection of signatures
+       * @param peers - collection of peers
+       * @return true, if all public keys of signatures are present in peers
+       * collection, false otherwise
+       */
+      bool peersSubset(std::vector<model::Signature> signatures,
+                       std::vector<model::Peer> peers);
 
       logger::Logger log_;
 

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include <algorithm>
 #include "validation/impl/stateful_validator_impl.hpp"
+#include <algorithm>
 
 namespace iroha {
   namespace validation {
@@ -29,14 +29,14 @@ namespace iroha {
         const model::Proposal &proposal,
         ametsuchi::TemporaryWsv &temporaryWsv) {
       log_->info("transactions in proposal: {}", proposal.transactions.size());
-      auto checking_transaction = [](auto &tx, auto &query) {
-        auto account = query.getAccount(tx.creator_account_id);
+      auto checking_transaction = [](auto &tx, auto &queries) {
+        auto account = queries.getAccount(tx.creator_account_id);
         // Check if tx creator has account and has quorum to execute transaction
         if (!account || tx.signatures.size() < account.value().quorum)
           return false;
 
         // Check if signatures in transaction are account signatory
-        auto account_signs = query.getSignatories(tx.creator_account_id);
+        auto account_signs = queries.getSignatories(tx.creator_account_id);
         if (not account_signs)
           // No signatories found
           return false;

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <algorithm>
-#include <numeric>
 #include "validation/impl/stateful_validator_impl.hpp"
 
 namespace iroha {
@@ -30,14 +29,14 @@ namespace iroha {
         const model::Proposal &proposal,
         ametsuchi::TemporaryWsv &temporaryWsv) {
       log_->info("transactions in proposal: {}", proposal.transactions.size());
-      auto checking_transaction = [&temporaryWsv](auto &tx, auto &query) {
-        auto account = temporaryWsv.getAccount(tx.creator_account_id);
+      auto checking_transaction = [](auto &tx, auto &query) {
+        auto account = query.getAccount(tx.creator_account_id);
         // Check if tx creator has account and has quorum to execute transaction
         if (!account || tx.signatures.size() < account.value().quorum)
           return false;
 
         // Check if signatures in transaction are account signatory
-        auto account_signs = temporaryWsv.getSignatories(tx.creator_account_id);
+        auto account_signs = query.getSignatories(tx.creator_account_id);
         if (not account_signs)
           // No signatories found
           return false;

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -22,10 +22,10 @@
 #include "ametsuchi/block_query.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/mutable_storage.hpp"
+#include "ametsuchi/peer_query.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "ametsuchi/temporary_wsv.hpp"
 #include "ametsuchi/wsv_query.hpp"
-#include "ametsuchi/peer_query.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -76,10 +76,8 @@ namespace iroha {
           rxcpp::observable<model::Transaction>(std::string account_id, std::string asset_id));
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
-      MOCK_METHOD1(getBlocksFrom,
-                   rxcpp::observable<model::Block>(uint32_t));
-      MOCK_METHOD1(getTopBlocks,
-                   rxcpp::observable<model::Block>(uint32_t));
+      MOCK_METHOD1(getBlocksFrom, rxcpp::observable<model::Block>(uint32_t));
+      MOCK_METHOD1(getTopBlocks, rxcpp::observable<model::Block>(uint32_t));
     };
 
     class MockTemporaryFactory : public TemporaryFactory {
@@ -91,19 +89,8 @@ namespace iroha {
      public:
       MOCK_METHOD2(apply,
                    bool(const model::Block &,
-                        std::function<bool(const model::Block &,
-                                           WsvQuery &, const hash256_t &)>));
-      MOCK_METHOD1(getAccount, nonstd::optional<model::Account>(
-                                   const std::string &account_id));
-      MOCK_METHOD1(getSignatories,
-                   nonstd::optional<std::vector<ed25519::pubkey_t>>(
-                       const std::string &account_id));
-      MOCK_METHOD1(getAsset,
-                   nonstd::optional<model::Asset>(const std::string &asset_id));
-      MOCK_METHOD2(getAccountAsset, nonstd::optional<model::AccountAsset>(
-                                        const std::string &account_id,
-                                        const std::string &asset_id));
-      MOCK_METHOD0(getPeers, nonstd::optional<std::vector<model::Peer>>());
+                        std::function<bool(const model::Block &, WsvQuery &,
+                                           const hash256_t &)>));
     };
 
     /**

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -60,6 +60,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   auto storage =
       StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
+  auto wsv = storage->getWsvQuery();
 
   Transaction txn;
   txn.creator_account_id = "admin1";
@@ -77,7 +78,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   block.prev_hash.fill(0);
   auto block1hash = hashProvider.get_hash(block);
   block.hash = block1hash;
-  block.txs_number = static_cast<uint16_t>(block.transactions.size());
+  block.txs_number = block.transactions.size();
 
   {
     auto ms = storage->createMutableStorage();
@@ -88,7 +89,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   }
 
   {
-    auto account = storage->getAccount(createAccount.account_name + "@" +
+    auto account = wsv->getAccount(createAccount.account_name + "@" +
                                        createAccount.domain_id);
     ASSERT_TRUE(account);
     ASSERT_EQ(account->account_id,
@@ -132,7 +133,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   block.prev_hash = block1hash;
   auto block2hash = hashProvider.get_hash(block);
   block.hash = block2hash;
-  block.txs_number = static_cast<uint16_t>(block.transactions.size());
+  block.txs_number = block.transactions.size();
 
   {
     auto ms = storage->createMutableStorage();
@@ -141,12 +142,12 @@ TEST_F(AmetsuchiTest, SampleTest) {
   }
 
   {
-    auto asset1 = storage->getAccountAsset("user1@ru", "RUB#ru");
+    auto asset1 = wsv->getAccountAsset("user1@ru", "RUB#ru");
     ASSERT_TRUE(asset1);
     ASSERT_EQ(asset1->account_id, "user1@ru");
     ASSERT_EQ(asset1->asset_id, "RUB#ru");
     ASSERT_EQ(asset1->balance, 50);
-    auto asset2 = storage->getAccountAsset("user2@ru", "RUB#ru");
+    auto asset2 = wsv->getAccountAsset("user2@ru", "RUB#ru");
     ASSERT_TRUE(asset2);
     ASSERT_EQ(asset2->account_id, "user2@ru");
     ASSERT_EQ(asset2->asset_id, "RUB#ru");
@@ -177,6 +178,7 @@ TEST_F(AmetsuchiTest, PeerTest) {
   auto storage =
       StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
+  auto wsv = storage->getWsvQuery();
 
   Transaction txn;
   AddPeer addPeer;
@@ -193,7 +195,7 @@ TEST_F(AmetsuchiTest, PeerTest) {
     storage->commit(std::move(ms));
   }
 
-  auto peers = storage->getPeers();
+  auto peers = wsv->getPeers();
   ASSERT_TRUE(peers);
   ASSERT_EQ(peers->size(), 1);
   ASSERT_EQ(peers->at(0).pubkey, addPeer.peer_key);
@@ -205,6 +207,7 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
 
   auto storage = StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
+  auto wsv = storage->getWsvQuery();
 
   const auto admin = "admin1";
   const auto domain = "domain";
@@ -275,25 +278,25 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   }
 
   {
-    auto account1 = storage->getAccount(user1id);
+    auto account1 = wsv->getAccount(user1id);
     ASSERT_TRUE(account1);
     ASSERT_EQ(account1->account_id, user1id);
     ASSERT_EQ(account1->domain_name, domain);
-    auto account2 = storage->getAccount(user2id);
+    auto account2 = wsv->getAccount(user2id);
     ASSERT_TRUE(account2);
     ASSERT_EQ(account2->account_id, user2id);
     ASSERT_EQ(account2->domain_name, domain);
-    auto account3 = storage->getAccount(user3id);
+    auto account3 = wsv->getAccount(user3id);
     ASSERT_TRUE(account3);
     ASSERT_EQ(account3->account_id, user3id);
     ASSERT_EQ(account3->domain_name, domain);
 
-    auto asset1 = storage->getAccountAsset(user1id, asset1id);
+    auto asset1 = wsv->getAccountAsset(user1id, asset1id);
     ASSERT_TRUE(asset1);
     ASSERT_EQ(asset1->account_id, user1id);
     ASSERT_EQ(asset1->asset_id, asset1id);
     ASSERT_EQ(asset1->balance, 300);
-    auto asset2 = storage->getAccountAsset(user2id, asset2id);
+    auto asset2 = wsv->getAccountAsset(user2id, asset2id);
     ASSERT_TRUE(asset2);
     ASSERT_EQ(asset2->account_id, user2id);
     ASSERT_EQ(asset2->asset_id, asset2id);
@@ -325,12 +328,12 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   }
 
   {
-    auto asset1 = storage->getAccountAsset(user1id, asset1id);
+    auto asset1 = wsv->getAccountAsset(user1id, asset1id);
     ASSERT_TRUE(asset1);
     ASSERT_EQ(asset1->account_id, user1id);
     ASSERT_EQ(asset1->asset_id, asset1id);
     ASSERT_EQ(asset1->balance, 180);
-    auto asset2 = storage->getAccountAsset(user2id, asset1id);
+    auto asset2 = wsv->getAccountAsset(user2id, asset1id);
     ASSERT_TRUE(asset2);
     ASSERT_EQ(asset2->account_id, user2id);
     ASSERT_EQ(asset2->asset_id, asset1id);
@@ -370,17 +373,17 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   }
 
   {
-    auto asset1 = storage->getAccountAsset(user2id, asset2id);
+    auto asset1 = wsv->getAccountAsset(user2id, asset2id);
     ASSERT_TRUE(asset1);
     ASSERT_EQ(asset1->account_id, user2id);
     ASSERT_EQ(asset1->asset_id, asset2id);
     ASSERT_EQ(asset1->balance, 90);
-    auto asset2 = storage->getAccountAsset(user3id, asset2id);
+    auto asset2 = wsv->getAccountAsset(user3id, asset2id);
     ASSERT_TRUE(asset2);
     ASSERT_EQ(asset2->account_id, user3id);
     ASSERT_EQ(asset2->asset_id, asset2id);
     ASSERT_EQ(asset2->balance, 150);
-    auto asset3 = storage->getAccountAsset(user1id, asset2id);
+    auto asset3 = wsv->getAccountAsset(user1id, asset2id);
     ASSERT_TRUE(asset3);
     ASSERT_EQ(asset3->account_id, user1id);
     ASSERT_EQ(asset3->asset_id, asset2id);

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -40,6 +40,7 @@ TEST_F(AmetsuchiTest, GetBlocksCompletedWhenCalled) {
   auto storage =
       StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
+  auto blocks = storage->getBlockQuery();
 
   Block block;
   block.height = 1;
@@ -49,7 +50,7 @@ TEST_F(AmetsuchiTest, GetBlocksCompletedWhenCalled) {
   storage->commit(std::move(ms));
 
   auto completed_wrapper =
-      make_test_subscriber<IsCompleted>(storage->getBlocks(1, 1));
+      make_test_subscriber<IsCompleted>(blocks->getBlocks(1, 1));
   completed_wrapper.subscribe();
   ASSERT_TRUE(completed_wrapper.validate());
 }
@@ -61,6 +62,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
       StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
+  auto blocks = storage->getBlockQuery();
 
   Transaction txn;
   txn.creator_account_id = "admin1";
@@ -155,7 +157,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   }
 
   // Block store tests
-  storage->getBlocks(1, 2).subscribe([block1hash, block2hash](auto eachBlock) {
+  blocks->getBlocks(1, 2).subscribe([block1hash, block2hash](auto eachBlock) {
     if (eachBlock.height == 1) {
       EXPECT_EQ(eachBlock.hash, block1hash);
     } else if (eachBlock.height == 2) {
@@ -163,14 +165,14 @@ TEST_F(AmetsuchiTest, SampleTest) {
     }
   });
 
-  storage->getAccountTransactions("admin1").subscribe(
+  blocks->getAccountTransactions("admin1").subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 2); });
-  storage->getAccountTransactions("admin2").subscribe(
+  blocks->getAccountTransactions("admin2").subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 4); });
 
-  storage->getAccountAssetTransactions("user1@ru", "RUB#ru").subscribe(
+  blocks->getAccountAssetTransactions("user1@ru", "RUB#ru").subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  storage->getAccountAssetTransactions("user2@ru", "RUB#ru").subscribe(
+  blocks->getAccountAssetTransactions("user2@ru", "RUB#ru").subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
 }
 
@@ -208,6 +210,7 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   auto storage = StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
+  auto blocks = storage->getBlockQuery();
 
   const auto admin = "admin1";
   const auto domain = "domain";
@@ -391,7 +394,7 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   }
 
   // Block store tests
-  storage->getBlocks(1, 3).subscribe([block1hash, block2hash, block3hash](auto eachBlock) {
+  blocks->getBlocks(1, 3).subscribe([block1hash, block2hash, block3hash](auto eachBlock) {
     if (eachBlock.height == 1) {
       EXPECT_EQ(eachBlock.hash, block1hash);
     } else if (eachBlock.height == 2) {
@@ -401,28 +404,28 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
     }
   });
 
-  storage->getAccountTransactions(admin).subscribe(
+  blocks->getAccountTransactions(admin).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 8); });
-  storage->getAccountTransactions(user1id).subscribe(
+  blocks->getAccountTransactions(user1id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  storage->getAccountTransactions(user2id).subscribe(
+  blocks->getAccountTransactions(user2id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 2); });
-  storage->getAccountTransactions(user3id).subscribe(
+  blocks->getAccountTransactions(user3id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 0); });
 
   // (user1 -> user2 # asset1)
   // (user2 -> user3 # asset2)
   // (user2 -> user1 # asset2)
-  storage->getAccountAssetTransactions(user1id, asset1id).subscribe(
+  blocks->getAccountAssetTransactions(user1id, asset1id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  storage->getAccountAssetTransactions(user2id, asset1id).subscribe(
+  blocks->getAccountAssetTransactions(user2id, asset1id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  storage->getAccountAssetTransactions(user3id, asset1id).subscribe(
+  blocks->getAccountAssetTransactions(user3id, asset1id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 0); });
-  storage->getAccountAssetTransactions(user1id, asset2id).subscribe(
+  blocks->getAccountAssetTransactions(user1id, asset2id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  storage->getAccountAssetTransactions(user2id, asset2id).subscribe(
+  blocks->getAccountAssetTransactions(user2id, asset2id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 2); });
-  storage->getAccountAssetTransactions(user3id, asset2id).subscribe(
+  blocks->getAccountAssetTransactions(user3id, asset2id).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
 }

--- a/test/module/irohad/ametsuchi/testing_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/testing_storage_test.cpp
@@ -19,7 +19,6 @@
 #include "logger/logger.hpp"
 #include "ametsuchi/impl/test_storage_impl.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
-#include "framework/test_block_generator.hpp"
 
 #include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/add_peer.hpp"
@@ -65,7 +64,8 @@ TEST_F(TestStorageFixture, TestingStorageWhenInsertBlock) {
   auto storage =
       TestStorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
-  ASSERT_EQ(0, storage->getPeers().value().size());
+  auto wsv = storage->getWsvQuery();
+  ASSERT_EQ(0, wsv->getPeers().value().size());
 
   log->info("Try insert block");
 
@@ -74,7 +74,7 @@ TEST_F(TestStorageFixture, TestingStorageWhenInsertBlock) {
 
   log->info("Request ledger information");
 
-  ASSERT_NE(0, storage->getPeers().value().size());
+  ASSERT_NE(0, wsv->getPeers().value().size());
 
   log->info("Drop ledger");
 
@@ -96,7 +96,8 @@ TEST_F(TestStorageFixture, TestingStorageWhenDropAll) {
   auto storage =
       TestStorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
-  ASSERT_EQ(0, storage->getPeers().value().size());
+  auto wsv = storage->getWsvQuery();
+  ASSERT_EQ(0, wsv->getPeers().value().size());
 
   log->info("Try insert block");
 
@@ -105,15 +106,15 @@ TEST_F(TestStorageFixture, TestingStorageWhenDropAll) {
 
   log->info("Request ledger information");
 
-  ASSERT_NE(0, storage->getPeers().value().size());
+  ASSERT_NE(0, wsv->getPeers().value().size());
 
   log->info("Drop ledger");
 
   storage->dropStorage();
 
-  ASSERT_EQ(0, storage->getPeers().value().size());
+  ASSERT_EQ(0, wsv->getPeers().value().size());
   auto new_storage =
       TestStorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
-  ASSERT_EQ(0, storage->getPeers().value().size());
+  ASSERT_EQ(0, wsv->getPeers().value().size());
   new_storage->dropStorage();
 }

--- a/test/module/irohad/consensus/yac/yac_common_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_common_test.cpp
@@ -16,10 +16,12 @@
  */
 
 #include <gtest/gtest.h>
+#include "consensus/consensus_common.hpp"
 #include "consensus/yac/storage/yac_common.hpp"
 #include "module/irohad/consensus/yac/yac_mocks.hpp"
 #include "logger/logger.hpp"
 
+using namespace iroha::consensus;
 using namespace iroha::consensus::yac;
 
 static logger::Logger log_ = logger::testLog("YacCommon");


### PR DESCRIPTION
## What is this pull request?
Remove redundant WsvQuery inheritance from Storage, add peer subset validation to chain validator
   
## Why do you implement it? Why do we need this pull request?
WsvQuery inheritance introduced redundant code