### PR TITLE
Update query builder

### DIFF
--- a/shared_model/builders/protobuf/queries.hpp
+++ b/shared_model/builders/protobuf/queries.hpp
@@ -18,8 +18,7 @@
 #ifndef IROHA_PROTO_QUERY_BUILDER_HPP
 #define IROHA_PROTO_QUERY_BUILDER_HPP
 
-// TODO @l4l IR-648
-// #include "backend/protobuf/queries.hpp"
+#include "backend/protobuf/queries/proto_query.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "queries.pb.h"
 
@@ -128,10 +127,9 @@ namespace shared_model {
         return *this;
       }
 
-      // TODO IR-648 @l4l: Uncomment on completing proto::Query
-      iroha::protocol::Query /*Query*/ build() {
+      Query build() {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-        return query_;  // Query(iroha::protocol::Query(query_));
+        return Query(iroha::protocol::Query(query_));
       }
     };
 

--- a/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
@@ -35,14 +35,12 @@ TEST(ProtoQuery, QueryLoad) {
   auto payload = query.mutable_payload();
   auto refl = payload->GetReflection();
   auto desc = payload->GetDescriptor()->FindOneofByName("query");
-  boost::for_each(
-      boost::irange(0, desc->field_count()),
-      [&](auto i) {
-        auto field = desc->field(i);
-        refl->SetAllocatedMessage(
-            payload, refl->GetMessage(*payload, field).New(), field);
-        ASSERT_EQ(i, shared_model::proto::Query(query).get().which());
-      });
+  boost::for_each(boost::irange(0, desc->field_count()), [&](auto i) {
+    auto field = desc->field(i);
+    refl->SetAllocatedMessage(
+        payload, refl->GetMessage(*payload, field).New(), field);
+    ASSERT_EQ(i, shared_model::proto::Query(query).get().which());
+  });
 }
 
 /**
@@ -71,8 +69,7 @@ TEST(ProtoQueryBuilder, Builder) {
                    .getAccountAssets(account_id, asset_id)
                    .queryCounter(query_counter)
                    .build();
-  // TODO IR-648 @l4l: Uncomment on completing proto::Query
-  auto &proto = query;  //.getTransport();
+  auto &proto = query.getTransport();
 
   ASSERT_EQ(proto_tx.SerializeAsString(), proto.SerializeAsString());
 }


### PR DESCRIPTION
This basically fix to consistent builder that returns `shared_model::proto` rather than `iroha::protocol` query