### PR TITLE
Feature/get transactions block query

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -49,37 +49,37 @@ namespace iroha {
        */
       virtual rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           const std::string &account_id, const std::string &asset_id) = 0;
-      
+
       /**
        * Get transactions from transactions' hashes
        * @param tx_hashes - transactions' hashes to retrieve
        * @return observable of Model Transaction
        */
-      virtual rxcpp::observable<model::Transaction> getTransactions(
-          const std::vector<iroha::hash256_t> &tx_hashes) = 0;
+      virtual rxcpp::observable<boost::optional<model::Transaction>>
+      getTransactions(const std::vector<iroha::hash256_t> &tx_hashes) = 0;
 
       /**
-      * Get given number of blocks starting with given height.
-      * @param height - starting height
-      * @param count - number of blocks to retrieve
-      * @return observable of Model Block
-      */
+       * Get given number of blocks starting with given height.
+       * @param height - starting height
+       * @param count - number of blocks to retrieve
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getBlocks(uint32_t height,
                                                         uint32_t count) = 0;
 
       /**
-      * Get all blocks starting from given height.
-      * @param from - starting height
-      * @return observable of Model Block
-      */
+       * Get all blocks starting from given height.
+       * @param from - starting height
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getBlocksFrom(
           uint32_t height) = 0;
 
       /**
-      * Get given number of blocks from top.
-      * @param count - number of blocks to retrieve
-      * @return observable of Model Block
-      */
+       * Get given number of blocks from top.
+       * @param count - number of blocks to retrieve
+       * @return observable of Model Block
+       */
       virtual rxcpp::observable<model::Block> getTopBlocks(uint32_t count) = 0;
 
       /**

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -49,6 +49,14 @@ namespace iroha {
        */
       virtual rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           const std::string &account_id, const std::string &asset_id) = 0;
