### PR TITLE
Add generification of crypto provider;

### DIFF
--- a/shared_model/cryptography/crypto_provider/crypto_defaults.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_defaults.hpp
@@ -1,19 +1,19 @@
 /**
-    * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
-    * http://soramitsu.co.jp
-    *
-    * Licensed under the Apache License, Version 2.0 (the "License");
-    * you may not use this file except in compliance with the License.
-    * You may obtain a copy of the License at
-        *
-        *        http://www.apache.org/licenses/LICENSE-2.0
-    *
-    * Unless required by applicable law or agreed to in writing, software
-    * distributed under the License is distributed on an "AS IS" BASIS,
-    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    * See the License for the specific language governing permissions and
-        * limitations under the License.
-    */
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef IROHA_SHARED_MODEL_CRYPTO_DEFAULTS_HPP
 #define IROHA_SHARED_MODEL_CRYPTO_DEFAULTS_HPP

--- a/shared_model/cryptography/crypto_provider/crypto_defaults.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_defaults.hpp
@@ -1,0 +1,29 @@
+/**
+    * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+    * http://soramitsu.co.jp
+    *
+    * Licensed under the Apache License, Version 2.0 (the "License");
+    * you may not use this file except in compliance with the License.
+    * You may obtain a copy of the License at
+        *
+        *        http://www.apache.org/licenses/LICENSE-2.0
+    *
+    * Unless required by applicable law or agreed to in writing, software
+    * distributed under the License is distributed on an "AS IS" BASIS,
+    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    * See the License for the specific language governing permissions and
+        * limitations under the License.
+    */
+
+#ifndef IROHA_SHARED_MODEL_CRYPTO_DEFAULTS_HPP
+#define IROHA_SHARED_MODEL_CRYPTO_DEFAULTS_HPP
+
+#include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
+
+namespace shared_model {
+  namespace crypto {
+    /// Default type of crypto algorithm
+    using DefaultCryptoAlgorithmType = CryptoProviderEd25519Sha3;
+  }  // namespace crypto
+}  // namespace shared_model
+#endif  // IROHA_SHARED_MODEL_CRYPTO_DEFAULTS_HPP

--- a/shared_model/cryptography/crypto_provider/crypto_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_signer.hpp
@@ -15,34 +15,23 @@
  * limitations under the License.
  */
 
-#ifndef IROHA_HASH_PROVIDER_HPP
-#define IROHA_HASH_PROVIDER_HPP
+#ifndef IROHA_CRYPTO_SIGNER_HPP
+#define IROHA_CRYPTO_SIGNER_HPP
 
 #include "cryptography/blob.hpp"
