### PR TITLE
Feature/pagination

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -41,6 +41,16 @@ namespace iroha {
           std::string account_id) = 0;
 
       /**
+       * Get all transactions of an account.
+       * @param account_id - account_id (accountName@domainName)
+       * @param tx_hash - until the transaction (exclusive)
+       * @param limit - size to get until the tx which has tx_hash
+       * @return observable of Model Transaction
+       */
+      virtual rxcpp::observable<model::Transaction> getAccountTransactionsWithPager(
+        std::string account_id, iroha::hash256_t tx_hash, size_t limit) = 0;
+
+      /**
        * Get asset transactions of an account.
        * @param account_id - account_id (accountName@domainName)
        * @param asset_id - asset_id (assetName#domainName)
@@ -48,6 +58,18 @@ namespace iroha {
        */
       virtual rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           std::string account_id, std::string asset_id) = 0;
+
+      /**
+       * Get asset transactions of an account with pagination.
+       * @param account_id - account_id (accountName@domainName)
+       * @param assets_id - list of asset_id (assetName#domainName)
+       * @param tx_hash - until the transaction (exclusive)
+       * @param limit - size to get until the tx which has tx_hash
+       * @return observable of Model Transaction
+       */
+      virtual rxcpp::observable<model::Transaction> getAccountAssetsTransactionsWithPager(
+        std::string account_id, std::vector<std::string> assets_id,
+        iroha::hash256_t tx_hash, size_t limit) = 0;
 
       /**
       * Get given number of blocks starting with given height.

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -23,6 +23,7 @@
 #include <model/block.hpp>
 #include <model/transaction.hpp>
 #include <rxcpp/rx-observable.hpp>
+#include "model/queries/get_transactions.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -43,12 +44,12 @@ namespace iroha {
       /**
        * Get all transactions of an account.
        * @param account_id - account_id (accountName@domainName)
-       * @param tx_hash - until the transaction (exclusive)
-       * @param limit - size to get until the tx which has tx_hash
+       * @param pager - pager for transactions
        * @return observable of Model Transaction
        */
-      virtual rxcpp::observable<model::Transaction> getAccountTransactionsWithPager(
-        std::string account_id, iroha::hash256_t tx_hash, size_t limit) = 0;
+      virtual rxcpp::observable<model::Transaction>
+      getAccountTransactionsWithPager(std::string account_id,
+                                      model::Pager pager) = 0;
 
       /**
        * Get asset transactions of an account.
@@ -63,36 +64,36 @@ namespace iroha {
        * Get asset transactions of an account with pagination.
        * @param account_id - account_id (accountName@domainName)
        * @param assets_id - list of asset_id (assetName#domainName)
-       * @param tx_hash - until the transaction (exclusive)
-       * @param limit - size to get until the tx which has tx_hash
+       * @param pager - pager for transactions
        * @return observable of Model Transaction
        */
-      virtual rxcpp::observable<model::Transaction> getAccountAssetsTransactionsWithPager(
-        std::string account_id, std::vector<std::string> assets_id,
-        iroha::hash256_t tx_hash, size_t limit) = 0;
+      virtual rxcpp::observable<model::Transaction>
+      getAccountAssetsTransactionsWithPager(std::string account_id,
+                                            std::vector<std::string> assets_id,
+                                            model::Pager pager) = 0;
 
       /**
-      * Get given number of blocks starting with given height.
-      * @param height - starting height
-      * @param count - number of blocks to retrieve
-      * @return observable of Model Block
-      */
+       * Get given number of blocks starting with given height.
+       * @param height - starting height
+       * @param count - number of blocks to retrieve
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getBlocks(uint32_t height,
                                                         uint32_t count) = 0;
 
       /**
-      * Get all blocks starting from given height.
-      * @param from - starting height
-      * @return observable of Model Block
-      */
+       * Get all blocks starting from given height.
+       * @param from - starting height
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getBlocksFrom(
           uint32_t height) = 0;
 
       /**
-      * Get given number of blocks from top.
-      * @param count - number of blocks to retrieve
-      * @return observable of Model Block
-      */
+       * Get given number of blocks from top.
+       * @param count - number of blocks to retrieve
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getTopBlocks(uint32_t count) = 0;
     };
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/flat_file_block_query.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.hpp
@@ -22,6 +22,7 @@
 
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include "model/converters/json_block_factory.hpp"
+#include "model/queries/get_transactions.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -40,14 +41,14 @@ namespace iroha {
         std::string account_id) override;
 
       rxcpp::observable<model::Transaction> getAccountTransactionsWithPager(
-        std::string account_id, iroha::hash256_t tx_hash, size_t limit) override;
+        std::string account_id, model::Pager pager) override;
 
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           std::string account_id, std::string asset_id) override;
 
       rxcpp::observable<model::Transaction> getAccountAssetsTransactionsWithPager(
           std::string account_id, std::vector<std::string> assets_id,
-          iroha::hash256_t tx_hash, size_t limit) override;
+          model::Pager pager) override;
 
     private:
       FlatFile &block_store_;

--- a/irohad/ametsuchi/impl/flat_file_block_query.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.hpp
@@ -29,9 +29,6 @@ namespace iroha {
      public:
       explicit FlatFileBlockQuery(FlatFile &block_store);
 
-      rxcpp::observable<model::Transaction> getAccountTransactions(
-          std::string account_id) override;
-
       rxcpp::observable<model::Block> getBlocks(uint32_t height,
                                                 uint32_t count) override;
 
@@ -39,10 +36,20 @@ namespace iroha {
 
       rxcpp::observable<model::Block> getTopBlocks(uint32_t count) override;
 
+      rxcpp::observable<model::Transaction> getAccountTransactions(
+        std::string account_id) override;
+
+      rxcpp::observable<model::Transaction> getAccountTransactionsWithPager(
+        std::string account_id, iroha::hash256_t tx_hash, size_t limit) override;
+
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           std::string account_id, std::string asset_id) override;
 
-     private:
+      rxcpp::observable<model::Transaction> getAccountAssetsTransactionsWithPager(
+          std::string account_id, std::vector<std::string> assets_id,
+          iroha::hash256_t tx_hash, size_t limit) override;
+
+    private:
       FlatFile &block_store_;
 
       model::converters::JsonBlockFactory serializer_;

--- a/irohad/model/converters/impl/json_common.cpp
+++ b/irohad/model/converters/impl/json_common.cpp
@@ -27,10 +27,21 @@ namespace iroha {
         Value document;
         document.SetObject();
 
-        document.AddMember("pubkey", signature.pubkey.to_hexstring(),
-                           allocator);
-        document.AddMember("signature", signature.signature.to_hexstring(),
-                           allocator);
+        document.AddMember(
+            "pubkey", signature.pubkey.to_hexstring(), allocator);
+        document.AddMember(
+            "signature", signature.signature.to_hexstring(), allocator);
+
+        return document;
+      }
+
+      Value serializePager(const Pager& pager,
+                           Document::AllocatorType& allocator) {
+        Value document;
+        document.SetObject();
+
+        document.AddMember("tx_hash", pager.tx_hash.to_hexstring(), allocator);
+        document.AddMember("limit", pager.limit, allocator);
 
         return document;
       }

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -62,6 +62,10 @@ namespace iroha {
              &JsonQueryFactory::serializeGetAccountTransactions},
             {typeid(GetAccountAssetTransactions),
              &JsonQueryFactory::serializeGetAccountAssetTransactions},
+            {typeid(GetAccountTransactionsWithPager),
+             &JsonQueryFactory::serializeGetAccountTransactionsWithPager},
+            {typeid(GetAccountAssetsTransactionsWithPager),
+             &JsonQueryFactory::serializeGetAccountAssetsTransactionsWithPager},
             {typeid(GetAssetInfo), &JsonQueryFactory::serializeGetAssetInfo},
             {typeid(GetRoles), &JsonQueryFactory::serializeGetRoles},
             {typeid(GetRolePermissions),
@@ -264,9 +268,14 @@ namespace iroha {
         auto &allocator = json_doc.GetAllocator();
         json_doc.AddMember("query_type", "GetAccountTransactionsWithPager",
                            allocator);
-        auto get_account =
-            std::static_pointer_cast<const GetAccountTransactions>(query);
-        json_doc.AddMember("account_id", get_account->account_id, allocator);
+        auto get_account_with_pg =
+            std::dynamic_pointer_cast<const GetAccountTransactionsWithPager>(query);
+        json_doc.AddMember("account_id", get_account_with_pg->account_id, allocator);
+        json_doc.AddMember("pager_tx_hash",
+                           get_account_with_pg->pager_tx_hash.to_hexstring(),
+                           allocator);
+        json_doc.AddMember("pager_limit", get_account_with_pg->pager_limit,
+                           allocator);
       }
 
       void JsonQueryFactory::serializeGetAccountAssetsTransactionsWithPager(
@@ -290,7 +299,8 @@ namespace iroha {
         }
         json_doc.AddMember("assets_id", assets_id, allocator);
         json_doc.AddMember("pager_tx_hash",
-                           get_account_assets_pg->pager_tx_hash.to_hexstring(), allocator);
+                           get_account_assets_pg->pager_tx_hash.to_hexstring(),
+                           allocator);
         json_doc.AddMember("pager_limit", get_account_assets_pg->pager_limit,
                            allocator);
       }

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -274,6 +274,7 @@ namespace iroha {
         auto get_account_with_pg =
             std::dynamic_pointer_cast<const GetAccountTransactionsWithPager>(
                 query);
+        assert(get_account_with_pg);
         json_doc.AddMember(
             "account_id", get_account_with_pg->account_id, allocator);
         Value json_pager;
@@ -294,16 +295,16 @@ namespace iroha {
             "account_id", get_account_assets_pg->account_id, allocator);
         Value json_assets_id;
         json_assets_id.SetArray();
-        for (auto id : get_account_assets_pg->assets_id) {
+        for (const auto& id : get_account_assets_pg->assets_id) {
           Value json_id;
-          json_assets_id.Set(id, allocator);
+          json_id.Set(id, allocator);
           json_assets_id.PushBack(json_id, allocator);
         }
+        json_doc.AddMember("assets_id", json_assets_id, allocator);
         Value json_pager;
         json_pager.SetObject();
         json_pager.CopyFrom(
-            serializePager(get_account_assets_pg->pager, allocator), allocator);
-        json_doc.AddMember("assets_id", json_assets_id, allocator);
+          serializePager(get_account_assets_pg->pager, allocator), allocator);
         json_doc.AddMember("pager", json_pager, allocator);
       }
 

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -290,7 +290,7 @@ namespace iroha {
         }
         json_doc.AddMember("assets_id", assets_id, allocator);
         json_doc.AddMember("pager_tx_hash",
-                           get_account_assets_pg->pager_tx_hash, allocator);
+                           get_account_assets_pg->pager_tx_hash.to_hexstring(), allocator);
         json_doc.AddMember("pager_limit", get_account_assets_pg->pager_limit,
                            allocator);
       }

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -239,8 +239,8 @@ namespace iroha {
                                 ->mutable_get_account_transactions_with_pager();
         pb_query_mut->set_account_id(tmp->account_id);
         auto pb_pager = pb_query_mut->mutable_pager();
-        pb_pager->set_tx_hash(tmp->pager_tx_hash.to_hexstring());
-        pb_pager->set_limit(tmp->pager_limit);
+        pb_pager->set_tx_hash(tmp->pager.tx_hash.to_hexstring());
+        pb_pager->set_limit(tmp->pager.limit);
         return pb_query;
       }
 
@@ -261,8 +261,8 @@ namespace iroha {
           (*pb_query_mut->add_assets_id()) = id;
         }
         auto pb_pager = pb_query_mut->mutable_pager();
-        pb_pager->set_tx_hash(tmp->pager_tx_hash.to_hexstring());
-        pb_pager->set_limit(tmp->pager_limit);
+        pb_pager->set_tx_hash(tmp->pager.tx_hash.to_hexstring());
+        pb_pager->set_limit(tmp->pager.limit);
         return pb_query;
       }
 

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -127,7 +127,14 @@ namespace iroha {
               query.account_id = pb_cast.account_id();
               std::copy(pb_cast.assets_id().begin(),
                         pb_cast.assets_id().end(),
-                        query.assets_id.begin());
+                        std::back_inserter(query.assets_id));
+              auto hex_opt =
+                iroha::hexstringToBytestring(pb_cast.pager().tx_hash());
+              assert(hex_opt);  // The string should be eliminated in stateless
+              // validator.
+              query.pager.tx_hash.from_string(*hex_opt);
+              query.pager.limit =
+                static_cast<uint16_t>(pb_cast.pager().limit());
               val = std::make_shared<
                   model::GetAccountAssetsTransactionsWithPager>(query);
               break;

