### PR TITLE
Use condition variable to wait until previous tx sent

### DIFF
--- a/test/integration/pipeline/transfer_asset_inter_domain_test.cpp
+++ b/test/integration/pipeline/transfer_asset_inter_domain_test.cpp
@@ -74,10 +74,6 @@ class TransferAssetInterDomainTest : public TxPipelineIntegrationTestFixture {
     ASSERT_TRUE(irohad->storage);
 
     iroha::main::BlockInserter(irohad->storage).applyToLedger({genesis_block});
-    irohad->storage->getBlockQuery()->getTopBlocks(1).subscribe([](auto block) {
-      std::cout << "hoge\n";
-      EXPECT_EQ(block.transactions.size(), 2);
-    });
     irohad->init();
     irohad->run();
   }
@@ -171,6 +167,5 @@ TEST_F(TransferAssetInterDomainTest, TransferAssetInterDomainTest) {
           getVal(iroha::Amount().createFromString("5.50")))});
   iroha::model::ModelCryptoProviderImpl(ivanKeypair_).sign(tx3);
 
-  sendTransactions({tx1, tx2, tx3});
-  validate();
+  sendTxsInOrderAndValidate({tx1, tx2, tx3});
 }

--- a/test/integration/pipeline/tx_pipeline_integration_test.cpp
+++ b/test/integration/pipeline/tx_pipeline_integration_test.cpp
@@ -85,7 +85,5 @@ TEST_F(TxPipelineIntegrationTest, TxPipelineTest) {
   iroha::model::ModelCryptoProviderImpl provider(keypair);
   provider.sign(tx);
 
-  sendTransactions({tx});
-
-  validate();
+  sendTxsInOrderAndValidate({tx});
 }

--- a/test/integration/pipeline/tx_pipeline_integration_test_fixture.hpp
+++ b/test/integration/pipeline/tx_pipeline_integration_test_fixture.hpp
@@ -93,65 +93,32 @@ class TxPipelineIntegrationTestFixture
   }
 
   /**
-   * @param transactions
-   * @param expected_block_height - change expected height when using additional
-   * initial blocks
+   * @param transactions in order
    */