-#include "cryptography/hash.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "cryptography/keypair.hpp"
+#include "cryptography/signed.hpp"
 
 namespace shared_model {
   namespace crypto {
-    /**
-     * Wrapper class for hashing.
-     */
-    class HashProvider {
+    template<typename Algorithm = DefaultCryptoAlgorithmType>
+    class CryptoSigner {
      public:
-      /**
-       * Hash with sha3-256
-       * @param blob - blob to hash
-       * @return Hash of provided blob
-       */
-      Hash sha3_256(const Blob &blob) const;
-
-      /**
-       * Hash with sha3-512
-       * @param blob - blob to hash
-       * @return Hash of provided blob
-       */
-      Hash sha3_512(const Blob &blob) const;
+      static Signed sign(const Blob &blob, const Keypair &keypair) {
+        return Algorithm::sign(blob, keypair);
+      }
     };
   }  // namespace crypto
 }  // namespace shared_model
-
-#endif  // IROHA_HASH_PROVIDER_HPP
+#endif  // IROHA_CRYPTO_SIGNER_HPP

--- a/shared_model/cryptography/crypto_provider/crypto_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_signer.hpp
@@ -25,12 +25,26 @@
 
 namespace shared_model {
   namespace crypto {
-    template<typename Algorithm = DefaultCryptoAlgorithmType>
+    /**
+     * CryptoSigner - wrapper for generalization signing for different
+     * cryptographic algorithms
+     * @tparam Algorithm - cryptographic algorithm for singing
+     */
+    template <typename Algorithm = DefaultCryptoAlgorithmType>
     class CryptoSigner {
      public:
+      /**
+       * Generate signature for target data
+       * @param blob - data for signing
+       * @param keypair - (public, private) keys for signing
+       * @return signature's blob
+       */
       static Signed sign(const Blob &blob, const Keypair &keypair) {
         return Algorithm::sign(blob, keypair);
       }
+
+      /// close constructor for forbidding instantiation
+      CryptoSigner() = delete;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/crypto_provider/crypto_verifier.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_verifier.hpp
@@ -15,16 +15,25 @@
  * limitations under the License.
  */
 
-#include "cryptography/ed25519_sha3_impl/hash_provider.hpp"
-#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
+#ifndef IROHA_CRYPTO_VERIFIER_HPP
+#define IROHA_CRYPTO_VERIFIER_HPP
+
+#include "cryptography/blob.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "cryptography/keypair.hpp"
+#include "cryptography/signed.hpp"
 
 namespace shared_model {
   namespace crypto {
-    Hash HashProvider::sha3_256(const Blob &blob) const {
-      return Hash(iroha::sha3_256(blob.blob()).to_string());
-    }
-    Hash HashProvider::sha3_512(const Blob &blob) const {
-      return Hash(iroha::sha3_512(blob.blob()).to_string());
-    }
+    template<typename Algorithm = DefaultCryptoAlgorithmType>
+    class CryptoVerifier {
+     public:
+      static bool verify(const Signed &signedData,
+                         const Blob &source,
+                         const PublicKey &pubKey) {
+        return Algorithm::verify(signedData, source, pubKey);
+      };
+    };
   }  // namespace crypto
 }  // namespace shared_model
+#endif  // IROHA_CRYPTO_VERIFIER_HPP

--- a/shared_model/cryptography/crypto_provider/crypto_verifier.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_verifier.hpp
@@ -25,14 +25,29 @@
 
 namespace shared_model {
   namespace crypto {
-    template<typename Algorithm = DefaultCryptoAlgorithmType>
+    /**
+     * CryptoVerifier - wrapper for generalization verification of cryptographic
+     * signatures
+     * @tparam Algorithm - cryptographic algorithm for verification
+     */
+    template <typename Algorithm = DefaultCryptoAlgorithmType>
     class CryptoVerifier {
      public:
+      /**
+       * Verify signature attached to source data
+       * @param signedData - cryptographic signature
+       * @param source - data that was signed
+       * @param pubKey - public key of signatory
+       * @return true if signature correct
+       */
       static bool verify(const Signed &signedData,
                          const Blob &source,
                          const PublicKey &pubKey) {
         return Algorithm::verify(signedData, source, pubKey);
-      };
+      }
+
+      /// close constructor for forbidding instantiation
+      CryptoVerifier() = delete;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/CMakeLists.txt
+++ b/shared_model/cryptography/ed25519_sha3_impl/CMakeLists.txt
@@ -15,13 +15,12 @@
 add_subdirectory(internal)
 add_subdirectory(bindings)
 
-add_library(shared_ed25519_sha3
-        signer.cpp
-        verifier.cpp
-        crypto_provider.cpp
-        hash_provider.cpp
-        )
+add_library(shared_model_ed25519_sha3
+    signer.cpp
+    verifier.cpp
+    crypto_provider.cpp
+    )
 
-target_link_libraries(shared_ed25519_sha3
-        cryptography
-        )
+target_link_libraries(shared_model_ed25519_sha3
+    cryptography
+    )

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
@@ -17,34 +17,35 @@
 
 #include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
+#include "cryptography/ed25519_sha3_impl/signer.hpp"
+#include "cryptography/ed25519_sha3_impl/verifier.hpp"
 
 namespace shared_model {
   namespace crypto {
 
-    Signed CryptoProvider::sign(const Blob &blob,
-                                const Keypair &keypair) const {
-      return signer_.sign(blob, keypair);
+    Signed CryptoProviderEd25519Sha3::sign(const Blob &blob, const Keypair &keypair) {
+      return Signer::sign(blob, keypair);
     }
 
-    bool CryptoProvider::verify(const Signed &signedData,
+    bool CryptoProviderEd25519Sha3::verify(const Signed &signedData,
                                 const Blob &orig,
-                                const PublicKey &publicKey) const {
-      return verifier_.verify(signedData, orig, publicKey);
+                                const PublicKey &publicKey) {
+      return Verifier::verify(signedData, orig, publicKey);
     }
 
-    Seed CryptoProvider::generateSeed() const {
+    Seed CryptoProviderEd25519Sha3::generateSeed() {
       return Seed(iroha::create_seed().to_string());
     }
 
-    Seed CryptoProvider::generateSeed(const std::string &passphrase) const {
+    Seed CryptoProviderEd25519Sha3::generateSeed(const std::string &passphrase) {
       return Seed(iroha::create_seed(passphrase).to_string());
     }
 
-    Keypair CryptoProvider::generateKeypair() const {
+    Keypair CryptoProviderEd25519Sha3::generateKeypair() const {
       return generateKeypair(generateSeed());
     }
 
-    Keypair CryptoProvider::generateKeypair(const Seed &seed) const {
+    Keypair CryptoProviderEd25519Sha3::generateKeypair(const Seed &seed) {
       auto keypair =
           iroha::create_keypair(seed.makeOldModel<Seed::OldSeedType>());
       return Keypair(PublicKey(keypair.pubkey.to_string()),

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
@@ -43,7 +43,7 @@ namespace shared_model {
       return Seed(iroha::create_seed(passphrase).to_string());
     }
 
-    Keypair CryptoProviderEd25519Sha3::generateKeypair() const {
+    Keypair CryptoProviderEd25519Sha3::generateKeypair() {
       return generateKeypair(generateSeed());
     }
 

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
@@ -23,13 +23,14 @@
 namespace shared_model {
   namespace crypto {
 
-    Signed CryptoProviderEd25519Sha3::sign(const Blob &blob, const Keypair &keypair) {
+    Signed CryptoProviderEd25519Sha3::sign(const Blob &blob,
+                                           const Keypair &keypair) {
       return Signer::sign(blob, keypair);
     }
 
     bool CryptoProviderEd25519Sha3::verify(const Signed &signedData,
-                                const Blob &orig,
-                                const PublicKey &publicKey) {
+                                           const Blob &orig,
+                                           const PublicKey &publicKey) {
       return Verifier::verify(signedData, orig, publicKey);
     }
 
@@ -37,7 +38,8 @@ namespace shared_model {
       return Seed(iroha::create_seed().to_string());
     }
 
-    Seed CryptoProviderEd25519Sha3::generateSeed(const std::string &passphrase) {
+    Seed CryptoProviderEd25519Sha3::generateSeed(
+        const std::string &passphrase) {
       return Seed(iroha::create_seed(passphrase).to_string());
     }
 

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
@@ -18,16 +18,16 @@
 #ifndef IROHA_CRYPTOPROVIDER_HPP
 #define IROHA_CRYPTOPROVIDER_HPP
 
-#include "cryptography/ed25519_sha3_impl/signer.hpp"
-#include "cryptography/ed25519_sha3_impl/verifier.hpp"
+#include "cryptography/keypair.hpp"
 #include "cryptography/seed.hpp"
+#include "cryptography/signed.hpp"
 
 namespace shared_model {
   namespace crypto {
     /**
      * Wrapper class for signing-related stuff.
      */
-    class CryptoProvider {
+    class CryptoProviderEd25519Sha3 {
      public:
       /**
        * Signs the message.
@@ -35,7 +35,7 @@ namespace shared_model {
        * @param keypair - keypair
        * @return Signed object with signed data
        */
-      Signed sign(const Blob &blob, const Keypair &keypair) const;
+      static Signed sign(const Blob &blob, const Keypair &keypair);
 
       /**
        * Verifies signature.
@@ -44,39 +44,34 @@ namespace shared_model {
        * @param publicKey - public key
        * @return true if verify was OK or false otherwise
        */
-      bool verify(const Signed &signedData,
-                  const Blob &orig,
-                  const PublicKey &publicKey) const;
-
+      static bool verify(const Signed &signedData,
+                         const Blob &orig,
+                         const PublicKey &publicKey);
       /**
        * Generates new seed
        * @return Seed generated
        */
-      Seed generateSeed() const;
+      static Seed generateSeed();
 
       /**
        * Generates new seed from a provided passphrase
        * @param passphrase - passphrase to generate seed from
        * @return Seed generated
        */
-      Seed generateSeed(const std::string &passphrase) const;
+      static Seed generateSeed(const std::string &passphrase);
 
       /**
        * Generates new keypair with a default seed
        * @return Keypair generated
        */
-      Keypair generateKeypair() const;
+      static Keypair generateKeypair();
 
       /**
        * Generates new keypair from a provided seed
        * @param seed - provided seed
        * @return generated keypair
        */
-      Keypair generateKeypair(const Seed &seed) const;
-
-     private:
-      Signer signer_;
-      Verifier verifier_;
+      static Keypair generateKeypair(const Seed &seed);
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
@@ -20,7 +20,7 @@
 
 namespace shared_model {
   namespace crypto {
-    Signed Signer::sign(const Blob &blob, const Keypair &keypair) const {
+    Signed Signer::sign(const Blob &blob, const Keypair &keypair) {
       return Signed(
           iroha::sign(
               blob.blob(),

--- a/shared_model/cryptography/ed25519_sha3_impl/signer.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/signer.hpp
@@ -35,7 +35,7 @@ namespace shared_model {
        * @param keypair - keypair with public and private keys
        * @return Signed object with signed data
        */
-      Signed sign(const Blob &blob, const Keypair &keypair) const;
+      static Signed sign(const Blob &blob, const Keypair &keypair);
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
@@ -22,7 +22,7 @@ namespace shared_model {
   namespace crypto {
     bool Verifier::verify(const Signed &signedData,
                           const Blob &orig,
-                          const PublicKey &publicKey) const {
+                          const PublicKey &publicKey) {
       return iroha::verify(
           orig.blob(),
           publicKey.makeOldModel<PublicKey::OldPublicKeyType>(),

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.hpp
@@ -28,9 +28,9 @@ namespace shared_model {
      */
     class Verifier {
      public:
-      bool verify(const Signed &signedData,
+      static bool verify(const Signed &signedData,
                   const Blob &orig,
-                  const PublicKey &publicKey) const;
+                  const PublicKey &publicKey);
     };
 
   }  // namespace crypto

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.hpp
@@ -29,8 +29,8 @@ namespace shared_model {
     class Verifier {
      public:
       static bool verify(const Signed &signedData,
-                  const Blob &orig,
-                  const PublicKey &publicKey);
+                         const Blob &orig,
+                         const PublicKey &publicKey);
     };
 
   }  // namespace crypto

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -67,9 +67,8 @@ namespace shared_model {
       interface::Primitive<Keypair, iroha::keypair_t>::OldModelType *
       makeOldModel() const override {
         return new iroha::keypair_t{
-            .pubkey = publicKey().makeOldModel<PublicKey::OldPublicKeyType>(),
-            .privkey =
-                privateKey().makeOldModel<PrivateKey::OldPrivateKeyType>()};
+            publicKey().makeOldModel<PublicKey::OldPublicKeyType>(),
+            privateKey().makeOldModel<PrivateKey::OldPrivateKeyType>()};
       }
 
       Keypair *copy() const override {

--- a/shared_model/cryptography/seed.hpp
+++ b/shared_model/cryptography/seed.hpp
@@ -41,6 +41,6 @@ namespace shared_model {
       }
     };
   }  // namespace crypto
-};   // namespace shared_model
+}  // namespace shared_model
 
 #endif  // IROHA_SEED_HPP

--- a/shared_model/interfaces/hashable.hpp
+++ b/shared_model/interfaces/hashable.hpp
@@ -37,7 +37,6 @@ namespace shared_model {
 
       /**
        * @return hash of object.
-       * Equality of hashes means equality of objects.
        */
       const HashType &hash() const { return *hash_; }
 
@@ -47,7 +46,8 @@ namespace shared_model {
       virtual const BlobType &blob() const = 0;
 
       /**
-       * Overriding operator== with equality hash semantics
+       * Overriding operator== with equality hash semantics:
+       * equality of hashes <=> equality of objects.
        * @param rhs - another model object
        * @return true, if hashes are equal, false otherwise
        */

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -16,4 +16,14 @@
 #
 
 add_subdirectory(backend_proto)
-AddTest(lazy_test lazy_test.cpp)
+AddTest(lazy_test
+    lazy_test.cpp
+    )
+
+AddTest(crypto_usage_test
+    crypto_usage_test.cpp
+    )
+target_link_libraries(crypto_usage_test
+    shared_model_ed25519_sha3
+    logger
+    )

--- a/test/module/shared_model/crypto_usage_test.cpp
+++ b/test/module/shared_model/crypto_usage_test.cpp
@@ -24,8 +24,6 @@
 
 using namespace shared_model::crypto;
 
-logger::Logger log_ = logger::log("SharedModel=>CryptoUsage");
-
 class CryptoInitialization : public ::testing::Test {
  public:
   void SetUp() override {

--- a/test/module/shared_model/crypto_usage_test.cpp
+++ b/test/module/shared_model/crypto_usage_test.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include "cryptography/crypto_provider/crypto_signer.hpp"
+#include "cryptography/crypto_provider/crypto_verifier.hpp"
+#include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
+#include "logger/logger.hpp"
+
+using namespace shared_model::crypto;
+
+logger::Logger log_ = logger::log("SharedModel=>CryptoUsage");
+
+class CryptoInitialization : public ::testing::Test {
+ public:
+  void SetUp() override {
+    keypair =
+        std::make_shared<Keypair>(CryptoProviderEd25519Sha3::generateKeypair());
+    data = std::make_shared<Blob>("raw data for signing");
+  }
+  std::shared_ptr<Blob> data;
+  std::shared_ptr<Keypair> keypair;
+};
+
+/**
+ * @given Initialized keypiar with _concrete_ algorithm
+ * @when sign date without knowledge of cryptography algorithm
+ * @then check that siganture valid without clarification of algorithm
+ */
+TEST_F(CryptoInitialization, RawSignAndVerifyTest) {
+  auto signed_blob = CryptoSigner<>::sign(*data, *keypair);
+  auto verified =
+      CryptoVerifier<>::verify(signed_blob, *data, keypair->publicKey());
+  ASSERT_TRUE(verified);
+}


### PR DESCRIPTION
## What is this pull request?
Now possible to use cryptography without explicit configuration of algorithm;

## Why do you implement it? Why do we need this pull request?
This PR provides separation of `crypto_provider` with `Signer` and `Verifier`. And make default algorithm specialization of it.

Additional changes:
* Rework hashable documentation
* Fix warnings in seed and keypair files
* Reworked crypto providers with static context
* Fix CMake dependencies
* Add usage tests
