### PR TITLE
Fix ccache problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ jobs:
       - run:
           name: ccache setup
           command: |
-            ccache --max-files=0
+            ccache --version
+            ccache --show-stats
+            ccache --zero-stats
             ccache --max-size=1G
       - run:
           name: cmake
@@ -33,6 +35,11 @@ jobs:
           name: make
           command: |
             cmake --build $IROHA_BUILD -- -j4
+      - run:
+          name: ccache teardown
+          command: |
+            ccache --cleanup
+            ccache --show-stats
       - save_cache:
           key: build-cache-linux-{{ .Branch }}-{{ epoch }}
           paths:
@@ -157,7 +164,13 @@ jobs:
             - external-macos-
           paths:
             - external
-      - run: ccache --show-stats
+      - run:
+          name: ccache setup
+          command: |
+            ccache --version
+            ccache --show-stats
+            ccache --zero-stats
+            ccache --max-size=1G
       - run:
           name: build
           command: |
@@ -171,7 +184,11 @@ jobs:
           key: external-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - external
-      - run: ccache --show-stats
+      - run:
+          name: ccache teardown
+          command: |
+            ccache --cleanup
+            ccache --show-stats
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ defaults: &defaults
   environment:
     IROHA_HOME: /opt/iroha
     IROHA_BUILD: /opt/iroha/build
-    CCACHE_DIR: ~/.ccache
 
 version: 2
 
@@ -18,8 +17,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - build-cache-{{ arch }}-{{ .Branch }}
-            - build-cache-{{ arch }}
+            - build-cache-linux-{{ .Branch }}
+            - build-cache-linux-
           paths:
             - ~/.ccache
       - run:
@@ -35,7 +34,11 @@ jobs:
           command: |
             cmake --build $IROHA_BUILD -- -j4
       - save_cache:
-          key: build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-cache-linux-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
+      - save_cache:
+          key: build-cache-linux-{{ epoch }}
           paths:
             - ~/.ccache
       - run: ccache --show-stats
@@ -148,13 +151,14 @@ jobs:
             - Library/Caches/Homebrew
       - restore_cache:
           keys:
-            - build-cache-{{ arch }}-{{ .Branch }}
+            - build-cache-macos-{{ .Branch }}
+            - build-cache-macos-
           paths:
             - ~/.ccache
       - restore_cache:
           keys:
-            - external-{{ arch }}-{{ .Branch }}
-            - external-{{ arch }}
+            - external-macos-{{ .Branch }}
+            - external-macos-
           paths:
             - external
       - run: ccache --show-stats
@@ -164,16 +168,24 @@ jobs:
             cmake -H. -Bbuild
             cmake --build build -- -j$(sysctl -n hw.ncpu)
       - save_cache:
-          key: build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-cache-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
       - save_cache:
-          key: external-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-cache-macos-{{ epoch }}
+          paths:
+            - ~/.ccache
+      - save_cache:
+          key: external-macos-{{ .Branch }}-{{ epoch }}
+          paths:
+            - external
+      - save_cache:
+          key: external-macos-{{ epoch }}
           paths:
             - external
 
       - run: ccache --show-stats
-     
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - build-cache-linux-{{ .Branch }}
+            - build-cache-linux-{{ .Branch }}-
             - build-cache-linux-
           paths:
             - ~/.ccache
@@ -35,10 +35,6 @@ jobs:
             cmake --build $IROHA_BUILD -- -j4
       - save_cache:
           key: build-cache-linux-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-      - save_cache:
-          key: build-cache-linux-{{ epoch }}
           paths:
             - ~/.ccache
       - run: ccache --show-stats
@@ -139,25 +135,25 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - brew-{{ arch }}
+            - brew-macos-
           paths:
             - Library/Caches/Homebrew
       - run:
           name: install dev dependencies
           command: brew install cmake boost postgres grpc autoconf automake libtool ccache
       - save_cache:
-          key: brew-{{ arch }}-{{ epoch }}
+          key: brew-macos-{{ epoch }}
           paths:
             - Library/Caches/Homebrew
       - restore_cache:
           keys:
-            - build-cache-macos-{{ .Branch }}
+            - build-cache-macos-{{ .Branch }}-
             - build-cache-macos-
           paths:
             - ~/.ccache
       - restore_cache:
           keys:
-            - external-macos-{{ .Branch }}
+            - external-macos-{{ .Branch }}-
             - external-macos-
           paths:
             - external
@@ -172,18 +168,9 @@ jobs:
           paths:
             - ~/.ccache
       - save_cache:
-          key: build-cache-macos-{{ epoch }}
-          paths:
-            - ~/.ccache
-      - save_cache:
           key: external-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - external
-      - save_cache:
-          key: external-macos-{{ epoch }}
-          paths:
-            - external
-
       - run: ccache --show-stats
 
 


### PR DESCRIPTION
This PR *possibly* (I don't have a way to test this) fixes the problem with `ccache`. 

- [x] As was suggested, it changes `{{ arch }}` to hardcoded word (linux/macos).
- [x] Adds new cross-branch cache. If cache from branch A is saved, then at branch B it is possible to recover it.