### PR TITLE
Fix check consistency method

### DIFF
--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -100,19 +100,13 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
   }
 
   auto n = static_cast<uint32_t>(status);
-  tmp_id++;
+  tmp_id = 2;
 
-  // get last available identifier
-  auto last = tmp_id;
-  for (auto i = 2u; i < n; ++i) {
-    if (id_to_name(tmp_id) != namelist[i]->d_name) {
-      for (auto j = i; j < n; ++j) {
-        remove(dump_dir, namelist[j]->d_name);
-      }
-      break;
-    }
-    tmp_id++;
-    last = name_to_id(namelist[i]->d_name);
+  while (tmp_id < n and id_to_name(tmp_id - 1) == namelist[tmp_id]->d_name) {
+    ++tmp_id;
+  }
+  for (auto j = tmp_id; j < n; ++j) {
+    remove(dump_dir, namelist[j]->d_name);
   }
 
   for (auto j = 0u; j < n; ++j) {
@@ -120,7 +114,7 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
   }
   free(namelist);
 
-  return last;
+  return tmp_id - 2;
 }
 
 /**

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -102,7 +102,7 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
   auto n = static_cast<uint32_t>(status);
   tmp_id++;
 
-  // get last available identificator
+  // get last available identifier
   auto last = tmp_id;
   for (auto i = 2u; i < n; ++i) {
     if (id_to_name(tmp_id) != namelist[i]->d_name) {

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -17,10 +17,7 @@
 
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include <dirent.h>
-#include <stdio.h>
-#include <sys/stat.h>
 #include <fstream>
-#include <iostream>
 #include "common/files.hpp"
 
 using namespace iroha::ametsuchi;

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -19,15 +19,16 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include "common/files.hpp"
 
 using namespace iroha::ametsuchi;
 
 const uint32_t DIGIT_CAPACITY = 16;
 
-// TODO 19/08/17 Muratov rework separator with platform independent approach IR-495 #goodfirstissue
+// TODO 19/08/17 Muratov rework separator with platform independent approach
+// IR-495 #goodfirstissue
 const std::string SEPARATOR = "/";
 
 /**
@@ -57,7 +58,7 @@ Identifier name_to_id(const std::string &name) {
  * @return true, if exists
  */
 bool file_exist(const std::string &name) {
-  struct stat buffer{};
+  struct stat buffer {};
   return stat(name.c_str(), &buffer) == 0;
 }
 
@@ -70,13 +71,14 @@ void remove(const std::string &dump_dir, std::string filename) {
   auto f_name = dump_dir + SEPARATOR + filename;
 
   if (std::remove(f_name.c_str()) != 0) {
-    logger::log("FLAT_FILE")->error("remove({}, {}): error on deleting file",
-                                    dump_dir, filename);
+    logger::log("FLAT_FILE")
+        ->error("remove({}, {}): error on deleting file", dump_dir, filename);
   }
 }
 
 /**
  * Checking consistency of storage for provided folder
+ * If some block in the middle is missing all blocks following it are deleted
  * @param dump_dir - folder of storage
  * @return - last available identifier
  */
@@ -102,6 +104,9 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
 
   auto n = static_cast<uint32_t>(status);
   tmp_id++;
+
+  // get last available identificator
+  auto last = tmp_id;
   for (auto i = 2u; i < n; ++i) {
     if (id_to_name(tmp_id) != namelist[i]->d_name) {
       for (auto j = i; j < n; ++j) {
@@ -109,7 +114,8 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
       }
       break;
     }
-    tmp_id = name_to_id(namelist[i]->d_name);
+    tmp_id++;
+    last = name_to_id(namelist[i]->d_name);
   }
 
   for (auto j = 0u; j < n; ++j) {
@@ -117,7 +123,7 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
   }
   free(namelist);
 
-  return tmp_id;
+  return last;
 }
 
 /**
@@ -126,7 +132,7 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
  * @return number of bytes contains in file
  */
 long file_size(const std::string &filename) {
-  struct stat stat_buf{};
+  struct stat stat_buf {};
   int rc = stat(filename.c_str(), &stat_buf);
   return rc == 0 ? stat_buf.st_size : 0u;
 }
