### PR TITLE
Fix/shared model tx validation

### DIFF
--- a/irohad/validation/impl/stateless_validator_impl.cpp
+++ b/irohad/validation/impl/stateless_validator_impl.cpp
@@ -44,7 +44,6 @@ namespace iroha {
       ts64_t now = time::now();
 
       // tx is not sent from future
-      // TODO 06/08/17 Muratov: make future gap for passing timestamp, like with old timestamps IR-511 #goodfirstissue
       if (now < transaction.created_ts) {
         log_->warn("timestamp broken: send from future ({}, now {})",
                    transaction.created_ts,

--- a/schema/commands.proto
+++ b/schema/commands.proto
@@ -78,15 +78,15 @@ message Command {
         AddAssetQuantity add_asset_quantity = 1;
         AddPeer add_peer = 2;
         AddSignatory add_signatory = 3;
-        CreateAsset create_asset = 4;
+        AppendRole append_role = 4;
         CreateAccount create_account = 5;
-        CreateDomain create_domain = 6;
-        RemoveSignatory remove_sign = 7;
-        SetAccountQuorum set_quorum = 9;
-        TransferAsset transfer_asset = 10;
-        AppendRole append_role = 11;
-        CreateRole create_role = 12;
-        GrantPermission grant_permission = 13;
-        RevokePermission revoke_permission = 14;
+        CreateAsset create_asset = 6;
+        CreateDomain create_domain = 7;
+        CreateRole create_role = 8;
+        GrantPermission grant_permission = 9;
+        RemoveSignatory remove_sign = 10;
+        RevokePermission revoke_permission = 11;
+        SetAccountQuorum set_quorum = 12;
+        TransferAsset transfer_asset = 13;
     }
 }

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -49,8 +49,8 @@ message Query {
        GetAccountAssetTransactions get_account_asset_transactions = 6;
        GetAccountAssets get_account_assets = 7;
        GetRoles get_roles = 8;
-       GetAssetInfo get_asset_info = 9;
-       GetRolePermissions get_role_permissions = 10;
+       GetRolePermissions get_role_permissions = 9;
+       GetAssetInfo get_asset_info = 10;
      }
      // used to prevent replay attacks.
      uint64 query_counter = 11;

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -19,7 +19,7 @@
 #define IROHA_ANSWER_HPP
 
 #include <boost/range/numeric.hpp>
-#include <unordered_map>
+#include <map>
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -50,7 +50,7 @@ namespace shared_model {
                          .init(command_reasons.first)
                          .appendAll(command_reasons.second,
                                     [](auto &element) { return element; })
-                         .finalize();
+                         .finalize() + "\n";
               return std::forward<decltype(acc)>(acc);
             });
       }
@@ -69,12 +69,12 @@ namespace shared_model {
         reasons_map_.insert(std::move(reasons));
       }
 
-      std::unordered_map<ReasonsGroupName, GroupedReasons> getReasonsMap(){
+      std::map<ReasonsGroupName, GroupedReasons> getReasonsMap(){
         return reasons_map_;
       };
 
      private:
-      std::unordered_map<ReasonsGroupName, GroupedReasons> reasons_map_;
+      std::map<ReasonsGroupName, GroupedReasons> reasons_map_;
     };
 
   }  // namespace validation

--- a/shared_model/validators/answer.hpp
+++ b/shared_model/validators/answer.hpp
@@ -69,6 +69,10 @@ namespace shared_model {
         reasons_map_.insert(std::move(reasons));
       }
 
+      std::unordered_map<ReasonsGroupName, GroupedReasons> getReasonsMap(){
+        return reasons_map_;
+      };
+
      private:
       std::unordered_map<ReasonsGroupName, GroupedReasons> reasons_map_;
     };

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -305,7 +305,7 @@ namespace shared_model {
             answer.addReason(std::move(reason));
           }
         }
