### PR TITLE
Make transaction builder const

### DIFF
--- a/shared_model/bindings/model_builder.cpp
+++ b/shared_model/bindings/model_builder.cpp
@@ -37,7 +37,7 @@ namespace shared_model {
         const interface::types::AccountIdType &account_id,
         const interface::types::AssetIdType &asset_id,
         const std::string &amount) {
-      return ModelBuilder(builder_.assetQuantity(account_id, asset_id, amount));
+      return ModelBuilder(builder_.addAssetQuantity(account_id, asset_id, amount));
     }
 
     ModelBuilder ModelBuilder::addPeer(

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -99,14 +99,14 @@ namespace shared_model {
 
       NextBuilder<TxCounter> txCounter(
           Transaction::TxCounterType tx_counter) const {
-        return transform<CreatorAccountId>([&](auto &tx) {
+        return transform<TxCounter>([&](auto &tx) {
           tx.mutable_payload()->set_tx_counter(tx_counter);
         });
       }
 
       NextBuilder<CreatedTime> createdTime(
           interface::types::TimestampType created_time) const {
-        return transform<CreatorAccountId>([&](auto &tx) {
+        return transform<CreatedTime>([&](auto &tx) {
           tx.mutable_payload()->set_created_time(created_time);
         });
       }

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -115,11 +115,11 @@ namespace shared_model {
           const interface::types::AccountIdType &account_id,
           const interface::types::AssetIdType &asset_id,
           const std::string &amount) const {
-        return addCommand([&](auto command) {
-          auto cmd = command->mutable_add_asset_quantity();
-          cmd->set_account_id(account_id);
-          cmd->set_asset_id(asset_id);
-          addAmount(cmd->mutable_amount(), amount);
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_add_asset_quantity();
+          command->set_account_id(account_id);
+          command->set_asset_id(asset_id);
+          addAmount(command->mutable_amount(), amount);
         });
       }
 

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -63,25 +63,27 @@ namespace shared_model {
 
       /**
        * Make transformation on copied content
+       * @tparam Transformation - callable type for changing the copy
        * @param f - transform function for proto object
        * @return new builder with updated state
        */
-      template <int Fields>
-      NextBuilder<Fields> transform(std::function<void(ProtoTx &)> f) const {
+      template <int Fields, typename Transformation>
+      NextBuilder<Fields> transform(Transformation t) const {
         auto copy = transaction_;
-        f(copy);
+        t(copy);
         return {copy, stateless_validator_};
       }
 
       /**
        * Make add command transformation on copied object
+       * @tparam Transformation - callable type for changing command
        * @param f - transform function for proto command
        * @return new builder with added command
        */
-      NextBuilder<Command> addCommand(
-          std::function<void(ProtoCommand *)> f) const {
+      template <typename Transformation>
+      NextBuilder<Command> addCommand(Transformation t) const {
         auto copy = transaction_;
-        f(copy.mutable_payload()->add_commands());
+        t(copy.mutable_payload()->add_commands());
         return {copy, stateless_validator_};
       }
 

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -31,6 +31,7 @@
 
 namespace shared_model {
   namespace proto {
+
     template <int S = 0, typename SV = validation::DefaultValidator>
     class TemplateTransactionBuilder {
      private:
@@ -46,113 +47,152 @@ namespace shared_model {
       };
 
       template <int s>
-      using NextBuilder = TemplateTransactionBuilder<S | (1 << s)>;
+      using NextBuilder = TemplateTransactionBuilder<S | (1 << s), SV>;
 
-      iroha::protocol::Transaction transaction_;
+      using ProtoTx = iroha::protocol::Transaction;
+      using ProtoCommand = iroha::protocol::Command;
 
       template <int Sp>
-      TemplateTransactionBuilder(const TemplateTransactionBuilder<Sp> &o,
-                                 SV&& stateless_validator = SV())
+      TemplateTransactionBuilder(const TemplateTransactionBuilder<Sp> &o)
           : transaction_(o.transaction_),
-            stateless_validator_(std::forward<SV>(stateless_validator)) {}
+            stateless_validator_(o.stateless_validator_) {}
 
-      SV stateless_validator_;
+      TemplateTransactionBuilder(const ProtoTx &tx,
+                                 const SV &stateless_validator)
+          : transaction_(tx), stateless_validator_(stateless_validator) {}
+
+      /**
+       * Make transformation on copied content
+       * @param f - transform function for proto object
+       * @return new builder with updated state
+       */
+      template <int Fields>
+      NextBuilder<Fields> transform(std::function<void(ProtoTx &)> f) const {
+        auto copy = transaction_;
+        f(copy);
+        return {copy, stateless_validator_};
+      }
+
+      /**
+       * Make add command transformation on copied object
+       * @param f - transform function for proto command
+       * @return new builder with added command
+       */
+      NextBuilder<Command> addCommand(
+          std::function<void(ProtoCommand *)> f) const {
+        auto copy = transaction_;
+        f(copy.mutable_payload()->add_commands());
+        return {copy, stateless_validator_};
+      }
 
      public:
       TemplateTransactionBuilder() = default;
 
       NextBuilder<CreatorAccountId> creatorAccountId(
-          const interface::types::AccountIdType &account_id) {
-        transaction_.mutable_payload()->set_creator_account_id(account_id);
-        return *this;
+          const interface::types::AccountIdType &account_id) const {
+        return transform<CreatorAccountId>([&](auto &tx) {
+          tx.mutable_payload()->set_creator_account_id(account_id);
+        });
       }
 
-      NextBuilder<TxCounter> txCounter(Transaction::TxCounterType tx_counter) {
-        transaction_.mutable_payload()->set_tx_counter(tx_counter);
-        return *this;
+      NextBuilder<TxCounter> txCounter(
+          Transaction::TxCounterType tx_counter) const {
+        return transform<CreatorAccountId>([&](auto &tx) {
+          tx.mutable_payload()->set_tx_counter(tx_counter);
+        });
       }
 
       NextBuilder<CreatedTime> createdTime(
-          interface::types::TimestampType created_time) {
-        transaction_.mutable_payload()->set_created_time(created_time);
-        return *this;
+          interface::types::TimestampType created_time) const {
+        return transform<CreatorAccountId>([&](auto &tx) {
+          tx.mutable_payload()->set_created_time(created_time);
+        });
       }
 
       NextBuilder<Command> assetQuantity(
           const interface::types::AccountIdType &account_id,
           const interface::types::AssetIdType &asset_id,
-          const std::string &amount) {
-        auto command = proto_command()->mutable_add_asset_quantity();
-        command->set_account_id(account_id);
-        command->set_asset_id(asset_id);
-        addAmount(command->mutable_amount(), amount);
-        return *this;
+          const std::string &amount) const {
+        return addCommand([&](auto command) {
+          auto cmd = command->mutable_add_asset_quantity();
+          cmd->set_account_id(account_id);
+          cmd->set_asset_id(asset_id);
+          addAmount(cmd->mutable_amount(), amount);
+        });
       }
 
       NextBuilder<Command> addPeer(
           const interface::types::AddressType &address,
-          const interface::types::PubkeyType &peer_key) {
-        auto command = proto_command()->mutable_add_peer();
-        command->set_address(address);
-        command->set_peer_key(peer_key.blob());
-        return *this;
+          const interface::types::PubkeyType &peer_key) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_add_peer();
+          command->set_address(address);
+          command->set_peer_key(peer_key.blob());
+        });
       }
 
       NextBuilder<Command> addSignatory(
           const interface::types::AddressType &account_id,
-          const interface::types::PubkeyType &public_key) {
-        auto command = proto_command()->mutable_add_signatory();
-        command->set_account_id(account_id);
-        command->set_public_key(public_key.blob());
-        return *this;
+          const interface::types::PubkeyType &public_key) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_add_signatory();
+          command->set_account_id(account_id);
+          command->set_public_key(public_key.blob());
+        });
       }
 
       NextBuilder<Command> removeSignatory(
           const interface::types::AddressType &account_id,
-          const interface::types::PubkeyType &public_key) {
-        auto command = proto_command()->mutable_remove_sign();
-        command->set_account_id(account_id);
-        command->set_public_key(public_key.blob());
-        return *this;
+          const interface::types::PubkeyType &public_key) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_remove_sign();
+          command->set_account_id(account_id);
+          command->set_public_key(public_key.blob());
+        });
       }
 
       NextBuilder<Command> createAsset(
           const std::string &asset_name,
           const interface::types::AddressType &domain_id,
-          uint32_t precision) {
-        auto command = proto_command()->mutable_create_asset();
-        command->set_asset_name(asset_name);
-        command->set_domain_id(domain_id);
-        command->set_precision(precision);
-        return *this;
+          uint32_t precision) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_create_asset();
+          command->set_asset_name(asset_name);
+          command->set_domain_id(domain_id);
+          command->set_precision(precision);
+        });
       }
 
       NextBuilder<Command> createAccount(
           const std::string &account_name,
           const interface::types::AddressType &domain_id,
-          const interface::types::PubkeyType &main_pubkey) {
-        auto command = proto_command()->mutable_create_account();
-        command->set_account_name(account_name);
-        command->set_domain_id(domain_id);
-        command->set_main_pubkey(main_pubkey.blob());
-        return *this;
+          const interface::types::PubkeyType &main_pubkey) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_create_account();
+          command->set_account_name(account_name);
+          command->set_domain_id(domain_id);
+          command->set_main_pubkey(main_pubkey.blob());
+        });
       }
 
       NextBuilder<Command> createDomain(
           const interface::types::AddressType &domain_id,
-          const interface::types::RoleIdType &default_role) {
-        auto command = proto_command()->mutable_create_domain();
-        command->set_domain_id(domain_id);
-        command->set_default_role(default_role);
-        return *this;
+          const interface::types::RoleIdType &default_role) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_create_domain();
+          command->set_domain_id(domain_id);
+          command->set_default_role(default_role);
+        });
       }
 
       NextBuilder<Command> setAccountQuorum(
-          const interface::types::AddressType &account_id, uint32_t quorum) {
-        auto command = proto_command()->mutable_set_quorum();
-        command->set_account_id(account_id);
-        command->set_quorum(quorum);
-        return *this;
+          const interface::types::AddressType &account_id,
+          uint32_t quorum) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_set_quorum();
+          command->set_account_id(account_id);
+          command->set_quorum(quorum);
+        });
       }
 
       NextBuilder<Command> transferAsset(
@@ -160,17 +200,18 @@ namespace shared_model {
           const interface::types::AccountIdType &dest_account_id,
           const interface::types::AssetIdType &asset_id,
           const std::string &description,
-          const std::string &amount) {
-        auto command = proto_command()->mutable_transfer_asset();
-        command->set_src_account_id(src_account_id);
-        command->set_dest_account_id(dest_account_id);
-        command->set_asset_id(asset_id);
-        command->set_description(description);
-        addAmount(command->mutable_amount(), amount);
-        return *this;
+          const std::string &amount) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_transfer_asset();
+          command->set_src_account_id(src_account_id);
+          command->set_dest_account_id(dest_account_id);
+          command->set_asset_id(asset_id);
+          command->set_description(description);
+          addAmount(command->mutable_amount(), amount);
+        });
       }
 
