### PR TITLE
Fix/mac build crypto boost

### DIFF
--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -64,6 +64,9 @@ target_link_libraries(iroha-cli
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     )
+target_include_directories(iroha-cli PUBLIC
+    ${Boost_INCLUDE_DIRS}
+    )
 
 add_install_step_for_bin(iroha-cli)
 

--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(client
     )
 target_link_libraries(client
     interactive_cli
-    crypto
+    cryptography
     optional
     logger
     rapidjson

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(application
     stateless_validator
     stateful_validator
     processors
-    crypto
+    cryptography
     simulator
     block_loader
     block_loader_service

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -1,7 +1,22 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 add_subdirectory(generators)
 add_subdirectory(converters)
-
-
 
 add_library(common_execution
     execution/impl/common_executor.cpp
@@ -20,7 +35,6 @@ target_link_libraries(command_execution
     common_execution
     )
 
-
 add_library(model
     model_crypto_provider_impl.cpp
     impl/model_operators.cpp
@@ -37,7 +51,6 @@ target_link_libraries(model
     cryptography
     rapidjson
     )
-
 
 add_library(model_registrations INTERFACE)
 target_include_directories(model_registrations INTERFACE

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(model
     iroha_amount
     common_execution
     schema
-    crypto
+    cryptography
     rapidjson
     )
 

--- a/irohad/model/converters/CMakeLists.txt
+++ b/irohad/model/converters/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 add_library(json_model_converters
     impl/json_block_factory.cpp
     impl/json_command_factory.cpp

--- a/irohad/model/converters/CMakeLists.txt
+++ b/irohad/model/converters/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(json_model_converters
     model
     rapidjson
     schema
-    crypto
+    cryptography
     logger
     )
 
@@ -24,6 +24,6 @@ add_library(pb_model_converters
 target_link_libraries(pb_model_converters
     model
     schema
-    crypto
+    cryptography
     logger
     )

--- a/irohad/model/converters/CMakeLists.txt
+++ b/irohad/model/converters/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries(pb_model_converters
     cryptography
     logger
     )
+target_include_directories(pb_model_converters PUBLIC
+    ${Boost_INCLUDE_DIRS}
+    )

--- a/irohad/validation/CMakeLists.txt
+++ b/irohad/validation/CMakeLists.txt
@@ -1,3 +1,19 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 add_library(stateful_validator
     impl/stateful_validator_impl.cpp

--- a/libs/amount/CMakeLists.txt
+++ b/libs/amount/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 add_library(iroha_amount
     amount.cpp
     )

--- a/libs/amount/CMakeLists.txt
+++ b/libs/amount/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(iroha_amount
-        amount.cpp
-        )
+    amount.cpp
+    )
 
-target_link_libraries(
-        iroha_amount
-        optional
-        logger
-)
+target_link_libraries(iroha_amount
+    optional
+    logger
+    )
+target_include_directories(iroha_amount PUBLIC
+    ${Boost_INCLUDE_DIRS}
+    )

--- a/libs/crypto/CMakeLists.txt
+++ b/libs/crypto/CMakeLists.txt
@@ -27,10 +27,10 @@ target_link_libraries(hash
     pb_model_converters
     )
 
-add_library(crypto
+add_library(cryptography
     ed25519_impl.cpp
     )
-target_link_libraries(crypto
+target_link_libraries(cryptography
     ed25519
     hash
     )
@@ -41,5 +41,5 @@ add_library(keys_manager
 
 target_link_libraries(keys_manager
     optional
-    crypto
+    cryptography
     )

--- a/test/module/irohad/model/CMakeLists.txt
+++ b/test/module/irohad/model/CMakeLists.txt
@@ -19,7 +19,7 @@ addtest(model_crypto_provider_test model_crypto_provider_test.cpp)
 target_link_libraries(model_crypto_provider_test
     model
     hash
-    crypto
+    cryptography
     model_generators
     )
 

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -2,7 +2,7 @@ addtest(stateless_transaction_validator_test stateless/transaction_validator_tes
 target_link_libraries(stateless_transaction_validator_test
     stateless_validator
     hash
-    crypto
+    cryptography
     schema
     model
     )

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 addtest(stateless_transaction_validator_test stateless/transaction_validator_test.cpp)
 target_link_libraries(stateless_transaction_validator_test
     stateless_validator

--- a/test/module/libs/amount/CMakeLists.txt
+++ b/test/module/libs/amount/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # amount Test
 
 AddTest(amount_test amount_test.cpp)

--- a/test/module/libs/crypto/CMakeLists.txt
+++ b/test/module/libs/crypto/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+# http://soramitsu.co.jp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Hash Test
 AddTest(hash_test hash_test.cpp)
 target_link_libraries(hash_test

--- a/test/module/libs/crypto/CMakeLists.txt
+++ b/test/module/libs/crypto/CMakeLists.txt
@@ -1,11 +1,17 @@
 # Hash Test
 AddTest(hash_test hash_test.cpp)
-target_link_libraries(hash_test crypto ssl)
+target_link_libraries(hash_test
+    cryptography
+    )
 
 # Base64 Test
 AddTest(base64_test base64_test.cpp)
-target_link_libraries(base64_test crypto ssl)
+target_link_libraries(base64_test
+    cryptography
+    )
 
 # Singature Test
 AddTest(signature_test signature_test.cpp)
-target_link_libraries(signature_test crypto)
+target_link_libraries(signature_test
+    cryptography
+    )


### PR DESCRIPTION
Fix failing build on Mac OS X
- Remove unused ssl `target_link_libraries` from crypto tests
- Rename crypto library to cryptography to avoid library name clash with OpenSSL
- Add boost `target_include_directories` to targets which use boost