### PR TITLE
Fix/createdomain - CreateDomain.json contains invalid json

### DIFF
--- a/example/CreateDomain.json
+++ b/example/CreateDomain.json
@@ -11,7 +11,8 @@
     "commands": [
         {
           "command_type": "CreateDomain",
-          "domain_name": "soramitsu"
+          "domain_id": "soramitsu",
+          "user_default_role": "user"
         }
     ]
 }


### PR DESCRIPTION
## What is this pull request?
The CreateDomain.json contains invalid JSON. The "domain_name" key should be "domain_id" and "user_default_role" is missing. 
   
## Why do you implement it? Why do we need this pull request?
Without this fix the `hakodate.sh` shell script returns `Json transaction has wrong format.`
  
## How to use the features provided in the pull request?
Running `./hakodate.sh` will now successfully create a domain.

## Details/Features
List of features / major commits
- Renamed "domain_name" to "domain_id" inside the CreateDomain.json
- Added "user_default_role" to CreateDomain.json
