### PR TITLE
Replace peer number with peer key in swarm deploy script

### DIFF
--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -356,7 +356,7 @@ namespace iroha_cli {
       auto asset_id = params[2];
       auto val_int =
           parser::parseValue<boost::multiprecision::uint256_t>(params[3]);
-      auto precision = parser::parseValue<uint8_t>(params[4]);
+      auto precision = parser::parseValue<uint32_t>(params[4]);
       if (not val_int.has_value() || not precision.has_value()) {
         std::cout << "Wrong format for amount" << std::endl;
         return nullptr;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -55,7 +55,7 @@ class Irohad {
    * @param redis_port - port of redis connection
    * @param pg_conn - initialization string for postgre
    * @param torii_port - port for torii binding
-   * @param peer_number - number of peer in ledger // todo replace with pub key
+   * @param keypair - public and private keys for crypto provider
    */
   Irohad(const std::string &block_store_dir,
          const std::string &redis_host,

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -56,8 +56,6 @@ inline rapidjson::Document parse_iroha_config(std::string const& iroha_conf_path
   assert_fatal(doc[mbr::ToriiPort].IsUint(),
                type_error(mbr::ToriiPort, "uint"));
 
-  // TODO restore key pair path parameter when crypto is ready
-
   assert_fatal(doc.HasMember(mbr::PgOpt), no_member_error(mbr::PgOpt));
   assert_fatal(doc[mbr::PgOpt].IsString(), type_error(mbr::PgOpt, "string"));
 

--- a/scripts/swarm-deploy.sh
+++ b/scripts/swarm-deploy.sh
@@ -69,9 +69,9 @@ do
     # copy config
     docker cp ${IROHA_HOME}/iroha.conf ${COMPOSE_PROJECT_NAME}_node_1:/
     # generate genesis block based on list of peers
-    docker exec ${COMPOSE_PROJECT_NAME}_node_1 /opt/iroha/iroha-cli --genesis_block --peers_address /peers.list
+    docker exec ${COMPOSE_PROJECT_NAME}_node_1 iroha-cli --genesis_block --peers_address /peers.list
     # run irohad with output redirection to /iroha.log
-    docker exec -d ${COMPOSE_PROJECT_NAME}_node_1 bash -c "/opt/iroha/irohad --config /iroha.conf --genesis_block /genesis.block --peer_number ${i} > /iroha.log"
+    docker exec -d ${COMPOSE_PROJECT_NAME}_node_1 bash -c "irohad --config /iroha.conf --genesis_block /genesis.block --keypair_name /node${i} > /iroha.log"
     ((i++))
 done < <(docker-machine ls -f "{{.Name}}")
 


### PR DESCRIPTION
`peer_number` was replaced with `keypair_name` in crypto PR.