### PR TITLE
Feature/apppend role check

### DIFF
--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -94,6 +94,8 @@ namespace iroha {
 
       bool isValid(const Command &command,
                    ametsuchi::WsvQuery &queries) override;
+    private:
+      Account creator_;
     };
 
     class DetachRoleExecutor : public CommandExecutor {

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -113,8 +113,6 @@ namespace iroha {
       bool isValid(const Command &command,
                    ametsuchi::WsvQuery &queries) override;
 
-     private:
-      Account creator_;
     };
 
     class CreateRoleExecutor : public CommandExecutor {

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -110,6 +110,9 @@ namespace iroha {
 
       bool isValid(const Command &command,
                    ametsuchi::WsvQuery &queries) override;
+
+     private:
+      Account creator_;
     };
 
     class CreateRoleExecutor : public CommandExecutor {

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -60,12 +60,26 @@ namespace iroha {
       log_ = logger::log("AppendRoleExecutor");
     }
 
-    bool AppendRoleExecutor::validate(const Command &command,
-                                      ametsuchi::WsvQuery &queries,
-                                      const Account &creator) {
+    bool AppendRoleExecutor::execute(const Command &command,
+                                     ametsuchi::WsvQuery &queries,
+                                     ametsuchi::WsvCommand &commands) {
+      auto cmd_value = static_cast<const AppendRole &>(command);
 
-      //return CommandExecutor::validate(command, queries, creator);
+      return commands.insertAccountRole(cmd_value.account_id,
+                                        cmd_value.role_name);
+    }
 
+    bool AppendRoleExecutor::hasPermissions(const Command &command,
+                                            ametsuchi::WsvQuery &queries,
+                                            const Account &creator) {
+      creator_ = creator;
+      return checkAccountRolePermission(
+          creator.account_id, queries, can_append_role);
+    }
+
+    bool AppendRoleExecutor::isValid(const Command &command,
+                                     ametsuchi::WsvQuery &queries) {
+      auto creator = creator_;
       auto cmd_value = static_cast<const AppendRole &>(command);
       auto role_permissions = queries.getRolePermissions(cmd_value.role_name);
       auto account_roles = queries.getAccountRoles(creator.account_id);
@@ -86,30 +100,6 @@ namespace iroha {
         if (account_permissions.find(role_permission)
             == account_permissions.end())
           return false;
-
-      return CommandExecutor::validate(command, queries, creator);
-
-    }
-    bool AppendRoleExecutor::execute(const Command &command,
-                                     ametsuchi::WsvQuery &queries,
-                                     ametsuchi::WsvCommand &commands) {
-      auto cmd_value = static_cast<const AppendRole &>(command);
-
-
-      return commands.insertAccountRole(cmd_value.account_id,
-                                        cmd_value.role_name);
-    }
-
-    bool AppendRoleExecutor::hasPermissions(const Command &command,
-                                            ametsuchi::WsvQuery &queries,
-                                            const Account &creator) {
-      return checkAccountRolePermission(
-          creator.account_id, queries, can_append_role);
-    }
-
-    bool AppendRoleExecutor::isValid(const Command &command,
-                                     ametsuchi::WsvQuery &queries) {
-      // TODO 26/09/17 grimadas: check. No additional checks required
       return true;
     }
 

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -1155,9 +1155,15 @@ class AppendRoleTest : public CommandValidateExecuteTest {
 
 TEST_F(AppendRoleTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(admin_id))
-      .WillOnce(Return(admin_roles));
+      .Times(2)
+      .WillRepeatedly(Return(admin_roles));
+
   EXPECT_CALL(*wsv_query, getRolePermissions(admin_role))
+      .Times(2)
+      .WillRepeatedly(Return(role_permissions));
+  EXPECT_CALL(*wsv_query, getRolePermissions("master"))
       .WillOnce(Return(role_permissions));
+
   EXPECT_CALL(*wsv_command, insertAccountRole(_, _)).WillOnce(Return(true));
   ASSERT_TRUE(validateAndExecute());
 }


### PR DESCRIPTION
Thanks for the pull request!
Pull requests should have these details:

## What is this pull request?
This pull requests adds an additional check on Append Role Executor. It checks if assigner has enough permissions to give a certain role to assignee.

## Why do you implement it? Why do we need this pull request?
If assigner X has a set of permissions **A** and want to append role with set **B** of permissions to the user Y. 
This command must succeed if and only if **B** is a subset of **A**. This PR performs this check.
  
