### PR TITLE
Fix/issue 630 platform dependent flat file implementation

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -1,14 +1,11 @@
 add_library(ametsuchi
     impl/flat_file/flat_file.cpp
-
     impl/storage_impl.cpp
     impl/temporary_wsv_impl.cpp
     impl/mutable_storage_impl.cpp
-
     impl/postgres_wsv_query.cpp
     impl/postgres_wsv_command.cpp
     impl/peer_query_wsv.cpp
-
     impl/redis_block_query.cpp
     )
 
@@ -21,4 +18,5 @@ target_link_libraries(ametsuchi
     cpp_redis
     libs_common
     command_execution
+    Boost::filesystem
     )

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -51,16 +51,6 @@ Identifier name_to_id(const std::string &name) {
 }
 
 /**
- * Check if file exists
- * @param name - full path to file
- * @return true, if exists
- */
-bool file_exist(const std::string &name) {
-  struct stat buffer {};
-  return stat(name.c_str(), &buffer) == 0;
-}
-
-/**
  * Remove file from folder
  * @param dump_dir - target dir
  * @param id - identifier of file
@@ -153,7 +143,7 @@ void FlatFile::add(Identifier id, const std::vector<uint8_t> &block) {
   auto file_name = dump_dir_ + SEPARATOR + id_to_name(id);
 
   // Write block to binary file
-  if (file_exist(file_name)) {
+  if (boost::filesystem::exists(file_name)) {
     // File already exist
     log_->warn("insertion for {} failed, because file already exists", id);
     return;
@@ -176,7 +166,7 @@ void FlatFile::add(Identifier id, const std::vector<uint8_t> &block) {
 
 nonstd::optional<std::vector<uint8_t>> FlatFile::get(Identifier id) const {
   std::string filename = dump_dir_ + SEPARATOR + id_to_name(id);
-  if (not file_exist(filename)) {
+  if (not boost::filesystem::exists(filename)) {
     log_->info("get({}) file not found", id);
     return nonstd::nullopt;
   }

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -22,9 +22,9 @@
 
 using namespace iroha::ametsuchi;
 
-const uint32_t DIGIT_CAPACITY = 16;
-
 namespace {
+  const uint32_t DIGIT_CAPACITY = 16;
+
   /**
    * Convert id to string repr
    * @param id - for conversion

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
-#include <dirent.h>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include "common/files.hpp"

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -51,20 +51,6 @@ Identifier name_to_id(const std::string &name) {
 }
 
 /**
- * Remove file from folder
- * @param dump_dir - target dir
- * @param id - identifier of file
- */
-void remove(const std::string &dump_dir, std::string filename) {
-  auto f_name = dump_dir + SEPARATOR + filename;
-
-  if (std::remove(f_name.c_str()) != 0) {
-    logger::log("FLAT_FILE")
-        ->error("remove({}, {}): error on deleting file", dump_dir, filename);
-  }
-}
-
-/**
  * Checking consistency of storage for provided folder
  * If some block in the middle is missing all blocks following it are deleted
  * @param dump_dir - folder of storage

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -92,10 +92,8 @@ nonstd::optional<Identifier> check_consistency(const std::string &dump_dir) {
 std::unique_ptr<FlatFile> FlatFile::create(const std::string &path) {
   auto log_ = logger::log("FlatFile::create()");
 
-  // TODO 19/08/17 Muratov change creating folder with system independent
-  // approach IR-496 #goodfirstissue
-  if (mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
-    if (errno != EEXIST) {
+  if (boost::filesystem::create_directory(path)) {
+    if (!boost::filesystem::is_directory(path)) {
       log_->error("Cannot create storage dir: {}", path);
     }
   }


### PR DESCRIPTION
## What is this pull request?
Replace platform-dependent filesystem calls with boost::filesystem to improve the portability of the code.
   
## Why do you implement it? Why do we need this pull request?
To improve the portability of the code and fix some issues discussed in the issue #630.
  
## How to use the features provided in the pull request?
No interface change.

## Details/Features
- Remove unused private functions.
- Overhaul of check_consistency(121fce6b)
- Replace handwritten/platform-dependent filesystem calls with boost::filesystem.

## P.S. (optional)
I have no way to confirm this PR to fix the memory related issue, but hopefully fix the memory leak related to scandir.

https://soramitsu.atlassian.net/browse/IR-409