### PR TITLE
Add hash strategy for shared_model;

### DIFF
--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -54,11 +54,7 @@ namespace shared_model {
         return add_asset_quantity_->asset_id();
       }
 
-      const interface::Amount &amount() const override {
-        return *amount_;
-      }
-
-      const HashType &hash() const override { return *hash_; }
+      const interface::Amount &amount() const override { return *amount_; }
 
       ModelType *copy() const override {
         iroha::protocol::Command command;
@@ -69,13 +65,8 @@ namespace shared_model {
      private:
       // ----------------------------| private API |----------------------------
       explicit AddAssetQuantity(RefAddAssetQuantity &&ref)
-          : add_asset_quantity_(std::move(ref)),
-            amount_([this] {
+          : add_asset_quantity_(std::move(ref)), amount_([this] {
               return proto::Amount(this->add_asset_quantity_->amount());
-            }),
-            hash_([this] {
-              // TODO 10/11/2017 muratovv replace with effective implementation
-              return crypto::Hash("");
             }) {}
 
       // ------------------------------| fields |-------------------------------
@@ -88,7 +79,6 @@ namespace shared_model {
 
       // lazy
       Lazy<proto::Amount> amount_;
-      Lazy<crypto::Hash> hash_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -45,7 +45,7 @@ namespace shared_model {
         return *precision_;
       }
 
-      const HashType &hash() const override { return *hash_; }
+      const BlobType &blob() const override { return *blob_; }
 
       Amount *copy() const override {
         return new Amount(iroha::protocol::Amount(*proto_amount_));
@@ -65,7 +65,9 @@ namespace shared_model {
               return result;
             }),
             precision_([this] { return proto_amount_->precision(); }),
-            hash_([this] { return crypto::Hash(""); }) {}
+            blob_([this] {
+              return BlobType(proto_amount_->SerializeAsString());
+            }) {}
 
       // proto
       RefAmount proto_amount_;
@@ -76,7 +78,7 @@ namespace shared_model {
       // lazy
       Lazy<boost::multiprecision::uint256_t> multiprecision_repr_;
       Lazy<interface::types::PrecisionType> precision_;
-      Lazy<crypto::Hash> hash_;
+      Lazy<BlobType> blob_;
     };
 
   }  // namespace proto

--- a/shared_model/cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_CRYPTO_HPP
 #define IROHA_CRYPTO_HPP
 
-#include <common/types.hpp>
+#include "common/types.hpp"
 #include <string>
 
 namespace iroha {

--- a/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_HASH_H
 #define IROHA_HASH_H
 
-#include <common/types.hpp>
+#include "common/types.hpp"
 #include "model/block.hpp"
 #include "model/query.hpp"
 #include "model/transaction.hpp"

--- a/shared_model/cryptography/hash_providers/sha3_512.hpp
+++ b/shared_model/cryptography/hash_providers/sha3_512.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_SHARED_MODEL_SHA3_512_HPP
 #define IROHA_SHARED_MODEL_SHA3_512_HPP
 
-#include <common/types.hpp>
+#include "common/types.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 
 namespace shared_model {

--- a/shared_model/cryptography/hash_providers/sha3_512.hpp
+++ b/shared_model/cryptography/hash_providers/sha3_512.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_SHARED_MODEL_SHA3_512_HPP
+#define IROHA_SHARED_MODEL_SHA3_512_HPP
+
+#include <common/types.hpp>
+#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
+
+namespace shared_model {
+  namespace crypto {
+    class Sha3_512 {
+     public:
+      static Hash makeHash(const Blob &blob) {
+        return Hash(iroha::sha3_512(blob.blob()).to_string());
+      }
+    };
+  }  // namespace crypto
+}  // namespace shared_model
+#endif  // IROHA_SHARED_MODEL_SHA3_512_HPP

--- a/shared_model/interfaces/commands/add_asset_quantity.hpp
+++ b/shared_model/interfaces/commands/add_asset_quantity.hpp
@@ -18,10 +18,10 @@
 #ifndef IROHA_SHARED_MODEL_ADD_ASSET_QUANTITY_HPP
 #define IROHA_SHARED_MODEL_ADD_ASSET_QUANTITY_HPP
 
-#include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
-#include "model/commands/add_asset_quantity.hpp"
 #include "interfaces/common_objects/amount.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "interfaces/primitive.hpp"
+#include "model/commands/add_asset_quantity.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -30,7 +30,7 @@ namespace shared_model {
      * Add amount of asset to an account
      */
     class AddAssetQuantity
-        : public Hashable<AddAssetQuantity, iroha::model::AddAssetQuantity> {
+        : public Primitive<AddAssetQuantity, iroha::model::AddAssetQuantity> {
      public:
       /**
        * @return Identity of user, that add quantity
@@ -64,6 +64,11 @@ namespace shared_model {
         oldModel->account_id = accountId();
         oldModel->asset_id = assetId();
         return oldModel;
+      }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId() and assetId() == rhs.assetId()
+            and amount() == rhs.amount();
       }
     };
   }  // namespace interface

--- a/shared_model/interfaces/commands/add_peer.hpp
+++ b/shared_model/interfaces/commands/add_peer.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_ADD_PEER_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/add_peer.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
     /**
      * Add new peer to Iroha
      */
-    class AddPeer : public Hashable<AddPeer, iroha::model::AddPeer> {
+    class AddPeer : public Primitive<AddPeer, iroha::model::AddPeer> {
      public:
       /**
        * @return Peer key, acts like peer identifier
@@ -53,7 +53,8 @@ namespace shared_model {
       OldModelType *makeOldModel() const override {
         auto oldModel = new iroha::model::AddPeer;
         oldModel->address = peerAddress();
-        oldModel->peer_key = peerKey().makeOldModel<decltype(oldModel->peer_key)>();
+        oldModel->peer_key =
+            peerKey().makeOldModel<decltype(oldModel->peer_key)>();
         return oldModel;
       }
     };

--- a/shared_model/interfaces/commands/add_peer.hpp
+++ b/shared_model/interfaces/commands/add_peer.hpp
@@ -57,6 +57,11 @@ namespace shared_model {
             peerKey().makeOldModel<decltype(oldModel->peer_key)>();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return peerKey() == rhs.peerKey()
+            and peerAddress() == rhs.peerAddress();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/add_signatory.hpp
+++ b/shared_model/interfaces/commands/add_signatory.hpp
@@ -54,6 +54,10 @@ namespace shared_model {
         oldModel->account_id = accountId();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return pubkey() == rhs.pubkey() and accountId() == rhs.accountId();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/add_signatory.hpp
+++ b/shared_model/interfaces/commands/add_signatory.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_ADD_SIGNATORY_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/add_signatory.hpp"
 
 namespace shared_model {
@@ -29,7 +29,7 @@ namespace shared_model {
      * Add new signatory to account
      */
     class AddSignatory
-        : public Hashable<AddSignatory, iroha::model::AddSignatory> {
+        : public Primitive<AddSignatory, iroha::model::AddSignatory> {
      public:
       /**
        * @return New signatory is identified with public key

--- a/shared_model/interfaces/commands/append_role.hpp
+++ b/shared_model/interfaces/commands/append_role.hpp
@@ -53,6 +53,10 @@ namespace shared_model {
         oldModel->account_id = accountId();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId() and roleName() == rhs.roleName();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/append_role.hpp
+++ b/shared_model/interfaces/commands/append_role.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_APPEND_ROLE_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/append_role.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
     /**
      * Add role to account used in Iroha
      */
-    class AppendRole : public Hashable<AppendRole, iroha::model::AppendRole> {
+    class AppendRole : public Primitive<AppendRole, iroha::model::AppendRole> {
      public:
       /**
        * @return Account to add the role

--- a/shared_model/interfaces/commands/command.hpp
+++ b/shared_model/interfaces/commands/command.hpp
@@ -34,7 +34,7 @@
 #include "interfaces/commands/set_quorum.hpp"
 #include "interfaces/commands/transfer_asset.hpp"
 #include "interfaces/polymorphic_wrapper.hpp"
-#include "interfaces/primitive.hpp"
+#include "interfaces/hashable.hpp"
 #include "interfaces/visitor_apply_for_all.hpp"
 #include "model/command.hpp"
 
@@ -45,7 +45,7 @@ namespace shared_model {
      * Class provides commands container for all commands in system.
      * General note: this class is container for commands, not a base class.
      */
-    class Command : public Primitive<Command, iroha::model::Command> {
+    class Command : public Hashable<Command, iroha::model::Command> {
      private:
       /// Shortcut type for polymorphic wrapper
       template <typename Value>

--- a/shared_model/interfaces/commands/create_account.hpp
+++ b/shared_model/interfaces/commands/create_account.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_CREATE_ACCOUNT_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/create_account.hpp"
 
 namespace shared_model {
@@ -29,7 +29,7 @@ namespace shared_model {
      * Create acccount in Iroha domain
      */
     class CreateAccount
-        : public Hashable<CreateAccount, iroha::model::CreateAccount> {
+        : public Primitive<CreateAccount, iroha::model::CreateAccount> {
      public:
       /// Type returned by accountName method
       using AccountNameType = std::string;

--- a/shared_model/interfaces/commands/create_account.hpp
+++ b/shared_model/interfaces/commands/create_account.hpp
@@ -62,6 +62,11 @@ namespace shared_model {
         oldModel->pubkey = pubkey().makeOldModel<decltype(oldModel->pubkey)>();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountName() == rhs.accountName()
+            and domainId() == rhs.domainId() and pubkey() == rhs.pubkey();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/create_asset.hpp
+++ b/shared_model/interfaces/commands/create_asset.hpp
@@ -63,6 +63,11 @@ namespace shared_model {
         oldModel->precision = precision();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return assetName() == rhs.assetName() and domainId() == rhs.domainId()
+            and precision() == rhs.precision();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/create_asset.hpp
+++ b/shared_model/interfaces/commands/create_asset.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_CREATE_ASSET_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/create_asset.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Create asset in Iroha domain
      */
     class CreateAsset
-        : public Hashable<CreateAsset, iroha::model::CreateAsset> {
+        : public Primitive<CreateAsset, iroha::model::CreateAsset> {
      public:
       /// Type returned by assetName function
       using AssetNameType = std::string;

--- a/shared_model/interfaces/commands/create_domain.hpp
+++ b/shared_model/interfaces/commands/create_domain.hpp
@@ -53,6 +53,11 @@ namespace shared_model {
         oldModel->user_default_role = userDefaultRole();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return domainId() == rhs.domainId()
+            and userDefaultRole() == rhs.userDefaultRole();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/create_domain.hpp
+++ b/shared_model/interfaces/commands/create_domain.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_CREATE_DOMAIN_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/create_domain.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Create domain in Iroha
      */
     class CreateDomain
-        : public Hashable<CreateDomain, iroha::model::CreateDomain> {
+        : public Primitive<CreateDomain, iroha::model::CreateDomain> {
      public:
       /**
        * @return Id of the domain to create

--- a/shared_model/interfaces/commands/create_role.hpp
+++ b/shared_model/interfaces/commands/create_role.hpp
@@ -18,10 +18,10 @@
 #ifndef IROHA_SHARED_MODEL_CREATE_ROLE_HPP
 #define IROHA_SHARED_MODEL_CREATE_ROLE_HPP
 
-#include <set>
 #include <numeric>
+#include <set>
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/create_role.hpp"
 
 namespace shared_model {
@@ -29,7 +29,7 @@ namespace shared_model {
     /**
      * Create new role in Iroha
      */
-    class CreateRole : public Hashable<CreateRole, iroha::model::CreateRole> {
+    class CreateRole : public Primitive<CreateRole, iroha::model::CreateRole> {
      public:
       /**
        * @return Id of the domain to create
@@ -47,9 +47,7 @@ namespace shared_model {
         return detail::PrettyStringBuilder()
             .init("CreateRole")
             .append("role_name", roleName())
-            .appendAll(roles_set, [](auto& role){
-              return role;
-            })
+            .appendAll(roles_set, [](auto &role) { return role; })
             .finalize();
       }
 
@@ -57,7 +55,8 @@ namespace shared_model {
         auto oldModel = new iroha::model::CreateRole;
         oldModel->role_name = roleName();
         auto roles = rolePermissions();
-        oldModel->permissions = std::unordered_set<std::string>(roles.begin(), roles.end());
+        oldModel->permissions =
+            std::unordered_set<std::string>(roles.begin(), roles.end());
         return oldModel;
       }
     };

--- a/shared_model/interfaces/commands/create_role.hpp
+++ b/shared_model/interfaces/commands/create_role.hpp
@@ -59,6 +59,11 @@ namespace shared_model {
             std::unordered_set<std::string>(roles.begin(), roles.end());
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return roleName() == rhs.roleName()
+            and rolePermissions() == rhs.rolePermissions();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/grant_permission.hpp
+++ b/shared_model/interfaces/commands/grant_permission.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_GRANT_PERMISSION_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/grant_permission.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Grant permission to the account
      */
     class GrantPermission
-        : public Hashable<GrantPermission, iroha::model::GrantPermission> {
+        : public Primitive<GrantPermission, iroha::model::GrantPermission> {
      public:
       /**
        * @return Id of the account to whom grant permission

--- a/shared_model/interfaces/commands/grant_permission.hpp
+++ b/shared_model/interfaces/commands/grant_permission.hpp
@@ -53,6 +53,11 @@ namespace shared_model {
         oldModel->permission_name = permissionName();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId()
+            and permissionName() == rhs.permissionName();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/remove_signatory.hpp
+++ b/shared_model/interfaces/commands/remove_signatory.hpp
@@ -53,6 +53,10 @@ namespace shared_model {
         oldModel->pubkey = pubkey().makeOldModel<decltype(oldModel->pubkey)>();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId() and pubkey() == rhs.pubkey();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/remove_signatory.hpp
+++ b/shared_model/interfaces/commands/remove_signatory.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_REMOVE_SIGNATORY_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/remove_signatory.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Remove signatory from the account
      */
     class RemoveSignatory
-        : public Hashable<RemoveSignatory, iroha::model::RemoveSignatory> {
+        : public Primitive<RemoveSignatory, iroha::model::RemoveSignatory> {
      public:
       /**
        * @return account from which remove signatory

--- a/shared_model/interfaces/commands/revoke_permission.hpp
+++ b/shared_model/interfaces/commands/revoke_permission.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_REVOKE_PERMISSION_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/revoke_permission.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Revoke permission from account
      */
     class RevokePermission
-        : public Hashable<RevokePermission, iroha::model::RevokePermission> {
+        : public Primitive<RevokePermission, iroha::model::RevokePermission> {
      public:
       /**
        * @return account from which revoke permission

--- a/shared_model/interfaces/commands/revoke_permission.hpp
+++ b/shared_model/interfaces/commands/revoke_permission.hpp
@@ -54,6 +54,11 @@ namespace shared_model {
         oldModel->permission_name = permissionName();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId()
+            and permissionName() == rhs.permissionName();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/set_quorum.hpp
+++ b/shared_model/interfaces/commands/set_quorum.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_SET_QUORUM_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/set_quorum.hpp"
 
 namespace shared_model {
@@ -27,7 +27,7 @@ namespace shared_model {
     /**
      * Set quorum of the account
      */
-    class SetQuorum : public Hashable<SetQuorum, iroha::model::SetQuorum> {
+    class SetQuorum : public Primitive<SetQuorum, iroha::model::SetQuorum> {
      public:
       /**
        * @return Id of the account to set quorum

--- a/shared_model/interfaces/commands/set_quorum.hpp
+++ b/shared_model/interfaces/commands/set_quorum.hpp
@@ -52,6 +52,11 @@ namespace shared_model {
         oldModel->new_quorum = newQuorum();
         return oldModel;
       }
+
+      bool operator==(const ModelType &rhs) const override {
+        return accountId() == rhs.accountId()
+            and newQuorum() == rhs.newQuorum();
+      }
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/commands/transfer_asset.hpp
+++ b/shared_model/interfaces/commands/transfer_asset.hpp
@@ -42,16 +42,17 @@ namespace shared_model {
        * @return Id of the asset to transfer
        */
       virtual const types::AssetIdType &assetId() const = 0;
+      /**
+       * @return asset amount to transfer
+       */
+      virtual const Amount &amount() const = 0;
+
       /// Type of the transfer message
       using MessageType = std::string;
       /**
        * @return message of the transfer
        */
       virtual const MessageType &message() const = 0;
-      /**
-       * @return asset amount to transfer
-       */
-      virtual const Amount &amount() const = 0;
 
       std::string toString() const override {
         return detail::PrettyStringBuilder()
@@ -69,13 +70,20 @@ namespace shared_model {
         oldModel->src_account_id = srcAccountId();
         oldModel->dest_account_id = destAccountId();
         using OldAmountType = iroha::Amount;
-        /// Use shared_ptr and placement-new to copy new model field to oldModel's field and
-        /// to return raw pointer
+        /// Use shared_ptr and placement-new to copy new model field to
+        /// oldModel's field and to return raw pointer
         auto p = std::shared_ptr<OldAmountType>(amount().makeOldModel());
         new (&oldModel->amount) OldAmountType(*p);
         oldModel->asset_id = assetId();
         oldModel->description = message();
         return oldModel;
+      }
+
+      bool operator==(const ModelType &rhs) const override {
+        return srcAccountId() == rhs.srcAccountId()
+            and destAccountId() == rhs.destAccountId()
+            and assetId() == rhs.assetId() and amount() == rhs.amount()
+            and message() == rhs.message();
       }
     };
   }  // namespace interface

--- a/shared_model/interfaces/commands/transfer_asset.hpp
+++ b/shared_model/interfaces/commands/transfer_asset.hpp
@@ -19,7 +19,7 @@
 #define IROHA_SHARED_MODEL_TRANSFER_ASSET_HPP
 
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/hashable.hpp"
+#include "interfaces/primitive.hpp"
 #include "model/commands/transfer_asset.hpp"
 
 namespace shared_model {
@@ -28,7 +28,7 @@ namespace shared_model {
      * Grant permission to account
      */
     class TransferAsset
-        : public Hashable<TransferAsset, iroha::model::TransferAsset> {
+        : public Primitive<TransferAsset, iroha::model::TransferAsset> {
      public:
       /**
        * @return Id of the account from which transfer assets

--- a/shared_model/interfaces/hashable.hpp
+++ b/shared_model/interfaces/hashable.hpp
@@ -56,9 +56,8 @@ namespace shared_model {
       }
 
      protected:
-      detail::LazyInitializer<HashType> hash_ =
-          detail::LazyInitializer<HashType>(
-              [this]() { return HashProvider::makeHash(blob()); });
+      detail::LazyInitializer<HashType> hash_ = detail::makeLazyInitializer(
+          [this] { return HashProvider::makeHash(blob()); });
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/hashable.hpp
+++ b/shared_model/interfaces/hashable.hpp
@@ -19,21 +19,32 @@
 #define IROHA_HASHABLE_HPP
 
 #include "cryptography/hash.hpp"
+#include "cryptography/hash_providers/sha3_512.hpp"
 #include "interfaces/primitive.hpp"
+#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace interface {
-    template <typename ModelType, typename OldModel>
+    template <typename ModelType,
+              typename OldModel,
+              typename HashProvider = crypto::Sha3_512>
     class Hashable : public Primitive<ModelType, OldModel> {
      public:
       /// Type of hash
       using HashType = crypto::Hash;
 
+      using BlobType = crypto::Blob;
+
       /**
        * @return hash of object.
        * Equality of hashes means equality of objects.
        */
-      virtual const HashType &hash() const = 0;
+      const HashType &hash() const { return *hash_; }
+
+      /**
+       * @return blob representation of object
+       */
+      virtual const BlobType &blob() const = 0;
 
       /**
        * Overriding operator== with equality hash semantics
@@ -43,6 +54,11 @@ namespace shared_model {
       bool operator==(const ModelType &rhs) const override {
         return this->hash() == rhs.hash();
       }
+
+     protected:
+      detail::LazyInitializer<HashType> hash_ =
+          detail::LazyInitializer<HashType>(
+              [this]() { return HashProvider::makeHash(blob()); });
     };
   }  // namespace interface
 }  // namespace shared_model


### PR DESCRIPTION
## Why do you implement it? Why do we need this pull request?
This pr provides hashing strategy into `Hashable` class and change requirement of hash with blob.

## Details/Features
* Rework hashable with crypto provider strategy
* Remove hash from concrete commands
* Add sha3 hash strategy
* Rework hashable classes