### PR TITLE
Set account detail model and conversion

### DIFF
--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -392,15 +392,6 @@ namespace iroha_cli {
       return generator_.generateSetQuorum(account_id, quorum.value());
     }
 
-    std::shared_ptr<Command>
-    InteractiveTransactionCli::parseSetAccountDetail(
-        std::vector<std::string> params) {
-      auto account_id = params[0];
-      auto key = params[1];
-      auto value = params[2];
-      return generator_.generateSetAccountDetail(account_id, key, value);
-    }
-
     std::shared_ptr<iroha::model::Command>
     InteractiveTransactionCli::parseSubtractAssetQuantity(
         std::vector<std::string> params) {

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -30,8 +30,8 @@
 #include "model/converters/json_transaction_factory.hpp"
 #include "model/converters/pb_common.hpp"
 #include "model/generators/transaction_generator.hpp"
-#include "parser/parser.hpp"
 #include "model/permissions.hpp"
+#include "parser/parser.hpp"
 
 using namespace iroha::model;
 
@@ -236,12 +236,9 @@ namespace iroha_cli {
       auto create_account = parser::parseValue<bool>(params[8]);
 
       if (not read_self.has_value() or not edit_self.has_value()
-          or not read_all.has_value()
-          or not transfer_receive.has_value()
-          or not asset_create.has_value()
-          or not create_domain.has_value()
-          or not roles.has_value()
-          or not create_account.has_value()) {
+          or not read_all.has_value() or not transfer_receive.has_value()
+          or not asset_create.has_value() or not create_domain.has_value()
+          or not roles.has_value() or not create_account.has_value()) {
         std::cout << "Wrong format for permission" << std::endl;
         return nullptr;
       }
@@ -395,6 +392,15 @@ namespace iroha_cli {
       return generator_.generateSetQuorum(account_id, quorum.value());
     }
 
+    std::shared_ptr<Command>
+    InteractiveTransactionCli::parseSetAccountDetail(
+        std::vector<std::string> params) {
+      auto account_id = params[0];
+      auto key = params[1];
+      auto value = params[2];
+      return generator_.generateSetAccountDetail(account_id, key, value);
+    }
+
     std::shared_ptr<iroha::model::Command>
     InteractiveTransactionCli::parseSubtractAssetQuantity(
         std::vector<std::string> params) {
@@ -439,8 +445,8 @@ namespace iroha_cli {
 
       // Forming a transaction
 
-      auto tx = tx_generator_.generateTransaction( creator_,
-                                                  tx_counter_, commands_);
+      auto tx =
+          tx_generator_.generateTransaction(creator_, tx_counter_, commands_);
       // clear commands so that we can start creating new tx
       commands_.clear();
 

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -117,13 +117,10 @@ namespace iroha_cli {
           std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseSetQuorum(
           std::vector<std::string> line);
-      std::shared_ptr<iroha::model::Command> parseSetAccountDetail(
-          std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseSubtractAssetQuantity(
           std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseTransferAsset(
           std::vector<std::string> line);
-
       std::shared_ptr<iroha::model::Command> parseAppendRole(
           std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseCreateRole(

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -117,6 +117,8 @@ namespace iroha_cli {
           std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseSetQuorum(
           std::vector<std::string> line);
+      std::shared_ptr<iroha::model::Command> parseSetAccountDetail(
+          std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseSubtractAssetQuantity(
           std::vector<std::string> line);
       std::shared_ptr<iroha::model::Command> parseTransferAsset(

--- a/irohad/model/commands/set_account_detail.hpp
+++ b/irohad/model/commands/set_account_detail.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_ADDACCOUNTDETAIL_HPP
+#define IROHA_ADDACCOUNTDETAIL_HPP
+
+#include <model/command.hpp>
+
+namespace iroha {
+  namespace model {
+
+    struct SetAccountDetail : public Command {
+      std::string account_id{};
+      std::string key{};
+      std::string value{};
+
+      bool operator==(const Command &command) const override;
+
+      SetAccountDetail() {}
+
+      SetAccountDetail(std::string account_id,
+                       std::string key,
+                       std::string value)
+          : account_id(account_id), key(key), value(value) {}
+    };
+
+  }  // namespace model
+}  // namespace iroha
+
+#endif  // IROHA_ADDACCOUNTDETAIL_HPP

--- a/irohad/model/commands/set_account_detail.hpp
+++ b/irohad/model/commands/set_account_detail.hpp
@@ -24,9 +24,9 @@ namespace iroha {
   namespace model {
 
     struct SetAccountDetail : public Command {
-      std::string account_id{};
-      std::string key{};
-      std::string value{};
+      std::string account_id;
+      std::string key;
+      std::string value;
 
       bool operator==(const Command &command) const override;
 

--- a/irohad/model/commands/set_account_detail.hpp
+++ b/irohad/model/commands/set_account_detail.hpp
@@ -32,9 +32,9 @@ namespace iroha {
 
       SetAccountDetail() {}
 
-      SetAccountDetail(std::string account_id,
-                       std::string key,
-                       std::string value)
+      SetAccountDetail(const std::string &account_id,
+                       const std::string &key,
+                       const std::string &value)
           : account_id(account_id), key(key), value(value) {}
     };
 

--- a/irohad/model/converters/impl/json_command_factory.cpp
+++ b/irohad/model/converters/impl/json_command_factory.cpp
@@ -17,6 +17,7 @@
 
 #include "model/converters/json_command_factory.hpp"
 
+#include <model/commands/set_account_detail.hpp>
 #include <regex>
 #include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/add_peer.hpp"
@@ -75,6 +76,8 @@ namespace iroha {
              &JsonCommandFactory::serializeCreateAccount},
             {typeid(CreateAsset), &JsonCommandFactory::serializeCreateAsset},
             {typeid(CreateDomain), &JsonCommandFactory::serializeCreateDomain},
+            {typeid(SetAccountDetail),
+             &JsonCommandFactory::serializeSetAccountDetail},
             {typeid(RemoveSignatory),
              &JsonCommandFactory::serializeRemoveSignatory},
             {typeid(SetQuorum), &JsonCommandFactory::serializeSetQuorum},
@@ -95,6 +98,8 @@ namespace iroha {
             {"CreateAccount", &JsonCommandFactory::deserializeCreateAccount},
             {"CreateAsset", &JsonCommandFactory::deserializeCreateAsset},
             {"CreateDomain", &JsonCommandFactory::deserializeCreateDomain},
+            {"SetAccountDetail",
+             &JsonCommandFactory::deserializeSetAccountDetail},
             {"RemoveSignatory",
              &JsonCommandFactory::deserializeRemoveSignatory},
             {"SetQuorum", &JsonCommandFactory::deserializeSetQuorum},
@@ -118,16 +123,16 @@ namespace iroha {
 
         document.SetObject();
         document.AddMember("command_type", "AddAssetQuantity", allocator);
-        document.AddMember("account_id", add_asset_quantity->account_id,
-                           allocator);
+        document.AddMember(
+            "account_id", add_asset_quantity->account_id, allocator);
         document.AddMember("asset_id", add_asset_quantity->asset_id, allocator);
 
         Value amount;
         amount.SetObject();
         amount.AddMember(
             "value", add_asset_quantity->amount.getIntValue().str(), allocator);
-        amount.AddMember("precision", add_asset_quantity->amount.getPrecision(),
-                         allocator);
+        amount.AddMember(
+            "precision", add_asset_quantity->amount.getPrecision(), allocator);
 
         document.AddMember("amount", amount, allocator);
 
@@ -154,8 +159,8 @@ namespace iroha {
         document.SetObject();
         document.AddMember("command_type", "AddPeer", allocator);
         document.AddMember("address", add_peer->address, allocator);
-        document.AddMember("peer_key", add_peer->peer_key.to_hexstring(),
-                           allocator);
+        document.AddMember(
+            "peer_key", add_peer->peer_key.to_hexstring(), allocator);
 
         return document;
       }
@@ -179,8 +184,8 @@ namespace iroha {
         document.SetObject();
         document.AddMember("command_type", "AddSignatory", allocator);
         document.AddMember("account_id", add_signatory->account_id, allocator);
-        document.AddMember("pubkey", add_signatory->pubkey.to_hexstring(),
-                           allocator);
+        document.AddMember(
+            "pubkey", add_signatory->pubkey.to_hexstring(), allocator);
 
         return document;
       }
@@ -203,11 +208,11 @@ namespace iroha {
 
         document.SetObject();
         document.AddMember("command_type", "CreateAccount", allocator);
-        document.AddMember("account_name", create_account->account_name,
-                           allocator);
+        document.AddMember(
+            "account_name", create_account->account_name, allocator);
         document.AddMember("domain_id", create_account->domain_id, allocator);
-        document.AddMember("pubkey", create_account->pubkey.to_hexstring(),
-                           allocator);
+        document.AddMember(
+            "pubkey", create_account->pubkey.to_hexstring(), allocator);
 
         return document;
       }
@@ -219,6 +224,34 @@ namespace iroha {
             | des.String(&CreateAccount::account_name, "account_name")
             | des.String(&CreateAccount::domain_id, "domain_id")
             | des.String(&CreateAccount::pubkey, "pubkey") | toCommand;
+      }
+
+      // Set Account Detail
+      rapidjson::Document JsonCommandFactory::serializeSetAccountDetail(
+          std::shared_ptr<Command> command) {
+        auto set_account_detail =
+            static_cast<SetAccountDetail *>(command.get());
+
+        Document document;
+        auto &allocator = document.GetAllocator();
+
+        document.SetObject();
+        document.AddMember("command_type", "SetAccountDetail", allocator);
+        document.AddMember(
+            "account_id", set_account_detail->account_id, allocator);
+        document.AddMember("key", set_account_detail->key, allocator);
+        document.AddMember("value", set_account_detail->value, allocator);
+
+        return document;
+      }
+
+      optional_ptr<Command> JsonCommandFactory::deserializeSetAccountDetail(
+          const rapidjson::Value &document) {
+        auto des = makeFieldDeserializer(document);
+        return make_optional_ptr<SetAccountDetail>()
+            | des.String(&SetAccountDetail::account_id, "account_id")
+            | des.String(&SetAccountDetail::key, "key")
+            | des.String(&SetAccountDetail::value, "value") | toCommand;
       }
 
       // CreateAsset
@@ -257,10 +290,9 @@ namespace iroha {
 
         document.SetObject();
         document.AddMember("command_type", "CreateDomain", allocator);
-        document.AddMember("domain_id", create_domain->domain_id,
-                           allocator);
-        document.AddMember("user_default_role", create_domain->user_default_role,
-                           allocator);
+        document.AddMember("domain_id", create_domain->domain_id, allocator);
+        document.AddMember(
+            "user_default_role", create_domain->user_default_role, allocator);
 
         return document;
       }
@@ -284,10 +316,10 @@ namespace iroha {
 
         document.SetObject();
         document.AddMember("command_type", "RemoveSignatory", allocator);
-        document.AddMember("account_id", remove_signatory->account_id,
-                           allocator);
-        document.AddMember("pubkey", remove_signatory->pubkey.to_hexstring(),
-                           allocator);
+        document.AddMember(
+            "account_id", remove_signatory->account_id, allocator);
+        document.AddMember(
+            "pubkey", remove_signatory->pubkey.to_hexstring(), allocator);
 
         return document;
       }
@@ -334,20 +366,20 @@ namespace iroha {
 
         document.SetObject();
         document.AddMember("command_type", "TransferAsset", allocator);
-        document.AddMember("src_account_id", transfer_asset->src_account_id,
-                           allocator);
-        document.AddMember("dest_account_id", transfer_asset->dest_account_id,
-                           allocator);
+        document.AddMember(
+            "src_account_id", transfer_asset->src_account_id, allocator);
+        document.AddMember(
+            "dest_account_id", transfer_asset->dest_account_id, allocator);
         document.AddMember("asset_id", transfer_asset->asset_id, allocator);
-        document.AddMember("description", transfer_asset->description,
-                           allocator);
+        document.AddMember(
+            "description", transfer_asset->description, allocator);
 
         Value amount;
         amount.SetObject();
-        amount.AddMember("value", transfer_asset->amount.getIntValue().str(),
-                         allocator);
-        amount.AddMember("precision", transfer_asset->amount.getPrecision(),
-                         allocator);
+        amount.AddMember(
+            "value", transfer_asset->amount.getIntValue().str(), allocator);
+        amount.AddMember(
+            "precision", transfer_asset->amount.getPrecision(), allocator);
 
         document.AddMember("amount", amount, allocator);
 

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -142,7 +142,8 @@ namespace iroha {
           const protocol::AddPeer &pb_add_peer) {
         model::AddPeer add_peer;
         add_peer.address = pb_add_peer.address();
-        std::copy(pb_add_peer.peer_key().begin(), pb_add_peer.peer_key().end(),
+        std::copy(pb_add_peer.peer_key().begin(),
+                  pb_add_peer.peer_key().end(),
                   add_peer.peer_key.begin());
         return add_peer;
       }
@@ -322,7 +323,8 @@ namespace iroha {
           const model::CreateRole &command) {
         protocol::CreateRole cmd;
         cmd.set_role_name(command.role_name);
-        std::for_each(command.permissions.begin(), command.permissions.end(),
+        std::for_each(command.permissions.begin(),
+                      command.permissions.end(),
                       [&cmd, this](auto perm) {
                         auto perm_name = this->pb_role_map_.right.at(perm);
                         cmd.add_permissions(perm_name);
@@ -343,7 +345,7 @@ namespace iroha {
       model::GrantPermission PbCommandFactory::deserializeGrantPermission(
           const protocol::GrantPermission &command) {
         auto it = pb_grant_map_.left.find(command.permission());
-        if (it == pb_grant_map_.left.end()){
+        if (it == pb_grant_map_.left.end()) {
           return {};
         }
         return GrantPermission(command.account_id(), it->second);
@@ -361,10 +363,28 @@ namespace iroha {
       model::RevokePermission PbCommandFactory::deserializeRevokePermission(
           const protocol::RevokePermission &command) {
         auto it = pb_grant_map_.left.find(command.permission());
-        if (it == pb_grant_map_.left.end()){
+        if (it == pb_grant_map_.left.end()) {
           return {};
         }
         return RevokePermission(command.account_id(), it->second);
+      }
+
+      protocol::SetAccountDetail PbCommandFactory::serializeSetAccountDetail(
+          const model::SetAccountDetail &command) {
+        protocol::SetAccountDetail cmd;
+        cmd.set_account_id(command.account_id);
+        cmd.set_key(command.key);
+        cmd.set_value(command.value);
+        return cmd;
+      }
+
+      model::SetAccountDetail PbCommandFactory::deserializeSetAccountDetail(
+          const protocol::SetAccountDetail &command) {
+        model::SetAccountDetail setAccountDetail;
+        setAccountDetail.account_id = command.account_id();
+        setAccountDetail.key = command.key();
+        setAccountDetail.value = command.value();
+        return setAccountDetail;
       }
 
       protocol::Command PbCommandFactory::serializeAbstractCommand(
@@ -439,6 +459,14 @@ namespace iroha {
               static_cast<const model::CreateAccount &>(command));
           cmd.set_allocated_create_account(
               new protocol::CreateAccount(serialized));
+        }
+
+        // -----|SetAccountDetail|-----
+        if (instanceof <model::SetAccountDetail>(command)) {
+          auto serialized = commandFactory.serializeSetAccountDetail(
+              static_cast<const model::SetAccountDetail &>(command));
+          cmd.set_allocated_set_account_detail(
+              new protocol::SetAccountDetail(serialized));
         }
 
         // -----|CreateDomain|-----
@@ -545,6 +573,13 @@ namespace iroha {
           val = std::make_shared<model::CreateAccount>(cmd);
         }
 
+        // -----|SetAccountDetail|-----
+        if (command.has_set_account_detail()) {
+          auto pb_command = command.set_account_detail();
+          auto cmd = commandFactory.deserializeSetAccountDetail(pb_command);
+          val = std::make_shared<model::SetAccountDetail>(cmd);
+        }
+
         // -----|CreateDomain|-----
         if (command.has_create_domain()) {
           auto pb_command = command.create_domain();
@@ -558,7 +593,6 @@ namespace iroha {
           auto cmd = commandFactory.deserializeRemoveSignatory(pb_command);
           val = std::make_shared<model::RemoveSignatory>(cmd);
         }
-
 
         // -----|SetAccountQuorum|-----
         if (command.has_set_quorum()) {

--- a/irohad/model/converters/json_command_factory.hpp
+++ b/irohad/model/converters/json_command_factory.hpp
@@ -55,6 +55,12 @@ namespace iroha {
         optional_ptr<Command> deserializeCreateAccount(
             const rapidjson::Value &document);
 
+        // SetAccountAsset
+        rapidjson::Document serializeSetAccountDetail(
+            std::shared_ptr<Command> command);
+        optional_ptr<Command> deserializeSetAccountDetail(
+            const rapidjson::Value &document);
+
         // CreateAsset
         rapidjson::Document serializeCreateAsset(
             std::shared_ptr<Command> command);
@@ -72,7 +78,7 @@ namespace iroha {
             std::shared_ptr<Command> command);
         optional_ptr<Command> deserializeRemoveSignatory(
             const rapidjson::Value &document);
-        
+
         // SetQuorum
         rapidjson::Document serializeSetQuorum(
             std::shared_ptr<Command> command);

--- a/irohad/model/converters/pb_command_factory.hpp
+++ b/irohad/model/converters/pb_command_factory.hpp
@@ -33,6 +33,7 @@
 #include "model/commands/grant_permission.hpp"
 #include "model/commands/remove_signatory.hpp"
 #include "model/commands/revoke_permission.hpp"
+#include "model/commands/set_account_detail.hpp"
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/transfer_asset.hpp"
 #include "model/permissions.hpp"
@@ -123,6 +124,12 @@ namespace iroha {
         model::RevokePermission deserializeRevokePermission(
             const protocol::RevokePermission &command);
 
+        // Set Account Detail
+        protocol::SetAccountDetail serializeSetAccountDetail(
+            const model::SetAccountDetail &command);
+        model::SetAccountDetail deserializeSetAccountDetail(
+            const protocol::SetAccountDetail &command);
+
         // abstract
         protocol::Command serializeAbstractCommand(
             const model::Command &command);
@@ -131,8 +138,8 @@ namespace iroha {
 
        protected:
         boost::bimap<iroha::protocol::RolePermission, std::string> pb_role_map_;
-        boost::bimap<iroha::protocol::GrantablePermission, std::string> pb_grant_map_;
-
+        boost::bimap<iroha::protocol::GrantablePermission, std::string>
+            pb_grant_map_;
       };
     }  // namespace converters
   }    // namespace model

--- a/irohad/model/generators/command_generator.hpp
+++ b/irohad/model/generators/command_generator.hpp
@@ -66,11 +66,6 @@ namespace iroha {
         std::shared_ptr<Command> generateSetQuorum(
             const std::string &account_id, uint32_t quorum);
 
-        std::shared_ptr<Command> generateSetAccountDetail(
-            const std::string &account_id,
-            const std::string &key,
-            const std::string &value);
-
         std::shared_ptr<Command> generateAddAssetQuantity(
             const std::string &account_id,
             const std::string &asset_id,

--- a/irohad/model/generators/command_generator.hpp
+++ b/irohad/model/generators/command_generator.hpp
@@ -66,6 +66,11 @@ namespace iroha {
         std::shared_ptr<Command> generateSetQuorum(
             const std::string &account_id, uint32_t quorum);
 
+        std::shared_ptr<Command> generateSetAccountDetail(
+            const std::string &account_id,
+            const std::string &key,
+            const std::string &value);
+
         std::shared_ptr<Command> generateAddAssetQuantity(
             const std::string &account_id,
             const std::string &asset_id,

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "model/generators/command_generator.hpp"
+#include <model/commands/set_account_detail.hpp>
 #include "model/commands/add_asset_quantity.hpp"
 #include "model/commands/add_peer.hpp"
 #include "model/commands/add_signatory.hpp"
@@ -55,7 +56,8 @@ namespace iroha {
           const std::string &account_name,
           const std::string &domain_id,
           const pubkey_t &key) {
-        return generateCommand<CreateAccount>(account_name, domain_id, key);
+        return generateCommand<CreateAccount>(
+            account_name, domain_id, key);
       }
 
       std::shared_ptr<Command> CommandGenerator::generateCreateDomain(
@@ -110,6 +112,12 @@ namespace iroha {
         return generateCommand<SetQuorum>(account_id, quorum);
       }
 
+      std::shared_ptr<Command> CommandGenerator::generateSetAccountDetail(
+          const std::string &account_id,
+          const std::string &key,
+          const std::string &value) {
+        return generateCommand<SetAccountDetail>(account_id, key, value);
+      }
 
       std::shared_ptr<Command> CommandGenerator::generateSubtractAssetQuantity(
           const std::string &account_id,

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -112,13 +112,6 @@ namespace iroha {
         return generateCommand<SetQuorum>(account_id, quorum);
       }
 
-      std::shared_ptr<Command> CommandGenerator::generateSetAccountDetail(
-          const std::string &account_id,
-          const std::string &key,
-          const std::string &value) {
-        return generateCommand<SetAccountDetail>(account_id, key, value);
-      }
-
       std::shared_ptr<Command> CommandGenerator::generateSubtractAssetQuantity(
           const std::string &account_id,
           const std::string &asset_id,

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -26,6 +26,7 @@
 #include "model/commands/grant_permission.hpp"
 #include "model/commands/remove_signatory.hpp"
 #include "model/commands/revoke_permission.hpp"
+#include "model/commands/set_account_detail.hpp"
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/transfer_asset.hpp"
 
@@ -111,6 +112,16 @@ namespace iroha {
           && create_account.account_name == account_name;
     }
 
+    /* SetAccountDetail */
+    bool SetAccountDetail::operator==(const Command &rhs) const {
+      if (! instanceof <SetAccountDetail>(rhs)) {
+        return false;
+      }
+      auto setAccountDetail = static_cast<const SetAccountDetail &>(rhs);
+      return setAccountDetail.account_id == account_id
+          and setAccountDetail.key == key and setAccountDetail.value == value;
+    }
+
     /* CreateAsset */
     bool CreateAsset::operator==(const Command &command) const {
       if (! instanceof <CreateAsset>(command)) return false;
@@ -162,7 +173,9 @@ namespace iroha {
 
     /* Transaction */
     bool Transaction::operator==(const Transaction &rhs) const {
-      return std::equal(commands.begin(), commands.end(), rhs.commands.begin(),
+      return std::equal(commands.begin(),
+                        commands.end(),
+                        rhs.commands.begin(),
                         rhs.commands.end(),
                         [](const auto &i, const auto &j) { return *i == *j; })
           && rhs.tx_counter == tx_counter && rhs.signatures == signatures

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -30,6 +30,12 @@ message CreateAccount {
     bytes main_pubkey = 3;
 }
 
+message SetAccountDetail{
+    string account_id = 1;
+    string key = 2;
+    string value = 3;
+}
+
 message CreateDomain {
     string domain_id = 1;
     string default_role = 2;
@@ -88,5 +94,6 @@ message Command {
         CreateRole create_role = 12;
         GrantPermission grant_permission = 13;
         RevokePermission revoke_permission = 14;
+        SetAccountDetail set_account_detail = 15;
     }
 }

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -31,6 +31,7 @@
 #include "model/commands/grant_permission.hpp"
 #include "model/commands/remove_signatory.hpp"
 #include "model/commands/revoke_permission.hpp"
+#include "model/commands/set_account_detail.hpp"
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/transfer_asset.hpp"
 #include "model/converters/json_command_factory.hpp"
@@ -171,6 +172,20 @@ TEST_F(JsonCommandTest, create_account) {
 
   auto json_command = factory.serializeCreateAccount(orig_command);
   auto serial_command = factory.deserializeCreateAccount(json_command);
+
+  ASSERT_TRUE(serial_command.has_value());
+  ASSERT_EQ(*orig_command, *serial_command.value());
+  command_converter_test(orig_command);
+}
+
+TEST_F(JsonCommandTest, set_account_detail) {
+  auto orig_command = std::make_shared<SetAccountDetail>();
+  orig_command->account_id = "kek";
+  orig_command->key = "key";
+  orig_command->value = "value";
+
+  auto json_command = factory.serializeSetAccountDetail(orig_command);
+  auto serial_command = factory.deserializeSetAccountDetail(json_command);
 
   ASSERT_TRUE(serial_command.has_value());
   ASSERT_EQ(*orig_command, *serial_command.value());

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -253,3 +253,16 @@ TEST(CommandTest, revoke_permission) {
 
   command_converter_test(orig_command);
 }
+
+TEST(CommandTest, set_account_detail) {
+  auto factory = iroha::model::converters::PbCommandFactory();
+
+  auto orig_command = SetAccountDetail("test@test", "key", "value");
+
+  auto proto_command = factory.serializeSetAccountDetail(orig_command);
+  auto serial_command = factory.deserializeSetAccountDetail(proto_command);
+
+  ASSERT_EQ(orig_command, serial_command);
+  
+  command_converter_test(orig_command);
+}


### PR DESCRIPTION
## What is this pull request?
Adds set account detail model with corresponding converters
   
## Why do you implement it? Why do we need this pull request?
To add key/value detail about account it is required to have set account detail command. Detail is the key/value data about account
  
## How to use the features provided in the pull request?
Take a look to new protobuf and json converters tests
