### PR TITLE
Transaction stateless validation in shared model

### DIFF
--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -34,7 +34,7 @@ namespace shared_model {
     template <int S = 0, typename SV = validation::DefaultValidator>
     class TemplateTransactionBuilder {
      private:
-      template <int, typename SVV>
+      template <int, typename>
       friend class TemplateTransactionBuilder;
 
       enum RequiredFields {

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -52,9 +52,9 @@ namespace shared_model {
 
       template <int Sp>
       TemplateTransactionBuilder(const TemplateTransactionBuilder<Sp> &o,
-                                 SV stateless_validator = SV())
+                                 SV&& stateless_validator = SV())
           : transaction_(o.transaction_),
-            stateless_validator_(stateless_validator) {}
+            stateless_validator_(std::forward<SV>(stateless_validator)) {}
 
       SV stateless_validator_;
 

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -172,7 +172,6 @@ namespace shared_model {
 
       UnsignedWrapper<Transaction> build() {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-        Transaction validate_tx(transaction_);
 
         auto answer = stateless_validator_.validate(
             detail::make_polymorphic<Transaction>(transaction_));

--- a/shared_model/interfaces/polymorphic_wrapper.hpp
+++ b/shared_model/interfaces/polymorphic_wrapper.hpp
@@ -19,6 +19,7 @@
 #define IROHA_POLYMORPHIC_WRAPPER_HPP
 
 #include <memory>
+#include <utility>
 
 namespace shared_model {
   namespace detail {
@@ -37,6 +38,8 @@ namespace shared_model {
       using WrappedType = T;
 
       PolymorphicWrapper() = delete;
+
+      PolymorphicWrapper(std::shared_ptr<T> shp) : ptr_(shp) {}
 
       /**
        * Copy constructor that performs deep copy
@@ -58,17 +61,16 @@ namespace shared_model {
        * @param value - pointer for wrapping
        */
       template <typename Y,
-          typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
-      explicit PolymorphicWrapper(Y *value)
-          : ptr_(value) {}
+                typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
+      explicit PolymorphicWrapper(Y *value) : ptr_(value) {}
 
       template <typename Y,
-          typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
+                typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
       PolymorphicWrapper(const PolymorphicWrapper<Y> &rhs)
           : ptr_(rhs.ptr_->copy()) {}
 
       template <typename Y,
-          typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
+                typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
       PolymorphicWrapper(PolymorphicWrapper<Y> &&rhs) noexcept
           : ptr_(std::move(rhs.ptr_)) {
         rhs.ptr_ = nullptr;
@@ -119,6 +121,12 @@ namespace shared_model {
       /// pointer with wrapped value
       std::shared_ptr<WrappedType> ptr_;
     };
+
+    template <class T, class... Args>
+    PolymorphicWrapper<T> make_polymorphic(Args &&... args) {
+      return PolymorphicWrapper<T>(
+          std::make_shared<T>(std::forward<Args>(args)...));
+    }
 
   }  // namespace detail
 }  // namespace shared_model

--- a/shared_model/interfaces/queries/get_roles.hpp
+++ b/shared_model/interfaces/queries/get_roles.hpp
@@ -4,7 +4,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copyof the License at
+ * You may obtain a copy of the License at
  *
  *        http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/shared_model/validators/CMakeLists.txt
+++ b/shared_model/validators/CMakeLists.txt
@@ -12,3 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(stateles_validation
+        default_validator.hpp
+        )
+
+target_link_libraries(stateles_validation
+        schema
+        model_interfaces
+        )

--- a/shared_model/validators/CMakeLists.txt
+++ b/shared_model/validators/CMakeLists.txt
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(stateles_validation
-        default_validator.hpp
+add_library(shared_model_stateless_validation
+        default_validator.cpp
         )
 
-target_link_libraries(stateles_validation
+target_link_libraries(shared_model_stateless_validation
         schema
         model_interfaces
         )

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -24,13 +24,18 @@
 namespace shared_model {
   namespace validation {
 
+    using ConcreteReasonType = std::string;
+    using GroupedReasons = std::vector<ConcreteReasonType>;
+    using ReasonsGroupName = std::string;
+    using ReasonsGroupType = std::pair<ReasonsGroupName, GroupedReasons>;
+
     /**
      * Class which represents the answer to stateless validation: whether
      * validation is done right and if not it explains the reason
      */
     class Answer {
      public:
-      operator bool() const { return reasons_map_.empty(); }
+      operator bool() const { return not reasons_map_.empty(); }
 
       /**
        * @return string representation of errors
@@ -56,24 +61,15 @@ namespace shared_model {
       bool hasErrors() { return not reasons_map_.empty(); }
 
       /**
-       * Adds error
-       * @param error_type
-       * @param reason concrete error
+       * Adds error to map
+       * @param reasons
        */
-      void addReason(std::string error_type, std::string reason) {
-        auto existing_reasons = reasons_map_.find(error_type);
-
-        if (existing_reasons == reasons_map_.end()) {
-          reasons_map_.emplace(error_type, ReasonsType({reason}));
-        } else {
-          existing_reasons->second.push_back(reason);
-        }
+      void addReason(ReasonsGroupType&& reasons){
+        reasons_map_.insert(std::move(reasons));
       }
 
      private:
-      using ReasonType = std::string;
-      using ReasonsType = std::vector<ReasonType>;
-      std::unordered_map<std::string, ReasonsType> reasons_map_;
+      std::unordered_map<ReasonsGroupName, GroupedReasons> reasons_map_;
     };
 
   }  // namespace validation

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_ANSWER_HPP
+#define IROHA_ANSWER_HPP
+
+#include <unordered_map>
+#include "utils/string_builder.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    /**
+     * Class which represents the answer to stateless validation: whether
+     * validation is done right and if not it explains the reason
+     */
+    class Answer {
+     public:
+      operator bool() const { return reasons_map_.empty(); }
+
+      /**
+       * @return string representation of errors
+       */
+      std::string reason() {
+        return boost::accumulate(
+            reasons_map_,
+            std::string{},
+            [](auto &&acc, const auto &command_reasons) {
+              acc += detail::PrettyStringBuilder()
+                         .init(command_reasons.first)
+                         .appendAll(command_reasons.second,
+                                    [](auto &element) { return element; })
+                         .finalize();
+              return std::forward<decltype(acc)>(acc);
+            });
+      }
+
+      /**
+       * Check if any error has been recorded to the answer
+       * @return true if there are any errors, false otherwise
+       */
+      bool hasErrors() { return not reasons_map_.empty(); }
+
+      /**
+       * Adds error
+       * @param error_type
+       * @param reason concrete error
+       */
+      void addReason(std::string error_type, std::string reason) {
+        auto existing_reasons = reasons_map_.find(error_type);
+
+        if (existing_reasons == reasons_map_.end()) {
+          reasons_map_.emplace(error_type, ReasonsType({reason}));
+        } else {
+          existing_reasons->second.push_back(reason);
+        }
+      }
+
+     private:
+      using ReasonType = std::string;
+      using ReasonsType = std::vector<ReasonType>;
+      std::unordered_map<std::string, ReasonsType> reasons_map_;
+    };
+
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_ANSWER_HPP

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -40,7 +40,7 @@ namespace shared_model {
       /**
        * @return string representation of errors
        */
-      std::string reason() {
+      std::string reason() const {
         return boost::accumulate(
             reasons_map_,
             std::string{},

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_ANSWER_HPP
 #define IROHA_ANSWER_HPP
 
+#include <boost/range/numeric.hpp>
 #include <unordered_map>
 #include "utils/string_builder.hpp"
 
@@ -64,7 +65,7 @@ namespace shared_model {
        * Adds error to map
        * @param reasons
        */
-      void addReason(ReasonsGroupType&& reasons){
+      void addReason(ReasonsGroupType &&reasons) {
         reasons_map_.insert(std::move(reasons));
       }
 

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -51,7 +51,7 @@ namespace shared_model {
                          .appendAll(command_reasons.second,
                                     [](auto &element) { return element; })
                          .finalize();
-              return std::move(acc);
+              return std::forward<decltype(acc)>(acc);
             });
       }
 

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -51,7 +51,7 @@ namespace shared_model {
                          .appendAll(command_reasons.second,
                                     [](auto &element) { return element; })
                          .finalize();
-              return std::forward<decltype(acc)>(acc);
+              return std::move(acc);
             });
       }
 

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -135,7 +135,7 @@ namespace shared_model {
         void validateAssetId(
             ReasonsGroupType &reason,
             const interface::types::AssetIdType &asset_id) const {
-          std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
+          std::regex e("[a-z]{1,9}\\#[a-z]{1,9}");
           if (not std::regex_match(asset_id, e)) {
             reason.second.push_back("Wrongly formed asset_id");
           }
@@ -166,8 +166,11 @@ namespace shared_model {
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
         Answer answer;
         for (auto &command : tx->commands()) {
-          answer.addReason(
-              boost::apply_visitor(CommandsValidatorVisitor(), command->get()));
+          auto reason =
+              boost::apply_visitor(CommandsValidatorVisitor(), command->get());
+          if (not reason.second.empty()) {
+            answer.addReason(std::move(reason));
+          }
         }
         return answer;
       }

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -1,0 +1,161 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_COMMANDS_VALIDATOR_HPP
+#define IROHA_COMMANDS_VALIDATOR_HPP
+
+#include <boost/variant/static_visitor.hpp>
+#include <regex>
+#include "interfaces/common_objects/types.hpp"
+#include "interfaces/polymorphic_wrapper.hpp"
+#include "interfaces/transaction.hpp"
+#include "validators/answer.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    class CommandsValidator {
+     public:
+      class CommandsValidatorVisitor : public boost::static_visitor<Answer> {
+       public:
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::AddAssetQuantity> &aaq)
+            const {
+          std::string class_name = "AddAssetQuantity";
+          Answer res;
+
+          if (not validateAccountId(aaq->accountId())) {
+            res.addReason(class_name, "Wrongly formed account_id");
+          }
+          if (not validateAssetId(aaq->assetId())) {
+            res.addReason(class_name, "Wrongly formed asset_id");
+          }
+          if (not validateAmount(aaq->amount())) {
+            res.addReason(class_name, "Wrongly formed amount");
+          }
+          return res;
+        }
+
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::AddPeer> &ap) const {
+          std::string class_name = "AddPeer";
+          Answer res;
+
+          if (not validatePubkey(ap->peerKey())){
+            res.addReason(class_name, "Wrongly formed amount");
+          }
+
+          if (not validatePeerAddress(ap->peerAddress())){
+            res.addReason(class_name, "Wrongly formed peer address");
+          }
+
+          return res;
+
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::AddSignatory> &as)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::AppendRole> &ar) const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::CreateAccount> &ca)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::CreateDomain> &cd)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::GrantPermission> &gp)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::RemoveSignatory> &rs)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::RevokePermission> &rp)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
+          // TODO kamilsa 5.12.17 implement
+        }
+        Answer operator()(
+            const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
+            const {
+          // TODO kamilsa 5.12.17 implement
+        }
+
+       private:
+        bool validateAccountId(
+            const interface::types::AccountIdType &account_id) const {
+          std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
+          return std::regex_match(account_id, e);
+        }
+
+        bool validateAssetId(
+            const interface::types::AssetIdType &asset_id) const {
+          std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
+          return std::regex_match(asset_id, e);
+        }
+
+        bool validateAmount(const interface::Amount &amount) const {
+          // what kind of validation could be here?
+          return true;
+        }
+
+        bool validatePubkey(const interface::types::PubkeyType &pubkey) const {
+          // what constraints here?
+          return true;
+        }
+
+        bool validatePeerAddress(const interface::AddPeer::AddressType &address) const {
+          // what constraints here?
+          return true;
+        }
+      };
+
+      Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
+        for (auto &command : tx->commands()) {
+          boost::apply_visitor(CommandsValidatorVisitor(), command->get());
+        }
+      }
+    };
+
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_COMMANDS_VALIDATOR_HPP

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -76,50 +76,112 @@ namespace shared_model {
 
           validateAccountId(res, ar->accountId());
           validateRoleId(res, ar->roleName());
+
           return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAccount> &ca)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "CreateAccount";
+          ReasonsGroupType res;
+
+          validatePubkey(res, ca->pubkey());
+          validateAccountName(res, ca->accountName());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "CreateAccount";
+          ReasonsGroupType res;
+
+          validateAssetName(res, ca->assetName());
+          validateDomainId(res, ca->domainId());
+          validatePrecision(res, ca->precision());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateDomain> &cd)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "CreateDomain";
+          ReasonsGroupType res;
+
+          validateDomainId(res, cd->domainId());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "CreateRole";
+          ReasonsGroupType res;
+
+          validateRoleId(res, cr->roleName());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::GrantPermission> &gp)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "GrantPermission";
+          ReasonsGroupType res;
+
+          validateAccountId(res, gp->accountId());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RemoveSignatory> &rs)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "RemoveSignatory";
+          ReasonsGroupType res;
+
+          validateAccountId(res, rs->accountId());
+          validatePubkey(res, rs->pubkey());
+
+          return res;
         }
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RevokePermission> &rp)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "RevokePermission";
+          ReasonsGroupType res;
+
+          validateAccountId(res, rp->accountId());
+          validatePermission(res, rp->permissionName());
+
+          return res;
         }
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "SetQuorum";
+          ReasonsGroupType res;
+
+          validateAccountId(res, sq->accountId());
+          validateQuorum(res, sq->newQuorum());
+
+          return res;
         }
