### PR TITLE
Fix tests for mac os;

### DIFF
--- a/irohad/model/operators/hash.hpp
+++ b/irohad/model/operators/hash.hpp
@@ -32,7 +32,7 @@ namespace iroha {
      public:
       using TxType = Tx;
       size_t operator()(const TxType &tx) const {
-        auto hash = string_hasher(tx->tx_hash.to_string());
+        auto hash = string_hasher(tx->tx_hash.to_hexstring());
         return hash;
       }
 

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -23,7 +23,6 @@
 #include <vector>
 #include "logger/logger.hpp"
 
-#include "common/types.hpp"
 #include "model/operators/hash.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 
@@ -55,9 +54,9 @@ namespace iroha {
 
   class TxHashEquality {
    public:
-    bool operator()(const DataType &left_tx, const DataType &rightTx) const {
+    bool operator()(const DataType &left_tx, const DataType &right_tx) const {
       return (*left_tx).tx_hash.to_hexstring()
-          == (*rightTx).tx_hash.to_hexstring();
+          == (*right_tx).tx_hash.to_hexstring();
     }
   };
 

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -53,6 +53,14 @@ namespace iroha {
     virtual ~Completer() = default;
   };
 
+  class TxHashEquality {
+   public:
+    bool operator()(const DataType &left_tx, const DataType &rightTx) const {
+      return (*left_tx).tx_hash.to_hexstring()
+          == (*rightTx).tx_hash.to_hexstring();
+    }
+  };
+
   /**
    * Class provide default behaviour for transaction completer
    */
@@ -144,7 +152,7 @@ namespace iroha {
 
     using InternalStateType =
         std::unordered_set<DataType, iroha::model::PointerTxHasher<DataType>,
-                           iroha::DereferenceEquals<DataType>>;
+                           TxHashEquality>;
 
     using IndexType =
         std::priority_queue<DataType, std::vector<DataType>, Less>;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -346,16 +346,5 @@ namespace iroha {
     return typeid(Base) == typeid(ptr);
   }
 
-  /**
-   * Dereference for equality of wrapped objects
-   */
-  template<typename T>
-  class DereferenceEquals {
-   public:
-    bool operator()(const T &lhs, const T &rhs) const {
-      return (*lhs) == (*rhs);
-    }
-  };
-
 }  // namespace iroha
 #endif  // IROHA_COMMON_TYPES_HPP

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -30,9 +30,14 @@ using ::testing::AtLeast;
 using ::testing::InvokeWithoutArgs;
 
 /**
- * Sends data over MstTransportGrpc (MstState and Peer objects) and receives
+ * @brief Sends data over MstTransportGrpc (MstState and Peer objects) and receives
  * them. When received deserializes them end ensures that deserialized
  * objects equal to objects before sending.
+ *
+ * @given Initialized transport
+ * AND MstState for transfer
+ * @when Send state via transport
+ * @then Assume that received state same as sent
  */
 TEST(TransportTest, SendAndReceive) {
   auto transport = std::make_shared<MstTransportGrpc>();

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -17,16 +17,16 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
+#include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 
 using namespace iroha::network;
 using namespace iroha::model;
 
-using ::testing::AtLeast;
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::InvokeWithoutArgs;
 
 /**
@@ -47,19 +47,11 @@ TEST(TransportTest, SendAndReceive) {
 
   auto peer = makePeer("localhost:50051", "abcdabcdabcdabcdabcdabcdabcdabcd");
 
-  auto tx1 = makeTx("1", "4", 3);
-  auto tx2 = makeTx("2", "5", 4);
-  auto tx3 = makeTx("3", "6", 5);
-  auto tx4 = Transaction{};
-  tx4.creator_account_id = "me";
-  tx4.quorum = 11;
-  tx4.created_ts = 12345;
-
   MstState state = MstState::empty();
-  state += tx1;
-  state += tx2;
-  state += tx3;
-  state += std::make_shared<Transaction>(tx4);
+  state += makeTx("1", "5", 3);
+  state += makeTx("2", "6", 4);
+  state += makeTx("3", "7", 5);
+  state += makeTx("4", "8", 5);
 
   // we want to ensure that server side will call onNewState()
   // with same parameters as on the client side


### PR DESCRIPTION
## What is this pull request?
Fix test passing for mac os platform
   
## What happens?
The different behavior of `std::hash` with respect to binary data in Linux and Mac OS environments.  Also, fix semantic of transaction equality for MST.
  
## Details/Features
List of features / major commits
* rework operator== with hash semantic for transactions
* rework hashing of transactions with hex strings
* cleanup transport test
