### PR TITLE
Add missing AmetsuchiTest setup call in pipeline test

### DIFF
--- a/test/integration/pipeline/tx_pipeline_integration_test.cpp
+++ b/test/integration/pipeline/tx_pipeline_integration_test.cpp
@@ -80,6 +80,7 @@ class TxPipelineIntegrationTest : public iroha::ametsuchi::AmetsuchiTest {
   TxPipelineIntegrationTest() { spdlog::set_level(spdlog::level::off); }
 
   void SetUp() override {
+    iroha::ametsuchi::AmetsuchiTest::SetUp();
     irohad = std::make_shared<TestIrohad>(
         block_store_path, redishost_, redisport_, pgopt_, 0, 0);
 


### PR DESCRIPTION
Pipeline test was failing in docker since database environment variables were not read in integration test.