### PR TITLE
Feature/tx mst handle

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(application
     simulator
     block_loader
     block_loader_service
+    mst_processor
     )
 
 add_executable(irohad irohad.cpp)

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -72,6 +72,7 @@ void Irohad::init() {
   initConsensusGate();
   initSynchronizer();
   initPeerCommunicationService();
+  initMstProcessor();
 
   // Torii
   initTransactionCommandService();
@@ -213,9 +214,22 @@ void Irohad::initPeerCommunicationService() {
   log_->info("[Init] => pcs");
 }
 
+void Irohad::initMstProcessor() {
+  auto mst_transport = std::make_shared<MstTransportGrpc>();
+  auto mst_completer = std::make_shared<DefaultCompleter>();
+  auto mst_storage = std::make_shared<MstStorageStateImpl>(mst_completer);
+  // TODO: @l4l magics should be fixed with options in cli branch
+  auto mst_propagation = std::make_shared<GossipPropagationStrategy>(
+      wsv, std::chrono::milliseconds(5) /*emitting period*/,
+      5 /*amount per once*/);
+  auto mst_time = std::make_shared<MstTimeProviderImpl>();
+  mst_proc = std::make_shared<FairMstProcessor>(mst_transport, mst_storage,
+                                                mst_propagation, mst_time);
+}
+
 void Irohad::initTransactionCommandService() {
-  auto tx_processor =
-      std::make_shared<TransactionProcessorImpl>(pcs, stateless_validator);
+  auto tx_processor = std::make_shared<TransactionProcessorImpl>(
+      pcs, stateless_validator, mst_proc);
 
   command_service =
       std::make_unique<::torii::CommandService>(pb_tx_factory, tx_processor);

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -221,8 +221,8 @@ void Irohad::initMstProcessor() {
   // TODO: @l4l magics should be fixed with options in cli branch
   //            check #661 for details
   auto mst_propagation = std::make_shared<GossipPropagationStrategy>(
-      wsv, std::chrono::milliseconds(5) /*emitting period*/,
-      5 /*amount per once*/);
+      wsv, std::chrono::seconds(5) /*emitting period*/,
+      2 /*amount per once*/);
   auto mst_time = std::make_shared<MstTimeProviderImpl>();
   mst_processor = std::make_shared<FairMstProcessor>(mst_transport, mst_storage,
                                                      mst_propagation, mst_time);

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -219,17 +219,18 @@ void Irohad::initMstProcessor() {
   auto mst_completer = std::make_shared<DefaultCompleter>();
   auto mst_storage = std::make_shared<MstStorageStateImpl>(mst_completer);
   // TODO: @l4l magics should be fixed with options in cli branch
+  //            check #661 for details
   auto mst_propagation = std::make_shared<GossipPropagationStrategy>(
       wsv, std::chrono::milliseconds(5) /*emitting period*/,
       5 /*amount per once*/);
   auto mst_time = std::make_shared<MstTimeProviderImpl>();
-  mst_proc = std::make_shared<FairMstProcessor>(mst_transport, mst_storage,
-                                                mst_propagation, mst_time);
+  mst_processor = std::make_shared<FairMstProcessor>(mst_transport, mst_storage,
+                                                     mst_propagation, mst_time);
 }
 
 void Irohad::initTransactionCommandService() {
   auto tx_processor = std::make_shared<TransactionProcessorImpl>(
-      pcs, stateless_validator, mst_proc);
+      pcs, stateless_validator, mst_processor);
 
   command_service =
       std::make_unique<::torii::CommandService>(pb_tx_factory, tx_processor);

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -170,7 +170,7 @@ class Irohad {
   std::shared_ptr<iroha::network::PeerCommunicationService> pcs;
 
   // mst
-  std::shared_ptr<iroha::MstProcessor> mst_proc;
+  std::shared_ptr<iroha::MstProcessor> mst_processor;
 
   // transaction service
   std::unique_ptr<torii::CommandService> command_service;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -27,6 +27,11 @@
 #include "main/impl/ordering_init.hpp"
 #include "main/server_runner.hpp"
 #include "model/model_crypto_provider_impl.hpp"
+#include "multi_sig_transactions/gossip_propagation_strategy.hpp"
+#include "multi_sig_transactions/mst_processor_impl.hpp"
+#include "multi_sig_transactions/mst_time_provider_impl.hpp"
+#include "multi_sig_transactions/storage/mst_storage_impl.hpp"
+#include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 #include "network/block_loader.hpp"
 #include "network/consensus_gate.hpp"
 #include "network/ordering_gate.hpp"
@@ -106,6 +111,8 @@ class Irohad {
 
   virtual void initPeerCommunicationService();
 
+  virtual void initMstProcessor();
+
   virtual void initTransactionCommandService();
 
   virtual void initQueryService();
@@ -161,6 +168,9 @@ class Irohad {
 
   // pcs
   std::shared_ptr<iroha::network::PeerCommunicationService> pcs;
+
+  // mst
+  std::shared_ptr<iroha::MstProcessor> mst_proc;
 
   // transaction service
   std::unique_ptr<torii::CommandService> command_service;

--- a/irohad/model/operators/hash.hpp
+++ b/irohad/model/operators/hash.hpp
@@ -20,7 +20,7 @@
 
 #include <functional>
 #include <string>
-#include "multi_sig_transactions/mst_types.hpp"
+#include "model/types.hpp"
 
 namespace iroha {
   namespace model {

--- a/irohad/model/transaction_response.hpp
+++ b/irohad/model/transaction_response.hpp
@@ -48,8 +48,8 @@ namespace iroha {
         ON_PROCESS,
         /// transaction is not in handler map
         NOT_RECEIVED,
-        /// tx is too old
-        EXPIRED,
+        /// tx is expired in mst validation
+        MST_EXPIRED,
       };
 
       Status current_status;

--- a/irohad/model/transaction_response.hpp
+++ b/irohad/model/transaction_response.hpp
@@ -47,10 +47,15 @@ namespace iroha {
         /// transaction is received, but not validated
         ON_PROCESS,
         /// transaction is not in handler map
-        NOT_RECEIVED
+        NOT_RECEIVED,
+        /// tx is too old
+        EXPIRED,
       };
 
-      Status current_status{};
+      Status current_status;
+
+      TransactionResponse(std::string tx_hash, Status stauts)
+          : tx_hash(tx_hash), current_status(stauts) {}
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/transaction_response.hpp
+++ b/irohad/model/transaction_response.hpp
@@ -34,18 +34,23 @@ namespace iroha {
       std::string tx_hash;
 
       enum Status {
-        STATELESS_VALIDATION_FAILED, // stateless validation failed
-        STATELESS_VALIDATION_SUCCESS, // stateless validation passed
-        STATEFUL_VALIDATION_FAILED, // stateful validation failed
-        STATEFUL_VALIDATION_SUCCESS, // stateful validation passed
-        COMMITTED, // tx pipeline succeeded, tx is committed
-        ON_PROCESS, // transaction is received, but not validated
-        NOT_RECEIVED // transaction is not in handler map
+        /// stateless validation failed
+        STATELESS_VALIDATION_FAILED,
+        /// stateless validation passed
+        STATELESS_VALIDATION_SUCCESS,
+        /// stateful validation failed
+        STATEFUL_VALIDATION_FAILED,
+        /// stateful validation passed
+        STATEFUL_VALIDATION_SUCCESS,
+        /// tx pipeline succeeded, tx is committed
+        COMMITTED,
+        /// transaction is received, but not validated
+        ON_PROCESS,
+        /// transaction is not in handler map
+        NOT_RECEIVED
       };
 
-      Status current_status;
-
-      virtual ~TransactionResponse() = default;
+      Status current_status{};
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/types.hpp
+++ b/irohad/model/types.hpp
@@ -15,16 +15,26 @@
  * limitations under the License.
  */
 
-#ifndef IROHA_MST_TYPES_HPP
-#define IROHA_MST_TYPES_HPP
+#ifndef IROHA_MODEL_TYPES_HPP
+#define IROHA_MODEL_TYPES_HPP
 
-#include "model/types.hpp"
+#include <memory>
+#include "model/peer.hpp"
+#include "model/transaction.hpp"
+#include "model/transaction_response.hpp"
 
 namespace iroha {
-  class MstState;
+  using TxType = model::Transaction;
+  using SharedTx = std::shared_ptr<TxType>;
+  using ConstPeer = const model::Peer;
+  using TimeType = model::Transaction::TimeType;
+  using TxResponse = std::shared_ptr<model::TransactionResponse>;
 
-  using ConstRefState = ConstRefT<MstState>;
+  template <typename T>
+  using ConstRefT = const T &;
 
-  using DataType = SharedTx;
+  using ConstRefTransaction = ConstRefT<SharedTx>;
+  using ConstRefPeer = ConstRefT<model::Peer>;
+  using ConstRefTime = ConstRefT<TimeType>;
 }  // namespace iroha
-#endif  // IROHA_MST_TYPES_HPP
+#endif  // IROHA_MODEL_TYPES_HPP

--- a/irohad/multi_sig_transactions/CMakeLists.txt
+++ b/irohad/multi_sig_transactions/CMakeLists.txt
@@ -28,4 +28,5 @@ target_link_libraries(mst_processor
     mst_transport
     mst_state
     logger
+    time64
     )

--- a/irohad/multi_sig_transactions/CMakeLists.txt
+++ b/irohad/multi_sig_transactions/CMakeLists.txt
@@ -28,5 +28,4 @@ target_link_libraries(mst_processor
     mst_transport
     mst_state
     logger
-    time64
     )

--- a/irohad/multi_sig_transactions/impl/mst_processor.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor.cpp
@@ -21,7 +21,7 @@ namespace iroha {
 
   MstProcessor::MstProcessor() { log_ = logger::log("MstProcessor"); }
 
-  void MstProcessor::propagateTransaction(ConstRefTransaction transaction) {
+  void MstProcessor::propagateTransaction(const DataType transaction) {
     this->propagateTransactionImpl(transaction);
   }
 
@@ -30,13 +30,11 @@ namespace iroha {
     return this->onStateUpdateImpl();
   }
 
-  rxcpp::observable<std::shared_ptr<model::Transaction>>
-  MstProcessor::onPreparedTransactions() const {
+  rxcpp::observable<DataType> MstProcessor::onPreparedTransactions() const {
     return this->onPreparedTransactionsImpl();
   }
 
-  rxcpp::observable<std::shared_ptr<model::Transaction>>
-  MstProcessor::onExpiredTransactions() const {
+  rxcpp::observable<DataType> MstProcessor::onExpiredTransactions() const {
     return this->onExpiredTransactionsImpl();
   }
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -48,8 +48,7 @@ namespace iroha {
 
   // -------------------------| MstProcessor override |-------------------------
 
-  auto FairMstProcessor::propagateTransactionImpl(
-      ConstRefTransaction transaction)
+  auto FairMstProcessor::propagateTransactionImpl(const DataType transaction)
       -> decltype(propagateTransaction(transaction)) {
     shareState(storage_->updateOwnState(transaction), transactions_subject_);
     shareState(

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -41,7 +41,7 @@ namespace iroha {
      * participants
      * @param transaction - transaction for propagation
      */
-    void propagateTransaction(ConstRefTransaction transaction);
+    void propagateTransaction(const DataType transaction);
 
     /**
      * Prove updating of state for handling status of signing
@@ -51,12 +51,12 @@ namespace iroha {
     /**
      * Observable emit transactions that prepared to processing in system
      */
-    rxcpp::observable<TransactionType> onPreparedTransactions() const;
+    rxcpp::observable<DataType> onPreparedTransactions() const;
 
     /**
      * Observable emit expired by time transactions
      */
-    rxcpp::observable<TransactionType> onExpiredTransactions() const;
+    rxcpp::observable<DataType> onExpiredTransactions() const;
 
     virtual ~MstProcessor() = default;
 
@@ -69,7 +69,7 @@ namespace iroha {
     /**
      * @see propagateTransaction method
      */
-    virtual auto propagateTransactionImpl(ConstRefTransaction transaction)
+    virtual auto propagateTransactionImpl(DataType transaction)
         -> decltype(propagateTransaction(transaction)) = 0;
 
     /**

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -48,7 +48,7 @@ namespace iroha {
 
     // ------------------------| MstProcessor override |------------------------
 
-    auto propagateTransactionImpl(ConstRefTransaction transaction)
+    auto propagateTransactionImpl(const DataType transaction)
         -> decltype(propagateTransaction(transaction)) override;
 
     auto onStateUpdateImpl() const -> decltype(onStateUpdate()) override;
@@ -90,12 +90,10 @@ namespace iroha {
     rxcpp::subjects::subject<std::shared_ptr<MstState>> state_subject_;
 
     /// use for share completed transactions
-    rxcpp::subjects::subject<std::shared_ptr<model::Transaction>>
-        transactions_subject_;
+    rxcpp::subjects::subject<DataType> transactions_subject_;
 
     /// use for share expired transactions
-    rxcpp::subjects::subject<std::shared_ptr<model::Transaction>>
-        expired_subject_;
+    rxcpp::subjects::subject<DataType> expired_subject_;
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_MST_TIME_PROVIDER_IMPL_HPP
+#define IROHA_MST_TIME_PROVIDER_IMPL_HPP
+
+#include <chrono>
+#include "multi_sig_transactions/mst_time_provider.hpp"
+
+namespace iroha {
+
+  class MstTimeProviderImpl : public MstTimeProvider {
+   public:
+    TimeType getCurrentTime() const override {
+      return std::chrono::system_clock::now().time_since_epoch().count();
+    }
+  };
+}  // namespace iroha
+
+#endif  // IROHA_MST_TIME_PROVIDER_IMPL_HPP

--- a/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_MST_TIME_PROVIDER_IMPL_HPP
 #define IROHA_MST_TIME_PROVIDER_IMPL_HPP
 
-#include <chrono>
 #include "datetime/time.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
 

--- a/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
@@ -18,14 +18,17 @@
 #ifndef IROHA_MST_TIME_PROVIDER_IMPL_HPP
 #define IROHA_MST_TIME_PROVIDER_IMPL_HPP
 
-#include "datetime/time.hpp"
+#include <chrono>
 #include "multi_sig_transactions/mst_time_provider.hpp"
 
 namespace iroha {
 
   class MstTimeProviderImpl : public MstTimeProvider {
    public:
-    TimeType getCurrentTime() const override { return time::now64(); }
+    TimeType getCurrentTime() const override {
+      return std::chrono::system_clock::now().time_since_epoch()
+          / std::chrono::milliseconds(1);
+    }
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_time_provider_impl.hpp
@@ -19,15 +19,14 @@
 #define IROHA_MST_TIME_PROVIDER_IMPL_HPP
 
 #include <chrono>
+#include "datetime/time.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
 
 namespace iroha {
 
   class MstTimeProviderImpl : public MstTimeProvider {
    public:
-    TimeType getCurrentTime() const override {
-      return std::chrono::system_clock::now().time_since_epoch().count();
-    }
+    TimeType getCurrentTime() const override { return time::now64(); }
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -61,9 +61,7 @@ namespace iroha {
         });
   }
 
-  bool MstState::isEmpty() const {
-    return internal_state_.empty();
-  }
+  bool MstState::isEmpty() const { return internal_state_.empty(); }
 
   std::vector<DataType> MstState::getTransactions() const {
     return std::vector<DataType>(internal_state_.begin(),
@@ -103,14 +101,14 @@ namespace iroha {
       return;
     }
 
-    // state already contains transaction, merge signatures
-    (*corresponding)->signatures = merge_unique<iroha::model::SignatureHasher>(
-        (*corresponding)->signatures, rhs_tx->signatures);
+    auto tx = *corresponding;
+    tx->signatures = merge_unique<iroha::model::SignatureHasher>(
+        tx->signatures, rhs_tx->signatures);
 
-    if ((*completer_)(*corresponding)) {
+    if ((*completer_)(tx)) {
       // state already has completed transaction,
       // remove from state and return it
-      out_state += *corresponding;
+      out_state += tx;
       internal_state_.erase(corresponding);
     }
   }

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -101,7 +101,7 @@ namespace iroha {
       return;
     }
 
-    auto tx = *corresponding;
+    auto &tx = *corresponding;
     tx->signatures = merge_unique<iroha::model::SignatureHasher>(
         tx->signatures, rhs_tx->signatures);
 

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -29,8 +29,6 @@
 
 namespace iroha {
 
-  using DataType = TransactionType;
-
   /**
    * Completer is strategy for verification transactions on
    * completeness and expiration

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
@@ -22,7 +22,7 @@
 namespace iroha {
   MstStorage::MstStorage() { log_ = logger::log("MstStorage"); }
 
-  MstState MstStorage::apply(ConstPeer &target_peer,
+  MstState MstStorage::apply(const model::Peer &target_peer,
                              const MstState &new_state) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return applyImpl(target_peer, new_state);
@@ -38,7 +38,7 @@ namespace iroha {
     return getExpiredTransactionsImpl(current_time);
   }
 
-  MstState MstStorage::getDiffState(ConstPeer &target_peer,
+  MstState MstStorage::getDiffState(const model::Peer &target_peer,
                                     const TimeType &current_time) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return getDiffStateImpl(target_peer, current_time);

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
@@ -20,21 +20,20 @@
 #include "multi_sig_transactions/storage/mst_storage.hpp"
 
 namespace iroha {
-  MstStorage::MstStorage() {
-    log_ = logger::log("MstStorage");
-  }
+  MstStorage::MstStorage() { log_ = logger::log("MstStorage"); }
 
-  MstState MstStorage::apply(ConstPeer &target_peer, const MstState &new_state) {
+  MstState MstStorage::apply(ConstPeer &target_peer,
+                             const MstState &new_state) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return applyImpl(target_peer, new_state);
   }
 
-  MstState MstStorage::updateOwnState(const TransactionType &tx) {
+  MstState MstStorage::updateOwnState(const DataType &tx) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return updateOwnStateImpl(std::move(tx));
   }
 
-  MstState MstStorage::getExpiredTransactions(const TimeType &current_time){
+  MstState MstStorage::getExpiredTransactions(const TimeType &current_time) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return getExpiredTransactionsImpl(current_time);
   }
@@ -49,4 +48,4 @@ namespace iroha {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return whatsNewImpl(new_state);
   }
-} // namespace iroha
+}  // namespace iroha

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -44,7 +44,7 @@ namespace iroha {
     return own_state_ += new_state;
   }
 
-  auto MstStorageStateImpl::updateOwnStateImpl(const TransactionType &tx)
+  auto MstStorageStateImpl::updateOwnStateImpl(const DataType &tx)
       -> decltype(updateOwnState(tx)) {
     return own_state_ += tx;
   }

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -20,7 +20,7 @@
 namespace iroha {
   // ------------------------------| private API |------------------------------
 
-  auto MstStorageStateImpl::getState(ConstPeer &target_peer) {
+  auto MstStorageStateImpl::getState(const model::Peer &target_peer) {
     auto target_state_iter = peer_states_.find(target_peer);
     if (target_state_iter == peer_states_.end()) {
       return peer_states_.insert({target_peer, MstState::empty(completer_)})
@@ -36,7 +36,7 @@ namespace iroha {
         completer_(completer),
         own_state_(MstState::empty(completer_)) {}
 
-  auto MstStorageStateImpl::applyImpl(ConstPeer &target_peer,
+  auto MstStorageStateImpl::applyImpl(const model::Peer &target_peer,
                                       const MstState &new_state)
       -> decltype(apply(target_peer, new_state)) {
     auto target_state_iter = getState(target_peer);
@@ -55,7 +55,7 @@ namespace iroha {
     return own_state_.eraseByTime(current_time);
   }
 
-  auto MstStorageStateImpl::getDiffStateImpl(ConstPeer &target_peer,
+  auto MstStorageStateImpl::getDiffStateImpl(const model::Peer &target_peer,
                                              const TimeType &current_time)
       -> decltype(getDiffState(target_peer, current_time)) {
     auto target_current_state_iter = getState(target_peer);

--- a/irohad/multi_sig_transactions/storage/mst_storage.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage.hpp
@@ -42,7 +42,7 @@ namespace iroha {
      * @return State with completed transaction
      * General note: implementation of method covered by lock
      */
-    MstState apply(ConstPeer &target_peer, const MstState &new_state);
+    MstState apply(const model::Peer &target_peer, const MstState &new_state);
 
     /**
      * Provide updating state of current peer with new transaction
@@ -65,7 +65,7 @@ namespace iroha {
      * @return difference between own and target state
      * General note: implementation of method covered by lock
      */
-    MstState getDiffState(ConstPeer &target_peer, const TimeType &current_time);
+    MstState getDiffState(const model::Peer &target_peer, const TimeType &current_time);
 
     /**
      * Return diff between own and new state
@@ -86,7 +86,7 @@ namespace iroha {
     MstStorage();
 
    private:
-    virtual auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
+    virtual auto applyImpl(const model::Peer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) = 0;
 
     virtual auto updateOwnStateImpl(const DataType &tx)
@@ -95,7 +95,7 @@ namespace iroha {
     virtual auto getExpiredTransactionsImpl(const TimeType &current_time)
         -> decltype(getExpiredTransactions(current_time)) = 0;
 
-    virtual auto getDiffStateImpl(ConstPeer &target_peer,
+    virtual auto getDiffStateImpl(const model::Peer &target_peer,
                                   const TimeType &current_time)
         -> decltype(getDiffState(target_peer, current_time)) = 0;
 

--- a/irohad/multi_sig_transactions/storage/mst_storage.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage.hpp
@@ -50,7 +50,7 @@ namespace iroha {
      * @return State with completed transaction
      * General note: implementation of method covered by lock
      */
-    MstState updateOwnState(const TransactionType &tx);
+    MstState updateOwnState(const DataType &tx);
 
     /**
      * Remove expired transactions and return them
@@ -89,7 +89,7 @@ namespace iroha {
     virtual auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) = 0;
 
-    virtual auto updateOwnStateImpl(const TransactionType &tx)
+    virtual auto updateOwnStateImpl(const DataType &tx)
         -> decltype(updateOwnState(tx)) = 0;
 
     virtual auto getExpiredTransactionsImpl(const TimeType &current_time)

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -41,7 +41,7 @@ namespace iroha {
     auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) override;
 
-    auto updateOwnStateImpl(const TransactionType &tx)
+    auto updateOwnStateImpl(const DataType &tx)
         -> decltype(updateOwnState(tx)) override;
 
     auto getExpiredTransactionsImpl(const TimeType &current_time)

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -32,13 +32,13 @@ namespace iroha {
      * @param target_peer - peer for searching
      * @return valid iterator for state of peer
      */
-    auto getState(ConstPeer &target_peer);
+    auto getState(const model::Peer &target_peer);
 
    public:
     // ----------------------------| interface API |----------------------------
     explicit MstStorageStateImpl(const CompleterType &completer);
 
-    auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
+    auto applyImpl(const model::Peer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) override;
 
     auto updateOwnStateImpl(const DataType &tx)
@@ -47,7 +47,7 @@ namespace iroha {
     auto getExpiredTransactionsImpl(const TimeType &current_time)
         -> decltype(getExpiredTransactions(current_time)) override;
 
-    auto getDiffStateImpl(ConstPeer &target_peer, const TimeType &current_time)
+    auto getDiffStateImpl(const model::Peer &target_peer, const TimeType &current_time)
         -> decltype(getDiffState(target_peer, current_time)) override;
 
     auto whatsNewImpl(ConstRefState new_state) const
@@ -57,7 +57,7 @@ namespace iroha {
     // ---------------------------| private fields |----------------------------
 
     const CompleterType completer_;
-    std::unordered_map<ConstPeer, MstState, iroha::model::PeerHasher>
+    std::unordered_map<const model::Peer, MstState, iroha::model::PeerHasher>
         peer_states_;
     MstState own_state_;
   };

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -66,9 +66,9 @@ namespace torii {
           res->second.set_tx_status(
               iroha::protocol::TxStatus::NOT_RECEIVED);
           break;
-        case iroha::model::TransactionResponse::EXPIRED:
+        case iroha::model::TransactionResponse::MST_EXPIRED:
           res->second.set_tx_status(
-              iroha::protocol::TxStatus::EXPIRED);
+              iroha::protocol::TxStatus::MST_EXPIRED);
           break;
       }
 

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -66,6 +66,10 @@ namespace torii {
           res->second.set_tx_status(
               iroha::protocol::TxStatus::NOT_RECEIVED);
           break;
+        case iroha::model::TransactionResponse::EXPIRED:
+          res->second.set_tx_status(
+              iroha::protocol::TxStatus::EXPIRED);
+          break;
       }
 
       this->handler_map_.insert({iroha_response->tx_hash, res->second});

--- a/irohad/torii/processor/CMakeLists.txt
+++ b/irohad/torii/processor/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(processors PUBLIC
     logger
     endpoint
     mst_processor
+    ${BOOST_LIBRARIES}
     )

--- a/irohad/torii/processor/CMakeLists.txt
+++ b/irohad/torii/processor/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(processors PUBLIC
     stateless_validator
     logger
     endpoint
+    mst_processor
     )

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -53,56 +53,34 @@ namespace iroha {
         }
       });
 
-      const auto notify_success = [this](const auto &tx) {
-        auto h = hash(tx).to_string();
-        this->proposal_set_.erase(h);
-        this->candidate_set_.insert(h);
-        this->notifier_.get_subscriber().on_next(
-            std::make_shared<TransactionResponse>(TransactionResponse{
-                h,
-                Status::STATEFUL_VALIDATION_SUCCESS,
-            }));
-      };
-
-      const auto notify_committed = [this](const auto &h) {
-        this->notifier_.get_subscriber().on_next(
-            std::make_shared<TransactionResponse>(
-                TransactionResponse{h, Status::COMMITTED}));
-      };
-
-      const auto notify_fail = [this](const auto &h) {
-        this->notifier_.get_subscriber().on_next(
-            std::make_shared<TransactionResponse>(
-                TransactionResponse{h, Status::STATEFUL_VALIDATION_FAILED}));
-      };
-
       // move commited txs from proposal to candidate map
-      pcs_->on_commit().subscribe([this, notify_success, notify_fail,
-                                   notify_committed](auto blocks) {
+      pcs_->on_commit().subscribe([this](auto blocks) {
         blocks.subscribe(
             // on next..
-            [this, notify_success](auto block) {
+            [this](auto block) {
               const auto in_proposal = [this](const auto &tx) {
                 return this->proposal_set_.count(hash(tx).to_string());
               };
               boost::for_each(
                   block.transactions | boost::adaptors::filtered(in_proposal),
-                  notify_success);
+                  [this](auto &t) { return this->notify_success(t); });
             },
             // on complete
-            [this, notify_fail, notify_committed]() {
-              boost::for_each(this->proposal_set_, notify_fail);
+            [this]() {
+              boost::for_each(this->proposal_set_,
+                              [this](auto &t) { return this->notify_fail(t); });
               this->proposal_set_.clear();
-              boost::for_each(this->candidate_set_, notify_committed);
+              boost::for_each(this->candidate_set_, [this](auto &t) {
+                return this->notify_commit(t);
+              });
               this->candidate_set_.clear();
             });
       });
 
       mst_proc_->onPreparedTransactions().subscribe(
-          [notify_success](auto tx) { return notify_success(*tx); });
-      mst_proc_->onExpiredTransactions().subscribe([notify_fail](auto tx) {
-        return notify_fail(hash(*tx).to_string());
-      });
+          [this](auto tx) { return this->notify_success(*tx); });
+      mst_proc_->onExpiredTransactions().subscribe(
+          [this](auto tx) { return this->notify_fail(hash(*tx).to_string()); });
     }
 
     void TransactionProcessorImpl::transactionHandle(
@@ -138,5 +116,26 @@ namespace iroha {
       return notifier_.get_observable();
     }
 
+    template <typename Model>
+    void TransactionProcessorImpl::notify_success(Model &&m) {
+      auto h = hash(m).to_string();
+      this->proposal_set_.erase(h);
+      this->candidate_set_.insert(h);
+      this->notifier_.get_subscriber().on_next(
+          std::make_shared<TransactionResponse>(TransactionResponse{
+              h,
+              Status::STATEFUL_VALIDATION_SUCCESS,
+          }));
+    }
+    void TransactionProcessorImpl::notify_commit(const std::string &hash) {
+      this->notifier_.get_subscriber().on_next(
+          std::make_shared<TransactionResponse>(
+              TransactionResponse{hash, Status::COMMITTED}));
+    }
+    void TransactionProcessorImpl::notify_fail(const std::string &hash) {
+      this->notifier_.get_subscriber().on_next(
+          std::make_shared<TransactionResponse>(
+              TransactionResponse{hash, Status::STATEFUL_VALIDATION_FAILED}));
+    }
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -78,7 +78,7 @@ namespace iroha {
       });
 
       mst_proc_->onPreparedTransactions().subscribe(
-          [this](auto tx) { return this->notify_success(*tx); });
+          [this](auto tx) { return this->transactionHandle(tx); });
       mst_proc_->onExpiredTransactions().subscribe(
           [this](auto tx) { return this->notify_fail(hash(*tx).to_string()); });
     }
@@ -92,16 +92,10 @@ namespace iroha {
       // TODO: nice place for code linearizing
       if (validator_->validate(*transaction)) {
         response.current_status = Status::STATELESS_VALIDATION_SUCCESS;
-        switch (transaction->signatures.size()) {
-          case 0:
-            response.current_status = Status::STATELESS_VALIDATION_FAILED;
-            break;
-          case 1:
-            pcs_->propagate_transaction(transaction);
-            break;
-          default:
-            mst_proc_->propagateTransaction(transaction);
-            break;
+        if (transaction->signatures.size() < transaction->quorum) {
+          mst_proc_->propagateTransaction(transaction);
+        } else {
+          pcs_->propagate_transaction(transaction);
         }
       }
       log_->info(

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -53,7 +53,7 @@ namespace iroha {
         }
       });
 
-      static const auto notify_success = [this](const auto &tx) {
+      const auto notify_success = [this](const auto &tx) {
         auto h = hash(tx).to_string();
         this->proposal_set_.erase(h);
         this->candidate_set_.insert(h);
@@ -64,18 +64,19 @@ namespace iroha {
             }));
       };
 
-      static const auto notify_fail = [this](const auto &h) {
+      const auto notify_fail = [this](const auto &h) {
         this->notifier_.get_subscriber().on_next(
             std::make_shared<TransactionResponse>(
                 TransactionResponse{h, Status::STATEFUL_VALIDATION_FAILED}));
       };
 
       // move commited txs from proposal to candidate map
-      pcs_->on_commit().subscribe([this](auto blocks) {
+      pcs_->on_commit().subscribe([this, notify_success,
+                                   notify_fail](auto blocks) {
         blocks.subscribe(
             // on next..
-            [this](auto block) {
-              static const auto in_proposal = [this](const auto &tx) {
+            [this, notify_success](auto block) {
+              const auto in_proposal = [this](const auto &tx) {
                 return this->proposal_set_.count(hash(tx).to_string());
               };
               boost::for_each(
@@ -83,7 +84,7 @@ namespace iroha {
                   notify_success);
             },
             // on complete
-            [this]() {
+            [this, notify_fail]() {
               boost::for_each(
                   boost::join(this->proposal_set_, this->candidate_set_),
                   notify_fail);
@@ -93,9 +94,10 @@ namespace iroha {
       });
 
       mst_proc_->onPreparedTransactions().subscribe(
-          [](auto tx) { return notify_success(*tx); });
-      mst_proc_->onExpiredTransactions().subscribe(
-          [](auto tx) { return notify_fail(hash(*tx).to_string()); });
+          [notify_success](auto tx) { return notify_success(*tx); });
+      mst_proc_->onExpiredTransactions().subscribe([notify_fail](auto tx) {
+        return notify_fail(hash(*tx).to_string());
+      });
     }
 
     void TransactionProcessorImpl::transactionHandle(

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-#include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/algorithm/for_each.hpp>
-#include <boost/range/join.hpp>
+#include "torii/processor/transaction_processor_impl.hpp"
+
 #include <iostream>
 #include <utility>
+
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/algorithm/for_each.hpp>
 
 #include "crypto/hash.hpp"
 #include "endpoint.pb.h"
 #include "model/transaction_response.hpp"
-#include "torii/processor/transaction_processor_impl.hpp"
 
 namespace iroha {
   namespace torii {
@@ -37,19 +38,17 @@ namespace iroha {
     TransactionProcessorImpl::TransactionProcessorImpl(
         std::shared_ptr<PeerCommunicationService> pcs,
         std::shared_ptr<StatelessValidator> validator,
-        std::shared_ptr<MstProcessor> mst_proc)
+        std::shared_ptr<MstProcessor> mst_processor)
         : pcs_(std::move(pcs)),
           validator_(std::move(validator)),
-          mst_proc_(std::move(mst_proc)) {
+          mst_processor_(std::move(mst_processor)) {
       log_ = logger::log("TxProcessor");
 
       // insert all txs from proposal to proposal set
       pcs_->on_proposal().subscribe([this](model::Proposal proposal) {
         for (const auto &tx : proposal.transactions) {
           proposal_set_.insert(hash(tx).to_string());
-          notifier_.get_subscriber().on_next(
-              std::make_shared<TransactionResponse>(TransactionResponse{
-                  hash(tx).to_string(), Status::STATELESS_VALIDATION_SUCCESS}));
+          notify(hash(tx).to_string(), Status::STATELESS_VALIDATION_SUCCESS);
         }
       });
 
@@ -57,54 +56,53 @@ namespace iroha {
       pcs_->on_commit().subscribe([this](auto blocks) {
         blocks.subscribe(
             // on next..
-            [this](auto block) {
+            [this](auto &&block) {
               const auto in_proposal = [this](const auto &tx) {
                 return this->proposal_set_.count(hash(tx).to_string());
               };
               boost::for_each(
                   block.transactions | boost::adaptors::filtered(in_proposal),
-                  [this](auto &t) { return this->notify_success(t); });
+                  [this](auto &t) { this->notify_success(t); });
             },
             // on complete
             [this]() {
-              boost::for_each(this->proposal_set_,
-                              [this](auto &t) { return this->notify_fail(t); });
+              boost::for_each(this->proposal_set_, [this](auto &t) {
+                return this->notify(t, Status::STATEFUL_VALIDATION_FAILED);
+              });
               this->proposal_set_.clear();
               boost::for_each(this->candidate_set_, [this](auto &t) {
-                return this->notify_commit(t);
+                return this->notify(t, Status::COMMITTED);
               });
               this->candidate_set_.clear();
             });
       });
 
-      mst_proc_->onPreparedTransactions().subscribe(
-          [this](auto tx) { return this->transactionHandle(tx); });
-      mst_proc_->onExpiredTransactions().subscribe(
-          [this](auto tx) { return this->notify_fail(hash(*tx).to_string()); });
+      mst_processor_->onPreparedTransactions().subscribe(
+          [this](auto &&tx) { return this->transactionHandle(tx); });
+      mst_processor_->onExpiredTransactions().subscribe([this](auto &&tx) {
+        return this->notify(hash(*tx).to_string(), Status::EXPIRED);
+      });
     }
 
     void TransactionProcessorImpl::transactionHandle(
         ConstRefTransaction transaction) {
       log_->info("handle transaction");
-      TransactionResponse response{hash(*transaction).to_string(),
-                                   Status::STATELESS_VALIDATION_FAILED};
+      auto h = hash(*transaction).to_string();
 
-      // TODO: nice place for code linearizing
-      if (validator_->validate(*transaction)) {
-        response.current_status = Status::STATELESS_VALIDATION_SUCCESS;
-        if (transaction->signatures.size() < transaction->quorum) {
-          log_->info("retrieving signatures for quorum");
-          mst_proc_->propagateTransaction(transaction);
-        } else {
-          log_->info("propagating tx");
-          pcs_->propagate_transaction(transaction);
-        }
+      if (!validator_->validate(*transaction)) {
+        log_->info("stateless validation failed");
+        notify(h, Status::STATELESS_VALIDATION_FAILED);
+        return;
       }
-      log_->info(
-          "stateless validation status: {}",
-          response.current_status == Status::STATELESS_VALIDATION_SUCCESS);
-      notifier_.get_subscriber().on_next(
-          std::make_shared<TransactionResponse>(response));
+
+      if (transaction->signatures.size() < transaction->quorum) {
+        log_->info("waiting for quorum signatures");
+        mst_processor_->propagateTransaction(transaction);
+      } else {
+        log_->info("propagating tx");
+        pcs_->propagate_transaction(transaction);
+      }
+      notify(h, Status::STATELESS_VALIDATION_SUCCESS);
     }
 
     rxcpp::observable<TxResponse>
@@ -115,23 +113,14 @@ namespace iroha {
     template <typename Model>
     void TransactionProcessorImpl::notify_success(Model &&m) {
       auto h = hash(m).to_string();
-      this->proposal_set_.erase(h);
-      this->candidate_set_.insert(h);
-      this->notifier_.get_subscriber().on_next(
-          std::make_shared<TransactionResponse>(TransactionResponse{
-              h,
-              Status::STATEFUL_VALIDATION_SUCCESS,
-          }));
+      proposal_set_.erase(h);
+      candidate_set_.insert(h);
+      notify(h, Status::STATEFUL_VALIDATION_SUCCESS);
     }
-    void TransactionProcessorImpl::notify_commit(const std::string &hash) {
-      this->notifier_.get_subscriber().on_next(
-          std::make_shared<TransactionResponse>(
-              TransactionResponse{hash, Status::COMMITTED}));
-    }
-    void TransactionProcessorImpl::notify_fail(const std::string &hash) {
-      this->notifier_.get_subscriber().on_next(
-          std::make_shared<TransactionResponse>(
-              TransactionResponse{hash, Status::STATEFUL_VALIDATION_FAILED}));
+
+    void TransactionProcessorImpl::notify(const std::string &hash, Status s) {
+      notifier_.get_subscriber().on_next(
+          std::make_shared<TransactionResponse>(hash, s));
     }
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -93,8 +93,10 @@ namespace iroha {
       if (validator_->validate(*transaction)) {
         response.current_status = Status::STATELESS_VALIDATION_SUCCESS;
         if (transaction->signatures.size() < transaction->quorum) {
+          log_->info("retrieving signatures for quorum");
           mst_proc_->propagateTransaction(transaction);
         } else {
+          log_->info("propagating tx");
           pcs_->propagate_transaction(transaction);
         }
       }

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -85,7 +85,7 @@ namespace iroha {
       mst_processor_->onPreparedTransactions().subscribe(
           [this](auto &&tx) { return this->transactionHandle(tx); });
       mst_processor_->onExpiredTransactions().subscribe([this](auto &&tx) {
-        return this->notify(hash(*tx).to_string(), Status::EXPIRED);
+        return this->notify(hash(*tx).to_string(), Status::MST_EXPIRED);
       });
     }
 

--- a/irohad/torii/processor/transaction_processor.hpp
+++ b/irohad/torii/processor/transaction_processor.hpp
@@ -18,9 +18,9 @@
 #ifndef IROHA_TRANSACTION_PROCESSOR_HPP
 #define IROHA_TRANSACTION_PROCESSOR_HPP
 
-#include <rxcpp/rx.hpp>
-#include <model/transaction.hpp>
 #include <model/client.hpp>
+#include <model/transaction.hpp>
+#include <rxcpp/rx.hpp>
 #include "model/transaction_response.hpp"
 
 namespace iroha {
@@ -32,19 +32,17 @@ namespace iroha {
      */
     class TransactionProcessor {
      public:
-
       /**
        * Add transaction to the system for processing
        * @param transaction - transaction for processing
        */
-      virtual void transactionHandle(std::shared_ptr<model::Transaction> transaction) = 0;
+      virtual void transactionHandle(ConstRefTransaction transaction) = 0;
 
       /**
        * Subscribers will be notified with transaction status
        * @return observable for subscribing
        */
-      virtual rxcpp::observable<std::shared_ptr<model::TransactionResponse>>
-      transactionNotifier() = 0;
+      virtual rxcpp::observable<TxResponse> transactionNotifier() = 0;
 
       virtual ~TransactionProcessor() = default;
     };

--- a/irohad/torii/processor/transaction_processor.hpp
+++ b/irohad/torii/processor/transaction_processor.hpp
@@ -18,10 +18,11 @@
 #ifndef IROHA_TRANSACTION_PROCESSOR_HPP
 #define IROHA_TRANSACTION_PROCESSOR_HPP
 
-#include <model/client.hpp>
-#include <model/transaction.hpp>
 #include <rxcpp/rx.hpp>
+#include "model/client.hpp"
+#include "model/transaction.hpp"
 #include "model/transaction_response.hpp"
+#include "model/types.hpp"
 
 namespace iroha {
   namespace torii {

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -39,7 +39,7 @@ namespace iroha {
       TransactionProcessorImpl(
           std::shared_ptr<network::PeerCommunicationService> pcs,
           std::shared_ptr<validation::StatelessValidator> validator,
-          std::shared_ptr<MstProcessor> mst_proc);
+          std::shared_ptr<MstProcessor> mst_processor);
 
       void transactionHandle(ConstRefTransaction transaction) override;
 
@@ -52,7 +52,7 @@ namespace iroha {
       // processing
       std::shared_ptr<validation::StatelessValidator> validator_;
 
-      std::shared_ptr<MstProcessor> mst_proc_;
+      std::shared_ptr<MstProcessor> mst_processor_;
 
       std::unordered_set<std::string> proposal_set_;
       std::unordered_set<std::string> candidate_set_;
@@ -62,10 +62,13 @@ namespace iroha {
 
       logger::Logger log_;
 
+      /// Notify validated tx and remove it from internal sets
       template <typename Model>
       void notify_success(Model &&m);
-      void notify_commit(const std::string &hash);
-      void notify_fail(const std::string &hash);
+
+      /// Wrapper on notifying on some hash
+      void notify(const std::string &hash,
+                  model::TransactionResponse::Status s);
     };
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -20,6 +20,7 @@
 
 #include "logger/logger.hpp"
 #include "model/transaction_response.hpp"
+#include "model/types.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "network/peer_communication_service.hpp"
 #include "torii/processor/transaction_processor.hpp"
@@ -40,11 +41,9 @@ namespace iroha {
           std::shared_ptr<validation::StatelessValidator> validator,
           std::shared_ptr<MstProcessor> mst_proc);
 
-      void transactionHandle(
-          std::shared_ptr<model::Transaction> transaction) override;
+      void transactionHandle(ConstRefTransaction transaction) override;
 
-      rxcpp::observable<std::shared_ptr<model::TransactionResponse>>
-      transactionNotifier() override;
+      rxcpp::observable<TxResponse> transactionNotifier() override;
 
      private:
       // connections
@@ -59,8 +58,7 @@ namespace iroha {
       std::unordered_set<std::string> candidate_set_;
 
       // internal
-      rxcpp::subjects::subject<std::shared_ptr<model::TransactionResponse>>
-          notifier_;
+      rxcpp::subjects::subject<TxResponse> notifier_;
 
       logger::Logger log_;
     };

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -62,10 +62,6 @@ namespace iroha {
 
       logger::Logger log_;
 
-      /// Notify validated tx and remove it from internal sets
-      template <typename Model>
-      void notify_success(Model &&m);
-
       /// Wrapper on notifying on some hash
       void notify(const std::string &hash,
                   model::TransactionResponse::Status s);

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -61,6 +61,11 @@ namespace iroha {
       rxcpp::subjects::subject<TxResponse> notifier_;
 
       logger::Logger log_;
+
+      template <typename Model>
+      void notify_success(Model &&m);
+      void notify_commit(const std::string &hash);
+      void notify_fail(const std::string &hash);
     };
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -18,11 +18,12 @@
 #ifndef IROHA_TRANSACTION_PROCESSOR_STUB_HPP
 #define IROHA_TRANSACTION_PROCESSOR_STUB_HPP
 
-#include <model/transaction_response.hpp>
-#include <network/peer_communication_service.hpp>
-#include <torii/processor/transaction_processor.hpp>
-#include <validation/stateless_validator.hpp>
 #include "logger/logger.hpp"
+#include "model/transaction_response.hpp"
+#include "multi_sig_transactions/mst_processor.hpp"
+#include "network/peer_communication_service.hpp"
+#include "torii/processor/transaction_processor.hpp"
+#include "validation/stateless_validator.hpp"
 
 namespace iroha {
   namespace torii {
@@ -36,7 +37,8 @@ namespace iroha {
        */
       TransactionProcessorImpl(
           std::shared_ptr<network::PeerCommunicationService> pcs,
-          std::shared_ptr<validation::StatelessValidator> validator);
+          std::shared_ptr<validation::StatelessValidator> validator,
+          std::shared_ptr<MstProcessor> mst_proc);
 
       void transactionHandle(
           std::shared_ptr<model::Transaction> transaction) override;
@@ -50,6 +52,8 @@ namespace iroha {
 
       // processing
       std::shared_ptr<validation::StatelessValidator> validator_;
+
+      std::shared_ptr<MstProcessor> mst_proc_;
 
       std::unordered_set<std::string> proposal_set_;
       std::unordered_set<std::string> candidate_set_;

--- a/schema/endpoint.proto
+++ b/schema/endpoint.proto
@@ -16,6 +16,7 @@ enum TxStatus {
   COMMITTED = 4;
   ON_PROCESS = 5;
   NOT_RECEIVED = 6;
+  EXPIRED = 7;
 }
 
 message ToriiResponse {

--- a/schema/endpoint.proto
+++ b/schema/endpoint.proto
@@ -16,7 +16,7 @@ enum TxStatus {
   COMMITTED = 4;
   ON_PROCESS = 5;
   NOT_RECEIVED = 6;
-  EXPIRED = 7;
+  MST_EXPIRED = 7;
 }
 
 message ToriiResponse {

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-#include <endpoint.pb.h>
-#include <responses.pb.h>
+#include "endpoint.pb.h"
+#include "responses.pb.h"
 
 #include "client.hpp"
 
 #include "crypto/hash.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
-#include "module/irohad/torii/torii_mocks.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include "main/server_runner.hpp"
@@ -57,7 +57,7 @@ class ClientServerTest : public testing::Test {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<MockPeerCommunicationService>();
       svMock = std::make_shared<MockStatelessValidator>();
-      mst = std::make_shared<iroha::torii::MockMstProcessorDummy>();
+      mst = std::make_shared<iroha::MockMstProcessor>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
@@ -115,7 +115,7 @@ class ClientServerTest : public testing::Test {
   std::thread th;
   std::shared_ptr<MockPeerCommunicationService> pcsMock;
   std::shared_ptr<MockStatelessValidator> svMock;
-  std::shared_ptr<iroha::torii::MockMstProcessorDummy> mst;
+  std::shared_ptr<iroha::MockMstProcessor> mst;
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
+#include <endpoint.pb.h>
 #include <responses.pb.h>
 
-#include <endpoint.pb.h>
+#include "client.hpp"
 
 #include "crypto/hash.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
+#include "module/irohad/torii/torii_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
-
-#include "client.hpp"
 
 #include "main/server_runner.hpp"
 #include "torii/processor/query_processor_impl.hpp"
@@ -37,10 +37,10 @@
 constexpr const char *Ip = "0.0.0.0";
 constexpr int Port = 50051;
 
-using ::testing::Return;
 using ::testing::A;
-using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::Return;
+using ::testing::_;
 
 using namespace iroha::ametsuchi;
 using namespace iroha::network;
@@ -51,12 +51,13 @@ class ClientServerTest : public testing::Test {
  public:
   virtual void SetUp() {
     // Run a server
-    runner = std::make_unique<ServerRunner>(std::string(Ip) + ":" +
-                                            std::to_string(Port));
+    runner = std::make_unique<ServerRunner>(std::string(Ip) + ":"
+                                            + std::to_string(Port));
     th = std::thread([this] {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<MockPeerCommunicationService>();
       svMock = std::make_shared<MockStatelessValidator>();
+      mst = std::make_shared<iroha::torii::MockMstProcessorDummy>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
@@ -71,7 +72,7 @@ class ClientServerTest : public testing::Test {
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock,
-                                                                   svMock);
+                                                                   svMock, mst);
       auto pb_tx_factory =
           std::make_shared<iroha::model::converters::PbTransactionFactory>();
       auto command_service =
@@ -108,6 +109,7 @@ class ClientServerTest : public testing::Test {
   std::thread th;
   std::shared_ptr<MockPeerCommunicationService> pcsMock;
   std::shared_ptr<MockStatelessValidator> svMock;
+  std::shared_ptr<iroha::torii::MockMstProcessorDummy> mst;
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -63,12 +63,18 @@ class ClientServerTest : public testing::Test {
 
       rxcpp::subjects::subject<iroha::model::Proposal> prop_notifier;
       rxcpp::subjects::subject<Commit> commit_notifier;
+      rxcpp::subjects::subject<iroha::DataType> mst_prepared_notifier;
+      rxcpp::subjects::subject<iroha::DataType> mst_expired_notifier;
 
       EXPECT_CALL(*pcsMock, on_proposal())
           .WillRepeatedly(Return(prop_notifier.get_observable()));
-
       EXPECT_CALL(*pcsMock, on_commit())
           .WillRepeatedly(Return(commit_notifier.get_observable()));
+
+      EXPECT_CALL(*mst, onPreparedTransactionsImpl())
+          .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
+      EXPECT_CALL(*mst, onExpiredTransactionsImpl())
+          .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock,

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -19,6 +19,7 @@
 #define IROHA_MST_MOCKS_HPP
 
 #include <gmock/gmock.h>
+#include "multi_sig_transactions/mst_processor.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
@@ -58,6 +59,16 @@ namespace iroha {
   class MockTimeProvider : public MstTimeProvider {
    public:
     MOCK_CONST_METHOD0(getCurrentTime, TimeType());
+  };
+
+  struct MockMstProcessor : public MstProcessor {
+    MOCK_METHOD1(propagateTransactionImpl, void(const DataType));
+    MOCK_CONST_METHOD0(onStateUpdateImpl,
+                       rxcpp::observable<std::shared_ptr<MstState>>());
+    MOCK_CONST_METHOD0(onPreparedTransactionsImpl,
+                       rxcpp::observable<DataType>());
+    MOCK_CONST_METHOD0(onExpiredTransactionsImpl,
+                       rxcpp::observable<DataType>());
   };
 }  // namespace iroha
 #endif  // IROHA_MST_MOCKS_HPP

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -28,7 +28,8 @@ namespace iroha {
 
   class MockMstTransport : public network::MstTransport {
    public:
-    MOCK_METHOD1(subscribe, void(std::shared_ptr<network::MstTransportNotification>));
+    MOCK_METHOD1(subscribe,
+                 void(std::shared_ptr<network::MstTransportNotification>));
     MOCK_METHOD2(sendState,
                  void(const model::Peer &to, const MstState &providing_state));
   };

--- a/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
@@ -98,7 +98,8 @@ auto initObservers(shared_ptr<FairMstProcessor> mst_processor, int a, int b,
 /*
  * Make sure that observables in the valid state
  */
-template <typename T> void check(T &t) {
+template <typename T>
+void check(T &t) {
   ASSERT_TRUE(std::get<0>(t).validate());
   ASSERT_TRUE(std::get<1>(t).validate());
   ASSERT_TRUE(std::get<2>(t).validate());

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -127,9 +127,8 @@ TEST_F(TransactionProcessorTest, MultisigTransaction) {
       .WillRepeatedly(Return(true));
 
   auto tx = std::make_shared<Transaction>();
-  // ensure that we have multiple signatures
-  tx->signatures.emplace_back();
-  tx->signatures.emplace_back();
+  // ensure we have bigger quorum than signatures
+  tx->quorum = 2;
 
   auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
   wrapper.subscribe([](auto response) {

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -43,12 +43,18 @@ class TransactionProcessorTest : public ::testing::Test {
 
     rxcpp::subjects::subject<Proposal> prop_notifier;
     rxcpp::subjects::subject<Commit> commit_notifier;
+    rxcpp::subjects::subject<DataType> mst_notifier;
 
     EXPECT_CALL(*pcs, on_proposal())
         .WillRepeatedly(Return(prop_notifier.get_observable()));
 
     EXPECT_CALL(*pcs, on_commit())
         .WillRepeatedly(Return(commit_notifier.get_observable()));
+
+    EXPECT_CALL(*mp, onPreparedTransactionsImpl())
+        .WillRepeatedly(Return(mst_notifier.get_observable()));
+    EXPECT_CALL(*mp, onExpiredTransactionsImpl())
+        .WillRepeatedly(Return(mst_notifier.get_observable()));
 
     tp = std::make_shared<TransactionProcessorImpl>(pcs, validation, mp);
   }
@@ -62,14 +68,15 @@ class TransactionProcessorTest : public ::testing::Test {
 /**
  * Transaction processor test case, when handling stateless valid transaction
  */
-TEST_F(TransactionProcessorTest,
-       TransactionProcessorWhereInvokeValidTransaction) {
+TEST_F(TransactionProcessorTest, ValidTransaction) {
+  EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(0);
   EXPECT_CALL(*pcs, propagate_transaction(_)).Times(1);
 
   EXPECT_CALL(*validation, validate(A<const Transaction &>()))
       .WillRepeatedly(Return(true));
 
   auto tx = std::make_shared<Transaction>();
+  tx->signatures.emplace_back();
 
   auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
   wrapper.subscribe([](auto response) {
@@ -85,8 +92,8 @@ TEST_F(TransactionProcessorTest,
 /**
  * Transaction processor test case, when handling invalid transaction
  */
-TEST_F(TransactionProcessorTest,
-       TransactionProcessorWhereInvokeInvalidTransaction) {
+TEST_F(TransactionProcessorTest, InvalidTransaction) {
+  EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(0);
   EXPECT_CALL(*pcs, propagate_transaction(_)).Times(0);
 
   EXPECT_CALL(*validation, validate(A<const Transaction &>()))
@@ -95,12 +102,40 @@ TEST_F(TransactionProcessorTest,
       .WillRepeatedly(Return(false));
 
   auto tx = std::make_shared<Transaction>();
+  tx->signatures.emplace_back();
 
   auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
   wrapper.subscribe([](auto response) {
     auto resp = static_cast<TransactionResponse &>(*response);
     ASSERT_EQ(resp.current_status,
               TransactionResponse::STATELESS_VALIDATION_FAILED);
+  });
+  tp->transactionHandle(tx);
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @when propagate tx with multiple signature
+ * @then it goes to mst and doesn't go to PeerCommunicationService
+ */
+TEST_F(TransactionProcessorTest, MultisigTransaction) {
+  EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(1);
+  EXPECT_CALL(*pcs, propagate_transaction(_)).Times(0);
+
+  EXPECT_CALL(*validation, validate(A<const Transaction &>()))
+      .WillRepeatedly(Return(true));
+
+  auto tx = std::make_shared<Transaction>();
+  // ensure that we have multiple signatures
+  tx->signatures.emplace_back();
+  tx->signatures.emplace_back();
+
+  auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
+  wrapper.subscribe([](auto response) {
+    auto resp = static_cast<TransactionResponse &>(*response);
+    ASSERT_EQ(resp.current_status,
+              TransactionResponse::STATELESS_VALIDATION_SUCCESS);
   });
   tp->transactionHandle(tx);
 

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
-#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include "framework/test_subscriber.hpp"
@@ -155,7 +155,7 @@ TEST_F(TransactionProcessorTest, MultisigTransaction) {
 /**
  * @given multisig tx and permanently true tx validator
  * @when transaction_processor handle it
- * @then ensure after expiring it leads to EXPIRED status
+ * @then ensure after expiring it leads to MST_EXPIRED status
  */
 TEST_F(TransactionProcessorTest, MultisigExpired) {
   EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(1);
@@ -174,7 +174,7 @@ TEST_F(TransactionProcessorTest, MultisigExpired) {
     auto resp = static_cast<TransactionResponse &>(*response);
     ASSERT_EQ(resp.current_status,
               idx++ == 0 ? TransactionResponse::STATELESS_VALIDATION_SUCCESS
-                         : TransactionResponse::EXPIRED);
+                         : TransactionResponse::MST_EXPIRED);
   });
   tp->transactionHandle(tx);
   mst_expired_notifier.get_subscriber().on_next(tx);

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "module/irohad/network/network_mocks.hpp"
+#include "module/irohad/torii/torii_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include "torii/processor/transaction_processor_impl.hpp"
@@ -29,9 +30,9 @@ using namespace iroha::torii;
 using namespace iroha::model;
 using namespace framework::test_subscriber;
 
+using ::testing::A;
 using ::testing::Return;
 using ::testing::_;
-using ::testing::A;
 
 class TransactionProcessorTest : public ::testing::Test {
  public:
@@ -39,6 +40,7 @@ class TransactionProcessorTest : public ::testing::Test {
   void SetUp() override {
     pcs = std::make_shared<MockPeerCommunicationService>();
     validation = std::make_shared<MockStatelessValidator>();
+    mp = std::make_shared<MockMstProcessorDummy>();
 
     rxcpp::subjects::subject<iroha::model::Proposal> prop_notifier;
     rxcpp::subjects::subject<Commit> commit_notifier;
@@ -51,12 +53,13 @@ class TransactionProcessorTest : public ::testing::Test {
                 on_commit())
         .WillRepeatedly(Return(commit_notifier.get_observable()));
 
-    tp = std::make_shared<TransactionProcessorImpl>(pcs, validation);
+    tp = std::make_shared<TransactionProcessorImpl>(pcs, validation, mp);
   }
 
   std::shared_ptr<MockPeerCommunicationService> pcs;
   std::shared_ptr<MockStatelessValidator> validation;
   std::shared_ptr<TransactionProcessorImpl> tp;
+  std::shared_ptr<MockMstProcessorDummy> mp;
 };
 
 /**

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -43,21 +43,22 @@ class TransactionProcessorTest : public ::testing::Test {
 
     rxcpp::subjects::subject<Proposal> prop_notifier;
     rxcpp::subjects::subject<Commit> commit_notifier;
-    rxcpp::subjects::subject<DataType> mst_notifier;
 
     EXPECT_CALL(*pcs, on_proposal())
         .WillRepeatedly(Return(prop_notifier.get_observable()));
-
     EXPECT_CALL(*pcs, on_commit())
         .WillRepeatedly(Return(commit_notifier.get_observable()));
 
     EXPECT_CALL(*mp, onPreparedTransactionsImpl())
-        .WillRepeatedly(Return(mst_notifier.get_observable()));
+        .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
     EXPECT_CALL(*mp, onExpiredTransactionsImpl())
-        .WillRepeatedly(Return(mst_notifier.get_observable()));
+        .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
 
     tp = std::make_shared<TransactionProcessorImpl>(pcs, validation, mp);
   }
+
+  rxcpp::subjects::subject<iroha::DataType> mst_prepared_notifier;
+  rxcpp::subjects::subject<iroha::DataType> mst_expired_notifier;
 
   std::shared_ptr<MockPeerCommunicationService> pcs;
   std::shared_ptr<MockStatelessValidator> validation;
@@ -116,10 +117,44 @@ TEST_F(TransactionProcessorTest, InvalidTransaction) {
 }
 
 /**
- * @when propagate tx with multiple signature
- * @then it goes to mst and doesn't go to PeerCommunicationService
+ * @given multisig tx
+ * @when propagate it with big quorum
+ * @then it goes to mst and after signing goes to PeerCommunicationService
  */
 TEST_F(TransactionProcessorTest, MultisigTransaction) {
+  EXPECT_CALL(*mp, propagateTransactionImpl(_))
+      .Times(1)
+      .WillRepeatedly(testing::Invoke([](auto &tx) {
+        tx->signatures.emplace_back();
+        tx->signatures.emplace_back();
+      }));
+  EXPECT_CALL(*pcs, propagate_transaction(_)).Times(1);
+
+  EXPECT_CALL(*validation, validate(A<const Transaction &>()))
+      .WillRepeatedly(Return(true));
+
+  auto tx = std::make_shared<Transaction>();
+  // ensure we have bigger quorum than signatures
+  tx->quorum = 2;
+
+  auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 2);
+  wrapper.subscribe([](auto response) {
+    auto resp = static_cast<TransactionResponse &>(*response);
+    ASSERT_EQ(resp.current_status,
+              TransactionResponse::STATELESS_VALIDATION_SUCCESS);
+  });
+  tp->transactionHandle(tx);
+  mst_prepared_notifier.get_subscriber().on_next(tx);
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @given multisig tx
+ * @when propagate it with big quorum
+ * @then ensure after expiring it leads to STATEFUL_VALIDATION_FAILED
+ */
+TEST_F(TransactionProcessorTest, MultisigExpired) {
   EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(1);
   EXPECT_CALL(*pcs, propagate_transaction(_)).Times(0);
 
@@ -130,13 +165,16 @@ TEST_F(TransactionProcessorTest, MultisigTransaction) {
   // ensure we have bigger quorum than signatures
   tx->quorum = 2;
 
-  auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
+  auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 2);
   wrapper.subscribe([](auto response) {
+    static int idx = 0;
     auto resp = static_cast<TransactionResponse &>(*response);
     ASSERT_EQ(resp.current_status,
-              TransactionResponse::STATELESS_VALIDATION_SUCCESS);
+              idx++ == 0 ? TransactionResponse::STATELESS_VALIDATION_SUCCESS
+                         : TransactionResponse::STATEFUL_VALIDATION_FAILED);
   });
   tp->transactionHandle(tx);
+  mst_expired_notifier.get_subscriber().on_next(tx);
 
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -68,7 +68,9 @@ class TransactionProcessorTest : public ::testing::Test {
 };
 
 /**
- * Transaction processor test case, when handling stateless valid transaction
+ * @given simple tx and permanently true tx validator
+ * @when transaction_processor handle it
+ * @then it returns STATELESS_VALIDATION_SUCCESS
  */
 TEST_F(TransactionProcessorTest, ValidTransaction) {
   EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(0);
@@ -92,7 +94,9 @@ TEST_F(TransactionProcessorTest, ValidTransaction) {
 }
 
 /**
- * Transaction processor test case, when handling invalid transaction
+ * @given simple tx and permanently false tx validator
+ * @when transaction_processor handle it
+ * @then it returns STATELESS_VALIDATION_FAILED
  */
 TEST_F(TransactionProcessorTest, InvalidTransaction) {
   EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(0);
@@ -116,8 +120,8 @@ TEST_F(TransactionProcessorTest, InvalidTransaction) {
 }
 
 /**
- * @given multisig tx
- * @when propagate it with big quorum
+ * @given multisig tx and permanently true tx validator
+ * @when transaction_processor handle it
  * @then it goes to mst and after signing goes to PeerCommunicationService
  */
 TEST_F(TransactionProcessorTest, MultisigTransaction) {
@@ -149,8 +153,8 @@ TEST_F(TransactionProcessorTest, MultisigTransaction) {
 }
 
 /**
- * @given multisig tx
- * @when propagate it with big quorum
+ * @given multisig tx and permanently true tx validator
+ * @when transaction_processor handle it
  * @then ensure after expiring it leads to EXPIRED status
  */
 TEST_F(TransactionProcessorTest, MultisigExpired) {

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -17,6 +17,7 @@
 
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include "framework/test_subscriber.hpp"
@@ -39,7 +40,7 @@ class TransactionProcessorTest : public ::testing::Test {
   void SetUp() override {
     pcs = std::make_shared<MockPeerCommunicationService>();
     validation = std::make_shared<MockStatelessValidator>();
-    mp = std::make_shared<MockMstProcessorDummy>();
+    mp = std::make_shared<MockMstProcessor>();
 
     rxcpp::subjects::subject<Proposal> prop_notifier;
     rxcpp::subjects::subject<Commit> commit_notifier;
@@ -63,7 +64,7 @@ class TransactionProcessorTest : public ::testing::Test {
   std::shared_ptr<MockPeerCommunicationService> pcs;
   std::shared_ptr<MockStatelessValidator> validation;
   std::shared_ptr<TransactionProcessorImpl> tp;
-  std::shared_ptr<MockMstProcessorDummy> mp;
+  std::shared_ptr<MockMstProcessor> mp;
 };
 
 /**
@@ -152,7 +153,7 @@ TEST_F(TransactionProcessorTest, MultisigTransaction) {
 /**
  * @given multisig tx
  * @when propagate it with big quorum
- * @then ensure after expiring it leads to STATEFUL_VALIDATION_FAILED
+ * @then ensure after expiring it leads to EXPIRED status
  */
 TEST_F(TransactionProcessorTest, MultisigExpired) {
   EXPECT_CALL(*mp, propagateTransactionImpl(_)).Times(1);
@@ -171,7 +172,7 @@ TEST_F(TransactionProcessorTest, MultisigExpired) {
     auto resp = static_cast<TransactionResponse &>(*response);
     ASSERT_EQ(resp.current_status,
               idx++ == 0 ? TransactionResponse::STATELESS_VALIDATION_SUCCESS
-                         : TransactionResponse::STATEFUL_VALIDATION_FAILED);
+                         : TransactionResponse::EXPIRED);
   });
   tp->transactionHandle(tx);
   mst_expired_notifier.get_subscriber().on_next(tx);

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -100,8 +100,6 @@ TEST_F(TransactionProcessorTest, InvalidTransaction) {
 
   EXPECT_CALL(*validation, validate(A<const Transaction &>()))
       .WillRepeatedly(Return(false));
-  EXPECT_CALL(*validation, validate(A<std::shared_ptr<const Query>>()))
-      .WillRepeatedly(Return(false));
 
   auto tx = std::make_shared<Transaction>();
   tx->signatures.emplace_back();

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_TORII_MOCKS_HPP
 #define IROHA_TORII_MOCKS_HPP
 
-#include "multi_sig_transactions/mst_processor.hpp"
 #include "torii/processor/query_processor.hpp"
 
 #include <gmock/gmock.h>
@@ -30,16 +29,6 @@ namespace iroha {
       MOCK_METHOD1(queryHandle, void(std::shared_ptr<model::Query>));
       MOCK_METHOD0(queryNotifier,
                    rxcpp::observable<std::shared_ptr<model::QueryResponse>>());
-    };
-
-    struct MockMstProcessorDummy : public MstProcessor {
-      MOCK_METHOD1(propagateTransactionImpl, void(const DataType));
-      MOCK_CONST_METHOD0(onStateUpdateImpl,
-                         rxcpp::observable<std::shared_ptr<MstState>>());
-      MOCK_CONST_METHOD0(onPreparedTransactionsImpl,
-                         rxcpp::observable<DataType>());
-      MOCK_CONST_METHOD0(onExpiredTransactionsImpl,
-                         rxcpp::observable<DataType>());
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_TORII_MOCKS_HPP
 #define IROHA_TORII_MOCKS_HPP
 
+#include "multi_sig_transactions/mst_processor.hpp"
 #include "torii/processor/query_processor.hpp"
 
 #include <gmock/gmock.h>
@@ -29,6 +30,16 @@ namespace iroha {
       MOCK_METHOD1(queryHandle, void(std::shared_ptr<model::Query>));
       MOCK_METHOD0(queryNotifier,
                    rxcpp::observable<std::shared_ptr<model::QueryResponse>>());
+    };
+
+    class MockMstProcessorDummy : public MstProcessor {
+      MOCK_METHOD1(propagateTransactionImpl, void(ConstRefTransaction));
+      MOCK_CONST_METHOD0(onStateUpdateImpl,
+                         rxcpp::observable<std::shared_ptr<MstState>>());
+      MOCK_CONST_METHOD0(onPreparedTransactionsImpl,
+                         rxcpp::observable<TransactionType>());
+      MOCK_CONST_METHOD0(onExpiredTransactionsImpl,
+                         rxcpp::observable<TransactionType>());
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -33,13 +33,13 @@ namespace iroha {
     };
 
     class MockMstProcessorDummy : public MstProcessor {
-      MOCK_METHOD1(propagateTransactionImpl, void(ConstRefTransaction));
+      MOCK_METHOD1(propagateTransactionImpl, void(DataType));
       MOCK_CONST_METHOD0(onStateUpdateImpl,
                          rxcpp::observable<std::shared_ptr<MstState>>());
       MOCK_CONST_METHOD0(onPreparedTransactionsImpl,
-                         rxcpp::observable<TransactionType>());
+                         rxcpp::observable<DataType>());
       MOCK_CONST_METHOD0(onExpiredTransactionsImpl,
-                         rxcpp::observable<TransactionType>());
+                         rxcpp::observable<DataType>());
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -32,8 +32,8 @@ namespace iroha {
                    rxcpp::observable<std::shared_ptr<model::QueryResponse>>());
     };
 
-    class MockMstProcessorDummy : public MstProcessor {
-      MOCK_METHOD1(propagateTransactionImpl, void(DataType));
+    struct MockMstProcessorDummy : public MstProcessor {
+      MOCK_METHOD1(propagateTransactionImpl, void(const DataType));
       MOCK_CONST_METHOD0(onStateUpdateImpl,
                          rxcpp::observable<std::shared_ptr<MstState>>());
       MOCK_CONST_METHOD0(onPreparedTransactionsImpl,

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -60,12 +60,18 @@ class ToriiQueriesTest : public testing::Test {
 
       rxcpp::subjects::subject<iroha::model::Proposal> prop_notifier;
       rxcpp::subjects::subject<Commit> commit_notifier;
+      rxcpp::subjects::subject<iroha::DataType> mst_prepared_notifier;
+      rxcpp::subjects::subject<iroha::DataType> mst_expired_notifier;
 
       EXPECT_CALL(*pcsMock, on_proposal())
           .WillRepeatedly(Return(prop_notifier.get_observable()));
-
       EXPECT_CALL(*pcsMock, on_commit())
           .WillRepeatedly(Return(commit_notifier.get_observable()));
+
+      EXPECT_CALL(*mst, onPreparedTransactionsImpl())
+          .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
+      EXPECT_CALL(*mst, onExpiredTransactionsImpl())
+          .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <generator/generator.hpp>
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
+#include "module/irohad/torii/torii_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 // to compare pb amount and iroha amount
@@ -35,14 +36,15 @@ constexpr size_t TimesToriiBlocking = 5;
 constexpr size_t TimesToriiNonBlocking = 5;
 constexpr size_t TimesFind = 1;
 
-using ::testing::Return;
 using ::testing::A;
-using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::Return;
+using ::testing::_;
 
 using namespace iroha::network;
 using namespace iroha::validation;
 using namespace iroha::ametsuchi;
+using namespace iroha::torii;
 
 class ToriiQueriesTest : public testing::Test {
  public:
@@ -52,6 +54,7 @@ class ToriiQueriesTest : public testing::Test {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<MockPeerCommunicationService>();
       statelessValidatorMock = std::make_shared<MockStatelessValidator>();
+      mst = std::make_shared<MockMstProcessorDummy>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
@@ -66,7 +69,7 @@ class ToriiQueriesTest : public testing::Test {
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(
-              pcsMock, statelessValidatorMock);
+              pcsMock, statelessValidatorMock, mst);
       auto pb_tx_factory =
           std::make_shared<iroha::model::converters::PbTransactionFactory>();
 
@@ -107,6 +110,7 @@ class ToriiQueriesTest : public testing::Test {
 
   std::shared_ptr<MockPeerCommunicationService> pcsMock;
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
+  std::shared_ptr<MockMstProcessorDummy> mst;
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 // to compare pb amount and iroha amount
@@ -54,7 +55,7 @@ class ToriiQueriesTest : public testing::Test {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<MockPeerCommunicationService>();
       statelessValidatorMock = std::make_shared<MockStatelessValidator>();
-      mst = std::make_shared<MockMstProcessorDummy>();
+      mst = std::make_shared<iroha::MockMstProcessor>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
@@ -116,7 +117,7 @@ class ToriiQueriesTest : public testing::Test {
 
   std::shared_ptr<MockPeerCommunicationService> pcsMock;
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
-  std::shared_ptr<MockMstProcessorDummy> mst;
+  std::shared_ptr<iroha::MockMstProcessor> mst;
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include <endpoint.pb.h>
@@ -85,7 +86,7 @@ class ToriiServiceTest : public testing::Test {
       pcsMock = std::make_shared<CustomPeerCommunicationServiceMock>(
           prop_notifier_, commit_notifier_);
       statelessValidatorMock = std::make_shared<MockStatelessValidator>();
-      mst = std::make_shared<MockMstProcessorDummy>();
+      mst = std::make_shared<iroha::MockMstProcessor>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
@@ -143,7 +144,7 @@ class ToriiServiceTest : public testing::Test {
 
   std::shared_ptr<CustomPeerCommunicationServiceMock> pcsMock;
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
-  std::shared_ptr<MockMstProcessorDummy> mst;
+  std::shared_ptr<iroha::MockMstProcessor> mst;
 };
 
 TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "model/converters/pb_transaction_factory.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
+#include "module/irohad/torii/torii_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 
 #include <endpoint.pb.h>
@@ -41,14 +42,15 @@ constexpr size_t TimesToriiBlocking = 5;
 constexpr size_t TimesToriiNonBlocking = 5;
 constexpr size_t TimesFind = 10;
 
-using ::testing::Return;
 using ::testing::A;
-using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::Return;
+using ::testing::_;
 
 using namespace iroha::network;
 using namespace iroha::validation;
 using namespace iroha::ametsuchi;
+using namespace iroha::torii;
 
 using Commit = rxcpp::observable<iroha::model::Block>;
 
@@ -83,12 +85,13 @@ class ToriiServiceTest : public testing::Test {
       pcsMock = std::make_shared<CustomPeerCommunicationServiceMock>(
           prop_notifier_, commit_notifier_);
       statelessValidatorMock = std::make_shared<MockStatelessValidator>();
+      mst = std::make_shared<MockMstProcessorDummy>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(
-              pcsMock, statelessValidatorMock);
+              pcsMock, statelessValidatorMock, mst);
       auto pb_tx_factory =
           std::make_shared<iroha::model::converters::PbTransactionFactory>();
       auto command_service =
@@ -133,6 +136,7 @@ class ToriiServiceTest : public testing::Test {
 
   std::shared_ptr<CustomPeerCommunicationServiceMock> pcsMock;
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
+  std::shared_ptr<MockMstProcessorDummy> mst;
 };
 
 TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -89,6 +89,11 @@ class ToriiServiceTest : public testing::Test {
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
 
+      EXPECT_CALL(*mst, onPreparedTransactionsImpl())
+          .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
+      EXPECT_CALL(*mst, onExpiredTransactionsImpl())
+          .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
+
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(
               pcsMock, statelessValidatorMock, mst);
@@ -133,6 +138,8 @@ class ToriiServiceTest : public testing::Test {
 
   rxcpp::subjects::subject<iroha::model::Proposal> prop_notifier_;
   rxcpp::subjects::subject<Commit> commit_notifier_;
+  rxcpp::subjects::subject<iroha::DataType> mst_prepared_notifier;
+  rxcpp::subjects::subject<iroha::DataType> mst_expired_notifier;
 
   std::shared_ptr<CustomPeerCommunicationServiceMock> pcsMock;
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;


### PR DESCRIPTION
In this PR TransactionProcessorImpl is able to handle multisignature transaction.

Some refactoring was done in c52c95c, there should be no (hopefully) logic changes. List of refactorings:
- Most of the types was moved out from mst_types to model ones
- Mst is fixed for using it's own type `DataType`, that basically an alias for `std::shared_ptr<iroha::model::Transaction>`
- In mst state is made an explicit copy of tx
- [tx_processor](https://github.com/hyperledger/iroha/pull/690/commits/c52c95cb42ecdd04e3f5bd3cd359e2f4aa8942b7#diff-2555aa1c75c15355ee489fce2274d681) code was shortened of boost (`join`, `for_each`, `adaptor::filtered`)
- also in [tx_processor](https://github.com/hyperledger/iroha/pull/690/commits/c52c95cb42ecdd04e3f5bd3cd359e2f4aa8942b7#diff-2555aa1c75c15355ee489fce2274d681) `TransactionResponse` is inlined, where it's possible

This also introduces a check of tx' [signatures](https://github.com/hyperledger/iroha/pull/690/files#diff-2555aa1c75c15355ee489fce2274d681R110), that also a good point for discussion

Note that it doesn't built due issue related FairMstProcessor problems usage (that's because of MstStorageStateImpl because of Peer, if you care). If you'd like to test you may build&run following targets:
- transaction_processor_test
- mst_processor_test
- maybe some other that I missed