--- a/irohad/model/converters/json_query_factory.hpp
+++ b/irohad/model/converters/json_query_factory.hpp
@@ -65,6 +65,10 @@ namespace iroha {
             const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAccountAssetTransactions(
             const rapidjson::Value &obj_query);
+        optional_ptr<Query> deserializeGetAccountTransactionsWithPager(
+            const rapidjson::Value &obj_query);
+        optional_ptr<Query> deserializeGetAccountAssetsTransactionsWithPager(
+            const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAccountAssets(
             const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAssetInfo(
@@ -84,11 +88,17 @@ namespace iroha {
             rapidjson::Document &json_doc,
             std::shared_ptr<const model::Query> query);
         void serializeGetAccountTransactions(
-            rapidjson::Document &json_doc,
-            std::shared_ptr<const model::Query> query);
+          rapidjson::Document &json_doc,
+          std::shared_ptr<const model::Query> query);
         void serializeGetAccountAssetTransactions(
-            rapidjson::Document &json_doc,
-            std::shared_ptr<const model::Query> query);
+          rapidjson::Document &json_doc,
+          std::shared_ptr<const model::Query> query);
+        void serializeGetAccountTransactionsWithPager(
+          rapidjson::Document &json_doc,
+          std::shared_ptr<const model::Query> query);
+        void serializeGetAccountAssetsTransactionsWithPager(
+          rapidjson::Document &json_doc,
+          std::shared_ptr<const model::Query> query);
         void serializeGetSignatories(rapidjson::Document &json_doc,
                                      std::shared_ptr<const model::Query> query);
 

--- a/irohad/model/converters/pb_query_factory.hpp
+++ b/irohad/model/converters/pb_query_factory.hpp
@@ -39,7 +39,7 @@ namespace iroha {
          * @return model Query
          */
         optional_ptr<model::Query> deserialize(
-            const protocol::Query& pb_query) const;
+            const protocol::Query &pb_query) const;
 
         /**
          * Convert model query to proto query
@@ -61,6 +61,10 @@ namespace iroha {
             std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetAccountAssetTransactions(
             std::shared_ptr<const Query> query) const;
+        protocol::Query serializeGetAccountTransactionsWithPager(
+            std::shared_ptr<const Query> query) const;
+        protocol::Query serializeGetAccountAssetsTransactionsWithPager(
+            std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetSignatories(
             std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetAssetInfo(
@@ -75,7 +79,7 @@ namespace iroha {
          * @param pb_query - protocol query  object
          * @param query - model query to serialize
          */
-        void serializeQueryMetaData(protocol::Query& pb_query,
+        void serializeQueryMetaData(protocol::Query &pb_query,
                                     std::shared_ptr<const Query> query) const;
 
         using Serializer = protocol::Query (PbQueryFactory::*)(

--- a/irohad/model/generators/impl/query_generator.cpp
+++ b/irohad/model/generators/impl/query_generator.cpp
@@ -93,28 +93,26 @@ namespace iroha {
 
       std::shared_ptr<GetAccountTransactionsWithPager> QueryGenerator::generateGetAccountTransactionsWithPager(
         ts64_t timestamp, std::string creator, uint64_t query_counter,
-        std::string account_id, iroha::hash256_t tx_hash, uint16_t limit) {
+        std::string account_id, model::Pager pager) {
         auto query = std::make_shared<GetAccountTransactionsWithPager>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
         query->query_counter = query_counter;
         query->account_id = account_id;
-        query->pager_tx_hash = tx_hash;
-        query->pager_limit = limit;
+        query->pager = pager;
         return query;
       }
 
       std::shared_ptr<GetAccountAssetsTransactionsWithPager> QueryGenerator::generateGetAccountAssetsTransactionsWithPager(
         ts64_t timestamp, std::string creator, uint64_t query_counter,
-        std::string account_id, std::vector<std::string> assets_id, iroha::hash256_t tx_hash, uint16_t limit) {
+        std::string account_id, std::vector<std::string> assets_id, model::Pager pager) {
         auto query = std::make_shared<GetAccountAssetsTransactionsWithPager>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
         query->query_counter = query_counter;
         query->account_id = account_id;
         query->assets_id = assets_id;
-        query->pager_tx_hash = tx_hash;
-        query->pager_limit = limit;
+        query->pager = pager;
         return query;
       }
 

--- a/irohad/model/generators/impl/query_generator.cpp
+++ b/irohad/model/generators/impl/query_generator.cpp
@@ -69,8 +69,8 @@ namespace iroha {
       }
 
       std::shared_ptr<GetAccountTransactions> QueryGenerator::generateGetAccountTransactions(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id) {
+        ts64_t timestamp, std::string creator, uint64_t query_counter,
+        std::string account_id) {
         auto query = std::make_shared<GetAccountTransactions>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
@@ -80,14 +80,41 @@ namespace iroha {
       }
 
       std::shared_ptr<GetAccountAssetTransactions> QueryGenerator::generateGetAccountAssetTransactions(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id, std::string asset_id) {
+        ts64_t timestamp, std::string creator, uint64_t query_counter,
+        std::string account_id, std::string asset_id) {
         auto query = std::make_shared<GetAccountAssetTransactions>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
         query->query_counter = query_counter;
         query->account_id = account_id;
         query->asset_id = asset_id;
+        return query;
+      }
+
+      std::shared_ptr<GetAccountTransactionsWithPager> QueryGenerator::generateGetAccountTransactionsWithPager(
+        ts64_t timestamp, std::string creator, uint64_t query_counter,
+        std::string account_id, iroha::hash256_t tx_hash, uint16_t limit) {
+        auto query = std::make_shared<GetAccountTransactionsWithPager>();
+        query->created_ts = timestamp;
+        query->creator_account_id = creator;
+        query->query_counter = query_counter;
+        query->account_id = account_id;
+        query->pager_tx_hash = tx_hash;
+        query->pager_limit = limit;
+        return query;
+      }
+
+      std::shared_ptr<GetAccountAssetsTransactionsWithPager> QueryGenerator::generateGetAccountAssetsTransactionsWithPager(
+        ts64_t timestamp, std::string creator, uint64_t query_counter,
+        std::string account_id, std::vector<std::string> assets_id, iroha::hash256_t tx_hash, uint16_t limit) {
+        auto query = std::make_shared<GetAccountAssetsTransactionsWithPager>();
+        query->created_ts = timestamp;
+        query->creator_account_id = creator;
+        query->query_counter = query_counter;
+        query->account_id = account_id;
+        query->assets_id = assets_id;
+        query->pager_tx_hash = tx_hash;
+        query->pager_limit = limit;
         return query;
       }
 

--- a/irohad/model/generators/query_generator.hpp
+++ b/irohad/model/generators/query_generator.hpp
@@ -29,38 +29,52 @@ namespace iroha {
     namespace generators {
       class QueryGenerator {
        public:
+        std::shared_ptr<GetAccount> generateGetAccount(ts64_t timestamp,
+                                                       std::string creator,
+                                                       uint64_t query_counter,
+                                                       std::string account_id);
 
-        std::shared_ptr<GetAccount> generateGetAccount(ts64_t timestamp, std::string creator,
-                                      uint64_t query_counter,
-                                      std::string account_id);
+        std::shared_ptr<GetAccountAssets> generateGetAccountAssets(
+            ts64_t timestamp,
+            std::string creator,
+            uint64_t query_counter,
+            std::string account_id,
+            std::string asset_id);
 
-        std::shared_ptr<GetAccountAssets> generateGetAccountAssets(ts64_t timestamp,
-                                                  std::string creator,
-                                                  uint64_t query_counter,
-                                                  std::string account_id,
-                                                  std::string asset_id);
-
-        std::shared_ptr<GetSignatories> generateGetSignatories(ts64_t timestamp,
-                                              std::string creator,
-                                              uint64_t query_counter,
-                                              std::string account_id);
+        std::shared_ptr<GetSignatories> generateGetSignatories(
+            ts64_t timestamp,
+            std::string creator,
+            uint64_t query_counter,
+            std::string account_id);
 
         std::shared_ptr<GetAccountTransactions> generateGetAccountTransactions(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id);
+            ts64_t timestamp,
+            std::string creator,
+            uint64_t query_counter,
+            std::string account_id);
 
-        std::shared_ptr<GetAccountAssetTransactions> generateGetAccountAssetTransactions(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id, std::string asset_id);
+        std::shared_ptr<GetAccountAssetTransactions>
+        generateGetAccountAssetTransactions(ts64_t timestamp,
+                                            std::string creator,
+                                            uint64_t query_counter,
+                                            std::string account_id,
+                                            std::string asset_id);
 
-        std::shared_ptr<GetAccountTransactionsWithPager> generateGetAccountTransactionsWithPager(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id, iroha::hash256_t tx_hash, uint16_t limit); // TODO: Replace with Pager type
+        std::shared_ptr<GetAccountTransactionsWithPager>
+        generateGetAccountTransactionsWithPager(ts64_t timestamp,
+                                                std::string creator,
+                                                uint64_t query_counter,
+                                                std::string account_id,
+                                                model::Pager pager);
 
-        std::shared_ptr<GetAccountAssetsTransactionsWithPager> generateGetAccountAssetsTransactionsWithPager(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id, std::vector<std::string> assets_id,
-          iroha::hash256_t tx_hash, uint16_t limit); // TODO: Replace with Pager type
+        std::shared_ptr<GetAccountAssetsTransactionsWithPager>
+        generateGetAccountAssetsTransactionsWithPager(
+            ts64_t timestamp,
+            std::string creator,
+            uint64_t query_counter,
+            std::string account_id,
+            std::vector<std::string> assets_id,
+            model::Pager);
 
         /**
          * Generate default query GetAssetInfo
@@ -80,8 +94,10 @@ namespace iroha {
          */
         std::shared_ptr<GetRolePermissions> generateGetRolePermissions();
 
-        void setQueryMetaData(std::shared_ptr<Query> query, ts64_t timestamp,
-                              std::string creator, uint64_t query_counter);
+        void setQueryMetaData(std::shared_ptr<Query> query,
+                              ts64_t timestamp,
+                              std::string creator,
+                              uint64_t query_counter);
       };
     }  // namespace generators
   }    // namespace model

--- a/irohad/model/generators/query_generator.hpp
+++ b/irohad/model/generators/query_generator.hpp
@@ -46,12 +46,21 @@ namespace iroha {
                                               std::string account_id);
 
         std::shared_ptr<GetAccountTransactions> generateGetAccountTransactions(
-            ts64_t timestamp, std::string creator, uint64_t query_counter,
-            std::string account_id);
+          ts64_t timestamp, std::string creator, uint64_t query_counter,
+          std::string account_id);
 
         std::shared_ptr<GetAccountAssetTransactions> generateGetAccountAssetTransactions(
-            ts64_t timestamp, std::string creator, uint64_t query_counter,
-            std::string account_id, std::string asset_id);
+          ts64_t timestamp, std::string creator, uint64_t query_counter,
+          std::string account_id, std::string asset_id);
+
+        std::shared_ptr<GetAccountTransactionsWithPager> generateGetAccountTransactionsWithPager(
+          ts64_t timestamp, std::string creator, uint64_t query_counter,
+          std::string account_id, iroha::hash256_t tx_hash, uint16_t limit); // TODO: Replace with Pager type
+
+        std::shared_ptr<GetAccountAssetsTransactionsWithPager> generateGetAccountAssetsTransactionsWithPager(
+          ts64_t timestamp, std::string creator, uint64_t query_counter,
+          std::string account_id, std::vector<std::string> assets_id,
+          iroha::hash256_t tx_hash, uint16_t limit); // TODO: Replace with Pager type
 
         /**
          * Generate default query GetAssetInfo

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -241,6 +241,29 @@ iroha::model::QueryProcessingFactory::executeGetAccountTransactions(
   return std::make_shared<iroha::model::TransactionsResponse>(response);
 }
 
+std::shared_ptr<iroha::model::QueryResponse> iroha::model::
+    QueryProcessingFactory::executeGetAccountAssetsTransactionsWithPager(
+        const model::GetAccountAssetsTransactionsWithPager &query) {
+  auto acc_asset_tx = _blockQuery->getAccountAssetsTransactionsWithPager(
+      query.account_id, query.assets_id, query.pager_tx_hash,
+      query.pager_limit);
+  iroha::model::TransactionsResponse response;
+  response.query_hash = iroha::hash(query);
+  response.transactions = acc_asset_tx;
+  return std::make_shared<iroha::model::TransactionsResponse>(response);
+}
+
+std::shared_ptr<iroha::model::QueryResponse>
+iroha::model::QueryProcessingFactory::executeGetAccountTransactionsWithPager(
+    const model::GetAccountTransactionsWithPager &query) {
+  auto acc_tx = _blockQuery->getAccountTransactionsWithPager(
+      query.account_id, query.pager_tx_hash, query.pager_limit);
+  iroha::model::TransactionsResponse response;
+  response.query_hash = iroha::hash(query);
+  response.transactions = acc_tx;
+  return std::make_shared<iroha::model::TransactionsResponse>(response);
+}
+
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetSignatories(
     const model::GetSignatories &query) {
@@ -316,6 +339,29 @@ iroha::model::QueryProcessingFactory::execute(
       return std::make_shared<iroha::model::ErrorResponse>(response);
     }
     return executeGetAccountAssetTransactions(*qry);
+  }
+  if (instanceof <iroha::model::GetAccountTransactionsWithPager>(query.get())) {
+    auto qry =
+      std::static_pointer_cast<const iroha::model::GetAccountTransactionsWithPager>(
+        query);
+    if (!validate(*qry)) {
+      iroha::model::ErrorResponse response;
+      response.query_hash = iroha::hash(*qry);
+      response.reason = model::ErrorResponse::STATEFUL_INVALID;
+      return std::make_shared<iroha::model::ErrorResponse>(response);
+    }
+    return executeGetAccountTransactionsWithPager(*qry);
+  }
+  if (instanceof <iroha::model::GetAccountAssetsTransactionsWithPager>(query.get())) {
+    auto qry = std::static_pointer_cast<
+      const iroha::model::GetAccountAssetsTransactionsWithPager>(query);
+    if (!validate(*qry)) {
+      iroha::model::ErrorResponse response;
+      response.query_hash = iroha::hash(*qry);
+      response.reason = model::ErrorResponse::STATEFUL_INVALID;
+      return std::make_shared<iroha::model::ErrorResponse>(response);
+    }
+    return executeGetAccountAssetsTransactionsWithPager(*qry);
   }
   if (instanceof <GetRoles>(query.get())) {
     auto qry = std::static_pointer_cast<const GetRoles>(query);

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -245,8 +245,7 @@ std::shared_ptr<iroha::model::QueryResponse> iroha::model::
     QueryProcessingFactory::executeGetAccountAssetsTransactionsWithPager(
         const model::GetAccountAssetsTransactionsWithPager &query) {
   auto acc_asset_tx = _blockQuery->getAccountAssetsTransactionsWithPager(
-      query.account_id, query.assets_id, query.pager_tx_hash,
-      query.pager_limit);
+      query.account_id, query.assets_id, query.pager);
   iroha::model::TransactionsResponse response;
   response.query_hash = iroha::hash(query);
   response.transactions = acc_asset_tx;
@@ -257,7 +256,7 @@ std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountTransactionsWithPager(
     const model::GetAccountTransactionsWithPager &query) {
   auto acc_tx = _blockQuery->getAccountTransactionsWithPager(
-      query.account_id, query.pager_tx_hash, query.pager_limit);
+      query.account_id, query.pager);
   iroha::model::TransactionsResponse response;
   response.query_hash = iroha::hash(query);
   response.transactions = acc_tx;

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include "crypto/hash.hpp"
 #include "model/query_execution.hpp"
+#include "crypto/hash.hpp"
 #include "model/queries/responses/account_assets_response.hpp"
 #include "model/queries/responses/account_response.hpp"
 #include "model/queries/responses/asset_response.hpp"
@@ -33,7 +33,7 @@ iroha::model::QueryProcessingFactory::QueryProcessingFactory(
     : _wsvQuery(wsvQuery), _blockQuery(blockQuery) {}
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetAssetInfo& query) {
+    const model::GetAssetInfo &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   // TODO: check signatures
   return
@@ -43,7 +43,7 @@ bool iroha::model::QueryProcessingFactory::validate(
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetRoles& query) {
+    const model::GetRoles &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   // TODO: check signatures
   return
@@ -52,7 +52,7 @@ bool iroha::model::QueryProcessingFactory::validate(
       creator.has_value();
 }
 
-bool QueryProcessingFactory::validate(const model::GetRolePermissions& query) {
+bool QueryProcessingFactory::validate(const model::GetRolePermissions &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   // TODO: check signatures
   return
@@ -62,63 +62,85 @@ bool QueryProcessingFactory::validate(const model::GetRolePermissions& query) {
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetAccount& query) {
+    const model::GetAccount &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   // TODO: check signatures
   return
       // Creator account exits
       creator.has_value() &&
       // Creator has permission to read, or account = creator
-      (creator.value().permissions.read_all_accounts ||
-       query.account_id == query.creator_account_id);
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetSignatories& query) {
+    const model::GetSignatories &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   return
       // Creator account exits
       creator.has_value() &&
       // Creator has permission to read, or account = creator
-      (creator.value().permissions.read_all_accounts ||
-       query.account_id == query.creator_account_id);
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetAccountAssets& query) {
+    const model::GetAccountAssets &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   return
       // Creator account exits
       creator.has_value() &&
       // Creator has permission to read, or account = creator
-      (creator.value().permissions.read_all_accounts ||
-       query.account_id == query.creator_account_id);
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetAccountTransactions& query) {
+    const model::GetAccountTransactions &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   return
       // Creator account exits
       creator.has_value() &&
       // Creator has permission to read, or account = creator
-      (creator.value().permissions.read_all_accounts ||
-       query.account_id == query.creator_account_id);
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
 }
 
 bool iroha::model::QueryProcessingFactory::validate(
-    const model::GetAccountAssetTransactions& query) {
+    const model::GetAccountAssetTransactions &query) {
   auto creator = _wsvQuery->getAccount(query.creator_account_id);
   return
       // Creator account exits
       creator.has_value() &&
       // Creator has permission to read, or account = creator
-      (creator.value().permissions.read_all_accounts ||
-       query.account_id == query.creator_account_id);
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
+}
+
+bool iroha::model::QueryProcessingFactory::validate(
+    const model::GetAccountTransactionsWithPager &query) {
+  auto creator = _wsvQuery->getAccount(query.creator_account_id);
+  return
+      // Creator account exits
+      creator.has_value() &&
+      // Creator has permission to read, or account = creator
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
+}
+
+bool iroha::model::QueryProcessingFactory::validate(
+    const model::GetAccountAssetsTransactionsWithPager &query) {
+  auto creator = _wsvQuery->getAccount(query.creator_account_id);
+  return
+      // Creator account exits
+      creator.has_value() &&
+      // Creator has permission to read, or account = creator
+      (creator.value().permissions.read_all_accounts
+       || query.account_id == query.creator_account_id);
 }
 
 std::shared_ptr<iroha::model::QueryResponse>
-QueryProcessingFactory::executeGetAssetInfo(const model::GetAssetInfo& query) {
+QueryProcessingFactory::executeGetAssetInfo(const model::GetAssetInfo &query) {
   auto ast = _wsvQuery->getAsset(query.asset_id);
   if (!ast.has_value()) {
     iroha::model::ErrorResponse response;
@@ -133,7 +155,7 @@ QueryProcessingFactory::executeGetAssetInfo(const model::GetAssetInfo& query) {
 }
 
 std::shared_ptr<iroha::model::QueryResponse>
-QueryProcessingFactory::executeGetRoles(const model::GetRoles& query) {
+QueryProcessingFactory::executeGetRoles(const model::GetRoles &query) {
   auto roles = _wsvQuery->getRoles();
   if (not roles.has_value()) {
     ErrorResponse response;
@@ -149,7 +171,7 @@ QueryProcessingFactory::executeGetRoles(const model::GetRoles& query) {
 
 std::shared_ptr<iroha::model::QueryResponse>
 QueryProcessingFactory::executeGetRolePermissions(
-    const model::GetRolePermissions& query) {
+    const model::GetRolePermissions &query) {
   auto perm = _wsvQuery->getRolePermissions(query.role_id);
   if (not perm.has_value()) {
     ErrorResponse response;
@@ -165,7 +187,7 @@ QueryProcessingFactory::executeGetRolePermissions(
 
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccount(
-    const model::GetAccount& query) {
+    const model::GetAccount &query) {
   auto acc = _wsvQuery->getAccount(query.account_id);
   if (!acc.has_value()) {
     iroha::model::ErrorResponse response;
@@ -181,7 +203,7 @@ iroha::model::QueryProcessingFactory::executeGetAccount(
 
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountAssets(
-    const model::GetAccountAssets& query) {
+    const model::GetAccountAssets &query) {
   auto acct_asset =
       _wsvQuery->getAccountAsset(query.account_id, query.asset_id);
   if (!acct_asset.has_value()) {
@@ -200,7 +222,7 @@ iroha::model::QueryProcessingFactory::executeGetAccountAssets(
 
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountAssetTransactions(
-    const model::GetAccountAssetTransactions& query) {
+    const model::GetAccountAssetTransactions &query) {
   auto acc_asset_tx = _blockQuery->getAccountAssetTransactions(query.account_id,
                                                                query.asset_id);
   iroha::model::TransactionsResponse response;
@@ -211,7 +233,7 @@ iroha::model::QueryProcessingFactory::executeGetAccountAssetTransactions(
 
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountTransactions(
-    const model::GetAccountTransactions& query) {
+    const model::GetAccountTransactions &query) {
   auto acc_tx = _blockQuery->getAccountTransactions(query.account_id);
   iroha::model::TransactionsResponse response;
   response.query_hash = iroha::hash(query);
@@ -221,7 +243,7 @@ iroha::model::QueryProcessingFactory::executeGetAccountTransactions(
 
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetSignatories(
-    const model::GetSignatories& query) {
+    const model::GetSignatories &query) {
   auto signs = _wsvQuery->getSignatories(query.account_id);
   if (!signs.has_value()) {
     iroha::model::ErrorResponse response;
@@ -295,35 +317,35 @@ iroha::model::QueryProcessingFactory::execute(
     }
     return executeGetAccountAssetTransactions(*qry);
   }
-  if (instanceof<GetRoles>(query.get())){
+  if (instanceof <GetRoles>(query.get())) {
     auto qry = std::static_pointer_cast<const GetRoles>(query);
-    if(not validate(*qry)){
+    if (not validate(*qry)) {
       ErrorResponse response;
       response.query_hash = iroha::hash(*qry);
       response.reason = ErrorResponse::STATEFUL_INVALID;
       return std::make_shared<ErrorResponse>(response);
     }
-    return  executeGetRoles(*qry);
+    return executeGetRoles(*qry);
   }
-  if (instanceof<GetRolePermissions>(query.get())){
+  if (instanceof <GetRolePermissions>(query.get())) {
     auto qry = std::static_pointer_cast<const GetRolePermissions>(query);
-    if(not validate(*qry)){
+    if (not validate(*qry)) {
       ErrorResponse response;
       response.query_hash = iroha::hash(*qry);
       response.reason = ErrorResponse::STATEFUL_INVALID;
       return std::make_shared<ErrorResponse>(response);
     }
-    return  executeGetRolePermissions(*qry);
+    return executeGetRolePermissions(*qry);
   }
-  if (instanceof<GetAssetInfo>(query.get())){
+  if (instanceof <GetAssetInfo>(query.get())) {
     auto qry = std::static_pointer_cast<const GetAssetInfo>(query);
-    if(not validate(*qry)){
+    if (not validate(*qry)) {
       ErrorResponse response;
       response.query_hash = iroha::hash(*qry);
       response.reason = ErrorResponse::STATEFUL_INVALID;
       return std::make_shared<ErrorResponse>(response);
     }
-    return  executeGetAssetInfo(*qry);
+    return executeGetAssetInfo(*qry);
   }
   iroha::model::ErrorResponse response;
   response.query_hash = iroha::hash(*query);

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -20,6 +20,7 @@
 
 #include <model/query.hpp>
 #include <string>
+#include <vector>
 
 namespace iroha {
   namespace model {
@@ -47,6 +48,45 @@ namespace iroha {
        * Account identifier
        */
       std::string account_id;
+    };
+
+    /**
+     * Query for getting transactions of given asset of an account
+     */
+    struct GetAccountAssetsTransactionsWithPager : Query {
+      /**
+       * Account identifier
+       */
+      std::string account_id;
+
+      /**
+       * Asset identifiers
+       */
+      std::vector<std::string> assets_id;
+
+      /**
+       * Pager for transactions
+       */
+      std::string pager_tx_hash;
+      uint16_t pager_limit;
+
+      using AssetsIdType = decltype(assets_id);
+    };
+
+    /**
+      * Query for getting transactions of account
+      */
+    struct GetAccountTransactionsWithPager : Query {
+      /**
+       * Account identifier
+       */
+      std::string account_id;
+
+      /**
+       * Pager for transactions
+       */
+      std::string pager_tx_hash;
+      uint16_t pager_limit;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -67,7 +67,7 @@ namespace iroha {
       /**
        * Pager for transactions
        */
-      std::string pager_tx_hash;
+      iroha::hash256_t pager_tx_hash;
       uint16_t pager_limit;
 
       using AssetsIdType = decltype(assets_id);
@@ -85,7 +85,7 @@ namespace iroha {
       /**
        * Pager for transactions
        */
-      std::string pager_tx_hash;
+      iroha::hash256_t pager_tx_hash;
       uint16_t pager_limit;
     };
   }  // namespace model

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -51,6 +51,14 @@ namespace iroha {
     };
 
     /**
+     * Pager for transactions queries
+     */
+    struct Pager {
+      iroha::hash256_t tx_hash;
+      uint16_t limit;
+    };
+
+    /**
      * Query for getting transactions of given asset of an account
      */
     struct GetAccountAssetsTransactionsWithPager : Query {
@@ -67,8 +75,7 @@ namespace iroha {
       /**
        * Pager for transactions
        */
-      iroha::hash256_t pager_tx_hash;
-      uint16_t pager_limit;
+      Pager pager;
 
       using AssetsIdType = decltype(assets_id);
     };
@@ -85,8 +92,7 @@ namespace iroha {
       /**
        * Pager for transactions
        */
-      iroha::hash256_t pager_tx_hash;
-      uint16_t pager_limit;
+      Pager pager;
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -41,8 +41,8 @@ namespace iroha {
     };
 
     /**
-      * Query for getting transactions of account
-      */
+     * Query for getting transactions of account
+     */
     struct GetAccountTransactions : Query {
       /**
        * Account identifier
@@ -56,6 +56,11 @@ namespace iroha {
     struct Pager {
       iroha::hash256_t tx_hash;
       uint16_t limit;
+
+      bool operator==(Pager const& rhs) const {
+        return tx_hash == rhs.tx_hash and limit == rhs.limit;
+      }
+      bool operator!=(Pager const& rhs) const { return not(operator==(rhs)); }
     };
 
     /**
@@ -78,11 +83,19 @@ namespace iroha {
       Pager pager;
 
       using AssetsIdType = decltype(assets_id);
+
+      bool operator==(GetAccountAssetsTransactionsWithPager const& rhs) const {
+        return account_id == rhs.account_id and assets_id == rhs.assets_id
+            and pager == rhs.pager;
+      }
+      bool operator!=(GetAccountAssetsTransactionsWithPager const& rhs) const {
+        return not(operator==(rhs));
+      }
     };
 
     /**
-      * Query for getting transactions of account
-      */
+     * Query for getting transactions of account
+     */
     struct GetAccountTransactionsWithPager : Query {
       /**
        * Account identifier
@@ -93,6 +106,13 @@ namespace iroha {
        * Pager for transactions
        */
       Pager pager;
+
+      bool operator==(GetAccountTransactionsWithPager const& rhs) const {
+        return account_id == rhs.account_id and pager == rhs.pager;
+      }
+      bool operator!=(GetAccountTransactionsWithPager const& rhs) const {
+        return not(operator==(rhs));
+      }
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/query_execution.hpp
+++ b/irohad/model/query_execution.hpp
@@ -72,6 +72,10 @@ namespace iroha {
 
       bool validate(const model::GetAccountAssetTransactions& query);
 
+      bool validate(const model::GetAccountTransactionsWithPager& query);
+
+      bool validate(const model::GetAccountAssetsTransactionsWithPager& query);
+
       std::shared_ptr<iroha::model::QueryResponse> executeGetAssetInfo(
           const model::GetAssetInfo& query);
 

--- a/irohad/model/query_execution.hpp
+++ b/irohad/model/query_execution.hpp
@@ -56,50 +56,58 @@ namespace iroha {
                              std::shared_ptr<ametsuchi::BlockQuery> blockQuery);
 
      private:
-      bool validate(const model::GetAssetInfo& query);
+      bool validate(const model::GetAssetInfo &query);
 
-      bool validate(const model::GetRoles& query);
+      bool validate(const model::GetRoles &query);
 
-      bool validate(const model::GetRolePermissions& query);
+      bool validate(const model::GetRolePermissions &query);
 
-      bool validate(const model::GetAccountAssets& query);
+      bool validate(const model::GetAccountAssets &query);
 
-      bool validate(const model::GetAccount& query);
+      bool validate(const model::GetAccount &query);
 
-      bool validate(const model::GetSignatories& query);
+      bool validate(const model::GetSignatories &query);
 
-      bool validate(const model::GetAccountTransactions& query);
+      bool validate(const model::GetAccountTransactions &query);
 
-      bool validate(const model::GetAccountAssetTransactions& query);
+      bool validate(const model::GetAccountAssetTransactions &query);
 
-      bool validate(const model::GetAccountTransactionsWithPager& query);
+      bool validate(const model::GetAccountTransactionsWithPager &query);
 
-      bool validate(const model::GetAccountAssetsTransactionsWithPager& query);
+      bool validate(const model::GetAccountAssetsTransactionsWithPager &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetAssetInfo(
-          const model::GetAssetInfo& query);
+          const model::GetAssetInfo &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetRoles(
-          const model::GetRoles& query);
+          const model::GetRoles &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetRolePermissions(
-          const model::GetRolePermissions& query);
+          const model::GetRolePermissions &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetAccountAssets(
-          const model::GetAccountAssets& query);
+          const model::GetAccountAssets &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetAccount(
-          const model::GetAccount& query);
+          const model::GetAccount &query);
 
       std::shared_ptr<iroha::model::QueryResponse> executeGetSignatories(
-          const model::GetSignatories& query);
+          const model::GetSignatories &query);
 
       std::shared_ptr<iroha::model::QueryResponse>
       executeGetAccountAssetTransactions(
-          const model::GetAccountAssetTransactions& query);
+          const model::GetAccountAssetTransactions &query);
 
       std::shared_ptr<iroha::model::QueryResponse>
-      executeGetAccountTransactions(const model::GetAccountTransactions& query);
+      executeGetAccountTransactions(const model::GetAccountTransactions &query);
+
+      std::shared_ptr<iroha::model::QueryResponse>
+      executeGetAccountAssetsTransactionsWithPager(
+          const model::GetAccountAssetsTransactionsWithPager &query);
+
+      std::shared_ptr<iroha::model::QueryResponse>
+      executeGetAccountTransactionsWithPager(
+          const model::GetAccountTransactionsWithPager &query);
 
       std::shared_ptr<ametsuchi::WsvQuery> _wsvQuery;
       std::shared_ptr<ametsuchi::BlockQuery> _blockQuery;

--- a/irohad/model/registration/query_registration.hpp
+++ b/irohad/model/registration/query_registration.hpp
@@ -43,6 +43,8 @@ namespace iroha {
         query_handler.register_type(typeid(GetSignatories));
         query_handler.register_type(typeid(GetAccountTransactions));
         query_handler.register_type(typeid(GetAccountAssetTransactions));
+        query_handler.register_type(typeid(GetAccountTransactionsWithPager));
+        query_handler.register_type(typeid(GetAccountAssetsTransactionsWithPager));
         query_handler.register_type(typeid(GetRoles));
         query_handler.register_type(typeid(GetAssetInfo));
         query_handler.register_type(typeid(GetRolePermissions));

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -63,13 +63,15 @@ message Query {
        GetSignatories get_account_signatories = 4;
        GetAccountTransactions get_account_transactions = 5;
        GetAccountAssetTransactions get_account_asset_transactions = 6;
-       GetAccountAssets get_account_assets = 7;
-       GetRoles get_roles = 8;
-       GetAssetInfo get_asset_info = 9;
-       GetRolePermissions get_role_permissions = 10;
+       GetAccountTransactionsWithPager get_account_transactions_with_pager = 7;
+       GetAccountAssetsTransactionsWithPager get_account_assets_transactions_with_pager = 8;
+       GetAccountAssets get_account_assets = 9;
+       GetRoles get_roles = 10;
+       GetAssetInfo get_asset_info = 11;
+       GetRolePermissions get_role_permissions = 12;
      }
      // used to prevent replay attacks.
-     uint64 query_counter = 11;
+     uint64 query_counter = 13;
   }
 
   Payload payload = 1;

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -20,6 +20,22 @@ message GetAccountAssetTransactions {
   string asset_id = 2;
 }
 
+message Pager {
+  bytes tx_hash = 1;
+  uint32 limit = 2;
+}
+
+message GetAccountTransactionsWithPager {
+  string account_id = 1;
+  Pager pager = 2;
+}
+
+message GetAccountAssetsTransactionsWithPager {
+  string account_id = 1;
+  repeated string assets_id = 2;
+  Pager pager = 3;
+}
+
 message GetAccountAssets {
   string account_id = 1;
   string asset_id = 2;

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -104,15 +104,13 @@ namespace iroha {
                    rxcpp::observable<model::Transaction>(std::string,
                                                          std::string));
 
-      MOCK_METHOD3(getAccountTransactionsWithPager,
+      MOCK_METHOD2(getAccountTransactionsWithPager,
                    rxcpp::observable<model::Transaction>(std::string,
-                                                         iroha::hash256_t,
-                                                         size_t));
+                                                         model::Pager));
 
-      MOCK_METHOD4(getAccountAssetsTransactionsWithPager,
+      MOCK_METHOD3(getAccountAssetsTransactionsWithPager,
                    rxcpp::observable<model::Transaction>(
-                       std::string, std::vector<std::string>, iroha::hash256_t,
-                       size_t));
+                       std::string, std::vector<std::string>, model::Pager));
 
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
@@ -127,10 +125,11 @@ namespace iroha {
 
     class MockMutableStorage : public MutableStorage {
      public:
-      MOCK_METHOD2(apply,
-                   bool(const model::Block &,
-                        std::function<bool(const model::Block &, WsvQuery &,
-                                           const hash256_t &)>));
+      MOCK_METHOD2(
+          apply,
+          bool(const model::Block &,
+               std::function<
+                   bool(const model::Block &, WsvQuery &, const hash256_t &)>));
     };
 
     /**

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -31,34 +31,38 @@ namespace iroha {
   namespace ametsuchi {
     class MockWsvQuery : public WsvQuery {
      public:
-      MOCK_METHOD1(getAccountRoles, nonstd::optional<std::vector<std::string>>(
-                                        const std::string &account_id));
+      MOCK_METHOD1(getAccountRoles,
+                   nonstd::optional<std::vector<std::string>>(
+                       const std::string &account_id));
       MOCK_METHOD1(getRolePermissions,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &role_name));
       MOCK_METHOD0(getRoles, nonstd::optional<std::vector<std::string>>());
-      MOCK_METHOD1(getAccount, nonstd::optional<model::Account>(
-                                   const std::string &account_id));
+      MOCK_METHOD1(
+          getAccount,
+          nonstd::optional<model::Account>(const std::string &account_id));
       MOCK_METHOD1(getSignatories,
                    nonstd::optional<std::vector<pubkey_t>>(
                        const std::string &account_id));
       MOCK_METHOD1(getAsset,
                    nonstd::optional<model::Asset>(const std::string &asset_id));
-      MOCK_METHOD2(getAccountAsset, nonstd::optional<model::AccountAsset>(
-                                        const std::string &account_id,
-                                        const std::string &asset_id));
+      MOCK_METHOD2(
+          getAccountAsset,
+          nonstd::optional<model::AccountAsset>(const std::string &account_id,
+                                                const std::string &asset_id));
       MOCK_METHOD0(getPeers, nonstd::optional<std::vector<model::Peer>>());
       MOCK_METHOD3(hasAccountGrantablePermission,
                    bool(const std::string &permitee_account_id,
-                       const std::string &account_id,
-                       const std::string &permission_id));
+                        const std::string &account_id,
+                        const std::string &permission_id));
     };
 
     class MockWsvCommand : public WsvCommand {
      public:
       MOCK_METHOD1(insertRole, bool(const std::string &role_name));
-      MOCK_METHOD2(insertAccountRole, bool(const std::string &account_id,
-                                           const std::string &role_name));
+      MOCK_METHOD2(insertAccountRole,
+                   bool(const std::string &account_id,
+                        const std::string &role_name));
       MOCK_METHOD2(insertRolePermissions,
                    bool(const std::string &role_id,
                         const std::vector<std::string> &permissions));
@@ -94,12 +98,22 @@ namespace iroha {
 
     class MockBlockQuery : public BlockQuery {
      public:
-      MOCK_METHOD1(
-          getAccountTransactions,
-          rxcpp::observable<model::Transaction>(std::string account_id));
+      MOCK_METHOD1(getAccountTransactions,
+                   rxcpp::observable<model::Transaction>(std::string));
       MOCK_METHOD2(getAccountAssetTransactions,
-                   rxcpp::observable<model::Transaction>(std::string account_id,
-                                                         std::string asset_id));
+                   rxcpp::observable<model::Transaction>(std::string,
+                                                         std::string));
+
+      MOCK_METHOD3(getAccountTransactionsWithPager,
+                   rxcpp::observable<model::Transaction>(std::string,
+                                                         iroha::hash256_t,
+                                                         size_t));
+
+      MOCK_METHOD4(getAccountAssetsTransactionsWithPager,
+                   rxcpp::observable<model::Transaction>(
+                       std::string, std::vector<std::string>, iroha::hash256_t,
+                       size_t));
+
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
       MOCK_METHOD1(getBlocksFrom, rxcpp::observable<model::Block>(uint32_t));

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -1095,4 +1095,9 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
       std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[1]));
   EXPECT_TRUE(
       std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[2]));
+
+  blocks->getAccountAssetsTransactionsWithPager(user1id, {}, iroha::hash256_t{}, 100)
+    .subscribe([&](auto tx) {
+      FAIL() << "Shouldn't subscribe if no assets.";
+    });
 }

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -90,8 +90,8 @@ TEST_F(AmetsuchiTest, SampleTest) {
   }
 
   {
-    auto account = wsv->getAccount(createAccount.account_name + "@" +
-                                       createAccount.domain_id);
+    auto account = wsv->getAccount(createAccount.account_name + "@"
+                                   + createAccount.domain_id);
     ASSERT_TRUE(account);
     ASSERT_EQ(account->account_id,
               createAccount.account_name + "@" + createAccount.domain_id);
@@ -165,10 +165,10 @@ TEST_F(AmetsuchiTest, SampleTest) {
   blocks->getAccountTransactions("admin2").subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 4); });
 
-  blocks->getAccountAssetTransactions("user1@ru", "RUB#ru").subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  blocks->getAccountAssetTransactions("user2@ru", "RUB#ru").subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
+  blocks->getAccountAssetTransactions("user1@ru", "RUB#ru")
+      .subscribe([](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
+  blocks->getAccountAssetTransactions("user2@ru", "RUB#ru")
+      .subscribe([](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
 }
 
 TEST_F(AmetsuchiTest, PeerTest) {
@@ -200,7 +200,8 @@ TEST_F(AmetsuchiTest, PeerTest) {
 }
 
 TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
-  auto storage = StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+  auto storage =
+      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
   auto blocks = storage->getBlockQuery();
@@ -387,15 +388,16 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   }
 
   // Block store tests
-  blocks->getBlocks(1, 3).subscribe([block1hash, block2hash, block3hash](auto eachBlock) {
-    if (eachBlock.height == 1) {
-      EXPECT_EQ(eachBlock.hash, block1hash);
-    } else if (eachBlock.height == 2) {
-      EXPECT_EQ(eachBlock.hash, block2hash);
-    } else if (eachBlock.height == 3) {
-      EXPECT_EQ(eachBlock.hash, block3hash);
-    }
-  });
+  blocks->getBlocks(1, 3).subscribe(
+      [block1hash, block2hash, block3hash](auto eachBlock) {
+        if (eachBlock.height == 1) {
+          EXPECT_EQ(eachBlock.hash, block1hash);
+        } else if (eachBlock.height == 2) {
+          EXPECT_EQ(eachBlock.hash, block2hash);
+        } else if (eachBlock.height == 3) {
+          EXPECT_EQ(eachBlock.hash, block3hash);
+        }
+      });
 
   blocks->getAccountTransactions(admin).subscribe(
       [](auto tx) { EXPECT_EQ(tx.commands.size(), 8); });
@@ -409,22 +411,29 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   // (user1 -> user2 # asset1)
   // (user2 -> user3 # asset2)
   // (user2 -> user1 # asset2)
-  blocks->getAccountAssetTransactions(user1id, asset1id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  blocks->getAccountAssetTransactions(user2id, asset1id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  blocks->getAccountAssetTransactions(user3id, asset1id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 0); });
-  blocks->getAccountAssetTransactions(user1id, asset2id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
-  blocks->getAccountAssetTransactions(user2id, asset2id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 2); });
-  blocks->getAccountAssetTransactions(user3id, asset2id).subscribe(
-      [](auto tx) { EXPECT_EQ(tx.commands.size(), 1); });
+  blocks->getAccountAssetTransactions(user1id, asset1id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 1);
+  });
+  blocks->getAccountAssetTransactions(user2id, asset1id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 1);
+  });
+  blocks->getAccountAssetTransactions(user3id, asset1id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 0);
+  });
+  blocks->getAccountAssetTransactions(user1id, asset2id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 1);
+  });
+  blocks->getAccountAssetTransactions(user2id, asset2id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 2);
+  });
+  blocks->getAccountAssetTransactions(user3id, asset2id).subscribe([](auto tx) {
+    EXPECT_EQ(tx.commands.size(), 1);
+  });
 }
 
 TEST_F(AmetsuchiTest, AddSignatoryTest) {
-  auto storage = StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+  auto storage =
+      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
 
@@ -514,7 +523,7 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   createAccount = CreateAccount();
   createAccount.account_name = "user2";
   createAccount.domain_id = "domain";
-  createAccount.pubkey = pubkey1; // same as user1's pubkey1
+  createAccount.pubkey = pubkey1;  // same as user1's pubkey1
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   block = Block();
@@ -659,23 +668,25 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   }
 }
 
-TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
+TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
   auto storage =
-    StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
   auto blocks = storage->getBlockQuery();
 
-  const std::string adminid = "admin@maindomain";
-  const std::string domain1name = "domain1";
-  const std::string domain2name = "domain2";
-  const std::string user1name = "alice";
-  const std::string user2name = "bob";
-  const std::string user3name = "charlie";
-  const std::string user4name = "eve";
-  const std::string user1id = "alice@domain1";
-  const std::string user2id = "bob@domain1";
-  const std::string user3id = "charlie@domain1";
+  const auto adminid = std::string("admin@maindomain");
+  const auto domain1name = std::string("domain1");
+  const auto user1name = std::string("alice");
+  const auto user2name = std::string("bob");
+  const auto user1id = user1name + "@" + domain1name;
+  const auto user2id = user2name + "@" + domain1name;
+  const auto alice_assetname = std::string("alice_asset");
+  const auto alice_domain = std::string("alice_domain");
+  const auto alice_assetid = alice_assetname + "#" + alice_domain;
+  const auto bob_assetname = std::string("bob_asset");
+  const auto bob_domain = std::string("bob_domain");
+  const auto bob_assetid = bob_assetname + "#" + bob_domain;
 
   auto commit_block = [&storage](auto block, auto height, auto prev_hash) {
     block.height = height;
@@ -688,7 +699,177 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     storage->commit(std::move(ms));
   };
 
-  Transaction tx1, tx2, tx3, tx4, tx5;
+  Transaction tx1, tx2;
+
+  Block block1;
+  {
+    // tx1: Admin send CreateDomain(domain1, domain2), CreateAccount(alice, bob)
+    tx1 = Transaction{};
+    tx1.creator_account_id = adminid;
+    tx1.commands = {std::make_shared<CreateDomain>(domain1name),
+                    std::make_shared<CreateAccount>(user1name, domain1name,
+                                                    iroha::pubkey_t{}),
+                    std::make_shared<CreateAccount>(user2name, domain1name,
+                                                    iroha::pubkey_t{})};
+    block1.transactions.push_back(tx1);
+
+    // tx2: Alice send CreateDomain
+    tx2 = Transaction{};
+    tx2.creator_account_id = user1id;
+    tx2.commands = {std::make_shared<CreateDomain>(alice_domain)};
+    block1.transactions.push_back(tx2);
+  }
+
+  commit_block(block1, 1, iroha::hash256_t{});
+
+  blocks->getTopBlocks(1).subscribe([](auto block) {
+    EXPECT_EQ(2, block.transactions.size());
+    EXPECT_EQ(3, block.transactions[0].commands.size());
+    EXPECT_EQ(1, block.transactions[1].commands.size());
+  });
+
+  auto account1 = wsv->getAccount(user1id);
+  ASSERT_TRUE(account1);
+  ASSERT_STREQ(user1id.c_str(), account1->account_id.c_str());
+
+  auto account2 = wsv->getAccount(user2id);
+  ASSERT_TRUE(account2);
+  ASSERT_STREQ(user2id.c_str(), account2->account_id.c_str());
+
+  Block block2;
+  {
+    // tx1: Alice send CreateAsset
+    tx1 = Transaction{};
+    tx1.creator_account_id = user1id;
+    tx1.commands = {
+        std::make_shared<CreateAsset>(alice_assetname, alice_domain, 0)};
+    block2.transactions.push_back(tx1);
+
+    // tx2: Bob send CreateDomain, CreateAsset
+    tx2 = Transaction{};
+    tx2.creator_account_id = user2id;
+    tx2.commands = {
+        std::make_shared<CreateDomain>(bob_domain),
+        std::make_shared<CreateAsset>(bob_assetname, bob_domain, 0)};
+    block2.transactions.push_back(tx2);
+  }
+
+  commit_block(block2, 2, block1.hash);
+
+  blocks->getTopBlocks(1).subscribe([&](auto block) {
+    EXPECT_EQ(2, block.transactions.size());
+    EXPECT_EQ(1, block.transactions[0].commands.size());
+    EXPECT_EQ(2, block.transactions[1].commands.size());
+  });
+
+  ASSERT_TRUE(wsv->getAsset(alice_assetid));
+  ASSERT_TRUE(wsv->getAsset(bob_assetid));
+
+  // When query with limit 0
+  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 0)
+      .subscribe([](auto) {
+        FAIL() << "Pager with limit 0 cannot subscribe any transactions";
+      });
+
+  // When query with a last alice's tx.
+  std::vector<Transaction> results;
+  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 1)
+      .subscribe([&](auto tx) { results.push_back(tx); });
+
+  ASSERT_EQ(1, results.size());
+  {
+    EXPECT_EQ(1, results[0].commands.size());
+    auto c = std::dynamic_pointer_cast<CreateAsset>(results[0].commands[0]);
+    ASSERT_TRUE(c);
+    EXPECT_EQ(alice_assetname, c->asset_name);
+    EXPECT_EQ(alice_domain, c->domain_id);
+  }
+
+  // When query with last two alice's txs.
+  results.clear();
+  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 2)
+      .subscribe([&](auto tx) { results.push_back(tx); });
+
+  ASSERT_EQ(2, results.size());
+  {
+    ASSERT_EQ(1, results[0].commands.size());
+    auto c1 = std::dynamic_pointer_cast<CreateAsset>(results[0].commands[0]);
+    ASSERT_TRUE(c1);
+    EXPECT_EQ(alice_assetname, c1->asset_name);
+    EXPECT_EQ(alice_domain, c1->domain_id);
+  }
+  {
+    ASSERT_EQ(1, results[1].commands.size());
+    auto c1 = std::dynamic_pointer_cast<CreateDomain>(results[1].commands[0]);
+    ASSERT_TRUE(c1);
+    EXPECT_EQ(alice_domain, c1->domain_name);
+  }
+
+  // When query with alice's txs with overflowed limit.
+  results.clear();
+  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 100)
+      .subscribe([&](auto tx) { results.push_back(tx); });
+
+  ASSERT_EQ(2, results.size());
+  {
+    ASSERT_EQ(1, results[0].commands.size());
+    auto c1 = std::dynamic_pointer_cast<CreateAsset>(results[0].commands[0]);
+    ASSERT_TRUE(c1);
+    EXPECT_EQ(alice_assetname, c1->asset_name);
+    EXPECT_EQ(alice_domain, c1->domain_id);
+  }
+  {
+    ASSERT_EQ(1, results[1].commands.size());
+    auto c1 = std::dynamic_pointer_cast<CreateDomain>(results[1].commands[0]);
+    ASSERT_TRUE(c1);
+    EXPECT_EQ(alice_domain, c1->domain_name);
+  }
+
+  // When query bob's txs with overflowed limit.
+  results.clear();
+  blocks->getAccountTransactionsWithPager(user2id, iroha::hash256_t{}, 100)
+      .subscribe([&](auto tx) { results.push_back(tx); });
+
+  ASSERT_EQ(1, results.size());
+  {
+    ASSERT_EQ(2, results[0].commands.size());
+    auto c1 = std::dynamic_pointer_cast<CreateDomain>(results[0].commands[0]);
+    ASSERT_TRUE(c1);
+    EXPECT_EQ(bob_domain, c1->domain_name);
+    auto c2 = std::dynamic_pointer_cast<CreateAsset>(results[0].commands[1]);
+    ASSERT_TRUE(c2);
+    EXPECT_EQ(bob_domain, c2->domain_id);
+    EXPECT_EQ(bob_assetname, c2->asset_name);
+  }
+}
+
+TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
+  auto storage =
+      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+  ASSERT_TRUE(storage);
+  auto wsv = storage->getWsvQuery();
+  auto blocks = storage->getBlockQuery();
+
+  const std::string adminid = "admin@maindomain";
+  const std::string domain1name = "domain1";
+  const std::string domain2name = "domain2";
+  const std::string user1name = "alice";
+  const std::string user2name = "bob";
+  const std::string user1id = "alice@domain1";
+  const std::string user2id = "bob@domain1";
+
+  auto commit_block = [&storage](auto block, auto height, auto prev_hash) {
+    block.height = height;
+    block.created_ts = 0;
+    block.txs_number = static_cast<uint16_t>(block.transactions.size());
+    block.prev_hash = prev_hash;
+    block.hash = iroha::hash(block);
+    auto ms = storage->createMutableStorage();
+    ms->apply(block, [](const auto &, auto &, const auto &) { return true; });
+    storage->commit(std::move(ms));
+  };
+
+  Transaction tx1, tx2;
 
   Block block1;
   {
@@ -701,21 +882,13 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
                     std::make_shared<CreateAccount>(user2name, domain1name,
                                                     iroha::pubkey_t{})};
     block1.transactions.push_back(tx1);
-
-    // CreateAccount charlie@domain1
-    tx2 = Transaction{};
-    tx2.creator_account_id = adminid;
-    tx2.commands = {std::make_shared<CreateAccount>(user3name, domain1name,
-                                                    iroha::pubkey_t{})};
-    block1.transactions.push_back(tx2);
   }
 
   commit_block(block1, 1, iroha::hash256_t{});
 
   blocks->getTopBlocks(1).subscribe([](auto block) {
-    EXPECT_EQ(2, block.transactions.size());
+    EXPECT_EQ(1, block.transactions.size());
     EXPECT_EQ(4, block.transactions[0].commands.size());
-    EXPECT_EQ(1, block.transactions[1].commands.size());
   });
 
   // Then Account alice@domain1 should be load.
@@ -727,11 +900,6 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
   auto account2 = wsv->getAccount(user2id);
   ASSERT_TRUE(account2);
   ASSERT_STREQ(user2id.c_str(), account2->account_id.c_str());
-
-  // Then Account charlie@domain1 should be load.
-  auto account3 = wsv->getAccount(user3id);
-  ASSERT_TRUE(account3);
-  ASSERT_STREQ(user3id.c_str(), account3->account_id.c_str());
 
   const auto asset1name = std::string("irh");
   const auto asset1id = asset1name + "#" + domain1name;
@@ -746,8 +914,8 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     tx1 = Transaction{};
     tx1.creator_account_id = adminid;
     tx1.commands = {
-      std::make_shared<CreateAsset>(asset1name, domain1name, asset1prec),
-      std::make_shared<CreateAsset>(asset2name, domain2name, asset2prec)};
+        std::make_shared<CreateAsset>(asset1name, domain1name, asset1prec),
+        std::make_shared<CreateAsset>(asset2name, domain2name, asset2prec)};
     block2.transactions.push_back(tx1);
   }
 
@@ -768,11 +936,12 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     // wallet.
     tx1 = Transaction{};
     tx1.creator_account_id = adminid;
-    tx1.commands = {
-      std::make_shared<AddAssetQuantity>(user1id, asset1id, iroha::Amount(1234, asset1prec)),
-      std::make_shared<AddAssetQuantity>(user2id, asset1id, iroha::Amount(100, asset1prec)),
-      std::make_shared<AddAssetQuantity>(user2id, asset2id, iroha::Amount(200, asset2prec))
-    };
+    tx1.commands = {std::make_shared<AddAssetQuantity>(
+                        user1id, asset1id, iroha::Amount(1234, asset1prec)),
+                    std::make_shared<AddAssetQuantity>(
+                        user2id, asset1id, iroha::Amount(100, asset1prec)),
+                    std::make_shared<AddAssetQuantity>(
+                        user2id, asset2id, iroha::Amount(200, asset2prec))};
     block3.transactions.push_back(tx1);
   }
 
@@ -803,48 +972,51 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     tx1 = Transaction{};
     tx1.creator_account_id = adminid;
     tx1.commands = {
-      std::make_shared<CreateDomain>("dummy"),
-      std::make_shared<TransferAsset>(
-        user1id, user2id, asset1id, iroha::Amount(1234, asset1prec)),
-      std::make_shared<CreateAccount>("dummy_acct_1", "dummy", iroha::pubkey_t{})
-    };
+        std::make_shared<CreateDomain>("dummy"),
+        std::make_shared<TransferAsset>(user1id, user2id, asset1id,
+                                        iroha::Amount(1234, asset1prec)),
+        std::make_shared<CreateAccount>("dummy_acct_1", "dummy",
+                                        iroha::pubkey_t{})};
     block4.transactions.push_back(tx1);
 
     tx2 = Transaction{};
     tx2.creator_account_id = adminid;
-    tx2.commands = {
-      std::make_shared<CreateAccount>("dummy_acct_2", "dummy", iroha::pubkey_t{}),
-      std::make_shared<AddAssetQuantity>(user1id, asset2id, iroha::Amount(500, asset2prec))
-    };
+    tx2.commands = {std::make_shared<CreateAccount>("dummy_acct_2", "dummy",
+                                                    iroha::pubkey_t{}),
+                    std::make_shared<AddAssetQuantity>(
+                        user1id, asset2id, iroha::Amount(500, asset2prec))};
     block4.transactions.push_back(tx2);
   };
 
   commit_block(block4, 4, block3.hash);
 
-  blocks->getTopBlocks(1).subscribe([&](auto block){
+  blocks->getTopBlocks(1).subscribe([&](auto block) {
     EXPECT_EQ(2, block.transactions.size());
     EXPECT_EQ(3, block.transactions[0].commands.size());
     EXPECT_EQ(2, block.transactions[1].commands.size());
   });
 
-  blocks->getAccountAssetsTransactionsWithPager(
-  user1id, {asset1id}, iroha::hash256_t{}, 0).subscribe([](auto) {
-    FAIL() << "subscribe shouldn't occur with limit 0";
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
+                                              iroha::hash256_t{}, 0)
+      .subscribe(
+          [](auto) { FAIL() << "subscribe shouldn't occur with limit 0"; });
 
-  blocks->getAccountAssetsTransactionsWithPager(
-    user1id, {asset1id}, iroha::hash256_t{}, 1).subscribe([&](auto tx){
-    EXPECT_EQ(3, tx.commands.size());
-    EXPECT_TRUE(std::dynamic_pointer_cast<CreateDomain>(tx.commands[0]));
-    EXPECT_TRUE(std::dynamic_pointer_cast<TransferAsset>(tx.commands[1]));
-    EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(tx.commands[2]));
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
+                                              iroha::hash256_t{}, 1)
+      .subscribe([&](auto tx) {
+        EXPECT_EQ(3, tx.commands.size());
+        EXPECT_TRUE(std::dynamic_pointer_cast<CreateDomain>(tx.commands[0]));
+        EXPECT_TRUE(std::dynamic_pointer_cast<TransferAsset>(tx.commands[1]));
+        EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(tx.commands[2]));
+      });
 
   std::vector<Transaction> result;
-  blocks->getAccountAssetsTransactionsWithPager(
-    user1id, {asset1id}, iroha::hash256_t{}, 2).subscribe([&](auto tx){
-    result.push_back(tx);
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
+                                              iroha::hash256_t{}, 2)
+      .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(2, result.size());
   ASSERT_EQ(3, result[0].commands.size());
@@ -852,15 +1024,18 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
   EXPECT_TRUE(std::dynamic_pointer_cast<TransferAsset>(result[0].commands[1]));
   EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(result[0].commands[2]));
   ASSERT_EQ(3, result[1].commands.size());
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[0]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[1]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[2]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[0]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[1]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[2]));
 
   result.clear();
-  blocks->getAccountAssetsTransactionsWithPager(
-    user1id, {asset1id}, iroha::hash256_t{}, 100).subscribe([&](auto tx){
-    result.push_back(tx);
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
+                                              iroha::hash256_t{}, 100)
+      .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(2, result.size());
   ASSERT_EQ(3, result[0].commands.size());
@@ -868,46 +1043,56 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
   EXPECT_TRUE(std::dynamic_pointer_cast<TransferAsset>(result[0].commands[1]));
   EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(result[0].commands[2]));
   ASSERT_EQ(3, result[1].commands.size());
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[0]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[1]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[2]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[0]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[1]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[1].commands[2]));
 
   result.clear();
-  blocks->getAccountAssetsTransactionsWithPager(
-    user1id, {asset1id, asset2id}, iroha::hash256_t{}, 100).subscribe([&](auto tx){
-    result.push_back(tx);
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id, asset2id},
+                                              iroha::hash256_t{}, 100)
+      .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(3, result.size());
   ASSERT_EQ(2, result[0].commands.size());
   EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(result[0].commands[0]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[1]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[1]));
   ASSERT_EQ(3, result[1].commands.size());
   EXPECT_TRUE(std::dynamic_pointer_cast<CreateDomain>(result[1].commands[0]));
   EXPECT_TRUE(std::dynamic_pointer_cast<TransferAsset>(result[1].commands[1]));
   EXPECT_TRUE(std::dynamic_pointer_cast<CreateAccount>(result[1].commands[2]));
   ASSERT_EQ(3, result[2].commands.size());
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[0]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[1]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[2]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[0]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[1]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[2].commands[2]));
 
   auto w = wsv->getAccountAsset(user1id, asset2id);
   ASSERT_TRUE(w);
   ASSERT_EQ(iroha::Amount(500, asset2prec), w->balance);
 
-  // Get transactions until a tx which has (CreateDomain, TransferAsset, CreateAccount).
-  // Tx which has until_tx_hash is excluded.
+  // Get transactions until a tx which has (CreateDomain, TransferAsset,
+  // CreateAccount). Tx which has until_tx_hash is excluded.
   auto until_tx_hash = iroha::hash(result[1]);
 
   result.clear();
-  blocks->getAccountAssetsTransactionsWithPager(
-    user1id, {asset1id, asset2id}, until_tx_hash, 100).subscribe([&](auto tx){
-    result.push_back(tx);
-  });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id, asset2id},
+                                              until_tx_hash, 100)
+      .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(1, result.size());
   ASSERT_EQ(3, result[0].commands.size());
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[0]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[1]));
-  EXPECT_TRUE(std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[2]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[0]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[1]));
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[2]));
 }

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -707,10 +707,10 @@ TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
     tx1 = Transaction{};
     tx1.creator_account_id = adminid;
     tx1.commands = {std::make_shared<CreateDomain>(domain1name),
-                    std::make_shared<CreateAccount>(user1name, domain1name,
-                                                    iroha::pubkey_t{}),
-                    std::make_shared<CreateAccount>(user2name, domain1name,
-                                                    iroha::pubkey_t{})};
+                    std::make_shared<CreateAccount>(
+                        user1name, domain1name, iroha::pubkey_t{}),
+                    std::make_shared<CreateAccount>(
+                        user2name, domain1name, iroha::pubkey_t{})};
     block1.transactions.push_back(tx1);
 
     // tx2: Alice send CreateDomain
@@ -766,14 +766,14 @@ TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
   ASSERT_TRUE(wsv->getAsset(bob_assetid));
 
   // When query with limit 0
-  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 0)
+  blocks->getAccountTransactionsWithPager(user1id, Pager{iroha::hash256_t{}, 0})
       .subscribe([](auto) {
         FAIL() << "Pager with limit 0 cannot subscribe any transactions";
       });
 
   // When query with a last alice's tx.
   std::vector<Transaction> results;
-  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 1)
+  blocks->getAccountTransactionsWithPager(user1id, Pager{iroha::hash256_t{}, 1})
       .subscribe([&](auto tx) { results.push_back(tx); });
 
   ASSERT_EQ(1, results.size());
@@ -787,7 +787,7 @@ TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
 
   // When query with last two alice's txs.
   results.clear();
-  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 2)
+  blocks->getAccountTransactionsWithPager(user1id, Pager{iroha::hash256_t{}, 2})
       .subscribe([&](auto tx) { results.push_back(tx); });
 
   ASSERT_EQ(2, results.size());
@@ -807,7 +807,8 @@ TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
 
   // When query with alice's txs with overflowed limit.
   results.clear();
-  blocks->getAccountTransactionsWithPager(user1id, iroha::hash256_t{}, 100)
+  blocks
+      ->getAccountTransactionsWithPager(user1id, Pager{iroha::hash256_t{}, 100})
       .subscribe([&](auto tx) { results.push_back(tx); });
 
   ASSERT_EQ(2, results.size());
@@ -827,7 +828,9 @@ TEST_F(AmetsuchiTest, GetAccountTransactionsWithPagerTest) {
 
   // When query bob's txs with overflowed limit.
   results.clear();
-  blocks->getAccountTransactionsWithPager(user2id, iroha::hash256_t{}, 100)
+  blocks
+      ->getAccountTransactionsWithPager(
+          user2id, Pager{iroha::hash256_t{}, 100})
       .subscribe([&](auto tx) { results.push_back(tx); });
 
   ASSERT_EQ(1, results.size());
@@ -877,10 +880,10 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     tx1.creator_account_id = adminid;
     tx1.commands = {std::make_shared<CreateDomain>(domain1name),
                     std::make_shared<CreateDomain>(domain2name),
-                    std::make_shared<CreateAccount>(user1name, domain1name,
-                                                    iroha::pubkey_t{}),
-                    std::make_shared<CreateAccount>(user2name, domain1name,
-                                                    iroha::pubkey_t{})};
+                    std::make_shared<CreateAccount>(
+                        user1name, domain1name, iroha::pubkey_t{}),
+                    std::make_shared<CreateAccount>(
+                        user2name, domain1name, iroha::pubkey_t{})};
     block1.transactions.push_back(tx1);
   }
 
@@ -973,16 +976,16 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
     tx1.creator_account_id = adminid;
     tx1.commands = {
         std::make_shared<CreateDomain>("dummy"),
-        std::make_shared<TransferAsset>(user1id, user2id, asset1id,
-                                        iroha::Amount(1234, asset1prec)),
-        std::make_shared<CreateAccount>("dummy_acct_1", "dummy",
-                                        iroha::pubkey_t{})};
+        std::make_shared<TransferAsset>(
+            user1id, user2id, asset1id, iroha::Amount(1234, asset1prec)),
+        std::make_shared<CreateAccount>(
+            "dummy_acct_1", "dummy", iroha::pubkey_t{})};
     block4.transactions.push_back(tx1);
 
     tx2 = Transaction{};
     tx2.creator_account_id = adminid;
-    tx2.commands = {std::make_shared<CreateAccount>("dummy_acct_2", "dummy",
-                                                    iroha::pubkey_t{}),
+    tx2.commands = {std::make_shared<CreateAccount>(
+                        "dummy_acct_2", "dummy", iroha::pubkey_t{}),
                     std::make_shared<AddAssetQuantity>(
                         user1id, asset2id, iroha::Amount(500, asset2prec))};
     block4.transactions.push_back(tx2);
@@ -997,14 +1000,14 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
   });
 
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
-                                              iroha::hash256_t{}, 0)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id}, Pager{iroha::hash256_t{}, 0})
       .subscribe(
           [](auto) { FAIL() << "subscribe shouldn't occur with limit 0"; });
 
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
-                                              iroha::hash256_t{}, 1)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id}, Pager{iroha::hash256_t{}, 1})
       .subscribe([&](auto tx) {
         EXPECT_EQ(3, tx.commands.size());
         EXPECT_TRUE(std::dynamic_pointer_cast<CreateDomain>(tx.commands[0]));
@@ -1014,8 +1017,8 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
 
   std::vector<Transaction> result;
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
-                                              iroha::hash256_t{}, 2)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id}, Pager{iroha::hash256_t{}, 2})
       .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(2, result.size());
@@ -1033,8 +1036,8 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
 
   result.clear();
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id},
-                                              iroha::hash256_t{}, 100)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id}, Pager{iroha::hash256_t{}, 100})
       .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(2, result.size());
@@ -1052,8 +1055,8 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
 
   result.clear();
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id, asset2id},
-                                              iroha::hash256_t{}, 100)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id, asset2id}, Pager{iroha::hash256_t{}, 100})
       .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(3, result.size());
@@ -1083,8 +1086,8 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
 
   result.clear();
   blocks
-      ->getAccountAssetsTransactionsWithPager(user1id, {asset1id, asset2id},
-                                              until_tx_hash, 100)
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {asset1id, asset2id}, Pager{until_tx_hash, 100})
       .subscribe([&](auto tx) { result.push_back(tx); });
 
   ASSERT_EQ(1, result.size());
@@ -1096,8 +1099,9 @@ TEST_F(AmetsuchiTest, GetAccountAssetsTransactionsWithPagerTest) {
   EXPECT_TRUE(
       std::dynamic_pointer_cast<AddAssetQuantity>(result[0].commands[2]));
 
-  blocks->getAccountAssetsTransactionsWithPager(user1id, {}, iroha::hash256_t{}, 100)
-    .subscribe([&](auto tx) {
-      FAIL() << "Shouldn't subscribe if no assets.";
-    });
+  blocks
+      ->getAccountAssetsTransactionsWithPager(
+          user1id, {}, Pager{iroha::hash256_t{}, 100})
+      .subscribe(
+          [&](auto tx) { FAIL() << "Shouldn't subscribe if no assets."; });
 }

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -46,7 +46,9 @@ TEST(QuerySerializerTest, ClassHandlerTest) {
       std::make_shared<GetAccountAssets>(),
       std::make_shared<GetSignatories>(),
       std::make_shared<GetAccountAssetTransactions>(),
-      std::make_shared<GetAccountTransactions>()
+      std::make_shared<GetAccountTransactions>(),
+      std::make_shared<GetAccountTransactionsWithPager>(),
+      std::make_shared<GetAccountAssetsTransactionsWithPager>()
   };
   for (const auto &command : commands) {
     auto ser = factory.serialize(command);
@@ -164,6 +166,18 @@ TEST(QuerySerializerTest, SerializeGetAccountTransactions){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
+TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions){
+  JsonQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto val = queryGenerator.generateGetAccountAssetTransactions(0, "123", 0, "test", "test_asset");
+  val->signature = generateSignature(42);
+  auto json = queryFactory.serialize(val);
+  auto ser_val = queryFactory.deserialize(json);
+  ASSERT_TRUE(ser_val.has_value());
+  ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
+  ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
+}
+
 TEST(QuerySerializerTest, SerializeGetSignatories){
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
@@ -197,4 +211,14 @@ TEST(QuerySerializerTest, get_role_permissions){
   runQueryTest(val);
 }
 
-
+TEST(QuerySerializerTest, SerializeGetAccountTransactionsWithPager){
+  JsonQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto val = queryGenerator.generateGetSignatories(0, "123", 0, "test");
+  val->signature = generateSignature(42);
+  auto json = queryFactory.serialize(val);
+  auto ser_val = queryFactory.deserialize(json);
+  ASSERT_TRUE(ser_val.has_value());
+  ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
+  ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
+}

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -184,7 +184,7 @@ TEST(QuerySerializerTest, SerializeGetAccountTransactionsWithPager) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAccountTransactionsWithPager(
-      0, "123", 0, "test", iroha::hash256_t{}, 1);
+      0, "123", 0, "test", Pager{iroha::hash256_t{}, 1});
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);
@@ -231,9 +231,10 @@ TEST(QuerySerializerTest,
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAccountAssetsTransactionsWithPager(
-      0, "123", 0, "test", {"a", "b"}, iroha::hash256_t{}, 1);
+      0, "123", 0, "test", {"a", "b"}, model::Pager{iroha::hash256_t{}, 1});
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
+  std::cout << json << std::endl;
   auto ser_val = queryFactory.deserialize(json);
   ASSERT_TRUE(ser_val.has_value());
   ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
@@ -245,7 +246,7 @@ TEST(QuerySerializerTest,
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAccountAssetsTransactionsWithPager(
-      0, "123", 0, "test", {}, iroha::hash256_t{}, 1);
+      0, "123", 0, "test", {}, model::Pager{iroha::hash256_t{}, 1});
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
+#include "model/converters/json_query_factory.hpp"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "crypto/hash.hpp"
-#include "model/converters/json_query_factory.hpp"
 #include "model/generators/query_generator.hpp"
 #include "model/generators/signature_generator.hpp"
 
@@ -30,7 +30,7 @@ using namespace iroha::model;
 using namespace iroha::model::converters;
 using namespace iroha::model::generators;
 
-void runQueryTest(std::shared_ptr<Query> val){
+void runQueryTest(std::shared_ptr<Query> val) {
   JsonQueryFactory queryFactory;
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);
@@ -51,8 +51,7 @@ TEST(QuerySerializerTest, ClassHandlerTest) {
       std::make_shared<GetAccountAssetsTransactionsWithPager>(),
       std::make_shared<GetRoles>(),
       std::make_shared<GetAssetInfo>(),
-      std::make_shared<GetRolePermissions>()
-  };
+      std::make_shared<GetRolePermissions>()};
   for (const auto &command : commands) {
     auto ser = factory.serialize(command);
     auto des = factory.deserialize(ser);
@@ -76,7 +75,7 @@ TEST(QuerySerializerTest, DeserializeGetAccountWhenValid) {
   })";
   auto res = querySerializer.deserialize(json_query);
   ASSERT_TRUE(res.has_value());
-  ASSERT_EQ("123",res.value()->creator_account_id);
+  ASSERT_EQ("123", res.value()->creator_account_id);
 }
 
 TEST(QuerySerializerTest, DeserializeGetAccountWhenInvalid) {
@@ -90,7 +89,6 @@ TEST(QuerySerializerTest, DeserializeGetAccountWhenInvalid) {
   auto res = querySerializer.deserialize(json_query);
   ASSERT_FALSE(res.has_value());
 }
-
 
 TEST(QuerySerializerTest, DeserializeGetAccountAssetsWhenValid) {
   JsonQueryFactory querySerializer;
@@ -108,11 +106,11 @@ TEST(QuerySerializerTest, DeserializeGetAccountAssetsWhenValid) {
   })";
   auto res = querySerializer.deserialize(json_query);
   ASSERT_TRUE(res.has_value());
-  auto casted = std::static_pointer_cast<iroha::model::GetAccountAssets>(res.value());
+  auto casted =
+      std::static_pointer_cast<iroha::model::GetAccountAssets>(res.value());
   ASSERT_EQ("test@test", casted->account_id);
   ASSERT_EQ("coin#test", casted->asset_id);
 }
-
 
 TEST(QuerySerializerTest, DeserializeWhenUnknownType) {
   JsonQueryFactory querySerializer;
@@ -132,7 +130,7 @@ TEST(QuerySerializerTest, DeserializeWhenUnknownType) {
   ASSERT_FALSE(res.has_value());
 }
 
-TEST(QuerySerializerTest, SerializeGetAccount){
+TEST(QuerySerializerTest, SerializeGetAccount) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAccount(0, "123", 0, "test");
@@ -144,20 +142,20 @@ TEST(QuerySerializerTest, SerializeGetAccount){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
-TEST(QuerySerializerTest, SerializeGetAccountAssets){
+TEST(QuerySerializerTest, SerializeGetAccountAssets) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
-  auto val = queryGenerator.generateGetAccountAssets(0, "123", 0, "test", "coin");
+  auto val =
+      queryGenerator.generateGetAccountAssets(0, "123", 0, "test", "coin");
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);
   ASSERT_TRUE(ser_val.has_value());
   ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
-
 }
 
-TEST(QuerySerializerTest, SerializeGetAccountTransactions){
+TEST(QuerySerializerTest, SerializeGetAccountTransactions) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAccountTransactions(0, "123", 0, "test");
@@ -169,10 +167,11 @@ TEST(QuerySerializerTest, SerializeGetAccountTransactions){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
-TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions){
+TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
-  auto val = queryGenerator.generateGetAccountAssetTransactions(0, "123", 0, "test", "test_asset");
+  auto val = queryGenerator.generateGetAccountAssetTransactions(
+      0, "123", 0, "test", "test_asset");
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);
@@ -181,7 +180,20 @@ TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
-TEST(QuerySerializerTest, SerializeGetSignatories){
+TEST(QuerySerializerTest, SerializeGetAccountTransactionsWithPager) {
+  JsonQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto val = queryGenerator.generateGetAccountTransactionsWithPager(
+      0, "123", 0, "test", iroha::hash256_t{}, 1);
+  val->signature = generateSignature(42);
+  auto json = queryFactory.serialize(val);
+  auto ser_val = queryFactory.deserialize(json);
+  ASSERT_TRUE(ser_val.has_value());
+  ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
+  ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
+}
+
+TEST(QuerySerializerTest, SerializeGetSignatories) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetSignatories(0, "123", 0, "test");
@@ -193,31 +205,47 @@ TEST(QuerySerializerTest, SerializeGetSignatories){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
-TEST(QuerySerializerTest, get_asset_info){
+TEST(QuerySerializerTest, get_asset_info) {
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetAssetInfo();
   val->signature = generateSignature(42);
   runQueryTest(val);
 }
 
-TEST(QuerySerializerTest, get_roles){
+TEST(QuerySerializerTest, get_roles) {
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetRoles();
   val->signature = generateSignature(42);
   runQueryTest(val);
 }
 
-TEST(QuerySerializerTest, get_role_permissions){
+TEST(QuerySerializerTest, get_role_permissions) {
   QueryGenerator queryGenerator;
   auto val = queryGenerator.generateGetRolePermissions();
   val->signature = generateSignature(42);
   runQueryTest(val);
 }
 
-TEST(QuerySerializerTest, SerializeGetAccountTransactionsWithPager){
+TEST(QuerySerializerTest,
+     SerializeGetAccountAssetsTransactionsWithPagerWhenValid) {
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
-  auto val = queryGenerator.generateGetSignatories(0, "123", 0, "test");
+  auto val = queryGenerator.generateGetAccountAssetsTransactionsWithPager(
+      0, "123", 0, "test", {"a", "b"}, iroha::hash256_t{}, 1);
+  val->signature = generateSignature(42);
+  auto json = queryFactory.serialize(val);
+  auto ser_val = queryFactory.deserialize(json);
+  ASSERT_TRUE(ser_val.has_value());
+  ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
+  ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
+}
+
+TEST(QuerySerializerTest,
+     SerializeGetAccountAssetsTransactionsWithPagerWhenAssetsEmpty) {
+  JsonQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto val = queryGenerator.generateGetAccountAssetsTransactionsWithPager(
+      0, "123", 0, "test", {}, iroha::hash256_t{}, 1);
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
   auto ser_val = queryFactory.deserialize(json);

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -48,7 +48,10 @@ TEST(QuerySerializerTest, ClassHandlerTest) {
       std::make_shared<GetAccountAssetTransactions>(),
       std::make_shared<GetAccountTransactions>(),
       std::make_shared<GetAccountTransactionsWithPager>(),
-      std::make_shared<GetAccountAssetsTransactionsWithPager>()
+      std::make_shared<GetAccountAssetsTransactionsWithPager>(),
+      std::make_shared<GetRoles>(),
+      std::make_shared<GetAssetInfo>(),
+      std::make_shared<GetRolePermissions>()
   };
   for (const auto &command : commands) {
     auto ser = factory.serialize(command);

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -234,7 +234,6 @@ TEST(QuerySerializerTest,
       0, "123", 0, "test", {"a", "b"}, model::Pager{iroha::hash256_t{}, 1});
   val->signature = generateSignature(42);
   auto json = queryFactory.serialize(val);
-  std::cout << json << std::endl;
   auto ser_val = queryFactory.deserialize(json);
   ASSERT_TRUE(ser_val.has_value());
   ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));

--- a/test/module/irohad/model/converters/pb_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_factory_test.cpp
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
+#include "model/converters/pb_query_factory.hpp"
 #include <gtest/gtest.h>
 #include "crypto/hash.hpp"
-#include "model/converters/pb_query_factory.hpp"
 #include "model/generators/query_generator.hpp"
 
-#include "model/queries/get_roles.hpp"
 #include "model/queries/get_asset_info.hpp"
+#include "model/queries/get_roles.hpp"
 
 using namespace iroha::model::converters;
 using namespace iroha::model::generators;
 using namespace iroha::model;
 
-void runQueryTest(std::shared_ptr<Query> query){
+void runQueryTest(std::shared_ptr<Query> query) {
   PbQueryFactory queryFactory;
   auto pb_query = queryFactory.serialize(query);
   ASSERT_TRUE(pb_query.has_value());
@@ -37,7 +37,7 @@ void runQueryTest(std::shared_ptr<Query> query){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
-TEST(PbQueryFactoryTest, SerializeGetAccount){
+TEST(PbQueryFactoryTest, SerializeGetAccount) {
   PbQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto query = queryGenerator.generateGetAccount(0, "123", 0, "test");
@@ -49,10 +49,11 @@ TEST(PbQueryFactoryTest, SerializeGetAccount){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
-TEST(PbQueryFactoryTest, SerializeGetAccountAssets){
+TEST(PbQueryFactoryTest, SerializeGetAccountAssets) {
   PbQueryFactory queryFactory;
   QueryGenerator queryGenerator;
-  auto query = queryGenerator.generateGetAccountAssets(0, "123", 0, "test", "coin");
+  auto query =
+      queryGenerator.generateGetAccountAssets(0, "123", 0, "test", "coin");
   auto pb_query = queryFactory.serialize(query);
   ASSERT_TRUE(pb_query.has_value());
   auto res_query = queryFactory.deserialize(pb_query.value());
@@ -61,10 +62,11 @@ TEST(PbQueryFactoryTest, SerializeGetAccountAssets){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
-TEST(PbQueryFactoryTest, SerializeGetAccountTransactions){
+TEST(PbQueryFactoryTest, SerializeGetAccountTransactions) {
   PbQueryFactory queryFactory;
   QueryGenerator queryGenerator;
-  auto query = queryGenerator.generateGetAccountTransactions(0, "123", 0, "test");
+  auto query =
+      queryGenerator.generateGetAccountTransactions(0, "123", 0, "test");
   auto pb_query = queryFactory.serialize(query);
   ASSERT_TRUE(pb_query.has_value());
   auto res_query = queryFactory.deserialize(pb_query.value());
@@ -73,7 +75,33 @@ TEST(PbQueryFactoryTest, SerializeGetAccountTransactions){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
-TEST(PbQueryFactoryTest, SerializeGetSignatories){
+TEST(PbQueryFactoryTest, SerializeGetAccountTransactionsWithPager) {
+  PbQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto query = queryGenerator.generateGetAccountTransactionsWithPager(
+      0, "123", 0, "test", Pager{iroha::hash256_t{}, 1});
+  auto pb_query = queryFactory.serialize(query);
+  ASSERT_TRUE(pb_query.has_value());
+  auto res_query = queryFactory.deserialize(pb_query.value());
+  ASSERT_TRUE(res_query.has_value());
+  // TODO: overload operator == for queries and replace with it
+  ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
+}
+
+TEST(PbQueryFactoryTest, SerializeGetAccountAssetsTransactionsWithPager) {
+  PbQueryFactory queryFactory;
+  QueryGenerator queryGenerator;
+  auto query = queryGenerator.generateGetAccountAssetsTransactionsWithPager(
+      0, "123", 0, "test", {"a", "b"}, Pager{iroha::hash256_t{}, 1});
+  auto pb_query = queryFactory.serialize(query);
+  ASSERT_TRUE(pb_query.has_value());
+  auto res_query = queryFactory.deserialize(pb_query.value());
+  ASSERT_TRUE(res_query.has_value());
+  // TODO: overload operator == for queries and replace with it
+  ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
+}
+
+TEST(PbQueryFactoryTest, SerializeGetSignatories) {
   PbQueryFactory queryFactory;
   QueryGenerator queryGenerator;
   auto query = queryGenerator.generateGetSignatories(0, "123", 0, "test");
@@ -85,18 +113,17 @@ TEST(PbQueryFactoryTest, SerializeGetSignatories){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
-TEST(PbQueryFactoryTest, get_roles){
-
+TEST(PbQueryFactoryTest, get_roles) {
   auto query = QueryGenerator{}.generateGetRoles();
   runQueryTest(query);
 }
 
-TEST(PbQueryFactoryTest, get_role_permissions){
+TEST(PbQueryFactoryTest, get_role_permissions) {
   auto query = QueryGenerator{}.generateGetRolePermissions();
   runQueryTest(query);
 }
 
-TEST(PbQueryFactoryTest, get_asset_info){
+TEST(PbQueryFactoryTest, get_asset_info) {
   auto query = QueryGenerator{}.generateGetAssetInfo();
   runQueryTest(query);
 }

--- a/test/module/irohad/model/static_map.cpp
+++ b/test/module/irohad/model/static_map.cpp
@@ -49,7 +49,7 @@ TEST(HandlerTest, QueryRegistration) {
               return index.name();
             }));
 
-  ASSERT_EQ(8, registry.query_handler.types().size());
+  ASSERT_EQ(10, registry.query_handler.types().size());
 }
 
 TEST(HandlerTest, QueryResponseRegistration) {


### PR DESCRIPTION
## What is this pull request?
Add pagination APIs.
- Add endpoints for pagination APIs.
  
## How to use the features provided in the pull request?
### Pager
```proto
message Pager {
  bytes tx_hash = 1;
  uint32 limit = 2;
}
```
- Get `limit` number transactions until the transaction which has a hash same as tx_hash. The transaction is excluded in response.
- Transaction response returns reversed order. The latest transaction which was committed is the beginning of `TransactionResponse`.
- This message will be extended in the next PR.

### GetAccountTransactionsWithPager()
```proto
message GetAccountTransactionsWithPager {
  string account_id = 1;
  Pager pager = 2;
}
```

### GetAccountAssetsWIthPager()
```proto
message GetAccountAssetsTransactionsWithPager {
  string account_id = 1;
  repeated string assets_id = 2;
  Pager pager = 3;
}
```
## Details/Features
List of features / major commits
- [x] Add AmetsuchiTest for pagination APIs.
- [x] Add JSON <-> Model test
- [x] Add Proto <-> Model test
- [x] Add Query generator test
- [x] Add Query executor test
- [x] Use model `struct Pager{};` instead of `pager_tx_hash`, `pager_limit`, write `Convert<Pager>` and test.
- [x] Rebasing commits.

## P.S.
There remains a task:
- Change API schema to use `since_tx_hash` and `until_tx_hash`.
After some discussion, an another PR is required to finish API.