### PR TITLE
Feature/shared model query responses

### DIFF
--- a/shared_model/interfaces/commands/command.hpp
+++ b/shared_model/interfaces/commands/command.hpp
@@ -31,8 +31,7 @@ namespace shared_model {
 
     /**
      * Class provides commands container for all commands in system.
-     * General note: this class is container for commands, not a base class, for
-     * avoid this misunderstanding class should be final
+     * General note: this class is container for commands, not a base class.
      */
     class Command : public Primitive<Command, iroha::model::Command> {
      private:

--- a/shared_model/interfaces/impl.cpp
+++ b/shared_model/interfaces/impl.cpp
@@ -18,4 +18,5 @@
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/queries/query.hpp"
+#include "interfaces/query_responses/query_response.hpp"
 #include "interfaces/transaction.hpp"

--- a/shared_model/interfaces/queries/query.hpp
+++ b/shared_model/interfaces/queries/query.hpp
@@ -32,8 +32,8 @@ namespace shared_model {
 
     /**
      * Class Query provides container with one of concrete query available in
-     * system. General note: this class is container for queries but not a base
-     * class.
+     * system.
+     * General note: this class is container for queries but not a base class.
      */
     class Query : public Signable<Query, iroha::model::Query> {
      private:

--- a/shared_model/interfaces/query_responses/account_assets_response.hpp
+++ b/shared_model/interfaces/query_responses/account_assets_response.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_SHARED_MODEL_ACCOUNT_ASSETS_RESPONSE_HPP
+#define IROHA_SHARED_MODEL_ACCOUNT_ASSETS_RESPONSE_HPP
+
+#include "interfaces/primitive.hpp"
+#include "model/account_asset.hpp"  // TODO 27/10/2017 muratovv replace with shared_model account_asset
+#include "model/queries/responses/account_assets_response.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class AccountAssetResponse
+        : public Primitive<AccountAssetResponse,
+                           iroha::model::AccountAssetResponse> {
+     public:
+      virtual const iroha::model::AccountAsset &accountAsset() = 0;
+
+      // TODO 27/10/2017 muratovv implement available primitive methods
+    };
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_SHARED_MODEL_ACCOUNT_ASSETS_RESPONSE_HPP

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_SHARED_MODEL_QUERY_RESPONSE_HPP
+#define IROHA_SHARED_MODEL_QUERY_RESPONSE_HPP
+
+#include <boost/variant.hpp>
+#include "interfaces/hashable.hpp"
+#include "interfaces/query_responses/account_assets_response.hpp"
+#include "model/query_response.hpp"
+
+namespace shared_model {
+  namespace interface {
+    /**
+     * Class QueryResponse(qr) provides container with concrete query responses
+     * available in the system.
+     * General note: this class is container for QRs but not a base class.
+     * Architecture note: query responses should be attached to following query.
+     * For perform it make QueryResponse hashable, thus, in hash() method
+     * expects hash of the following query.
+     */
+    class QueryResponse
+        : public Hashable<QueryResponse, iroha::model::QueryResponse> {
+     private:
+      /// Shortcut type for polymorphic wrapper
+      template <typename Value>
+      using w = detail::PolymorphicWrapper<Value>;
+
+     public:
+      /// Type of container with all concrete query response
+      using QueryResponseVariantType = boost::variant<w<AccountAssetResponse>>;
+
+      /// Type of all available query responses
+      using QueryResponseListType = QueryResponseVariantType::types;
+
+      /**
+       * @return reference to const variant with concrete qr
+       */
+      virtual const QueryResponseVariantType &get() const = 0;
+
+      // ------------------------| Primitive override |-------------------------
+
+      std::string toString() const override {
+        return boost::apply_visitor(detail::ToStringVisitor(), get());
+      }
+
+      OldModelType *makeOldModel() const {
+        return boost::apply_visitor(
+            detail::OldModelCreatorVisitor<OldModelType *>(), get());
+      }
+
+      bool operator==(const ModelType &rhs) const override {
+        return this->get() == rhs.get();
+      }
+    };
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_SHARED_MODEL_QUERY_RESPONSE_HPP

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -30,7 +30,7 @@ namespace shared_model {
      * available in the system.
      * General note: this class is container for QRs but not a base class.
      * Architecture note: query responses should be attached to following query.
-     * For perform it make QueryResponse hashable, thus, in hash() method
+     * To perform it make QueryResponse hashable, thus, in hash() method
      * expects hash of the following query.
      */
     class QueryResponse

--- a/shared_model/interfaces/transaction.hpp
+++ b/shared_model/interfaces/transaction.hpp
@@ -23,6 +23,7 @@
 #include "interfaces/commands/command.hpp"
 #include "interfaces/common_objects/hash.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/polymorphic_wrapper.hpp"
 #include "interfaces/primitive.hpp"
 #include "interfaces/signable.hpp"
 #include "model/transaction.hpp"


### PR DESCRIPTION
## What is this pull request?
This PR provides a new interface of shared_model - query response. Query `interface::QueryResponse` reflects on `iroha::model::QueryResponse` and achieve same functionality. Provides it not via inheritance but via delegation with `boost::variant`. Also, this pr changes the design of `Command` and `Query` with more consistent.

## Details/Features
* Add QueryResponse and concrete QR as example
* Rework query and command, currently they are interfaces