### PR TITLE
Feature/nested kv storage

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -308,16 +308,35 @@ namespace iroha {
     }
 
     bool PostgresWsvCommand::setAccountKV(const std::string &account_id,
+                                          const std::string &creator_account_id,
                                           const std::string &key,
                                           const std::string &val) {
+      std::string prefix;
+      std::string account_prefix;
+
+      if (account_id != creator_account_id) {
+        prefix = "others, ";
+        account_prefix = creator_account_id + ", ";
+      } else {
+        prefix = "own, ";
+        account_prefix = "";
+      }
+
       try {
-        transaction_.exec("UPDATE account SET data = jsonb_set(data,"
-                          + transaction_.quote("{" + key + "}")
-                          + ","
-                          + transaction_.quote("\"" + val + "\"")
-                          + ") WHERE account_id="
-                          + transaction_.quote(account_id)
-                          + ";");
+        transaction_.exec(
+            "UPDATE account SET data = jsonb_set(CASE WHEN data ?"
+            + transaction_.quote(creator_account_id)
+            + " THEN data ELSE jsonb_set(data, "
+            + transaction_.quote("{" + creator_account_id + "}")
+            + ","
+            + transaction_.quote("{}")
+            + ") END,"
+            + transaction_.quote("{" + creator_account_id + ", " + key + "}")
+            + ","
+            + transaction_.quote("\"" + val + "\"")
+            + ") WHERE account_id="
+            + transaction_.quote(account_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return false;

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -311,17 +311,6 @@ namespace iroha {
                                           const std::string &creator_account_id,
                                           const std::string &key,
                                           const std::string &val) {
-      std::string prefix;
-      std::string account_prefix;
-
-      if (account_id != creator_account_id) {
-        prefix = "others, ";
-        account_prefix = creator_account_id + ", ";
-      } else {
-        prefix = "own, ";
-        account_prefix = "";
-      }
-
       try {
         transaction_.exec(
             "UPDATE account SET data = jsonb_set(CASE WHEN data ?"

--- a/irohad/ametsuchi/impl/postgres_wsv_command.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.hpp
@@ -41,6 +41,7 @@ namespace iroha {
       bool insertAccount(const model::Account &account) override;
       bool updateAccount(const model::Account &account) override;
       bool setAccountKV(const std::string &account_id,
+                        const std::string &creator_account_id,
                         const std::string &key,
                         const std::string &val) override;
       bool insertAsset(const model::Asset &asset) override;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -42,9 +42,12 @@ namespace iroha {
         result = transaction_.exec(
             "SELECT * FROM account_has_grantable_permissions WHERE "
             "permittee_account_id = "
-            + transaction_.quote(permitee_account_id) + " AND account_id = "
-            + transaction_.quote(account_id) + " AND permission_id = "
-            + transaction_.quote(permission_id) + ";");
+            + transaction_.quote(permitee_account_id)
+            + " AND account_id = "
+            + transaction_.quote(account_id)
+            + " AND permission_id = "
+            + transaction_.quote(permission_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return false;
@@ -58,7 +61,8 @@ namespace iroha {
       try {
         result = transaction_.exec(
             "SELECT role_id FROM account_has_roles WHERE account_id = "
-            + transaction_.quote(account_id) + ";");
+            + transaction_.quote(account_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -76,7 +80,8 @@ namespace iroha {
       try {
         result = transaction_.exec(
             "SELECT permission_id FROM role_has_permissions WHERE role_id = "
-            + transaction_.quote(role_name) + ";");
+            + transaction_.quote(role_name)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -107,7 +112,8 @@ namespace iroha {
       pqxx::result result;
       try {
         result = transaction_.exec("SELECT * FROM account WHERE account_id = "
-                                   + transaction_.quote(account_id) + ";");
+                                   + transaction_.quote(account_id)
+                                   + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -127,12 +133,17 @@ namespace iroha {
     }
 
     nonstd::optional<std::string> PostgresWsvQuery::getAccountDetail(
-        const std::string &account_id, const std::string &detail) {
+        const std::string &account_id,
+        const std::string &creator_id,
+        const std::string &detail) {
       pqxx::result result;
       try {
-        result = transaction_.exec("SELECT data->>" + transaction_.quote(detail)
-                                   + " FROM account WHERE account_id = "
-                                   + transaction_.quote(account_id) + ";");
+        result = transaction_.exec(
+            "SELECT data#>>"
+            + transaction_.quote("{" + creator_id + ", " + detail + "}")
+            + " FROM account WHERE account_id = "
+            + transaction_.quote(account_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -158,7 +169,8 @@ namespace iroha {
       try {
         result = transaction_.exec(
             "SELECT public_key FROM account_has_signatory WHERE account_id = "
-            + transaction_.quote(account_id) + ";");
+            + transaction_.quote(account_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -177,7 +189,8 @@ namespace iroha {
       pqxx::result result;
       try {
         result = transaction_.exec("SELECT * FROM asset WHERE asset_id = "
-                                   + transaction_.quote(asset_id) + ";");
+                                   + transaction_.quote(asset_id)
+                                   + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -204,7 +217,9 @@ namespace iroha {
         result = transaction_.exec(
             "SELECT * FROM account_has_asset WHERE account_id = "
             + transaction_.quote(account_id)
-            + " AND asset_id = " + transaction_.quote(asset_id) + ";");
+            + " AND asset_id = "
+            + transaction_.quote(asset_id)
+            + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;
@@ -228,7 +243,8 @@ namespace iroha {
       pqxx::result result;
       try {
         result = transaction_.exec("SELECT * FROM domain WHERE domain_id = "
-                                   + transaction_.quote(domain_id) + ";");
+                                   + transaction_.quote(domain_id)
+                                   + ";");
       } catch (const std::exception &e) {
         log_->error(e.what());
         return nullopt;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -134,13 +134,13 @@ namespace iroha {
 
     nonstd::optional<std::string> PostgresWsvQuery::getAccountDetail(
         const std::string &account_id,
-        const std::string &creator_id,
+        const std::string &creator_account_id,
         const std::string &detail) {
       pqxx::result result;
       try {
         result = transaction_.exec(
             "SELECT data#>>"
-            + transaction_.quote("{" + creator_id + ", " + detail + "}")
+            + transaction_.quote("{" + creator_account_id + ", " + detail + "}")
             + " FROM account WHERE account_id = "
             + transaction_.quote(account_id)
             + ";");

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -39,7 +39,7 @@ namespace iroha {
           const std::string &account_id) override;
       nonstd::optional<std::string> getAccountDetail(
           const std::string &account_id,
-          const std::string &creator_id,
+          const std::string &creator_account_id,
           const std::string &detail) override;
       nonstd::optional<std::vector<pubkey_t>> getSignatories(
           const std::string &account_id) override;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -38,7 +38,9 @@ namespace iroha {
       nonstd::optional<model::Account> getAccount(
           const std::string &account_id) override;
       nonstd::optional<std::string> getAccountDetail(
-          const std::string &account_id, const std::string &detail) override;
+          const std::string &account_id,
+          const std::string &creator_id,
+          const std::string &detail) override;
       nonstd::optional<std::vector<pubkey_t>> getSignatories(
           const std::string &account_id) override;
       nonstd::optional<model::Asset> getAsset(

--- a/irohad/ametsuchi/wsv_command.hpp
+++ b/irohad/ametsuchi/wsv_command.hpp
@@ -24,8 +24,8 @@
 #include <model/asset.hpp>
 #include <model/domain.hpp>
 #include <model/peer.hpp>
-#include <string>
 #include <set>
+#include <string>
 
 namespace iroha {
   namespace ametsuchi {
@@ -53,14 +53,14 @@ namespace iroha {
       virtual bool insertAccountRole(const std::string &account_id,
                                      const std::string &role_name) = 0;
 
-
       /**
        * Bind role and permissions
        * @param role_id
        * @param permissions
        * @return true is insert successful, false otherwise
        */
-      virtual bool insertRolePermissions(const std::string &role_id,
+      virtual bool insertRolePermissions(
+          const std::string &role_id,
           const std::set<std::string> &permissions) = 0;
 
       /**
@@ -72,18 +72,21 @@ namespace iroha {
        */
       virtual bool insertAccountGrantablePermission(
           const std::string &permittee_account_id,
-          const std::string &account_id, const std::string &permission_id) = 0;
+          const std::string &account_id,
+          const std::string &permission_id) = 0;
 
       /**
        * Delete grantable permission
-       * @param permittee_account_id to who the grant permission was previously granted
+       * @param permittee_account_id to who the grant permission was previously
+       * granted
        * @param account_id on which account
        * @param permission_id what permission
        * @return true is execution is successful
        */
       virtual bool deleteAccountGrantablePermission(
           const std::string &permittee_account_id,
-          const std::string &account_id, const std::string &permission_id) = 0;
+          const std::string &account_id,
+          const std::string &permission_id) = 0;
 
       /**
        *
@@ -101,11 +104,14 @@ namespace iroha {
 
       /**
        * @param account_id  account in which update key value
+       * @param creator_account_id creator's account who wants to update
+       * account_id
        * @param key - key to set
        * @param val - value of the key/value pair
        * @return true if no error occurred, false otherwise
        */
       virtual bool setAccountKV(const std::string &account_id,
+                                const std::string &creator_account_id,
                                 const std::string &key,
                                 const std::string &val) = 0;
 
@@ -136,9 +142,8 @@ namespace iroha {
        * @param signatory
        * @return
        */
-      virtual bool insertAccountSignatory(
-          const std::string &account_id,
-          const pubkey_t &signatory) = 0;
+      virtual bool insertAccountSignatory(const std::string &account_id,
+                                          const pubkey_t &signatory) = 0;
 
       /**
        * Delete account signatory relationship
@@ -146,17 +151,15 @@ namespace iroha {
        * @param signatory
        * @return
        */
-      virtual bool deleteAccountSignatory(
-          const std::string &account_id,
-          const pubkey_t &signatory) = 0;
+      virtual bool deleteAccountSignatory(const std::string &account_id,
+                                          const pubkey_t &signatory) = 0;
 
       /**
        * Delete signatory
        * @param signatory
        * @return
        */
-      virtual bool deleteSignatory(
-          const pubkey_t &signatory) = 0;
+      virtual bool deleteSignatory(const pubkey_t &signatory) = 0;
 
       /**
        *

--- a/irohad/ametsuchi/wsv_command.hpp
+++ b/irohad/ametsuchi/wsv_command.hpp
@@ -18,14 +18,14 @@
 #ifndef IROHA_WSV_COMMAND_HPP
 #define IROHA_WSV_COMMAND_HPP
 
-#include <common/types.hpp>
-#include <model/account.hpp>
-#include <model/account_asset.hpp>
-#include <model/asset.hpp>
-#include <model/domain.hpp>
-#include <model/peer.hpp>
 #include <set>
 #include <string>
+#include "common/types.hpp"
+#include "model/account.hpp"
+#include "model/account_asset.hpp"
+#include "model/asset.hpp"
+#include "model/domain.hpp"
+#include "model/peer.hpp"
 
 namespace iroha {
   namespace ametsuchi {

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -92,7 +92,9 @@ namespace iroha {
        * @return
        */
       virtual nonstd::optional<std::string> getAccountDetail(
-          const std::string &account_id, const std::string &detail) = 0;
+          const std::string &account_id,
+          const std::string &creator_id,
+          const std::string &detail) = 0;
 
       /**
        * Get signatories of account by user account_id

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -88,12 +88,13 @@ namespace iroha {
       /**
        * Get accounts information from its key-value storage
        * @param account_id
+       * @param creator_account_id
        * @param detail
        * @return
        */
       virtual nonstd::optional<std::string> getAccountDetail(
           const std::string &account_id,
-          const std::string &creator_id,
+          const std::string &creator_account_id,
           const std::string &detail) = 0;
 
       /**

--- a/irohad/model/commands/create_account.hpp
+++ b/irohad/model/commands/create_account.hpp
@@ -42,23 +42,14 @@ namespace iroha {
        */
       pubkey_t pubkey;
 
-      /**
-       * Json data for the account
-       */
-      std::string json_data;
-
       bool operator==(const Command &command) const override;
 
-      CreateAccount() : json_data("{}") {}
+      CreateAccount() {}
 
       CreateAccount(const std::string &account_name,
                     const std::string &domain_id,
-                    const pubkey_t &pubkey,
-                    const std::string &data)
-          : account_name(account_name),
-            domain_id(domain_id),
-            pubkey(pubkey),
-            json_data(data) {}
+                    const pubkey_t &pubkey)
+          : account_name(account_name), domain_id(domain_id), pubkey(pubkey) {}
     };
   }  // namespace model
 }  // namespace iroha

--- a/irohad/model/converters/impl/json_command_factory.cpp
+++ b/irohad/model/converters/impl/json_command_factory.cpp
@@ -213,25 +213,17 @@ namespace iroha {
         document.AddMember("domain_id", create_account->domain_id, allocator);
         document.AddMember(
             "pubkey", create_account->pubkey.to_hexstring(), allocator);
-        document.AddMember("json_data", create_account->json_data, allocator);
-
         return document;
       }
 
       optional_ptr<Command> JsonCommandFactory::deserializeCreateAccount(
           const Value &document) {
         auto des = makeFieldDeserializer(document);
-        auto des_val = make_optional_ptr<CreateAccount>()
+        return make_optional_ptr<CreateAccount>()
             | des.String(&CreateAccount::account_name, "account_name")
             | des.String(&CreateAccount::domain_id, "domain_id")
-            | des.String(&CreateAccount::pubkey, "pubkey");
-
-        if (document.HasMember("json_data")) {
-          des_val =
-              des_val | des.String(&CreateAccount::json_data, "json_data");
-        }
-
-        return des_val | toCommand;
+            | des.String(&CreateAccount::pubkey, "pubkey")
+            | toCommand;
       }
 
       // Set Account Detail

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -23,6 +23,7 @@
 #include <set>
 
 #include <boost/assign/list_inserter.hpp>
+#include <primitive.pb.h>
 
 namespace iroha {
   namespace model {
@@ -60,8 +61,6 @@ namespace iroha {
             (protocol::RolePermission::can_create_domain, can_create_domain)
             // Can create account
             (protocol::RolePermission::can_create_account, can_create_account)
-            // Can set quorum
-            (protocol::RolePermission::can_set_quorum, can_set_quorum)
             // Can add peer
             (protocol::RolePermission::can_add_peer, can_add_peer)
             // Can add asset quantity
@@ -97,7 +96,10 @@ namespace iroha {
              (protocol::RolePermission::can_grant_can_transfer,
              can_grant + can_transfer)
             // Can get roles
-            (protocol::RolePermission::can_get_roles, can_get_roles);
+            (protocol::RolePermission::can_get_roles, can_get_roles)
+            // Can write details to other accounts
+            (protocol::RolePermission::can_grant_can_set_detail, can_grant+can_set_detail)
+            ;
 
         boost::assign::insert(pb_grant_map_)
             // Can add my signatory
@@ -107,7 +109,9 @@ namespace iroha {
             (protocol::GrantablePermission::can_remove_my_signatory,
              can_remove_signatory)
             // Can set my quorum
-            (protocol::GrantablePermission::can_set_my_quorum, can_set_quorum);
+            (protocol::GrantablePermission::can_set_my_quorum, can_set_quorum)
+            // Can write details to other accounts
+            (protocol::GrantablePermission::can_set_my_account_detail, can_set_detail);
       }
 
       // asset quantity

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -16,14 +16,8 @@
  */
 
 #include "model/converters/pb_command_factory.hpp"
-#include "model/converters/pb_common.hpp"
-
-#include <commands.pb.h>
-#include <model/permissions.hpp>
-#include <set>
-
 #include <boost/assign/list_inserter.hpp>
-#include <primitive.pb.h>
+#include "model/converters/pb_common.hpp"
 
 namespace iroha {
   namespace model {
@@ -92,14 +86,14 @@ namespace iroha {
             // Can grant add signatory
             (protocol::RolePermission::can_grant_add_signatory,
              can_grant + can_add_signatory)
-             // Can grant + can_transfer
-             (protocol::RolePermission::can_grant_can_transfer,
+            // Can grant + can_transfer
+            (protocol::RolePermission::can_grant_can_transfer,
              can_grant + can_transfer)
             // Can get roles
             (protocol::RolePermission::can_get_roles, can_get_roles)
             // Can write details to other accounts
-            (protocol::RolePermission::can_grant_can_set_detail, can_grant+can_set_detail)
-            ;
+            (protocol::RolePermission::can_grant_can_set_detail,
+             can_grant + can_set_detail);
 
         boost::assign::insert(pb_grant_map_)
             // Can add my signatory
@@ -111,7 +105,8 @@ namespace iroha {
             // Can set my quorum
             (protocol::GrantablePermission::can_set_my_quorum, can_set_quorum)
             // Can write details to other accounts
-            (protocol::GrantablePermission::can_set_my_account_detail, can_set_detail);
+            (protocol::GrantablePermission::can_set_my_account_detail,
+             can_set_detail);
       }
 
       // asset quantity

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -260,6 +260,8 @@ namespace iroha {
 
       bool isValid(const Command &command,
                    ametsuchi::WsvQuery &queries) override;
+     private:
+      Account creator_;
     };
 
     class SetQuorumExecutor : public CommandExecutor {

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -345,7 +345,7 @@ namespace iroha {
 
       account.domain_id = create_account.domain_id;
       account.quorum = 1;
-      account.json_data = create_account.json_data;
+      account.json_data = "{}";
       auto domain = queries.getDomain(create_account.domain_id);
       if (not domain.has_value()) {
         log_->error("Domain {} not found", create_account.domain_id);

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -57,7 +57,7 @@ namespace iroha {
           const std::string &domain_id,
           const pubkey_t &key) {
         return generateCommand<CreateAccount>(
-            account_name, domain_id, key, "{}");
+            account_name, domain_id, key);
       }
 
       std::shared_ptr<Command> CommandGenerator::generateCreateDomain(

--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -109,8 +109,7 @@ namespace iroha {
       auto create_account = static_cast<const CreateAccount &>(command);
       return create_account.pubkey == pubkey
           && create_account.domain_id == domain_id
-          && create_account.account_name == account_name
-          && create_account.json_data == create_account.json_data;
+          && create_account.account_name == account_name;
     }
 
     /* SetAccountDetail */

--- a/irohad/model/permissions.hpp
+++ b/irohad/model/permissions.hpp
@@ -36,6 +36,7 @@ namespace iroha {
     const std::string can_set_quorum = "CanSetQuorum";
     const std::string can_transfer = "CanTransfer";
     const std::string can_receive = "CanReceive";
+    const std::string can_set_detail = "CanSetAccountInfo";
 
     // ---------|Query permissions|-------------
     const std::string can_read_assets = "CanReadAssets";
@@ -77,7 +78,8 @@ namespace iroha {
         can_grant + can_set_quorum,
         can_grant + can_add_signatory,
         can_grant + can_remove_signatory,
-        can_grant + can_transfer
+        can_grant + can_transfer,
+        can_grant + can_set_detail
         };
 
     const std::set<std::string> edit_self_group = {
@@ -103,6 +105,7 @@ namespace iroha {
         can_grant + can_add_signatory,
         can_grant + can_remove_signatory,
         can_grant + can_transfer,
+        can_grant + can_set_detail,
         can_set_quorum,
         can_add_signatory,
         can_remove_signatory,

--- a/schema/primitive.proto
+++ b/schema/primitive.proto
@@ -33,12 +33,14 @@ enum RolePermission {
     can_grant_remove_signatory = 25;
     can_grant_set_quorum = 26;
     can_grant_can_transfer = 27;
+    can_grant_can_set_detail = 28;
 }
 
 enum GrantablePermission {
     can_add_my_signatory = 0;
     can_remove_my_signatory = 1;
     can_set_my_quorum = 2;
+    can_set_my_account_detail = 3;
 }
 
 

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -37,10 +37,11 @@ namespace iroha {
       MOCK_METHOD1(getAccountRoles,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &account_id));
-      MOCK_METHOD3(getAccountDetail,
-                   nonstd::optional<std::string>(const std::string &account_id,
-                                                 const std::string &creator_id,
-                                                 const std::string &detail));
+      MOCK_METHOD3(
+          getAccountDetail,
+          nonstd::optional<std::string>(const std::string &account_id,
+                                        const std::string &creator_account_id,
+                                        const std::string &detail));
       MOCK_METHOD1(getRolePermissions,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &role_name));

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -37,8 +37,9 @@ namespace iroha {
       MOCK_METHOD1(getAccountRoles,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &account_id));
-      MOCK_METHOD2(getAccountDetail,
+      MOCK_METHOD3(getAccountDetail,
                    nonstd::optional<std::string>(const std::string &account_id,
+                                                 const std::string &creator_id,
                                                  const std::string &detail));
       MOCK_METHOD1(getRolePermissions,
                    nonstd::optional<std::vector<std::string>>(
@@ -103,8 +104,9 @@ namespace iroha {
       MOCK_METHOD1(deletePeer, bool(const model::Peer &));
 
       MOCK_METHOD1(insertDomain, bool(const model::Domain &));
-      MOCK_METHOD3(setAccountKV,
+      MOCK_METHOD4(setAccountKV,
                    bool(const std::string &,
+                        const std::string &,
                         const std::string &,
                         const std::string &));
     };
@@ -123,7 +125,7 @@ namespace iroha {
                                                 const std::string &asset_id));
       MOCK_METHOD1(getTransactions,
                    rxcpp::observable<boost::optional<model::Transaction>>(
-                     const std::vector<iroha::hash256_t> &tx_hashes));
+                       const std::vector<iroha::hash256_t> &tx_hashes));
       MOCK_METHOD2(getBlocks,
                    rxcpp::observable<model::Block>(uint32_t, uint32_t));
       MOCK_METHOD1(getBlocksFrom, rxcpp::observable<model::Block>(uint32_t));

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -83,7 +83,6 @@ TEST_F(AmetsuchiTest, SampleTest) {
   CreateAccount createAccount;
   createAccount.account_name = "user1";
   createAccount.domain_id = "ru";
-  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   // Compose block
@@ -120,7 +119,6 @@ TEST_F(AmetsuchiTest, SampleTest) {
   createAccount = CreateAccount();
   createAccount.account_name = "user2";
   createAccount.domain_id = "ru";
-  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   // Create asset RUB#ru
@@ -290,21 +288,18 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   CreateAccount createAccount1;
   createAccount1.account_name = user1name;
   createAccount1.domain_id = domain;
-  createAccount1.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount1));
 
   // Create account 2
   CreateAccount createAccount2;
   createAccount2.account_name = user2name;
   createAccount2.domain_id = domain;
-  createAccount2.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount2));
 
   // Create account 3
   CreateAccount createAccount3;
   createAccount3.account_name = user3name;
   createAccount3.domain_id = domain;
-  createAccount3.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount3));
 
   // Create asset 1
@@ -555,7 +550,6 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   createAccount.account_name = "user1";
   createAccount.domain_id = "domain";
   createAccount.pubkey = pubkey1;
-  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   Block block;
@@ -628,7 +622,6 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   createAccount.account_name = "user2";
   createAccount.domain_id = "domain";
   createAccount.pubkey = pubkey1;  // same as user1's pubkey1
-  createAccount.json_data = "{}";
   txn.commands.push_back(std::make_shared<CreateAccount>(createAccount));
 
   block = Block();

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -108,7 +108,7 @@ class KVTest : public AmetsuchiTest {
 
 
 /**
- * @given storage with account1 containing json data
+ * @given empty in account1
  * @when non existing detail is queried using GetAccountDetail
  * @then nullopt is returned
  */

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -103,7 +103,6 @@ class KVTest : public AmetsuchiTest {
 
   std::string domain_id = "ru";
   std::string account_name1 = "user1";
-  std::string account_data1 = R"({"user1": {"age": "30"}})";
   std::string account_name2 = "user2";
 };
 

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -64,14 +64,12 @@ class KVTest : public AmetsuchiTest {
     CreateAccount createAccount1;
     createAccount1.account_name = account_name1;
     createAccount1.domain_id = domain_id;
-    createAccount1.json_data = account_data1;
     txn1_1.commands.push_back(std::make_shared<CreateAccount>(createAccount1));
 
     // Create account user2
     CreateAccount createAccount2;
     createAccount2.account_name = account_name2;
     createAccount2.domain_id = domain_id;
-    createAccount2.json_data = "{}";
     txn1_1.commands.push_back(std::make_shared<CreateAccount>(createAccount2));
 
     // Set age for user2
@@ -109,23 +107,6 @@ class KVTest : public AmetsuchiTest {
   std::string account_name2 = "user2";
 };
 
-/**
- * @given storage with account of user1 containing json data
- * @when get account detail query is invoked
- * @then the requested information of user1 is returned
- */
-TEST_F(KVTest, GetAccountDetail) {
-  auto account_id1 = account_name1 + "@" + domain_id;
-  auto account = wsv_query->getAccount(account_id1);
-  ASSERT_TRUE(account);
-  ASSERT_EQ(account->account_id, account_id1);
-  ASSERT_EQ(account->domain_id, domain_id);
-  ASSERT_EQ(account->json_data, account_data1);
-
-  auto age = wsv_query->getAccountDetail(account_id1, "user1", "age");
-  ASSERT_TRUE(age);
-  ASSERT_EQ(age.value(), "30");
-}
 
 /**
  * @given storage with account1 containing json data

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -46,7 +46,7 @@ class KVTest : public AmetsuchiTest {
 
     // First transaction in block1
     Transaction txn1_1;
-    txn1_1.creator_account_id = "user1@test";
+    txn1_1.creator_account_id = "user1@ru";
 
     CreateRole createRole;
     createRole.role_name = "user";
@@ -105,7 +105,7 @@ class KVTest : public AmetsuchiTest {
 
   std::string domain_id = "ru";
   std::string account_name1 = "user1";
-  std::string account_data1 = R"({"age": "30"})";
+  std::string account_data1 = R"({"user1": {"age": "30"}})";
   std::string account_name2 = "user2";
 };
 
@@ -122,7 +122,7 @@ TEST_F(KVTest, GetAccountDetail) {
   ASSERT_EQ(account->domain_id, domain_id);
   ASSERT_EQ(account->json_data, account_data1);
 
-  auto age = wsv_query->getAccountDetail(account_id1, "age");
+  auto age = wsv_query->getAccountDetail(account_id1, "user1", "age");
   ASSERT_TRUE(age);
   ASSERT_EQ(age.value(), "30");
 }
@@ -136,7 +136,8 @@ TEST_F(KVTest, GetNonexistingDetail) {
   auto account_id1 = account_name1 + "@" + domain_id;
   auto account = wsv_query->getAccount(account_id1);
 
-  auto age = wsv_query->getAccountDetail(account_id1, "nonexisting-field");
+  auto age =
+      wsv_query->getAccountDetail(account_id1, "genesis", "nonexisting-field");
   ASSERT_FALSE(age);
 }
 
@@ -147,7 +148,7 @@ TEST_F(KVTest, GetNonexistingDetail) {
  */
 TEST_F(KVTest, SetAccountDetail) {
   auto account_id2 = account_name2 + "@" + domain_id;
-  auto age = wsv_query->getAccountDetail(account_id2, "age");
+  auto age = wsv_query->getAccountDetail(account_id2, "genesis", "age");
 
   ASSERT_TRUE(age);
   ASSERT_EQ(age.value(), "24");

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -1063,6 +1063,7 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
     role_permissions = {can_set_quorum};
   }
   std::shared_ptr<SetAccountDetail> cmd;
+  std::string needed_permission = can_set_detail;
 };
 
 /**
@@ -1070,7 +1071,7 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
  * @then successfully execute the command
  */
 TEST_F(SetAccountDetailTest, ValidWhenCreatorHasPermissions) {
-  EXPECT_CALL(*wsv_command, setAccountKV(_, _, _)).WillOnce(Return(true));
+  EXPECT_CALL(*wsv_command, setAccountKV(_, _, _, _)).WillOnce(Return(true));
   ASSERT_TRUE(validateAndExecute());
 }
 
@@ -1080,5 +1081,8 @@ TEST_F(SetAccountDetailTest, ValidWhenCreatorHasPermissions) {
  */
 TEST_F(SetAccountDetailTest, InValidWhenOtherCreator) {
   cmd->account_id = account_id;
+  EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(
+      admin_id, cmd->account_id, needed_permission))
+      .WillOnce(Return(false));
   ASSERT_FALSE(validateAndExecute());
 }

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -168,7 +168,6 @@ TEST_F(JsonCommandTest, create_account) {
   auto orig_command = std::make_shared<CreateAccount>();
   orig_command->account_name = "keker";
   orig_command->domain_id = "cheburek";
-  orig_command->json_data = R"({"key" : "value"})";
 
   auto json_command = factory.serializeCreateAccount(orig_command);
   auto serial_command = factory.deserializeCreateAccount(json_command);


### PR DESCRIPTION
## What is this pull request?
PR for nested key-value storage support with specific grants and permission. 
   
## Why do you implement it? Why do we need this pull request?
To support set_account_detail not only to owner account, but also to all other account if having permissions.  
  
## How to use the features provided in the pull request?
Set Account Detail is refactored to support multiple contributors to one account. 
Each account now has nested json with account_id of a contributor serving as main keys and json values.   

When inserting account detail in genesis block the user_id will be "genesis".
