### PR TITLE
Feature/get transactions endpoint

### DIFF
--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -40,6 +40,7 @@ namespace iroha {
              &JsonQueryFactory::deserializeGetAccountTransactions},
             {"GetAccountAssetTransactions",
              &JsonQueryFactory::deserializeGetAccountAssetTransactions},
+            {"GetTransactions", &JsonQueryFactory::deserializeGetTransactions},
             {"GetAccountSignatories",
              &JsonQueryFactory::deserializeGetSignatories},
             {"GetRoles", &JsonQueryFactory::deserializeGetRoles},
@@ -57,6 +58,8 @@ namespace iroha {
              &JsonQueryFactory::serializeGetAccountTransactions},
             {typeid(GetAccountAssetTransactions),
              &JsonQueryFactory::serializeGetAccountAssetTransactions},
+            {typeid(GetTransactions),
+             &JsonQueryFactory::serializeGetTransactions},
             {typeid(GetAssetInfo), &JsonQueryFactory::serializeGetAssetInfo},
             {typeid(GetRoles), &JsonQueryFactory::serializeGetRoles},
             {typeid(GetRolePermissions),
@@ -110,6 +113,25 @@ namespace iroha {
         return make_optional_ptr<GetAccountAssetTransactions>()
             | des.String(&GetAccountAssetTransactions::account_id, "account_id")
             | des.String(&GetAccountAssetTransactions::asset_id, "asset_id")
+            | toQuery;
+      }
+
+      optional_ptr<Query> JsonQueryFactory::deserializeGetTransactions(
+          const Value &obj_query) {
+        auto des = makeFieldDeserializer(obj_query);
+        return make_optional_ptr<GetTransactions>()
+            | des.Array(
+                  &GetTransactions::tx_hashes,
+                  "tx_hashes",
+                  [](auto tx_hashes) {
+                    return deserializeArray<std::vector<iroha::hash256_t>>(
+                        tx_hashes, [](auto tx_hash) {
+                          auto opt = iroha::hexstringToBytestring(tx_hash);
+                          return opt.has_value()
+                              ? iroha::hash256_t::from_string(*opt)
+                              : iroha::hash256_t{};  // alternative to nullopt
+                        });
+                  })
             | toQuery;
       }
 
@@ -209,6 +231,25 @@ namespace iroha {
         json_doc.AddMember("account_id", get_account_asset->account_id,
                            allocator);
         json_doc.AddMember("asset_id", get_account_asset->asset_id, allocator);
+      }
+
+      void JsonQueryFactory::serializeGetTransactions(
+          Document &json_doc, std::shared_ptr<const Query> query) {
+        auto &allocator = json_doc.GetAllocator();
+        json_doc.AddMember("query_type", "GetTransactions", allocator);
+        auto get_transactions =
+            std::static_pointer_cast<const GetTransactions>(query);
+        Value json_tx_hashes;
+        json_tx_hashes.SetArray();
+        const auto &tx_hashes = get_transactions->tx_hashes;
+        std::for_each(tx_hashes.begin(),
+                      tx_hashes.end(),
+                      [&json_tx_hashes, &allocator](auto tx_hash) {
+                        Value json_tx_hash;
+                        json_tx_hash.Set(tx_hash.to_hexstring(), allocator);
+                        json_tx_hashes.PushBack(json_tx_hash, allocator);
+                      });
+        json_doc.AddMember("tx_hashes", json_tx_hashes, allocator);
       }
 
       void JsonQueryFactory::serializeGetAssetInfo(

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -120,19 +120,7 @@ namespace iroha {
           const Value &obj_query) {
         auto des = makeFieldDeserializer(obj_query);
         return make_optional_ptr<GetTransactions>()
-            | des.Array(
-                  &GetTransactions::tx_hashes,
-                  "tx_hashes",
-                  [](auto tx_hashes) {
-                    return deserializeArray<std::vector<iroha::hash256_t>>(
-                        tx_hashes, [](auto tx_hash) {
-                          auto opt = iroha::hexstringToBytestring(tx_hash);
-                          return opt.has_value()
-                              ? iroha::hash256_t::from_string(*opt)
-                              : iroha::hash256_t{};  // alternative to nullopt
-                        });
-                  })
-            | toQuery;
+            | des.Array(&GetTransactions::tx_hashes, "tx_hashes") | toQuery;
       }
 
       optional_ptr<Query> JsonQueryFactory::deserializeGetAccountAssets(

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -39,6 +39,8 @@ namespace iroha {
             &PbQueryFactory::serializeGetAccountTransactions;
         serializers_[typeid(GetAccountAssetTransactions)] =
             &PbQueryFactory::serializeGetAccountAssetTransactions;
+        serializers_[typeid(GetTransactions)] =
+            &PbQueryFactory::serializeGetTransactions;
         serializers_[typeid(GetSignatories)] =
             &PbQueryFactory::serializeGetSignatories;
         serializers_[typeid(GetRolePermissions)] =
@@ -96,6 +98,19 @@ namespace iroha {
               auto query = GetAccountTransactions();
               query.account_id = pb_cast.account_id();
               val = std::make_shared<model::GetAccountTransactions>(query);
+              break;
+            }
+            case Query_Payload::QueryCase::kGetTransactions: {
+              // Convert to get transactions
+              const auto &pb_cast = pl.get_transactions();
+              auto query = GetTransactions();
+              std::for_each(pb_cast.tx_hashes().begin(),
+                            pb_cast.tx_hashes().end(),
+                            [&query](auto tx_hash) {
+                              query.tx_hashes.push_back(
+                                  iroha::hash256_t::from_string(tx_hash));
+                            });
+              val = std::make_shared<GetTransactions>(query);
               break;
             }
             case Query_Payload::QueryCase::kGetRoles: {
@@ -203,6 +218,23 @@ namespace iroha {
                                 ->mutable_get_account_asset_transactions();
         pb_query_mut->set_account_id(account_id);
         pb_query_mut->set_asset_id(asset_id);
+        return pb_query;
+      }
+
+      protocol::Query PbQueryFactory::serializeGetTransactions(
+          std::shared_ptr<const Query> query) const {
+        protocol::Query pb_query;
+        serializeQueryMetaData(pb_query, query);
+        auto tmp = std::static_pointer_cast<const GetTransactions>(query);
+        auto tx_hashes = tmp->tx_hashes;
+        auto pb_query_mut =
+          pb_query.mutable_payload()->mutable_get_transactions();
+        std::for_each(tmp->tx_hashes.begin(),
+                      tmp->tx_hashes.end(),
+                      [&pb_query_mut](auto tx_hash) {
+                        auto adder = pb_query_mut->add_tx_hashes();
+                        *adder = tx_hash.to_string();
+                      });
         return pb_query;
       }
 

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -104,12 +104,12 @@ namespace iroha {
               // Convert to get transactions
               const auto &pb_cast = pl.get_transactions();
               auto query = GetTransactions();
-              std::for_each(pb_cast.tx_hashes().begin(),
-                            pb_cast.tx_hashes().end(),
-                            [&query](auto tx_hash) {
-                              query.tx_hashes.push_back(
-                                  iroha::hash256_t::from_string(tx_hash));
-                            });
+              std::transform(pb_cast.tx_hashes().begin(),
+                             pb_cast.tx_hashes().end(),
+                             std::back_inserter(query.tx_hashes),
+                             [](auto tx_hash) {
+                               return iroha::hash256_t::from_string(tx_hash);
+                             });
               val = std::make_shared<GetTransactions>(query);
               break;
             }
@@ -226,7 +226,6 @@ namespace iroha {
         protocol::Query pb_query;
         serializeQueryMetaData(pb_query, query);
         auto tmp = std::static_pointer_cast<const GetTransactions>(query);
-        auto tx_hashes = tmp->tx_hashes;
         auto pb_query_mut =
           pb_query.mutable_payload()->mutable_get_transactions();
         std::for_each(tmp->tx_hashes.begin(),

--- a/irohad/model/converters/json_common.hpp
+++ b/irohad/model/converters/json_common.hpp
@@ -264,6 +264,49 @@ namespace iroha {
           const Signature &signature,
           rapidjson::Document::AllocatorType &allocator);
 
+
+      /**
+       * Deserialize JSON array to std::vector<Model>, for applying to converter
+       * function
+       * @tparam T - Model type
+       * @tparam F - Mapping function type
+       * @param values - JSON array
+       * @param mapper - Mapping function to apply each element
+       * @return Deserialized array on success, nullopt otherwise
+       */
+      template <typename T, typename F>
+      nonstd::optional<T> deserializeArray(
+          const rapidjson::Value::ConstArray &values, const F &mapper) {
+        auto accumulateString = [&mapper](auto init, auto &x) {
+          return init | [&x, &mapper](auto commands) {
+            return (x.IsString() ? nonstd::make_optional(mapper(x.GetString()))
+                                 : nonstd::nullopt)
+                   | [&commands](auto command) {
+              commands.push_back(command);
+              return nonstd::make_optional(commands);
+            };
+          };
+        };
+        return std::accumulate(values.begin(),
+                               values.end(),
+                               nonstd::make_optional<T>(),
+                               accumulateString);
+      }
+
+      /**
+       * Deserialize JSON array to std::vector<Model>, for applying to converter
+       * function
+       * @tparam T - Model type
+       * @tparam Array - JSON Array type, for perfect forwarding
+       * @param values - JSON array
+       * @return Deserialized array on success, nullopt otherwise
+       */
+      template <typename T, typename Array>
+      nonstd::optional<T> deserializeArray(Array &&values) {
+        return deserializeArray(std::forward<Array>(values),
+                                [](auto x) { return x; });
+      }
+
       /**
        * Try to parse JSON from string
        * @param string - string for parsing

--- a/irohad/model/converters/json_query_factory.hpp
+++ b/irohad/model/converters/json_query_factory.hpp
@@ -65,6 +65,8 @@ namespace iroha {
             const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAccountAssetTransactions(
             const rapidjson::Value &obj_query);
+        optional_ptr<Query> deserializeGetTransactions(
+            const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAccountAssets(
             const rapidjson::Value &obj_query);
         optional_ptr<Query> deserializeGetAssetInfo(
@@ -89,6 +91,8 @@ namespace iroha {
         void serializeGetAccountAssetTransactions(
             rapidjson::Document &json_doc,
             std::shared_ptr<const model::Query> query);
+        void serializeGetTransactions(
+            rapidjson::Document &json_doc, std::shared_ptr<const Query> query);
         void serializeGetSignatories(rapidjson::Document &json_doc,
                                      std::shared_ptr<const model::Query> query);
 

--- a/irohad/model/converters/pb_query_factory.hpp
+++ b/irohad/model/converters/pb_query_factory.hpp
@@ -57,6 +57,8 @@ namespace iroha {
             std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetAccountAssets(
             std::shared_ptr<const Query> query) const;
+        protocol::Query serializeGetTransactions(
+            std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetAccountTransactions(
             std::shared_ptr<const Query> query) const;
         protocol::Query serializeGetAccountAssetTransactions(

--- a/irohad/model/generators/impl/query_generator.cpp
+++ b/irohad/model/generators/impl/query_generator.cpp
@@ -91,6 +91,17 @@ namespace iroha {
         return query;
       }
 
+      std::shared_ptr<GetTransactions> QueryGenerator::generateGetTransactions(
+          ts64_t timestamp, const std::string& creator, uint64_t query_counter,
+          const std::vector<iroha::hash256_t>& tx_hashes) {
+        auto query = std::make_shared<GetTransactions>();
+        query->created_ts = timestamp;
+        query->creator_account_id = creator;
+        query->query_counter = query_counter;
+        query->tx_hashes = tx_hashes;
+        return query;
+      }
+
       std::shared_ptr<GetAssetInfo> QueryGenerator::generateGetAssetInfo() {
         auto query = std::make_shared<GetAssetInfo>("coin#test");
         query->created_ts = 0;

--- a/irohad/model/generators/query_generator.hpp
+++ b/irohad/model/generators/query_generator.hpp
@@ -53,6 +53,10 @@ namespace iroha {
             ts64_t timestamp, std::string creator, uint64_t query_counter,
             std::string account_id, std::string asset_id);
 
+        std::shared_ptr<GetTransactions> generateGetTransactions(
+            ts64_t timestamp, const std::string& creator, uint64_t query_counter,
+            const std::vector<iroha::hash256_t>& tx_hahses);
+
         /**
          * Generate default query GetAssetInfo
          * @return default GetAssetInfo

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_GET_TRANSACTIONS_HPP
 #define IROHA_GET_TRANSACTIONS_HPP
 
+#include <nonstd/optional.hpp>
 #include <model/query.hpp>
 #include <string>
 
@@ -47,6 +48,16 @@ namespace iroha {
        * Account identifier
        */
       std::string account_id{};
+    };
+
+    /**
+     * Query for getting transactions of given transactions' hashes
+     */
+    struct GetTransactions : Query {
+      /**
+       * Hashes of the transaction to be retrieved
+       */
+      std::vector<iroha::hash256_t> tx_hashes{};
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_GET_TRANSACTIONS_HPP
 #define IROHA_GET_TRANSACTIONS_HPP
 
-#include <nonstd/optional.hpp>
 #include <model/query.hpp>
 #include <string>
 
@@ -54,10 +53,12 @@ namespace iroha {
      * Query for getting transactions of given transactions' hashes
      */
     struct GetTransactions : Query {
+      using TxHashType = iroha::hash256_t;
+      using TxHashCollectionType = std::vector<TxHashType>;
       /**
        * Hashes of the transaction to be retrieved
        */
-      std::vector<iroha::hash256_t> tx_hashes{};
+      TxHashCollectionType tx_hashes{};
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/registration/query_registration.hpp
+++ b/irohad/model/registration/query_registration.hpp
@@ -43,6 +43,7 @@ namespace iroha {
         query_handler.register_type(typeid(GetSignatories));
         query_handler.register_type(typeid(GetAccountTransactions));
         query_handler.register_type(typeid(GetAccountAssetTransactions));
+        query_handler.register_type(typeid(GetTransactions));
         query_handler.register_type(typeid(GetRoles));
         query_handler.register_type(typeid(GetAssetInfo));
         query_handler.register_type(typeid(GetRolePermissions));

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -20,6 +20,10 @@ message GetAccountAssetTransactions {
   string asset_id = 2;
 }
 
+message GetTransactions {
+  repeated string tx_hashes = 1;
+}
+
 message GetAccountAssets {
   string account_id = 1;
   string asset_id = 2;
@@ -47,13 +51,14 @@ message Query {
        GetSignatories get_account_signatories = 4;
        GetAccountTransactions get_account_transactions = 5;
        GetAccountAssetTransactions get_account_asset_transactions = 6;
-       GetAccountAssets get_account_assets = 7;
-       GetRoles get_roles = 8;
-       GetAssetInfo get_asset_info = 9;
-       GetRolePermissions get_role_permissions = 10;
+       GetTransactions get_transactions = 7;
+       GetAccountAssets get_account_assets = 8;
+       GetRoles get_roles = 9;
+       GetAssetInfo get_asset_info = 10;
+       GetRolePermissions get_role_permissions = 11;
      }
      // used to prevent replay attacks.
-     uint64 query_counter = 11;
+     uint64 query_counter = 12;
   }
 
   Payload payload = 1;

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -164,6 +164,16 @@ TEST(QuerySerializerTest, SerializeGetAccountTransactions){
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
 }
 
+TEST(QuerySerializerTest, SerialzieGetTransactions) {
+  QueryGenerator queryGenerator;
+  iroha::hash256_t hash1, hash2;
+  hash1[0] = 1, hash2[0] = 2;
+  auto val =
+    queryGenerator.generateGetTransactions(0, "admin", 0, {hash1, hash2});
+  val->signature = generateSignature(42);
+  runQueryTest(val);
+}
+
 TEST(QuerySerializerTest, SerializeGetSignatories){
   JsonQueryFactory queryFactory;
   QueryGenerator queryGenerator;
@@ -196,5 +206,3 @@ TEST(QuerySerializerTest, get_role_permissions){
   val->signature = generateSignature(42);
   runQueryTest(val);
 }
-
-

--- a/test/module/irohad/model/converters/pb_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_factory_test.cpp
@@ -88,6 +88,14 @@ TEST(PbQueryFactoryTest, SerializeGetAccountTransactions){
   ASSERT_EQ(iroha::hash(*res_query.value()), iroha::hash(*query));
 }
 
+TEST(PbQueryFactoryTest, SerializeGetTransactions){
+  iroha::hash256_t hash1, hash2;
+  hash1[0] = 1;
+  hash2[1] = 2;
+  auto query = QueryGenerator{}.generateGetTransactions(0, "admin", 1, {hash1, hash2});
+  runQueryTest(query);
+}
+
 TEST(PbQueryFactoryTest, SerializeGetSignatories){
   PbQueryFactory query_factory;
   QueryGenerator query_generator;

--- a/test/module/irohad/model/static_map.cpp
+++ b/test/module/irohad/model/static_map.cpp
@@ -38,7 +38,7 @@ TEST(HandlerTest, QueryRegistration) {
 
   QueryRegistry registry;
 
-  ASSERT_EQ(8, registry.query_handler.types().size());
+  ASSERT_EQ(9, registry.query_handler.types().size());
 }
 
 TEST(HandlerTest, QueryResponseRegistration) {


### PR DESCRIPTION
## What is this pull request?
Endpoint of `GetTransactions()`

## Why do you implement it? Why do we need this pull request?
- As a server or client, I want to get transactions from transactions' hashes.
https://soramitsu.atlassian.net/browse/IR-622
  
## How to use the features provided in the pull request?
```proto
message GetTransactions {
  repeated string tx_hashes = 1;
}
```

**UPDATE**
- If there are some invalid transaction hashes, they are just ignored (skipped).
  - This behavior is tested at https://github.com/hyperledger/iroha/pull/703/files#diff-b8b4c7df15e84aef9b09063de9653c8fR134

## P.S. (optional)
- I'll implement the feature for IrohaCli in another PR.