### PR TITLE
Add missed init() function

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -48,6 +48,7 @@ Irohad::Irohad(const std::string &block_store_dir,
       peer_number_(peer_number) {
   log_ = logger::log("IROHAD");
   log_->info("created");
+  init();
 }
 
 Irohad::~Irohad() {


### PR DESCRIPTION
## What is this pull request?
Calling `init()` is missed in `Irohad constructor`.

## Why do you implement it? Why do we need this pull request?
To initialize `storage` in `Irohad` class.

Fix the following bug:
```
iroha@b9d4388ecf48:/opt/iroha$ ./build/bin/irohad --config iroha.conf --genesis_block docs/zero.block --peer_number 1
[07:05:30][th: 3054][info] [MAIN] << start
[07:05:30][th: 3054][info] [MAIN] << config initialized
[07:05:30][th: 3054][info] [IROHAD] << created
[07:05:30][th: 3054][info] [MAIN] << storage initialized: false
[07:05:30][th: 3054][info] [MAIN] << Block is parsed
Segmentation fault
```

## Details/Features
- Add `init()` in Irohad constructor.

## P.S. (optional)
- TODO: `Out of range` exception occurs because at first there is no peers in storage. So `Irohad::initPeerAddress()` throws exception.