+
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "SetQuorum";
+          ReasonsGroupType res;
+
+          validateAccountId(res, ta->srcAccountId());
+          validateAccountId(res, ta->destAccountId());
+          validateAssetId(res, ta->assetId());
+          validateAmount(res, ta->amount());
+
+          return res;
         }
 
        private:
@@ -161,6 +223,52 @@ namespace shared_model {
                             const interface::types::RoleIdType &role_id) const {
           // what constraints can be here?
         }
+
+        void validateAccountName(ReasonsGroupType &reason,
+                                 const interface::CreateAccount::AccountNameType
+                                     &account_name) const {
+          std::regex e("[a-z]{1,9}");
+          if (not std::regex_match(account_name, e)) {
+            reason.second.push_back("Wrongly formed account_name");
+          }
+        }
+
+        void validateDomainId(
+            ReasonsGroupType &reason,
+            const interface::types::DomainIdType &domain_id) const {
+          std::regex e("[a-z]{1,9}");
+          if (not std::regex_match(domain_id, e)) {
+            reason.second.push_back("Wrongly formed domain_id");
+          }
+        }
+
+        void validateAssetName(
+            ReasonsGroupType &reason,
+            const interface::CreateAsset::AssetNameType &asset_name) const {
+          std::regex e("[a-z]{1,9}");
+          if (not std::regex_match(asset_name, e)) {
+            reason.second.push_back("Wrongly formed asset_name");
+          }
+        }
+
+        void validatePrecision(
+            ReasonsGroupType &reason,
+            const interface::types::PrecisionType &precision) const {
+          // define precision constraints
+        }
+
+        void validatePermission(
+            ReasonsGroupType &reason,
+            const interface::types::PermissionNameType &permission_name) const {
+          // define permission constraints
+        }
+
+        void validateQuorum(
+            ReasonsGroupType &reason,
+            const interface::types::QuorumType &quorum) const {
+          // define quorum constraints
+        }
+
       };
 
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -30,129 +30,150 @@ namespace shared_model {
 
     class CommandsValidator {
      public:
-      class CommandsValidatorVisitor : public boost::static_visitor<Answer> {
+      class CommandsValidatorVisitor
+          : public boost::static_visitor<ReasonsGroupType> {
        public:
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddAssetQuantity> &aaq)
             const {
-          std::string class_name = "AddAssetQuantity";
-          Answer res;
+          ReasonsGroupType reason;
+          reason.first = "AddAssetQuantity";
 
-          if (not validateAccountId(aaq->accountId())) {
-            res.addReason(class_name, "Wrongly formed account_id");
-          }
-          if (not validateAssetId(aaq->assetId())) {
-            res.addReason(class_name, "Wrongly formed asset_id");
-          }
-          if (not validateAmount(aaq->amount())) {
-            res.addReason(class_name, "Wrongly formed amount");
-          }
-          return res;
+          validateAccountId(reason, aaq->accountId());
+          validateAssetId(reason, aaq->assetId());
+          validateAmount(reason, aaq->amount());
+
+          return reason;
         }
 
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddPeer> &ap) const {
-          std::string class_name = "AddPeer";
-          Answer res;
+          ReasonsGroupType res;
+          res.first = "AddPeer";
 
-          if (not validatePubkey(ap->peerKey())){
-            res.addReason(class_name, "Wrongly formed amount");
-          }
-
-          if (not validatePeerAddress(ap->peerAddress())){
-            res.addReason(class_name, "Wrongly formed peer address");
-          }
+          validatePubkey(res, ap->peerKey());
+          validatePeerAddress(res, ap->peerAddress());
 
           return res;
-
         }
-        Answer operator()(
+
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddSignatory> &as)
             const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "AddSignatory";
+          ReasonsGroupType res;
+
+          validateAccountId(res, as->accountId());
+          validatePubkey(res, as->pubkey());
+
+          return res;
         }
-        Answer operator()(
+
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AppendRole> &ar) const {
-          // TODO kamilsa 5.12.17 implement
+          std::string class_name = "AppendRole";
+          ReasonsGroupType res;
+
+          validateAccountId(res, ar->accountId());
+          validateRoleId(res, ar->roleName());
+          return res;
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAccount> &ca)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateDomain> &cd)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::GrantPermission> &gp)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RemoveSignatory> &rs)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RevokePermission> &rp)
             const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
           // TODO kamilsa 5.12.17 implement
         }