-        std::string tx_reason_name = "Trasaction";
+        std::string tx_reason_name = "Transaction";
         ReasonsGroupType tx_reason(tx_reason_name, GroupedReasons());
         validateCreatorAccountId(tx_reason, tx->creatorAccountId());
         validateCreatedTime(tx_reason, tx->createdTime());

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -18,8 +18,10 @@
 #ifndef IROHA_COMMANDS_VALIDATOR_HPP
 #define IROHA_COMMANDS_VALIDATOR_HPP
 
+#include <boost/format.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <regex>
+#include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/transaction.hpp"
 #include "utils/polymorphic_wrapper.hpp"
@@ -54,150 +56,151 @@ namespace shared_model {
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddPeer> &ap) const {
-          ReasonsGroupType res;
-          res.first = "AddPeer";
+          ReasonsGroupType reason;
+          reason.first = "AddPeer";
 
-          validatePubkey(res, ap->peerKey());
-          validatePeerAddress(res, ap->peerAddress());
+          validatePubkey(reason, ap->peerKey());
+          validatePeerAddress(reason, ap->peerAddress());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddSignatory> &as)
             const {
           std::string class_name = "AddSignatory";
-          ReasonsGroupType res;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, as->accountId());
-          validatePubkey(res, as->pubkey());
+          validateAccountId(reason, as->accountId());
+          validatePubkey(reason, as->pubkey());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AppendRole> &ar) const {
           std::string class_name = "AppendRole";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, ar->accountId());
-          validateRoleId(res, ar->roleName());
+          validateAccountId(reason, ar->accountId());
+          validateRoleId(reason, ar->roleName());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAccount> &ca)
             const {
           std::string class_name = "CreateAccount";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validatePubkey(res, ca->pubkey());
-          validateAccountName(res, ca->accountName());
+          validatePubkey(reason, ca->pubkey());
+          validateAccountName(reason, ca->accountName());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
             const {
           std::string class_name = "CreateAsset";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAssetName(res, ca->assetName());
-          validateDomainId(res, ca->domainId());
-          validatePrecision(res, ca->precision());
+          validateAssetName(reason, ca->assetName());
+          validateDomainId(reason, ca->domainId());
+          validatePrecision(reason, ca->precision());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateDomain> &cd)
             const {
           std::string class_name = "CreateDomain";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateDomainId(res, cd->domainId());
+          validateDomainId(reason, cd->domainId());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
           std::string class_name = "CreateRole";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateRoleId(res, cr->roleName());
+          validateRoleId(reason, cr->roleName());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::GrantPermission> &gp)
             const {
           std::string class_name = "GrantPermission";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, gp->accountId());
+          validateAccountId(reason, gp->accountId());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RemoveSignatory> &rs)
             const {
           std::string class_name = "RemoveSignatory";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, rs->accountId());
-          validatePubkey(res, rs->pubkey());
+          validateAccountId(reason, rs->accountId());
+          validatePubkey(reason, rs->pubkey());
 
-          return res;
+          return reason;
         }
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RevokePermission> &rp)
             const {
           std::string class_name = "RevokePermission";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, rp->accountId());
-          validatePermission(res, rp->permissionName());
+          validateAccountId(reason, rp->accountId());
+          validatePermission(reason, rp->permissionName());
 
-          return res;
+          return reason;
         }
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
           std::string class_name = "SetQuorum";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, sq->accountId());
-          validateQuorum(res, sq->newQuorum());
+          validateAccountId(reason, sq->accountId());
+          validateQuorum(reason, sq->newQuorum());
 
-          return res;
+          return reason;
         }
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
             const {
           std::string class_name = "TransferAsset";
-          ReasonsGroupType res;
-          res.first = class_name;
+          ReasonsGroupType reason;
+          reason.first = class_name;
 
-          validateAccountId(res, ta->srcAccountId());
-          validateAccountId(res, ta->destAccountId());
-          validateAssetId(res, ta->assetId());
-          validateAmount(res, ta->amount());
+          validateAccountId(reason, ta->srcAccountId());
+          validateAccountId(reason, ta->destAccountId());
+          validateAssetId(reason, ta->assetId());
+          validateAmount(reason, ta->amount());
 
-          return res;
+          return reason;
         }
 
        private:
@@ -307,18 +310,61 @@ namespace shared_model {
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
         Answer answer;
         for (auto &command : tx->commands()) {
-          //FIXME print only for debug purposes, put your comment if you see this comment during review
-          std::cout << command->toString() << std::endl;
           auto reason =
               boost::apply_visitor(CommandsValidatorVisitor(), command->get());
           if (not reason.second.empty()) {
             answer.addReason(std::move(reason));
           }
         }
+        std::string tx_reason_name = "Trasaction";
+        ReasonsGroupType tx_reason(tx_reason_name, GroupedReasons());
+        validateCreatorAccountId(tx_reason, tx->creatorAccountId());
+        validateCreatedTime(tx_reason, tx->createdTime());
+
+        if (not tx_reason.second.empty()) {
+          answer.addReason(std::move(tx_reason));
+        }
         return answer;
       }
 
      private:
+      void validateCreatorAccountId(
+          ReasonsGroupType &reason,
+          const interface::types::AccountIdType &account_id) const {
+        // TODO kamilsa 08.12.17 this validation is the same as
+        // validateAccountId, but adds another message, make template method
+        // overcome similar code dublicating
+        std::regex e(R"([a-z]{1,9}\@[a-z]{1,9})");
+        if (not std::regex_match(account_id, e)) {
+          reason.second.push_back("Wrongly formed creator_account_id");
+        }
+      }
+
+      void validateCreatedTime(
+          ReasonsGroupType &reason,
+          const interface::types::TimestampType &timestamp) {
+        iroha::ts64_t now = iroha::time::now();
+        // TODO 06/08/17 Muratov: make future gap for passing timestamp, like
+        // with old timestamps IR-511 #goodfirstissue
+        if (now < timestamp) {
+          auto message =
+              boost::format(
+                  "timestamp broken: send from future (%llu, now %llu)")
+              % timestamp % now;
+          reason.second.push_back(message.str());
+        }
+
+        if (now - timestamp > MAX_DELAY) {
+          auto message =
+              boost::format("timestamp broken: too old (%llu, now %llu)")
+              % timestamp % now;
+          reason.second.push_back(message.str());
+        }
+      }
+
+      // max-delay between tx creation and validation
+      static constexpr auto MAX_DELAY =
+          std::chrono::hours(24) / std::chrono::milliseconds(1);
       Answer answer_;
     };
 

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -307,6 +307,8 @@ namespace shared_model {
       Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
         Answer answer;
         for (auto &command : tx->commands()) {
+          //FIXME print only for debug purposes, put your comment if you see this comment during review
+          std::cout << command->toString() << std::endl;
           auto reason =
               boost::apply_visitor(CommandsValidatorVisitor(), command->get());
           if (not reason.second.empty()) {

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -68,9 +68,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AddSignatory> &as)
             const {
-          std::string class_name = "AddSignatory";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "AddSignatory";
 
           validateAccountId(reason, as->accountId());
           validatePubkey(reason, as->pubkey());
@@ -80,9 +79,8 @@ namespace shared_model {
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::AppendRole> &ar) const {
-          std::string class_name = "AppendRole";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "AppendRole";
 
           validateAccountId(reason, ar->accountId());
           validateRoleId(reason, ar->roleName());
@@ -92,10 +90,9 @@ namespace shared_model {
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAccount> &ca)
-            const {
-          std::string class_name = "CreateAccount";
+            const {;
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "CreateAccount";
 
           validatePubkey(reason, ca->pubkey());
           validateAccountName(reason, ca->accountName());
@@ -106,9 +103,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
             const {
-          std::string class_name = "CreateAsset";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "CreateAsset";
 
           validateAssetName(reason, ca->assetName());
           validateDomainId(reason, ca->domainId());
@@ -120,9 +116,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateDomain> &cd)
             const {
-          std::string class_name = "CreateDomain";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "CreateDomain";
 
           validateDomainId(reason, cd->domainId());
 
@@ -131,9 +126,8 @@ namespace shared_model {
 
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
-          std::string class_name = "CreateRole";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "CreateRole";
 
           validateRoleId(reason, cr->roleName());
 
@@ -143,9 +137,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::GrantPermission> &gp)
             const {
-          std::string class_name = "GrantPermission";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "GrantPermission";
 
           validateAccountId(reason, gp->accountId());
 
@@ -155,9 +148,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RemoveSignatory> &rs)
             const {
-          std::string class_name = "RemoveSignatory";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "RemoveSignatory";
 
           validateAccountId(reason, rs->accountId());
           validatePubkey(reason, rs->pubkey());
@@ -167,9 +159,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::RevokePermission> &rp)
             const {
-          std::string class_name = "RevokePermission";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "RevokePermission";
 
           validateAccountId(reason, rp->accountId());
           validatePermission(reason, rp->permissionName());
@@ -178,9 +169,8 @@ namespace shared_model {
         }
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
-          std::string class_name = "SetQuorum";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "SetQuorum";
 
           validateAccountId(reason, sq->accountId());
           validateQuorum(reason, sq->newQuorum());
@@ -191,9 +181,8 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
             const {
-          std::string class_name = "TransferAsset";
           ReasonsGroupType reason;
-          reason.first = class_name;
+          reason.first = "TransferAsset";
 
           validateAccountId(reason, ta->srcAccountId());
           validateAccountId(reason, ta->destAccountId());
@@ -331,9 +320,6 @@ namespace shared_model {
       void validateCreatorAccountId(
           ReasonsGroupType &reason,
           const interface::types::AccountIdType &account_id) const {
-        // TODO kamilsa 08.12.17 this validation is the same as
-        // validateAccountId, but adds another message, make template method
-        // overcome similar code dublicating
         std::regex e(R"([a-z]{1,9}\@[a-z]{1,9})");
         if (not std::regex_match(account_id, e)) {
           reason.second.push_back("Wrongly formed creator_account_id");

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -79,6 +79,7 @@ namespace shared_model {
             const detail::PolymorphicWrapper<interface::AppendRole> &ar) const {
           std::string class_name = "AppendRole";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, ar->accountId());
           validateRoleId(res, ar->roleName());
@@ -91,6 +92,7 @@ namespace shared_model {
             const {
           std::string class_name = "CreateAccount";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validatePubkey(res, ca->pubkey());
           validateAccountName(res, ca->accountName());
@@ -101,8 +103,9 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::CreateAsset> &ca)
             const {
-          std::string class_name = "CreateAccount";
+          std::string class_name = "CreateAsset";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAssetName(res, ca->assetName());
           validateDomainId(res, ca->domainId());
@@ -116,6 +119,7 @@ namespace shared_model {
             const {
           std::string class_name = "CreateDomain";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateDomainId(res, cd->domainId());
 
@@ -126,6 +130,7 @@ namespace shared_model {
             const detail::PolymorphicWrapper<interface::CreateRole> &cr) const {
           std::string class_name = "CreateRole";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateRoleId(res, cr->roleName());
 
@@ -137,6 +142,7 @@ namespace shared_model {
             const {
           std::string class_name = "GrantPermission";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, gp->accountId());
 
@@ -148,6 +154,7 @@ namespace shared_model {
             const {
           std::string class_name = "RemoveSignatory";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, rs->accountId());
           validatePubkey(res, rs->pubkey());
@@ -159,6 +166,7 @@ namespace shared_model {
             const {
           std::string class_name = "RevokePermission";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, rp->accountId());
           validatePermission(res, rp->permissionName());
@@ -169,6 +177,7 @@ namespace shared_model {
             const detail::PolymorphicWrapper<interface::SetQuorum> &sq) const {
           std::string class_name = "SetQuorum";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, sq->accountId());
           validateQuorum(res, sq->newQuorum());
@@ -179,8 +188,9 @@ namespace shared_model {
         ReasonsGroupType operator()(
             const detail::PolymorphicWrapper<interface::TransferAsset> &ta)
             const {
-          std::string class_name = "SetQuorum";
+          std::string class_name = "TransferAsset";
           ReasonsGroupType res;
+          res.first = class_name;
 
           validateAccountId(res, ta->srcAccountId());
           validateAccountId(res, ta->destAccountId());

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -36,7 +36,7 @@ TEST(ProtoTransaction, Create) {
 }
 
 // common data for tests
-auto created_time = 10000000000ull;
+auto created_time = iroha::time::now();
 shared_model::interface::Transaction::TxCounterType tx_counter = 1;
 std::string creator_account_id = "admin@test";
 

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -35,7 +35,7 @@ TEST(ProtoTransaction, Create) {
   ASSERT_EQ(proto.transactionCounter(), transaction.payload().tx_counter());
 }
 
-// global variables for tests
+// common data for tests
 auto created_time = 10000000000ull;
 shared_model::interface::Transaction::TxCounterType tx_counter = 1;
 std::string creator_account_id = "admin@test";
@@ -117,29 +117,14 @@ TEST(ProtoTransaction, Builder) {
  * @then transaction throws exception due to badly formed fields in commands
  */
 TEST(ProtoTransaction, BuilderWithInvalidTx) {
-  std::string account_id = "admintest";  // account_id without @
-  std::string asset_id = "cointest",     // asset_id without #
+  std::string invalid_account_id = "admintest";  // invalid account_id without @
+  std::string invalid_asset_id = "cointest",     // invalid asset_id without #
       amount = "10.00";
-
-  iroha::protocol::Transaction proto_tx = generateEmptyTransaction();
-  auto command =
-      proto_tx.mutable_payload()->add_commands()->mutable_add_asset_quantity();
-
-  command->CopyFrom(generateAddAssetQuantity(account_id, asset_id));
-
-  auto keypair =
-      shared_model::crypto::CryptoProviderEd25519Sha3::generateKeypair();
-  auto signedProto = shared_model::crypto::CryptoSigner<>::sign(
-      shared_model::crypto::Blob(proto_tx.SerializeAsString()), keypair);
-
-  auto sig = proto_tx.add_signature();
-  sig->set_pubkey(keypair.publicKey().blob());
-  sig->set_signature(signedProto.blob());
 
   ASSERT_THROW(shared_model::proto::TransactionBuilder()
                    .txCounter(tx_counter)
-                   .creatorAccountId(account_id)
-                   .assetQuantity(account_id, asset_id, amount)
+                   .creatorAccountId(invalid_account_id)
+                   .assetQuantity(invalid_account_id, invalid_asset_id, amount)
                    .createdTime(created_time)
                    .build(),
                std::invalid_argument);

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -15,29 +15,9 @@
 # limitations under the License.
 #
 
-add_subdirectory(backend_proto)
-add_subdirectory(validators)
-
-AddTest(lazy_test
-    lazy_test.cpp
-    )
-target_include_directories(lazy_test PUBLIC
-    ${Boost_INCLUDE_DIRS}
-    )
-
-AddTest(crypto_usage_test
-    crypto_usage_test.cpp
-    )
-target_link_libraries(crypto_usage_test
-    shared_model_ed25519_sha3
-    logger
-    )
-
-AddTest(blob_test cryptography/blob_test.cpp)
-
-AddTest(reference_holder_test
-    reference_holder_test.cpp
-    )
-target_include_directories(reference_holder_test PUBLIC
-    ${Boost_INCLUDE_DIRS}
-    )
+addtest(commands_validator_test
+        commands_validator_test.cpp
+        )
+target_link_libraries(commands_validator_test
+        shared_model_proto_backend
+        )

--- a/test/module/shared_model/validators/commands_validator_test.cpp
+++ b/test/module/shared_model/validators/commands_validator_test.cpp
@@ -1,0 +1,205 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "builders/protobuf/transaction.hpp"
+#include "utils/polymorphic_wrapper.hpp"
+
+iroha::protocol::Transaction generateEmptyTransaction() {
+  auto created_time = 10000000000ull;
+  shared_model::interface::Transaction::TxCounterType tx_counter = 1;
+  std::string creator_account_id = "admin@test";
+
+  iroha::protocol::Transaction proto_tx;
+  auto &payload = *proto_tx.mutable_payload();
+  payload.set_tx_counter(tx_counter);
+  payload.set_creator_account_id(creator_account_id);
+  payload.set_created_time(created_time);
+  return proto_tx;
+}
+
+iroha::protocol::AddAssetQuantity generateAddAssetQuantity(
+    std::string account_id, std::string asset_id) {
+  iroha::protocol::AddAssetQuantity command;
+
+  command.set_account_id(account_id);
+  command.set_asset_id(asset_id);
+  command.mutable_amount()->mutable_value()->set_fourth(1000);
+  command.mutable_amount()->set_precision(2);
+
+  return command;
+}
+
+iroha::protocol::AddPeer generateAddPeer(std::string address,
+                                         std::string peer_key) {
+  iroha::protocol::AddPeer command;
+
+  command.set_address(address);
+  command.set_peer_key(peer_key);
+
+  return command;
+}
+
+iroha::protocol::AddSignatory generateAddSignatory(std::string account_id,
+                                                   std::string public_key) {
+  iroha::protocol::AddSignatory command;
+
+  command.set_account_id(account_id);
+  command.set_public_key(public_key);
+
+  return command;
+}
+
+iroha::protocol::CreateAsset generateCreateAsset(std::string asset_name,
+                                                 std::string domain_id,
+                                                 uint32_t precision) {
+  iroha::protocol::CreateAsset command;
+
+  command.set_asset_name(asset_name);
+  command.set_domain_id(domain_id);
+  command.set_precision(precision);
+
+  return command;
+}
+
+iroha::protocol::CreateDomain generateCreateDomain(std::string domain_id,
+                                                   std::string default_role) {
+  iroha::protocol::CreateDomain command;
+
+  command.set_domain_id(domain_id);
+  command.set_default_role(default_role);
+
+  return command;
+}
+
+iroha::protocol::RemoveSignatory generateRemoveSignatory(
+    std::string account_id, std::string public_key) {
+  iroha::protocol::RemoveSignatory command;
+
+  command.set_account_id(account_id);
+  command.set_public_key(public_key);
+
+  return command;
+}
+
+iroha::protocol::SetAccountQuorum generateSetAccountQuorum(
+    std::string account_id, uint32_t quorum) {
+  iroha::protocol::SetAccountQuorum command;
+
+  command.set_account_id(account_id);
+  command.set_quorum(quorum);
+
+  return command;
+}
+
+iroha::protocol::TransferAsset generateTransferAsset(
+    std::string src_account_id,
+    std::string dest_account_id,
+    std::string asset_id,
+    std::string description,
+    std::string amount) {
+  iroha::protocol::TransferAsset command;
+
+  command.set_src_account_id(src_account_id);
+  command.set_dest_account_id(dest_account_id);
+  command.set_asset_id(asset_id);
+  command.set_description(description);
+
+  auto iroha_amount = iroha::Amount::createFromString(amount).value();
+  auto proto_amount = command.mutable_amount();
+  proto_amount->set_precision(iroha_amount.getPrecision());
+  auto proto_amount_value = proto_amount->mutable_value();
+  auto uint64s = iroha_amount.to_uint64s();
+  proto_amount_value->set_first(uint64s.at(0));
+  proto_amount_value->set_second(uint64s.at(1));
+  proto_amount_value->set_third(uint64s.at(2));
+  proto_amount_value->set_fourth(uint64s.at(3));
+
+  return command;
+}
+
+iroha::protocol::AppendRole generateAppendRole(std::string account_id,
+                                               std::string role_name) {
+  iroha::protocol::AppendRole command;
+
+  command.set_account_id(account_id);
+  command.set_role_name(role_name);
+
+  return command;
+}
+
+iroha::protocol::CreateRole generateCreateRole(
+    std::string role_name,
+    std::vector<iroha::protocol::RolePermission> permissions) {
+  iroha::protocol::CreateRole command;
+
+  command.set_role_name(role_name);
+  for (auto permission : permissions) {
+    command.add_permissions(permission);
+  }
+
+  return command;
+}
+
+iroha::protocol::GrantPermission generateGrantPermission(
+    std::string account_id, iroha::protocol::GrantablePermission permission) {
+  iroha::protocol::GrantPermission command;
+
+  command.set_account_id(account_id);
+  command.set_permission(permission);
+
+  return command;
+}
+
+iroha::protocol::RevokePermission generateRevokePermission(
+    std::string account_id, iroha::protocol::GrantablePermission permission) {
+  iroha::protocol::RevokePermission command;
+
+  command.set_account_id(account_id);
+  command.set_permission(permission);
+
+  return command;
+}
+
+using namespace iroha::protocol;
+using namespace shared_model;
+
+TEST(CommandsValidatorTest, StatelessInvalidTest) {
+  iroha::protocol::Transaction tx = generateEmptyTransaction();
+  auto payload = tx.mutable_payload();
+
+  std::string invalid_account_id = "invalid_account_id";
+  std::string invalid_asset_id = "invalid_asset_id";
+
+  payload->add_commands()->mutable_add_asset_quantity()->CopyFrom(AddAssetQuantity());
+  payload->add_commands()->mutable_add_peer()->CopyFrom(AddPeer());
+  payload->add_commands()->mutable_add_signatory()->CopyFrom(AddSignatory());
+  payload->add_commands()->mutable_append_role()->CopyFrom(AppendRole());
+  payload->add_commands()->mutable_create_account()->CopyFrom(CreateAccount());
+  payload->add_commands()->mutable_create_domain()->CopyFrom(CreateDomain());
+  payload->add_commands()->mutable_create_role()->CopyFrom(CreateRole());
+  payload->add_commands()->mutable_grant_permission()->CopyFrom(GrantPermission());
+  payload->add_commands()->mutable_remove_sign()->CopyFrom(RemoveSignatory());
+  payload->add_commands()->mutable_revoke_permission()->CopyFrom(RevokePermission());
+  payload->add_commands()->mutable_set_quorum()->CopyFrom(SetAccountQuorum());
+  payload->add_commands()->mutable_transfer_asset()->CopyFrom(TransferAsset());
+
+  shared_model::validation::CommandsValidator commands_validator;
+  auto answer = commands_validator.validate(detail::make_polymorphic<proto::Transaction>(tx));
+
+  ASSERT_EQ(answer.getReasonsMap().size(), 12);
+}

--- a/test/module/shared_model/validators/commands_validator_test.cpp
+++ b/test/module/shared_model/validators/commands_validator_test.cpp
@@ -19,6 +19,9 @@
 #include "builders/protobuf/transaction.hpp"
 #include "utils/polymorphic_wrapper.hpp"
 
+// TODO kamilsa 08.12.2017 IR-701 improve transaction builder api, so that we
+// can omit generate methods below
+
 iroha::protocol::Transaction generateEmptyTransaction() {
   auto created_time = 10000000000ull;
   shared_model::interface::Transaction::TxCounterType tx_counter = 1;


### PR DESCRIPTION
## What is this pull request?
Fixes stateless validation
   
## Why do you implement it? Why do we need this pull request?
This PR should fix stateless validation bug, which caused the following problem.

When we create CommandsValidator which validates tx, we invoke validate method, where we go through every command and call `boost::apply_visitor` using CommandsValidatorVisitor where for every possible command we have implemented operators to perform validation logic. Problem is that visitor wrongly deduces the command type which should be validated and invokes wrong operator. For example when we do `boost::apply_visitor` to AppendRole for some reason invokes RemoveSignatory operator, which is wrong.
The reason was found fixed: the order of commands in commands.proto should be the same as in variant template parameters
  
## How to use the features provided in the pull request?
Please check commands_validator_test

## Details/Features
Fixed order of commands in commands.proto
