### PR TITLE
Rethrow build exceptions to target language exceptions.

### DIFF
--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -23,6 +23,15 @@
 
 %include "std_string.i"
 %include "stdint.i"
+%include "exception.i"
+
+%exception {
+  try {
+    $action
+  } catch (const std::invalid_argument &e) {
+    SWIG_exception(SWIG_ValueError, e.what());
+  }
+}
 
 %rename(ModelTransaction) iroha::protocol::Transaction;
 %rename(_interface) interface;
@@ -51,11 +60,3 @@
 %include "bindings/model_transaction_proto.hpp"
 
 %template (UnsignedTx) shared_model::proto::UnsignedWrapper<shared_model::proto::Transaction>;
-
-namespace shared_model {
-  namespace bindings {
-    class ModelBuilder;
-    class ModelCrypto;
-    class ModelTransactionProto;
-  }
-}


### PR DESCRIPTION
## What is this pull request?
Exceptions rethrow from Swig to native languages
   
## Why do you implement it? Why do we need this pull request?
C++ exceptions are hard to catch from other languages (if even possible).
  
## How to use the features provided in the pull request?
From Python:
```
import iroha

builder = iroha.ModelBuilder()
crypto = iroha.ModelCrypto()

me_kp = crypto.generateKeypair()
peer_kp = crypto.generateKeypair()
signatory_kp = crypto.generateKeypair()
account_kp = crypto.generateKeypair()
time = 1513049580000
startCounter = 1
creator = "me@iroha"
signatory = "fyodor@iroha"

commands = []

commands.append(builder.txCounter(startCounter).creatorAccountId(creator).createdTime(time).addPeer("127.0.0.256", peer_kp.publicKey()).build())

protoHelper = iroha.ModelTransactionProto()

for command in commands:
    print(protoHelper.signAndAddSignature(command, me_kp).toString())
```
This snippet will result in next exception thrown:
```
 File "my.py", line 17, in <module>
    commands.append(builder.txCounter(startCounter).creatorAccountId(creator).createdTime(time).addPeer("127.0.0.256", peer_kp.publicKey()).build())
  File "/Users/konstantinmunichev/src/iroha/build/shared_model/bindings/iroha.py", line 335, in build
    return _iroha.ModelBuilder_build(self)
ValueError: AddPeer: [[Wrongly formed PeerAddress ]]
```
Same for Java:
```
import java.math.BigInteger;
import java.util.*;

public class my {
  static {
    try {
        System.loadLibrary("iroha");
    } catch (UnsatisfiedLinkError e) {
      System.err.println("Native code library failed to load. \n" + e);
      System.exit(1);
    }
  }

  public static void main(String argv[]) {
    ModelBuilder builder = new ModelBuilder();
    ModelCrypto crypto = new ModelCrypto();
    Keypair me_kp = crypto.generateKeypair();
    Keypair peer_kp = crypto.generateKeypair();
    Keypair signatory_kp = crypto.generateKeypair();
    Keypair account_kp = crypto.generateKeypair();
    long time = 1513049580000L;
    long startCounter = 1;
    String creator = "me@iroha";
    String signatory = "fyodor@iroha";

    ArrayList<UnsignedTx> commands = new ArrayList<UnsignedTx>();
  
    commands.add(builder.txCounter(BigInteger.valueOf(startCounter))
      .creatorAccountId(creator).createdTime(BigInteger.valueOf(time))
      .addPeer("127.0.0.256", peer_kp.publicKey()).build());
    
    ModelTransactionProto protoHelper = new ModelTransactionProto();
    for (UnsignedTx tx: commands) {
      System.out.println(protoHelper.signAndAddSignature(tx, me_kp).toString());
    }
  }
}
```
Result:
```
Exception in thread "main" java.lang.IllegalArgumentException: AddPeer: [[Wrongly formed PeerAddress ]]

	at irohaJNI.ModelBuilder_build(Native Method)
	at ModelBuilder.build(ModelBuilder.java:86)
	at my.main(my.java:27)
```