### PR TITLE
Add const specifier and remove duplication

### DIFF
--- a/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.cpp
@@ -27,48 +27,37 @@ extern "C" {
 #include "model/converters/pb_query_factory.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
 
-namespace sha3 {
-  void sha3_256_(const unsigned char *message, size_t message_len,
-                 unsigned char *out) {
-    sha3_256(message, message_len, out);
-  }
-  void sha3_512_(const unsigned char *message, size_t message_len,
-                 unsigned char *out) {
-    sha3_512(message, message_len, out);
-  }
-}
-
 namespace iroha {
 
-  void sha3_256(unsigned char *output, unsigned char *input, size_t in_size) {
-    sha3::sha3_256_(input, in_size, output);
+  void sha3_256(uint8_t *output, const uint8_t *input, size_t in_size) {
+    ::sha3_256(input, in_size, output);
   }
 
-  void sha3_512(unsigned char *output, unsigned char *input, size_t in_size) {
-    sha3::sha3_512_(input, in_size, output);
+  void sha3_512(uint8_t *output, const uint8_t *input, size_t in_size) {
+    ::sha3_512(input, in_size, output);
   }
 
   hash256_t sha3_256(const uint8_t *input, size_t in_size) {
     hash256_t h;
-    sha3::sha3_256_(input, in_size, h.data());
+    ::sha3_256(input, in_size, h.data());
     return h;
   }
 
   hash512_t sha3_512(const uint8_t *input, size_t in_size) {
     hash512_t h;
-    sha3::sha3_512_(input, in_size, h.data());
+    ::sha3_512(input, in_size, h.data());
     return h;
   }
 
   hash256_t sha3_256(const std::string &msg) {
     hash256_t h;
-    sha3::sha3_256_((uint8_t *)msg.data(), msg.size(), h.data());
+    ::sha3_256((uint8_t *)msg.data(), msg.size(), h.data());
     return h;
   }
 
   hash512_t sha3_512(const std::string &msg) {
     hash512_t h;
-    sha3::sha3_512_((uint8_t *)msg.data(), msg.size(), h.data());
+    ::sha3_512((uint8_t *)msg.data(), msg.size(), h.data());
     return h;
   }
 

--- a/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
@@ -25,8 +25,8 @@
 
 namespace iroha {
 
-  void sha3_256(unsigned char *output, unsigned char *input, size_t in_size);
-  void sha3_512(unsigned char *output, unsigned char *input, size_t in_size);
+  void sha3_256(uint8_t *output, const uint8_t *input, size_t in_size);
+  void sha3_512(uint8_t *output, const uint8_t *input, size_t in_size);
 
   hash256_t sha3_256(const uint8_t *input, size_t in_size);
   hash256_t sha3_256(const std::string &msg);


### PR DESCRIPTION
## What is this pull request?
Small refactoring of sha3_hash, which removes some code duplication, and adds const where needed

## Details/Features
List of features / major commits
- Add const specifier to input parameter in hash functions
- Remove sha3 namespace in favor of namespace resolution operator "::"
