### PR TITLE
Add trunks to sonar-release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,6 +364,7 @@ workflows:
               only:
                 - develop
                 - master
+                - trunk/.*
             tags:
               only: /v[\.0-9]+.*/
 


### PR DESCRIPTION
This PR adds `trunk/.*` branches to sonar-release build, which means that all trunks will be persisted as separate projects on sonar.