### PR TITLE
Add permission to genesis block

### DIFF
--- a/docs/zero.block
+++ b/docs/zero.block
@@ -67,16 +67,16 @@
                     "command_type": "SetAccountPermissions",
                     "account_id": "admin@test",
                     "new_permissions": {
-                        "add_signatory": false,
+                        "add_signatory": true,
                         "can_transfer": true,
-                        "create_accounts": false,
-                        "create_assets": false,
-                        "create_domains": false,
+                        "create_accounts": true,
+                        "create_assets": true,
+                        "create_domains": true,
                         "issue_assets": true,
                         "read_all_accounts": true,
-                        "remove_signatory": false,
+                        "remove_signatory": true,
                         "set_permissions": true,
-                        "set_quorum": false
+                        "set_quorum": true
                     }
                 }
             ]


### PR DESCRIPTION
## What is this pull request?
Now when genesis block is created, we create admin@test account which does not have necessary permissions to create domains, assets and transactions. This pull request fixes it and grants admin user with all permissions
   
## Why do you implement it? Why do we need this pull request?
That stops from creating suitable environment in iroha for testing creating accounts and transferring money among them
  
## How to use the features provided in the pull request?
After this pull request we are able to create domains, assets and accounts via iroha-cli

