### PR TITLE
Add description field to asset transfer.

### DIFF
--- a/irohad/model/commands/transfer_asset.hpp
+++ b/irohad/model/commands/transfer_asset.hpp
@@ -43,6 +43,12 @@ namespace iroha {
        * Asset to transfer. Identifier is asset_id
        */
       std::string asset_id;
+
+      /**
+       * Transfer description
+       */
+      std::string description;
+
       /**
        * Amount of transferred asset
        */

--- a/irohad/model/converters/impl/json_command_factory.cpp
+++ b/irohad/model/converters/impl/json_command_factory.cpp
@@ -478,6 +478,8 @@ namespace iroha {
         document.AddMember("dest_account_id", transfer_asset->dest_account_id,
                            allocator);
         document.AddMember("asset_id", transfer_asset->asset_id, allocator);
+        document.AddMember("description", transfer_asset->description,
+                           allocator);
 
         Value amount;
         amount.SetObject();
@@ -505,6 +507,9 @@ namespace iroha {
         // asset_id
         transfer_asset->asset_id = command["asset_id"].GetString();
 
+        // description
+        transfer_asset->description = command["description"].GetString();
+
         // amount
         auto json_amount = command["amount"].GetObject();
         transfer_asset->amount.int_part = json_amount["int_part"].GetUint64();
@@ -523,8 +528,8 @@ namespace iroha {
         return Document();
       }
 
-      optional_ptr<model::Command> JsonCommandFactory::deserializeAbstractCommand(
-          const Document &command) {
+      optional_ptr<model::Command>
+      JsonCommandFactory::deserializeAbstractCommand(const Document &command) {
         auto command_type = command["command_type"].GetString();
 
         auto it = deserializers_.find(command_type);

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -24,8 +24,7 @@ namespace iroha {
     namespace converters {
 
       // asset quantity
-      protocol::AddAssetQuantity
-      PbCommandFactory::serializeAddAssetQuantity(
+      protocol::AddAssetQuantity PbCommandFactory::serializeAddAssetQuantity(
           const model::AddAssetQuantity &add_asset_quantity) {
         protocol::AddAssetQuantity pb_add_asset_quantity;
         pb_add_asset_quantity.set_account_id(add_asset_quantity.account_id);
@@ -36,8 +35,7 @@ namespace iroha {
         return pb_add_asset_quantity;
       }
 
-      model::AddAssetQuantity
-      PbCommandFactory::deserializeAddAssetQuantity(
+      model::AddAssetQuantity PbCommandFactory::deserializeAddAssetQuantity(
           const protocol::AddAssetQuantity &pb_add_asset_quantity) {
         model::AddAssetQuantity add_asset_quantity;
         add_asset_quantity.account_id = pb_add_asset_quantity.account_id();
@@ -51,16 +49,16 @@ namespace iroha {
       }
 
       // add peer
-      protocol::AddPeer
-      PbCommandFactory::serializeAddPeer(const model::AddPeer &add_peer) {
+      protocol::AddPeer PbCommandFactory::serializeAddPeer(
+          const model::AddPeer &add_peer) {
         protocol::AddPeer pb_add_peer;
         pb_add_peer.set_address(add_peer.address);
         pb_add_peer.set_peer_key(add_peer.peer_key.data(),
                                  add_peer.peer_key.size());
         return pb_add_peer;
       }
-      model::AddPeer
-      PbCommandFactory::deserializeAddPeer(const protocol::AddPeer &pb_add_peer) {
+      model::AddPeer PbCommandFactory::deserializeAddPeer(
+          const protocol::AddPeer &pb_add_peer) {
         model::AddPeer add_peer;
         add_peer.address = pb_add_peer.address();
         std::copy(pb_add_peer.peer_key().begin(), pb_add_peer.peer_key().end(),
@@ -69,15 +67,16 @@ namespace iroha {
       }
 
       // add signatory
-      protocol::AddSignatory
-      PbCommandFactory::serializeAddSignatory(const model::AddSignatory &add_signatory) {
+      protocol::AddSignatory PbCommandFactory::serializeAddSignatory(
+          const model::AddSignatory &add_signatory) {
         protocol::AddSignatory pb_add_signatory;
         pb_add_signatory.set_account_id(add_signatory.account_id);
         pb_add_signatory.set_public_key(add_signatory.pubkey.data(),
                                         add_signatory.pubkey.size());
         return pb_add_signatory;
       }
-      model::AddSignatory PbCommandFactory::deserializeAddSignatory(const protocol::AddSignatory &pb_add_signatory) {
+      model::AddSignatory PbCommandFactory::deserializeAddSignatory(
+          const protocol::AddSignatory &pb_add_signatory) {
         model::AddSignatory add_signatory;
         add_signatory.account_id = pb_add_signatory.account_id();
         std::copy(pb_add_signatory.public_key().begin(),
@@ -87,8 +86,8 @@ namespace iroha {
       }
 
       // assign master key
-      protocol::AssignMasterKey
-      PbCommandFactory::serializeAssignMasterKey(const model::AssignMasterKey &assign_master_key) {
+      protocol::AssignMasterKey PbCommandFactory::serializeAssignMasterKey(
+          const model::AssignMasterKey &assign_master_key) {
         protocol::AssignMasterKey pb_assign_master_key;
         pb_assign_master_key.set_account_id(assign_master_key.account_id);
         pb_assign_master_key.set_public_key(assign_master_key.pubkey.data(),
@@ -107,8 +106,8 @@ namespace iroha {
       }
 
       // create asset
-      protocol::CreateAsset
-      PbCommandFactory::serializeCreateAsset(const model::CreateAsset &create_asset) {
+      protocol::CreateAsset PbCommandFactory::serializeCreateAsset(
+          const model::CreateAsset &create_asset) {
         protocol::CreateAsset pb_create_asset;
         pb_create_asset.set_asset_name(create_asset.asset_name);
         pb_create_asset.set_domain_id(create_asset.domain_id);
@@ -116,8 +115,8 @@ namespace iroha {
         return pb_create_asset;
       }
 
-      model::CreateAsset
-      PbCommandFactory::deserializeCreateAsset(const protocol::CreateAsset &pb_create_asset) {
+      model::CreateAsset PbCommandFactory::deserializeCreateAsset(
+          const protocol::CreateAsset &pb_create_asset) {
         model::CreateAsset create_asset;
         create_asset.asset_name = pb_create_asset.asset_name();
         create_asset.domain_id = pb_create_asset.domain_id();
@@ -127,8 +126,8 @@ namespace iroha {
       }
 
       // create account
-      protocol::CreateAccount
-      PbCommandFactory::serializeCreateAccount(const model::CreateAccount &create_account) {
+      protocol::CreateAccount PbCommandFactory::serializeCreateAccount(
+          const model::CreateAccount &create_account) {
         protocol::CreateAccount pb_create_account;
         pb_create_account.set_account_name(create_account.account_name);
         pb_create_account.set_domain_id(create_account.domain_id);
@@ -136,7 +135,8 @@ namespace iroha {
                                           create_account.pubkey.size());
         return pb_create_account;
       }
-      model::CreateAccount PbCommandFactory::deserializeCreateAccount(const protocol::CreateAccount &pb_create_account) {
+      model::CreateAccount PbCommandFactory::deserializeCreateAccount(
+          const protocol::CreateAccount &pb_create_account) {
         model::CreateAccount create_account;
         create_account.account_name = pb_create_account.account_name();
         create_account.domain_id = pb_create_account.domain_id();
@@ -147,21 +147,23 @@ namespace iroha {
       }
 
       // create domain
-      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(const model::CreateDomain &create_domain) {
+      protocol::CreateDomain PbCommandFactory::serializeCreateDomain(
+          const model::CreateDomain &create_domain) {
         protocol::CreateDomain pb_create_domain;
         pb_create_domain.set_domain_name(create_domain.domain_name);
         return pb_create_domain;
       }
 
-      model::CreateDomain PbCommandFactory::deserializeCreateDomain(const protocol::CreateDomain &pb_create_domain) {
+      model::CreateDomain PbCommandFactory::deserializeCreateDomain(
+          const protocol::CreateDomain &pb_create_domain) {
         model::CreateDomain create_domain;
         create_domain.domain_name = pb_create_domain.domain_name();
         return create_domain;
       }
 
       // remove signatory
-      protocol::RemoveSignatory
-      PbCommandFactory::serializeRemoveSignatory(const model::RemoveSignatory &remove_signatory) {
+      protocol::RemoveSignatory PbCommandFactory::serializeRemoveSignatory(
+          const model::RemoveSignatory &remove_signatory) {
         protocol::RemoveSignatory pb_remove_signatory;
         pb_remove_signatory.set_account_id(remove_signatory.account_id);
         pb_remove_signatory.set_public_key(remove_signatory.pubkey.data(),
@@ -180,20 +182,31 @@ namespace iroha {
       }
 
       // set account permissions
-      protocol::SetAccountPermissions PbCommandFactory::serializeSetAccountPermissions(
+      protocol::SetAccountPermissions
+      PbCommandFactory::serializeSetAccountPermissions(
           const model::SetAccountPermissions &set_account_permissions) {
         protocol::SetAccountPermissions pb_set_account_permissions;
-        pb_set_account_permissions.set_account_id(set_account_permissions.account_id);
+        pb_set_account_permissions.set_account_id(
+            set_account_permissions.account_id);
         auto permissions = pb_set_account_permissions.mutable_permissions();
-        permissions->set_issue_assets(set_account_permissions.new_permissions.issue_assets);
-        permissions->set_create_assets(set_account_permissions.new_permissions.create_assets);
-        permissions->set_create_accounts(set_account_permissions.new_permissions.create_accounts);
-        permissions->set_create_domains(set_account_permissions.new_permissions.create_domains);
-        permissions->set_read_all_accounts(set_account_permissions.new_permissions.read_all_accounts);
-        permissions->set_add_signatory(set_account_permissions.new_permissions.add_signatory);
-        permissions->set_remove_signatory(set_account_permissions.new_permissions.remove_signatory);
-        permissions->set_set_quorum(set_account_permissions.new_permissions.set_quorum);
-        permissions->set_can_transfer(set_account_permissions.new_permissions.can_transfer);
+        permissions->set_issue_assets(
+            set_account_permissions.new_permissions.issue_assets);
+        permissions->set_create_assets(
+            set_account_permissions.new_permissions.create_assets);
+        permissions->set_create_accounts(
+            set_account_permissions.new_permissions.create_accounts);
+        permissions->set_create_domains(
+            set_account_permissions.new_permissions.create_domains);
+        permissions->set_read_all_accounts(
+            set_account_permissions.new_permissions.read_all_accounts);
+        permissions->set_add_signatory(
+            set_account_permissions.new_permissions.add_signatory);
+        permissions->set_remove_signatory(
+            set_account_permissions.new_permissions.remove_signatory);
+        permissions->set_set_quorum(
+            set_account_permissions.new_permissions.set_quorum);
+        permissions->set_can_transfer(
+            set_account_permissions.new_permissions.can_transfer);
         return pb_set_account_permissions;
       }
 
@@ -227,15 +240,15 @@ namespace iroha {
       }
 
       // set account quorum
-      protocol::SetAccountQuorum
-      PbCommandFactory::serializeSetQuorum(const model::SetQuorum &set_account_quorum) {
+      protocol::SetAccountQuorum PbCommandFactory::serializeSetQuorum(
+          const model::SetQuorum &set_account_quorum) {
         protocol::SetAccountQuorum pb_set_account_quorum;
         pb_set_account_quorum.set_account_id(set_account_quorum.account_id);
         pb_set_account_quorum.set_quorum(set_account_quorum.new_quorum);
         return pb_set_account_quorum;
       }
-      model::SetQuorum
-      PbCommandFactory::deserializeSetQuorum(const protocol::SetAccountQuorum &pb_set_account_quorum) {
+      model::SetQuorum PbCommandFactory::deserializeSetQuorum(
+          const protocol::SetAccountQuorum &pb_set_account_quorum) {
         model::SetQuorum set_quorum;
         set_quorum.account_id = pb_set_account_quorum.account_id();
         set_quorum.new_quorum = pb_set_account_quorum.quorum();
@@ -243,26 +256,28 @@ namespace iroha {
       }
 
       // transfer asset
-      protocol::TransferAsset
-      PbCommandFactory::serializeTransferAsset(const model::TransferAsset &transfer_asset) {
+      protocol::TransferAsset PbCommandFactory::serializeTransferAsset(
+          const model::TransferAsset &transfer_asset) {
         protocol::TransferAsset pb_transfer_asset;
         pb_transfer_asset.set_src_account_id(transfer_asset.src_account_id);
         pb_transfer_asset.set_dest_account_id(transfer_asset.dest_account_id);
         pb_transfer_asset.set_asset_id(transfer_asset.asset_id);
+        pb_transfer_asset.set_description(transfer_asset.description);
         auto amount = pb_transfer_asset.mutable_amount();
         amount->set_integer_part(transfer_asset.amount.int_part);
         amount->set_fractial_part(transfer_asset.amount.frac_part);
         return pb_transfer_asset;
       }
 
-      model::TransferAsset
-      PbCommandFactory::deserializeTransferAsset(const protocol::TransferAsset &pb_subtract_asset_quantity) {
+      model::TransferAsset PbCommandFactory::deserializeTransferAsset(
+          const protocol::TransferAsset &pb_subtract_asset_quantity) {
         model::TransferAsset transfer_asset;
         transfer_asset.src_account_id =
             pb_subtract_asset_quantity.src_account_id();
         transfer_asset.dest_account_id =
             pb_subtract_asset_quantity.dest_account_id();
         transfer_asset.asset_id = pb_subtract_asset_quantity.asset_id();
+        transfer_asset.description = pb_subtract_asset_quantity.description();
         transfer_asset.amount.int_part =
             pb_subtract_asset_quantity.amount().integer_part();
         transfer_asset.amount.frac_part =
@@ -270,109 +285,103 @@ namespace iroha {
         return transfer_asset;
       }
 
-      protocol::Command
-      PbCommandFactory::serializeAbstractCommand(const model::Command &command) {
+      protocol::Command PbCommandFactory::serializeAbstractCommand(
+          const model::Command &command) {
         PbCommandFactory commandFactory;
         auto cmd = protocol::Command();
 
         // -----|AddAssetQuantity|-----
-        if (instanceof<model::AddAssetQuantity>(command)) {
-          auto serialized = commandFactory
-              .serializeAddAssetQuantity(
-                  static_cast<const model::AddAssetQuantity &>(command));
-          cmd.set_allocated_add_asset_quantity(new protocol::AddAssetQuantity(
-              serialized));
+        if (instanceof <model::AddAssetQuantity>(command)) {
+          auto serialized = commandFactory.serializeAddAssetQuantity(
+              static_cast<const model::AddAssetQuantity &>(command));
+          cmd.set_allocated_add_asset_quantity(
+              new protocol::AddAssetQuantity(serialized));
         }
 
         // -----|AddPeer|-----
-        if (instanceof<model::AddPeer>(command)) {
-          auto serialized = commandFactory
-              .serializeAddPeer(
-                  static_cast<const model::AddPeer &>(command));
+        if (instanceof <model::AddPeer>(command)) {
+          auto serialized = commandFactory.serializeAddPeer(
+              static_cast<const model::AddPeer &>(command));
           cmd.set_allocated_add_peer(new protocol::AddPeer(serialized));
         }
 
         // -----|AddSignatory|-----
-        if (instanceof<model::AddSignatory>(command)) {
-          auto serialized = commandFactory
-              .serializeAddSignatory(
-                  static_cast<const model::AddSignatory &>(command));
-          cmd.set_allocated_add_signatory(new protocol::AddSignatory(serialized));
+        if (instanceof <model::AddSignatory>(command)) {
+          auto serialized = commandFactory.serializeAddSignatory(
+              static_cast<const model::AddSignatory &>(command));
+          cmd.set_allocated_add_signatory(
+              new protocol::AddSignatory(serialized));
         }
 
         // -----|AssignMasterKey|-----
-        if (instanceof<model::AssignMasterKey>(command)) {
-          auto serialized = commandFactory
-              .serializeAssignMasterKey(
-                  static_cast<const model::AssignMasterKey &>(command));
-          cmd.set_allocated_account_assign_mk(new protocol::AssignMasterKey(
-              serialized));
+        if (instanceof <model::AssignMasterKey>(command)) {
+          auto serialized = commandFactory.serializeAssignMasterKey(
+              static_cast<const model::AssignMasterKey &>(command));
+          cmd.set_allocated_account_assign_mk(
+              new protocol::AssignMasterKey(serialized));
         }
 
         // -----|AssignMasterKey|-----
-        if (instanceof<model::CreateAsset>(command)) {
-          auto serialized = commandFactory
-              .serializeCreateAsset(
-                  static_cast<const model::CreateAsset &>(command));
+        if (instanceof <model::CreateAsset>(command)) {
+          auto serialized = commandFactory.serializeCreateAsset(
+              static_cast<const model::CreateAsset &>(command));
           cmd.set_allocated_create_asset(new protocol::CreateAsset(serialized));
         }
 
         // -----|CreateAccount|-----
-        if (instanceof<model::CreateAccount>(command)) {
-          auto serialized = commandFactory
-              .serializeCreateAccount(
-                  static_cast<const model::CreateAccount &>(command));
-          cmd.set_allocated_create_account(new protocol::CreateAccount(
-              serialized));
+        if (instanceof <model::CreateAccount>(command)) {
+          auto serialized = commandFactory.serializeCreateAccount(
+              static_cast<const model::CreateAccount &>(command));
+          cmd.set_allocated_create_account(
+              new protocol::CreateAccount(serialized));
         }
 
         // -----|CreateDomain|-----
-        if (instanceof<model::CreateDomain>(command)) {
-          auto serialized = commandFactory
-              .serializeCreateDomain(
-                  static_cast<const model::CreateDomain &>(command));
-          cmd.set_allocated_create_domain(new protocol::CreateDomain(serialized));
+        if (instanceof <model::CreateDomain>(command)) {
+          auto serialized = commandFactory.serializeCreateDomain(
+              static_cast<const model::CreateDomain &>(command));
+          cmd.set_allocated_create_domain(
+              new protocol::CreateDomain(serialized));
         }
 
         // -----|RemoveSignatory|-----
-        if (instanceof<model::RemoveSignatory>(command)) {
-          auto serialized = commandFactory
-              .serializeRemoveSignatory(
-                  static_cast<const model::RemoveSignatory &>(command));
-          cmd.set_allocated_remove_sign(new protocol::RemoveSignatory(serialized));
+        if (instanceof <model::RemoveSignatory>(command)) {
+          auto serialized = commandFactory.serializeRemoveSignatory(
+              static_cast<const model::RemoveSignatory &>(command));
+          cmd.set_allocated_remove_sign(
+              new protocol::RemoveSignatory(serialized));
         }
 
         // -----|SetAccountPermissions|-----
-        if (instanceof<model::SetAccountPermissions>(command)) {
-          auto serialized = commandFactory
-              .serializeSetAccountPermissions(
-                  static_cast<const model::SetAccountPermissions &>(command));
-          cmd.set_allocated_set_permission(new protocol::SetAccountPermissions(
-              serialized));
+        if (instanceof <model::SetAccountPermissions>(command)) {
+          auto serialized = commandFactory.serializeSetAccountPermissions(
+              static_cast<const model::SetAccountPermissions &>(command));
+          cmd.set_allocated_set_permission(
+              new protocol::SetAccountPermissions(serialized));
         }
 
         // -----|SetAccountQuorum|-----
-        if (instanceof<model::SetQuorum>(command)) {
-          auto serialized = commandFactory
-              .serializeSetQuorum(
-                  static_cast<const model::SetQuorum &>(command));
-          cmd.set_allocated_set_quorum(new protocol::SetAccountQuorum(serialized));
+        if (instanceof <model::SetQuorum>(command)) {
+          auto serialized = commandFactory.serializeSetQuorum(
+              static_cast<const model::SetQuorum &>(command));
+          cmd.set_allocated_set_quorum(
+              new protocol::SetAccountQuorum(serialized));
         }
 
         // -----|TransferAsset|-----
-        if (instanceof<model::TransferAsset>(command)) {
-          auto serialized = commandFactory
-              .serializeTransferAsset(
-                  static_cast<const model::TransferAsset &>(command));
-          cmd.set_allocated_transfer_asset(new protocol::TransferAsset(
-              serialized));
+        if (instanceof <model::TransferAsset>(command)) {
+          auto serialized = commandFactory.serializeTransferAsset(
+              static_cast<const model::TransferAsset &>(command));
+          cmd.set_allocated_transfer_asset(
+              new protocol::TransferAsset(serialized));
         }
 
         return cmd;
       }
 
       std::shared_ptr<model::Command>
-      PbCommandFactory::deserializeAbstractCommand(const protocol::Command &command) {
+      PbCommandFactory::deserializeAbstractCommand(
+          const protocol::Command &command) {
         PbCommandFactory commandFactory;
         std::shared_ptr<model::Command> val;
 
@@ -435,8 +444,8 @@ namespace iroha {
         // -----|SetAccountPermissions|-----
         if (command.has_set_permission()) {
           auto pb_command = command.set_permission();
-          auto
-              cmd = commandFactory.deserializeSetAccountPermissions(pb_command);
+          auto cmd =
+              commandFactory.deserializeSetAccountPermissions(pb_command);
           val = std::make_shared<model::SetAccountPermissions>(cmd);
         }
 
@@ -457,6 +466,6 @@ namespace iroha {
         return val;
       }
 
-    } // namespace converters
-  }  // namespace model
+    }  // namespace converters
+  }    // namespace model
 }  // namespace iroha

--- a/irohad/model/converters/pb_command_factory.hpp
+++ b/irohad/model/converters/pb_command_factory.hpp
@@ -41,54 +41,76 @@ namespace iroha {
       class PbCommandFactory {
        public:
         // asset quantity
-        protocol::AddAssetQuantity serializeAddAssetQuantity(const model::AddAssetQuantity &addAssetQuantity);
-        model::AddAssetQuantity deserializeAddAssetQuantity(const protocol::AddAssetQuantity &addAssetQuantity);
+        protocol::AddAssetQuantity serializeAddAssetQuantity(
+            const model::AddAssetQuantity &addAssetQuantity);
+        model::AddAssetQuantity deserializeAddAssetQuantity(
+            const protocol::AddAssetQuantity &addAssetQuantity);
 
         // add peer
         protocol::AddPeer serializeAddPeer(const model::AddPeer &addPeer);
         model::AddPeer deserializeAddPeer(const protocol::AddPeer &addPeer);
 
         // add signatory
-        protocol::AddSignatory serializeAddSignatory(const model::AddSignatory &addSignatory);
-        model::AddSignatory deserializeAddSignatory(const protocol::AddSignatory &addSignatory);
+        protocol::AddSignatory serializeAddSignatory(
+            const model::AddSignatory &addSignatory);
+        model::AddSignatory deserializeAddSignatory(
+            const protocol::AddSignatory &addSignatory);
 
         // assign master key
-        protocol::AssignMasterKey serializeAssignMasterKey(const model::AssignMasterKey &assignMasterKey);
-        model::AssignMasterKey deserializeAssignMasterKey(const protocol::AssignMasterKey &assignMasterKey);
+        protocol::AssignMasterKey serializeAssignMasterKey(
+            const model::AssignMasterKey &assignMasterKey);
+        model::AssignMasterKey deserializeAssignMasterKey(
+            const protocol::AssignMasterKey &assignMasterKey);
 
         // create asset
-        protocol::CreateAsset serializeCreateAsset(const model::CreateAsset &createAsset);
-        model::CreateAsset deserializeCreateAsset(const protocol::CreateAsset &createAsset);
+        protocol::CreateAsset serializeCreateAsset(
+            const model::CreateAsset &createAsset);
+        model::CreateAsset deserializeCreateAsset(
+            const protocol::CreateAsset &createAsset);
 
         // create account
-        protocol::CreateAccount serializeCreateAccount(const model::CreateAccount &createAccount);
-        model::CreateAccount deserializeCreateAccount(const protocol::CreateAccount &createAccount);
+        protocol::CreateAccount serializeCreateAccount(
+            const model::CreateAccount &createAccount);
+        model::CreateAccount deserializeCreateAccount(
+            const protocol::CreateAccount &createAccount);
 
         // create domain
-        protocol::CreateDomain serializeCreateDomain(const model::CreateDomain &createDomain);
-        model::CreateDomain deserializeCreateDomain(const protocol::CreateDomain &createDomain);
+        protocol::CreateDomain serializeCreateDomain(
+            const model::CreateDomain &createDomain);
+        model::CreateDomain deserializeCreateDomain(
+            const protocol::CreateDomain &createDomain);
 
         // remove signatory
-        protocol::RemoveSignatory serializeRemoveSignatory(const model::RemoveSignatory &removeSignatory);
-        model::RemoveSignatory deserializeRemoveSignatory(const protocol::RemoveSignatory &removeSignatory);
+        protocol::RemoveSignatory serializeRemoveSignatory(
+            const model::RemoveSignatory &removeSignatory);
+        model::RemoveSignatory deserializeRemoveSignatory(
+            const protocol::RemoveSignatory &removeSignatory);
 
         // set account permissions
-        protocol::SetAccountPermissions serializeSetAccountPermissions(const model::SetAccountPermissions &setAccountPermissions);
-        model::SetAccountPermissions deserializeSetAccountPermissions(const protocol::SetAccountPermissions &setAccountPermissions);
+        protocol::SetAccountPermissions serializeSetAccountPermissions(
+            const model::SetAccountPermissions &setAccountPermissions);
+        model::SetAccountPermissions deserializeSetAccountPermissions(
+            const protocol::SetAccountPermissions &setAccountPermissions);
 
         // set account quorum
-        protocol::SetAccountQuorum serializeSetQuorum(const model::SetQuorum &setAccountQuorum);
-        model::SetQuorum deserializeSetQuorum(const protocol::SetAccountQuorum &setAccountQuorum);
+        protocol::SetAccountQuorum serializeSetQuorum(
+            const model::SetQuorum &setAccountQuorum);
+        model::SetQuorum deserializeSetQuorum(
+            const protocol::SetAccountQuorum &setAccountQuorum);
 
         // transfer asset
-        protocol::TransferAsset serializeTransferAsset(const model::TransferAsset &subtractAssetQuantity);
-        model::TransferAsset deserializeTransferAsset(const protocol::TransferAsset &subtractAssetQuantity);
+        protocol::TransferAsset serializeTransferAsset(
+            const model::TransferAsset &subtractAssetQuantity);
+        model::TransferAsset deserializeTransferAsset(
+            const protocol::TransferAsset &subtractAssetQuantity);
 
         // abstract
-        protocol::Command serializeAbstractCommand(const model::Command &command);
-        std::shared_ptr<model::Command> deserializeAbstractCommand(const protocol::Command &command);
+        protocol::Command serializeAbstractCommand(
+            const model::Command &command);
+        std::shared_ptr<model::Command> deserializeAbstractCommand(
+            const protocol::Command &command);
       };
-    } // namespace converters
-  }  // namespace model
+    }  // namespace converters
+  }    // namespace model
 }  // namespace iroha
-#endif //IROHA_PB_COMMAND_FACTORY_HPP
+#endif  // IROHA_PB_COMMAND_FACTORY_HPP

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -484,7 +484,9 @@ bool TransferAssetExecutor::execute(const Command &command,
   if (not src_account_asset.has_value()) {
     log_->info("asset {} is absent of {}",
                transfer_asset.asset_id,
-               transfer_asset.src_account_id);
+               transfer_asset.src_account_id,
+               transfer_asset.description
+    );
 
     return false;
   }
@@ -496,7 +498,9 @@ bool TransferAssetExecutor::execute(const Command &command,
   if (not asset.has_value()) {
     log_->info("asset {} is absent of {}",
                transfer_asset.asset_id,
-               transfer_asset.dest_account_id);
+               transfer_asset.dest_account_id,
+               transfer_asset.description
+    );
 
     return false;
   }

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -27,7 +27,7 @@
 #include <model/commands/set_permissions.hpp>
 #include <model/commands/set_quorum.hpp>
 #include <model/commands/transfer_asset.hpp>
-#include <model/transaction.hpp>
+
 namespace iroha {
   namespace model {
 
@@ -177,7 +177,8 @@ namespace iroha {
       return transfer_asset.asset_id == asset_id &&
              transfer_asset.amount == amount &&
              transfer_asset.src_account_id == src_account_id &&
-             transfer_asset.dest_account_id == dest_account_id;
+             transfer_asset.dest_account_id == dest_account_id &&
+             transfer_asset.description == description;
     }
     bool TransferAsset::operator!=(const Command &command) const {
       return !operator==(command);

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -63,7 +63,8 @@ message TransferAsset {
     string src_account_id = 1;
     string dest_account_id = 2;
     string asset_id = 3;
-    Amount amount = 4;
+    string description = 4;
+    Amount amount = 5;
 }
 
 message Command {

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -123,6 +123,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   transferAsset.src_account_id = "user1@ru";
   transferAsset.dest_account_id = "user2@ru";
   transferAsset.asset_id = "RUB#ru";
+  transferAsset.description = "test transfer";
   iroha::Amount transfer_amount;
   transfer_amount.int_part = 1;
   transfer_amount.frac_part = 0;

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -67,7 +67,7 @@ class CommandValidateExecuteTest : public ::testing::Test {
   }
 
   std::string admin_id = "admin@test", account_id = "test@test",
-      asset_id = "coin#test", domain_id = "test";
+      asset_id = "coin#test", domain_id = "test", description = "test transfer";
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockWsvCommand> wsv_command;
@@ -654,6 +654,7 @@ class TransferAssetTest : public CommandValidateExecuteTest {
     transfer_asset->src_account_id = admin_id;
     transfer_asset->dest_account_id = account_id;
     transfer_asset->asset_id = asset_id;
+    transfer_asset->description = description;
     transfer_asset->amount.int_part = 1;
     transfer_asset->amount.frac_part = 50;
 

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -58,7 +58,7 @@ TEST_F(JsonCommandTest, add_asset_quantity) {
 
   orig_command->amount = amount;
   orig_command->asset_id = "23";
-  
+
   auto json_command = factory.serializeAddAssetQuantity(orig_command);
   auto serial_command = factory.deserializeAddAssetQuantity(json_command);
 
@@ -83,7 +83,6 @@ TEST_F(JsonCommandTest, add_signatory) {
   auto orig_command = std::make_shared<AddSignatory>();
   orig_command->account_id = "23";
 
-  
   auto json_command = factory.serializeAddSignatory(orig_command);
   auto serial_command = factory.deserializeAddSignatory(json_command);
 
@@ -104,7 +103,7 @@ TEST_F(JsonCommandTest, add_signatory_abstract_factory) {
 TEST_F(JsonCommandTest, assign_master_key) {
   auto orig_command = std::make_shared<AssignMasterKey>();
   orig_command->account_id = "23";
-  
+
   auto json_command = factory.serializeAssignMasterKey(orig_command);
   auto serial_command = factory.deserializeAssignMasterKey(json_command);
 
@@ -130,7 +129,7 @@ TEST_F(JsonCommandTest, create_account) {
   auto orig_command = std::make_shared<CreateAccount>();
   orig_command->account_name = "keker";
   orig_command->domain_id = "cheburek";
-  
+
   auto json_command = factory.serializeCreateAccount(orig_command);
   auto serial_command = factory.deserializeCreateAccount(json_command);
   ASSERT_EQ(*orig_command, *serial_command);
@@ -186,6 +185,7 @@ TEST_F(JsonCommandTest, set_transfer_asset) {
   orig_command->asset_id = "tugrik";
   orig_command->src_account_id = "Vasya";
   orig_command->dest_account_id = "Petya";
+  orig_command->description = "from Vasya to Petya with love";
 
   auto json_command = factory.serializeTransferAsset(orig_command);
   auto serial_command = factory.deserializeTransferAsset(json_command);

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -191,6 +191,7 @@ TEST(CommandTest, set_transfer_asset) {
   orig_command.asset_id = "tugrik";
   orig_command.src_account_id = "Vasya";
   orig_command.dest_account_id = "Petya";
+  orig_command.description = "from Vasya to Petya without love";
 
   auto proto_command = factory.serializeTransferAsset(orig_command);
   auto serial_command = factory.deserializeTransferAsset(proto_command);

--- a/test/module/irohad/model/operators/model_operators_test.cpp
+++ b/test/module/irohad/model/operators/model_operators_test.cpp
@@ -223,6 +223,7 @@ TransferAsset createTransferAsset() {
   transferAsset.amount.frac_part = 10;
   transferAsset.src_account_id = "1";
   transferAsset.dest_account_id = "2";
+  transferAsset.description = "test";
   return transferAsset;
 }
 


### PR DESCRIPTION
## What is this pull request?
Description field was added to asset transfers.
   
## Why do you implement it? Why do we need this pull request?
It is useful to have a description for asset transfers; they can be added by end users and help them to describe what does a transfer mean (like "for Bogdan's birthday" or "rent for house" etc)
  
## How to use the features provided in the pull request?
Similar to any other fields of TransferAsset objects.

## Details/Features
List of features / major commits
- Add description field to commands.proto
- Add description field to transfer_asset model
- Serializers and deserializers are now aware of description field
- Tests are changed accordingly

