### PR TITLE
Add dynamic port selection to several tests

### DIFF
--- a/test/integration/pipeline/tx_pipeline_integration_test.cpp
+++ b/test/integration/pipeline/tx_pipeline_integration_test.cpp
@@ -17,6 +17,7 @@
 
 #include "integration/pipeline/tx_pipeline_integration_test_fixture.hpp"
 
+// TODO: refactor services to allow dynamic port binding IR-741
 class TxPipelineIntegrationTest : public TxPipelineIntegrationTestFixture {
  public:
   void SetUp() override {

--- a/test/module/irohad/api/connection/command_connection_test.cpp
+++ b/test/module/irohad/api/connection/command_connection_test.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 
 using iroha::protocol::Transaction;
 
+// TODO: allow dynamic port binding in ServerRunner IR-741
 class CommandConnectionTest : public ::testing::Test {
  protected:
   virtual void SetUp() {

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -33,7 +33,6 @@ namespace iroha {
         void SetUp() override {
           notifications = std::make_shared<MockYacNetworkNotifications>();
 
-          peer = mk_peer("0.0.0.0:50051");
           network = std::make_shared<NetworkImpl>();
 
           message.hash.proposal_hash = "proposal";
@@ -43,13 +42,15 @@ namespace iroha {
 
           grpc::ServerBuilder builder;
           int port = 0;
-          builder.AddListeningPort(peer.address,
+          builder.AddListeningPort("0.0.0.0:0",
                                    grpc::InsecureServerCredentials(),
                                    &port);
           builder.RegisterService(network.get());
           server = builder.BuildAndStart();
           ASSERT_TRUE(server);
           ASSERT_NE(port, 0);
+
+          peer = mk_peer("0.0.0.0:" + std::to_string(port));
         }
 
         void TearDown() override {

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -39,9 +39,6 @@ using testing::A;
 class BlockLoaderTest : public testing::Test {
  public:
   void SetUp() override {
-    peer = Peer();
-    peer.address = "0.0.0.0:50051";
-    peers.push_back(peer);
     peer_query = std::make_shared<MockPeerQuery>();
     storage = std::make_shared<MockBlockQuery>();
     provider = std::make_shared<MockCryptoProvider>();
@@ -50,14 +47,20 @@ class BlockLoaderTest : public testing::Test {
 
     grpc::ServerBuilder builder;
     int port = 0;
-    builder.AddListeningPort(peer.address, grpc::InsecureServerCredentials(),
+    builder.AddListeningPort(address, grpc::InsecureServerCredentials(),
                              &port);
     builder.RegisterService(service.get());
     server = builder.BuildAndStart();
+
+    peer = Peer();
+    peer.address = "0.0.0.0:" + std::to_string(port);
+    peers.push_back(peer);
+
     ASSERT_TRUE(server);
     ASSERT_NE(port, 0);
   }
 
+  std::string address{"0.0.0.0:0"};
   Peer peer;
   std::vector<Peer> peers;
   std::shared_ptr<MockPeerQuery> peer_query;

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -47,7 +47,7 @@ class BlockLoaderTest : public testing::Test {
 
     grpc::ServerBuilder builder;
     int port = 0;
-    builder.AddListeningPort(address, grpc::InsecureServerCredentials(),
+    builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials(),
                              &port);
     builder.RegisterService(service.get());
     server = builder.BuildAndStart();
@@ -60,7 +60,6 @@ class BlockLoaderTest : public testing::Test {
     ASSERT_NE(port, 0);
   }
 
-  std::string address{"0.0.0.0:0"};
   Peer peer;
   std::vector<Peer> peers;
   std::shared_ptr<MockPeerQuery> peer_query;

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -31,6 +31,7 @@ using namespace iroha::ametsuchi;
 using namespace std::chrono_literals;
 using ::testing::Return;
 
+// TODO: refactor services to allow dynamic port binding IR-741
 class OrderingGateServiceTest : public ::testing::Test {
  public:
   OrderingGateServiceTest() {

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -55,12 +55,12 @@ class OrderingGateTest : public ::testing::Test {
       grpc::ServerBuilder builder;
       int port = 0;
       builder.AddListeningPort(
-          address, grpc::InsecureServerCredentials(), &port);
+           "0.0.0.0:0", grpc::InsecureServerCredentials(), &port);
 
       builder.RegisterService(fake_service.get());
 
       server = builder.BuildAndStart();
-      address = "0.0.0.0:" + std::to_string(port);
+      auto address = "0.0.0.0:" + std::to_string(port);
       // Initialize components after port has been bind
       transport = std::make_shared<OrderingGateTransportGrpc>(address);
       gate_impl = std::make_shared<OrderingGateImpl>(transport);
@@ -85,7 +85,7 @@ class OrderingGateTest : public ::testing::Test {
 
   std::unique_ptr<grpc::Server> server;
 
-  std::string address{"0.0.0.0:0"};
+
   std::shared_ptr<OrderingGateTransportGrpc> transport;
   std::shared_ptr<OrderingGateImpl> gate_impl;
   std::shared_ptr<MockOrderingGateTransportGrpcService> fake_service;

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -47,9 +47,8 @@ class MockOrderingGateTransportGrpcService
 
 class OrderingGateTest : public ::testing::Test {
  public:
-  OrderingGateTest() {
-    fake_service = std::make_shared<MockOrderingGateTransportGrpcService>();
-  }
+  OrderingGateTest():
+    fake_service{std::make_shared<MockOrderingGateTransportGrpcService>()} {}
 
   void SetUp() override {
     thread = std::thread([this] {

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -48,9 +48,6 @@ class MockOrderingGateTransportGrpcService
 class OrderingGateTest : public ::testing::Test {
  public:
   OrderingGateTest() {
-    transport = std::make_shared<OrderingGateTransportGrpc>(address);
-    gate_impl = std::make_shared<OrderingGateImpl>(transport);
-    transport->subscribe(gate_impl);
     fake_service = std::make_shared<MockOrderingGateTransportGrpcService>();
   }
 
@@ -64,6 +61,11 @@ class OrderingGateTest : public ::testing::Test {
       builder.RegisterService(fake_service.get());
 
       server = builder.BuildAndStart();
+      address = "0.0.0.0:" + std::to_string(port);
+      // Initialize components after port has been bind
+      transport = std::make_shared<OrderingGateTransportGrpc>(address);
+      gate_impl = std::make_shared<OrderingGateImpl>(transport);
+      transport->subscribe(gate_impl);
 
       ASSERT_NE(port, 0);
       ASSERT_TRUE(server);
@@ -84,7 +86,7 @@ class OrderingGateTest : public ::testing::Test {
 
   std::unique_ptr<grpc::Server> server;
 
-  std::string address{"0.0.0.0:50051"};
+  std::string address{"0.0.0.0:0"};
   std::shared_ptr<OrderingGateTransportGrpc> transport;
   std::shared_ptr<OrderingGateImpl> gate_impl;
   std::shared_ptr<MockOrderingGateTransportGrpcService> fake_service;

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -43,6 +43,7 @@ using namespace iroha::validation;
 using namespace iroha::ametsuchi;
 using namespace iroha::model;
 
+// TODO: allow dynamic port binding in ServerRunner IR-741
 class ToriiQueriesTest : public testing::Test {
  public:
   virtual void SetUp() {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -73,6 +73,7 @@ class CustomPeerCommunicationServiceMock : public PeerCommunicationService {
   rxcpp::subjects::subject<Commit> commit_notifier_;
 };
 
+// TODO: allow dynamic port binding in ServerRunner IR-741
 class ToriiServiceTest : public testing::Test {
  public:
   virtual void SetUp() {


### PR DESCRIPTION
## What is this pull request?
This pull request removes hardcoded ports from several test classes, and replaces them with dynamic port selection
   
## Why do you implement it? Why do we need this pull request?
Hardcoded ports can be already taken by something else, which produces test failure. Such a failure is hard to detect and reproduce, so it is best to avoid such issues.
  

## Details/Features
List of features / major commits
- Add dynamic ports to block_loader_test and ordering_gate_test

## P.S. (optional)
I was not able to change several tests, because address needs to be known beforehand for them to work. This means that adding dynamic port requires major changes in core classes.
