### PR TITLE
Fix compilation error due to missing include; remove empty block commits

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -24,8 +24,9 @@ target_link_libraries(server_runner
 
 add_library(raw_block_insertion impl/raw_block_insertion.cpp)
 target_link_libraries(raw_block_insertion
-  model #json_model_converters
-  )
+    model
+    json_model_converters
+    )
 
 add_library(application
     application.cpp

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -56,8 +56,11 @@ namespace iroha {
         return;
       }
       auto temporaryStorage = ametsuchi_factory_->createTemporaryWsv();
-      notifier_.get_subscriber().on_next(
-          validator_->validate(proposal, *temporaryStorage));
+      auto verified_proposal =
+          validator_->validate(proposal, *temporaryStorage);
+      if (not verified_proposal.transactions.empty()) {
+        notifier_.get_subscriber().on_next(verified_proposal);
+      }
     }
 
     void Simulator::process_verified_proposal(model::Proposal proposal) {


### PR DESCRIPTION
- rapidjson header was not found in `raw_block_insertion.cpp` since it was not linked with `rapidjson` library target.
- Empty verified proposals were sent to block creator due to missing validation.