### PR TITLE
Fix issue with lack of query_counter when Query serialization.

### DIFF
--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -138,6 +138,7 @@ namespace iroha {
         auto pl = pb_query.mutable_payload();
         pl->set_creator_account_id(query->creator_account_id);
         pl->set_created_time(query->created_ts);
+        pl->set_query_counter(query->query_counter);
         // Set signatures
         auto sig = pb_query.mutable_signature();
         sig->set_signature(query->signature.signature.to_string());


### PR DESCRIPTION
## What is this pull request?
Fix issue with lack of query_counter when Query serialization.

## Details/Features
- Add set_query_counter method to query serialization process.