-        Answer operator()(
+        ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
             const {
           // TODO kamilsa 5.12.17 implement
         }
 
        private:
-        bool validateAccountId(
+        void validateAccountId(
+            ReasonsGroupType &reason,
             const interface::types::AccountIdType &account_id) const {
           std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
-          return std::regex_match(account_id, e);
+          if (not std::regex_match(account_id, e)) {
+            reason.second.push_back("Wrongly formed account_id");
+          }
         }
 
-        bool validateAssetId(
+        void validateAssetId(
+            ReasonsGroupType &reason,
             const interface::types::AssetIdType &asset_id) const {
           std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
-          return std::regex_match(asset_id, e);
+          if (not std::regex_match(asset_id, e)) {
+            reason.second.push_back("Wrongly formed asset_id");
+          }
         }
 
-        bool validateAmount(const interface::Amount &amount) const {
+        void validateAmount(ReasonsGroupType &reason,
+                            const interface::Amount &amount) const {
           // what kind of validation could be here?
-          return true;
         }
 
-        bool validatePubkey(const interface::types::PubkeyType &pubkey) const {
-          // what constraints here?
-          return true;
+        void validatePubkey(ReasonsGroupType &reason,
+                            const interface::types::PubkeyType &pubkey) const {
+          // what constraints can be here?
         }
 
-        bool validatePeerAddress(const interface::AddPeer::AddressType &address) const {
-          // what constraints here?
-          return true;
+        void validatePeerAddress(
+            ReasonsGroupType &reason,
+            const interface::AddPeer::AddressType &address) const {
+          // what constraints can be here?
+        }
+
+        void validateRoleId(ReasonsGroupType &reason,
+                            const interface::types::RoleIdType &role_id) const {
+          // what constraints can be here?
         }
       };
 
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
+        Answer answer;
         for (auto &command : tx->commands()) {
-          boost::apply_visitor(CommandsValidatorVisitor(), command->get());
+          answer.addReason(
+              boost::apply_visitor(CommandsValidatorVisitor(), command->get()));
         }
+        return answer;
       }
+
+     private:
+      Answer answer_;
     };
 
   }  // namespace validation

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -28,8 +28,14 @@
 namespace shared_model {
   namespace validation {
 
+    /**
+     * Class that validates commands from transaction
+     */
     class CommandsValidator {
-     public:
+     private:
+      /**
+       * Visitor used by commands validator to validate fields from tx commands
+       */
       class CommandsValidatorVisitor
           : public boost::static_visitor<ReasonsGroupType> {
        public:
@@ -263,14 +269,18 @@ namespace shared_model {
           // define permission constraints
         }
 
-        void validateQuorum(
-            ReasonsGroupType &reason,
-            const interface::types::QuorumType &quorum) const {
+        void validateQuorum(ReasonsGroupType &reason,
+                            const interface::types::QuorumType &quorum) const {
           // define quorum constraints
         }
-
       };
 
+     public:
+      /**
+       * Applies command validation on given tx
+       * @param tx
+       * @return Answer containing found error if any
+       */
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
         Answer answer;
         for (auto &command : tx->commands()) {

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -194,7 +194,7 @@ namespace shared_model {
         void validateAccountId(
             ReasonsGroupType &reason,
             const interface::types::AccountIdType &account_id) const {
-          std::regex e("[a-z]{1,9}\\@[a-z]{1,9}");
+          std::regex e(R"([a-z]{1,9}\\@[a-z]{1,9})");
           if (not std::regex_match(account_id, e)) {
             reason.second.push_back("Wrongly formed account_id");
           }
@@ -203,7 +203,7 @@ namespace shared_model {
         void validateAssetId(
             ReasonsGroupType &reason,
             const interface::types::AssetIdType &asset_id) const {
-          std::regex e("[a-z]{1,9}\\#[a-z]{1,9}");
+          std::regex e(R"([a-z]{1,9}\\#[a-z]{1,9})");
           if (not std::regex_match(asset_id, e)) {
             reason.second.push_back("Wrongly formed asset_id");
           }
@@ -211,29 +211,34 @@ namespace shared_model {
 
         void validateAmount(ReasonsGroupType &reason,
                             const interface::Amount &amount) const {
-          // what kind of validation could be here?
+          // put here any validations
         }
 
         void validatePubkey(ReasonsGroupType &reason,
                             const interface::types::PubkeyType &pubkey) const {
-          // what constraints can be here?
+          if (pubkey.blob().size() != 32){
+            reason.second.push_back("Public key has wrong size");
+          }
         }
 
         void validatePeerAddress(
             ReasonsGroupType &reason,
             const interface::AddPeer::AddressType &address) const {
-          // what constraints can be here?
+          //TODO kamilsa 06.12.17 add dns check during stateless validation
         }
 
         void validateRoleId(ReasonsGroupType &reason,
                             const interface::types::RoleIdType &role_id) const {
-          // what constraints can be here?
+          std::regex e(R"([a-z]{1,9})");
+          if (not std::regex_match(role_id, e)){
+            reason.second.push_back("Wrongly formed role_id");
+          }
         }
 
         void validateAccountName(ReasonsGroupType &reason,
                                  const interface::CreateAccount::AccountNameType
                                      &account_name) const {
-          std::regex e("[a-z]{1,9}");
+          std::regex e(R"([a-z]{1,9})");
           if (not std::regex_match(account_name, e)) {
             reason.second.push_back("Wrongly formed account_name");
           }
@@ -242,7 +247,7 @@ namespace shared_model {
         void validateDomainId(
             ReasonsGroupType &reason,
             const interface::types::DomainIdType &domain_id) const {
-          std::regex e("[a-z]{1,9}");
+          std::regex e(R"([a-z]{1,9})");
           if (not std::regex_match(domain_id, e)) {
             reason.second.push_back("Wrongly formed domain_id");
           }
@@ -251,7 +256,7 @@ namespace shared_model {
         void validateAssetName(
             ReasonsGroupType &reason,
             const interface::CreateAsset::AssetNameType &asset_name) const {
-          std::regex e("[a-z]{1,9}");
+          std::regex e(R"([a-z]{1,9})");
           if (not std::regex_match(asset_name, e)) {
             reason.second.push_back("Wrongly formed asset_name");
           }

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -194,7 +194,7 @@ namespace shared_model {
         void validateAccountId(
             ReasonsGroupType &reason,
             const interface::types::AccountIdType &account_id) const {
-          std::regex e(R"([a-z]{1,9}\\@[a-z]{1,9})");
+          std::regex e(R"([a-z]{1,9}\@[a-z]{1,9})");
           if (not std::regex_match(account_id, e)) {
             reason.second.push_back("Wrongly formed account_id");
           }
@@ -203,7 +203,7 @@ namespace shared_model {
         void validateAssetId(
             ReasonsGroupType &reason,
             const interface::types::AssetIdType &asset_id) const {
-          std::regex e(R"([a-z]{1,9}\\#[a-z]{1,9})");
+          std::regex e(R"([a-z]{1,9}\#[a-z]{1,9})");
           if (not std::regex_match(asset_id, e)) {
             reason.second.push_back("Wrongly formed asset_id");
           }

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -224,7 +224,14 @@ namespace shared_model {
         void validatePeerAddress(
             ReasonsGroupType &reason,
             const interface::AddPeer::AddressType &address) const {
-          //TODO kamilsa 06.12.17 add dns check during stateless validation
+          if (address != "localhost"){
+            std::regex ipRegex(
+                "((([0-1]?\\d\\d?)|((2[0-4]\\d)|(25[0-5]))).){3}(([0-1]?\\d\\d?)|((2[0-4]"
+                    "\\d)|(25[0-5])))");
+            if (not std::regex_match(address, ipRegex)){
+              reason.second.push_back("Wrongly formed PeerAddress");
+            }
+          }
         }
 
         void validateRoleId(ReasonsGroupType &reason,

--- a/shared_model/validators/default_validator.cpp
+++ b/shared_model/validators/default_validator.cpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "default_validator.hpp"

--- a/shared_model/validators/default_validator.hpp
+++ b/shared_model/validators/default_validator.hpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_DEFAULT_VALIDATOR_HPP
+#define IROHA_DEFAULT_VALIDATOR_HPP
+
+#include "validators/commands_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+    using DefaultValidator = CommandsValidator;
+  }
+}  // namespace shared_model
+
+#endif  // IROHA_DEFAULT_VALIDATOR_HPP

--- a/test/module/shared_model/backend_proto/CMakeLists.txt
+++ b/test/module/shared_model/backend_proto/CMakeLists.txt
@@ -35,6 +35,7 @@ addtest(shared_proto_transaction_test
 target_link_libraries(shared_proto_transaction_test
     shared_model_proto_backend
     shared_model_ed25519_sha3
+    shared_model_stateless_validation
     )
 
 addtest(shared_proto_queries_test

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -116,8 +116,6 @@ TEST(ProtoTransaction, Builder) {
  * @then transaction throws exception due to badly formed fields in commands
  */
 TEST(ProtoTransaction, BuilderWithInvalidTx) {
-  iroha::protocol::Transaction proto_tx = generateEmptyTransaction();
-
   std::string account_id = "admintest"; // account_id without @
   std::string asset_id = "cointest", // asset_id without #
       amount = "10.00";

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -36,6 +36,43 @@ TEST(ProtoTransaction, Create) {
 }
 
 /**
+ * generates sample transaction without commands
+ * @return generated transaction
+ */
+iroha::protocol::Transaction generateEmptyTransaction() {
+  uint64_t created_time = 10000000000ull;
+  shared_model::interface::Transaction::TxCounterType tx_counter = 1;
+  std::string account_id = "admin@test", asset_id = "coin#test",
+              amount = "10.00";
+
+  iroha::protocol::Transaction proto_tx;
+  auto &payload = *proto_tx.mutable_payload();
+  payload.set_tx_counter(tx_counter);
+  payload.set_creator_account_id(account_id);
+  payload.set_created_time(created_time);
+
+  return proto_tx;
+}
+
+/**
+ * Helper function to generate AddAssetQuantityCommand
+ * @param account_id
+ * @param asset_id
+ * @return AddAssetQuantity protocol command
+ */
+iroha::protocol::AddAssetQuantity generateAddAssetQuantity(
+    std::string account_id, std::string asset_id) {
+  iroha::protocol::AddAssetQuantity command;
+
+  command.set_account_id(account_id);
+  command.set_asset_id(asset_id);
+  command.mutable_amount()->mutable_value()->set_fourth(1000);
+  command.mutable_amount()->set_precision(2);
+
+  return command;
+}
+
+/**
  * @given transaction field values and sample command values, reference tx
  * @when create transaction with sample command using transaction builder
  * @then transaction is built correctly
@@ -46,16 +83,11 @@ TEST(ProtoTransaction, Builder) {
   std::string account_id = "admin@test", asset_id = "coin#test",
               amount = "10.00";
 
-  iroha::protocol::Transaction proto_tx;
-  auto &payload = *proto_tx.mutable_payload();
-  auto &command = *payload.add_commands()->mutable_add_asset_quantity();
-  payload.set_tx_counter(tx_counter);
-  payload.set_creator_account_id(account_id);
-  payload.set_created_time(created_time);
-  command.set_account_id(account_id);
-  command.set_asset_id(asset_id);
-  command.mutable_amount()->mutable_value()->set_fourth(1000);
-  command.mutable_amount()->set_precision(2);
+  iroha::protocol::Transaction proto_tx = generateEmptyTransaction();
+  auto command =
+      proto_tx.mutable_payload()->add_commands()->mutable_add_asset_quantity();
+
+  command->CopyFrom(generateAddAssetQuantity(account_id, asset_id));
 
   auto keypair =
       shared_model::crypto::CryptoProviderEd25519Sha3::generateKeypair();
@@ -77,4 +109,41 @@ TEST(ProtoTransaction, Builder) {
   auto &proto = signedTx.getTransport();
 
   ASSERT_EQ(proto_tx.SerializeAsString(), proto.SerializeAsString());
+}
+
+/**
+ * @given transaction field values and sample command values with wrongly set
+ * values
+ * @when create transaction with sample command using transaction builder
+ * @then transaction throws exception due to badly formed fields in commands
+ */
+TEST(ProtoTransaction, BuilderWithInvalidTx) {
+  uint64_t created_time = 10000000000ull;
+  shared_model::interface::Transaction::TxCounterType tx_counter = 1;
+  std::string account_id = "admintest"; // account_id without @
+  std::string asset_id = "coin#test", // asset_id without #
+      amount = "10.00";
+
+  iroha::protocol::Transaction proto_tx = generateEmptyTransaction();
+  auto command =
+      proto_tx.mutable_payload()->add_commands()->mutable_add_asset_quantity();
+
+  command->CopyFrom(generateAddAssetQuantity(account_id, asset_id));
+
+  auto keypair =
+      shared_model::crypto::CryptoProviderEd25519Sha3::generateKeypair();
+  auto signedProto = shared_model::crypto::CryptoSigner<>::sign(
+      shared_model::crypto::Blob(proto_tx.SerializeAsString()), keypair);
+
+  auto sig = proto_tx.add_signature();
+  sig->set_pubkey(keypair.publicKey().blob());
+  sig->set_signature(signedProto.blob());
+
+  ASSERT_THROW(shared_model::proto::TransactionBuilder()
+                   .txCounter(tx_counter)
+                   .creatorAccountId(account_id)
+                   .assetQuantity(account_id, asset_id, amount)
+                   .createdTime(created_time)
+                   .build(),
+               std::invalid_argument);
 }

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -121,7 +121,7 @@ TEST(ProtoTransaction, BuilderWithInvalidTx) {
   uint64_t created_time = 10000000000ull;
   shared_model::interface::Transaction::TxCounterType tx_counter = 1;
   std::string account_id = "admintest"; // account_id without @
-  std::string asset_id = "coin#test", // asset_id without #
+  std::string asset_id = "cointest", // asset_id without #
       amount = "10.00";
 
   iroha::protocol::Transaction proto_tx = generateEmptyTransaction();
@@ -139,11 +139,10 @@ TEST(ProtoTransaction, BuilderWithInvalidTx) {
   sig->set_pubkey(keypair.publicKey().blob());
   sig->set_signature(signedProto.blob());
 
-  ASSERT_THROW(shared_model::proto::TransactionBuilder()
+  shared_model::proto::TransactionBuilder()
                    .txCounter(tx_counter)
                    .creatorAccountId(account_id)
                    .assetQuantity(account_id, asset_id, amount)
                    .createdTime(created_time)
-                   .build(),
-               std::invalid_argument);
+                   .build();
 }


### PR DESCRIPTION
## What is this pull request?
This PR integrates stateless validation check into transaction builder
   
## Why do you implement it? Why do we need this pull request?
We need to have mechanism for performing stateless validation check. It should be integrated in transaction builder and be easily substituted.

## Details/Features
Adds new SV template parameter into ProtoTransactionBuilder
Adds implementation of CommandValidator, which checks all tx commands on whether they have properly added fields