-      UnsignedWrapper<Transaction> build() {
+      UnsignedWrapper<Transaction> build() const {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
 
         auto answer = stateless_validator_.validate(
@@ -185,9 +226,8 @@ namespace shared_model {
       static const int total = RequiredFields::TOTAL;
 
      private:
-      iroha::protocol::Command *proto_command() {
-        return transaction_.mutable_payload()->add_commands();
-      }
+      ProtoTx transaction_;
+      SV stateless_validator_;
     };
 
     using TransactionBuilder = TemplateTransactionBuilder<>;

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -64,8 +64,8 @@ namespace shared_model {
        * @return new builder with updated state
        */
       template <int Fields, typename Transformation>
-      NextBuilder<Fields> transform(Transformation t) const {
-        auto copy = *this;
+      auto transform(Transformation t) const {
+        NextBuilder<Fields> copy = *this;
         t(copy.transaction_);
         return copy;
       }
@@ -77,18 +77,15 @@ namespace shared_model {
        * @return new builder with added command
        */
       template <typename Transformation>
-      NextBuilder<Command> addCommand(Transformation t) const {
-        auto copy = *this;
+      auto addCommand(Transformation t) const {
+        NextBuilder<Command> copy = *this;
         t(copy.transaction_.mutable_payload()->add_commands());
         return copy;
       }
 
      public:
-      TemplateTransactionBuilder() = default;
-
-      TemplateTransactionBuilder(const TemplateTransactionBuilder &o) = default;
-
-      TemplateTransactionBuilder(TemplateTransactionBuilder &&o) = default;
+      TemplateTransactionBuilder(const SV &validator = SV())
+          : stateless_validator_(validator) {}
 
       auto creatorAccountId(
           const interface::types::AccountIdType &account_id) const {
@@ -205,7 +202,7 @@ namespace shared_model {
         });
       }
 
-      UnsignedWrapper<Transaction> build() const {
+      auto build() const {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
 
         auto answer = stateless_validator_.validate(

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -57,11 +57,6 @@ namespace shared_model {
           : transaction_(o.transaction_),
             stateless_validator_(o.stateless_validator_) {}
 
-      template <int Sp>
-      TemplateTransactionBuilder(TemplateTransactionBuilder<Sp> &&o)
-          : transaction_(std::move(o.transaction_)),
-            stateless_validator_(std::move(o.stateless_validator_)) {}
-
       /**
        * Make transformation on copied content
        * @tparam Transformation - callable type for changing the copy

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -57,6 +57,11 @@ namespace shared_model {
           : transaction_(o.transaction_),
             stateless_validator_(o.stateless_validator_) {}
 
+      template <int Sp>
+      TemplateTransactionBuilder(TemplateTransactionBuilder<Sp> &&o)
+          : transaction_(std::move(o.transaction_)),
+            stateless_validator_(std::move(o.stateless_validator_)) {}
+
       /**
        * Make transformation on copied content
        * @tparam Transformation - callable type for changing the copy
@@ -86,6 +91,10 @@ namespace shared_model {
      public:
       TemplateTransactionBuilder() = default;
 
+      TemplateTransactionBuilder(const TemplateTransactionBuilder &o) = default;
+
+      TemplateTransactionBuilder(TemplateTransactionBuilder &&o) = default;
+
       auto creatorAccountId(
           const interface::types::AccountIdType &account_id) const {
         return transform<CreatorAccountId>([&](auto &tx) {
@@ -93,24 +102,21 @@ namespace shared_model {
         });
       }
 
-      auto txCounter(
-          Transaction::TxCounterType tx_counter) const {
+      auto txCounter(Transaction::TxCounterType tx_counter) const {
         return transform<TxCounter>([&](auto &tx) {
           tx.mutable_payload()->set_tx_counter(tx_counter);
         });
       }
 
-      auto createdTime(
-          interface::types::TimestampType created_time) const {
+      auto createdTime(interface::types::TimestampType created_time) const {
         return transform<CreatedTime>([&](auto &tx) {
           tx.mutable_payload()->set_created_time(created_time);
         });
       }
 
-      auto addAssetQuantity(
-          const interface::types::AccountIdType &account_id,
-          const interface::types::AssetIdType &asset_id,
-          const std::string &amount) const {
+      auto addAssetQuantity(const interface::types::AccountIdType &account_id,
+                            const interface::types::AssetIdType &asset_id,
+                            const std::string &amount) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_asset_quantity();
           command->set_account_id(account_id);
@@ -119,9 +125,8 @@ namespace shared_model {
         });
       }
 
-      auto addPeer(
-          const interface::types::AddressType &address,
-          const interface::types::PubkeyType &peer_key) const {
+      auto addPeer(const interface::types::AddressType &address,
+                   const interface::types::PubkeyType &peer_key) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_peer();
           command->set_address(address);
@@ -129,9 +134,8 @@ namespace shared_model {
         });
       }
 
-      auto addSignatory(
-          const interface::types::AddressType &account_id,
-          const interface::types::PubkeyType &public_key) const {
+      auto addSignatory(const interface::types::AddressType &account_id,
+                        const interface::types::PubkeyType &public_key) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_signatory();
           command->set_account_id(account_id);
@@ -149,10 +153,9 @@ namespace shared_model {
         });
       }
 
-      auto createAsset(
-          const std::string &asset_name,
-          const interface::types::AddressType &domain_id,
-          uint32_t precision) const {
+      auto createAsset(const std::string &asset_name,
+                       const interface::types::AddressType &domain_id,
+                       uint32_t precision) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_create_asset();
           command->set_asset_name(asset_name);
@@ -183,9 +186,8 @@ namespace shared_model {
         });
       }
 
-      auto setAccountQuorum(
-          const interface::types::AddressType &account_id,
-          uint32_t quorum) const {
+      auto setAccountQuorum(const interface::types::AddressType &account_id,
+                            uint32_t quorum) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_set_quorum();
           command->set_account_id(account_id);
@@ -193,12 +195,11 @@ namespace shared_model {
         });
       }
 
-      auto transferAsset(
-          const interface::types::AccountIdType &src_account_id,
-          const interface::types::AccountIdType &dest_account_id,
-          const interface::types::AssetIdType &asset_id,
-          const std::string &description,
-          const std::string &amount) const {
+      auto transferAsset(const interface::types::AccountIdType &src_account_id,
+                         const interface::types::AccountIdType &dest_account_id,
+                         const interface::types::AssetIdType &asset_id,
+                         const std::string &description,
+                         const std::string &amount) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_transfer_asset();
           command->set_src_account_id(src_account_id);

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -57,10 +57,6 @@ namespace shared_model {
           : transaction_(o.transaction_),
             stateless_validator_(o.stateless_validator_) {}
 
-      TemplateTransactionBuilder(const ProtoTx &tx,
-                                 const SV &stateless_validator)
-          : transaction_(tx), stateless_validator_(stateless_validator) {}
-
       /**
        * Make transformation on copied content
        * @tparam Transformation - callable type for changing the copy
@@ -69,9 +65,9 @@ namespace shared_model {
        */
       template <int Fields, typename Transformation>
       NextBuilder<Fields> transform(Transformation t) const {
-        auto copy = transaction_;
-        t(copy);
-        return {copy, stateless_validator_};
+        auto copy = *this;
+        t(copy.transaction_);
+        return copy;
       }
 
       /**
@@ -82,36 +78,36 @@ namespace shared_model {
        */
       template <typename Transformation>
       NextBuilder<Command> addCommand(Transformation t) const {
-        auto copy = transaction_;
-        t(copy.mutable_payload()->add_commands());
-        return {copy, stateless_validator_};
+        auto copy = *this;
+        t(copy.transaction_.mutable_payload()->add_commands());
+        return copy;
       }
 
      public:
       TemplateTransactionBuilder() = default;
 
-      NextBuilder<CreatorAccountId> creatorAccountId(
+      auto creatorAccountId(
           const interface::types::AccountIdType &account_id) const {
         return transform<CreatorAccountId>([&](auto &tx) {
           tx.mutable_payload()->set_creator_account_id(account_id);
         });
       }
 
-      NextBuilder<TxCounter> txCounter(
+      auto txCounter(
           Transaction::TxCounterType tx_counter) const {
         return transform<TxCounter>([&](auto &tx) {
           tx.mutable_payload()->set_tx_counter(tx_counter);
         });
       }
 
-      NextBuilder<CreatedTime> createdTime(
+      auto createdTime(
           interface::types::TimestampType created_time) const {
         return transform<CreatedTime>([&](auto &tx) {
           tx.mutable_payload()->set_created_time(created_time);
         });
       }
 
-      NextBuilder<Command> assetQuantity(
+      auto assetQuantity(
           const interface::types::AccountIdType &account_id,
           const interface::types::AssetIdType &asset_id,
           const std::string &amount) const {
@@ -123,7 +119,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> addPeer(
+      auto addPeer(
           const interface::types::AddressType &address,
           const interface::types::PubkeyType &peer_key) const {
         return addCommand([&](auto proto_command) {
@@ -133,7 +129,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> addSignatory(
+      auto addSignatory(
           const interface::types::AddressType &account_id,
           const interface::types::PubkeyType &public_key) const {
         return addCommand([&](auto proto_command) {
@@ -143,7 +139,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> removeSignatory(
+      auto removeSignatory(
           const interface::types::AddressType &account_id,
           const interface::types::PubkeyType &public_key) const {
         return addCommand([&](auto proto_command) {
@@ -153,7 +149,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> createAsset(
+      auto createAsset(
           const std::string &asset_name,
           const interface::types::AddressType &domain_id,
           uint32_t precision) const {
@@ -165,7 +161,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> createAccount(
+      auto createAccount(
           const std::string &account_name,
           const interface::types::AddressType &domain_id,
           const interface::types::PubkeyType &main_pubkey) const {
@@ -177,7 +173,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> createDomain(
+      auto createDomain(
           const interface::types::AddressType &domain_id,
           const interface::types::RoleIdType &default_role) const {
         return addCommand([&](auto proto_command) {
@@ -187,7 +183,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> setAccountQuorum(
+      auto setAccountQuorum(
           const interface::types::AddressType &account_id,
           uint32_t quorum) const {
         return addCommand([&](auto proto_command) {
@@ -197,7 +193,7 @@ namespace shared_model {
         });
       }
 
-      NextBuilder<Command> transferAsset(
+      auto transferAsset(
           const interface::types::AccountIdType &src_account_id,
           const interface::types::AccountIdType &dest_account_id,
           const interface::types::AssetIdType &asset_id,

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -107,7 +107,7 @@ namespace shared_model {
         });
       }
 
-      auto assetQuantity(
+      auto addAssetQuantity(
           const interface::types::AccountIdType &account_id,
           const interface::types::AssetIdType &asset_id,
           const std::string &amount) const {

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -38,6 +38,8 @@ namespace shared_model {
        */
       explicit UnsignedWrapper(const T &o) : unsigned_(o) {}
 
+      explicit UnsignedWrapper(T &&o) : unsigned_(std::move(o)) {}
+
       /**
        * Add signature and retrieve signed result
        * @param signature - signature to add

--- a/shared_model/validators/commands_validator.hpp
+++ b/shared_model/validators/commands_validator.hpp
@@ -294,7 +294,8 @@ namespace shared_model {
        * @param tx
        * @return Answer containing found error if any
        */
-      Answer validate(detail::PolymorphicWrapper<interface::Transaction> tx) {
+      Answer validate(
+          detail::PolymorphicWrapper<interface::Transaction> tx) const {
         Answer answer;
         for (auto &command : tx->commands()) {
           auto reason =

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -100,7 +100,7 @@ TEST(ProtoTransaction, Builder) {
   auto tx = shared_model::proto::TransactionBuilder()
                 .txCounter(tx_counter)
                 .creatorAccountId(creator_account_id)
-                .assetQuantity(account_id, asset_id, amount)
+                .addAssetQuantity(account_id, asset_id, amount)
                 .createdTime(created_time)
                 .build();
 
@@ -139,7 +139,7 @@ TEST(ProtoTransaction, BuilderWithInvalidTx) {
   ASSERT_THROW(shared_model::proto::TransactionBuilder()
                    .txCounter(tx_counter)
                    .creatorAccountId(account_id)
-                   .assetQuantity(account_id, asset_id, amount)
+                   .addAssetQuantity(account_id, asset_id, amount)
                    .createdTime(created_time)
                    .build(),
                std::invalid_argument);


### PR DESCRIPTION
## What is this pull request?
This PR provides a constant interface for transaction builder.

## Details/Features
* make all generation methods of builder constant
* fix bug (silently) when on setter copy default stateless validator
* fix interface of stateless validator as a constant