### PR TITLE
Rework primitive: make modelPrimitive class

### DIFF
--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_SHARED_MODEL_BLOB_HPP
 #define IROHA_SHARED_MODEL_BLOB_HPP
 
-#include "interfaces/primitive.hpp"
+#include "interfaces/model_primitive.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Blob interface present user-friendly blob for working with low-level
      * binary stuff. Its length is not fixed in compile time.
      */
-    class Blob : public interface::Primitive<Blob, Blob> {
+    class Blob : public interface::ModelPrimitive<Blob> {
      public:
       /**
        * @return provides raw representation of blob
@@ -54,6 +54,18 @@ namespace shared_model {
 
       bool operator==(const Blob &rhs) const override {
         return blob() == rhs.blob();
+      }
+
+      /**
+       * Method perform transforming object to old-fashion blob_t format
+       * @tparam Blob - type of blob
+       * @return blob_t array with own data
+       * Design note: this method is deprecated and should be removed after
+       * migration to shared model in whole project
+       */
+      template <typename Blob>
+      [[deprecated]] Blob makeOldModel() {
+        return Blob::from_string(hex());
       }
     };
   }  // namespace crypto

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -58,14 +58,14 @@ namespace shared_model {
 
       /**
        * Method perform transforming object to old-fashion blob_t format
-       * @tparam Blob - type of blob
+       * @tparam BlobType - type of blob
        * @return blob_t array with own data
        * Design note: this method is deprecated and should be removed after
        * migration to shared model in whole project
        */
-      template <typename Blob>
-      [[deprecated]] Blob makeOldModel() {
-        return Blob::from_string(hex());
+      template <typename BlobType>
+      [[deprecated]] BlobType makeOldModel() {
+        return BlobType::from_string(blob());
       }
     };
   }  // namespace crypto

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -20,7 +20,7 @@
 
 #include "cryptography/private_key.hpp"
 #include "cryptography/public_key.hpp"
-#include "interfaces/primitive.hpp"
+#include "interfaces/model_primitive.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -28,8 +28,7 @@ namespace shared_model {
     /**
      * Class for holding a keypair: public key and private key
      */
-    // TODO: luckychess 02.11.2017 Think about type for old model IR-559
-    class Keypair : public interface::Primitive<Keypair, Keypair> {
+    class Keypair : public interface::ModelPrimitive<Keypair> {
      public:
       /// Type of public key
       using PublicKeyType = PublicKey;

--- a/shared_model/interfaces/model_primitive.hpp
+++ b/shared_model/interfaces/model_primitive.hpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_MODEL_PRIMITIVE_HPP
+#define IROHA_MODEL_PRIMITIVE_HPP
+
+#include "utils/string_builder.hpp"
+
+namespace shared_model {
+  namespace interface {
+    /**
+     * ModelPrimitive is a base class of whole domain objects in system.
+     * This class required for guarantee consistent interface on all shared
+     * model objects.
+     * @tparam Model - your new style model
+     */
+    template <typename Model>
+    class ModelPrimitive {
+     public:
+      /**
+       * Reference for model type.
+       */
+      using ModelType = Model;
+
+      /**
+       * Make string developer representation of object
+       * @return string with internal state of object
+       */
+      virtual std::string toString() const {
+        return detail::PrettyStringBuilder()
+            .init("Primitive")
+            .append("address", std::to_string(reinterpret_cast<uint64_t>(this)))
+            .finalize();
+      }
+
+      virtual bool operator==(const ModelType &rhs) const = 0;
+
+      virtual bool operator!=(const ModelType &rhs) const {
+        return not(*this == rhs);
+      }
+
+      /**
+       * Polymorphic copy constructor.
+       * Method guarantee deep-copy.
+       * @return pointer to copied object
+       * discussion note: this method possible to rework with in-place pointer
+       * as parameter. such as: copy(T* ptr=nullptr), on nullptr allocate object
+       * on heap, otherwise in passed pointer
+       */
+      virtual ModelType *copy() const = 0;
+
+      virtual ~ModelPrimitive() = default;
+    };
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_MODEL_PRIMITIVE_HPP

--- a/shared_model/interfaces/primitive.hpp
+++ b/shared_model/interfaces/primitive.hpp
@@ -18,47 +18,25 @@
 #ifndef IROHA_PRIMITIVE_HPP
 #define IROHA_PRIMITIVE_HPP
 
-#include <string>
+#include "interfaces/model_primitive.hpp"
 
 namespace shared_model {
   namespace interface {
 
     /**
-     * Primitive is a base class of whole domain objects in system.
-     * This class required for guarantee consistent interface on all model
-     * objects.
+     * Primitive it the base class for all model objects, that require backward
+     * compatibility
      * @tparam Model - your new style model;
      * @tparam OldModel - old-style model, that changed with new model;
      */
     template <typename Model, typename OldModel>
-    class Primitive {
+    class Primitive : public ModelPrimitive<Model> {
      public:
-      /**
-       * Reference for model type.
-       */
-      using ModelType = Model;
 
       /**
        * Reference for old-style model type
        */
       using OldModelType = OldModel;
-
-      /**
-       * Make string developer representation of object
-       * @return string with internal state of object
-       */
-      virtual std::string toString() const {
-        std::string s = "Primitive at address[";
-        s += std::to_string(reinterpret_cast<uint64_t>(this));
-        s += "]";
-        return s;
-      }
-
-      virtual bool operator==(const ModelType &rhs) const = 0;
-
-      virtual bool operator!=(const ModelType &rhs) const {
-        return not(*this == rhs);
-      }
 
       /**
        * Create new old-style object for model.
@@ -69,18 +47,6 @@ namespace shared_model {
        * @return pointer for old-style object
        */
       [[deprecated]] virtual OldModelType *makeOldModel() const = 0;
-
-      /**
-       * Polymorphic copy constructor.
-       * Method guarantee deep-copy.
-       * @return pointer to copied object
-       * discussion note: this method possible to rework with in-place pointer
-       * as parameter. such as: copy(T* ptr=nullptr), on nullptr allocate object
-       * on heap, otherwise in passed pointer
-       */
-      virtual ModelType *copy() const = 0;
-
-      virtual ~Primitive() = default;
     };
 
   }  // namespace interface


### PR DESCRIPTION
## What is this pull request?
Rework `Primitive` with `ModelPrimitive` interface, that directly not support converting to the old-fashion interface. Rework with it Blob and Keypair. Add template method Blob::makeOldModel for converting to the old model.
  
## Details/Features
- Rework Primitive
- Add makeOldModel to blob
- Little rework of toSting of ModelPrimitive