### PR TITLE
Fix compilers warnings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,5 @@ BinPackArguments: false
 BinPackParameters: false
 DerivePointerAlignment: false
 PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(iroha C CXX)
 SET(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 SET(CMAKE_CXX_FLAGS "-std=c++1y -Wall")
 SET(CMAKE_CXX_FLAGS_RELEASE "-O3")
-SET(CMAKE_CXX_FLAGS_DEBUG   "-g -Wextra -Wno-unused-parameter -O0")
+SET(CMAKE_CXX_FLAGS_DEBUG   "-g -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -O0")
 SET(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 SET(CMAKE_INSTALL_RPATH "../lib")
 

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -10,7 +10,7 @@ function(strictmode target)
   if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
-    target_compile_options(${target} PRIVATE -Wall -Wpedantic)
+    target_compile_options(${target} PRIVATE -Wall -Wpedantic -Werror -Wno-potentially-evaluated-expression)
   elseif ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"))
     target_compile_options(${target} PRIVATE /W3 /WX)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -32,6 +32,13 @@ function(addtest test_name SOURCES)
       COMMAND $<TARGET_FILE:${test_name}> ${test_xml_output}
   )
   strictmode(${test_name})
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+  (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR
+  (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+    target_compile_options(${test_name} PRIVATE -Wno-inconsistent-missing-override)
+  else ()
+    message(AUTHOR_WARNING "Unknown compiler: building target ${target} with default options")
+  endif ()
 endfunction()
 
 # Creates benchmark "bench_name", with "SOURCES" (use string as second argument)

--- a/iroha-cli/client.cpp
+++ b/iroha-cli/client.cpp
@@ -67,4 +67,4 @@ namespace iroha_cli {
     return response;
   }
 
-};  // namespace iroha_cli
+} // namespace iroha_cli

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -27,7 +27,7 @@ namespace iroha_cli {
           {SEND_CODE, "Send to Iroha peer"}
           // commonDescriptionMap
       };
-    };
+    }
 
     ParamsMap getCommonParamsMap() {
       return {
@@ -36,15 +36,15 @@ namespace iroha_cli {
           {SEND_CODE, {"Peer address", "Peer port"}}
           // commonParamsMap
       };
-    };
+    }
 
     void handleEmptyCommand() {
       std::cout << "Put not empty command" << std::endl;
-    };
+    }
 
     void handleUnknownCommand(std::string &command) {
       std::cout << "Command not found: " << command << std::endl;
-    };
+    }
 
     void addBackOption(MenuPoints &menu) {
       menu.push_back("0. Back (" + BACK_CODE + ")");
@@ -54,7 +54,7 @@ namespace iroha_cli {
       auto command = parser::parseFirstCommand(line);
       return command.has_value()
           and (command.value() == "0" or command.value() == BACK_CODE);
-    };
+    }
 
     void printCommandParameters(std::string &command,
                                 std::vector<std::string> parameters) {
@@ -63,14 +63,14 @@ namespace iroha_cli {
       std::for_each(parameters.begin(), parameters.end(), [](auto el) {
         std::cout << "  " << el << std::endl;
       });
-    };
+    }
 
     void printMenu(const std::string &message, MenuPoints menu_points) {
       std::cout << message << std::endl;
       std::for_each(menu_points.begin(), menu_points.end(), [](auto el) {
         std::cout << el << std::endl;
       });
-    };
+    }
 
     std::string promtString(const std::string &message) {
       std::string line;
@@ -79,7 +79,7 @@ namespace iroha_cli {
       return line;
     }
 
-    void printEnd() { std::cout << "--------------------" << std::endl; };
+    void printEnd() { std::cout << "--------------------" << std::endl; }
 
     nonstd::optional<std::pair<std::string, uint16_t>> parseIrohaPeerParams(
         ParamsDescription params) {

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -155,7 +155,7 @@ namespace iroha_cli {
     template <typename K, typename V>
     std::size_t getNextIndex(std::unordered_map<K, V> parsers_map) {
       return parsers_map.size() == 0 ? 1 : parsers_map.size();
-    };
+    }
 
     /**
      * Find in unordered map with error reporting.
@@ -223,7 +223,7 @@ namespace iroha_cli {
         return nonstd::nullopt;
       }
       return (class_pointer->*parser.value())(params.value());
-    };
+    }
 
     /**
      * Add new  cli command to menu points and menu handlers (parsers)

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -96,6 +96,11 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
   }
   if (status < 3) {
     log->info("check_consistency({}), directory is empty", dump_dir);
+    auto n = static_cast<uint32_t>(status);
+    for (auto j = 0u; j < n; ++j) {
+      free(namelist[j]);
+    }
+    free(namelist);
     return 0;
   }
 

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -98,7 +98,7 @@ namespace iroha {
         return command_executors_->getCommandExecutor(command)->execute(
             *command, *wsv_, *executor_);
       };
-      auto execute_transaction = [this, execute_command](auto &transaction) {
+      auto execute_transaction = [execute_command](auto &transaction) {
         return std::all_of(transaction.commands.begin(),
                            transaction.commands.end(),
                            execute_command);

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -35,7 +35,7 @@ namespace iroha {
         return false;
       }
       return true;
-    };
+    }
 
     bool PostgresWsvCommand::insertAccountRole(const std::string &account_id,
                                                const std::string &role_name) {
@@ -49,7 +49,7 @@ namespace iroha {
         return false;
       }
       return true;
-    };
+    }
 
     bool PostgresWsvCommand::insertRolePermissions(
         const std::string &role_id,
@@ -71,7 +71,7 @@ namespace iroha {
         return false;
       }
       return true;
-    };
+    }
 
     bool PostgresWsvCommand::insertAccountGrantablePermission(
         const std::string &permittee_account_id, const std::string &account_id,
@@ -89,7 +89,7 @@ namespace iroha {
         return false;
       }
       return true;
-    };
+    }
 
     bool PostgresWsvCommand::deleteAccountGrantablePermission(
         const std::string &permittee_account_id, const std::string &account_id,
@@ -106,7 +106,7 @@ namespace iroha {
         return false;
       }
       return true;
-    };
+    }
 
     bool PostgresWsvCommand::insertAccount(const model::Account &account) {
       try {

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -53,7 +53,7 @@ namespace iroha {
         return false;
       }
       return result.size() == 1;
-    };
+    }
 
     nonstd::optional<std::vector<std::string>>
     PostgresWsvQuery::getAccountRoles(const std::string &account_id) {
@@ -72,7 +72,7 @@ namespace iroha {
         roles.emplace_back(row.at("role_id").c_str());
       }
       return roles;
-    };
+    }
 
     nonstd::optional<std::vector<std::string>>
     PostgresWsvQuery::getRolePermissions(const std::string &role_name) {
@@ -91,7 +91,7 @@ namespace iroha {
         permissions.emplace_back(row.at("permission_id").c_str());
       }
       return permissions;
-    };
+    }
 
     nonstd::optional<std::vector<std::string>> PostgresWsvQuery::getRoles() {
       pqxx::result result;
@@ -106,7 +106,7 @@ namespace iroha {
         roles.emplace_back(row.at("role_id").c_str());
       }
       return roles;
-    };
+    }
 
     optional<Account> PostgresWsvQuery::getAccount(const string &account_id) {
       pqxx::result result;

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -72,17 +72,16 @@ namespace iroha {
     std::vector<iroha::model::Block::BlockHeightType>
     RedisBlockQuery::getBlockIds(const std::string &account_id) {
       std::vector<uint64_t> block_ids;
-      client_.lrange(
-          account_id, 0, -1, [this, &block_ids](cpp_redis::reply &reply) {
-            for (const auto &block_reply : reply.as_array()) {
-              const auto &string_reply = block_reply.as_string();
+      client_.lrange(account_id, 0, -1, [&block_ids](cpp_redis::reply &reply) {
+        for (const auto &block_reply : reply.as_array()) {
+          const auto &string_reply = block_reply.as_string();
 
-              // check if reply is an integer
-              if (isdigit(string_reply.c_str()[0])) {
-                block_ids.push_back(std::stoul(string_reply));
-              }
-            }
-          });
+          // check if reply is an integer
+          if (isdigit(string_reply.c_str()[0])) {
+            block_ids.push_back(std::stoul(string_reply));
+          }
+        }
+      });
       client_.sync_commit();
       return block_ids;
     }

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -89,7 +89,7 @@ namespace iroha {
     boost::optional<iroha::model::Block::BlockHeightType>
     RedisBlockQuery::getBlockId(const std::string &hash) {
       boost::optional<uint64_t> blockId;
-      client_.get(hash, [this, &blockId](cpp_redis::reply &reply) {
+      client_.get(hash, [&blockId](cpp_redis::reply &reply) {
         if (reply.is_null()) {
           blockId = boost::none;
         } else {

--- a/irohad/consensus/yac/impl/peer_orderer_impl.cpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.cpp
@@ -36,7 +36,6 @@ namespace iroha {
         // TODO 01/08/17 Muratov: implement effective ordering based on hash value IR-504
         return getInitialOrdering();
       }
-
     }  // namespace yac
   }    // namespace consensus
 }  // namespace iroha

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -81,7 +81,7 @@ namespace iroha {
         this->cluster_order_ = order;
         auto vote = crypto_->getVote(hash);
         votingStep(vote);
-      };
+      }
 
       rxcpp::observable<CommitMessage> Yac::on_commit() {
         return this->notifier_.get_observable();
@@ -136,7 +136,7 @@ namespace iroha {
         }
       }
 
-      void Yac::closeRound() { timer_->deny(); };
+      void Yac::closeRound() { timer_->deny(); }
 
       // ------|Apply data|------
 
@@ -164,12 +164,12 @@ namespace iroha {
           vote_storage_.markAsProcessedState(proposal_hash);
         }
         closeRound();
-      };
+      }
 
       void Yac::applyReject(model::Peer from, RejectMessage reject) {
         // TODO 01/08/17 Muratov: apply to vote storage IR-497
         closeRound();
-      };
+      }
 
       void Yac::applyVote(model::Peer from, VoteMessage vote) {
         log_->info(
@@ -217,7 +217,7 @@ namespace iroha {
             propagateRejectDirectly(from, answer->reject.value());
           }
         }
-      };
+      }
 
       // ------|Propagation|------
 

--- a/irohad/consensus/yac/storage/impl/storage_result.cpp
+++ b/irohad/consensus/yac/storage/impl/storage_result.cpp
@@ -24,7 +24,7 @@ namespace iroha {
       bool Answer::operator==(const Answer &rhs) const {
         return this->commit == rhs.commit and
             this->reject == rhs.reject;
-      };
+      }
     } // namespace yac
   } // namespace consensus
 } // namespace iroha

--- a/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
@@ -84,7 +84,7 @@ namespace iroha {
           }
         }
         return getState();
-      };
+      }
 
       nonstd::optional<Answer> YacProposalStorage::insert(std::vector<
           VoteMessage> messages) {

--- a/irohad/main/impl/raw_block_insertion.cpp
+++ b/irohad/main/impl/raw_block_insertion.cpp
@@ -36,7 +36,7 @@ namespace iroha {
         return nonstd::nullopt;
       }
       return block_factory_.deserialize(document.value());
-    };
+    }
 
     void BlockInserter::applyToLedger(std::vector<model::Block> blocks) {
       auto storage = factory_->createMutableStorage();
@@ -45,14 +45,14 @@ namespace iroha {
                                  const auto &top_hash) { return true; });
       }
       factory_->commit(std::move(storage));
-    };
+    }
 
     nonstd::optional<std::string> BlockInserter::loadFile(std::string path) {
       std::ifstream file(path);
       std::string str((std::istreambuf_iterator<char>(file)),
                       std::istreambuf_iterator<char>());
       return str;
-    };
+    }
 
   } // namespace main
 } // namespace iroha

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -46,6 +46,13 @@ DEFINE_validator(keypair_name, &validate_keypair_name);
 int main(int argc, char *argv[]) {
   auto log = logger::log("MAIN");
   log->info("start");
+
+  if (not config_validator_registered or not genesis_block_validator_registered
+      or not keypair_name_validator_registered) {
+    log->error("Flag validator is not registered");
+    return EXIT_FAILURE;
+  }
+
   namespace mbr = config_members;
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
   auto log = logger::log("MAIN");
   log->info("start");
 
-  if (not config_validator_registered or not genesis_block_validator_registered
+  if (not config_validator_registered
       or not keypair_name_validator_registered) {
     log->error("Flag validator is not registered");
     return EXIT_FAILURE;

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -78,7 +78,7 @@ namespace iroha {
             | des.String(&Query::creator_account_id, "creator_account_id")
             | des.Uint64(&Query::query_counter, "query_counter")
             | des.Object(&Query::signature, "signature") |
-            [this](auto query) { return nonstd::make_optional(query); };
+            [](auto query) { return nonstd::make_optional(query); };
       }
 
       optional_ptr<Query> JsonQueryFactory::deserializeGetAccount(

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -99,7 +99,6 @@ namespace iroha {
               break;
             }
             case Query_Payload::QueryCase::kGetRoles: {
-              // Convert to get Roles
               val = std::make_shared<GetRoles>();
               break;
             }
@@ -165,7 +164,7 @@ namespace iroha {
         auto pb_query_mut = pl->mutable_get_account();
         pb_query_mut->set_account_id(account_id);
         return pb_query;
-      };
+      }
 
       protocol::Query PbQueryFactory::serializeGetAccountAssets(
           std::shared_ptr<const Query> query) const {
@@ -177,7 +176,7 @@ namespace iroha {
         pb_query_mut->set_account_id(tmp->account_id);
         pb_query_mut->set_asset_id(tmp->asset_id);
         return pb_query;
-      };
+      }
 
       protocol::Query PbQueryFactory::serializeGetAccountTransactions(
           std::shared_ptr<const Query> query) const {

--- a/irohad/model/converters/json_common.hpp
+++ b/irohad/model/converters/json_common.hpp
@@ -22,10 +22,6 @@
 #include <string>
 #include <unordered_map>
 
-// omit -Wmacro-redefined
-#ifdef RAPIDJSON_HAS_STDSTRING
-  #undef RAPIDJSON_HAS_STDSTRING
-#endif
 // Enable std::string support in rapidjson
 #define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>

--- a/irohad/model/converters/json_common.hpp
+++ b/irohad/model/converters/json_common.hpp
@@ -22,6 +22,10 @@
 #include <string>
 #include <unordered_map>
 
+// omit -Wmacro-redefined
+#ifdef RAPIDJSON_HAS_STDSTRING
+  #undef RAPIDJSON_HAS_STDSTRING
+#endif
 // Enable std::string support in rapidjson
 #define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>

--- a/irohad/model/converters/pb_block_factory.hpp
+++ b/irohad/model/converters/pb_block_factory.hpp
@@ -30,6 +30,8 @@ namespace iroha {
        */
       class PbBlockFactory {
        public:
+        PbBlockFactory() {}
+
         /**
          * Convert block to proto block
          * @param block - reference to block

--- a/irohad/model/converters/pb_transaction_factory.hpp
+++ b/irohad/model/converters/pb_transaction_factory.hpp
@@ -31,6 +31,8 @@ namespace iroha {
        */
       class PbTransactionFactory {
        public:
+        PbTransactionFactory() {}
+
         /**
          * Convert block to proto block
          * @param block - reference to block

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -51,7 +51,7 @@ namespace iroha {
 
     bool Signature::operator!=(const Signature &rhs) const {
       return not operator==(rhs);
-    };
+    }
 
     bool AppendRole::operator==(const Command &command) const {
       if (! instanceof <AppendRole>(command)) return false;

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -53,7 +53,7 @@ grpc::Status BlockLoaderService::retrieveBlock(
 
   nonstd::optional<protocol::Block> result;
   storage_->getBlocksFrom(1)
-      .filter([this, hash](auto block) {
+      .filter([hash](auto block) {
         return block.hash == hash.value();
       })
       .map([this](auto block) { return factory_.serialize(block); })

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -32,10 +32,11 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
 
   model::Proposal proposal(transactions);
   proposal.height = request->height();
-  if (not subscriber_.expired())
+  if (not subscriber_.expired()) {
     subscriber_.lock()->onProposal(std::move(proposal));
-  else
+  } else {
     log_->error("(onProposal) No subscriber");
+  }
 
   return grpc::Status::OK;
 }

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -29,8 +29,8 @@ namespace iroha {
                                            ametsuchi::MutableStorage &storage) {
       log_->info("validate block: height {}, hash {}", block.height,
                  block.hash.to_hexstring());
-      auto apply_block = [this](const auto &block, auto &queries,
-                                const auto &top_hash) {
+      auto apply_block = [](const auto &block, auto &queries,
+                            const auto &top_hash) {
         auto peers = queries.getPeers();
         if (not peers.has_value()) {
           return false;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -310,6 +310,9 @@ namespace iroha {
   struct keypair_t {
     pubkey_t pubkey;
     privkey_t privkey;
+
+    keypair_t() = default;
+    keypair_t(pubkey_t pubkey, privkey_t privkey): pubkey(pubkey), privkey(privkey) {}
   };
 
   // timestamps

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -258,7 +258,9 @@ namespace iroha {
    */
   template <typename T, typename... Args>
   auto makeMethodInvoke(T &object, Args &&... args) {
-    return [&](auto f) { return (object.*f)(std::forward<Args>(args)...); };
+    return [&](auto f) {
+      return (object.*f)(std::forward<Args>(args)...);
+    };
   }
 
   /**
@@ -308,11 +310,13 @@ namespace iroha {
   using privkey_t = blob_t<64>;
 
   struct keypair_t {
+    keypair_t() = default;
+
+    keypair_t(pubkey_t pubkey, privkey_t privkey)
+        : pubkey(pubkey), privkey(privkey) {}
+
     pubkey_t pubkey;
     privkey_t privkey;
-
-    keypair_t() = default;
-    keypair_t(pubkey_t pubkey, privkey_t privkey): pubkey(pubkey), privkey(privkey) {}
   };
 
   // timestamps

--- a/libs/crypto/ed25519/seed.c
+++ b/libs/crypto/ed25519/seed.c
@@ -30,7 +30,10 @@ int ed25519_create_seed(unsigned char *seed) {
         return 1;
     }
 
-    fread(seed, 1, 32, f);
+    if (fread(seed, 1, 32, f) != 32) {
+        fclose(f);
+        return 1;
+    }
     fclose(f);
 #endif
 

--- a/libs/crypto/ed25519/sha3.c
+++ b/libs/crypto/ed25519/sha3.c
@@ -27,8 +27,8 @@
 #define SHA3_TRACE( format, ...)
 #define SHA3_TRACE_BUF( format, buf, l, ...)
 #else
-#define SHA3_TRACE(format, args...)
-#define SHA3_TRACE_BUF(format, buf, l, args...)
+#define SHA3_TRACE(format, ...)
+#define SHA3_TRACE_BUF(format, buf, l)
 #endif
 
 //#define SHA3_USE_KECCAK

--- a/libs/crypto/ed25519_impl.cpp
+++ b/libs/crypto/ed25519_impl.cpp
@@ -54,7 +54,6 @@ namespace iroha {
                                pub.data());
   }
 
-
   /**
    * Generate seed
    */
@@ -82,7 +81,7 @@ namespace iroha {
 
     ed25519_create_keypair(pub.data(), priv.data(), seed.data());
 
-    return keypair_t{.pubkey = pub, .privkey = priv};
+    return keypair_t(pub, priv);
   }
 
   keypair_t create_keypair() { return create_keypair(create_seed()); }

--- a/libs/ip_tools/ip_tools.cpp
+++ b/libs/ip_tools/ip_tools.cpp
@@ -103,7 +103,7 @@ namespace iroha {
       result.second = (1u << cidrmask) - 2;
 
       return result;
-    };
+    }
 
   }  // namespace ip_tools
 }  // namespace iroha

--- a/libs/ip_tools/ip_tools.cpp
+++ b/libs/ip_tools/ip_tools.cpp
@@ -1,18 +1,19 @@
-/*
-Copyright Soramitsu Co., Ltd. 2016 All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "ip_tools.hpp"
 #include "logger/logger.hpp"
@@ -24,7 +25,9 @@ namespace iroha {
   namespace ip_tools {
 
     bool isIpValid(const std::string &ip) {
-      if (ip == "localhost") return true;
+      if (ip == "localhost") {
+        return true;
+      }
       std::regex ipRegex(
         "((([0-1]?\\d\\d?)|((2[0-4]\\d)|(25[0-5]))).){3}(([0-1]?\\d\\d?)|((2[0-4]"
           "\\d)|(25[0-5])))");

--- a/libs/ip_tools/ip_tools.hpp
+++ b/libs/ip_tools/ip_tools.hpp
@@ -1,18 +1,19 @@
-/*
-Copyright Soramitsu Co., Ltd. 2016 All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef IROHA_IP_TOOLS_HPP
 #define IROHA_IP_TOOLS_HPP

--- a/libs/parser/parser.cpp
+++ b/libs/parser/parser.cpp
@@ -31,7 +31,7 @@ namespace parser {
       return nonstd::nullopt;
     }
     return vec[0];
-  };
+  }
 
   std::vector<std::string> split(std::string line) {
     std::transform(line.begin(), line.end(), line.begin(), ::tolower);

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -67,7 +67,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
     network = std::make_shared<NetworkImpl>(my_peer.address, default_peers);
     crypto = std::make_shared<FixedCryptoProvider>(std::to_string(my_num));
     timer = std::make_shared<TimerImpl>();
-    yac = Yac::create(std::move(YacVoteStorage()),
+    yac = Yac::create(YacVoteStorage(),
                       network,
                       crypto,
                       timer,

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -79,7 +79,6 @@ DROP TABLE IF EXISTS role;
         client.connect(redishost_, redisport_);
         client.flushall();
         client.sync_commit();
-        client.disconnect();
 
         iroha::remove_all(block_store_path);
       }

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -195,9 +195,8 @@ namespace iroha {
           network = std::make_shared<MockYacNetwork>();
           crypto = std::make_shared<MockYacCryptoProvider>();
           timer = std::make_shared<MockTimer>();
-          yac = Yac::create(
-              std::move(YacVoteStorage()), network, crypto,
-              timer, ClusterOrdering(default_peers), delay);
+          yac = Yac::create(YacVoteStorage(), network, crypto, timer,
+                            ClusterOrdering(default_peers), delay);
           network->subscribe(yac);
         };
 

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -18,7 +18,6 @@
 #include <algorithm>
 
 #include <gtest/gtest.h>
-#include <rapidjson/writer.h>
 
 #include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/add_peer.hpp"

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -102,6 +102,7 @@ TEST_F(OrderingGateTest, TransactionReceivedByServerWhenSent) {
       .WillRepeatedly(InvokeWithoutArgs([&] {
         ++call_count;
         cv.notify_one();
+        return grpc::Status::OK;
       }));
 
   for (size_t i = 0; i < 5; ++i) {

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -31,8 +31,6 @@ limitations under the License.
 constexpr const char *Ip = "0.0.0.0";
 constexpr int Port = 50051;
 
-constexpr size_t TimesToriiBlocking = 5;
-constexpr size_t TimesToriiNonBlocking = 5;
 constexpr size_t TimesFind = 1;
 
 using ::testing::Return;

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -39,7 +39,6 @@ constexpr int Port = 50051;
 
 constexpr size_t TimesToriiBlocking = 5;
 constexpr size_t TimesToriiNonBlocking = 5;
-constexpr size_t TimesFind = 10;
 
 using ::testing::Return;
 using ::testing::A;

--- a/test/module/vendor/rxcpp_subject_usage.cpp
+++ b/test/module/vendor/rxcpp_subject_usage.cpp
@@ -35,23 +35,23 @@ struct Person {
 };
 
 TEST(rxcppTest, usage_subject_test) {
-  subject<Person> person$;
+  subject<Person> person;
 
   // group ages by gender
-  auto agebygender$ = person$.
+  auto agebygender = person.
       get_observable().subscribe([](auto val) {
     cout << val.name << " " << val.gender << endl;
   });
 
-  person$.get_observable().subscribe([](auto val) {
+  person.get_observable().subscribe([](auto val) {
     cout << "YET ANOTHER " << val.name << " " << val.gender << endl;
   });
 
   for (auto i = 0; i < 10; i++) {
-    person$.get_subscriber().on_next(Person{"Tom", "Male", 32});
+    person.get_subscriber().on_next(Person{"Tom", "Male", 32});
     cout << "next" << endl;
   }
-  person$.get_subscriber().on_completed();
-  person$.get_subscriber().on_next(Person{"Vasya", "Male", 32});
+  person.get_subscriber().on_completed();
+  person.get_subscriber().on_next(Person{"Vasya", "Male", 32});
 }
 #endif //IROHA_RXCPP_SUBJECT_USAGE_HPP


### PR DESCRIPTION
Checked with:
- gcc 7.2.0
- clang 4.0.1
- clang 5.0.0

Fixes:
- Remove redundant rapidjson include in json_commands_test.cpp
- Add default constructors to pb block and transaction factory
- Remove async redis disconnect from ametsuchi fixture
- Disable warnings for potentially evaluated expressions and missing override in tests