### PR TITLE
Feature/get account asset transactions with pager

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -52,10 +52,11 @@ namespace iroha {
        * @param pager - pager for transactions
        * @return observable of Model Transaction
        */
-      virtual rxcpp::observable<model::Transaction>
-      getAccountAssetTransactions(const std::string& account_id,
-                                  const std::vector<std::string>& assets_id,
-                                  const model::Pager& pager) = 0;
+      virtual rxcpp::observable<model::Transaction> getAccountAssetTransactions(
+          const std::string &account_id,
+          const std::vector<std::string> &assets_id,
+          const model::Pager &pager = model::Pager{
+              iroha::hash256_t{}, model::Pager::MAX_PAGER_LIMIT}) = 0;
 
       /**
        * Get transactions from transactions' hashes

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -48,11 +48,14 @@ namespace iroha {
       /**
        * Get asset transactions of an account.
        * @param account_id - account_id (accountName@domainName)
-       * @param asset_id - asset_id (assetName#domainName)
+       * @param assets_id - list of asset_id (assetName#domainName)
+       * @param pager - pager for transactions
        * @return observable of Model Transaction
        */
-      virtual rxcpp::observable<model::Transaction> getAccountAssetTransactions(
-          const std::string &account_id, const std::string &asset_id) = 0;
+      virtual rxcpp::observable<model::Transaction>
+      getAccountAssetTransactions(const std::string& account_id,
+                                  const std::vector<std::string>& assets_id,
+                                  const model::Pager& pager) = 0;
 
       /**
        * Get transactions from transactions' hashes

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -17,6 +17,8 @@
 
 #include "ametsuchi/impl/redis_block_query.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
+#include "model/commands/transfer_asset.hpp"
+#include "model/commands/add_asset_quantity.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -149,33 +151,62 @@ namespace iroha {
               .take_last(pager.limit));
     }
 
-    rxcpp::observable<model::Transaction>
-    RedisBlockQuery::getAccountAssetTransactions(const std::string &account_id,
-                                                 const std::string &asset_id) {
-      return rxcpp::observable<>::create<model::Transaction>(
-          [this, account_id, asset_id](auto subscriber) {
-            auto block_ids = this->getBlockIds(account_id);
-            if (block_ids.empty()) {
-              subscriber.on_completed();
-              return;
-            }
+    bool RedisBlockQuery::hasAccountAssetRelatedCommand(
+        const std::string &account_id,
+        const std::vector<std::string> &assets_id,
+        const std::shared_ptr<iroha::model::Command> &command) const {
+      auto predicate_producer = [&](const auto &check_target_id) {
+        return [&check_target_id, &assets_id](const auto &com) {
+          return check_target_id(com)
+                 and std::any_of(assets_id.begin(),
+                                 assets_id.end(),
+                                 [&com](const auto &asset_id) {
+                                   return asset_id == com.asset_id;
+                                 });
+        };
+      };
 
-            for (auto block_id : block_ids) {
-              // create key for querying redis
-              std::string account_assets_key;
-              account_assets_key.append(account_id);
-              account_assets_key.append(":");
-              account_assets_key.append(std::to_string(block_id));
-              account_assets_key.append(":");
-              account_assets_key.append(asset_id);
-              client_.lrange(account_assets_key,
-                             0,
-                             -1,
-                             this->callbackToLrange(subscriber, block_id));
-            }
-            client_.sync_commit();
-            subscriber.on_completed();
-          });
+      return isCommandValid<model::TransferAsset>(
+        command,
+        predicate_producer([&account_id](const auto &transfer) {
+          return transfer.src_account_id == account_id
+                 or transfer.dest_account_id == account_id;
+        }))
+             or isCommandValid<model::AddAssetQuantity>(
+        command, predicate_producer([&account_id](const auto &add) {
+          return add.account_id == account_id;
+        }));
+    }
+
+    rxcpp::observable<model::Transaction>
+    RedisBlockQuery::getAccountAssetTransactions(
+        const std::string &account_id,
+        const std::vector<std::string> &assets_id,
+        const model::Pager &pager) {
+      // TODO 06/11/17 motxx: Improve API by Redis
+      return reverseObservable(
+          getBlocksFrom(1)
+              .flat_map([](auto block) {
+                return rxcpp::observable<>::iterate(block.transactions);
+              })
+              // local variables can be captured because this observable will be
+              // subscribed in this function.
+              .take_while([&pager](auto tx) {
+                return iroha::hash(tx) != pager.tx_hash;
+              })
+              .filter([this, &account_id, &assets_id](auto tx) {
+                return std::any_of(
+                    tx.commands.begin(),
+                    tx.commands.end(),
+                    [this, &account_id, &assets_id](auto command) {
+                      // This "this->" is required by gcc.
+                      return this->hasAccountAssetRelatedCommand(
+                          account_id, assets_id, command);
+                    });
+              })
+              // size of retrievable blocks and transactions should be
+              // restricted in stateless validation.
+              .take_last(pager.limit));
     }
 
     rxcpp::observable<boost::optional<model::Transaction>>

--- a/irohad/ametsuchi/impl/redis_block_query.hpp
+++ b/irohad/ametsuchi/impl/redis_block_query.hpp
@@ -100,13 +100,6 @@ namespace iroha {
       }
 
       /**
-       * @param o - given observable
-       * @return observable reversed the elements to emit
-       */
-      rxcpp::observable<model::Transaction> reverseObservable(
-        const rxcpp::observable<model::Transaction> &o) const;
-
-      /**
        * @param account_id - account identifier
        * @param assets_id - asset identifiers
        * @param command - command to check if it is account asset related

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -24,6 +24,7 @@
 #include "model/queries/get_asset_info.hpp"
 #include "model/queries/get_roles.hpp"
 #include "model/queries/get_signatories.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 #include "model/queries/get_transactions.hpp"
 #include "model/queries/get_account_transactions.hpp"
 
@@ -117,9 +118,31 @@ namespace iroha {
       JsonQueryFactory::deserializeGetAccountAssetTransactions(
           const Value &obj_query) {
         auto des = makeFieldDeserializer(obj_query);
+
+        auto des_assets_id = [this](auto assets_id) {
+          auto acc_string = [this](auto init, auto &x) {
+            return init | [this, &x](auto commands) {
+              return (x.IsString() ? nonstd::make_optional(x.GetString())
+                                   : nonstd::nullopt)
+                     | [&commands](auto command) {
+                commands.push_back(command);
+                return nonstd::make_optional(commands);
+              };
+            };
+          };
+          return std::accumulate(
+            assets_id.begin(),
+            assets_id.end(),
+            nonstd::make_optional<
+              GetAccountAssetTransactions::AssetsIdType>(),
+            acc_string);
+        };
+
         return make_optional_ptr<GetAccountAssetTransactions>()
             | des.String(&GetAccountAssetTransactions::account_id, "account_id")
-            | des.String(&GetAccountAssetTransactions::asset_id, "asset_id")
+            | des.Array(&GetAccountAssetTransactions::assets_id, "assets_id",
+                        des_assets_id)
+            | des.Object(&GetAccountAssetTransactions::pager, "pager")
             | toQuery;
       }
 
@@ -250,7 +273,21 @@ namespace iroha {
             std::static_pointer_cast<const GetAccountAssetTransactions>(query);
         json_doc.AddMember("account_id", get_account_asset->account_id,
                            allocator);
-        json_doc.AddMember("asset_id", get_account_asset->asset_id, allocator);
+        Value json_assets_id;
+        json_assets_id.SetArray();
+        const auto& assets_id = get_account_asset->assets_id;
+        std::for_each(assets_id.begin(), assets_id.end(),
+                      [&json_assets_id, &allocator](auto asset_id) {
+                        Value json_id;
+                        json_id.Set(asset_id, allocator);
+                        json_assets_id.PushBack(json_id, allocator);
+                      });
+        json_doc.AddMember("assets_id", json_assets_id, allocator);
+        Value json_pager;
+        json_pager.SetObject();
+        json_pager.CopyFrom(
+          serializePager(get_account_asset->pager, allocator), allocator);
+        json_doc.AddMember("pager", json_pager, allocator);
       }
 
       void JsonQueryFactory::serializeGetTransactions(

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -26,6 +26,7 @@
 #include "model/queries/get_roles.hpp"
 #include "model/queries/get_signatories.hpp"
 #include "model/queries/get_account_transactions.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 #include "model/queries/get_transactions.hpp"
 #include "queries.pb.h"
 
@@ -126,6 +127,19 @@ namespace iroha {
                                return iroha::hash256_t::from_string(tx_hash);
                              });
               val = std::make_shared<GetTransactions>(query);
+              break;
+            }
+            case Query_Payload::QueryCase::kGetAccountAssetTransactions: {
+              const auto &pb_cast =
+                pl.get_account_asset_transactions();
+              auto query = GetAccountAssetTransactions();
+              query.account_id = pb_cast.account_id();
+              std::copy(pb_cast.assets_id().begin(),
+                        pb_cast.assets_id().end(),
+                        std::back_inserter(query.assets_id));
+              query.pager = deserializePager(pb_cast.pager());
+              val = std::make_shared<
+                model::GetAccountAssetTransactions>(query);
               break;
             }
             case Query_Payload::QueryCase::kGetRoles: {
@@ -241,11 +255,14 @@ namespace iroha {
         auto tmp =
             std::static_pointer_cast<const GetAccountAssetTransactions>(query);
         auto account_id = tmp->account_id;
-        auto asset_id = tmp->asset_id;
+        auto assets_id = tmp->assets_id;
         auto pb_query_mut = pb_query.mutable_payload()
                                 ->mutable_get_account_asset_transactions();
         pb_query_mut->set_account_id(account_id);
-        pb_query_mut->set_asset_id(asset_id);
+        std::for_each(assets_id.begin(), assets_id.end(), [&pb_query_mut](auto id) {
+          (*pb_query_mut->add_assets_id()) = id;
+        });
+        *pb_query_mut->mutable_pager() = serializePager(tmp->pager);
         return pb_query;
       }
 

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -91,14 +91,6 @@ namespace iroha {
               val = std::make_shared<model::GetAccountDetail>(query);
               break;
             }
-            case Query_Payload::QueryCase::kGetAccountAssetTransactions: {
-              const auto &pb_cast = pl.get_account_asset_transactions();
-              auto query = GetAccountAssetTransactions();
-              query.account_id = pb_cast.account_id();
-              query.asset_id = pb_cast.asset_id();
-              val = std::make_shared<model::GetAccountAssetTransactions>(query);
-              break;
-            }
             case Query_Payload::QueryCase::kGetAccountSignatories: {
               // Convert to get Signatories
               const auto &pb_cast = pl.get_account_signatories();

--- a/irohad/model/generators/impl/query_generator.cpp
+++ b/irohad/model/generators/impl/query_generator.cpp
@@ -97,15 +97,19 @@ namespace iroha {
         return query;
       }
 
-      std::shared_ptr<GetAccountAssetTransactions> QueryGenerator::generateGetAccountAssetTransactions(
-          ts64_t timestamp, std::string creator, uint64_t query_counter,
-          std::string account_id, std::string asset_id) {
+      optional_ptr<GetAccountAssetTransactions>
+      QueryGenerator::generateGetAccountAssetTransactions(
+          ts64_t timestamp, const std::string& creator,
+          uint64_t query_counter, const std::string& account_id,
+          const std::vector<std::string>& assets_id,
+          const model::Pager& pager) const {
         auto query = std::make_shared<GetAccountAssetTransactions>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
         query->query_counter = query_counter;
         query->account_id = account_id;
-        query->asset_id = asset_id;
+        query->assets_id = assets_id;
+        query->pager = pager;
         return query;
       }
 

--- a/irohad/model/generators/query_generator.hpp
+++ b/irohad/model/generators/query_generator.hpp
@@ -19,6 +19,8 @@
 #include "model/queries/get_account_assets.hpp"
 #include "model/queries/get_account_detail.hpp"
 #include "model/queries/get_signatories.hpp"
+#include "model/queries/get_account_transactions.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 #include "model/queries/get_transactions.hpp"
 #include "model/queries/get_account_transactions.hpp"
 #include "model/queries/get_asset_info.hpp"
@@ -54,10 +56,6 @@ namespace iroha {
                                               uint64_t query_counter,
                                               std::string account_id);
 
-        std::shared_ptr<GetAccountAssetTransactions> generateGetAccountAssetTransactions(
-            ts64_t timestamp, std::string creator, uint64_t query_counter,
-            std::string account_id, std::string asset_id);
-
         std::shared_ptr<GetTransactions> generateGetTransactions(
             ts64_t timestamp, const std::string& creator, uint64_t query_counter,
             const std::vector<iroha::hash256_t>& tx_hahses);
@@ -68,6 +66,16 @@ namespace iroha {
             uint64_t query_counter,
             const std::string &account_id,
             const model::Pager &pager = model::Pager{
+              iroha::hash256_t{}, model::Pager::MAX_PAGER_LIMIT}) const;
+
+        optional_ptr<GetAccountAssetTransactions>
+        generateGetAccountAssetTransactions(
+            ts64_t timestamp,
+            const std::string& creator,
+            uint64_t query_counter,
+            const std::string& account_id,
+            const std::vector<std::string>& assets_id,
+            const model::Pager& pager = model::Pager{
               iroha::hash256_t{}, model::Pager::MAX_PAGER_LIMIT}) const;
 
         /**

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -263,8 +263,8 @@ iroha::model::QueryProcessingFactory::executeGetAccountDetail(
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountAssetTransactions(
     const model::GetAccountAssetTransactions& query) {
-  auto acc_asset_tx = _blockQuery->getAccountAssetTransactions(query.account_id,
-                                                               query.asset_id);
+  auto acc_asset_tx = _blockQuery->getAccountAssetTransactions(
+    query.account_id, query.assets_id, query.pager);
   TransactionsResponse response;
   response.query_hash = iroha::hash(query);
   response.transactions = acc_asset_tx;

--- a/irohad/model/queries/get_account_asset_transactions.hpp
+++ b/irohad/model/queries/get_account_asset_transactions.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
+#define IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
+
+#include <model/query.hpp>
+#include <string>
+#include <vector>
+#include "model/queries/pager.hpp"
+
+namespace iroha {
+  namespace model {
+    /**
+     * Query for getting transactions of given asset of an account
+     */
+    struct GetAccountAssetTransactions : Query {
+      /**
+       * Account identifier
+       */
+      std::string account_id{};
+
+      /**
+       * Asset identifiers
+       */
+      std::vector<std::string> assets_id{};
+
+      /**
+       * Pager for transactions
+       */
+      Pager pager{};
+
+      using AssetsIdType = decltype(assets_id);
+
+      bool operator==(GetAccountAssetTransactions const& rhs) const {
+        return account_id == rhs.account_id and assets_id == rhs.assets_id
+               and pager == rhs.pager;
+      }
+      bool operator!=(GetAccountAssetTransactions const& rhs) const {
+        return not(operator==(rhs));
+      }
+    };
+  }  // namespace model
+}  // namespace iroha
+#endif  // IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP

--- a/irohad/model/queries/get_transactions.hpp
+++ b/irohad/model/queries/get_transactions.hpp
@@ -26,21 +26,6 @@
 namespace iroha {
   namespace model {
     /**
-     * Query for getting transactions of given asset of an account
-     */
-    struct GetAccountAssetTransactions : Query {
-      /**
-       * Account identifier
-       */
-      std::string account_id{};
-
-      /**
-       * Asset identifier
-       */
-      std::string asset_id{};
-    };
-
-    /**
      * Query for getting transactions of given transactions' hashes
      */
     struct GetTransactions : Query {

--- a/irohad/model/query_execution.hpp
+++ b/irohad/model/query_execution.hpp
@@ -27,6 +27,7 @@
 #include "model/queries/get_asset_info.hpp"
 #include "model/queries/get_roles.hpp"
 #include "model/queries/get_signatories.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 #include "model/queries/get_transactions.hpp"
 #include "model/queries/get_account_transactions.hpp"
 

--- a/irohad/model/registration/query_registration.hpp
+++ b/irohad/model/registration/query_registration.hpp
@@ -27,6 +27,8 @@
 #include "model/queries/get_asset_info.hpp"
 #include "model/queries/get_roles.hpp"
 #include "model/queries/get_signatories.hpp"
+#include "model/queries/get_account_transactions.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 #include "model/queries/get_transactions.hpp"
 #include "model/queries/get_account_transactions.hpp"
 

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -23,7 +23,8 @@ message GetAccountTransactions {
 
 message GetAccountAssetTransactions {
   string account_id = 1;
-  string asset_id = 2;
+  repeated string assets_id = 2;
+  Pager pager = 3;
 }
 
 message GetTransactions {

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -19,6 +19,7 @@
 #define IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 
 #include "interfaces/queries/get_account_transactions.hpp"
+#include "interfaces/common_objects/types.hpp"
 
 #include "queries.pb.h"
 #include "utils/lazy_initializer.hpp"
@@ -37,7 +38,16 @@ namespace shared_model {
             account_asset_transactions_(detail::makeReferenceGenerator(
                 &proto_->payload(),
                 &iroha::protocol::Query::Payload::
-                    get_account_asset_transactions)) {}
+                    get_account_asset_transactions)),
+            assets_id_([this] {
+              return boost::accumulate(
+                  account_asset_transactions_->assets_id(),
+                  interface::types::AssetIdCollectionType{},
+                  [](auto &&acc, const auto &asset) {
+                    acc.emplace_back(asset);
+                    return std::forward<decltype(acc)>(acc);
+                  });
+            }) {}
 
       GetAccountAssetTransactions(const GetAccountAssetTransactions &o)
           : GetAccountAssetTransactions(o.proto_) {}
@@ -49,8 +59,8 @@ namespace shared_model {
         return account_asset_transactions_->account_id();
       }
 
-      const interface::types::AssetIdType &assetId() const override {
-        return account_asset_transactions_->asset_id();
+      const interface::types::AssetIdCollectionType &assetsId() const override {
+        return *assets_id_;
       }
 
      private:
@@ -61,6 +71,8 @@ namespace shared_model {
 
       const Lazy<const iroha::protocol::GetAccountAssetTransactions &>
           account_asset_transactions_;
+
+      const Lazy<interface::types::AssetIdCollectionType> assets_id_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -18,8 +18,9 @@
 #ifndef IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 #define IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 
-#include "interfaces/queries/get_account_transactions.hpp"
+#include "backend/protobuf/common_objects/pager.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/queries/get_account_transactions.hpp"
 
 #include "queries.pb.h"
 #include "utils/lazy_initializer.hpp"
@@ -47,7 +48,8 @@ namespace shared_model {
                     acc.emplace_back(asset);
                     return std::forward<decltype(acc)>(acc);
                   });
-            }) {}
+            }),
+            pager_([this] { return Pager(account_asset_transactions_->pager()); }) {}
 
       GetAccountAssetTransactions(const GetAccountAssetTransactions &o)
           : GetAccountAssetTransactions(o.proto_) {}
@@ -63,6 +65,10 @@ namespace shared_model {
         return *assets_id_;
       }
 
+      const Pager &pager() const override {
+        return *pager_;
+      }
+
      private:
       // ------------------------------| fields |-------------------------------
 
@@ -73,6 +79,8 @@ namespace shared_model {
           account_asset_transactions_;
 
       const Lazy<interface::types::AssetIdCollectionType> assets_id_;
+
+      const Lazy<Pager> pager_;
     };
 
   }  // namespace proto

