### PR TITLE
Remove logger include

### DIFF
--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -16,5 +16,3 @@
 #
 
 AddTest(lazy_test lazy_test.cpp)
-
-

--- a/test/module/shared_model/lazy_test.cpp
+++ b/test/module/shared_model/lazy_test.cpp
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 #include <string>
-#include "logger/logger.hpp"
 #include "utils/lazy_initializer.hpp"
 
 struct SourceValue {


### PR DESCRIPTION
## What is this pull request?
Remove logger include from lazy_test
   
## Why do you implement it? Why do we need this pull request?
To make mac os compilation success
