### PR TITLE
Feature/add redis indexing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,5 @@ DerivePointerAlignment: false
 PointerAlignment: Right
 BinPackArguments: false
 BinPackParameters: false
+DerivePointerAlignment: false
+PointerAlignment: Right

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(ametsuchi
     impl/peer_query_wsv.cpp
 
     impl/flat_file_block_query.cpp
+    impl/redis_flat_block_query.cpp
     )
 
 target_link_libraries(ametsuchi

--- a/irohad/ametsuchi/impl/flat_file_block_query.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_query.hpp
@@ -42,7 +42,7 @@ namespace iroha {
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           std::string account_id, std::string asset_id) override;
 
-     private:
+     protected:
       FlatFile &block_store_;
 
       model::converters::JsonBlockFactory serializer_;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -16,14 +16,16 @@
  */
 
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
+#include <model/commands/transfer_asset.hpp>
 
-#include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
+#include "ametsuchi/impl/postgres_wsv_query.hpp"
 
 namespace iroha {
   namespace ametsuchi {
     MutableStorageImpl::MutableStorageImpl(
-        hash256_t top_hash, std::unique_ptr<cpp_redis::redis_client> index,
+        hash256_t top_hash,
+        std::unique_ptr<cpp_redis::redis_client> index,
         std::unique_ptr<pqxx::lazyconnection> connection,
         std::unique_ptr<pqxx::nontransaction> transaction,
         std::shared_ptr<model::CommandExecutorFactory> command_executors)
@@ -39,26 +41,73 @@ namespace iroha {
       transaction_->exec("BEGIN;");
     }
 
+    void MutableStorageImpl::index_block(uint64_t height, model::Block block) {
+      for (size_t i = 0; i < block.transactions.size(); i++) {
+        auto tx = block.transactions.at(i);
+        auto account_id = tx.creator_account_id;
+
+        // to make index account_id -> list of blocks where his txs exist
+        index_->rpush(account_id, {std::to_string(height)});
+
+        // to make index account_id:height -> list of tx indexes (where
+        // tx is placed in the block)
+        index_->rpush(account_id + ":" + std::to_string(height),
+                      {std::to_string(i)});
+
+        // collect all assets belonging to user "account_id"
+        std::set<std::string> users_assets_in_tx;
+        std::for_each(tx.commands.begin(),
+                      tx.commands.end(),
+                      [&account_id, &users_assets_in_tx](auto command) {
+                        if (instanceof <model::TransferAsset>(*command)) {
+                          auto transferAsset =
+                              (model::TransferAsset *)command.get();
+                          if (transferAsset->dest_account_id == account_id
+                              or transferAsset->src_account_id == account_id) {
+                            users_assets_in_tx.insert(transferAsset->asset_id);
+                          }
+                        }
+                      });
+
+        // to make account_id:height:asset_id -> list of tx indexes (where tx
+        // with certain asset is placed in the block )
+        for (const auto &asset_id : users_assets_in_tx) {
+          // create key to put user's txs with given asset_id
+          std::string account_assets_key;
+          account_assets_key.append(account_id);
+          account_assets_key.append(":");
+          account_assets_key.append(std::to_string(height));
+          account_assets_key.append(":");
+          account_assets_key.append(asset_id);
+          index_->rpush(account_assets_key, {std::to_string(i)});
+        }
+      }
+    }
+
     bool MutableStorageImpl::apply(
         const model::Block &block,
         std::function<bool(const model::Block &, WsvQuery &, const hash256_t &)>
-        function) {
+            function) {
       auto execute_command = [this](auto command) {
         return command_executors_->getCommandExecutor(command)->execute(
             *command, *wsv_, *executor_);
       };
       auto execute_transaction = [this, execute_command](auto &transaction) {
         return std::all_of(transaction.commands.begin(),
-                           transaction.commands.end(), execute_command);
+                           transaction.commands.end(),
+                           execute_command);
       };
 
       transaction_->exec("SAVEPOINT savepoint_;");
-      auto result = function(block, *wsv_, top_hash_) &&
-          std::all_of(block.transactions.begin(),
-                      block.transactions.end(), execute_transaction);
+      auto result = function(block, *wsv_, top_hash_)
+          && std::all_of(block.transactions.begin(),
+                         block.transactions.end(),
+                         execute_transaction);
 
       if (result) {
         block_store_.insert(std::make_pair(block.height, block));
+        index_block(block.height, block);
+
         top_hash_ = block.hash;
         transaction_->exec("RELEASE SAVEPOINT savepoint_;");
       } else {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -100,9 +100,9 @@ namespace iroha {
 
       transaction_->exec("SAVEPOINT savepoint_;");
       auto result = function(block, *wsv_, top_hash_)
-          && std::all_of(block.transactions.begin(),
-                         block.transactions.end(),
-                         execute_transaction);
+          and std::all_of(block.transactions.begin(),
+                          block.transactions.end(),
+                          execute_transaction);
 
       if (result) {
         block_store_.insert(std::make_pair(block.height, block));

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -46,6 +46,8 @@ namespace iroha {
       ~MutableStorageImpl() override;
 
      private:
+      void index_block(uint64_t height, model::Block block);
+
       hash256_t top_hash_;
       std::unordered_map<uint32_t, model::Block> block_store_;
       std::unique_ptr<cpp_redis::redis_client> index_;

--- a/irohad/ametsuchi/impl/redis_flat_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.cpp
@@ -69,13 +69,13 @@ namespace iroha {
           [this, account_id](auto subscriber) {
             auto block_ids = this->getBlockIds(account_id);
             for (auto block_id : block_ids) {
-              this->client_.lrange(
+              client_.lrange(
                   account_id + ":" + std::to_string(block_id),
                   0,
                   -1,
                   this->callbackToLrange(subscriber, block_id));
             }
-            this->client_.sync_commit();
+            client_.sync_commit();
           });
     }
 

--- a/irohad/ametsuchi/impl/redis_flat_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.cpp
@@ -30,7 +30,7 @@ namespace iroha {
     RedisFlatBlockQuery::~RedisFlatBlockQuery() { client_.disconnect(); }
 
     std::vector<uint64_t> RedisFlatBlockQuery::getBlockIds(
-        std::string& account_id) {
+        const std::string& account_id) {
       std::vector<uint64_t> block_ids;
       client_.lrange(
           account_id, 0, -1, [this, &block_ids](cpp_redis::reply& reply) {
@@ -72,7 +72,7 @@ namespace iroha {
     rxcpp::observable<model::Transaction>
     RedisFlatBlockQuery::getAccountTransactions(std::string account_id) {
       return rxcpp::observable<>::create<model::Transaction>(
-          [this, &account_id](auto subscriber) {
+          [this, account_id](auto subscriber) {
             auto block_ids = this->getBlockIds(account_id);
             for (auto block_id : block_ids) {
               this->client_.lrange(
@@ -89,7 +89,7 @@ namespace iroha {
     RedisFlatBlockQuery::getAccountAssetTransactions(std::string account_id,
                                                     std::string asset_id) {
       return rxcpp::observable<>::create<model::Transaction>(
-          [this, &account_id, &asset_id](auto subscriber) {
+          [this, account_id, asset_id](auto subscriber) {
             auto block_ids = this->getBlockIds(account_id);
             for (auto block_id : block_ids) {
               // create key for querying redis

--- a/irohad/ametsuchi/impl/redis_flat_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.cpp
@@ -1,0 +1,113 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "redis_flat_block_query.hpp"
+
+#include "model/converters/json_common.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+
+    RedisFlatBlockFile::RedisFlatBlockFile(std::string redis_host,
+                                           size_t redis_port,
+                                           FlatFile& file_store)
+        : FlatFileBlockQuery(file_store), client_() {
+      client_.connect(redis_host, redis_port);
+    }
+
+    RedisFlatBlockFile::~RedisFlatBlockFile() { client_.disconnect(); }
+
+    std::vector<uint64_t> RedisFlatBlockFile::getBlockIdsByAccountId(
+        std::string& account_id) {
+      std::vector<uint64_t> block_ids;
+      client_.lrange(
+          account_id, 0, -1, [this, &block_ids](cpp_redis::reply& reply) {
+            for (const auto& block_reply : reply.as_array()) {
+              block_ids.push_back(std::stoul(block_reply.as_string()));
+            }
+          });
+      client_.sync_commit();
+      return block_ids;
+    }
+
+    std::function<void(cpp_redis::reply&)> RedisFlatBlockFile::callbackToLrange(
+        const rxcpp::subscriber<model::Transaction>& s, uint64_t block_id) {
+      return [this, &s, block_id](cpp_redis::reply& reply) {
+        auto tx_ids_reply = reply.as_array();
+
+        auto bytes = block_store_.get(block_id);
+        auto document =
+            model::converters::stringToJson(bytesToString(bytes.value()));
+        if (not document.has_value()) {
+          s.on_completed();
+          return;
+        }
+        auto block = serializer_.deserialize(document.value());
+        if (not block.has_value()) {
+          s.on_completed();
+          return;
+        }
+
+        for (const auto& tx_reply : tx_ids_reply) {
+          auto tx_id = std::stoul(tx_reply.as_string());
+          auto&& tx = block->transactions.at(tx_id);
+          s.on_next(tx);
+        }
+        s.on_completed();
+      };
+    }
+
+    rxcpp::observable<model::Transaction>
+    RedisFlatBlockFile::getAccountTransactions(std::string account_id) {
+      return rxcpp::observable<>::create<model::Transaction>(
+          [this, &account_id](auto subscriber) {
+            auto block_ids = this->getBlockIdsByAccountId(account_id);
+            for (auto block_id : block_ids) {
+              this->client_.lrange(account_id + ":" + std::to_string(block_id),
+                             0,
+                             -1,
+                             this->callbackToLrange(subscriber, block_id));
+            }
+            this->client_.sync_commit();
+          });
+    }
+
+    rxcpp::observable<model::Transaction>
+    RedisFlatBlockFile::getAccountAssetTransactions(std::string account_id,
+                                                    std::string asset_id) {
+      return rxcpp::observable<>::create<model::Transaction>(
+          [this, &account_id, &asset_id](auto subscriber) {
+            auto block_ids = this->getBlockIdsByAccountId(account_id);
+            for (auto block_id : block_ids) {
+              // create key for querying redis
+              std::string account_assets_key;
+              account_assets_key.append(account_id);
+              account_assets_key.append(":");
+              account_assets_key.append(std::to_string(block_id));
+              account_assets_key.append(":");
+              account_assets_key.append(asset_id);
+              client_.lrange(account_assets_key,
+                             0,
+                             -1,
+                             this->callbackToLrange(subscriber, block_id));
+            }
+            client_.sync_commit();
+          });
+    }
+
+  }  // namespace ametsuchi
+}  // namespace iroha

--- a/irohad/ametsuchi/impl/redis_flat_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.hpp
@@ -46,7 +46,7 @@ namespace iroha {
        * @param account_id
        * @return vector of block ids
        */
-      std::vector<uint64_t> getBlockIds(std::string& account_id);
+      std::vector<uint64_t> getBlockIds(const std::string& account_id);
 
       /**
        * creates callback to lrange query to redis to supply result to

--- a/irohad/ametsuchi/impl/redis_flat_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.hpp
@@ -18,24 +18,21 @@
 #ifndef IROHA_REDIS_FLAT_BLOCK_QUERY_HPP
 #define IROHA_REDIS_FLAT_BLOCK_QUERY_HPP
 
-#include <ametsuchi/impl/flat_file/flat_file.hpp>
 #include <cpp_redis/redis_client.hpp>
-//#include "ametsuchi/block_query.hpp"
+#include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include "ametsuchi/impl/flat_file_block_query.hpp"
 
 #include "model/converters/json_block_factory.hpp"
 
 namespace iroha {
   namespace ametsuchi {
-    class RedisFlatBlockFile : public FlatFileBlockQuery {
+    class RedisFlatBlockQuery : public FlatFileBlockQuery {
      public:
-      RedisFlatBlockFile(std::string redis_host,
+      RedisFlatBlockQuery(std::string redis_host,
                          size_t redis_port,
                          FlatFile& file_store);
 
-      RedisFlatBlockFile(FlatFile& block_store) = delete;
-
-      ~RedisFlatBlockFile() override;
+      ~RedisFlatBlockQuery() override;
 
       rxcpp::observable<model::Transaction> getAccountTransactions(
           std::string account_id) override;
@@ -49,7 +46,7 @@ namespace iroha {
        * @param account_id
        * @return vector of block ids
        */
-      std::vector<uint64_t> getBlockIdsByAccountId(std::string& account_id);
+      std::vector<uint64_t> getBlockIds(std::string& account_id);
 
       /**
        * creates callback to lrange query to redis to supply result to

--- a/irohad/ametsuchi/impl/redis_flat_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.hpp
@@ -28,11 +28,8 @@ namespace iroha {
   namespace ametsuchi {
     class RedisFlatBlockQuery : public FlatFileBlockQuery {
      public:
-      RedisFlatBlockQuery(std::string redis_host,
-                         size_t redis_port,
-                         FlatFile& file_store);
-
-      ~RedisFlatBlockQuery() override;
+      RedisFlatBlockQuery(cpp_redis::redis_client &client,
+                          FlatFile &file_store);
 
       rxcpp::observable<model::Transaction> getAccountTransactions(
           std::string account_id) override;
@@ -46,7 +43,7 @@ namespace iroha {
        * @param account_id
        * @return vector of block ids
        */
-      std::vector<uint64_t> getBlockIds(const std::string& account_id);
+      std::vector<uint64_t> getBlockIds(const std::string &account_id);
 
       /**
        * creates callback to lrange query to redis to supply result to
@@ -55,10 +52,10 @@ namespace iroha {
        * @param block_id
        * @return
        */
-      std::function<void(cpp_redis::reply&)> callbackToLrange(
-          const rxcpp::subscriber<model::Transaction>& s, uint64_t block_id);
+      std::function<void(cpp_redis::reply &)> callbackToLrange(
+          const rxcpp::subscriber<model::Transaction> &s, uint64_t block_id);
 
-      cpp_redis::redis_client client_;
+      cpp_redis::redis_client &client_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/redis_flat_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_REDIS_FLAT_BLOCK_QUERY_HPP
+#define IROHA_REDIS_FLAT_BLOCK_QUERY_HPP
+
+#include <ametsuchi/impl/flat_file/flat_file.hpp>
+#include <cpp_redis/redis_client.hpp>
+//#include "ametsuchi/block_query.hpp"
+#include "ametsuchi/impl/flat_file_block_query.hpp"
+
+#include "model/converters/json_block_factory.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+    class RedisFlatBlockFile : public FlatFileBlockQuery {
+     public:
+      RedisFlatBlockFile(std::string redis_host,
+                         size_t redis_port,
+                         FlatFile& file_store);
+
+      RedisFlatBlockFile(FlatFile& block_store) = delete;
+
+      ~RedisFlatBlockFile() override;
+
+      rxcpp::observable<model::Transaction> getAccountTransactions(
+          std::string account_id) override;
+
+      rxcpp::observable<model::Transaction> getAccountAssetTransactions(
+          std::string account_id, std::string asset_id) override;
+
+     private:
+      /**
+       * Returns all blocks' ids containing given account id
+       * @param account_id
+       * @return vector of block ids
+       */
+      std::vector<uint64_t> getBlockIdsByAccountId(std::string& account_id);
+
+      /**
+       * creates callback to lrange query to redis to supply result to
+       * subscriber s
+       * @param s
+       * @param block_id
+       * @return
+       */
+      std::function<void(cpp_redis::reply&)> callbackToLrange(
+          const rxcpp::subscriber<model::Transaction>& s, uint64_t block_id);
+
+      cpp_redis::redis_client client_;
+    };
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif  // IROHA_REDIS_FLAT_BLOCK_QUERY_HPP

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -44,8 +44,8 @@ namespace iroha {
           wsv_connection_(std::move(wsv_connection)),
           wsv_transaction_(std::move(wsv_transaction)),
           wsv_(std::make_shared<PostgresWsvQuery>(*wsv_transaction_)),
-          blocks_(std::make_shared<RedisFlatBlockQuery>(
-              redis_host_, redis_port, *block_store_)) {
+          blocks_(
+              std::make_shared<RedisFlatBlockQuery>(*index_, *block_store_)) {
       log_ = logger::log("StorageImpl");
 
       wsv_transaction_->exec(init_);

--- a/test/module/irohad/model/converters/pb_transaction_test.cpp
+++ b/test/module/irohad/model/converters/pb_transaction_test.cpp
@@ -61,20 +61,6 @@ TEST(TransactionTest, tx_test) {
 
   auto factory = iroha::model::converters::PbTransactionFactory();
   auto proto_tx = factory.serialize(orig_tx);
-  switch (proto_tx.payload().commands().Get(0).command_case()){
-
-    case iroha::protocol::Command::kAddAssetQuantity:break;
-    case iroha::protocol::Command::kAddPeer:break;
-    case iroha::protocol::Command::kAddSignatory:break;
-    case iroha::protocol::Command::kCreateAsset:break;
-    case iroha::protocol::Command::kCreateAccount:break;
-    case iroha::protocol::Command::kCreateDomain:break;
-    case iroha::protocol::Command::kRemoveSign:break;
-    case iroha::protocol::Command::kSetPermission:break;
-    case iroha::protocol::Command::kSetQuorum:break;
-    case iroha::protocol::Command::kTransferAsset:break;
-    case iroha::protocol::Command::COMMAND_NOT_SET:break;
-  }
   auto serial_tx = factory.deserialize(proto_tx);
   ASSERT_EQ(orig_tx, *serial_tx);
 }


### PR DESCRIPTION
## What is this pull request?
Allows using redis to index blocks for fast querying account's  and account's assets transactions
   
## Why do you implement it? Why do we need this pull request?
So far to query account's transactions we went through the block and checked every transaction if it was created by this account. Applying redis indices we can speed up such queries, so that we don't need to go through every transaction in a block
  
## How to use the features provided in the pull request?
New block query class implements block query api, so that it is easy to plug in to current implementation

## Details/Features
During this PR new class RedisFlatBlockQuery was introduced, which inherits from FlatFileBlockQuery and overrides methods to get account's transactions and get account's assets transactions. There is no point to change methods to query blocks, so they were inherited from parent class without changes