### PR TITLE
Add unsigned postgres checks for precision and transaction count

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -134,7 +134,7 @@ CREATE TABLE IF NOT EXISTS account (
     account_id character varying(197),
     domain_id character varying(164) NOT NULL REFERENCES domain,
     quorum int NOT NULL,
-    transaction_count int NOT NULL DEFAULT 0,
+    transaction_count int NOT NULL DEFAULT 0 CHECK (transaction_count >= 0),
     permissions bit varying NOT NULL,
     PRIMARY KEY (account_id)
 );
@@ -151,7 +151,7 @@ CREATE TABLE IF NOT EXISTS peer (
 CREATE TABLE IF NOT EXISTS asset (
     asset_id character varying(197),
     domain_id character varying(164) NOT NULL REFERENCES domain,
-    precision int NOT NULL,
+    precision int NOT NULL CHECK (precision >= 0),
     data json,
     PRIMARY KEY (asset_id)
 );


### PR DESCRIPTION
## What is this pull request?
PR adds checks for PostgreSQL tables
   
## Why do you implement it? Why do we need this pull request?
To guarantee that in database we don't store negative integers
  
## P.S. (optional)
Since we don't have checks for underflow or overflow — this is useless and guarantees only datatype validity for data storage layer. We need to fix corresponding logic in business layer (model classes).
