### PR TITLE
Update SQL schema: Add json data to account

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -113,13 +113,19 @@ namespace iroha {
         transaction_.exec(
             "INSERT INTO account(\n"
             "            account_id, domain_id, quorum, "
-            "transaction_count \n"
+            "transaction_count, data \n"
             "            )\n"
-            "    VALUES (" +
-            transaction_.quote(account.account_id) + ", " +
-            transaction_.quote(account.domain_id) + ", " +
-            transaction_.quote(account.quorum) + ", " +
-            /*account.transaction_count*/ transaction_.quote(0) + ");");
+            "    VALUES ("
+            + transaction_.quote(account.account_id)
+            + ", "
+            + transaction_.quote(account.domain_id)
+            + ", "
+            + transaction_.quote(account.quorum)
+            + ", "
+            + transaction_.quote(0)
+            + ", "
+            + transaction_.quote(account.json_data)
+            + ");");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return false;

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -122,6 +122,7 @@ namespace iroha {
             + ", "
             + transaction_.quote(account.quorum)
             + ", "
+            // Transaction counter, by default zero
             + transaction_.quote(0)
             + ", "
             + transaction_.quote(account.json_data)

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -111,18 +111,15 @@ namespace iroha {
     bool PostgresWsvCommand::insertAccount(const model::Account &account) {
       try {
         transaction_.exec(
-            "INSERT INTO account(\n"
-            "            account_id, domain_id, quorum, "
-            "transaction_count, data \n"
-            "            )\n"
-            "    VALUES ("
+            "INSERT INTO account(account_id, domain_id, quorum, "
+            "transaction_count, data) VALUES ("
             + transaction_.quote(account.account_id)
             + ", "
             + transaction_.quote(account.domain_id)
             + ", "
             + transaction_.quote(account.quorum)
             + ", "
-            // Transaction counter, by default zero
+            // Transaction counter
             + transaction_.quote(0)
             + ", "
             + transaction_.quote(account.json_data)

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -127,6 +127,7 @@ namespace iroha {
       row.at("account_id") >> account.account_id;
       row.at("domain_id") >> account.domain_id;
       row.at("quorum") >> account.quorum;
+      row.at("data") >> account.json_data;
       //      row.at("transaction_count") >> ?
       return account;
     }

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -144,6 +144,7 @@ CREATE TABLE IF NOT EXISTS account (
     domain_id character varying(164) NOT NULL REFERENCES domain,
     quorum int NOT NULL,
     transaction_count int NOT NULL DEFAULT 0,
+    data JSONB,
     PRIMARY KEY (account_id)
 );
 CREATE TABLE IF NOT EXISTS account_has_signatory (

--- a/irohad/model/account.hpp
+++ b/irohad/model/account.hpp
@@ -45,6 +45,11 @@ namespace iroha {
        */
       uint32_t quorum;
 
+      /**
+       * Key/Value account data
+       */
+      std::string json_data;
+
       Account() {}
     };
   }

--- a/irohad/model/commands/create_account.hpp
+++ b/irohad/model/commands/create_account.hpp
@@ -30,17 +30,22 @@ namespace iroha {
       /**
        * Account's user name
        */
-      std::string account_name{};
+      std::string account_name;
 
       /**
        * Account's domain (full name)
        */
-      std::string domain_id{};
+      std::string domain_id;
 
       /**
        * Signatory of account
        */
-      pubkey_t pubkey{};
+      pubkey_t pubkey;
+
+      /**
+       * Json data for the account
+       */
+      std::string json_data;
 
       bool operator==(const Command &command) const override;
 
@@ -48,8 +53,9 @@ namespace iroha {
 
       CreateAccount(const std::string &account_name,
                     const std::string &domain_id,
-                    const pubkey_t &pubkey)
-          : account_name(account_name), domain_id(domain_id), pubkey(pubkey) {}
+                    const pubkey_t &pubkey,
+                    const std::string &data)
+          : account_name(account_name), domain_id(domain_id), pubkey(pubkey), json_data(data) {}
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -343,6 +343,7 @@ namespace iroha {
 
       account.domain_id = create_account.domain_id;
       account.quorum = 1;
+      account.json_data = create_account.json_data;
       auto domain = queries.getDomain(create_account.domain_id);
       if (not domain.has_value()) {
         log_->error("Domain {} not found", create_account.domain_id);

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -57,7 +57,7 @@ namespace iroha {
           const std::string &domain_id,
           const pubkey_t &key) {
         return generateCommand<CreateAccount>(
-            account_name, domain_id, key,"{}");
+            account_name, domain_id, key, "{}");
       }
 
       std::shared_ptr<Command> CommandGenerator::generateCreateDomain(

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -57,7 +57,7 @@ namespace iroha {
           const std::string &domain_id,
           const pubkey_t &key) {
         return generateCommand<CreateAccount>(
-            account_name, domain_id, key);
+            account_name, domain_id, key, R"({})");
       }
 
       std::shared_ptr<Command> CommandGenerator::generateCreateDomain(

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -57,7 +57,7 @@ namespace iroha {
           const std::string &domain_id,
           const pubkey_t &key) {
         return generateCommand<CreateAccount>(
-            account_name, domain_id, key, R"({})");
+            account_name, domain_id, key,"{}");
       }
 
       std::shared_ptr<Command> CommandGenerator::generateCreateDomain(

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -85,6 +85,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   CreateAccount createAccount;
   createAccount.account_name = "user1";
   createAccount.domain_id = "ru";
+  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   // Compose block
@@ -121,6 +122,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   createAccount = CreateAccount();
   createAccount.account_name = "user2";
   createAccount.domain_id = "ru";
+  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   // Create asset RUB#ru
@@ -290,18 +292,21 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   CreateAccount createAccount1;
   createAccount1.account_name = user1name;
   createAccount1.domain_id = domain;
+  createAccount1.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount1));
 
   // Create account 2
   CreateAccount createAccount2;
   createAccount2.account_name = user2name;
   createAccount2.domain_id = domain;
+  createAccount2.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount2));
 
   // Create account 3
   CreateAccount createAccount3;
   createAccount3.account_name = user3name;
   createAccount3.domain_id = domain;
+  createAccount3.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount3));
 
   // Create asset 1
@@ -552,6 +557,7 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   createAccount.account_name = "user1";
   createAccount.domain_id = "domain";
   createAccount.pubkey = pubkey1;
+  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   Block block;
@@ -624,6 +630,7 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   createAccount.account_name = "user2";
   createAccount.domain_id = "domain";
   createAccount.pubkey = pubkey1;  // same as user1's pubkey1
+  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   block = Block();

--- a/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
@@ -177,6 +177,12 @@ CREATE TABLE IF NOT EXISTS account_has_grantable_permissions (
       }
     };
 
+
+    /**
+     * @given inserted role, domain
+     * @when insert account with filled json data
+     * @then get account and check json data is the same
+     */
     TEST_F(AccountTest, InsertAccountWithJSONData) {
       ASSERT_TRUE(command->insertAccount(account));
       auto acc = query->getAccount(account.account_id);


### PR DESCRIPTION
## What is this pull request?
Add json data to account and update sql schema 
   
## Why do you implement it? Why do we need this pull request?
To allow storage of account personal info we need add JSONb field in account table.
  
## How to use the features provided in the pull request?
- Add new test in wsv_command_query


## Details/Features
 - By default account is created with empty JSON data
 