### PR TITLE
Fix make old model for query

### DIFF
--- a/shared_model/interfaces/queries/query.hpp
+++ b/shared_model/interfaces/queries/query.hpp
@@ -86,7 +86,7 @@ namespace shared_model {
         return detail::PrettyStringBuilder()
             .init("Query")
             .append("creatorId", creatorAccountId())
-            .append("queryCounter", std::to_string(this->queryCounter()))
+            .append("queryCounter", std::to_string(queryCounter()))
             .append(Signable::toString())
             .append(boost::apply_visitor(detail::ToStringVisitor(), get()))
             .finalize();

--- a/shared_model/interfaces/queries/query.hpp
+++ b/shared_model/interfaces/queries/query.hpp
@@ -31,6 +31,7 @@
 #include "interfaces/signable.hpp"
 #include "interfaces/visitor_apply_for_all.hpp"
 #include "model/query.hpp"
+#include "utils/string_builder.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -77,17 +78,34 @@ namespace shared_model {
        * system queries plus 1. Required for preventing replay attacks.
        * @return attached query counter
        */
-      virtual const QueryCounterType &queryCounter() = 0;
+      virtual const QueryCounterType &queryCounter() const = 0;
 
       // ------------------------| Primitive override |-------------------------
 
       std::string toString() const override {
-        return boost::apply_visitor(detail::ToStringVisitor(), get());
+        return detail::PrettyStringBuilder()
+            .init("Query")
+            .append("creator_id", creatorAccountId())
+            .append("query_counter", std::to_string(this->queryCounter()))
+            .append(Signable::toString())
+            .append("domain_data",
+                    boost::apply_visitor(detail::ToStringVisitor(), get()))
+            .finalize();
       }
 
       OldModelType *makeOldModel() const override {
-        return boost::apply_visitor(
+         auto old_model = boost::apply_visitor(
             detail::OldModelCreatorVisitor<OldModelType *>(), get());
+        old_model->creator_account_id = creatorAccountId();
+        old_model->query_counter = queryCounter();
+        // signature related
+        old_model->created_ts = createdTime();
+        std::for_each(signatures().begin(), signatures().end(), [&old_model](auto &signature_wrapper) {
+          auto old_sig = signature_wrapper->makeOldModel();
+          old_model->signature = *old_sig;
+          delete old_sig;
+        });
+        return old_model;
       }
 
       bool operator==(const ModelType &rhs) const override {

--- a/shared_model/interfaces/signable.hpp
+++ b/shared_model/interfaces/signable.hpp
@@ -23,6 +23,7 @@
 #include "interfaces/common_objects/signature.hpp"
 #include "interfaces/hashable.hpp"
 #include "interfaces/polymorphic_wrapper.hpp"
+#include "utils/string_builder.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -88,6 +89,25 @@ namespace shared_model {
        * @return time of creation
        */
       virtual const TimestampType &createdTime() const = 0;
+
+      /**
+       * Provides comparison based on equality of objects and signatures.
+       * @param rhs - another model object
+       * @return true, if objects totally equal
+       */
+      virtual bool equals(const Model &rhs) {
+        return *this == rhs and this->signatures() == rhs.signatures()
+            and this->createdTime() == rhs.createdTime();
+      }
+
+      std::string toString() const override {
+        return detail::PrettyStringBuilder()
+            .init("Signable")
+            .append("created_time", std::to_string(createdTime()))
+            .appendAll(signatures(),
+                       [](auto &signature) { return signature->toString(); })
+            .finalize();
+      }
     };
 
   }  // namespace interface

--- a/shared_model/interfaces/signable.hpp
+++ b/shared_model/interfaces/signable.hpp
@@ -95,10 +95,12 @@ namespace shared_model {
        * @param rhs - another model object
        * @return true, if objects totally equal
        */
-      virtual bool equals(const Model &rhs) {
+      virtual bool equals(const Model &rhs) const {
         return *this == rhs and this->signatures() == rhs.signatures()
             and this->createdTime() == rhs.createdTime();
       }
+
+      // ------------------------| Primitive override |-------------------------
 
       std::string toString() const override {
         return detail::PrettyStringBuilder()


### PR DESCRIPTION
## What is this pull request?
Pr provides fix for `makeOldModel` method for the Query. Provided `toString` methods for `Signable` and `Query`. Also, provided compare method for `Signable`.

List of features / major commits
- fix implementation for make old model
- add toString methods
- add total compare method for `Signable`
- the absence of tests, because providing only interfaces