### PR TITLE
Fix transaction validation for empty commands

### DIFF
--- a/test/module/shared_model/validators/commands_validator_test.cpp
+++ b/test/module/shared_model/validators/commands_validator_test.cpp
@@ -194,6 +194,20 @@ using namespace iroha::protocol;
 using namespace shared_model;
 
 /**
+ * @given transaction without any commands
+ * @when commands validator is invoked
+ * @then answer has error about empty transaction
+ */
+TEST(commandsValidatorTest, EmptyTransactionTest) {
+  auto tx = generateEmptyTransaction();
+  tx.mutable_payload()->set_created_time(iroha::time::now());
+  shared_model::validation::CommandsValidator commands_validator;
+  auto answer = commands_validator.validate(
+          detail::make_polymorphic<proto::Transaction>(tx));
+  ASSERT_TRUE(answer.hasErrors());
+}
+
+/**
  * @given transaction made of commands with valid fields
  * @when commands validation is invoked
  * @then answer has no errors

--- a/test/module/shared_model/validators/commands_validator_test.cpp
+++ b/test/module/shared_model/validators/commands_validator_test.cpp
@@ -204,7 +204,7 @@ TEST(commandsValidatorTest, EmptyTransactionTest) {
   shared_model::validation::CommandsValidator commands_validator;
   auto answer = commands_validator.validate(
           detail::make_polymorphic<proto::Transaction>(tx));
-  ASSERT_TRUE(answer.hasErrors());
+  ASSERT_EQ(answer.getReasonsMap().size(), 1);
 }
 
 /**


### PR DESCRIPTION
## What is this pull request?
Fix for empty transaction validation
   
## Why do you implement it? Why do we need this pull request?
Transaction without commands are not allowed
  
## How to use the features provided in the pull request?
Test included

## Details/Features
- Add validation step for zero commands in transaction case
- Add test for empty transaction validation
