### PR TITLE
Fix problem with proto object signing:

### DIFF
--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -83,6 +83,9 @@ namespace shared_model {
             variant_(
                 [this] { return load_query<ProtoQueryListType>(*proto_); }),
             blob_([this] { return BlobType(proto_->SerializeAsString()); }),
+            payload_([this] {
+              return BlobType(proto_->payload().SerializeAsString());
+            }),
             signatures_([this] {
               SignatureSetType set;
               set.emplace(new Signature(proto_->signature()));
@@ -104,6 +107,8 @@ namespace shared_model {
       }
 
       const BlobType &blob() const override { return *blob_; }
+
+      const BlobType &payload() const override { return *payload_; }
 
       // ------------------------| Signable override  |-------------------------
       const SignatureSetType &signatures() const override {
@@ -130,6 +135,7 @@ namespace shared_model {
       const LazyVariantType variant_;
 
       const Lazy<BlobType> blob_;
+      const Lazy<BlobType> payload_;
       const Lazy<SignatureSetType> signatures_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -24,15 +24,14 @@
 
 #include "backend/protobuf/commands/proto_command.hpp"
 #include "backend/protobuf/common_objects/signature.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "block.pb.h"
 #include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
     class Transaction FINAL : public CopyableProto<interface::Transaction,
-                                             iroha::protocol::Transaction,
-                                             Transaction> {
+                                                   iroha::protocol::Transaction,
+                                                   Transaction> {
      public:
       template <typename TransactionType>
       explicit Transaction(TransactionType &&transaction)
@@ -49,6 +48,8 @@ namespace shared_model {
                   });
             }),
             blob_([this] { return BlobType(proto_->SerializeAsString()); }),
+            blobTypePayload_(
+                [this] { return BlobType(payload_->SerializeAsString()); }),
             signatures_([this] {
               return boost::accumulate(
                   proto_->signature(),
@@ -79,6 +80,8 @@ namespace shared_model {
       }
 
       const crypto::Blob &blob() const override { return *blob_; }
+
+      const crypto::Blob &payload() const override { return *blobTypePayload_; }
 
       const shared_model::interface::Signable<
           shared_model::interface::Transaction,
@@ -113,6 +116,8 @@ namespace shared_model {
       const Lazy<CommandsType> commands_;
 
       const Lazy<BlobType> blob_;
+
+      const Lazy<BlobType> blobTypePayload_;
 
       const Lazy<SignatureSetType> signatures_;
     };

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -45,7 +45,7 @@ namespace shared_model {
        */
       T signAndAddSignature(const crypto::Keypair &keypair) {
         auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
-            shared_model::crypto::Blob(unsigned_.blob()), keypair);
+            shared_model::crypto::Blob(unsigned_.payload()), keypair);
         iroha::protocol::Signature protosig;
         protosig.set_pubkey(keypair.publicKey().blob());
         protosig.set_signature(signedBlob.blob());

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -87,6 +87,12 @@ namespace shared_model {
       virtual types::TimestampType createdTime() const = 0;
 
       /**
+       * @return object payload (everything except signatures)
+       */
+      virtual const typename Hashable<Model, OldModel>::BlobType &payload()
+          const = 0;
+
+      /**
        * Provides comparison based on equality of objects and signatures.
        * @param rhs - another model object
        * @return true, if objects totally equal

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -90,7 +90,8 @@ TEST(ProtoTransaction, Builder) {
   auto keypair =
       shared_model::crypto::CryptoProviderEd25519Sha3::generateKeypair();
   auto signedProto = shared_model::crypto::CryptoSigner<>::sign(
-      shared_model::crypto::Blob(proto_tx.SerializeAsString()), keypair);
+      shared_model::crypto::Blob(proto_tx.payload().SerializeAsString()),
+      keypair);
 
   auto sig = proto_tx.add_signature();
   sig->set_pubkey(keypair.publicKey().blob());


### PR DESCRIPTION
## What is this pull request?
Fix about using payload of Transaction and Query when signing instead of whole blob.
   
## Why do you implement it? Why do we need this pull request?
Whole blob may contain other signatures which should not be signed. Also it creates a problem on verification step.

## Details/Features
- Add payload() abstract method into Signable
- Implement payload() in both Transaction and Query
- Use payload() call when signing instead of blob()
- Fix test according to changes above
