### PR TITLE
Redis block query test

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -53,7 +53,7 @@ namespace iroha {
         index_->set(hash, std::to_string(height));
 
         // to make index account_id -> list of blocks where his txs exist
-        index_->rpush(account_id, {std::to_string(height)});
+        index_->sadd(account_id, {std::to_string(height)});
 
         // to make index account_id:height -> list of tx indexes (where
         // tx is placed in the block)

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -72,7 +72,7 @@ namespace iroha {
     std::vector<iroha::model::Block::BlockHeightType>
     RedisBlockQuery::getBlockIds(const std::string &account_id) {
       std::vector<uint64_t> block_ids;
-      client_.lrange(account_id, 0, -1, [&block_ids](cpp_redis::reply &reply) {
+      client_.smembers(account_id, [&block_ids](cpp_redis::reply &reply) {
         for (const auto &block_reply : reply.as_array()) {
           const auto &string_reply = block_reply.as_string();
 

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -16,6 +16,12 @@ target_link_libraries(flat_file_test
     libs_common
     )
 
+addtest(redis_block_query_test redis_block_query_test.cpp)
+target_link_libraries(redis_block_query_test
+        ametsuchi
+        libs_common
+        )
+
 add_library(ametsuchi_fixture INTERFACE)
 target_link_libraries(ametsuchi_fixture INTERFACE
     pqxx

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -16,8 +16,8 @@ target_link_libraries(flat_file_test
     libs_common
     )
 
-addtest(redis_block_query_test redis_block_query_test.cpp)
-target_link_libraries(redis_block_query_test
+addtest(block_query_test block_query_test.cpp)
+target_link_libraries(block_query_test
         ametsuchi
         libs_common
         )

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "ametsuchi/impl/redis_block_query.hpp"
 #include "ametsuchi/impl/storage_impl.hpp"
 #include "crypto/hash.hpp"
 #include "framework/test_subscriber.hpp"

--- a/test/module/irohad/ametsuchi/redis_block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/redis_block_query_test.cpp
@@ -1,0 +1,100 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ametsuchi/impl/redis_flat_block_query.hpp"
+#include "ametsuchi/impl/storage_impl.hpp"
+#include "crypto/hash.hpp"
+#include "framework/test_subscriber.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace iroha::model;
+using namespace framework::test_subscriber;
+
+/**
+ * @given block store with 2 blocks totally containing 3 txs created by
+ * user1@test and 1 tx created by user2@test
+ * @when queries to get transactions created by both users are invoked
+ * @then query over user1@test returns 3 txs and query over user2@test returns 1
+ * tx and query over non-existing user returns 0 txs
+ */
+TEST_F(AmetsuchiTest, GetAccountTransactions) {
+  auto storage =
+      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+
+  ASSERT_TRUE(storage);
+
+  auto blocks = storage->getBlockQuery();
+
+  std::string creator1 = "user1@test";
+  std::string creator2 = "user2@test";
+
+  // First transaction in block1
+  Transaction txn1_1;
+  txn1_1.creator_account_id = creator1;
+
+  // Second transaction in block1
+  Transaction txn1_2;
+  txn1_2.creator_account_id = creator1;
+
+  Block block1;
+  block1.height = 1;
+  block1.transactions.push_back(txn1_1);
+  block1.transactions.push_back(txn1_2);
+  auto block1hash = iroha::hash(block1);
+
+  // First tx in block 1
+  Transaction txn2_1;
+  txn2_1.creator_account_id = creator1;
+
+  // Second tx in block 2
+  Transaction txn2_2;
+  // this tx has another creator
+  txn2_2.creator_account_id = creator2;
+
+  Block block2;
+  block2.height = 2;
+  block2.prev_hash = block1hash;
+  block2.transactions.push_back(txn2_1);
+  block2.transactions.push_back(txn2_2);
+
+  auto ms = storage->createMutableStorage();
+  ms->apply(block1, [](const auto &, auto &, const auto &) { return true; });
+  ms->apply(block2, [](const auto &, auto &, const auto &) { return true; });
+  storage->commit(std::move(ms));
+
+  // Check that creator1 has created 3 transactions
+  auto getCreator1TxWrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountTransactions(creator1), 3);
+  getCreator1TxWrapper.subscribe(
+      [&creator1](auto val) { EXPECT_EQ(val.creator_account_id, creator1); });
+  ASSERT_TRUE(getCreator1TxWrapper.validate());
+
+  // Check that creator1 has created 1 transaction
+  auto getCreator2TxWrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountTransactions(creator2), 1);
+  getCreator2TxWrapper.subscribe(
+      [&creator2](auto val) { EXPECT_EQ(val.creator_account_id, creator2); });
+  ASSERT_TRUE(getCreator2TxWrapper.validate());
+
+  // Check that "nonexisting" user has no transaction
+  auto getNonexistingTxWrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountTransactions("nonexisting user"), 0);
+  getNonexistingTxWrapper.subscribe(
+      [&creator2](auto val) { EXPECT_TRUE(false); });
+  ASSERT_TRUE(getNonexistingTxWrapper.validate());
+}

--- a/test/module/irohad/ametsuchi/redis_block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/redis_block_query_test.cpp
@@ -25,6 +25,58 @@ using namespace iroha::ametsuchi;
 using namespace iroha::model;
 using namespace framework::test_subscriber;
 
+class BlockQueryTest : public AmetsuchiTest {
+ protected:
+  void SetUp() override {
+
+    AmetsuchiTest::SetUp();
+    storage =
+        StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+
+    ASSERT_TRUE(storage);
+
+    blocks = storage->getBlockQuery();
+    // First transaction in block1
+    Transaction txn1_1;
+    txn1_1.creator_account_id = creator1;
+
+    // Second transaction in block1
+    Transaction txn1_2;
+    txn1_2.creator_account_id = creator1;
+
+    Block block1;
+    block1.height = 1;
+    block1.transactions.push_back(txn1_1);
+    block1.transactions.push_back(txn1_2);
+    auto block1hash = iroha::hash(block1);
+
+    // First tx in block 1
+    Transaction txn2_1;
+    txn2_1.creator_account_id = creator1;
+
+    // Second tx in block 2
+    Transaction txn2_2;
+    // this tx has another creator
+    txn2_2.creator_account_id = creator2;
+
+    Block block2;
+    block2.height = 2;
+    block2.prev_hash = block1hash;
+    block2.transactions.push_back(txn2_1);
+    block2.transactions.push_back(txn2_2);
+
+    auto ms = storage->createMutableStorage();
+    ms->apply(block1, [](const auto &, auto &, const auto &) { return true; });
+    ms->apply(block2, [](const auto &, auto &, const auto &) { return true; });
+    storage->commit(std::move(ms));
+  }
+
+  std::shared_ptr<StorageImpl> storage;
+  std::shared_ptr<BlockQuery> blocks;
+  std::string creator1 = "user1@test";
+  std::string creator2 = "user2@test";
+};
+
 /**
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test and 1 tx created by user2@test
@@ -32,69 +84,23 @@ using namespace framework::test_subscriber;
  * @then query over user1@test returns 3 txs and query over user2@test returns 1
  * tx and query over non-existing user returns 0 txs
  */
-TEST_F(AmetsuchiTest, GetAccountTransactions) {
-  auto storage =
-      StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
-
-  ASSERT_TRUE(storage);
-
-  auto blocks = storage->getBlockQuery();
-
-  std::string creator1 = "user1@test";
-  std::string creator2 = "user2@test";
-
-  // First transaction in block1
-  Transaction txn1_1;
-  txn1_1.creator_account_id = creator1;
-
-  // Second transaction in block1
-  Transaction txn1_2;
-  txn1_2.creator_account_id = creator1;
-
-  Block block1;
-  block1.height = 1;
-  block1.transactions.push_back(txn1_1);
-  block1.transactions.push_back(txn1_2);
-  auto block1hash = iroha::hash(block1);
-
-  // First tx in block 1
-  Transaction txn2_1;
-  txn2_1.creator_account_id = creator1;
-
-  // Second tx in block 2
-  Transaction txn2_2;
-  // this tx has another creator
-  txn2_2.creator_account_id = creator2;
-
-  Block block2;
-  block2.height = 2;
-  block2.prev_hash = block1hash;
-  block2.transactions.push_back(txn2_1);
-  block2.transactions.push_back(txn2_2);
-
-  auto ms = storage->createMutableStorage();
-  ms->apply(block1, [](const auto &, auto &, const auto &) { return true; });
-  ms->apply(block2, [](const auto &, auto &, const auto &) { return true; });
-  storage->commit(std::move(ms));
-
+TEST_F(BlockQueryTest, GetAccountTransactions) {
   // Check that creator1 has created 3 transactions
   auto getCreator1TxWrapper = make_test_subscriber<CallExact>(
       blocks->getAccountTransactions(creator1), 3);
   getCreator1TxWrapper.subscribe(
-      [&creator1](auto val) { EXPECT_EQ(val.creator_account_id, creator1); });
+      [this](auto val) { EXPECT_EQ(val.creator_account_id, creator1); });
   ASSERT_TRUE(getCreator1TxWrapper.validate());
-
   // Check that creator1 has created 1 transaction
   auto getCreator2TxWrapper = make_test_subscriber<CallExact>(
       blocks->getAccountTransactions(creator2), 1);
   getCreator2TxWrapper.subscribe(
-      [&creator2](auto val) { EXPECT_EQ(val.creator_account_id, creator2); });
+      [this](auto val) { EXPECT_EQ(val.creator_account_id, creator2); });
   ASSERT_TRUE(getCreator2TxWrapper.validate());
 
   // Check that "nonexisting" user has no transaction
   auto getNonexistingTxWrapper = make_test_subscriber<CallExact>(
       blocks->getAccountTransactions("nonexisting user"), 0);
-  getNonexistingTxWrapper.subscribe(
-      [&creator2](auto val) { EXPECT_TRUE(false); });
+  getNonexistingTxWrapper.subscribe();
   ASSERT_TRUE(getNonexistingTxWrapper.validate());
 }

--- a/test/module/irohad/ametsuchi/redis_block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/redis_block_query_test.cpp
@@ -78,10 +78,10 @@ class BlockQueryTest : public AmetsuchiTest {
 
 /**
  * @given block store with 2 blocks totally containing 3 txs created by
- * user1@test and 1 tx created by user2@test
+ * user1@test
+ * AND 1 tx created by user2@test
  * @when query to get transactions created by user1@test is invoked
- * @then query over user1@test returns 2 txs and query over user2@test returns 1
- * tx and query over non-existing user returns 0 txs
+ * @then query over user1@test returns 3 txs
  */
 TEST_F(BlockQueryTest, GetAccountTransactionsFromSeveralBlocks) {
   // Check that creator1 has created 3 transactions
@@ -94,7 +94,8 @@ TEST_F(BlockQueryTest, GetAccountTransactionsFromSeveralBlocks) {
 
 /**
  * @given block store with 2 blocks totally containing 3 txs created by
- * user1@test and 1 tx created by user2@test
+ * user1@test
+ * AND 1 tx created by user2@test
  * @when query to get transactions created by user2@test is invoked
  * @then query over user2@test returns 1 tx
  */

--- a/test/module/irohad/ametsuchi/redis_block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/redis_block_query_test.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "ametsuchi/impl/redis_flat_block_query.hpp"
+#include "ametsuchi/impl/redis_block_query.hpp"
 #include "ametsuchi/impl/storage_impl.hpp"
 #include "crypto/hash.hpp"
 #include "framework/test_subscriber.hpp"


### PR DESCRIPTION
## What is this pull request?
Describe simply what this pull request is about.
   
## Why do you implement it? Why do we need this pull request?
We had bug in PR #655 but did not have test for it. This PR adds test for it
  
## How to use the features provided in the pull request?
Take a look for the redis_block_query_test

## Details/Features
During writing a test another bug was discovered:
when block has `N` txs created by the same account, then every transaction from this block was returned by redis_block_query `N` times. 
Bug was resolved by changing index from `account_id->[list of blocks containing account_id's txs]` to `account_id->{set of blocks containing account_id's txs}`
