### PR TITLE
Fix issue with duplicated txs return from GetAccountTransactions

### DIFF
--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -69,16 +69,16 @@ namespace iroha {
       return getBlocks(last_id - count + 1, count);
     }
 
-    std::vector<iroha::model::Block::BlockHeightType>
+    std::set<iroha::model::Block::BlockHeightType>
     RedisBlockQuery::getBlockIds(const std::string &account_id) {
-      std::vector<uint64_t> block_ids;
+      std::set<uint64_t> block_ids;
       client_.lrange(account_id, 0, -1, [&block_ids](cpp_redis::reply &reply) {
         for (const auto &block_reply : reply.as_array()) {
           const auto &string_reply = block_reply.as_string();
 
           // check if reply is an integer
           if (isdigit(string_reply.c_str()[0])) {
-            block_ids.push_back(std::stoul(string_reply));
+            block_ids.insert(std::stoul(string_reply));
           }
         }
       });

--- a/irohad/ametsuchi/impl/redis_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_block_query.hpp
@@ -57,7 +57,7 @@ namespace iroha {
        * @param account_id
        * @return vector of block ids
        */
-      std::vector<iroha::model::Block::BlockHeightType> getBlockIds(
+      std::set<iroha::model::Block::BlockHeightType> getBlockIds(
           const std::string &account_id);
 
       /**


### PR DESCRIPTION
## What is this pull request?

Fix issue with duplicated txs return from GetAccountTransactions

## Why do you implement it? Why do we need this pull request?

In case of, there are two same user's transactions in a same block, GetAccountTransactions returns twice transactions.
In case of, there are three same user's transactions in a same block, GetAccountTransactions returns three times transactions.

For example:

If there are two same user's transactions, `getBlockIds( lrange username 0 -1 )` returns two same block ids.
ex.)
> 1) "1"
> 2) "1"

Thus, the number of transactions are 4.

If there are three same user's transactions, `getBlockIds( lrange username 0 -1 )` returns two same block ids.
ex.)
> 1) "1"
> 2) "1"
> 3) "1"

Thus, the number of transactions are 9.

I expected to be returned only one transaction. 

So I changed `std::vector<uint64_t> block_ids` in getBlockIds to `std::set<uint64_t> block_ids` to remove duplicated block ids.

## Details/Features
- Dedup block ids from getBlockIds method.
