### PR TITLE
Search SO libs in default path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,10 @@ endif()
 PROJECT(iroha C CXX)
 
 SET(CMAKE_CXX_FLAGS "-std=c++1y -Wall -fPIC")
-SET(CMAKE_CXX_FLAGS_RELEASE "-O3")
+# -Wl,-rpath,lib says to the compiler: first directory where binary looks for
+# static libs is lib in current directory. Will be triggered by -DCMAKE_BUILD_TYPE=Release
+# equivalent of ld -rpath lib
+SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wl,-rpath,lib")
 SET(CMAKE_CXX_FLAGS_DEBUG   "-g -Wextra -Wno-unused-parameter -O0")
 SET(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 


### PR DESCRIPTION
Now, it is not necessary to add `LD_PRELOAD` or `LD_LIBRARY_PATH` before `irohad` binary. 

It is enough to have the following structure:
```
.
|-- conf
|   |-- example.genesis.block
|   `-- example.iroha.conf
|-- iroha-cli
|-- irohad
`-- lib
    |-- libc.so.6
    |-- libcares.so.2
    |-- libcrypto.so.1.0.0
    |-- libdl.so.2
    |-- libed25519.so
    |-- libgcc_s.so.1
    |-- libgrpc++.so.1
    |-- libgrpc.so.3
    |-- libm.so.6
    |-- libpq.so.5
    |-- libprotobuf.so.13
    |-- libpthread.so.0
    |-- librt.so.1
    |-- libssl.so.1.0.0
    |-- libstdc++.so.6
    |-- libtbb.so.2
    |-- libuv.so.1
    `-- libz.so.1
```
