### PR TITLE
CI build step for MAC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,6 @@ jobs:
 
 
   macos-build:
-    #docker:
-    #  - image: postgres:9.5
-    #  - image: redis:3.2.8
     macos:
       xcode: 9.0.0
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
       - run:
           name: ccache setup
           command: |
-            ccache --version
-            ccache --show-stats
-            ccache --zero-stats
             ccache -F 0
             ccache -M 0
 
@@ -51,6 +48,8 @@ jobs:
           key: build-cache-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+
+      - run: ccache --show-stats
 
       # test and coverage info
       - run:
@@ -92,20 +91,22 @@ jobs:
       - run:
           name: execute sonar-scanner to analyze PR
           command: >
-            [ ! -z "$SONAR_TOKEN" ] && \
+            if [ ! -z "$SONAR_TOKEN" ] && \
               [ ! -z "$SORABOT_TOKEN" ] && \
               [ ! -z "$CIRCLE_BUILD_NUM" ] && \
-              [ ! -z "$CI_PULL_REQUEST" ] || \
-              (echo "required env vars not found"; exit 0)
-
-            sonar-scanner \
-              -Dsonar.github.disableInlineComments \
-              -Dsonar.github.repository="hyperledger/iroha" \
-              -Dsonar.analysis.mode=preview \
-              -Dsonar.login=${SONAR_TOKEN} \
-              -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
-              -Dsonar.github.oauth="${SORABOT_TOKEN}" \
-              -Dsonar.github.pullRequest="$(echo $CI_PULL_REQUEST | egrep -o "[0-9]+")"
+              [ ! -z "$CI_PULL_REQUEST" ]; then
+              echo "required env vars not found"
+              exit 0
+            else
+              sonar-scanner \
+                -Dsonar.github.disableInlineComments \
+                -Dsonar.github.repository="hyperledger/iroha" \
+                -Dsonar.analysis.mode=preview \
+                -Dsonar.login=${SONAR_TOKEN} \
+                -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
+                -Dsonar.github.oauth="${SORABOT_TOKEN}" \
+                -Dsonar.github.pullRequest="$(echo $CI_PULL_REQUEST | egrep -o "[0-9]+")"
+            fi
 
       - save_cache:
           key: sonar-{{ epoch }}
@@ -226,9 +227,3 @@ workflows:
                 - master
             tags:
               only: /v[\.0-9]+.*/
-
-
-      # # - dockerize:
-      # #     requires:
-      # #       - sonar
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,6 @@ jobs:
       - image: redis:3.2.8
     steps:
       - checkout
-      - run:
-          name: notify upsource about current build
-          command: |
-            python3 housekeeping/upsource-webhook.py --in-progress || true
       - restore_cache:
           keys:
             - build-cache-{{ .Branch }}-
@@ -34,7 +30,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=1G
+            ccache -F 0
+            ccache -M 0
 
       # cmake and make
       - run:
@@ -75,23 +72,6 @@ jobs:
             - compile_commands.json
             - reports
 
-
-      # - run:
-      #     name: prepare redistributable dir
-      #     command: |
-      #       IROHAD=$IROHA_BUILD/bin/irohad
-      #       IROHA_CLI=$IROHA_BUILD/bin/iroha-cli
-      #       TEST_DIR=$IROHA_BUILD/test_bin
-      #       RELEASE=$IROHA_BUILD/release
-      #       mkdir -p $RELEASE
-
-
-
-      # - persist_to_workspace:
-      #     root: /opt/iroha/build/release
-      #     paths:
-      #       - bin
-      #       - test_bin
 
 
   # used to push info about issues to github
@@ -161,23 +141,67 @@ jobs:
             - ~/.sonar
 
 
-  # dockerize:
-  #   <<: *defaults
-  #   machine: true
-  #   steps:
-  #     - attach_workspace:
-  #         at: /opt/iroha/build
-  #     - run: TODO
-  #         name: todo
-  #         command: echo "I am happy albatross"
+  macos-build:
+    #docker:
+    #  - image: postgres:9.5
+    #  - image: redis:3.2.8
+    macos:
+      xcode: 9.0.0
+    steps:
+      - checkout
+      
+      - restore_cache:
+          keys:
+            - brew-
 
+      - restore_cache:
+          keys:
+            - build-cache-{{ .Branch }}-
+            - build-cache-
+          paths:
+            - ~/.ccache
+      
+      - run:
+          name: install dev dependencies
+          command: brew install cmake boost postgres grpc autoconf automake libtool ccache
 
