### PR TITLE
Hotfix Transaction's signatures fix

### DIFF
--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -73,7 +73,7 @@ namespace iroha {
             tx.commands.push_back(
                 commandFactory.deserializeAbstractCommand(pb_command));
           }
-        } catch( std::invalid_argument e ) {
+        } catch( std::invalid_argument &e ) {
           log_->error(e.what());
         }
 

--- a/schema/block.proto
+++ b/schema/block.proto
@@ -17,7 +17,7 @@ message Header {
    }
 
   Payload payload = 1;
-  repeated Signature signature = 2;
+  repeated Signature signatures = 2;
  }
 
  message Block {


### PR DESCRIPTION
## What is this pull request?
Pre:
```
message Transaction {
    ...
    repeated Signature signature = 2;
}
```
After:
```
message Transaction {
    ...
    repeated Signature signatures = 2;
}
```
   
## Why do you implement it? Why do we need this pull request?
Spell miss.
Because to avoid confusion of Client developers.
  
## Details/Features
List of features / major commits
- Change block.proto
- Change PbTransactionFactory
- Add Log by PbTransactionFactory::deserialize