--- a/shared_model/bindings/model_query_builder.cpp
+++ b/shared_model/bindings/model_query_builder.cpp
@@ -51,9 +51,10 @@ namespace shared_model {
 
     ModelQueryBuilder ModelQueryBuilder::getAccountAssetTransactions(
         const interface::types::AccountIdType &account_id,
-        const interface::types::AssetIdCollectionType &assets_id) {
+        const interface::types::AssetIdCollectionType &assets_id,
+        const interface::Pager &pager) {
       return ModelQueryBuilder(
-          builder_.getAccountAssetTransactions(account_id, assets_id));
+          builder_.getAccountAssetTransactions(account_id, assets_id, pager));
     }
 
     ModelQueryBuilder ModelQueryBuilder::getAccountAssets(

--- a/shared_model/bindings/model_query_builder.cpp
+++ b/shared_model/bindings/model_query_builder.cpp
@@ -51,9 +51,9 @@ namespace shared_model {
 
     ModelQueryBuilder ModelQueryBuilder::getAccountAssetTransactions(
         const interface::types::AccountIdType &account_id,
-        const interface::types::AssetIdType &asset_id) {
+        const interface::types::AssetIdCollectionType &assets_id) {
       return ModelQueryBuilder(
-          builder_.getAccountAssetTransactions(account_id, asset_id));
+          builder_.getAccountAssetTransactions(account_id, assets_id));
     }
 
     ModelQueryBuilder ModelQueryBuilder::getAccountAssets(

--- a/shared_model/bindings/model_query_builder.hpp
+++ b/shared_model/bindings/model_query_builder.hpp
@@ -87,12 +87,12 @@ namespace shared_model {
       /**
        * Queries account transaction collection for a given asset
        * @param account_id - id of account to query
-       * @param asset_id - asset id to query about
+       * @param assets_id - asset id collection to query about
        * @return builder with getAccountAssetTransactions query inside
        */
       ModelQueryBuilder getAccountAssetTransactions(
           const interface::types::AccountIdType &account_id,
-          const interface::types::AssetIdType &asset_id);
+          const interface::types::AssetIdCollectionType &assets_id);
 
       /**
        * Queries balance of specific asset for given account

--- a/shared_model/bindings/model_query_builder.hpp
+++ b/shared_model/bindings/model_query_builder.hpp
@@ -88,11 +88,13 @@ namespace shared_model {
        * Queries account transaction collection for a given asset
        * @param account_id - id of account to query
        * @param assets_id - asset id collection to query about
+       * @param pager - pager for requested transactions
        * @return builder with getAccountAssetTransactions query inside
        */
       ModelQueryBuilder getAccountAssetTransactions(
           const interface::types::AccountIdType &account_id,
-          const interface::types::AssetIdCollectionType &assets_id);
+          const interface::types::AssetIdCollectionType &assets_id,
+          const interface::Pager &pager);
 
       /**
        * Queries balance of specific asset for given account

--- a/shared_model/builders/protobuf/queries.hpp
+++ b/shared_model/builders/protobuf/queries.hpp
@@ -89,11 +89,13 @@ namespace shared_model {
 
       NextBuilder<QueryField> getAccountAssetTransactions(
           const interface::types::AccountIdType &account_id,
-          const interface::types::AssetIdType &asset_id) {
+          const interface::types::AssetIdCollectionType &assets_id) {
         auto query =
             query_.mutable_payload()->mutable_get_account_asset_transactions();
         query->set_account_id(account_id);
-        query->set_asset_id(asset_id);
+        boost::for_each(assets_id, [&query](const auto &asset) {
+          query->add_assets_id(asset);
+        });
         return *this;
       }
 

--- a/shared_model/builders/protobuf/queries.hpp
+++ b/shared_model/builders/protobuf/queries.hpp
@@ -89,13 +89,18 @@ namespace shared_model {
 
       NextBuilder<QueryField> getAccountAssetTransactions(
           const interface::types::AccountIdType &account_id,
-          const interface::types::AssetIdCollectionType &assets_id) {
+          const interface::types::AssetIdCollectionType &assets_id,
+          const interface::Pager &pager) {
         auto query =
             query_.mutable_payload()->mutable_get_account_asset_transactions();
         query->set_account_id(account_id);
         boost::for_each(assets_id, [&query](const auto &asset) {
           query->add_assets_id(asset);
         });
+        auto &mutable_pager = *query->mutable_pager();
+        mutable_pager.set_tx_hash(
+          shared_model::crypto::toBinaryString(pager.transactionHash()));
+        mutable_pager.set_limit(pager.limit());
         return *this;
       }
 

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -47,6 +47,8 @@ namespace shared_model {
       using DomainIdType = std::string;
       /// Type of asset id
       using AssetIdType = std::string;
+      /// Type of asset id collection
+      using AssetIdCollectionType = std::vector<AssetIdType>;
       /// Permission type used in permission commands
       using PermissionNameType = std::string;
       /// Type of Quorum used in transaction and set quorum

--- a/shared_model/interfaces/queries/get_account_asset_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_asset_transactions.hpp
@@ -18,6 +18,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include "interfaces/base/primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/common_objects/pager.hpp"
 #include "model/queries/get_account_asset_transactions.hpp"
 
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
@@ -41,7 +42,10 @@ namespace shared_model {
        * @return assetsId of requested transactions
        */
       virtual const types::AssetIdCollectionType &assetsId() const = 0;
-      //virtual const
+      /**
+       * @return pager of requested transactions
+       */
+      virtual const interface::Pager &pager() const = 0;
 
       OldModelType *makeOldModel() const override {
         auto oldModel = new iroha::model::GetAccountAssetTransactions;

--- a/shared_model/interfaces/queries/get_account_asset_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_asset_transactions.hpp
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
+#include <boost/algorithm/string/join.hpp>
 #include "interfaces/base/primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
-#include "model/queries/get_transactions.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
@@ -37,14 +38,15 @@ namespace shared_model {
        */
       virtual const types::AccountIdType &accountId() const = 0;
       /**
-       * @return assetId of requested transactions
+       * @return assetsId of requested transactions
        */
-      virtual const types::AccountIdType &assetId() const = 0;
+      virtual const types::AssetIdCollectionType &assetsId() const = 0;
+      //virtual const
 
       OldModelType *makeOldModel() const override {
         auto oldModel = new iroha::model::GetAccountAssetTransactions;
         oldModel->account_id = accountId();
-        oldModel->asset_id = assetId();
+        oldModel->assets_id = assetsId();
         return oldModel;
       }
 
@@ -52,12 +54,12 @@ namespace shared_model {
         return detail::PrettyStringBuilder()
             .init("GetAccountAssetTransactions")
             .append("account_id", accountId())
-            .append("asset_id", assetId())
+            .append("assets_id", boost::algorithm::join(assetsId(), ","))
             .finalize();
       }
 
       bool operator==(const ModelType &rhs) const override {
-        return accountId() == rhs.accountId() and assetId() == rhs.assetId();
+        return accountId() == rhs.accountId() and assetsId() == rhs.assetsId();
       }
     };
 

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -43,6 +43,13 @@ target_link_libraries(get_account_transactions_test
     model_generators
     libs_common)
 
+addtest(get_account_asset_transactions_test get_account_asset_transactions_test.cpp)
+target_link_libraries(get_account_asset_transactions_test
+    ametsuchi
+    model_generators
+    libs_common
+    )
+
 add_library(ametsuchi_fixture INTERFACE)
 target_link_libraries(ametsuchi_fixture INTERFACE
     pqxx

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -123,10 +123,9 @@ namespace iroha {
       MOCK_METHOD1(
           getTxByHashSync,
           boost::optional<model::Transaction>(const std::string &hash));
-      MOCK_METHOD2(
-          getAccountAssetTransactions,
-          rxcpp::observable<model::Transaction>(const std::string &account_id,
-                                                const std::string &asset_id));
+      MOCK_METHOD3(getAccountAssetTransactions,
+                   rxcpp::observable<model::Transaction>(const std::string&,
+                     const std::vector<std::string>&, const model::Pager&));
       MOCK_METHOD1(getTransactions,
                    rxcpp::observable<boost::optional<model::Transaction>>(
                        const std::vector<iroha::hash256_t> &tx_hashes));

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <boost/algorithm/string/join.hpp>
 #include <boost/range/combine.hpp>
 #include <boost/range/algorithm/for_each.hpp>
 
@@ -93,14 +94,14 @@ void validateAccountTransactions(B &&blocks,
 template <typename B>
 void validateAccountAssetTransactions(B &&blocks,
                                       const std::string &account,
-                                      const std::string &asset,
+                                      const std::vector<std::string> &assets,
                                       int call_count,
                                       int command_count) {
   validateCalls(
-      blocks->getAccountAssetTransactions(account, asset),
+      blocks->getAccountAssetTransactions(account, assets),
       [&](const auto &tx) { EXPECT_EQ(tx.commands.size(), command_count); },
       call_count,
-      " for " + account + " " + asset);
+      " for " + account + " " + boost::algorithm::join(assets, ","));
 }
 
 /**
@@ -257,10 +258,10 @@ TEST_F(AmetsuchiTest, SampleTest) {
   validateAccountTransactions(blocks, "admin2", 1, 4);
   validateAccountTransactions(blocks, "non_existing_user", 0, 0);
 
-  validateAccountAssetTransactions(blocks, user1id, assetid, 1, 4);
-  validateAccountAssetTransactions(blocks, user2id, assetid, 1, 4);
+  validateAccountAssetTransactions(blocks, user1id, {assetid}, 1, 4);
+  validateAccountAssetTransactions(blocks, user2id, {assetid}, 1, 4);
   validateAccountAssetTransactions(
-      blocks, "non_existing_user", "non_existing_asset", 0, 0);
+      blocks, "non_existing_user", {"non_existing_asset"}, 0, 0);
 }
 
 TEST_F(AmetsuchiTest, PeerTest) {
@@ -413,12 +414,12 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   // (user1 -> user2 # asset1)
   // (user2 -> user3 # asset2)
   // (user2 -> user1 # asset2)
-  validateAccountAssetTransactions(blocks, user1id, asset1id, 1, 1);
-  validateAccountAssetTransactions(blocks, user2id, asset1id, 1, 1);
-  validateAccountAssetTransactions(blocks, user3id, asset1id, 0, 0);
-  validateAccountAssetTransactions(blocks, user1id, asset2id, 1, 2);
-  validateAccountAssetTransactions(blocks, user2id, asset2id, 1, 2);
-  validateAccountAssetTransactions(blocks, user3id, asset2id, 1, 2);
+  validateAccountAssetTransactions(blocks, user1id, {asset1id}, 1, 1);
+  validateAccountAssetTransactions(blocks, user2id, {asset1id}, 1, 1);
+  validateAccountAssetTransactions(blocks, user3id, {asset1id}, 0, 0);
+  validateAccountAssetTransactions(blocks, user1id, {asset2id}, 1, 2);
+  validateAccountAssetTransactions(blocks, user2id, {asset2id}, 1, 2);
+  validateAccountAssetTransactions(blocks, user3id, {asset2id}, 1, 2);
 }
 
 TEST_F(AmetsuchiTest, AddSignatoryTest) {

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -97,8 +97,10 @@ void validateAccountAssetTransactions(B &&blocks,
                                       const std::vector<std::string> &assets,
                                       int call_count,
                                       int command_count) {
+  // to check only latest account asset tx
+  const Pager pager {iroha::hash256_t{}, 1};
   validateCalls(
-      blocks->getAccountAssetTransactions(account, assets),
+      blocks->getAccountAssetTransactions(account, assets, pager),
       [&](const auto &tx) { EXPECT_EQ(tx.commands.size(), command_count); },
       call_count,
       " for " + account + " " + boost::algorithm::join(assets, ","));

--- a/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
@@ -108,7 +108,8 @@ namespace iroha {
      * @given block store and index with block containing 1 transaction
      * from creator 3 with transfer from creator 1 to creator 2 sending asset
      * @when query to get asset transactions of transaction creator
-     * @then query returns the transaction
+     * @then query returns nothing because api account_id and
+     * creator_account_id are unrelated.
      */
     TEST_F(BlockQueryTransferTest, GrantedTransfer) {
       model::Block block;
@@ -122,8 +123,23 @@ namespace iroha {
       block.height = 1;
       insert(block);
 
+      // creator_account_id is unrelated to account_id
       auto wrapper = make_test_subscriber<CallExact>(
-          blocks->getAccountAssetTransactions(creator3, assets), 1);
+          blocks->getAccountAssetTransactions(creator3, assets), 0);
+      wrapper.subscribe(
+          [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
+      ASSERT_TRUE(wrapper.validate());
+
+      // src_account_id is related to account_id
+      wrapper = make_test_subscriber<CallExact>(
+          blocks->getAccountAssetTransactions(creator1, assets), 1);
+      wrapper.subscribe(
+          [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
+      ASSERT_TRUE(wrapper.validate());
+
+      // dest_account_id is related to account_id
+      wrapper = make_test_subscriber<CallExact>(
+          blocks->getAccountAssetTransactions(creator2, assets), 1);
       wrapper.subscribe(
           [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
       ASSERT_TRUE(wrapper.validate());

--- a/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
@@ -53,6 +53,7 @@ namespace iroha {
       std::string creator2 = "user2@test";
       std::string creator3 = "user3@test";
       std::string asset = "coin#test";
+      std::vector<std::string> assets = {asset};
     };
 
     /**
@@ -73,7 +74,7 @@ namespace iroha {
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
-          blocks->getAccountAssetTransactions(creator1, asset), 1);
+          blocks->getAccountAssetTransactions(creator1, assets), 1);
       wrapper.subscribe(
           [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
       ASSERT_TRUE(wrapper.validate());
@@ -97,7 +98,7 @@ namespace iroha {
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
-          blocks->getAccountAssetTransactions(creator2, asset), 1);
+          blocks->getAccountAssetTransactions(creator2, assets), 1);
       wrapper.subscribe(
           [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
       ASSERT_TRUE(wrapper.validate());
@@ -122,7 +123,7 @@ namespace iroha {
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
-          blocks->getAccountAssetTransactions(creator3, asset), 1);
+          blocks->getAccountAssetTransactions(creator3, assets), 1);
       wrapper.subscribe(
           [this](auto val) { ASSERT_EQ(tx_hashes.at(0), iroha::hash(val)); });
       ASSERT_TRUE(wrapper.validate());
@@ -156,7 +157,7 @@ namespace iroha {
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
-          blocks->getAccountAssetTransactions(creator1, asset), 2);
+          blocks->getAccountAssetTransactions(creator1, assets), 2);
       wrapper.subscribe([ i = 0, this ](auto val) mutable {
         ASSERT_EQ(tx_hashes.at(i), iroha::hash(val));
         ++i;

--- a/test/module/irohad/ametsuchi/get_account_asset_transactions_test.cpp
+++ b/test/module/irohad/ametsuchi/get_account_asset_transactions_test.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/optional.hpp>
 #include "ametsuchi/impl/storage_impl.hpp"
-#include "crypto/hash.hpp"
+#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 #include "framework/test_subscriber.hpp"
 #include "generator/generator.hpp"
 #include "model/commands/add_asset_quantity.hpp"

--- a/test/module/irohad/ametsuchi/get_account_asset_transactions_test.cpp
+++ b/test/module/irohad/ametsuchi/get_account_asset_transactions_test.cpp
@@ -1,0 +1,279 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <boost/optional.hpp>
+#include "ametsuchi/impl/storage_impl.hpp"
+#include "crypto/hash.hpp"
+#include "framework/test_subscriber.hpp"
+#include "generator/generator.hpp"
+#include "model/commands/add_asset_quantity.hpp"
+#include "model/commands/create_account.hpp"
+#include "model/commands/create_asset.hpp"
+#include "model/commands/create_domain.hpp"
+#include "model/commands/create_role.hpp"
+#include "model/commands/transfer_asset.hpp"
+#include "model/generators/block_generator.hpp"
+#include "model/generators/transaction_generator.hpp"
+#include "model/permissions.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace iroha::model;
+using namespace framework::test_subscriber;
+using iroha::model::Transaction;
+using iroha::model::Command;
+using iroha::model::generators::BlockGenerator;
+using iroha::model::generators::TransactionGenerator;
+using iroha::model::generators::CommandGenerator;
+
+static const auto ADMIN_ID = std::string("admin@test");
+static const auto DOMAIN_ID = std::string("domain");
+static const auto USER_DEFAULT_ROLE = std::string("user");
+static const auto ALICE_NAME = std::string("alice");
+static const auto ALICE_ID = ALICE_NAME + "@" + DOMAIN_ID;
+static const auto BOB_NAME = std::string("bob");
+static const auto BOB_ID = BOB_NAME + "@" + DOMAIN_ID;
+static const auto IRH_ASSET_NAME = std::string("irh");
+static const auto IRH_ASSET_ID = IRH_ASSET_NAME + "#" + DOMAIN_ID;
+static const auto MEK_ASSET_NAME = std::string("moeka");
+static const auto MEK_ASSET_ID = MEK_ASSET_NAME + "#" + DOMAIN_ID;
+
+/**
+ * StorageImpl
+ * genesis_block
+ *   CreateRole, CreateDomain(domain), CreateAccount(alice@domain, bob@domain),
+ *   CreateAsset(irh#domain), CreateAsset(moeka#domain)
+ * block1:
+ *   given_txs[0]: creator_account_id = admin@domain
+ *     - AddAssetQuantity(alice@domain, irh#domain, 123.4)
+ *   given_txs[1]: creator_account_id = admin@domain
+ *     - AddAssetQuantity(bob@domain, moeka#domain, 100.50)
+ * block2:
+ *   given_txs[2]: creator_account_id = admin@domain
+ *     - TransferAsset(src: alice@domain, dest: bob@domain, irh#domain, 23.4)
+ *   given_txs[3]: creator_account_id = admin@domain
+ *     - random command
+ *     - TransferAsset(src: bob@domain, dest: alice@domain, moeka#domain, 20.00)
+ *     - random command
+ */
+class GetAccountAssetTransactionsTest : public AmetsuchiTest {
+ protected:
+  void SetUp() override {
+    AmetsuchiTest::SetUp();
+    storage =
+        StorageImpl::create(block_store_path, redishost_, redisport_, pgopt_);
+    ASSERT_TRUE(storage);
+
+    blocks = storage->getBlockQuery();
+
+    const auto genesis_block = BlockGenerator().generateBlock(
+        0, 1, iroha::hash256_t{}, {[] {
+          return TransactionGenerator().generateTransaction(
+              ADMIN_ID,
+              0,
+              {std::make_shared<iroha::model::CreateRole>(
+                   USER_DEFAULT_ROLE, iroha::model::all_perm_group),
+               CommandGenerator().generateCreateDomain(DOMAIN_ID,
+                                                       USER_DEFAULT_ROLE),
+               CommandGenerator().generateCreateAccount(
+                   ALICE_NAME,
+                   DOMAIN_ID,
+                   generator::random_blob<iroha::pubkey_t::size()>(1)),
+               CommandGenerator().generateCreateAccount(
+                   BOB_NAME,
+                   DOMAIN_ID,
+                   generator::random_blob<iroha::pubkey_t::size()>(2)),
+               CommandGenerator().generateCreateAsset(
+                   IRH_ASSET_NAME, DOMAIN_ID, 1),
+               CommandGenerator().generateCreateAsset(
+                   MEK_ASSET_NAME, DOMAIN_ID, 2)});
+        }()});
+    ASSERT_TRUE(storage->insertBlock(genesis_block));
+
+    given_txs.emplace_back(TransactionGenerator().generateTransaction(
+        ADMIN_ID,
+        0,
+        {CommandGenerator().generateAddAssetQuantity(
+            ALICE_ID,
+            IRH_ASSET_ID,
+            *iroha::Amount::createFromString("123.4"))}));
+    given_txs.emplace_back(TransactionGenerator().generateTransaction(
+        ADMIN_ID,
+        1,
+        {CommandGenerator().generateAddAssetQuantity(
+            BOB_ID,
+            MEK_ASSET_ID,
+            *iroha::Amount::createFromString("100.50"))}));
+
+    const auto block1 = BlockGenerator().generateBlock(
+        0, 2, genesis_block.hash, {given_txs[0], given_txs[1]});
+    ASSERT_TRUE(storage->insertBlock(block1));
+
+    given_txs.emplace_back(TransactionGenerator().generateTransaction(
+        ADMIN_ID,
+        0,
+        {CommandGenerator().generateTransferAsset(
+            ALICE_ID,
+            BOB_ID,
+            IRH_ASSET_ID,
+            *iroha::Amount::createFromString("23.4"))}));
+    given_txs.emplace_back(TransactionGenerator().generateTransaction(
+        ADMIN_ID,
+        0,
+        {generate_random_command(),
+         CommandGenerator().generateTransferAsset(
+             BOB_ID,
+             ALICE_ID,
+             MEK_ASSET_ID,
+             *iroha::Amount::createFromString("20.00")),
+         generate_random_command()}));
+    const auto block2 = BlockGenerator().generateBlock(
+        0, 3, block1.hash, {given_txs[2], given_txs[3]});
+    ASSERT_TRUE(storage->insertBlock(block2));
+  }
+
+  std::shared_ptr<Command> generate_random_command() {
+    return CommandGenerator().generateCreateDomain(
+        generator::random_string(20, generator::random_lower_char), "user");
+  }
+
+  std::vector<Transaction> given_txs;
+  std::shared_ptr<StorageImpl> storage;
+  std::shared_ptr<BlockQuery> blocks;
+};
+
+/**
+ * @brief No transactions when pager.limit = 0.
+ *
+ * @given StorageImpl
+ * @when GetAccountAssetTxs(account_id: alice@domain1, asset_id: [irh#domain],
+ *       pager: {tx_hash: {}, limit: 0})
+ * @then No transactions can be retrieved.
+ */
+TEST_F(GetAccountAssetTransactionsTest, NoTxsWhenPagerLimitIs0) {
+  const auto pager = Pager{iroha::hash256_t{}, 0};
+
+  auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {IRH_ASSET_ID}, pager), 0);
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @brief Parts of matched transactions when pager.limit specified.
+ *
+ * @given StorageImpl
+ * @when (account_id: alice@domain1, asset_id: [irh#domain], pager: {tx_hash:
+ * {}, limit: 1})
+ * @then Transactions [2] can be retrieved.
+ */
+TEST_F(GetAccountAssetTransactionsTest, PartsOfTxsWhenPagerLimit) {
+  const auto pager = Pager{iroha::hash256_t{}, 1};
+
+  auto wrapper = make_test_subscriber<EqualToList>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {IRH_ASSET_ID}, pager),
+      std::vector<Transaction>{given_txs[2]});
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @brief All transactions when num of inserted txs less than pager.limit.
+ *
+ * @given StorageImpl
+ * @when (account_id: alice@domain1, asset_id: [irh#domain], pager: {tx_hash:
+ * {}, limit: MAX_PAGER_LIMIT})
+ * @then All matched transactions can be retrieved.
+ */
+TEST_F(GetAccountAssetTransactionsTest,
+       AllTxsWhenInsertedTxsIsLessThanPagerLimit) {
+  const auto pager = Pager{iroha::hash256_t{}, Pager::MAX_PAGER_LIMIT};
+
+  auto wrapper = make_test_subscriber<EqualToList>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {IRH_ASSET_ID}, pager),
+      std::vector<Transaction>{given_txs[2], given_txs[0]});
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @brief Transactions when specified multiple asset id related to account id.
+ *
+ * @given StorageImpl
+ * @when (account_id: alice@domain1, asset_id: [irh#domain, moeka#domain],
+ *        pager: {tx_hash: {}, limit: MAX_PAGER_LIMIT})
+ * @then All matched transactions can be retrieved.
+ * @note account id matches either txs which have TransferAsset's source or
+ * destination id.
+ */
+TEST_F(GetAccountAssetTransactionsTest, MultipleAssetId) {
+  const auto pager = Pager{iroha::hash256_t{}, Pager::MAX_PAGER_LIMIT};
+
+  auto wrapper = make_test_subscriber<EqualToList>(
+      blocks->getAccountAssetTransactions(
+          ALICE_ID, {IRH_ASSET_ID, MEK_ASSET_ID}, pager),
+      std::vector<Transaction>{given_txs[3], given_txs[2], given_txs[0]});
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @brief Transactions with pager.tx_hash
+ *
+ * @given StorageImpl
+ * @when (account_id: alice@domain1, asset_id: [irh#domain1],
+ * pager: {tx_hash: hash(given_txs[2]), limit: MAX_PAGER_LIMIT})
+ * @then Transaction 0 can be retrieved.
+ * @note The transaction of tx_hash is excluded.
+ *       Retrieving transactions from newer to older transactions.
+ */
+TEST_F(GetAccountAssetTransactionsTest, SpecificPagerTxHash) {
+  const auto pager = Pager{iroha::hash(given_txs[2]), Pager::MAX_PAGER_LIMIT};
+
+  auto wrapper1 = make_test_subscriber<EqualToList>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {IRH_ASSET_ID}, pager),
+      std::vector<Transaction>{given_txs[0]});
+  ASSERT_TRUE(wrapper1.subscribe().validate());
+}
+
+/**
+ * @brief No transactions with empty asset id vector.
+ *
+ * @given StorageImpl
+ * @when (account_id: alice@domain1, asset_id: [],
+ * pager: {tx_hash: {}, limit: MAX_PAGER_LIMIT})
+ * @then No transactions can be retrieved.
+ */
+TEST_F(GetAccountAssetTransactionsTest, EmptyAssetId) {
+  const auto pager = Pager{iroha::hash256_t{}, Pager::MAX_PAGER_LIMIT};
+
+  auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {}, pager), 0);
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}
+
+/**
+ * @brief No transactions with empty storage.
+ *
+ * @given Empty StorageImpl
+ * @when some query
+ * @then No transactions can be retrieved.
+ */
+TEST_F(GetAccountAssetTransactionsTest, EmptyStorage) {
+  storage->dropStorage();
+  const auto pager = Pager{iroha::hash256_t{}, Pager::MAX_PAGER_LIMIT};
+
+  auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getAccountAssetTransactions(ALICE_ID, {IRH_ASSET_ID}, pager), 0);
+  ASSERT_TRUE(wrapper.subscribe().validate());
+}

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -324,7 +324,7 @@ TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions) {
   auto val_ = queryGenerator.generateGetAccountAssetTransactions(
     0, "admin", 0, "alice", {"a", "b"},
     iroha::model::Pager{iroha::hash256_t{}, 1});
-  ASSERT_TRUE(val.has_value());
+  ASSERT_TRUE(val_.has_value());
   auto val = *val_;
   val->signature = generateSignature(42);
   runQueryTest(val);

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -24,6 +24,7 @@
 #include "model/generators/signature_generator.hpp"
 #include "model/queries/get_asset_info.hpp"
 #include "model/queries/get_roles.hpp"
+#include "model/queries/get_account_asset_transactions.hpp"
 
 using namespace iroha;
 using namespace iroha::model;
@@ -46,6 +47,8 @@ TEST(QuerySerializerTest, ClassHandlerTest) {
       std::make_shared<GetAccountAssets>(),
       std::make_shared<GetSignatories>(),
       std::make_shared<GetAccountTransactions>(),
+      std::make_shared<GetAccountAssetTransactions>(),
+      std::make_shared<GetTransactions>(),
       std::make_shared<GetRoles>(),
       std::make_shared<GetAssetInfo>(),
       std::make_shared<GetRolePermissions>()
@@ -216,7 +219,6 @@ TEST(QuerySerializerTest, SerializeGetAccountAssets){
   ASSERT_TRUE(ser_val.has_value());
   ASSERT_EQ(iroha::hash(*val), iroha::hash(*ser_val.value()));
   ASSERT_EQ(val->signature.signature, ser_val.value()->signature.signature);
-
 }
 
 TEST(QuerySerializerTest, SerialiizeGetTransactions) {
@@ -307,6 +309,22 @@ TEST(QuerySerializerTest, SerializeGetAccountTransactions){
   auto val_ = queryGenerator.generateGetAccountTransactions(
     0, "123", 0, "test", Pager{iroha::hash256_t{}, 1});
   ASSERT_TRUE(val_.has_value());
+  auto val = *val_;
+  val->signature = generateSignature(42);
+  runQueryTest(val);
+}
+
+/**
+ * @given Generated GetAccountAssetTransactions query with random signature.
+ * @when serialize it, then deserialize the product.
+ * @then Validate the generated value is equal to the deserialized value.
+ */
+TEST(QuerySerializerTest, SerializeGetAccountAssetTransactions) {
+  QueryGenerator queryGenerator;
+  auto val_ = queryGenerator.generateGetAccountAssetTransactions(
+    0, "admin", 0, "alice", {"a", "b"},
+    iroha::model::Pager{iroha::hash256_t{}, 1});
+  ASSERT_TRUE(val.has_value());
   auto val = *val_;
   val->signature = generateSignature(42);
   runQueryTest(val);

--- a/test/module/irohad/model/converters/pb_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_factory_test.cpp
@@ -153,3 +153,16 @@ TEST(PbQueryFactoryTest, SerializeGetAccountTransactions){
   ASSERT_TRUE(query.has_value());
   runQueryTest(*query);
 }
+
+/**
+ * @given generated GetAccountAssetTransaction
+ * @when runQueryTest(), serialize and deserialize test
+ * @then validate success.
+ */
+TEST(PbQueryFactoryTest, SerializeGetAccountAssetTransactions) {
+  auto query = QueryGenerator{}.generateGetAccountAssetTransactions(
+    0, "admin", 0, "alice", {"a", "b"},
+    iroha::model::Pager{iroha::hash256_t{}, 1});
+  ASSERT_TRUE(query.has_value());
+  runQueryTest(*query);
+}


### PR DESCRIPTION
## What is this pull request?
- Implement `GetAccountAssetTransactions` API with pagination
   
## Why do you implement it? Why do we need this pull request?
- To separate PR of https://github.com/hyperledger/iroha/pull/650
  
## Details/Features
- Add pagination into `GetAccountAssetTransactions`
- Add `TODO` and comment out Redis implementation.
- Test of `getAccountAssetTransactions()` has been separated into `get_account_asset_transactions_test.cpp` and use test fixture.
- Test of converters.

## P.S. (optional)
- CLI is in another PR.