+      - save_cache:
+          key: brew-{{ epoch }}
+          paths:
+            - $HOME/Library/Caches/Homebrew
+
+      - run:
+          name: ccache setup
+          command: |
+            ccache -F 0
+            ccache -M 0      
+      
+      - run:
+          name: build
+          command: |
+            cmake -H. -Bbuild
+            cmake --build build -- -j$(sysctl -n hw.ncpu)
+
+      - run:
+          name: ccache teardown
+          command: |
+            ccache --cleanup
+            ccache --show-stats
+      
+      - save_cache:
+          key: build-cache-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
+
+      - run: ccache --show-stats
+     
 
 workflows:
   version: 2
   full_pipeline:
     jobs:
-      # build -> sonar -> dockerize
+      # macos-build/build -> sonar -> dockerize
+      - macos-build
       - build
       - sonar-pr:
           requires:
@@ -204,11 +228,7 @@ workflows:
               only: /v[\.0-9]+.*/
 
 
-      # - dockerize:
-      #     requires:
-      #       - sonar
+      # # - dockerize:
+      # #     requires:
+      # #       - sonar
 
-
-notify:
-  webhooks:
-    - url: http://upsource.soramitsu.co.jp:1112

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   environment:
     IROHA_HOME: /opt/iroha
     IROHA_BUILD: /opt/iroha/build
-
+    CCACHE_DIR: ~/.ccache
 
 version: 2
 
@@ -18,19 +18,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - build-cache-{{ .Branch }}-
-            - build-cache-
+            - build-cache-{{ .Branch }}-{{ arch }}
           paths:
             - ~/.ccache
-
-      # build and cache build results
       - run:
           name: ccache setup
           command: |
             ccache -F 0
             ccache -M 0
-
-      # cmake and make
       - run:
           name: cmake
           command: cmake -DCOVERAGE=ON -H$IROHA_HOME -B$IROHA_BUILD
@@ -38,33 +33,20 @@ jobs:
           name: make
           command: |
             cmake --build $IROHA_BUILD -- -j4
-      # save cache
-      - run:
-          name: ccache teardown
-          command: |
-            ccache --cleanup
-            ccache --show-stats
       - save_cache:
-          key: build-cache-{{ .Branch }}-{{ epoch }}
+          key: build-cache-{{ .Branch }}-{{ arch }}-{{ epoch }}
           paths:
             - ~/.ccache
-
       - run: ccache --show-stats
-
-      # test and coverage info
       - run:
           name: unit tests, generate xunit-*.xml
           command: cmake --build $IROHA_BUILD --target test
       - run:
           name: coverage info
           command: cmake --build $IROHA_BUILD --target gcovr
-
-      # analysis
       - run:
           name: cppcheck
           command: cmake --build $IROHA_BUILD --target cppcheck
-
-      # persist reports
       - persist_to_workspace:
           root: /opt/iroha/build
           paths:
@@ -95,9 +77,6 @@ jobs:
               [ ! -z "$SORABOT_TOKEN" ] && \
               [ ! -z "$CIRCLE_BUILD_NUM" ] && \
               [ ! -z "$CI_PULL_REQUEST" ]; then
-              echo "required env vars not found"
-              exit 0
-            else
               sonar-scanner \
                 -Dsonar.github.disableInlineComments \
                 -Dsonar.github.repository="hyperledger/iroha" \
@@ -106,8 +85,9 @@ jobs:
                 -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
                 -Dsonar.github.oauth="${SORABOT_TOKEN}" \
                 -Dsonar.github.pullRequest="$(echo $CI_PULL_REQUEST | egrep -o "[0-9]+")"
+            else
+              echo "required env vars not found"
             fi
-
       - save_cache:
           key: sonar-{{ epoch }}
           paths:
@@ -132,10 +112,16 @@ jobs:
       - run:
           name: execute sonar-scanner
           command: >
-            sonar-scanner \
-              -Dsonar.login="${SONAR_TOKEN}" \
-              -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
-              -Dsonar.branch="${CIRCLE_BRANCH}"
+            if [ ! -z "$SONAR_TOKEN" ] && \
+              [ ! -z "$CIRCLE_BUILD_NUM" ] && \
+              [ ! -z "$CIRCLE_BRANCH" ]; then
+              sonar-scanner \
+                -Dsonar.login="${SONAR_TOKEN}" \
+                -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
+                -Dsonar.branch="${CIRCLE_BRANCH}"
+            else
+              echo "required env vars not found"
+            fi
       - save_cache:
           key: sonar-{{ epoch }}
           paths:
@@ -150,49 +136,43 @@ jobs:
       xcode: 9.0.0
     steps:
       - checkout
-      
       - restore_cache:
           keys:
             - brew-
-
-      - restore_cache:
-          keys:
-            - build-cache-{{ .Branch }}-
-            - build-cache-
           paths:
-            - ~/.ccache
-      
+            - Library/Caches/Homebrew
       - run:
           name: install dev dependencies
           command: brew install cmake boost postgres grpc autoconf automake libtool ccache
-
       - save_cache:
-          key: brew-{{ epoch }}
+          key: brew-{{ arch }}-{{ epoch }}
           paths:
-            - $HOME/Library/Caches/Homebrew
-
-      - run:
-          name: ccache setup
-          command: |
-            ccache -F 0
-            ccache -M 0      
-      
+            - Library/Caches/Homebrew
+      - restore_cache:
+          keys:
+            - build-cache-{{ .Branch }}-{{ arch }}
+          paths:
+            - ~/.ccache
+      - restore_cache:
+          keys:
+            - external-{{ arch }}-{{ .Branch }}
+            - external-{{ arch }}
+          paths:
+            - external
+      - run: ccache --show-stats
       - run:
           name: build
           command: |
             cmake -H. -Bbuild
             cmake --build build -- -j$(sysctl -n hw.ncpu)
-
-      - run:
-          name: ccache teardown
-          command: |
-            ccache --cleanup
-            ccache --show-stats
-      
       - save_cache:
-          key: build-cache-{{ .Branch }}-{{ epoch }}
+          key: build-cache-{{ .Branch }}-{{ arch }}-{{ epoch }}
           paths:
             - ~/.ccache
+      - save_cache:
+          key: external-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          paths:
+            - external
 
       - run: ccache --show-stats
      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - build-cache-{{ .Branch }}-{{ arch }}
+            - build-cache-{{ arch }}-{{ .Branch }}
+            - build-cache-{{ arch }}
           paths:
             - ~/.ccache
       - run:
           name: ccache setup
           command: |
-            ccache -F 0
-            ccache -M 0
+            ccache --max-files=0
+            ccache --max-size=1G
       - run:
           name: cmake
           command: cmake -DCOVERAGE=ON -H$IROHA_HOME -B$IROHA_BUILD
@@ -34,7 +35,7 @@ jobs:
           command: |
             cmake --build $IROHA_BUILD -- -j4
       - save_cache:
-          key: build-cache-{{ .Branch }}-{{ arch }}-{{ epoch }}
+          key: build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
       - run: ccache --show-stats
@@ -135,7 +136,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - brew-
+            - brew-{{ arch }}
           paths:
             - Library/Caches/Homebrew
       - run:
@@ -147,7 +148,7 @@ jobs:
             - Library/Caches/Homebrew
       - restore_cache:
           keys:
-            - build-cache-{{ .Branch }}-{{ arch }}
+            - build-cache-{{ arch }}-{{ .Branch }}
           paths:
             - ~/.ccache
       - restore_cache:
@@ -163,7 +164,7 @@ jobs:
             cmake -H. -Bbuild
             cmake --build build -- -j$(sysctl -n hw.ncpu)
       - save_cache:
-          key: build-cache-{{ .Branch }}-{{ arch }}-{{ epoch }}
+          key: build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
       - save_cache:

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -y --no-install-recommends install build-essential python-software-p
         lcov \
         # other
         wget curl cmake file unzip gdb iputils-ping vim ccache \
-        gcovr vera++ cppcheck doxygen graphviz graphviz-dev; \
+        gcovr vera++ cppcheck doxygen graphviz graphviz-dev ninja; \
     apt-get -y clean
 
 RUN pip3 install --upgrade pip; \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -y --no-install-recommends install build-essential python-software-p
         lcov \
         # other
         wget curl cmake file unzip gdb iputils-ping vim ccache \
-        gcovr vera++ cppcheck doxygen graphviz graphviz-dev ninja; \
+        gcovr vera++ cppcheck doxygen graphviz graphviz-dev; \
     apt-get -y clean
 
 RUN pip3 install --upgrade pip; \


### PR DESCRIPTION
This pull request:
- [x] adds step `macos-build` to circle ci 
- [x] fixes `sonar-pr`+`sonar-release` steps: when you push to your  branch and you don't have PR, these steps fail.

Sometimes MAC VM on circle ci 2.0 fails during its start. It updates branch state to "Failed". BUT, circle ci restarts VM and all steps are executed. Only after this CircleCI updates PR/branch status to success.