+      
+      /**
+       * Get transactions from transactions' hashes
+       * @param tx_hashes - transactions' hashes to retrieve
+       * @return observable of Model Transaction
+       */
+      virtual rxcpp::observable<model::Transaction> getTransactions(
+          const std::vector<iroha::hash256_t> &tx_hashes) = 0;
 
       /**
       * Get given number of blocks starting with given height.

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -170,17 +170,18 @@ namespace iroha {
           });
     }
 
-    rxcpp::observable<model::Transaction> RedisBlockQuery::getTransactions(
+    rxcpp::observable<nonstd::optional<model::Transaction>>
+    RedisBlockQuery::getTransactions(
         const std::vector<iroha::hash256_t> &tx_hashes) {
-      return rxcpp::observable<>::create<model::Transaction>(
+      return rxcpp::observable<>::create<nonstd::optional<model::Transaction>>(
           [this, tx_hashes](auto subscriber) {
-            std::for_each(
-                tx_hashes.begin(),
-                tx_hashes.end(),
-                [ that = this, &subscriber ](auto tx_hash) {
-                  auto tx = that->getTxByHashSync(tx_hash.to_string());
-                  subscriber.on_next(tx.value_or(iroha::model::Transaction{}));
-                });
+            std::for_each(tx_hashes.begin(),
+                          tx_hashes.end(),
+                          [ that = this, &subscriber ](auto tx_hash) {
+                            auto tx =
+                                that->getTxByHashSync(tx_hash.to_string());
+                            subscriber.on_next(tx);
+                          });
             subscriber.on_completed();
           });
     }

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -170,6 +170,21 @@ namespace iroha {
           });
     }
 
+    rxcpp::observable<model::Transaction> RedisBlockQuery::getTransactions(
+        const std::vector<iroha::hash256_t> &tx_hashes) {
+      return rxcpp::observable<>::create<model::Transaction>(
+          [this, tx_hashes](auto subscriber) {
+            std::for_each(
+                tx_hashes.begin(),
+                tx_hashes.end(),
+                [ that = this, &subscriber ](auto tx_hash) {
+                  auto tx = that->getTxByHashSync(tx_hash.to_string());
+                  subscriber.on_next(tx.value_or(iroha::model::Transaction{}));
+                });
+            subscriber.on_completed();
+          });
+    }
+
     boost::optional<model::Transaction> RedisBlockQuery::getTxByHashSync(
         const std::string &hash) {
       return getBlockId(hash) |

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -170,10 +170,10 @@ namespace iroha {
           });
     }
 
-    rxcpp::observable<nonstd::optional<model::Transaction>>
+    rxcpp::observable<boost::optional<model::Transaction>>
     RedisBlockQuery::getTransactions(
         const std::vector<iroha::hash256_t> &tx_hashes) {
-      return rxcpp::observable<>::create<nonstd::optional<model::Transaction>>(
+      return rxcpp::observable<>::create<boost::optional<model::Transaction>>(
           [this, tx_hashes](auto subscriber) {
             std::for_each(tx_hashes.begin(),
                           tx_hashes.end(),

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -178,9 +178,8 @@ namespace iroha {
             std::for_each(tx_hashes.begin(),
                           tx_hashes.end(),
                           [ that = this, &subscriber ](auto tx_hash) {
-                            auto tx =
-                                that->getTxByHashSync(tx_hash.to_string());
-                            subscriber.on_next(tx);
+                            subscriber.on_next(
+                                that->getTxByHashSync(tx_hash.to_string()));
                           });
             subscriber.on_completed();
           });

--- a/irohad/ametsuchi/impl/redis_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_block_query.hpp
@@ -41,8 +41,8 @@ namespace iroha {
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           const std::string &account_id, const std::string &asset_id) override;
 
-      rxcpp::observable<model::Transaction> getTransactions(
-        const std::vector<iroha::hash256_t> &tx_hashes) override;
+      rxcpp::observable<nonstd::optional<model::Transaction>> getTransactions(
+          const std::vector<iroha::hash256_t> &tx_hashes) override;
 
       boost::optional<model::Transaction> getTxByHashSync(
           const std::string &hash) override;

--- a/irohad/ametsuchi/impl/redis_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_block_query.hpp
@@ -41,7 +41,7 @@ namespace iroha {
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           const std::string &account_id, const std::string &asset_id) override;
 
-      rxcpp::observable<nonstd::optional<model::Transaction>> getTransactions(
+      rxcpp::observable<boost::optional<model::Transaction>> getTransactions(
           const std::vector<iroha::hash256_t> &tx_hashes) override;
 
       boost::optional<model::Transaction> getTxByHashSync(

--- a/irohad/ametsuchi/impl/redis_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_block_query.hpp
@@ -41,6 +41,9 @@ namespace iroha {
       rxcpp::observable<model::Transaction> getAccountAssetTransactions(
           const std::string &account_id, const std::string &asset_id) override;
 
+      rxcpp::observable<model::Transaction> getTransactions(
+        const std::vector<iroha::hash256_t> &tx_hashes) override;
+
       boost::optional<model::Transaction> getTxByHashSync(
           const std::string &hash) override;
 

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -114,10 +114,9 @@ namespace iroha {
           getAccountAssetTransactions,
           rxcpp::observable<model::Transaction>(const std::string &account_id,
                                                 const std::string &asset_id));
-      MOCK_METHOD1(
-        getTransactions, rxcpp::observable<model::Transaction>(
-        const std::vector<iroha::hash256_t> &tx_hashes));
-
+      MOCK_METHOD1(getTransactions,
+                   rxcpp::observable<boost::optional<model::Transaction>>(
+                     const std::vector<iroha::hash256_t> &tx_hashes));
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
       MOCK_METHOD1(getBlocksFrom, rxcpp::observable<model::Block>(uint32_t));

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -114,6 +114,10 @@ namespace iroha {
           getAccountAssetTransactions,
           rxcpp::observable<model::Transaction>(const std::string &account_id,
                                                 const std::string &asset_id));
+      MOCK_METHOD1(
+        getTransactions, rxcpp::observable<model::Transaction>(
+        const std::vector<iroha::hash256_t> &tx_hashes));
+
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
       MOCK_METHOD1(getBlocksFrom, rxcpp::observable<model::Block>(uint32_t));

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -37,10 +37,12 @@ class BlockQueryTest : public AmetsuchiTest {
     // First transaction in block1
     Transaction txn1_1;
     txn1_1.creator_account_id = creator1;
+    tx_hashes.push_back(iroha::hash(txn1_1));
 
     // Second transaction in block1
     Transaction txn1_2;
     txn1_2.creator_account_id = creator1;
+    tx_hashes.push_back(iroha::hash(txn1_2));
 
     Block block1;
     block1.height = 1;
@@ -51,11 +53,13 @@ class BlockQueryTest : public AmetsuchiTest {
     // First tx in block 1
     Transaction txn2_1;
     txn2_1.creator_account_id = creator1;
+    tx_hashes.push_back(iroha::hash(txn2_1));
 
     // Second tx in block 2
     Transaction txn2_2;
     // this tx has another creator
     txn2_2.creator_account_id = creator2;
+    tx_hashes.push_back(iroha::hash(txn2_2));
 
     Block block2;
     block2.height = 2;
@@ -69,6 +73,7 @@ class BlockQueryTest : public AmetsuchiTest {
     storage->commit(std::move(ms));
   }
 
+  std::vector<iroha::hash256_t> tx_hashes;
   std::shared_ptr<StorageImpl> storage;
   std::shared_ptr<BlockQuery> blocks;
   std::string creator1 = "user1@test";
@@ -119,4 +124,71 @@ TEST_F(BlockQueryTest, GetAccountTransactionsNonExistingUser) {
       blocks->getAccountTransactions("nonexisting user"), 0);
   getNonexistingTxWrapper.subscribe();
   ASSERT_TRUE(getNonexistingTxWrapper.validate());
+}
+
+/**
+ * @given block store with 2 blocks totally containing 3 txs created by
+ * user1@test
+ * AND 1 tx created by user2@test
+ * @when query to get transactions with transactions' hashes
+ * @then queried transactions
+ */
+TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
+  //TODO 15/11/17 motxx - Use EqualList VerificationStrategy
+  {
+    auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTransactions(tx_hashes), 4);
+    wrapper.subscribe();
+    ASSERT_TRUE(wrapper.validate());
+  }
+  {
+    auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTransactions({tx_hashes[1], tx_hashes[3]}), 2);
+    wrapper.subscribe();
+    ASSERT_TRUE(wrapper.validate());
+  }
+}
+
+/**
+ * @given block store with 2 blocks totally containing 3 txs created by
+ * user1@test
+ * AND 1 tx created by user2@test
+ * @when query to get transactions with non-existing transaction hashes
+ * @then queried transactions and empty transaction
+ */
+TEST_F(BlockQueryTest, GetTransactionsIncludesNonExistingTxHashes) {
+  iroha::hash256_t invalid_tx_hash_1, invalid_tx_hash_2;
+  invalid_tx_hash_1[0] = 1;
+  invalid_tx_hash_2[0] = 2;
+  {
+    auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTransactions({invalid_tx_hash_1, invalid_tx_hash_2}), 2);
+    wrapper.subscribe([](auto transaction) {
+      iroha::model::Transaction expected{};
+      EXPECT_EQ(expected, transaction);
+    });
+    ASSERT_TRUE(wrapper.validate());
+  }
+  {
+    // transactions' hashes are empty.
+    auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTransactions({}), 0);
+    wrapper.subscribe();
+    ASSERT_TRUE(wrapper.validate());
+  }
+  {
+    //TODO 15/11/17 motxx - Use EqualList VerificationStrategy
+    auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTransactions({invalid_tx_hash_1, tx_hashes[0]}), 2);
+    auto subs_cnt = 0;
+    wrapper.subscribe([this, &subs_cnt](auto transaction) {
+      if (subs_cnt == 0) {
+        iroha::model::Transaction expected{};
+        EXPECT_EQ(expected, transaction);
+      } else {
+        EXPECT_EQ(tx_hashes[0], iroha::hash(transaction));
+      }
+    });
+    ASSERT_TRUE(wrapper.validate());
+  }
 }

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -131,8 +131,8 @@ TEST_F(BlockQueryTest, GetAccountTransactionsNonExistingUser) {
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test
  * AND 1 tx created by user2@test
- * @when query to get transactions with non-existing transaction hashes
- * @then queried transactions and empty transaction
+ * @when query to get transactions with existing transaction hashes
+ * @then queried transactions
  */
 TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
   auto wrapper = make_test_subscriber<CallExact>(
@@ -156,7 +156,7 @@ TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
  * user1@test
  * AND 1 tx created by user2@test
  * @when query to get transactions with non-existing transaction hashes
- * @then queried transactions and nullopt values are retrieved
+ * @then nullopt values are retrieved
  */
 TEST_F(BlockQueryTest, GetTransactionsIncludesNonExistingTxHashes) {
   iroha::hash256_t invalid_tx_hash_1, invalid_tx_hash_2;


### PR DESCRIPTION
## What is this pull request?
`RedisBlockQuery::getTransactions()` API.

## Why do you implement it? Why do we need this pull request?
As a server, I want to get transactions from tx hashes.
  
## How to use the features provided in the pull request?
```cpp
block_query_->getTransactions({tx_hash_1, tx_hash_2}).subscribe([](auto tx) {
    // get transactions which have specified transactions' hashes.
  });
```

## Details/Features
- Using `RedisBlockQuery::getTxByHashSync()` in `RedisBlockQuery::getTransactions()`