@@ -136,7 +142,8 @@ long file_size(const std::string &filename) {
 std::unique_ptr<FlatFile> FlatFile::create(const std::string &path) {
   auto log_ = logger::log("FlatFile::create()");
 
-  // TODO 19/08/17 Muratov change creating folder with system independent approach IR-496 #goodfirstissue
+  // TODO 19/08/17 Muratov change creating folder with system independent
+  // approach IR-496 #goodfirstissue
   if (mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
     if (errno != EEXIST) {
       log_->error("Cannot create storage dir: {}", path);
@@ -171,8 +178,8 @@ void FlatFile::add(Identifier id, const std::vector<uint8_t> &block) {
     log_->warn("Cannot open file by index {} for writing", id);
   }
 
-  auto val_size = sizeof(std::remove_reference<decltype(block)>::
-  type::value_type);
+  auto val_size =
+      sizeof(std::remove_reference<decltype(block)>::type::value_type);
 
   file.write(reinterpret_cast<const char *>(block.data()),
              block.size() * val_size);

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -81,7 +81,6 @@ int main(int argc, char *argv[]) {
   }
 
   if (not FLAGS_genesis_block.empty()) {
-    log->info("Genesis block specified");
     iroha::main::BlockInserter inserter(irohad.storage);
     auto file = inserter.loadFile(FLAGS_genesis_block);
     auto block = inserter.parseBlock(file.value());
@@ -99,9 +98,6 @@ int main(int argc, char *argv[]) {
     inserter.applyToLedger({block.value()});
     log->info("Genesis block inserted, number of transactions: {}",
               block.value().transactions.size());
-  }
-  else {
-    log->info("Genesis block not specified");
   }
   // init pipeline components
   irohad.init();

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -81,6 +81,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (not FLAGS_genesis_block.empty()) {
+    log->info("Genesis block specified");
     iroha::main::BlockInserter inserter(irohad.storage);
     auto file = inserter.loadFile(FLAGS_genesis_block);
     auto block = inserter.parseBlock(file.value());
@@ -98,6 +99,9 @@ int main(int argc, char *argv[]) {
     inserter.applyToLedger({block.value()});
     log->info("Genesis block inserted, number of transactions: {}",
               block.value().transactions.size());
+  }
+  else {
+    log->info("Genesis block not specified");
   }
   // init pipeline components
   irohad.init();

--- a/test/module/irohad/ametsuchi/flat_file_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_test.cpp
@@ -112,13 +112,8 @@ TEST_F(BlStore_Test, BlockStoreInitializationFromNonemptyFolder){
   ASSERT_TRUE(bl_store1);
 
   // Add two blocks to storage
-  std::vector<uint8_t > block1(1000, 5);
-  auto id1 = 1u;
-  bl_store1->add(id1, block1);
-
-  std::vector<uint8_t > block2(1000, 5);
-  auto id2 = 2u;
-  bl_store1->add(id2, block2);
+  bl_store1->add(1u, std::vector<uint8_t>(1000, 5));
+  bl_store1->add(2u, std::vector<uint8_t>(1000, 5));
 
   // create second block storage from the same folder
   auto bl_store2 = FlatFile::create(block_store_path);

--- a/test/module/irohad/ametsuchi/flat_file_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_test.cpp
@@ -102,7 +102,12 @@ TEST_F(BlStore_Test, BlockStoreWhenAbsentFolder) {
   rmdir(target_path.c_str());
 }
 
-TEST_F(BlStore_Test, BlockStoreInitializationWhenPreviousStorageExist){
+/**
+ * @given non-empty folder from previous block store
+ * @when new block storage is initialized
+ * @then new block storage has all blocks from the folder
+ */
+TEST_F(BlStore_Test, BlockStoreInitializationFromNonemptyFolder){
   auto bl_store1 = FlatFile::create(block_store_path);
   ASSERT_TRUE(bl_store1);
 

--- a/test/module/irohad/ametsuchi/flat_file_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_test.cpp
@@ -101,3 +101,24 @@ TEST_F(BlStore_Test, BlockStoreWhenAbsentFolder) {
   }
   rmdir(target_path.c_str());
 }
+
+TEST_F(BlStore_Test, BlockStoreInitializationWhenPreviousStorageExist){
+  auto bl_store1 = FlatFile::create(block_store_path);
+  ASSERT_TRUE(bl_store1);
+
+  // Add two blocks to storage
+  std::vector<uint8_t > block1(1000, 5);
+  auto id1 = 1u;
+  bl_store1->add(id1, block1);
+
+  std::vector<uint8_t > block2(1000, 5);
+  auto id2 = 2u;
+  bl_store1->add(id2, block2);
+
+  // create second block storage from the same folder
+  auto bl_store2 = FlatFile::create(block_store_path);
+  ASSERT_TRUE(bl_store2);
+
+  // check that last ids of both block storages are the same
+  ASSERT_EQ(bl_store1->last_id(), bl_store2->last_id());
+}


### PR DESCRIPTION
## What is this pull request?
Describe simply what this pull request is about.

We had a bug of deleting all blocks but the first one, when iroha initializes from the "hot" state, when ledger has several blocks commited
   
## Why do you implement it? Why do we need this pull request?
Describe features, what this pull request resolves, and reasons for this pull request.

This PR fixes aforementioned bug and adds tests to check if block store does not delete blocks when it initializes
  
## How to use the features provided in the pull request?

Take a look at new test case in flat file test

## Details/Features
The problem was with `check_consistency` method, which wrongly removed consistent blocks