### PR TITLE
Add hash field to QueryResponse proto object

### DIFF
--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -44,6 +44,11 @@ namespace torii {
                                iroha::protocol::QueryResponse &response) {
     // Get iroha model query
     auto query = pb_query_factory_->deserialize(request);
+    if (not query) {
+      response.mutable_error_response()->set_reason(
+          iroha::protocol::ErrorResponse::WRONG_FORMAT);
+      return;
+    }
     auto hash = iroha::hash(**query).to_string();
 
     if (not query.has_value()) {

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -63,6 +63,6 @@ namespace torii {
       // Send query to iroha
       query_processor_->queryHandle(query.value());
     }
-    response.set_hash(hash);
+    response.set_query_hash(hash);
   }
 }  // namespace torii

--- a/schema/responses.proto
+++ b/schema/responses.proto
@@ -70,14 +70,15 @@ message TransactionsResponse {
 
 
 message QueryResponse {
+    bytes hash = 1;
     oneof response {
-        AccountAssetResponse account_assets_response = 1;
-        AccountResponse account_response = 2;
-        ErrorResponse error_response = 3;
-        SignatoriesResponse signatories_response = 4;
-        TransactionsResponse transactions_response = 5;
-        AssetResponse asset_response = 6;
-        RolesResponse roles_response = 7;
-        RolePermissionsResponse role_permissions_response = 8;
+        AccountAssetResponse account_assets_response = 2;
+        AccountResponse account_response = 3;
+        ErrorResponse error_response = 4;
+        SignatoriesResponse signatories_response = 5;
+        TransactionsResponse transactions_response = 6;
+        AssetResponse asset_response = 7;
+        RolesResponse roles_response = 8;
+        RolePermissionsResponse role_permissions_response = 9;
     }
 }

--- a/schema/responses.proto
+++ b/schema/responses.proto
@@ -70,15 +70,15 @@ message TransactionsResponse {
 
 
 message QueryResponse {
-    bytes hash = 1;
     oneof response {
-        AccountAssetResponse account_assets_response = 2;
-        AccountResponse account_response = 3;
-        ErrorResponse error_response = 4;
-        SignatoriesResponse signatories_response = 5;
-        TransactionsResponse transactions_response = 6;
-        AssetResponse asset_response = 7;
-        RolesResponse roles_response = 8;
-        RolePermissionsResponse role_permissions_response = 9;
+        AccountAssetResponse account_assets_response = 1;
+        AccountResponse account_response = 2;
+        ErrorResponse error_response = 3;
+        SignatoriesResponse signatories_response = 4;
+        TransactionsResponse transactions_response = 5;
+        AssetResponse asset_response = 6;
+        RolesResponse roles_response = 7;
+        RolePermissionsResponse role_permissions_response = 8;
     }
+    bytes query_hash = 9;
 }

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -140,6 +140,7 @@ TEST_F(ToriiQueriesTest, FindWhenResponseInvalid) {
   // Must return Error Response
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATELESS_INVALID);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 /**
@@ -156,8 +157,9 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
   auto creator = "accountA";
 
   // TODO: refactor this to use stateful validation mocks
-  EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(
-                              creator, account.account_id, can_get_my_account))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator, account.account_id, can_get_my_account))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(nonstd::nullopt));
@@ -180,6 +182,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
@@ -193,8 +196,9 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   accountB.account_id = "accountB";
 
   // TODO: refactor this to use stateful validation mocks
-  EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(
-      creator, accountB.account_id, can_get_my_account))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator, accountB.account_id, can_get_my_account))
       .WillOnce(Return(true));
 
   // Should be called once, after successful stateful validation
@@ -202,8 +206,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
       .WillOnce(Return(accountB));
 
   std::vector<std::string> roles = {"user"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(_))
-      .WillRepeatedly(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles(_)).WillRepeatedly(Return(roles));
 
   iroha::protocol::QueryResponse response;
 
@@ -220,6 +223,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   ASSERT_FALSE(response.has_error_response());
   ASSERT_EQ(response.account_response().account().account_id(), "accountB");
   ASSERT_EQ(response.account_response().account_roles().size(), 1);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
@@ -231,16 +235,14 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   account.account_id = "accountA";
 
   // Should be called once when stateful validation is in progress
-  EXPECT_CALL(*wsv_query, getAccount("accountA"))
-      .WillOnce(Return(account));
+  EXPECT_CALL(*wsv_query, getAccount("accountA")).WillOnce(Return(account));
   // TODO: refactor this to use stateful validation mocks
-  auto creator =  "accountA";
+  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillRepeatedly(Return(roles));
   std::vector<std::string> perm = {can_get_my_account};
-  EXPECT_CALL(*wsv_query, getRolePermissions("test"))
-      .WillOnce(Return(perm));
+  EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
 
   iroha::protocol::QueryResponse response;
 
@@ -256,6 +258,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
   ASSERT_EQ(response.account_response().account().account_id(), "accountA");
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 /**
@@ -284,8 +287,9 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
   auto creator = "accountA";
 
   // TODO: refactor this to use stateful validation mocks
-  EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(
-      creator, account.account_id, can_get_my_acc_ast))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator, account.account_id, can_get_my_acc_ast))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(nonstd::nullopt));
@@ -310,6 +314,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
   // to read account asset
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
@@ -332,13 +337,11 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   asset.precision = 2;
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator =  "accountA";
+  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(creator))
-      .WillOnce(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_acc_ast};
-  EXPECT_CALL(*wsv_query, getRolePermissions("test"))
-      .WillOnce(Return(perm));
+  EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*wsv_query, getAccountAsset(_, _))
       .WillOnce(Return(account_asset));
 
@@ -365,6 +368,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   auto iroha_amount_asset = iroha::model::converters::deserializeAmount(
       response.account_assets_response().account_asset().balance());
   ASSERT_EQ(iroha_amount_asset, account_asset.balance);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 /**
@@ -385,9 +389,10 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
   keys.push_back(pubkey);
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator =  "accountA";
-  EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(
-      creator, account.account_id, can_get_my_signatories))
+  auto creator = "accountA";
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator, account.account_id, can_get_my_signatories))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(nonstd::nullopt));
@@ -408,6 +413,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
@@ -424,13 +430,11 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   keys.push_back(pubkey);
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator =  "accountA";
+  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(creator))
-      .WillOnce(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_signatories};
-  EXPECT_CALL(*wsv_query, getRolePermissions("test"))
-      .WillOnce(Return(perm));
+  EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*wsv_query, getSignatories(_)).WillOnce(Return(keys));
 
   iroha::protocol::QueryResponse response;
@@ -453,6 +457,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   decltype(pubkey) response_pubkey;
   std::copy(signatory.begin(), signatory.end(), response_pubkey.begin());
   ASSERT_EQ(response_pubkey, pubkey);
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 /**
@@ -479,13 +484,11 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   }());
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator =  "accountA";
+  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(creator))
-      .WillOnce(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_acc_txs};
-  EXPECT_CALL(*wsv_query, getRolePermissions("test"))
-      .WillOnce(Return(perm));
+  EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*block_query, getAccountTransactions(account.account_id))
       .WillOnce(Return(txs_observable));
 
@@ -514,6 +517,7 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
         response.transactions_response().transactions(i).payload().tx_counter(),
         i);
   }
+  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
 }
 
 TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
@@ -536,5 +540,6 @@ TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
     // Must return Error Response
     ASSERT_EQ(response.error_response().reason(),
               iroha::model::ErrorResponse::STATELESS_INVALID);
+    ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
   }
 }

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -140,7 +140,7 @@ TEST_F(ToriiQueriesTest, FindWhenResponseInvalid) {
   // Must return Error Response
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATELESS_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 /**
@@ -182,7 +182,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
@@ -223,7 +223,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   ASSERT_FALSE(response.has_error_response());
   ASSERT_EQ(response.account_response().account().account_id(), "accountB");
   ASSERT_EQ(response.account_response().account_roles().size(), 1);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
@@ -258,7 +258,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
   ASSERT_EQ(response.account_response().account().account_id(), "accountA");
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 /**
@@ -314,7 +314,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
   // to read account asset
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
@@ -368,7 +368,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   auto iroha_amount_asset = iroha::model::converters::deserializeAmount(
       response.account_assets_response().account_asset().balance());
   ASSERT_EQ(iroha_amount_asset, account_asset.balance);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 /**
@@ -413,7 +413,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
@@ -457,7 +457,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   decltype(pubkey) response_pubkey;
   std::copy(signatory.begin(), signatory.end(), response_pubkey.begin());
   ASSERT_EQ(response_pubkey, pubkey);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 /**
@@ -517,7 +517,7 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
         response.transactions_response().transactions(i).payload().tx_counter(),
         i);
   }
-  ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
@@ -540,6 +540,6 @@ TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
     // Must return Error Response
     ASSERT_EQ(response.error_response().reason(),
               iroha::model::ErrorResponse::STATELESS_INVALID);
-    ASSERT_EQ(iroha::hash(query).to_string(), response.hash());
+    ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
   }
 }


### PR DESCRIPTION
## What is this pull request?
Pull request adds hash field to QueryResponse proto object.
   
## Why do you implement it? Why do we need this pull request?
According our model QueryResponse always contains a hash of a corresponding query but it was not reflected in proto scheme.

## Details/Features
- Add hash field in QueryResponse proto
- Hash field is set in QueryService
- Tests know about hash field and check it

## P.S. (optional)
Since every QueryResponse hash should be the same as hash of corresponding query I decided not to create additional test for hash but add checks for every existing test similar to status call checking.
