### PR TITLE
Fix boost __int128 pedantic warning, add boost CMake target

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -77,7 +77,7 @@ find_package(tbb)
 ##########################
 #         boost          #
 ##########################
-find_package(Boost REQUIRED
+find_package(Boost 1.58.0 REQUIRED
     COMPONENTS
     filesystem
     system

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -75,14 +75,18 @@ find_package(rxcpp)
 find_package(tbb)
 
 ##########################
-# boost multiprecision   #
+#         boost          #
 ##########################
 find_package(Boost REQUIRED
     COMPONENTS
     filesystem
     system
     )
-
+add_library(boost INTERFACE IMPORTED)
+set_target_properties(boost PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS}
+    INTERFACE_LINK_LIBRARIES "${Boost_LIBRARIES}"
+    )
 
 ##########################
 #       benchmark        #

--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -61,11 +61,7 @@ target_link_libraries(iroha-cli
     client
     cli-flags_validators
     keys_manager
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    )
-target_include_directories(iroha-cli PUBLIC
-    ${Boost_INCLUDE_DIRS}
+    boost
     )
 
 add_install_step_for_bin(iroha-cli)

--- a/irohad/model/converters/CMakeLists.txt
+++ b/irohad/model/converters/CMakeLists.txt
@@ -43,7 +43,5 @@ target_link_libraries(pb_model_converters
     schema
     cryptography
     logger
-    )
-target_include_directories(pb_model_converters PUBLIC
-    ${Boost_INCLUDE_DIRS}
+    boost
     )

--- a/libs/amount/CMakeLists.txt
+++ b/libs/amount/CMakeLists.txt
@@ -22,7 +22,5 @@ add_library(iroha_amount
 target_link_libraries(iroha_amount
     optional
     logger
-    )
-target_include_directories(iroha_amount PUBLIC
-    ${Boost_INCLUDE_DIRS}
+    boost
     )


### PR DESCRIPTION
## What is this pull request?
Add boost CMake target - now it is not required to `target_include_directories` and `target_link_libraries` each time boost is required.
   
## Why do you implement it? Why do we need this pull request?
Fix issue with `-Werror -Wpedantic` and boost using `__int128` by including boost directories as system include files.