### PR TITLE
Fix of permissions' wrong order

### DIFF
--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -245,7 +245,7 @@ namespace iroha_cli {
         std::cout << "Wrong format for permission" << std::endl;
         return nullptr;
       }
-      std::unordered_set<std::string> perms;
+      std::set<std::string> perms;
       if (read_self.value()) {
         perms.insert(read_self_group.begin(), read_self_group.end());
       }

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -53,7 +53,7 @@ namespace iroha {
 
     bool PostgresWsvCommand::insertRolePermissions(
         const std::string &role_id,
-        const std::unordered_set<std::string> &permissions) {
+        const std::set<std::string> &permissions) {
       auto entry = [this, &role_id](auto permission) {
         return "(" + transaction_.quote(role_id) + ", "
             + transaction_.quote(permission) + ")";

--- a/irohad/ametsuchi/impl/postgres_wsv_command.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.hpp
@@ -36,7 +36,7 @@ namespace iroha {
 
       bool insertRolePermissions(
           const std::string &role_id,
-          const std::unordered_set<std::string> &permissions) override;
+          const std::set<std::string> &permissions) override;
 
       bool insertAccount(const model::Account &account) override;
       bool updateAccount(const model::Account &account) override;

--- a/irohad/ametsuchi/wsv_command.hpp
+++ b/irohad/ametsuchi/wsv_command.hpp
@@ -25,7 +25,7 @@
 #include <model/domain.hpp>
 #include <model/peer.hpp>
 #include <string>
-#include <unordered_set>
+#include <set>
 
 namespace iroha {
   namespace ametsuchi {
@@ -61,7 +61,7 @@ namespace iroha {
        * @return true is insert successful, false otherwise
        */
       virtual bool insertRolePermissions(const std::string &role_id,
-          const std::unordered_set<std::string> &permissions) = 0;
+          const std::set<std::string> &permissions) = 0;
 
       /**
        * Insert grantable permission

--- a/irohad/model/commands/create_role.hpp
+++ b/irohad/model/commands/create_role.hpp
@@ -17,8 +17,8 @@
 #ifndef IROHA_CREATE_ROLE_HPP
 #define IROHA_CREATE_ROLE_HPP
 
+#include <set>
 #include <string>
-#include <unordered_set>
 #include "model/command.hpp"
 
 namespace iroha {
@@ -36,7 +36,7 @@ namespace iroha {
       /**
        * Role permissions
        */
-      std::unordered_set<std::string> permissions;
+      std::set<std::string> permissions;
 
       bool operator==(const Command &command) const override;
 
@@ -46,7 +46,7 @@ namespace iroha {
        * @param perms - set of permissions for the role
        */
       CreateRole(const std::string &role_name_,
-                 const std::unordered_set<std::string> &perms)
+                 const std::set<std::string> &perms)
           : role_name(role_name_), permissions(perms) {}
     };
   }  // namespace model

--- a/irohad/model/converters/impl/json_command_factory.cpp
+++ b/irohad/model/converters/impl/json_command_factory.cpp
@@ -413,7 +413,7 @@ namespace iroha {
         if (document.HasMember("role_name") and document["role_name"].IsString()
             and document.HasMember("permissions")
             and document["permissions"].IsArray()) {
-          std::unordered_set<std::string> perms;
+          std::set<std::string> perms;
           for (auto &v : document["permissions"].GetArray()) {
             if (not v.IsString()) {
               return nonstd::nullopt;

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -304,7 +304,7 @@ namespace iroha {
       // Create Role
       model::CreateRole PbCommandFactory::deserializeCreateRole(
           const protocol::CreateRole &command) {
-        std::unordered_set<std::string> perms;
+        std::set<std::string> perms;
 
         std::for_each(command.permissions().begin(),
                       command.permissions().end(),

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -72,7 +72,7 @@ namespace iroha {
 
       std::shared_ptr<Command> CommandGenerator::generateCreateAdminRole(
           std::string role_name) {
-        std::unordered_set<std::string> perms = {
+        std::set<std::string> perms = {
             can_create_domain, can_create_account, can_add_peer};
         perms.insert(edit_self_group.begin(), edit_self_group.end());
         perms.insert(read_all_group.begin(), read_all_group.end());
@@ -81,7 +81,7 @@ namespace iroha {
 
       std::shared_ptr<Command> CommandGenerator::generateCreateUserRole(
           std::string role_name) {
-        std::unordered_set<std::string> perms = {can_receive, can_transfer};
+        std::set<std::string> perms = {can_receive, can_transfer};
         // User can read their account
         perms.insert(read_self_group.begin(), read_self_group.end());
         // User can grant permissions to others
@@ -92,7 +92,7 @@ namespace iroha {
 
       std::shared_ptr<Command> CommandGenerator::generateCreateAssetCreatorRole(
           std::string role_name) {
-        std::unordered_set<std::string> perms = {can_receive, can_transfer};
+        std::set<std::string> perms = {can_receive, can_transfer};
         perms.insert(asset_creator_group.begin(), asset_creator_group.end());
         perms.insert(read_self_group.begin(), read_self_group.begin());
         return std::make_shared<CreateRole>(role_name, perms);

--- a/irohad/model/permissions.hpp
+++ b/irohad/model/permissions.hpp
@@ -19,7 +19,7 @@
 #define IROHA_PERMISSIONS_HPP
 
 #include <string>
-#include <unordered_set>
+#include <set>
 
 namespace iroha {
   namespace model {
@@ -57,14 +57,14 @@ namespace iroha {
     const std::string can_get_all_acc_ast_txs =
         "CanGetAllAccountAssetsTransactions";
 
-    const std::unordered_set<std::string> read_self_group = {
+    const std::set<std::string> read_self_group = {
         can_get_my_account,
         can_get_my_acc_txs,
         can_get_my_acc_ast,
         can_get_my_acc_ast_txs,
         can_get_my_signatories};
 
-    const std::unordered_set<std::string> read_all_group = {
+    const std::set<std::string> read_all_group = {
         can_get_all_accounts,
         can_get_all_acc_txs,
         can_get_all_acc_ast,
@@ -73,18 +73,18 @@ namespace iroha {
         can_get_roles,
         can_read_assets};
     const std::string can_grant = "CanGrant";
-    const std::unordered_set<std::string> grant_group = {
+    const std::set<std::string> grant_group = {
         can_grant + can_set_quorum,
         can_grant + can_add_signatory,
         can_grant + can_remove_signatory};
 
-    const std::unordered_set<std::string> edit_self_group = {
+    const std::set<std::string> edit_self_group = {
         can_set_quorum, can_add_signatory, can_remove_signatory};
 
-    const std::unordered_set<std::string> asset_creator_group = {
+    const std::set<std::string> asset_creator_group = {
         can_create_asset, can_add_asset_qty};
 
-    const std::unordered_set<std::string> all_perm_group = {
+    const std::set<std::string> all_perm_group = {
         can_get_my_account,
         can_get_my_acc_txs,
         can_get_my_acc_ast,

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -62,7 +62,7 @@ namespace iroha {
                                            const std::string &role_name));
       MOCK_METHOD2(insertRolePermissions,
                    bool(const std::string &role_id,
-                        const std::unordered_set<std::string> &permissions));
+                        const std::set<std::string> &permissions));
 
       MOCK_METHOD3(insertAccountGrantablePermission,
                    bool(const std::string &permittee_account_id,

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -885,7 +885,7 @@ class CreateRoleTest : public CommandValidateExecuteTest {
  public:
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
-    std::unordered_set<std::string> perm = {can_create_role};
+    std::set<std::string> perm = {can_create_role};
     create_role = std::make_shared<CreateRole>("master", perm);
     command = create_role;
     role_permissions = {can_create_role};
@@ -916,7 +916,7 @@ TEST_F(CreateRoleTest, InvalidCaseWhenRoleSuperset) {
       .WillRepeatedly(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getRolePermissions(admin_role))
       .WillRepeatedly(Return(role_permissions));
-  std::unordered_set<std::string> perms = {can_add_peer, can_append_role};
+  std::set<std::string> perms = {can_add_peer, can_append_role};
   command = std::make_shared<CreateRole>("master", perms);
   ASSERT_FALSE(validateAndExecute());
 }
@@ -926,7 +926,7 @@ TEST_F(CreateRoleTest, InvalidCaseWhenWrongRoleName) {
       .WillRepeatedly(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getRolePermissions(admin_role))
       .WillRepeatedly(Return(role_permissions));
-  std::unordered_set<std::string> perms = {can_create_role};
+  std::set<std::string> perms = {can_create_role};
   command = std::make_shared<CreateRole>("m!Aster", perms);
   ASSERT_FALSE(validateAndExecute());
 }

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -193,7 +193,7 @@ class TestablePbCommandFactory : public iroha::model::converters::PbCommandFacto
 
 TEST(CommandTest, create_role) {
   auto factory = iroha::model::converters::PbCommandFactory();
-  std::unordered_set<std::string> perms;
+  std::set<std::string> perms;
   perms.insert(all_perm_group.begin(), all_perm_group.end());
 
   for (auto perm : perms){
@@ -201,7 +201,7 @@ TEST(CommandTest, create_role) {
     auto map = test_factory.getPermMap();
     auto it = map.right.find(perm);
     ASSERT_NE(map.right.end(), it) << "On permission " << perm;
-    std::unordered_set<std::string> tmp_perms = {perm};
+    std::set<std::string> tmp_perms = {perm};
     auto orig_command = CreateRole("master", tmp_perms);
     auto proto_command = factory.serializeCreateRole(orig_command);
     auto serial_command = factory.deserializeCreateRole(proto_command);


### PR DESCRIPTION
## What is this pull request?
Fix for case when order of permissions inside CreateRole command could change after serialization/deserialization.
   
## Why do you implement it? Why do we need this pull request?
Order of permissions is not important semantically but it it critical for hash calculation. Hash of Transaction which contains CreateRole command with set of permissions inside should remains the same after serialization/deserialization.

## Details/Features
- Use std::map instead of std::unordered map everywhere which guarantees element order
- Add test which checks not only command equality but also their hashes
