### PR TITLE
Fix/peer join

### DIFF
--- a/example/config.sample
+++ b/example/config.sample
@@ -1,6 +1,7 @@
 {
   "block_store_path" : "/tmp/block_store/",
   "torii_port" : 50051,
+  "internal_port" : 10001,
   "pg_opt" : "host=localhost port=5432 user=postgres password=mysecretpassword",
   "redis_host" : "localhost",
   "redis_port" : 6379

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -150,6 +150,11 @@ std::unique_ptr<FlatFile> FlatFile::create(const std::string &path) {
 }
 
 void FlatFile::add(Identifier id, const std::vector<uint8_t> &block) {
+  if (id != current_id_ + 1) {
+    log_->warn("Cannot append non-consecutive block");
+    return;
+  }
+
   auto next_id = id;
   auto file_name = dump_dir_ + SEPARATOR + id_to_name(id);
 

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -49,7 +49,7 @@ namespace iroha {
       void index_block(uint64_t height, model::Block block);
 
       hash256_t top_hash_;
-      std::unordered_map<uint32_t, model::Block> block_store_;
+      std::map<uint32_t, model::Block> block_store_;
       std::unique_ptr<cpp_redis::redis_client> index_;
 
       std::unique_ptr<pqxx::lazyconnection> connection_;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -49,6 +49,8 @@ namespace iroha {
       void index_block(uint64_t height, model::Block block);
 
       hash256_t top_hash_;
+      // ordered collection is used to enforce block insertion order in
+      // StorageImpl::commit
       std::map<uint32_t, model::Block> block_store_;
       std::unique_ptr<cpp_redis::redis_client> index_;
 

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -21,10 +21,12 @@
 #include <atomic>
 #include <thread>
 #include <unordered_map>
-#include "network/impl/async_grpc_client.hpp"
+
+#include "ametsuchi/peer_query.hpp"
 #include "consensus/yac/transport/yac_network_interface.hpp"
-#include "yac.grpc.pb.h"
 #include "logger/logger.hpp"
+#include "network/impl/async_grpc_client.hpp"
+#include "yac.grpc.pb.h"
 
 namespace iroha {
   namespace consensus {
@@ -81,6 +83,8 @@ namespace iroha {
             ::google::protobuf::Empty *response) override;
 
        private:
+
+        void createPeerConnection(const model::Peer &peer);
 
         /**
          * Address of current peer

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -84,6 +84,11 @@ namespace iroha {
 
        private:
 
+        /**
+         * Create GRPC connection for given peer if it does not exist in
+         * peers map
+         * @param peer to instantiate connection with
+         */
         void createPeerConnection(const model::Peer &peer);
 
         /**

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -62,6 +62,7 @@ class Irohad {
          size_t redis_port,
          const std::string &pg_conn,
          size_t torii_port,
+         size_t internal_port,
          const iroha::keypair_t &keypair);
 
   /**
@@ -84,8 +85,6 @@ class Irohad {
   virtual void initProtoFactories();
 
   virtual void initPeerQuery();
-
-  virtual void initPeer();
 
   virtual void initCryptoProvider();
 
@@ -113,6 +112,7 @@ class Irohad {
   size_t redis_port_;
   std::string pg_conn_;
   size_t torii_port_;
+  size_t internal_port_;
 
   // ------------------------| internal dependencies |-------------------------
 
@@ -132,9 +132,6 @@ class Irohad {
 
   // peer query
   std::shared_ptr<iroha::ametsuchi::PeerQuery> wsv;
-
-  // peer
-  iroha::model::Peer peer;
 
   // ordering gate
   std::shared_ptr<iroha::network::OrderingGate> ordering_gate;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -55,6 +55,8 @@ class Irohad {
    * @param redis_port - port of redis connection
    * @param pg_conn - initialization string for postgre
    * @param torii_port - port for torii binding
+   * @param internal_port - port for internal communication - ordering service,
+   * consensus, and block loader
    * @param keypair - public and private keys for crypto provider
    */
   Irohad(const std::string &block_store_dir,

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -27,6 +27,7 @@
 namespace config_members {
   const char* BlockStorePath = "block_store_path";
   const char* ToriiPort = "torii_port";
+  const char* InternalPort = "internal_port";
   const char* KeyPairPath = "key_pair_path";
   const char* PgOpt = "pg_opt";
   const char* RedisHost = "redis_host";
@@ -55,6 +56,10 @@ inline rapidjson::Document parse_iroha_config(std::string const& iroha_conf_path
   assert_fatal(doc.HasMember(mbr::ToriiPort), no_member_error(mbr::ToriiPort));
   assert_fatal(doc[mbr::ToriiPort].IsUint(),
                type_error(mbr::ToriiPort, "uint"));
+
+  assert_fatal(doc.HasMember(mbr::InternalPort), no_member_error(mbr::InternalPort));
+  assert_fatal(doc[mbr::InternalPort].IsUint(),
+               type_error(mbr::InternalPort, "uint"));
 
   assert_fatal(doc.HasMember(mbr::PgOpt), no_member_error(mbr::PgOpt));
   assert_fatal(doc[mbr::PgOpt].IsString(), type_error(mbr::PgOpt, "string"));

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -72,6 +72,7 @@ int main(int argc, char *argv[]) {
                 config[mbr::RedisPort].GetUint(),
                 config[mbr::PgOpt].GetString(),
                 config[mbr::ToriiPort].GetUint(),
+                config[mbr::InternalPort].GetUint(),
                 keypair);
 
   if (not irohad.storage) {
@@ -84,11 +85,15 @@ int main(int argc, char *argv[]) {
   auto block = inserter.parseBlock(file.value());
   log->info("Block is parsed");
 
-  if (block.has_value()) {
-    inserter.applyToLedger({block.value()});
-    log->info("Genesis block inserted, number of transactions: {}",
-              block.value().transactions.size());
+  if (not block.has_value()) {
+    log->error("Failed to parse genesis block");
+    return EXIT_FAILURE;
   }
+
+  inserter.applyToLedger({block.value()});
+  log->info("Genesis block inserted, number of transactions: {}",
+            block.value().transactions.size());
+
   // init pipeline components
   irohad.init();
 

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -52,8 +52,14 @@ namespace iroha {
           .subscribe([this](auto block) {
             last_block = block;
           });
-      if (not last_block.has_value() or
-          last_block.value().height + 1 != proposal.height) {
+      if (not last_block.has_value()) {
+        log_->warn("Could not fetch last block");
+        return;
+      }
+      if (last_block.value().height + 1 != proposal.height) {
+        log_->warn("Last block height: {}, proposal height: {}",
+                   last_block.value().height,
+                   proposal.height);
         return;
       }
       auto temporaryStorage = ametsuchi_factory_->createTemporaryWsv();


### PR DESCRIPTION
Fix issues with peer join to existing network
- Update genesis block for new permission model
- Add internal port configuration parameter - required to initialize new peer, which does not have itself in genesis block
- Consensus network - allow creation of new GRPC connections with `send_x` methods - previously connections were only created for peers, which were initially in the ledger
- Fix block append to block store - previous implementation used `unordered_map`, which did not guarantee the order of iteration, leading to inconsistent `current_it` of block store
