### PR TITLE
feature/env-var-config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,4 @@
 BasedOnStyle: Google
 NamespaceIndentation: All
+BreakBeforeBinaryOperators: NonAssignment
+AlignOperands: false

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -37,15 +37,17 @@ using namespace iroha::consensus::yac;
 
 Irohad::Irohad(const std::string &block_store_dir,
                const std::string &redis_host, size_t redis_port,
-               const std::string &pg_conn, size_t torii_port,
-               uint64_t peer_number)
+               const std::string &pg_host, size_t pg_port,
+               const std::string &pg_user, const std::string &pg_pass,
+               size_t torii_port, uint64_t peer_number)
     : block_store_dir_(block_store_dir),
       redis_host_(redis_host),
       redis_port_(redis_port),
-      pg_conn_(pg_conn),
+      pg_conn_("host=" + pg_host + " port=" + std::to_string(pg_port) +
+               " user=" + pg_user + " password=" + pg_pass),
       torii_port_(torii_port),
       storage(StorageImpl::create(block_store_dir, redis_host, redis_port,
-                                  pg_conn)),
+                                  pg_conn_)),
       peer_number_(peer_number) {
   log_ = logger::log("IROHAD");
   log_->info("created");

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -55,8 +55,9 @@ class Irohad {
    * @param peer_number - number of peer in ledger // todo replace with pub key
    */
   Irohad(const std::string &block_store_dir, const std::string &redis_host,
-         size_t redis_port, const std::string &pg_conn, size_t torii_port,
-         uint64_t peer_number);
+         size_t redis_port, const std::string &pg_host, size_t pg_port,
+         const std::string &pg_user, const std::string &pg_pass,
+         size_t torii_port, uint64_t peer_number);
   void run();
   ~Irohad();
 

--- a/irohad/model/converters/json_common.hpp
+++ b/irohad/model/converters/json_common.hpp
@@ -51,7 +51,9 @@ namespace iroha {
          */
         template <typename T>
         auto operator()(T &&x) {
-          return nonstd::optional<V>(x);
+          nonstd::optional<V> result;
+          result.emplace(x);
+          return result;
         }
       };
 


### PR DESCRIPTION
- Add separate parameters for PostgreSQL
- Read peer number from env var
- Convert<V>::operator<T>() now uses emplace

## Why do you implement it? Why do we need this pull request?
Allows simpler deployment of docker instances by setting environment variables with `-e` instead of modifying docker image or creating a volume.
  
## How to use the features provided in the pull request?
Set environment variables before running `irohad`.
Example:
```
IROHA_BLOCK_STORE_PATH=$(pwd)/block_store IROHA_TORII_PORT=50051 IROHA_PG_HOST=localhost IROHA_PG_PORT=5432 IROHA_PG_USER=postgres IROHA_PG_PASS=mysecretpassword IROHA_REDIS_HOST=localhost IROHA_REDIS_PORT=6379 IROHA_PEER_NUMBER=0 ./cmake-build-debug/bin/irohad --genesis_block ./docs/zero.block
```

## Details/Features
- `IROHA_BLOCK_STORE_PATH` - path to block store
- `IROHA_TORII_PORT` - port for client interaction
- `IROHA_PG_HOST`, `IROHA_PG_PORT`, `IROHA_PG_USER`, `IROHA_PG_PASS` - PostgreSQL connection details
- `IROHA_REDIS_HOST`, `IROHA_REDIS_PORT` - Redis connection details
- `IROHA_PEER_NUMBER` - number of current peer from list of peers in genesis block