### PR TITLE
Fix/consensus network unknown peer

### DIFF
--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -76,13 +76,13 @@ namespace iroha {
                    logger::to_string(order.getPeers(),
                                      [](auto val) { return val.address; }));
 
-        this->cluster_order_ = order;
+        cluster_order_ = order;
         auto vote = crypto_->getVote(hash);
         votingStep(vote);
       }
 
       rxcpp::observable<CommitMessage> Yac::on_commit() {
-        return this->notifier_.get_observable();
+        return notifier_.get_observable();
       }
 
       // ------|Network notifications|------
@@ -90,7 +90,7 @@ namespace iroha {
       void Yac::on_vote(VoteMessage vote) {
         std::lock_guard<std::mutex> guard(mutex_);
         if (crypto_->verify(vote)) {
-          this->applyVote(findPeer(vote), vote);
+          applyVote(findPeer(vote), vote);
         } else {
           log_->warn(cryptoError({vote}));
         }
@@ -100,7 +100,7 @@ namespace iroha {
         std::lock_guard<std::mutex> guard(mutex_);
         if (crypto_->verify(commit)) {
           // Commit does not contain data about peer which sent the message
-          this->applyCommit(nonstd::nullopt, commit);
+          applyCommit(nonstd::nullopt, commit);
         } else {
           log_->warn(cryptoError(commit.votes));
         }
@@ -110,7 +110,7 @@ namespace iroha {
         std::lock_guard<std::mutex> guard(mutex_);
         if (crypto_->verify(reject)) {
           // Reject does not contain data about peer which sent the message
-          this->applyReject(nonstd::nullopt, reject);
+          applyReject(nonstd::nullopt, reject);
         } else {
           log_->warn(cryptoError(reject.votes));
         }

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -99,6 +99,7 @@ namespace iroha {
       void Yac::on_commit(CommitMessage commit) {
         std::lock_guard<std::mutex> guard(mutex_);
         if (crypto_->verify(commit)) {
+          // Commit does not contain data about peer which sent the message
           this->applyCommit(nonstd::nullopt, commit);
         } else {
           log_->warn(cryptoError(commit.votes));
@@ -108,6 +109,7 @@ namespace iroha {
       void Yac::on_reject(RejectMessage reject) {
         std::lock_guard<std::mutex> guard(mutex_);
         if (crypto_->verify(reject)) {
+          // Reject does not contain data about peer which sent the message
           this->applyReject(nonstd::nullopt, reject);
         } else {
           log_->warn(cryptoError(reject.votes));

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -40,12 +40,7 @@ namespace iroha {
                           network::AsyncGrpcClient<google::protobuf::Empty> {
        public:
 
-        /**
-         * @param address - address of current peer
-         * @param peers - peers in network
-         */
-        explicit NetworkImpl(const std::string &address,
-                             const std::vector<model::Peer> &peers);
+        NetworkImpl();
         void subscribe(
             std::shared_ptr<YacNetworkNotifications> handler) override;
         void send_commit(model::Peer to, CommitMessage commit) override;
@@ -92,11 +87,6 @@ namespace iroha {
         void createPeerConnection(const model::Peer &peer);
 
         /**
-         * Address of current peer
-         */
-        std::string address_;
-
-        /**
          * Mapping of peer objects to connections
          */
         std::unordered_map<model::Peer, std::unique_ptr<proto::Yac::Stub>>
@@ -106,11 +96,6 @@ namespace iroha {
          * Subscriber of network messages
          */
         std::weak_ptr<YacNetworkNotifications> handler_;
-
-        /**
-         * Mapping of addresses to peers
-         */
-        std::unordered_map<std::string, model::Peer> peers_addresses_;
 
         /**
          * Internal logger

--- a/irohad/consensus/yac/transport/yac_network_interface.hpp
+++ b/irohad/consensus/yac/transport/yac_network_interface.hpp
@@ -30,24 +30,21 @@ namespace iroha {
        public:
         /**
          * Callback on receiving commit message
-         * @param from - peer that provide message
          * @param commit - provided message
          */
-        virtual void on_commit(model::Peer from, CommitMessage commit) = 0;
+        virtual void on_commit(CommitMessage commit) = 0;
 
         /**
          * Callback on receiving reject message
-         * @param from - peer that provide message
          * @param reject - provided message
          */
-        virtual void on_reject(model::Peer from, RejectMessage reject) = 0;
+        virtual void on_reject(RejectMessage reject) = 0;
 
         /**
          * Callback on receiving vote message
-         * @param from - peer that provide message
          * @param vote - provided message
          */
-        virtual void on_vote(model::Peer from, VoteMessage vote) = 0;
+        virtual void on_vote(VoteMessage vote) = 0;
 
         virtual ~YacNetworkNotifications() = default;
       };

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -66,11 +66,11 @@ namespace iroha {
 
         // ------|Network notifications|------
 
-        virtual void on_commit(model::Peer from, CommitMessage commit);
+        virtual void on_commit(CommitMessage commit);
 
-        virtual void on_reject(model::Peer from, RejectMessage reject);
+        virtual void on_reject(RejectMessage reject);
 
-        virtual void on_vote(model::Peer from, VoteMessage vote);
+        virtual void on_vote(VoteMessage vote);
 
        private:
         // ------|Private interface|------
@@ -87,9 +87,11 @@ namespace iroha {
         void closeRound();
 
         // ------|Apply data|------
-        void applyCommit(model::Peer from, CommitMessage commit);
-        void applyReject(model::Peer from, RejectMessage reject);
-        void applyVote(model::Peer from, VoteMessage vote);
+        void applyCommit(nonstd::optional<model::Peer> from,
+                         CommitMessage commit);
+        void applyReject(nonstd::optional<model::Peer> from,
+                         RejectMessage reject);
+        void applyVote(nonstd::optional<model::Peer> from, VoteMessage vote);
 
         // ------|Propagation|------
         void propagateCommit(CommitMessage msg);

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -86,6 +86,13 @@ namespace iroha {
          */
         void closeRound();
 
+        /**
+         * Find corresponding peer in the ledger from vote message
+         * @param vote message containing peer information
+         * @return peer if it is present in the ledger, nullopt otherwise
+         */
+        nonstd::optional<model::Peer> findPeer(const VoteMessage &vote);
+
         // ------|Apply data|------
         void applyCommit(nonstd::optional<model::Peer> from,
                          CommitMessage commit);

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -94,6 +94,13 @@ namespace iroha {
         nonstd::optional<model::Peer> findPeer(const VoteMessage &vote);
 
         // ------|Apply data|------
+
+        /**
+         * Methods take optional peer as argument since peer which sent the
+         * message could be missing from the ledger. This is the case when the
+         * top block in ledger does not correspond to consensus round number
+         */
+
         void applyCommit(nonstd::optional<model::Peer> from,
                          CommitMessage commit);
         void applyReject(nonstd::optional<model::Peer> from,

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -151,8 +151,7 @@ void Irohad::initBlockLoader() {
 
 void Irohad::initConsensusGate() {
   consensus_gate =
-      yac_init.initConsensusGate("0.0.0.0:" + std::to_string(internal_port_),
-                                 wsv,
+      yac_init.initConsensusGate(wsv,
                                  simulator,
                                  block_loader,
                                  keypair,

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -33,10 +33,9 @@ namespace iroha {
         return std::make_shared<PeerOrdererImpl>(wsv);
       }
 
-      auto YacInit::createNetwork(std::string network_address,
-                                  std::vector<model::Peer> initial_peers) {
+      auto YacInit::createNetwork() {
         consensus_network =
-            std::make_shared<NetworkImpl>(network_address, initial_peers);
+            std::make_shared<NetworkImpl>();
         return consensus_network;
       }
 
@@ -53,13 +52,12 @@ namespace iroha {
       }
 
       std::shared_ptr<consensus::yac::Yac> YacInit::createYac(
-          std::string network_address,
           ClusterOrdering initial_order,
           const keypair_t &keypair,
           std::chrono::milliseconds delay_milliseconds) {
         return Yac::create(
             YacVoteStorage(),
-            createNetwork(std::move(network_address), initial_order.getPeers()),
+            createNetwork(),
             createCryptoProvider(keypair),
             createTimer(),
             initial_order,
@@ -67,7 +65,6 @@ namespace iroha {
       }
 
       std::shared_ptr<YacGate> YacInit::initConsensusGate(
-          std::string network_address,
           std::shared_ptr<ametsuchi::PeerQuery> wsv,
           std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<network::BlockLoader> block_loader,
@@ -76,8 +73,7 @@ namespace iroha {
           std::chrono::milliseconds load_delay_milliseconds) {
         auto peer_orderer = createPeerOrderer(wsv);
 
-        auto yac = createYac(std::move(network_address),
-                             peer_orderer->getInitialOrdering().value(),
+        auto yac = createYac(peer_orderer->getInitialOrdering().value(),
                              keypair,
                              vote_delay_milliseconds);
         consensus_network->subscribe(yac);

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -43,8 +43,7 @@ namespace iroha {
 
         auto createPeerOrderer(std::shared_ptr<ametsuchi::PeerQuery> wsv);
 
-        auto createNetwork(std::string network_address,
-                           std::vector<model::Peer> initial_peers);
+        auto createNetwork();
 
         auto createCryptoProvider(const keypair_t &keypair);
 
@@ -53,14 +52,12 @@ namespace iroha {
         auto createHashProvider();
 
         std::shared_ptr<consensus::yac::Yac> createYac(
-            std::string network_address,
             ClusterOrdering initial_order,
             const keypair_t &keypair,
             std::chrono::milliseconds delay_milliseconds);
 
        public:
         std::shared_ptr<YacGate> initConsensusGate(
-            std::string network_address,
             std::shared_ptr<ametsuchi::PeerQuery> wsv,
             std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<network::BlockLoader> block_loader,

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -64,7 +64,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
   static const size_t port = 10001;
 
   void SetUp() override {
-    network = std::make_shared<NetworkImpl>(my_peer.address, default_peers);
+    network = std::make_shared<NetworkImpl>();
     crypto = std::make_shared<FixedCryptoProvider>(std::to_string(my_num));
     timer = std::make_shared<TimerImpl>();
     yac = Yac::create(YacVoteStorage(),

--- a/test/module/irohad/consensus/yac/CMakeLists.txt
+++ b/test/module/irohad/consensus/yac/CMakeLists.txt
@@ -32,6 +32,12 @@ target_link_libraries(yac_sunny_day_test
     model
     )
 
+addtest(yac_unknown_peer_test yac_unknown_peer_test.cpp)
+target_link_libraries(yac_unknown_peer_test
+    yac
+    model
+    )
+
 addtest(yac_block_storage_test yac_block_storage_test.cpp)
 target_link_libraries(yac_block_storage_test
     yac

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -34,8 +34,7 @@ namespace iroha {
           notifications = std::make_shared<MockYacNetworkNotifications>();
 
           peer = mk_peer("0.0.0.0:50051");
-          std::vector<model::Peer> peers = {peer};
-          network = std::make_shared<NetworkImpl>(peer.address, peers);
+          network = std::make_shared<NetworkImpl>();
 
           message.hash.proposal_hash = "proposal";
           message.hash.block_hash = "block";
@@ -72,7 +71,7 @@ namespace iroha {
        * @then vote handled
        */
       TEST_F(YacNetworkTest, MessageHandledWhenMessageSent) {
-        EXPECT_CALL(*notifications, on_vote(peer, message))
+        EXPECT_CALL(*notifications, on_vote(message))
             .Times(1)
             .WillRepeatedly(
                 InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
@@ -93,13 +92,12 @@ namespace iroha {
         auto client = proto::Yac::NewStub(grpc::CreateChannel(
             peer.address, grpc::InsecureChannelCredentials()));
 
-        EXPECT_CALL(*notifications, on_vote(_, _))
+        EXPECT_CALL(*notifications, on_vote(_))
             .Times(1)
             .WillRepeatedly(
                 InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
 
         grpc::ClientContext context;
-        context.AddMetadata("address", "0.0.0.0:50052");
         auto vote = PbConverters::serializeVote(message);
         google::protobuf::Empty response;
 

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -18,52 +18,97 @@
 #include "module/irohad/consensus/yac/yac_mocks.hpp"
 
 #include <grpc++/grpc++.h>
-#include "consensus/yac/transport/impl/network_impl.hpp"
 
-using namespace iroha::consensus::yac;
-using iroha::model::Peer;
+#include "consensus/yac/transport/yac_pb_converters.hpp"
+#include "consensus/yac/transport/impl/network_impl.hpp"
 
 using ::testing::_;
 using ::testing::InvokeWithoutArgs;
 
-TEST(NetworkTest, MessageHandledWhenMessageSent) {
-  auto notifications = std::make_shared<MockYacNetworkNotifications>();
+namespace iroha {
+  namespace consensus {
+    namespace yac {
+      class YacNetworkTest : public ::testing::Test {
+       public:
+        void SetUp() override {
+          notifications = std::make_shared<MockYacNetworkNotifications>();
 
-  auto peer = mk_peer("0.0.0.0:50051");
-  std::vector<Peer> peers = {peer};
-  std::shared_ptr<NetworkImpl> network =
-      std::make_shared<NetworkImpl>(peer.address, peers);
+          peer = mk_peer("0.0.0.0:50051");
+          std::vector<model::Peer> peers = {peer};
+          network = std::make_shared<NetworkImpl>(peer.address, peers);
 
-  VoteMessage message;
-  message.hash.proposal_hash = "proposal";
-  message.hash.block_hash = "block";
+          message.hash.proposal_hash = "proposal";
+          message.hash.block_hash = "block";
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  ON_CALL(*notifications, on_vote(peer, message))
-      .WillByDefault(
-          InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
+          network->subscribe(notifications);
 
-  EXPECT_CALL(*notifications, on_vote(peer, message)).Times(1);
+          grpc::ServerBuilder builder;
+          int port = 0;
+          builder.AddListeningPort(peer.address,
+                                   grpc::InsecureServerCredentials(),
+                                   &port);
+          builder.RegisterService(network.get());
+          server = builder.BuildAndStart();
+          ASSERT_TRUE(server);
+          ASSERT_NE(port, 0);
+        }
 
-  network->subscribe(notifications);
+        void TearDown() override {
+          server->Shutdown();
+        }
 
-  std::unique_ptr<grpc::Server> server;
+        std::shared_ptr<MockYacNetworkNotifications> notifications;
+        std::shared_ptr<NetworkImpl> network;
+        model::Peer peer;
+        VoteMessage message;
+        std::unique_ptr<grpc::Server> server;
+        std::mutex mtx;
+        std::condition_variable cv;
+      };
 
-  grpc::ServerBuilder builder;
-  int port = 0;
-  builder.AddListeningPort(peer.address, grpc::InsecureServerCredentials(),
-                           &port);
-  builder.RegisterService(network.get());
-  server = builder.BuildAndStart();
-  ASSERT_TRUE(server);
-  ASSERT_NE(port, 0);
+      /**
+       * @given initialized network
+       * @when send vote to itself
+       * @then vote handled
+       */
+      TEST_F(YacNetworkTest, MessageHandledWhenMessageSent) {
+        EXPECT_CALL(*notifications, on_vote(peer, message))
+            .Times(1)
+            .WillRepeatedly(
+                InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
 
-  network->send_vote(peer, message);
+        network->send_vote(peer, message);
 
-  // wait for response reader thread
-  std::unique_lock<std::mutex> lock(mtx);
-  cv.wait_for(lock, std::chrono::milliseconds(100));
+        // wait for response reader thread
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait_for(lock, std::chrono::milliseconds(100));
+      }
 
-  server->Shutdown();
-}
+      /**
+       * @given initialized network
+       * @when send vote from previously unknown peer
+       * @then vote handled
+       */
+      TEST_F(YacNetworkTest, MesssageHandledWhenUnknownPeer) {
+        auto client = proto::Yac::NewStub(grpc::CreateChannel(
+            peer.address, grpc::InsecureChannelCredentials()));
+
+        EXPECT_CALL(*notifications, on_vote(_, _))
+            .Times(1)
+            .WillRepeatedly(
+                InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
+
+        grpc::ClientContext context;
+        context.AddMetadata("address", "0.0.0.0:50052");
+        auto vote = PbConverters::serializeVote(message);
+        google::protobuf::Empty response;
+
+        client->SendVote(&context, vote, &response);
+
+        // wait for response reader thread
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait_for(lock, std::chrono::milliseconds(100));
+      }
+    } // namespace yac
+  } // namespace consensus
+} // namespace iroha

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -82,31 +82,6 @@ namespace iroha {
         std::unique_lock<std::mutex> lock(mtx);
         cv.wait_for(lock, std::chrono::milliseconds(100));
       }
-
-      /**
-       * @given initialized network
-       * @when send vote from previously unknown peer
-       * @then vote handled
-       */
-      TEST_F(YacNetworkTest, MesssageHandledWhenUnknownPeer) {
-        auto client = proto::Yac::NewStub(grpc::CreateChannel(
-            peer.address, grpc::InsecureChannelCredentials()));
-
-        EXPECT_CALL(*notifications, on_vote(_))
-            .Times(1)
-            .WillRepeatedly(
-                InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
-
-        grpc::ClientContext context;
-        auto vote = PbConverters::serializeVote(message);
-        google::protobuf::Empty response;
-
-        client->SendVote(&context, vote, &response);
-
-        // wait for response reader thread
-        std::unique_lock<std::mutex> lock(mtx);
-        cv.wait_for(lock, std::chrono::milliseconds(100));
-      }
     } // namespace yac
   } // namespace consensus
 } // namespace iroha

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -168,9 +168,9 @@ namespace iroha {
 
       class MockYacNetworkNotifications : public YacNetworkNotifications {
        public:
-        MOCK_METHOD2(on_commit, void(model::Peer, CommitMessage));
-        MOCK_METHOD2(on_reject, void(model::Peer, RejectMessage));
-        MOCK_METHOD2(on_vote, void(model::Peer, VoteMessage));
+        MOCK_METHOD1(on_commit, void(CommitMessage));
+        MOCK_METHOD1(on_reject, void(RejectMessage));
+        MOCK_METHOD1(on_vote, void(VoteMessage));
       };
 
       class YacTest : public ::testing::Test {

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -127,7 +127,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveSupermajorityOfVotes) {
       .WillRepeatedly(Return(true));
 
   YacHash received_hash("my_proposal", "my_block");
-  for (auto &peer : default_peers) {
+  for (size_t i = 0; i < default_peers.size(); ++i) {
     network->notification->on_vote(crypto->getVote(received_hash));
   }
 
@@ -160,11 +160,8 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveCommitMessage) {
 
   auto committed_peer = default_peers.at(0);
   auto msg = CommitMessage();
-  uint64_t number_of_peer = 0;
-  for (auto &peer : default_peers) {
-    (void) peer;
-    msg.votes.push_back(create_vote(propagated_hash,
-                                    std::to_string(number_of_peer++)));
+  for (size_t i = 0; i < default_peers.size(); ++i) {
+    msg.votes.push_back(create_vote(propagated_hash, std::to_string(i)));
   }
   network->notification->on_commit(msg);
 

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -98,7 +98,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveOneVote) {
   YacHash received_hash("my_proposal", "my_block");
   auto peer = default_peers.at(0);
   // assume that our peer receive message
-  network->notification->on_vote(peer, crypto->getVote(received_hash));
+  network->notification->on_vote(crypto->getVote(received_hash));
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -128,7 +128,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveSupermajorityOfVotes) {
 
   YacHash received_hash("my_proposal", "my_block");
   for (auto &peer : default_peers) {
-    network->notification->on_vote(peer, crypto->getVote(received_hash));
+    network->notification->on_vote(crypto->getVote(received_hash));
   }
 
   ASSERT_TRUE(wrapper.validate());
@@ -166,7 +166,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveCommitMessage) {
     msg.votes.push_back(create_vote(propagated_hash,
                                     std::to_string(number_of_peer++)));
   }
-  network->notification->on_commit(committed_peer, msg);
+  network->notification->on_commit(msg);
 
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -69,7 +69,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
   yac->vote(my_hash, my_order);
 
   for (auto i = 0; i < 3; ++i) {
-    yac->on_vote(my_peers.at(i), create_vote(my_hash, std::to_string(i)));
+    yac->on_vote(create_vote(my_hash, std::to_string(i)));
   };
 }
 
@@ -118,7 +118,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   for (auto i = 0; i < 4; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(my_peers.at(0), CommitMessage(votes));
+  yac->on_commit(CommitMessage(votes));
   ASSERT_TRUE(wrapper.validate());
 }
 
@@ -168,13 +168,13 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   for (auto i = 0; i < 3; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(my_peers.at(0), CommitMessage(votes));
+  yac->on_commit(CommitMessage(votes));
 
   // second commit
   for (auto i = 1; i < 4; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(my_peers.at(1), CommitMessage(votes));
+  yac->on_commit(CommitMessage(votes));
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -222,11 +222,11 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
 
   auto vote_message = create_vote(my_hash, std::to_string(0));
 
-  yac->on_vote(my_peers.at(0), vote_message);
+  yac->on_vote(vote_message);
 
   auto commit_message = CommitMessage({vote_message});
 
-  yac->on_commit(my_peers.at(0), commit_message);
+  yac->on_commit(commit_message);
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -267,7 +267,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
   for (auto i = 0; i < 3; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(my_peers.at(0), CommitMessage(votes));
+  yac->on_commit(CommitMessage(votes));
 
   yac->vote(my_hash, my_order);
 }

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "framework/test_subscriber.hpp"
+#include "yac_mocks.hpp"
+
+using ::testing::Return;
+using ::testing::_;
+using ::testing::An;
+using ::testing::AtLeast;
+
+using namespace iroha::consensus::yac;
+using namespace framework::test_subscriber;
+using namespace std;
+
+/**
+ * @given initialized yac
+ * @when receive vote from unknown peer
+ * @then commit not emitted
+ */
+TEST_F(YacTest, UnknownVoteBeforeCommit) {
+  // verify that commit not emitted
+  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 0);
+  wrapper.subscribe();
+
+  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
+  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
+  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
+
+  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
+  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
+  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
+      .Times(1)
+      .WillRepeatedly(Return(true));
+
+  VoteMessage vote;
+  vote.hash = YacHash("my_proposal", "my_block");
+  std::string unknown = "unknown";
+  std::copy(unknown.begin(), unknown.end(), vote.signature.pubkey.begin());
+  // assume that our peer receive message
+  network->notification->on_vote(vote);
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @given initialized yac, received commit
+ * @when receive vote from unknown peer for committed hash
+ * @then commit not emitted
+ */
+TEST_F(YacTest, UnknownVoteAfterCommit) {
+  auto my_peers = std::vector<iroha::model::Peer>(
+      {default_peers.begin(), default_peers.begin() + 4});
+  ASSERT_EQ(4, my_peers.size());
+
+  ClusterOrdering my_order(my_peers);
+
+  // delay preference
+  uint64_t wait_seconds = 10;
+  delay = wait_seconds * 1000;
+
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
+
+  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
+  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
+  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
+
+  EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
+
+  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).WillOnce(Return(true));
+  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
+  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillOnce(Return(true));
+
+  YacHash my_hash("proposal_hash", "block_hash");
+
+  std::vector<VoteMessage> votes;
+
+  for (auto i = 0; i < 3; ++i) {
+    votes.push_back(create_vote(my_hash, std::to_string(i)));
+  };
+  yac->on_commit(CommitMessage(votes));
+
+  VoteMessage vote;
+  vote.hash = my_hash;
+  std::string unknown = "unknown";
+  std::copy(unknown.begin(), unknown.end(), vote.signature.pubkey.begin());
+
+  yac->on_vote(vote);
+}

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -58,7 +58,8 @@ TEST_F(YacTest, UnknownVoteBeforeCommit) {
 }
 
 /**
- * @given initialized yac, received commit
+ * @given initialized yac
+ * AND received commit
  * @when receive vote from unknown peer for committed hash
  * @then commit not emitted
  */


### PR DESCRIPTION
## What is this pull request?
Fix issue with crash when consensus message is received from unknown peer.

## Details/Features
- YacNetwork is now unaware of peers in the ledger
- YacNetworkNotifications handle querying peers in the ledger
