### PR TITLE
Fix redis file queries returning result only for the first indexed block

### DIFF
--- a/irohad/ametsuchi/impl/redis_flat_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_flat_block_query.cpp
@@ -59,7 +59,6 @@ namespace iroha {
             s.on_next(tx);
           }
         };
-        s.on_completed();
       };
     }
 
@@ -80,6 +79,7 @@ namespace iroha {
                              this->callbackToLrange(subscriber, block_id));
             }
             client_.sync_commit();
+            subscriber.on_completed();
           });
     }
 
@@ -108,6 +108,7 @@ namespace iroha {
                              this->callbackToLrange(subscriber, block_id));
             }
             client_.sync_commit();
+            subscriber.on_completed();
           });
     }
 


### PR DESCRIPTION
Redis flat file query was returning results only for the first indexed block, since `on_completed` was called in the first invocation of `lrange` callback.