### PR TITLE
Feature/txresp fix proto

### DIFF
--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <endpoint.pb.h>
-#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 #include "torii/command_service.hpp"
 #include "common/types.hpp"
+#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
+#include "endpoint.pb.h"
 
 namespace torii {
+
+  using iroha::model::TransactionResponse;
+  using namespace iroha::protocol;
 
   CommandService::CommandService(
       std::shared_ptr<iroha::model::converters::PbTransactionFactory>
@@ -27,59 +30,54 @@ namespace torii {
       std::shared_ptr<iroha::torii::TransactionProcessor> txProccesor)
       : pb_factory_(pb_factory), tx_processor_(txProccesor) {
     // Notifier for all clients
-    tx_processor_->transactionNotifier().subscribe([this](
-        std::shared_ptr<iroha::model::TransactionResponse> iroha_response) {
-      // Find response in handler map
-      auto res = this->handler_map_.find(iroha_response->tx_hash);
-      if (res == this->handler_map_.end()) {
-        iroha::protocol::ToriiResponse response;
-        response.set_tx_status(iroha::protocol::NOT_RECEIVED);
-        this->handler_map_.insert({iroha_response->tx_hash, response});
-        return;
-      }
-      switch (iroha_response->current_status) {
-        case iroha::model::TransactionResponse::STATELESS_VALIDATION_FAILED:
-          res->second.set_tx_status(iroha::protocol::TxStatus::
-                                         STATELESS_VALIDATION_FAILED);
-          break;
-        case iroha::model::TransactionResponse::STATELESS_VALIDATION_SUCCESS:
-          res->second.set_tx_status(iroha::protocol::TxStatus::
-                                         STATELESS_VALIDATION_SUCCESS);
-          break;
-        case iroha::model::TransactionResponse::STATEFUL_VALIDATION_FAILED:
-          res->second.set_tx_status(
-              iroha::protocol::TxStatus::STATEFUL_VALIDATION_FAILED);
-          break;
-        case iroha::model::TransactionResponse::STATEFUL_VALIDATION_SUCCESS:
-          res->second.set_tx_status(iroha::protocol::TxStatus::
-                                         STATEFUL_VALIDATION_SUCCESS);
-          break;
-        case iroha::model::TransactionResponse::COMMITTED:
-          res->second.set_tx_status(
-              iroha::protocol::TxStatus::COMMITTED);
-          break;
-        case iroha::model::TransactionResponse::ON_PROCESS:
-          res->second.set_tx_status(
-              iroha::protocol::TxStatus::ON_PROCESS);
-          break;
-        case iroha::model::TransactionResponse::NOT_RECEIVED:
-          res->second.set_tx_status(
-              iroha::protocol::TxStatus::NOT_RECEIVED);
-          break;
-      }
+    tx_processor_->transactionNotifier().subscribe(
+        [this](std::shared_ptr<TransactionResponse> iroha_response) {
+          // Find response in handler map
+          auto res = this->handler_map_.find(iroha_response->tx_hash);
+          if (res == this->handler_map_.end()) {
+            ToriiResponse response;
+            response.set_tx_hash(iroha_response->tx_hash);
+            response.set_tx_status(TxStatus::NOT_RECEIVED);
+            this->handler_map_.insert({iroha_response->tx_hash, response});
+            return;
+          }
+          switch (iroha_response->current_status) {
+            case TransactionResponse::STATELESS_VALIDATION_FAILED:
+              res->second.set_tx_status(TxStatus::STATELESS_VALIDATION_FAILED);
+              break;
+            case TransactionResponse::STATELESS_VALIDATION_SUCCESS:
+              res->second.set_tx_status(TxStatus::STATELESS_VALIDATION_SUCCESS);
+              break;
+            case TransactionResponse::STATEFUL_VALIDATION_FAILED:
+              res->second.set_tx_status(TxStatus::STATEFUL_VALIDATION_FAILED);
+              break;
+            case TransactionResponse::STATEFUL_VALIDATION_SUCCESS:
+              res->second.set_tx_status(TxStatus::STATEFUL_VALIDATION_SUCCESS);
+              break;
+            case TransactionResponse::COMMITTED:
+              res->second.set_tx_status(TxStatus::COMMITTED);
+              break;
+            case TransactionResponse::ON_PROCESS:
+              res->second.set_tx_status(TxStatus::ON_PROCESS);
+              break;
+            case TransactionResponse::NOT_RECEIVED:
+              res->second.set_tx_status(TxStatus::NOT_RECEIVED);
+              break;
+          }
 
-      this->handler_map_.insert({iroha_response->tx_hash, res->second});
-    });
+          this->handler_map_.insert({iroha_response->tx_hash, res->second});
+        });
   }
 
-  void CommandService::ToriiAsync(iroha::protocol::Transaction const &request,
+  void CommandService::ToriiAsync(Transaction const &request,
                                   google::protobuf::Empty &empty) {
     auto iroha_tx = pb_factory_->deserialize(request);
 
     auto tx_hash = iroha::hash(*iroha_tx).to_string();
 
-    iroha::protocol::ToriiResponse response;
-    response.set_tx_status(iroha::protocol::TxStatus::ON_PROCESS);
+    ToriiResponse response;
+    response.set_tx_hash(tx_hash);
+    response.set_tx_status(TxStatus::ON_PROCESS);
 
     if (handler_map_.count(tx_hash) > 0) {
       return;
@@ -90,14 +88,13 @@ namespace torii {
     tx_processor_->transactionHandle(iroha_tx);
   }
 
-  void CommandService::StatusAsync(
-      iroha::protocol::TxStatusRequest const &request,
-      iroha::protocol::ToriiResponse &response) {
+  void CommandService::StatusAsync(TxStatusRequest const &request,
+                                   ToriiResponse &response) {
     auto resp = handler_map_.find(request.tx_hash());
 
     if (resp == handler_map_.end()) {
-      response.set_tx_status(
-          iroha::protocol::TxStatus::NOT_RECEIVED);
+      response.set_tx_hash(request.tx_hash());
+      response.set_tx_status(TxStatus::NOT_RECEIVED);
       return;
     }
     response.CopyFrom(resp->second);

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -61,6 +61,7 @@ namespace torii {
               res->second.set_tx_status(TxStatus::ON_PROCESS);
               break;
             case TransactionResponse::NOT_RECEIVED:
+            default:
               res->second.set_tx_status(TxStatus::NOT_RECEIVED);
               break;
           }

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -1,18 +1,19 @@
-/*
-Copyright 2017 Soramitsu Co., Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "torii/command_service.hpp"
 #include "common/types.hpp"

--- a/schema/endpoint.proto
+++ b/schema/endpoint.proto
@@ -20,6 +20,7 @@ enum TxStatus {
 
 message ToriiResponse {
   TxStatus tx_status = 1;
+  bytes tx_hash = 2;
 }
 
 message TxStatusRequest{

--- a/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
+++ b/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
@@ -100,9 +100,9 @@ namespace shared_model {
               return ResponseVariantType(
                   load<ProtoResponseListType>(*response_));
             })),
-            // fixme @l4l: proto should be changed and this one replaced as well
-            //             or some other solution needed
-            hash_([]() { return crypto::Hash(""); }) {}
+            hash_([this]() {
+              return crypto::Hash(this->response_->tx_hash());
+            }) {}
 
       /**
        * @return hash of corresponding transaction

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -135,6 +135,11 @@ class ToriiServiceTest : public testing::Test {
   std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
 };
 
+/**
+ * @given torii service and number of transactions
+ * @when retrieving their status
+ * @then ensure those are not received
+ */
 TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {
   std::vector<iroha::model::Transaction> txs;
   std::vector<std::string> tx_hashes;
@@ -167,12 +172,17 @@ TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {
 }
 
 /**
- * That test simulates the behavior of the Torii.
- * Instead of real implementation fake PCS is used.
- * In fake PCS instead of being subscribed to ordering service and simulator
- * we create our own rxcpp::subjects and subscribe on them.
- * During the test we supply that subjects with transactions or commits
- * just like ordering service or simulator would do
+ * That test simulates the real behavior of the blocking Torii.
+ *
+ * @given torii service with mocked CommunicationService
+ *        that is subscribed on custom rxcpp::subjects
+ * @when sending some number of transactions to the Torii
+ * @then ensure it perform as real one:
+ *       - Torii returns ok status
+ *       - Proper txs responses in Status are STATELESS_VALIDATION_SUCCESS,
+ *         then STATEFUL_VALIDATION_SUCCESS and COMMITTED (order matters)
+ *       - Tx that not in a block returns STATELESS_VALIDATION_SUCCESS and
+           then STATEFUL_VALIDATION_FAILED
  */
 TEST_F(ToriiServiceTest, StatusWhenBlocking) {
   EXPECT_CALL(*statelessValidatorMock,
@@ -264,9 +274,20 @@ TEST_F(ToriiServiceTest, StatusWhenBlocking) {
             iroha::protocol::TxStatus::STATEFUL_VALIDATION_FAILED);
 }
 
+/**
+ * Note that this test assume that Torii is non-blocking so it waits
+ * for some time if it required thus on failing may hang
+ *
+ * @given torii service with mocked CommunicationService
+ *        that is subscribed on custom rxcpp::subjects
+ * @when sending some number of transactions to the Torii
+ * @then txs responses in Status are STATELESS_VALIDATION_SUCCESS,
+ *         then STATEFUL_VALIDATION_SUCCESS and COMMITTED (order matters)
+ */
 TEST_F(ToriiServiceTest, StatusWhenNonBlocking) {
   torii::CommandAsyncClient client(Ip, Port);
-  std::atomic_int torii_count{0};  // counts how many times torii was invoked
+  // counts how many times torii was invoked
+  std::atomic_int torii_count{0};
 
   EXPECT_CALL(*statelessValidatorMock,
               validate(A<const iroha::model::Transaction &>()))
@@ -297,8 +318,8 @@ TEST_F(ToriiServiceTest, StatusWhenNonBlocking) {
     ;
   ASSERT_EQ(torii_count, TimesToriiNonBlocking);
 
-  std::atomic_int status_counter{
-      0};  // counts how many times statuses of txs were invoked
+  // counts how many times statuses of txs were invoked
+  std::atomic_int status_counter{0};
 
   // create proposal from these transactions
   iroha::model::Proposal proposal(txs);
@@ -366,13 +387,19 @@ TEST_F(ToriiServiceTest, StatusWhenNonBlocking) {
   ASSERT_EQ(status_counter, TimesToriiNonBlocking);
 }
 
+/**
+ * @given torii service and some number of transactions with hashes
+ * @when sending request on this txs
+ * @then ensure that response has the same hash as sent tx
+ */
 TEST_F(ToriiServiceTest, CheckHash) {
-  std::vector<iroha::model::Transaction> txs;
+  // given
   std::vector<std::string> tx_hashes;
   const int tx_num = 10;
 
   iroha::model::converters::PbTransactionFactory tx_factory;
 
+  // create transactions, but do not send them
   for (size_t i = 0; i < tx_num; ++i) {
     auto new_tx = iroha::protocol::Transaction();
     auto payload = new_tx.mutable_payload();
@@ -382,12 +409,14 @@ TEST_F(ToriiServiceTest, CheckHash) {
     tx_hashes.push_back(iroha::hash(*tx).to_string());
   }
 
+  // get statuses of transactions
   for (auto &hash : tx_hashes) {
     iroha::protocol::TxStatusRequest tx_request;
     tx_request.set_tx_hash(hash);
     iroha::protocol::ToriiResponse toriiResponse;
+    // when
     torii::CommandSyncClient(Ip, Port).Status(tx_request, toriiResponse);
-
+    // then
     ASSERT_EQ(toriiResponse.tx_hash(), hash);
   }
 }

--- a/test/module/shared_model/backend_proto/shared_proto_tx_response_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_tx_response_test.cpp
@@ -18,6 +18,7 @@
 #include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 
 #include <gtest/gtest.h>
+#include "cryptography/hash.hpp"
 
 // Quite hacky way to extract the class name
 // probably not stable and should be improved
@@ -35,13 +36,19 @@ class ProtoTxResponse : public testing::Test {
  public:
   void SetUp() override {}
   void SetUp(iroha::protocol::TxStatus status) {
+    r.set_tx_hash(hash);
     r.set_tx_status(status);
     proto = std::make_shared<shared_model::proto::TransactionResponse>(r);
+  }
+
+  void TearDown() override {
+    ASSERT_EQ(proto->transactionHash(), shared_model::crypto::Hash(hash));
   }
 
   iroha::protocol::ToriiResponse r;
   std::shared_ptr<shared_model::proto::TransactionResponse> proto;
   ClassNameVisitor visitor;
+  const std::string hash = "123";
 };
 
 /**


### PR DESCRIPTION
This pr introduces a hash inside ToriiResponse that require for #712

Besides there's a test that checks hash in torii service output

### How to check that it works

`make -j10 && test_bin/torii_service_test`
`test_bin/shared_proto_tx_response_test` remain unbroken (just added additional check for hash)