### PR TITLE
PR+issues throughput plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![CircleCI](https://circleci.com/gh/hyperledger/iroha/tree/master.svg?style=svg)](https://circleci.com/gh/hyperledger/iroha/tree/master)
 [![codecov](https://codecov.io/gh/hyperledger/iroha/branch/master/graph/badge.svg)](https://codecov.io/gh/hyperledger/iroha)
 
+[![Throughput Graph](https://graphs.waffle.io/hyperledger/iroha/throughput.svg)](https://waffle.io/hyperledger/iroha/metrics/throughput)
+
 Blockchain platform Hyperledger Iroha is designed for simple creation and management of assets. This is a distributed ledger of transactions.
 
 <img height="300px" src="docs/Iroha_3_sm.png"


### PR DESCRIPTION
Adds waffle PR+issues throughput plot to [README.md](https://github.com/hyperledger/iroha/blob/8289825364b35733b887feb8c8b7d50171060d7e/README.md).

It is autoupdated and looks like this:

![](https://graphs.waffle.io/hyperledger/iroha/throughput.svg)