### PR TITLE
Feature/shared model bindings extend interface

### DIFF
--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -17,6 +17,7 @@
 
 #include "interactive/interactive_status_cli.hpp"
 #include "client.hpp"
+#include "common/byteutils.hpp"
 
 namespace iroha_cli {
   namespace interactive {
@@ -152,5 +153,5 @@ namespace iroha_cli {
     std::string InteractiveStatusCli::parseGetHash(ActionParams params) {
       return params[0];
     }
-  }
-}
+  }  // namespace interactive
+}  // namespace iroha_cli

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -18,12 +18,9 @@
 #ifndef IROHA_BYTEUTILS_H
 #define IROHA_BYTEUTILS_H
 
-#include <string>
-
+#include <algorithm>
 #include <nonstd/optional.hpp>
-
-#include "crypto/base64.hpp"
-
+#include <string>
 #include "common/types.hpp"
 
 namespace iroha {
@@ -97,11 +94,11 @@ namespace iroha {
   }
 
   /**
-  * Convert hexstring to array of given size
-  * @tparam size - output array size
-  * @param string - input string for transform
-  * @return array of given size if size matches, nullopt otherwise
-  */
+   * Convert hexstring to array of given size
+   * @tparam size - output array size
+   * @param string - input string for transform
+   * @return array of given size if size matches, nullopt otherwise
+   */
   template <size_t size>
   nonstd::optional<blob_t<size>> hexstringToArray(const std::string &string) {
     return hexstringToBytestring(string) | stringToBlob<size>;

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -34,7 +34,7 @@ namespace iroha {
    * @param s - string to convert
    * @return blob, if conversion was successful, otherwise nullopt
    */
-  template<size_t size>
+  template <size_t size>
   nonstd::optional<blob_t<size>> stringToBlob(const std::string &string) {
     if (size != string.size()) {
       return nonstd::nullopt;
@@ -45,15 +45,68 @@ namespace iroha {
   }
 
   /**
-   * Convert hexstring to array of given size
-   * @tparam size - output array size
-   * @param string - input string for transform
-   * @return array of given size if size matches, nullopt otherwise
+   * Convert string of raw bytes to printable hex string
+   * @param str
+   * @return
    */
+  inline std::string bytestringToHexstring(const std::string &str) {
+    std::stringstream ss;
+    ss << std::hex << std::setfill('0');
+    for (const auto &c : str) {
+      ss << std::setw(2) << (static_cast<int>(c) & 0xff);
+    }
+    return ss.str();
+  }
+
+  /**
+   * Convert printable hex string to string of raw bytes
+   * @param str
+   * @return
+   */
+  inline nonstd::optional<std::string> hexstringToBytestring(
+      const std::string &str) {
+    if (str.empty() or str.size() % 2 != 0) {
+      return nonstd::nullopt;
+    }
+    std::string result(str.size() / 2, 0);
+    for (size_t i = 0; i < result.length(); ++i) {
+      std::string byte = str.substr(i * 2, 2);
+      try {
+        result.at(i) = std::stoul(byte, nullptr, 16);
+      } catch (const std::invalid_argument &e) {
+        return nonstd::nullopt;
+      } catch (const std::out_of_range &e) {
+        return nonstd::nullopt;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Generates new random string from lower-case letters
+   * @param len - size of string to generate
+   * @return generated string
+   */
+  inline std::string randomString(int len) {
+    std::string str(len, 0);
+    std::generate_n(str.begin(), len, []() {
+      char c = 'a';
+      return c + std::rand() % ('z' - 'a' + 1);
+    });
+    return str;
+  }
+
+  /**
+  * Convert hexstring to array of given size
+  * @tparam size - output array size
+  * @param string - input string for transform
+  * @return array of given size if size matches, nullopt otherwise
+  */
   template <size_t size>
   nonstd::optional<blob_t<size>> hexstringToArray(const std::string &string) {
     return hexstringToBytestring(string) | stringToBlob<size>;
   }
-}
+
+}  // namespace iroha
 
 #endif  // IROHA_BYTEUTILS_H

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -43,8 +43,8 @@ namespace iroha {
 
   /**
    * Convert string of raw bytes to printable hex string
-   * @param str
-   * @return
+   * @param str - raw bytes string to convert
+   * @return - converted hex string
    */
   inline std::string bytestringToHexstring(const std::string &str) {
     std::stringstream ss;
@@ -57,8 +57,9 @@ namespace iroha {
 
   /**
    * Convert printable hex string to string of raw bytes
-   * @param str
-   * @return
+   * @param str - hex string to convert
+   * @return - raw bytes converted string or nonstd::nullopt if provided string
+   * was not a correct hex string
    */
   inline nonstd::optional<std::string> hexstringToBytestring(
       const std::string &str) {

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -80,19 +80,6 @@ namespace iroha {
   }
 
   /**
-   * Generates new random string from lower-case letters
-   * @param len - size of string to generate
-   * @return generated string
-   */
-  inline std::string randomString(int len) {
-    std::string str(len, 0);
-    std::generate_n(str.begin(), len, []() {
-      return 'a' + std::rand() % ('z' - 'a' + 1);
-    });
-    return str;
-  }
-
-  /**
    * Convert hexstring to array of given size
    * @tparam size - output array size
    * @param string - input string for transform

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -87,8 +87,7 @@ namespace iroha {
   inline std::string randomString(int len) {
     std::string str(len, 0);
     std::generate_n(str.begin(), len, []() {
-      char c = 'a';
-      return c + std::rand() % ('z' - 'a' + 1);
+      return 'a' + std::rand() % ('z' - 'a' + 1);
     });
     return str;
   }

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <nonstd/optional.hpp>
+#include "crypto/base64.hpp"
 
 /**
  * This file defines common types used in iroha.

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -127,44 +127,6 @@ namespace iroha {
   }
 
   /**
-   * Convert string of raw bytes to printable hex string
-   * @param str
-   * @return
-   */
-  inline std::string bytestringToHexstring(const std::string &str) {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (const auto &c : str) {
-      ss << std::setw(2) << (static_cast<int>(c) & 0xff);
-    }
-    return ss.str();
-  }
-
-  /**
-   * Convert printable hex string to string of raw bytes
-   * @param str
-   * @return
-   */
-  inline nonstd::optional<std::string> hexstringToBytestring(
-      const std::string &str) {
-    if (str.empty() or str.size() % 2 != 0) {
-      return nonstd::nullopt;
-    }
-    std::string result(str.size() / 2, 0);
-    for (size_t i = 0; i < result.length(); ++i) {
-      std::string byte = str.substr(i * 2, 2);
-      try {
-        result.at(i) = std::stoul(byte, nullptr, 16);
-      } catch (const std::invalid_argument &e) {
-        return nonstd::nullopt;
-      } catch (const std::out_of_range &e) {
-        return nonstd::nullopt;
-      }
-    }
-    return result;
-  }
-
-  /**
    * Bind operator. If argument has value, dereferences argument and calls
    * given function, which should return wrapped value
    * operator| is used since it has to be binary and left-associative

--- a/libs/generator/generator.cpp
+++ b/libs/generator/generator.cpp
@@ -30,4 +30,11 @@ namespace generator {
     return (uint8_t)random_number(32, 126 + 1);
   }
 
+  std::string randomString(int len) {
+    std::string str(len, 0);
+    std::generate_n(
+        str.begin(), len, []() { return 'a' + std::rand() % ('z' - 'a' + 1); });
+    return str;
+  }
+
 }  // namespace generator

--- a/libs/generator/generator.cpp
+++ b/libs/generator/generator.cpp
@@ -30,7 +30,7 @@ namespace generator {
     return (uint8_t)random_number(32, 126 + 1);
   }
 
-  std::string randomString(int len) {
+  std::string randomString(size_t len) {
     std::string str(len, 0);
     std::generate_n(
         str.begin(), len, []() { return 'a' + std::rand() % ('z' - 'a' + 1); });

--- a/libs/generator/generator.hpp
+++ b/libs/generator/generator.hpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef __IROHA_GENERATOR_GENERATOR_HPP__
-#define __IROHA_GENERATOR_GENERATOR_HPP__
+#ifndef IROHA_GENERATOR_HPP
+#define IROHA_GENERATOR_HPP
 
 #include <algorithm>
 #include "common/types.hpp"
@@ -38,6 +38,13 @@ namespace generator {
     return v;
   }
 
+  /**
+   * Generates new random string from lower-case letters
+   * @param len - size of string to generate
+   * @return generated string
+   */
+  std::string randomString(int len);
+
 }  // namespace generator
 
-#endif  // __IROHA_GENERATOR_GENERATOR_HPP__
+#endif  // IROHA_GENERATOR_HPP

--- a/libs/generator/generator.hpp
+++ b/libs/generator/generator.hpp
@@ -43,7 +43,7 @@ namespace generator {
    * @param len - size of string to generate
    * @return generated string
    */
-  std::string randomString(int len);
+  std::string randomString(size_t len);
 
 }  // namespace generator
 

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(bindings
 target_link_libraries(bindings
         shared_model_proto_backend
         shared_model_ed25519_sha3
+        generator
         )
 
 

--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -21,8 +21,12 @@
 namespace shared_model {
   namespace bindings {
     crypto::Keypair ModelCrypto::generateKeypair() {
-      // TODO: 06.12.2017 luckychess create keypair generation interface IR-684
       return crypto::CryptoProviderEd25519Sha3::generateKeypair();
+    }
+
+    crypto::Keypair ModelCrypto::generateKeypair(const std::string &seed) {
+      return crypto::CryptoProviderEd25519Sha3::generateKeypair(
+              crypto::Seed(seed));
     }
   }  // namespace bindings
 }  // namespace shared_model

--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -26,7 +26,26 @@ namespace shared_model {
 
     crypto::Keypair ModelCrypto::generateKeypair(const std::string &seed) {
       return crypto::CryptoProviderEd25519Sha3::generateKeypair(
-              crypto::Seed(seed));
+          crypto::Seed(seed));
+    }
+
+    crypto::Keypair ModelCrypto::convertFromExisting(
+        const std::string &publicKey, const std::string &privateKey) {
+      crypto::Keypair keypair((crypto::Keypair::PublicKeyType(
+                                  crypto::Blob::fromHexString(publicKey))),
+                              crypto::Keypair::PrivateKeyType(
+                                  crypto::Blob::fromHexString(privateKey)));
+
+      auto randStr = iroha::randomString(32);
+      if (not crypto::CryptoProviderEd25519Sha3::verify(
+              crypto::CryptoProviderEd25519Sha3::sign(crypto::Blob(randStr),
+                                                      keypair),
+              crypto::Blob(randStr),
+              keypair.publicKey())) {
+        throw std::invalid_argument("Provided keypair is not correct");
+      }
+
+      return keypair;
     }
   }  // namespace bindings
 }  // namespace shared_model

--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -17,6 +17,7 @@
 
 #include "bindings/model_crypto.hpp"
 #include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
+#include "generator/generator.hpp"
 
 namespace shared_model {
   namespace bindings {
@@ -36,7 +37,7 @@ namespace shared_model {
                               crypto::Keypair::PrivateKeyType(
                                   crypto::Blob::fromHexString(private_key)));
 
-      auto rand_str = iroha::randomString(32);
+      auto rand_str = generator::randomString(32);
       if (not crypto::CryptoProviderEd25519Sha3::verify(
               crypto::CryptoProviderEd25519Sha3::sign(crypto::Blob(rand_str),
                                                       keypair),

--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -30,17 +30,17 @@ namespace shared_model {
     }
 
     crypto::Keypair ModelCrypto::convertFromExisting(
-        const std::string &publicKey, const std::string &privateKey) {
+        const std::string &public_key, const std::string &private_key) {
       crypto::Keypair keypair((crypto::Keypair::PublicKeyType(
-                                  crypto::Blob::fromHexString(publicKey))),
+                                  crypto::Blob::fromHexString(public_key))),
                               crypto::Keypair::PrivateKeyType(
-                                  crypto::Blob::fromHexString(privateKey)));
+                                  crypto::Blob::fromHexString(private_key)));
 
-      auto randStr = iroha::randomString(32);
+      auto rand_str = iroha::randomString(32);
       if (not crypto::CryptoProviderEd25519Sha3::verify(
-              crypto::CryptoProviderEd25519Sha3::sign(crypto::Blob(randStr),
+              crypto::CryptoProviderEd25519Sha3::sign(crypto::Blob(rand_str),
                                                       keypair),
-              crypto::Blob(randStr),
+              crypto::Blob(rand_str),
               keypair.publicKey())) {
         throw std::invalid_argument("Provided keypair is not correct");
       }

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -34,6 +34,12 @@ namespace shared_model {
        * @return generated keypair
        */
       crypto::Keypair generateKeypair();
+
+      /**
+       * Generates new keypair (ed25519) based on user-provided seed
+       * @return generated keypair
+       */
+      crypto::Keypair generateKeypair(const std::string &seed);
     };
   }  // namespace bindings
 }  // namespace shared_model

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -47,8 +47,8 @@ namespace shared_model {
        * @param privateKey - ed25519 hex-encoded private key
        * @return keypair from provided keys
        */
-      crypto::Keypair convertFromExisting(const std::string &publicKey,
-                                          const std::string &privateKey);
+      crypto::Keypair convertFromExisting(const std::string &public_key,
+                                          const std::string &private_key);
     };
   }  // namespace bindings
 }  // namespace shared_model

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -40,6 +40,15 @@ namespace shared_model {
        * @return generated keypair
        */
       crypto::Keypair generateKeypair(const std::string &seed);
+
+      /**
+       * Retrieves Keypair object (ed25519) from existing keypair.
+       * @param publicKey - ed25519 hex-encoded public key
+       * @param privateKey - ed25519 hex-encoded private key
+       * @return keypair from provided keys
+       */
+      crypto::Keypair convertFromExisting(const std::string &publicKey,
+                                          const std::string &privateKey);
     };
   }  // namespace bindings
 }  // namespace shared_model

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -21,7 +21,9 @@
 #include <iomanip>
 #include <sstream>
 #include <vector>
+#include "common/byteutils.hpp"
 #include "interfaces/base/model_primitive.hpp"
+#include "utils/swig_keyword_hider.hpp"
 #include "utils/lazy_initializer.hpp"
 #include "utils/string_builder.hpp"
 #include "utils/swig_keyword_hider.hpp"
@@ -52,12 +54,7 @@ namespace shared_model {
        */
       explicit Blob(const Bytes &blob) : Blob(Bytes(blob)) {}
       explicit Blob(Bytes &&blob) : blob_(std::move(blob)) {
-        std::stringstream ss;
-        ss << std::hex << std::setfill('0');
-        for (const auto &c : blob_) {
-          ss << std::setw(2) << (static_cast<int>(c) & 0xff);
-        }
-        hex_ = ss.str();
+        hex_ = iroha::bytestringToHexstring(blob_);
       }
 
       /**

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -58,6 +58,18 @@ namespace shared_model {
       }
 
       /**
+       * Creates new Blob object from provided hex string
+       * @param hex - string in hex format to create Blob from
+       * @return created Blob object
+       */
+      static Blob fromHexString(const std::string &hex) {
+        using iroha::operator|;
+        Blob b("");
+        iroha::hexstringToBytestring(hex) | [&](auto &&s){b = Blob(s);};
+        return b;
+      }
+
+      /**
        * @return provides raw representation of blob
        */
       virtual const Bytes &blob() const { return blob_; }

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -54,7 +54,7 @@ namespace shared_model {
        */
       explicit Blob(const Bytes &blob) : Blob(Bytes(blob)) {}
       explicit Blob(Bytes &&blob) : blob_(std::move(blob)) {
-        hex_ = iroha::bytestringToHexstring(blob_);
+        hex_ = iroha::bytestringToHexstring(toBinaryString(*this));
       }
 
       /**

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -60,7 +60,8 @@ namespace shared_model {
       /**
        * Creates new Blob object from provided hex string
        * @param hex - string in hex format to create Blob from
-       * @return created Blob object
+       * @return Blob from provided hex string if it was correct or
+       * Blob from empty string if provided string was not a correct hex string
        */
       static Blob fromHexString(const std::string &hex) {
         using iroha::operator|;

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -38,8 +38,8 @@ namespace shared_model {
       /// Type of private key
       using PrivateKeyType = PrivateKey;
 
-      explicit Keypair(PublicKeyType publickKey, PrivateKeyType privateKey)
-          : publicKey_(publickKey), privateKey_(privateKey) {}
+      explicit Keypair(PublicKeyType publicKey, PrivateKeyType privateKey)
+          : publicKey_(publicKey), privateKey_(privateKey) {}
 
       /**
        * @return public key

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -38,18 +38,18 @@ namespace shared_model {
       /// Type of private key
       using PrivateKeyType = PrivateKey;
 
-      explicit Keypair(PublicKeyType publicKey, PrivateKeyType privateKey)
-          : publicKey_(publicKey), privateKey_(privateKey) {}
+      explicit Keypair(PublicKeyType public_key, PrivateKeyType private_key)
+          : public_key_(public_key), private_key_(private_key) {}
 
       /**
        * @return public key
        */
-      const PublicKeyType &publicKey() const { return publicKey_; };
+      const PublicKeyType &publicKey() const { return public_key_; };
 
       /**
        * @return private key
        */
-      const PrivateKeyType &privateKey() const { return privateKey_; };
+      const PrivateKeyType &privateKey() const { return private_key_; };
 
       bool operator==(const Keypair &keypair) const override {
         return publicKey() == keypair.publicKey()
@@ -76,8 +76,8 @@ namespace shared_model {
       };
 
      private:
-      PublicKey publicKey_;
-      PrivateKey privateKey_;
+      PublicKey public_key_;
+      PrivateKey private_key_;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -38,18 +38,23 @@ namespace shared_model {
       /// Type of private key
       using PrivateKeyType = PrivateKey;
 
-      explicit Keypair(PublicKeyType public_key, PrivateKeyType private_key)
+      explicit Keypair(const PublicKeyType &public_key,
+                       const PrivateKeyType &private_key)
           : public_key_(public_key), private_key_(private_key) {}
 
       /**
        * @return public key
        */
-      const PublicKeyType &publicKey() const { return public_key_; };
+      const PublicKeyType &publicKey() const {
+        return public_key_;
+      };
 
       /**
        * @return private key
        */
-      const PrivateKeyType &privateKey() const { return private_key_; };
+      const PrivateKeyType &privateKey() const {
+        return private_key_;
+      };
 
       bool operator==(const Keypair &keypair) const override {
         return publicKey() == keypair.publicKey()

--- a/shared_model/cryptography/private_key.hpp
+++ b/shared_model/cryptography/private_key.hpp
@@ -31,6 +31,9 @@ namespace shared_model {
     class PrivateKey : public Blob {
      public:
       explicit PrivateKey(const std::string &privateKey) : Blob(privateKey) {}
+
+      explicit PrivateKey(const Blob &blob) : Blob(blob.blob()) {}
+
       using OldPrivateKeyType = iroha::privkey_t;
       std::string toString() const override {
         return detail::PrettyStringBuilder()

--- a/shared_model/cryptography/private_key.hpp
+++ b/shared_model/cryptography/private_key.hpp
@@ -30,7 +30,7 @@ namespace shared_model {
      */
     class PrivateKey : public Blob {
      public:
-      explicit PrivateKey(const std::string &privateKey) : Blob(privateKey) {}
+      explicit PrivateKey(const std::string &private_key) : Blob(private_key) {}
 
       explicit PrivateKey(const Blob &blob) : Blob(blob.blob()) {}
 

--- a/shared_model/cryptography/public_key.hpp
+++ b/shared_model/cryptography/public_key.hpp
@@ -30,7 +30,7 @@ namespace shared_model {
      */
     class PublicKey : public Blob {
      public:
-      explicit PublicKey(const std::string &publicKey) : Blob(publicKey) {}
+      explicit PublicKey(const std::string &public_key) : Blob(public_key) {}
 
       explicit PublicKey(const Blob &blob) : Blob(blob.blob()) {}
 

--- a/shared_model/cryptography/public_key.hpp
+++ b/shared_model/cryptography/public_key.hpp
@@ -31,6 +31,9 @@ namespace shared_model {
     class PublicKey : public Blob {
      public:
       explicit PublicKey(const std::string &publicKey) : Blob(publicKey) {}
+
+      explicit PublicKey(const Blob &blob) : Blob(blob.blob()) {}
+
       using OldPublicKeyType = iroha::pubkey_t;
       std::string toString() const override {
         return detail::PrettyStringBuilder()

--- a/test/module/libs/converter/string_converter_test.cpp
+++ b/test/module/libs/converter/string_converter_test.cpp
@@ -16,7 +16,7 @@
  */
 
 #include <gtest/gtest.h>
-#include "common/types.hpp"
+#include "common/byteutils.hpp"
 
 using namespace iroha;
 using namespace std::string_literals;

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -38,6 +38,7 @@ AddTest(blob_test
     )
 target_link_libraries(blob_test
     boost
+    optional
     )
 
 AddTest(reference_holder_test


### PR DESCRIPTION
## What is this pull request?
Extending Swig interface with generating keypair based on provided seed string and using existing keypair.
   
## Why do you implement it? Why do we need this pull request?
These features are needed for Iroha lib clients.
  
## How to use the features provided in the pull request?
```
import iroha
crypto = iroha.ModelCrypto()
 # seed string length should be equal 32
kp_gen_test = crypto.generateKeypair("somerandomstring0123456789abcdef"); 
kp_test = crypto.convertFromExisting("227a458045f8d7d520907fb400461ae3c9101a68af2851d56a85b96fd791911a", "1011098aebf697597a59151a0ba1bb34bcf081f5195fa8de551b9a2b52be864613aae9771f35df7318e0d7b8571f043cd54581a0b1c5cf36fb05ac8956d291fe");
```
Same from Java. If provided keypair will not pass validation, exception will be thrown.

## Details/Features
- Extend Swig API with seed keypair generation
- Create convertFromExisting() method in ModelCrypto class
- Add static method to create Blobs from hex strings
- Add Blob argument constructors to key classes
- Add generate random string function
- Move some functions from types.hpp to byteutils.hpp