-  void sendTransactions(std::vector<iroha::model::Transaction> transactions) {
-    // generate expected proposal
-    expected_proposal = std::make_shared<iroha::model::Proposal>(transactions);
-    expected_proposal->height = 2;
+  void sendTxsInOrderAndValidate(
+      const std::vector<iroha::model::Transaction> &transactions) {
+    // test subscribers can't solve duplicate func call.
+    ASSERT_FALSE(duplicate_sent);
+    duplicate_sent = true;
 
-    // generate expected block
-    expected_block = iroha::model::Block{};
-    expected_block.height = expected_proposal->height;
-    expected_block.prev_hash = genesis_block.hash;
-    expected_block.transactions = transactions;
-    expected_block.txs_number = transactions.size();
-    expected_block.created_ts = 0;
-    expected_block.merkle_root.fill(0);
-    expected_block.hash = iroha::hash(expected_block);
-    irohad->getCryptoProvider()->sign(expected_block);
+    const auto num_blocks =
+        transactions.size();  // Use one block per one transaction
+    setTestSubscribers(num_blocks);
+    std::for_each(
+        transactions.begin(), transactions.end(), [this](auto const &tx) {
+          // this-> is needed by gcc
+          this->sendTransaction(tx);
+          // wait for commit
+          std::unique_lock<std::mutex> lk(m);
+          cv.wait_for(lk, 20s);
+        });
+    ASSERT_TRUE(proposal_wrapper->validate());
+    ASSERT_EQ(num_blocks, proposals.size());
+    ASSERT_EQ(expected_proposals, proposals);
 
-    // send transactions to torii
-    for (const auto &tx : transactions) {
-      auto pb_tx =
-          iroha::model::converters::PbTransactionFactory().serialize(tx);
-
-      google::protobuf::Empty response;
-      irohad->getCommandService()->ToriiAsync(pb_tx, response);
-    }
-  }
-
-  void validate() {
-    // verify proposal
-    auto proposal_wrapper = make_test_subscriber<CallExact>(
-        irohad->getPeerCommunicationService()->on_proposal(), 1);
-    proposal_wrapper.subscribe(
-        [this](auto proposal) { proposals.push_back(proposal); });
-
-    // verify commit and block
-    auto commit_wrapper = make_test_subscriber<CallExact>(
-        irohad->getPeerCommunicationService()->on_commit(), 1);
-    commit_wrapper.subscribe([this](auto commit) {
-      auto block_wrapper = make_test_subscriber<CallExact>(commit, 1);
-      block_wrapper.subscribe([this](auto block) { blocks.push_back(block); });
-    });
-    irohad->getPeerCommunicationService()->on_commit().subscribe(
-        [this](auto) { cv.notify_one(); });
-
-    // wait for commit
-    std::unique_lock<std::mutex> lk(m);
-
-    cv.wait_for(lk, 10s, [this] { return blocks.size() == 1; });
-
-    ASSERT_TRUE(proposal_wrapper.validate());
-    ASSERT_EQ(1, proposals.size());
-    ASSERT_EQ(*expected_proposal, proposals.front());
-
-    ASSERT_TRUE(commit_wrapper.validate());
-    ASSERT_EQ(1, blocks.size());
-    ASSERT_EQ(expected_block, blocks.front());
+    ASSERT_TRUE(commit_wrapper->validate());
+    ASSERT_EQ(num_blocks, blocks.size());
+    ASSERT_EQ(expected_blocks, blocks);
   }
 
   iroha::keypair_t createNewAccountKeypair(
@@ -167,13 +134,70 @@ class TxPipelineIntegrationTestFixture
   std::condition_variable cv;
   std::mutex m;
 
-  std::shared_ptr<iroha::model::Proposal> expected_proposal;
-  iroha::model::Block genesis_block, expected_block;
-
   std::vector<iroha::model::Proposal> proposals;
   std::vector<iroha::model::Block> blocks;
 
+  using Commit = rxcpp::observable<iroha::model::Block>;
+  std::unique_ptr<TestSubscriber<iroha::model::Proposal>> proposal_wrapper;
+  std::unique_ptr<TestSubscriber<Commit>> commit_wrapper;
+
+  iroha::model::Block genesis_block;
+  std::vector<iroha::model::Proposal> expected_proposals;
+  std::vector<iroha::model::Block> expected_blocks;
+
   std::shared_ptr<iroha::KeysManager> manager;
+
+  bool duplicate_sent = false;
+  size_t next_height_count = 2;
+
+ private:
+  void setTestSubscribers(size_t num_blocks) {
+    // verify proposal
+    proposal_wrapper = std::make_unique<TestSubscriber<iroha::model::Proposal>>(
+        make_test_subscriber<CallExact>(
+            irohad->getPeerCommunicationService()->on_proposal(), num_blocks));
+    proposal_wrapper->subscribe(
+        [this](auto proposal) { proposals.push_back(proposal); });
+
+    // verify commit and block
+    commit_wrapper = std::make_unique<TestSubscriber<Commit>>(
+        make_test_subscriber<CallExact>(
+            irohad->getPeerCommunicationService()->on_commit(), num_blocks));
+    commit_wrapper->subscribe([this](auto commit) {
+      commit.subscribe([this](auto block) { blocks.push_back(block); });
+    });
+    irohad->getPeerCommunicationService()->on_commit().subscribe(
+        [this](auto) { cv.notify_all(); });
+  }
+
+  void sendTransaction(const iroha::model::Transaction &transaction) {
+    // generate expected proposal
+    iroha::model::Proposal expected_proposal{
+        std::vector<Transaction>{transaction}};
+    expected_proposal.height = next_height_count++;
+    expected_proposals.emplace_back(expected_proposal);
+
+    // generate expected block
+    iroha::model::Block expected_block = iroha::model::Block{};
+    expected_block.height = expected_proposal.height;
+    expected_block.prev_hash = next_height_count == 3
+        ? genesis_block.hash
+        : expected_blocks.back().hash;
+    expected_block.transactions = expected_proposal.transactions;
+    expected_block.txs_number = expected_proposal.transactions.size();
+    expected_block.created_ts = 0;
+    expected_block.merkle_root.fill(0);
+    expected_block.hash = iroha::hash(expected_block);
+    irohad->getCryptoProvider()->sign(expected_block);
+    expected_blocks.emplace_back(expected_block);
+
+    // send transactions to torii
+    auto pb_tx =
+        iroha::model::converters::PbTransactionFactory().serialize(transaction);
+
+    google::protobuf::Empty response;
+    irohad->getCommandService()->ToriiAsync(pb_tx, response);
+  }
 };
 
 #endif


### PR DESCRIPTION
## What is this pull request?
Fix sending transactions in integration test to be able to guarantee the order of transactions.

## Why do you implement it? Why do we need this pull request?
To solve the issue of sending multiple transactions in the test.
Being lack this fix, the test of https://github.com/hyperledger/iroha/pull/692 sometimes fails because of sending multiple transactions. 

## How to use the features provided in the pull request?
```cpp
sendTxsInOrderAndValidate({tx1, tx2, tx3});
```

## Details/Features
- Remove useless debug.
- Use condition variable to wait previous txs are sent.
- One transaction in one block.
- Remove the feature of sending multiple transactions which are independent each other inside one block because it is not used.