### PR TITLE
Remove own peer identification from mst_storage;

### DIFF
--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -30,8 +30,11 @@ namespace iroha {
   }
   // -----------------------------| interface API |-----------------------------
 
-  MstStorageStateImpl::MstStorageStateImpl(const CompleterType &completer)
-      : MstStorage(), completer_(completer), own_state_(MstState::empty(completer_)) {}
+  MstStorageStateImpl::MstStorageStateImpl(
+      const CompleterType &completer)
+      : MstStorage(),
+        completer_(completer),
+        own_state_(MstState::empty(completer_)) {}
 
   auto MstStorageStateImpl::applyImpl(ConstPeer &target_peer,
                                       const MstState &new_state)

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -30,13 +30,8 @@ namespace iroha {
   }
   // -----------------------------| interface API |-----------------------------
 
-  MstStorageStateImpl::MstStorageStateImpl(ConstPeer &own_peer,
-                                           const CompleterType &completer)
-      : MstStorage(),
-        own_peer_(own_peer),
-        completer_(completer),
-        own_state_(peer_states_.insert({own_peer_, MstState::empty(completer_)})
-                       .first->second) {}
+  MstStorageStateImpl::MstStorageStateImpl(const CompleterType &completer)
+      : MstStorage(), completer_(completer), own_state_(MstState::empty(completer_)) {}
 
   auto MstStorageStateImpl::applyImpl(ConstPeer &target_peer,
                                       const MstState &new_state)

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -36,7 +36,7 @@ namespace iroha {
 
    public:
     // ----------------------------| interface API |----------------------------
-    MstStorageStateImpl(ConstPeer &own_peer, const CompleterType &completer);
+    MstStorageStateImpl(const CompleterType &completer);
 
     auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) override;
