### PR TITLE
Add VerificationStrategy EqualToList

### DIFF
--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -286,7 +286,7 @@ namespace framework {
       explicit EqualToList(std::vector<T> expected_values) noexcept
         : expected_values_(std::move(expected_values)) {}
 
-      explicit EqualToList(EqualToList<T> &&rhs) noexcept {
+      EqualToList(EqualToList<T> &&rhs) noexcept {
         std::move(rhs.expected_values_.begin(),
                   rhs.expected_values_.end(),
                   std::back_inserter(expected_values_.begin()));

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -272,6 +272,63 @@ namespace framework {
       bool on_complete_called = false;
     };
 
+    /**
+     * EqualToList checks subscribed values equals to vector<T>
+     * @tparam T - observable parameter
+     */
+    template <typename T>
+    class EqualToList : public VerificationStrategy<T> {
+     public:
+      /**
+       * @param expected_values - expected vector<T> values
+       * equals to list from observable
+       */
+      explicit EqualToList(std::vector<T> expected_values) noexcept
+        : expected_values_(std::move(expected_values)) {}
+
+      explicit EqualToList(EqualToList<T> &&rhs) noexcept {
+        std::move(rhs.expected_values_.begin(),
+                  rhs.expected_values_.end(),
+                  std::back_inserter(expected_values_.begin()));
+        std::move(rhs.actual_values_.begin(),
+                  rhs.actual_values_.end(),
+                  std::back_inserter(actual_values_.begin()));
+      }
+
+      EqualToList<T> &operator=(EqualToList<T> &&rhs) noexcept {
+        std::move(rhs.expected_values_.begin(),
+                  rhs.expected_values_.end(),
+                  std::back_inserter(expected_values_.begin()));
+        std::move(rhs.actual_values_.begin(),
+                  rhs.actual_values_.end(),
+                  std::back_inserter(actual_values_.begin()));
+        return *this;
+      }
+
+      /**
+       * Remove copy operator=
+       */
+      EqualToList<T> &operator=(EqualToList<T> &rhs) = delete;
+
+      /**
+       * Remove copy constructor
+       */
+      EqualToList(const EqualToList<T> &rhs) = delete;
+
+      void on_next_after(T next) override {
+        actual_values_.push_back(next);
+      }
+
+     protected:
+      bool validate() override {
+        return expected_values_ == actual_values_;
+      }
+
+     private:
+      std::vector<T> expected_values_;
+      std::vector<T> actual_values_;
+    };
+
   }  // namespace test_subscriber
 }  // namespace framework
 #endif  // IROHA_TEST_SUBSCRIBER_HPP

--- a/test/framework/test_subscriber_testing.cpp
+++ b/test/framework/test_subscriber_testing.cpp
@@ -63,3 +63,37 @@ TEST_F(TestSubscriberTesting, DefaultSubscriberTest) {
 
   ASSERT_TRUE(wrapper.validate());
 }
+
+/**
+ * @given observable created by sequence: on_next(1), on_next(2)
+ * @when validate subscriber with the vector {1, 2}, using EqualToList
+ * @then true because subscribed values are same as the vector
+ */
+TEST_F(TestSubscriberTesting, ValidEqualToListTest) {
+  auto ints = rxcpp::observable<>::create<int>([](auto s) {
+    s.on_next(1);
+    s.on_next(2);
+    s.on_completed();
+  });
+
+  auto wrapper = make_test_subscriber<EqualToList>(
+    ints, std::vector<int>{1, 2});
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @given observable created by sequence: on_next(1), on_next(2)
+ * @when validate subscriber with the vector {1, 2, 3}, using EqualList
+ * @then false because subscribed values are not same as the vector.
+ */
+TEST_F(TestSubscriberTesting, UnsatisfiedEqualToListTest) {
+  auto ints = rxcpp::observable<>::create<int>([](auto s) {
+    s.on_next(1);
+    s.on_next(2);
+    s.on_completed();
+  });
+
+  auto wrapper = make_test_subscriber<EqualToList>(
+    ints, std::vector<int>{1, 2, 3});
+  ASSERT_FALSE(wrapper.subscribe().validate());
+}


### PR DESCRIPTION
## What is this pull request?
- `EqualToList` inherited of `VerificationStrategy`
- Verifies emitted `rxcpp::observable<T>` equals to `std::vector<T>`
Part of https://github.com/hyperledger/iroha/pull/650

## Why do you implement it? Why do we need this pull request?
It's useful in block query test.

## How to use the features provided in the pull request?
```cpp
TEST_F(TestSubscriberTesting, ValidEqualToListTest) {
  auto ints = rxcpp::observable<>::create<int>([](auto s) {
     s.on_next(1);
     s.on_next(2);
     s.on_completed();
   });

   auto wrapper = make_test_subscriber<EqualToList>(
     ints, std::vector<int>{1, 2});
   ASSERT_TRUE(wrapper.subscribe().validate());
}
```
## Details/Features
- `EqualToTest` to `VerificationStrategy` in `test/framework/test_subscriber.hpp`
