### PR TITLE
Add CMakeCache.txt and CMakeFiles directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ build/*
 *xcworkspace*
 *cmake-build-debug*
 CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles/*
 cmake-build-debu/*
 docker/build/iroha.tar
 cmake-build-debug/*


### PR DESCRIPTION
## What is this pull request?
`CMake` generates intermediate files and directories that do not have to be committed.
To avoid developers from committing such files these paths should be added to gitignore.
```
CMakeCache.txt
CMakeFiles/*
```
   
## Why do you implement it? Why do we need this pull request?
This has been implemented to avoid developers committing such files and directories by mistake.