@@ -56,12 +56,10 @@ namespace iroha {
    private:
     // ---------------------------| private fields |----------------------------
 
+    const CompleterType completer_;
     std::unordered_map<ConstPeer, MstState, iroha::model::PeerHasher>
         peer_states_;
-    ConstPeer own_peer_;
-    const CompleterType completer_;
-
-    MstState &own_state_;
+    MstState own_state_;
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -36,7 +36,7 @@ namespace iroha {
 
    public:
     // ----------------------------| interface API |----------------------------
-    MstStorageStateImpl(const CompleterType &completer);
+    explicit MstStorageStateImpl(const CompleterType &completer);
 
     auto applyImpl(ConstPeer &target_peer, const MstState &new_state)
         -> decltype(apply(target_peer, new_state)) override;

--- a/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
@@ -48,7 +48,6 @@ class MstProcessorTest : public testing::Test {
  public:
   // --------------------------------| fields |---------------------------------
 
-  Peer own_peer = makePeer("iam", "1");
   /// propagation subject, useful for propagation control
   rxcpp::subjects::subject<PropagationStrategy::PropagationData>
       propagation_subject;
@@ -65,8 +64,7 @@ class MstProcessorTest : public testing::Test {
  protected:
   void SetUp() override {
     transport = make_shared<MockMstTransport>();
-    storage = make_shared<MstStorageStateImpl>(own_peer,
-                                               make_shared<TestCompleter>());
+    storage = make_shared<MstStorageStateImpl>(make_shared<TestCompleter>());
 
     propagation_strategy = make_shared<MockPropagationStrategy>();
     EXPECT_CALL(*propagation_strategy, emitter())

--- a/test/module/irohad/multi_sig_transactions/storage_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/storage_test.cpp
@@ -16,10 +16,10 @@
  */
 
 #include <gtest/gtest.h>
-#include "logger/logger.hpp"
-#include "multi_sig_transactions/storage/mst_storage_impl.hpp"
-#include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include <memory>
+#include "logger/logger.hpp"
+#include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
+#include "multi_sig_transactions/storage/mst_storage_impl.hpp"
 
 auto log_ = logger::log("MstStorageTest");
 
@@ -27,21 +27,18 @@ using namespace iroha;
 
 class StorageTestCompleter : public DefaultCompleter {
  public:
-  bool operator()(const DataType &tx,
-                  const TimeType &time) const override {
+  bool operator()(const DataType &tx, const TimeType &time) const override {
     return tx->created_ts < time;
   }
 };
 
 class StorageTest : public testing::Test {
  public:
-  StorageTest() : my_peer(makePeer("1", "1")),
-                  absent_peer(makePeer("absent", "absent")) {}
+  StorageTest() : absent_peer(makePeer("absent", "absent")) {}
 
   void SetUp() override {
-    storage = make_shared<MstStorageStateImpl>(my_peer,
-                                               std::make_shared<
-                                                   StorageTestCompleter>());
+    storage = make_shared<MstStorageStateImpl>(
+        std::make_shared<StorageTestCompleter>());
     fillOwnState();
   }
 
@@ -52,7 +49,6 @@ class StorageTest : public testing::Test {
   }
 
   shared_ptr<MstStorage> storage;
-  iroha::model::Peer my_peer;
   iroha::model::Peer absent_peer;
 
   static const auto quorum = 3u;
@@ -60,8 +56,9 @@ class StorageTest : public testing::Test {
 };
 
 TEST_F(StorageTest, StorageWhenApplyOtherState) {
-  log_->info("create state with default peers and other state => "
-                 "apply state");
+  log_->info(
+      "create state with default peers and other state => "
+      "apply state");
 
   auto new_state = MstState::empty(std::make_shared<StorageTestCompleter>());
   new_state += makeTx("5", "5", quorum, creation_time);
@@ -70,34 +67,43 @@ TEST_F(StorageTest, StorageWhenApplyOtherState) {
 
   storage->apply(makePeer("another", "another"), new_state);
 
-  ASSERT_EQ(6, storage->getDiffState(absent_peer, creation_time)
-      .getTransactions().size());
+  ASSERT_EQ(6,
+            storage->getDiffState(absent_peer, creation_time)
+                .getTransactions()
+                .size());
 }
 
 TEST_F(StorageTest, StorageInsertOtherState) {
   log_->info("init fixture state => get expired state");
 
-  ASSERT_EQ(3, storage->getExpiredTransactions(creation_time + 1)
-      .getTransactions().size());
-  ASSERT_EQ(0, storage->getDiffState(absent_peer, creation_time + 1)
-      .getTransactions().size());
-
+  ASSERT_EQ(3,
+            storage->getExpiredTransactions(creation_time + 1)
+                .getTransactions()
+                .size());
+  ASSERT_EQ(0,
+            storage->getDiffState(absent_peer, creation_time + 1)
+                .getTransactions()
+                .size());
 }
 
 TEST_F(StorageTest, StorageWhenCreateValidDiff) {
   log_->info("insert transactions => check their presence");
 
-  ASSERT_EQ(3, storage->getDiffState(absent_peer, creation_time)
-      .getTransactions().size());
-
+  ASSERT_EQ(3,
+            storage->getDiffState(absent_peer, creation_time)
+                .getTransactions()
+                .size());
 }
 
 TEST_F(StorageTest, StorageWhenCreate) {
-  log_->info("insert transactions => wait until expiring => "
-                 " check their absence");
+  log_->info(
+      "insert transactions => wait until expiring => "
+      " check their absence");
 
   auto expiration_time = creation_time + 1;
 
-  ASSERT_EQ(0, storage->getDiffState(absent_peer, expiration_time)
-      .getTransactions().size());
+  ASSERT_EQ(0,
+            storage->getDiffState(absent_peer, expiration_time)
+                .getTransactions()
+                .size());
 }


### PR DESCRIPTION
## What is this pull request?
This PR provides the fix of dependencies of MST storage. There is no reason for identification own peer in storage.
   
## Why do you implement it? Why do we need this pull request?
This fix was required to integrate MST processor to transaction processor.
 
