### PR TITLE
Fix memory leaks in proto shared model usage

### DIFF
--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -68,7 +68,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<iroha::protocol::AddAssetQuantity> add_asset_quantity_;
+      const Lazy<const iroha::protocol::AddAssetQuantity &> add_asset_quantity_;
 
       const Lazy<proto::Amount> amount_;
     };

--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -65,10 +65,12 @@ namespace shared_model {
       detail::ReferenceHolder<iroha::protocol::Command> command_;
 
       // lazy
-      const detail::LazyInitializer<iroha::protocol::AddAssetQuantity>
-          add_asset_quantity_;
+      template <typename T>
+      using Lazy = detail::LazyInitializer<T>;
 
-      const detail::LazyInitializer<proto::Amount> amount_;
+      const Lazy<iroha::protocol::AddAssetQuantity> add_asset_quantity_;
+
+      const Lazy<proto::Amount> amount_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -41,7 +41,10 @@ namespace shared_model {
       using w = detail::PolymorphicWrapper<Value>;
 
       /// lazy variant shortcut
-      using LazyVariantType = detail::LazyInitializer<CommandVariantType>;
+      template <typename T>
+      using Lazy = detail::LazyInitializer<T>;
+
+      using LazyVariantType = Lazy<CommandVariantType>;
 
      public:
       /// type of proto variant
@@ -78,7 +81,7 @@ namespace shared_model {
       // lazy
       const LazyVariantType variant_;
 
-      const detail::LazyInitializer<BlobType> blob_;
+      const Lazy<BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -26,7 +26,7 @@
 
 template <typename... T, typename Archive>
 auto load(Archive &&ar) {
-  int which = ar.command_case() - 1;
+  int which = ar.GetDescriptor()->FindFieldByNumber(ar.command_case())->index();
   return shared_model::detail::variant_impl<T...>::
       template load<shared_model::interface::Command::CommandVariantType>(
           std::forward<Archive>(ar), which);

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -24,11 +24,12 @@
 #include "utils/lazy_initializer.hpp"
 #include "utils/variant_deserializer.hpp"
 
-template <typename... T>
-auto load(const iroha::protocol::Command &ar) {
+template <typename... T, typename Archive>
+auto load(Archive &&ar) {
   int which = ar.command_case() - 1;
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::Command::CommandVariantType>(ar, which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::Command::CommandVariantType>(
+          std::forward<Archive>(ar), which);
 }
 
 namespace shared_model {
@@ -42,8 +43,6 @@ namespace shared_model {
       /// lazy variant shortcut
       using LazyVariantType = detail::LazyInitializer<CommandVariantType>;
 
-      using RefCommand = detail::ReferenceHolder<iroha::protocol::Command>;
-
      public:
       /// type of proto variant
       using ProtoCommandVariantType = boost::variant<w<AddAssetQuantity>>;
@@ -51,11 +50,16 @@ namespace shared_model {
       /// list of types in proto variant
       using ProtoCommandListType = ProtoCommandVariantType::types;
 
-      explicit Command(const iroha::protocol::Command &command)
-          : Command(RefCommand(command)) {}
+      template <typename CommandType>
+      explicit Command(CommandType &&command)
+          : command_(std::forward<CommandType>(command)),
+            variant_([this] { return load<ProtoCommandListType>(*command_); }),
+            blob_([this] { return BlobType(command_->SerializeAsString()); }) {}
 
-      explicit Command(iroha::protocol::Command &&command)
-          : Command(RefCommand(std::move(command))) {}
+      Command(const Command &o) : Command(*o.command_) {}
+
+      Command(Command &&o) noexcept : Command(std::move(o.command_.variant())) {
+      }
 
       const CommandVariantType &get() const override { return *variant_; }
 
@@ -66,21 +70,15 @@ namespace shared_model {
       }
 
      private:
-      explicit Command(RefCommand &&ref)
-          : command_(std::move(ref)),
-            variant_(detail::makeLazyInitializer([this] {
-              return CommandVariantType(load<ProtoCommandListType>(*command_));
-            })),
-            blob_([this] { return BlobType(command_->SerializeAsString()); }) {}
-
       // ------------------------------| fields |-------------------------------
 
       // proto
-      RefCommand command_;
+      detail::ReferenceHolder<iroha::protocol::Command> command_;
 
       // lazy
-      LazyVariantType variant_;
-      detail::LazyInitializer<BlobType> blob_;
+      const LazyVariantType variant_;
+
+      const detail::LazyInitializer<BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -70,12 +70,14 @@ namespace shared_model {
       detail::ReferenceHolder<iroha::protocol::Amount> proto_amount_;
 
       // lazy
-      const detail::LazyInitializer<boost::multiprecision::uint256_t>
-          multiprecision_repr_;
+      template <typename T>
+      using Lazy = detail::LazyInitializer<T>;
 
-      const detail::LazyInitializer<interface::types::PrecisionType> precision_;
+      const Lazy<boost::multiprecision::uint256_t> multiprecision_repr_;
 
-      const detail::LazyInitializer<BlobType> blob_;
+      const Lazy<interface::types::PrecisionType> precision_;
+
+      const Lazy<BlobType> blob_;
     };
 
   }  // namespace proto

--- a/shared_model/utils/lazy_initializer.hpp
+++ b/shared_model/utils/lazy_initializer.hpp
@@ -35,10 +35,9 @@ namespace shared_model {
       using GeneratorType = std::function<Target()>;
 
      public:
-      explicit LazyInitializer(const GeneratorType &generator)
-          : generator_(generator) {}
-
-      LazyInitializer(const LazyInitializer &) = default;
+      template <typename T>
+      explicit LazyInitializer(T &&generator)
+          : generator_(std::forward<T>(generator)) {}
 
       using PointerType = typename std::add_pointer_t<Target>;
 
@@ -46,7 +45,7 @@ namespace shared_model {
 
       const PointerType ptr() const {
         if (target_value_ == boost::none) {
-          target_value_ = boost::make_optional<Target>(generator_());
+          target_value_.emplace(generator_());
         }
         return target_value_.get_ptr();
       }

--- a/shared_model/utils/lazy_initializer.hpp
+++ b/shared_model/utils/lazy_initializer.hpp
@@ -45,6 +45,8 @@ namespace shared_model {
 
       const PointerType ptr() const {
         if (target_value_ == boost::none) {
+          // Use type move constuctor with emplace
+          // since Target copy assignment operator could be deleted
           target_value_.emplace(generator_());
         }
         return target_value_.get_ptr();

--- a/shared_model/utils/reference_holder.hpp
+++ b/shared_model/utils/reference_holder.hpp
@@ -23,8 +23,9 @@
 namespace shared_model {
   namespace detail {
     /**
-     * Structure designed to contain reference or value depending on called ctor
-     * @tparam T
+     * Structure designed to contain reference to const
+     * or value depending on called ctor
+     * @tparam T type of stored value
      */
     template <typename T>
     class ReferenceHolder {

--- a/shared_model/utils/reference_holder.hpp
+++ b/shared_model/utils/reference_holder.hpp
@@ -23,50 +23,38 @@
 namespace shared_model {
   namespace detail {
     /**
-     * Structure designed to contain pointer or value depending on called ctor
+     * Structure designed to contain reference or value depending on called ctor
      * @tparam T
-     * @tparam V
      */
-    template <typename T, typename V = const T &>
+    template <typename T>
     class ReferenceHolder {
      private:
-      using MapperType = std::function<const V &(const T &)>;
-
-      //  T_T*
-      using VariantType = boost::variant<T, const T *>;
-
-      static const V &identity(const T &x) { return x; }
+      using VariantType = boost::variant<T, const T &>;
 
      public:
-      ReferenceHolder(T &&value, const MapperType &mapper = identity)
-          : ReferenceHolder(VariantType(std::move(value)), mapper) {}
+      template <typename V>
+      explicit ReferenceHolder(V &&value) : variant_(std::forward<V>(value)) {}
 
-      ReferenceHolder(const T &ref, const MapperType &mapper = identity)
-          : ReferenceHolder(VariantType(&ref), mapper) {}
+      using ReferenceType = typename std::add_lvalue_reference_t<const T>;
+      using PointerType = typename std::add_pointer_t<const T>;
 
-      using PointerType = typename std::add_pointer_t<V>;
+      ReferenceType operator*() const { return *ptr(); }
 
-      const V &operator*() const { return *ptr(); }
+      PointerType operator->() const { return ptr(); }
 
-      const PointerType ptr() const { return value_.ptr(); }
+      PointerType ptr() const {
+        return &boost::apply_visitor(getter_visitor_, variant_);
+      }
 
-      const PointerType operator->() const { return ptr(); }
+      VariantType &variant() { return variant_; }
 
      private:
-      ReferenceHolder(VariantType &&variant, const MapperType &mapper)
-          : variant_(std::move(variant)), value_([mapper, this]() -> const V & {
-              return mapper(boost::apply_visitor(getter_visitor_, variant_));
-            }) {}
-
       class GetterVisitor : public boost::static_visitor<const T &> {
        public:
         const T &operator()(const T &value) const { return value; }
-        const T &operator()(const T *ref) const { return *ref; }
       } getter_visitor_;
 
       VariantType variant_;
-
-      LazyInitializer<const V &> value_;
     };
 
     /**

--- a/shared_model/utils/variant_deserializer.hpp
+++ b/shared_model/utils/variant_deserializer.hpp
@@ -40,7 +40,7 @@ namespace shared_model {
          * @tparam Archive container type
          */
         template <class V, class T = typename V::types, class Archive>
-        static V invoke(const Archive &, int) {
+        static V invoke(Archive &&, int) {
           BOOST_ASSERT_MSG(false, "Required type not found");
         }
       };
@@ -62,15 +62,20 @@ namespace shared_model {
          * @param v result variant
          */
         template <class V, class T = typename V::types, class Archive>
-        static V invoke(const Archive &ar, int which) {
+        static V invoke(Archive &&ar, int which) {
           if (which == 0) {
             using head_type = typename boost::mpl::front<S>::type;
-            return V(head_type(ar));
+            using variant_head_type = typename boost::mpl::front<T>::type;
+            static_assert(
+                std::is_base_of<typename variant_head_type::WrappedType,
+                                typename head_type::WrappedType>::value,
+                "variant_head_type is not base of head_type");
+            return V(head_type(std::forward<Archive>(ar)));
           } else {
             using type = typename boost::mpl::pop_front<S>::type;
             using variant_type = typename boost::mpl::pop_front<T>::type;
             return variant_impl<type>::template load<V, variant_type>(
-                ar, which - 1);
+                std::forward<Archive>(ar), which - 1);
           }
         }
       };
@@ -86,12 +91,12 @@ namespace shared_model {
        * @param v result variant
        */
       template <class V, class T = typename V::types, class Archive>
-      static V load(const Archive &ar, int which) {
+      static V load(Archive &&ar, int which) {
         using typex =
             typename boost::mpl::eval_if<boost::mpl::empty<S>,
                                          boost::mpl::identity<load_null>,
                                          boost::mpl::identity<load_impl>>::type;
-        return typex::template invoke<V, T>(ar, which);
+        return typex::template invoke<V, T>(std::forward<Archive>(ar), which);
       }
     };
   }  // namespace detail

--- a/shared_model/utils/variant_deserializer.hpp
+++ b/shared_model/utils/variant_deserializer.hpp
@@ -66,6 +66,11 @@ namespace shared_model {
           if (which == 0) {
             using head_type = typename boost::mpl::front<S>::type;
             using variant_head_type = typename boost::mpl::front<T>::type;
+            // Given two variant type lists T and S, where T is list of abstract
+            // types, and S is list of implementations, ensure that there is a
+            // corresponding implementation for each abstract type
+            // Probably there is a missing type either in interfaces/.h
+            // abstract variant, or backend/type/.h implementation variant
             static_assert(
                 std::is_base_of<typename variant_head_type::WrappedType,
                                 typename head_type::WrappedType>::value,

--- a/test/module/shared_model/backend_proto/CMakeLists.txt
+++ b/test/module/shared_model/backend_proto/CMakeLists.txt
@@ -15,5 +15,9 @@
 # limitations under the License.
 #
 
-add_subdirectory(backend_proto)
-AddTest(lazy_test lazy_test.cpp)
+addtest(shared_proto_commands_test
+    shared_proto_commands_test.cpp
+    )
+target_link_libraries(shared_proto_commands_test
+    shared_model_proto_backend
+    )

--- a/test/module/shared_model/backend_proto/shared_proto_commands_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_commands_test.cpp
@@ -18,39 +18,29 @@
 #include "backend/protobuf/commands/proto_command.hpp"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
-// Quite hacky way to extract the class name
-// probably not stable and should be improved
-class ClassNameVisitor : public boost::static_visitor<const std::string> {
- public:
-  template <typename T>
-  const std::string operator()(const T &t) const {
-    auto s = t->toString();
-    // skip everything except class name
-    return std::string(s.begin(), s.begin() + s.find(':'));
-  }
-};
+using ::testing::StartsWith;
 
 class ProtoCommand : public testing::Test {
  public:
-  void SetUp() override {}
   template <typename T>
-  void SetUp(T &&command) {
+  void initializeCommand(T &&command) {
     (r.*command)();
     proto = std::make_shared<shared_model::proto::Command>(r);
   }
 
   iroha::protocol::Command r;
   std::shared_ptr<shared_model::proto::Command> proto;
-  ClassNameVisitor visitor;
 };
 
 /**
- * The following test ensures that the command is deserialized properly
+ * @given add asset quantity protobuf command object
+ * @when create shared model command object
+ * @then corresponding add asset quantity shared model object is created
  */
-
 TEST_F(ProtoCommand, AddAssetQuantityLoad) {
-  SetUp(&iroha::protocol::Command::mutable_add_asset_quantity);
-  ASSERT_STREQ("AddAssetQuantity",
-               boost::apply_visitor(visitor, proto->get()).c_str());
+  initializeCommand(&iroha::protocol::Command::mutable_add_asset_quantity);
+
+  ASSERT_THAT(proto->toString(), StartsWith("AddAssetQuantity"));
 }

--- a/test/module/shared_model/backend_proto/shared_proto_commands_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_commands_test.cpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/protobuf/commands/proto_command.hpp"
+
+#include <gtest/gtest.h>
+
+// Quite hacky way to extract the class name
+// probably not stable and should be improved
+class ClassNameVisitor : public boost::static_visitor<const std::string> {
+ public:
+  template <typename T>
+  const std::string operator()(const T &t) const {
+    auto s = t->toString();
+    // skip everything except class name
+    return std::string(s.begin(), s.begin() + s.find(':'));
+  }
+};
+
+class ProtoCommand : public testing::Test {
+ public:
+  void SetUp() override {}
+  template <typename T>
+  void SetUp(T &&command) {
+    (r.*command)();
+    proto = std::make_shared<shared_model::proto::Command>(r);
+  }
+
+  iroha::protocol::Command r;
+  std::shared_ptr<shared_model::proto::Command> proto;
+  ClassNameVisitor visitor;
+};
+
+/**
+ * The following test ensures that the command is deserialized properly
+ */
+
+TEST_F(ProtoCommand, AddAssetQuantityLoad) {
+  SetUp(&iroha::protocol::Command::mutable_add_asset_quantity);
+  ASSERT_STREQ("AddAssetQuantity",
+               boost::apply_visitor(visitor, proto->get()).c_str());
+}


### PR DESCRIPTION
 - Consolidate constructors by using std::forward

 - Remove lazy and mapper from reference holder to allow move semantics

 - Allow move semantics in variant_deserializer

 - Add variants type check in deserializer

 - Add sample test for proto model creation