### PR TITLE
Return vector in Blob::blob()

### DIFF
--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -92,7 +92,7 @@ namespace shared_model {
       explicit Command(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
             variant_([this] { return load<ProtoCommandListType>(*proto_); }),
-            blob_([this] { return make_blob(*proto_); }) {}
+            blob_([this] { return makeBlob(*proto_); }) {}
 
       Command(const Command &o) : Command(o.proto_) {}
 

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -37,6 +37,7 @@
 #include "backend/protobuf/commands/proto_subtract_asset_quantity.hpp"
 #include "backend/protobuf/commands/proto_transfer_asset.hpp"
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/util.hpp"
 #include "commands.pb.h"
 #include "utils/lazy_initializer.hpp"
 #include "utils/variant_deserializer.hpp"
@@ -91,7 +92,7 @@ namespace shared_model {
       explicit Command(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
             variant_([this] { return load<ProtoCommandListType>(*proto_); }),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }) {}
+            blob_([this] { return make_blob(*proto_); }) {}
 
       Command(const Command &o) : Command(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/account.hpp
+++ b/shared_model/backend/protobuf/common_objects/account.hpp
@@ -38,7 +38,7 @@ namespace shared_model {
             domainId_(proto_->domain_id()),
             quorum_(proto_->quorum()),
             json_data_(proto_->json_data()),
-            blob_([this] { return make_blob(*proto_); }) {}
+            blob_([this] { return makeBlob(*proto_); }) {}
 
       Account(const Account &o) : Account(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/account.hpp
+++ b/shared_model/backend/protobuf/common_objects/account.hpp
@@ -19,6 +19,7 @@
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_HPP
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/util.hpp"
 #include "interfaces/common_objects/account.hpp"
 #include "responses.pb.h"
 #include "utils/lazy_initializer.hpp"
@@ -37,7 +38,7 @@ namespace shared_model {
             domainId_(proto_->domain_id()),
             quorum_(proto_->quorum()),
             json_data_(proto_->json_data()),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }) {}
+            blob_([this] { return make_blob(*proto_); }) {}
 
       Account(const Account &o) : Account(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/account_asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/account_asset.hpp
@@ -20,6 +20,7 @@
 
 #include "backend/protobuf/common_objects/amount.hpp"
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/util.hpp"
 #include "interfaces/common_objects/account_asset.hpp"
 #include "responses.pb.h"
 #include "utils/lazy_initializer.hpp"
@@ -38,7 +39,7 @@ namespace shared_model {
             accountId_(proto_->account_id()),
             assetId_(proto_->asset_id()),
             balance_([this] { return Amount(proto_->balance()); }),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }) {}
+            blob_([this] { return make_blob(*proto_); }) {}
 
       AccountAsset(const AccountAsset &o) : AccountAsset(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/account_asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/account_asset.hpp
@@ -39,7 +39,7 @@ namespace shared_model {
             accountId_(proto_->account_id()),
             assetId_(proto_->asset_id()),
             balance_([this] { return Amount(proto_->balance()); }),
-            blob_([this] { return make_blob(*proto_); }) {}
+            blob_([this] { return makeBlob(*proto_); }) {}
 
       AccountAsset(const AccountAsset &o) : AccountAsset(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -48,7 +48,7 @@ namespace shared_model {
               return result;
             }),
             precision_([this] { return proto_->precision(); }),
-            blob_([this] { return make_blob(*proto_); }) {}
+            blob_([this] { return makeBlob(*proto_); }) {}
 
       Amount(const Amount &o) : Amount(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -23,6 +23,7 @@
 #include <numeric>
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/util.hpp"
 #include "primitive.pb.h"
 #include "utils/lazy_initializer.hpp"
 
@@ -47,7 +48,7 @@ namespace shared_model {
               return result;
             }),
             precision_([this] { return proto_->precision(); }),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }) {}
+            blob_([this] { return make_blob(*proto_); }) {}
 
       Amount(const Amount &o) : Amount(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/asset.hpp
@@ -36,7 +36,7 @@ namespace shared_model {
             assetId_(proto_->asset_id()),
             domainId_(proto_->domain_id()),
             precision_(proto_->precision()),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }) {}
+            blob_([this] { return make_blob(*proto_); }) {}
 
       Asset(const Asset &o) : Asset(o.proto_) {}
 

--- a/shared_model/backend/protobuf/common_objects/asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/asset.hpp
@@ -36,7 +36,7 @@ namespace shared_model {
             assetId_(proto_->asset_id()),
             domainId_(proto_->domain_id()),
             precision_(proto_->precision()),
-            blob_([this] { return make_blob(*proto_); }) {}
+            blob_([this] { return makeBlob(*proto_); }) {}
 
       Asset(const Asset &o) : Asset(o.proto_) {}
 

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -86,8 +86,8 @@ namespace shared_model {
           : CopyableProto(std::forward<QueryType>(query)),
             variant_(
                 [this] { return load_query<ProtoQueryListType>(*proto_); }),
-            blob_([this] { return make_blob(*proto_); }),
-            payload_([this] { return make_blob(proto_->payload()); }),
+            blob_([this] { return makeBlob(*proto_); }),
+            payload_([this] { return makeBlob(proto_->payload()); }),
             signatures_([this] {
               SignatureSetType set;
               set.emplace(new Signature(proto_->signature()));

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -124,8 +124,8 @@ namespace shared_model {
         }
 
         auto sig = proto_->mutable_signature();
-        sig->set_pubkey(signature->publicKey().str());
-        sig->set_signature(signature->signedData().str());
+        sig->set_pubkey(crypto::toBinaryString(signature->publicKey()));
+        sig->set_signature(crypto::toBinaryString(signature->signedData()));
         return true;
       }
 

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -119,7 +119,9 @@ namespace shared_model {
 
       bool addSignature(
           const interface::types::SignatureType &signature) override {
-        if (proto_->has_signature()) return false;
+        if (proto_->has_signature()) {
+          return false;
+        }
 
         auto sig = proto_->mutable_signature();
         sig->set_pubkey(signature->publicKey().str());

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -92,8 +92,8 @@ namespace shared_model {
           return false;
         }
         auto sig = proto_->add_signature();
-        sig->set_pubkey(signature->publicKey().str());
-        sig->set_signature(signature->signedData().str());
+        sig->set_pubkey(crypto::toBinaryString(signature->publicKey()));
+        sig->set_signature(crypto::toBinaryString(signature->signedData()));
         signatures_.invalidate();
         return true;
       }

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -47,9 +47,8 @@ namespace shared_model {
                     return std::forward<decltype(acc)>(acc);
                   });
             }),
-            blob_([this] { return BlobType(proto_->SerializeAsString()); }),
-            blobTypePayload_(
-                [this] { return BlobType(payload_->SerializeAsString()); }),
+            blob_([this] { return make_blob(*proto_); }),
+            blobTypePayload_([this] { return make_blob(*payload_); }),
             signatures_([this] {
               return boost::accumulate(
                   proto_->signature(),
@@ -93,8 +92,8 @@ namespace shared_model {
           return false;
         }
         auto sig = proto_->add_signature();
-        sig->set_pubkey(signature->publicKey().blob());
-        sig->set_signature(signature->signedData().blob());
+        sig->set_pubkey(signature->publicKey().str());
+        sig->set_signature(signature->signedData().str());
         signatures_.invalidate();
         return true;
       }

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -47,8 +47,8 @@ namespace shared_model {
                     return std::forward<decltype(acc)>(acc);
                   });
             }),
-            blob_([this] { return make_blob(*proto_); }),
-            blobTypePayload_([this] { return make_blob(*payload_); }),
+            blob_([this] { return makeBlob(*proto_); }),
+            blobTypePayload_([this] { return makeBlob(*payload_); }),
             signatures_([this] {
               return boost::accumulate(
                   proto_->signature(),

--- a/shared_model/backend/protobuf/util.hpp
+++ b/shared_model/backend/protobuf/util.hpp
@@ -27,7 +27,7 @@ namespace shared_model {
 
     template <typename T>
     crypto::Blob make_blob(T &message) {
-      crypto::Blob::bytes data;
+      crypto::Blob::Bytes data;
       data.resize(message.ByteSizeLong());
       message.SerializeToArray(data.data(), data.size());
       return crypto::Blob(std::move(data));

--- a/shared_model/backend/protobuf/util.hpp
+++ b/shared_model/backend/protobuf/util.hpp
@@ -15,19 +15,25 @@
  * limitations under the License.
  */
 
-#include "cryptography/ed25519_sha3_impl/signer.hpp"
-#include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
+#ifndef IROHA_SHARED_MODEL_PROTO_UTIL_HPP
+#define IROHA_SHARED_MODEL_PROTO_UTIL_HPP
+
+#include <google/protobuf/message.h>
+#include <vector>
+#include "cryptography/blob.hpp"
 
 namespace shared_model {
-  namespace crypto {
-    Signed Signer::sign(const Blob &blob, const Keypair &keypair) {
-      return Signed(
-          iroha::sign(
-              blob.str(),
-              keypair.publicKey().makeOldModel<PublicKey::OldPublicKeyType>(),
-              keypair.privateKey()
-                  .makeOldModel<PrivateKey::OldPrivateKeyType>())
-              .to_string());
+  namespace proto {
+
+    template <typename T>
+    crypto::Blob make_blob(T &message) {
+      crypto::Blob::bytes data;
+      data.resize(message.ByteSizeLong());
+      message.SerializeToArray(data.data(), data.size());
+      return crypto::Blob(std::move(data));
     }
-  }  // namespace crypto
+
+  }  // namespace proto
 }  // namespace shared_model
+
+#endif  // IROHA_SHARED_MODEL_PROTO_UTIL_HPP

--- a/shared_model/backend/protobuf/util.hpp
+++ b/shared_model/backend/protobuf/util.hpp
@@ -26,7 +26,7 @@ namespace shared_model {
   namespace proto {
 
     template <typename T>
-    crypto::Blob make_blob(T &message) {
+    crypto::Blob makeBlob(T &message) {
       crypto::Blob::Bytes data;
       data.resize(message.ByteSizeLong());
       message.SerializeToArray(data.data(), data.size());

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -24,6 +24,11 @@
 %include "std_string.i"
 %include "stdint.i"
 %include "exception.i"
+%include "std_vector.i"
+
+namespace std {
+  %template(ByteVector) vector<uint8_t>;
+};
 
 %exception {
   try {

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -305,7 +305,7 @@ namespace shared_model {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
 
         auto answer = stateless_validator_.validate(
-            detail::make_polymorphic<Transaction>(transaction_));
+            detail::makePolymorphic<Transaction>(transaction_));
         if (answer.hasErrors()) {
           throw std::invalid_argument(answer.reason());
         }

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -124,7 +124,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_peer();
           command->set_address(address);
-          command->set_peer_key(peer_key.blob());
+          command->set_peer_key(peer_key.str());
         });
       }
 
@@ -133,7 +133,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_signatory();
           command->set_account_id(account_id);
-          command->set_public_key(public_key.blob());
+          command->set_public_key(public_key.str());
         });
       }
 
@@ -143,7 +143,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_remove_sign();
           command->set_account_id(account_id);
-          command->set_public_key(public_key.blob());
+          command->set_public_key(public_key.str());
         });
       }
 
@@ -175,7 +175,7 @@ namespace shared_model {
           auto command = proto_command->mutable_create_account();
           command->set_account_name(account_name);
           command->set_domain_id(domain_id);
-          command->set_main_pubkey(main_pubkey.blob());
+          command->set_main_pubkey(main_pubkey.str());
         });
       }
 
@@ -203,9 +203,8 @@ namespace shared_model {
       }
 
       template <typename Collection>
-      auto createRole(
-          const interface::types::RoleIdType &role_name,
-          const Collection &permissions) const {
+      auto createRole(const interface::types::RoleIdType &role_name,
+                      const Collection &permissions) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command()->mutable_create_role();
           command->set_role_name(role_name);

--- a/shared_model/builders/protobuf/transaction.hpp
+++ b/shared_model/builders/protobuf/transaction.hpp
@@ -124,7 +124,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_peer();
           command->set_address(address);
-          command->set_peer_key(peer_key.str());
+          command->set_peer_key(crypto::toBinaryString(peer_key));
         });
       }
 
@@ -133,7 +133,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_signatory();
           command->set_account_id(account_id);
-          command->set_public_key(public_key.str());
+          command->set_public_key(crypto::toBinaryString(public_key));
         });
       }
 
@@ -143,7 +143,7 @@ namespace shared_model {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_remove_sign();
           command->set_account_id(account_id);
-          command->set_public_key(public_key.str());
+          command->set_public_key(crypto::toBinaryString(public_key));
         });
       }
 
@@ -175,7 +175,7 @@ namespace shared_model {
           auto command = proto_command->mutable_create_account();
           command->set_account_name(account_name);
           command->set_domain_id(domain_id);
-          command->set_main_pubkey(main_pubkey.str());
+          command->set_main_pubkey(crypto::toBinaryString(main_pubkey));
         });
       }
 

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -49,8 +49,8 @@ namespace shared_model {
         auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
             shared_model::crypto::Blob(unsigned_.payload()), keypair);
         iroha::protocol::Signature protosig;
-        protosig.set_pubkey(keypair.publicKey().blob());
-        protosig.set_signature(signedBlob.blob());
+        protosig.set_pubkey(keypair.publicKey().str());
+        protosig.set_signature(signedBlob.str());
         auto *s1 = new Signature(protosig);
         unsigned_.addSignature(detail::PolymorphicWrapper<Signature>(
             s1));  // TODO: 05.12.2017 luckychess think about false case

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -49,8 +49,8 @@ namespace shared_model {
         auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
             shared_model::crypto::Blob(unsigned_.payload()), keypair);
         iroha::protocol::Signature protosig;
-        protosig.set_pubkey(keypair.publicKey().str());
-        protosig.set_signature(signedBlob.str());
+        protosig.set_pubkey(crypto::toBinaryString(keypair.publicKey()));
+        protosig.set_signature(crypto::toBinaryString(signedBlob));
         auto *s1 = new Signature(protosig);
         unsigned_.addSignature(detail::PolymorphicWrapper<Signature>(
             s1));  // TODO: 05.12.2017 luckychess think about false case

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -29,6 +29,8 @@
 namespace shared_model {
   namespace crypto {
 
+    class Blob;
+    static inline std::string toBinaryString(const Blob &b);
     /**
      * Blob class present user-friendly blob for working with low-level
      * binary stuff. Its length is not fixed in compile time.
@@ -64,13 +66,6 @@ namespace shared_model {
       virtual const Bytes &blob() const { return blob_; }
 
       /**
-       * @return provides raw representation of blob as string
-       */
-      virtual const std::string str() const {
-        return std::string(blob_.begin(), blob_.end());
-      }
-
-      /**
        * @return provides human-readable representation of blob without leading
        * 0x
        */
@@ -104,7 +99,7 @@ namespace shared_model {
 
       template <typename BlobType>
       DEPRECATED BlobType makeOldModel() const {
-        return BlobType::from_string(str());
+        return BlobType::from_string(toBinaryString(*this));
       }
 
      private:
@@ -112,6 +107,10 @@ namespace shared_model {
       Bytes blob_;
       std::string hex_;
     };
+
+    static inline std::string toBinaryString(const Blob &b) {
+      return std::string(b.blob().begin(), b.blob().end());
+    }
   }  // namespace crypto
 }  // namespace shared_model
 #endif  // IROHA_SHARED_MODEL_BLOB_HPP

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -35,21 +35,21 @@ namespace shared_model {
      */
     class Blob : public interface::ModelPrimitive<Blob> {
      public:
-      using bytes = std::vector<uint8_t>;
+      using Bytes = std::vector<uint8_t>;
 
       /**
        * Create blob from a string
        * @param blob - string to create blob from
        */
       explicit Blob(const std::string &blob)
-          : Blob(bytes(blob.begin(), blob.end())) {}
+          : Blob(Bytes(blob.begin(), blob.end())) {}
 
       /**
        * Create blob from a vector
        * @param blob - vector to create blob from
        */
-      explicit Blob(const bytes &blob) : Blob(bytes(blob)) {}
-      explicit Blob(bytes &&blob) : blob_(std::move(blob)) {
+      explicit Blob(const Bytes &blob) : Blob(Bytes(blob)) {}
+      explicit Blob(Bytes &&blob) : blob_(std::move(blob)) {
         std::stringstream ss;
         ss << std::hex << std::setfill('0');
         for (const auto &c : blob_) {
@@ -61,7 +61,7 @@ namespace shared_model {
       /**
        * @return provides raw representation of blob
        */
-      virtual const bytes &blob() const { return blob_; }
+      virtual const Bytes &blob() const { return blob_; }
 
       /**
        * @return provides raw representation of blob as string
@@ -109,7 +109,7 @@ namespace shared_model {
 
      private:
       // TODO: 17/11/2017 luckychess use improved Lazy with references support
-      bytes blob_;
+      Bytes blob_;
       std::string hex_;
     };
   }  // namespace crypto

--- a/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.cpp
@@ -61,6 +61,18 @@ namespace iroha {
     return h;
   }
 
+  hash512_t sha3_512(const std::vector<uint8_t> &msg) {
+    hash512_t h;
+    ::sha3_512(msg.data(), msg.size(), h.data());
+    return h;
+  }
+
+  hash256_t sha3_256(const std::vector<uint8_t> &msg) {
+    hash256_t h;
+    ::sha3_256(msg.data(), msg.size(), h.data());
+    return h;
+  }
+
   // TODO: remove factories
   const static model::converters::PbTransactionFactory tx_factory;
   const static model::converters::PbBlockFactory block_factory;

--- a/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp
@@ -30,8 +30,10 @@ namespace iroha {
 
   hash256_t sha3_256(const uint8_t *input, size_t in_size);
   hash256_t sha3_256(const std::string &msg);
+  hash256_t sha3_256(const std::vector<uint8_t> &msg);
   hash512_t sha3_512(const uint8_t *input, size_t in_size);
   hash512_t sha3_512(const std::string &msg);
+  hash512_t sha3_512(const std::vector<uint8_t> &msg);
 
   hash256_t hash(const model::Transaction &tx);
   hash256_t hash(const model::Block &tx);

--- a/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
@@ -23,7 +23,7 @@ namespace shared_model {
     Signed Signer::sign(const Blob &blob, const Keypair &keypair) {
       return Signed(
           iroha::sign(
-              blob.str(),
+              crypto::toBinaryString(blob),
               keypair.publicKey().makeOldModel<PublicKey::OldPublicKeyType>(),
               keypair.privateKey()
                   .makeOldModel<PrivateKey::OldPrivateKeyType>())

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
@@ -24,7 +24,7 @@ namespace shared_model {
                           const Blob &orig,
                           const PublicKey &publicKey) {
       return iroha::verify(
-          orig.blob(),
+          orig.str(),
           publicKey.makeOldModel<PublicKey::OldPublicKeyType>(),
           signedData.makeOldModel<Signed::OldSignatureType>());
     }

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
@@ -24,7 +24,7 @@ namespace shared_model {
                           const Blob &orig,
                           const PublicKey &publicKey) {
       return iroha::verify(
-          orig.str(),
+          crypto::toBinaryString(orig),
           publicKey.makeOldModel<PublicKey::OldPublicKeyType>(),
           signedData.makeOldModel<Signed::OldSignatureType>());
     }

--- a/shared_model/cryptography/public_key.hpp
+++ b/shared_model/cryptography/public_key.hpp
@@ -39,7 +39,9 @@ namespace shared_model {
             .finalize();
       }
 
-      PublicKey *copy() const override { return new PublicKey(str()); }
+      PublicKey *copy() const override {
+        return new PublicKey(crypto::toBinaryString(*this));
+      }
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/public_key.hpp
+++ b/shared_model/cryptography/public_key.hpp
@@ -39,9 +39,7 @@ namespace shared_model {
             .finalize();
       }
 
-      PublicKey *copy() const override {
-        return new PublicKey(blob());
-      }
+      PublicKey *copy() const override { return new PublicKey(str()); }
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/interfaces/transaction_responses/tx_response.hpp
+++ b/shared_model/interfaces/transaction_responses/tx_response.hpp
@@ -75,7 +75,7 @@ namespace shared_model {
       OldModelType *makeOldModel() const override {
         auto response = boost::apply_visitor(
             detail::OldModelCreatorVisitor<OldModelType *>(), get());
-        response->tx_hash = transactionHash().blob();
+        response->tx_hash = transactionHash().str();
         return response;
       }
 

--- a/shared_model/interfaces/transaction_responses/tx_response.hpp
+++ b/shared_model/interfaces/transaction_responses/tx_response.hpp
@@ -75,7 +75,7 @@ namespace shared_model {
       OldModelType *makeOldModel() const override {
         auto response = boost::apply_visitor(
             detail::OldModelCreatorVisitor<OldModelType *>(), get());
-        response->tx_hash = transactionHash().str();
+        response->tx_hash = crypto::toBinaryString(transactionHash());
         return response;
       }
 

--- a/shared_model/utils/polymorphic_wrapper.hpp
+++ b/shared_model/utils/polymorphic_wrapper.hpp
@@ -123,7 +123,7 @@ namespace shared_model {
     };
 
     template <class T, class... Args>
-    PolymorphicWrapper<T> make_polymorphic(Args &&... args) {
+    PolymorphicWrapper<T> makePolymorphic(Args &&... args) {
       return PolymorphicWrapper<T>(
           std::make_shared<T>(std::forward<Args>(args)...));
     }

--- a/test/module/shared_model/backend_proto/CMakeLists.txt
+++ b/test/module/shared_model/backend_proto/CMakeLists.txt
@@ -53,3 +53,10 @@ target_link_libraries(shared_proto_query_responses_test
     shared_model_proto_backend
     shared_model_ed25519_sha3
     )
+
+addtest(shared_proto_util_test
+    shared_proto_util_test.cpp
+    )
+target_link_libraries(shared_proto_util_test
+    shared_model_proto_backend
+    )

--- a/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
@@ -70,8 +70,8 @@ TEST(ProtoQueryBuilder, Builder) {
       keypair);
 
   auto sig = proto_query.mutable_signature();
-  sig->set_pubkey(keypair.publicKey().blob());
-  sig->set_signature(signedProto.blob());
+  sig->set_pubkey(keypair.publicKey().str());
+  sig->set_signature(signedProto.str());
 
   auto query = shared_model::proto::QueryBuilder()
                    .createdTime(created_time)

--- a/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
@@ -70,8 +70,8 @@ TEST(ProtoQueryBuilder, Builder) {
       keypair);
 
   auto sig = proto_query.mutable_signature();
-  sig->set_pubkey(keypair.publicKey().str());
-  sig->set_signature(signedProto.str());
+  sig->set_pubkey(shared_model::crypto::toBinaryString(keypair.publicKey()));
+  sig->set_signature(shared_model::crypto::toBinaryString(signedProto));
 
   auto query = shared_model::proto::QueryBuilder()
                    .createdTime(created_time)

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -94,8 +94,8 @@ TEST(ProtoTransaction, Builder) {
       keypair);
 
   auto sig = proto_tx.add_signature();
-  sig->set_pubkey(keypair.publicKey().str());
-  sig->set_signature(signedProto.str());
+  sig->set_pubkey(shared_model::crypto::toBinaryString(keypair.publicKey()));
+  sig->set_signature(shared_model::crypto::toBinaryString(signedProto));
 
   auto tx = shared_model::proto::TransactionBuilder()
                 .txCounter(tx_counter)

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -94,8 +94,8 @@ TEST(ProtoTransaction, Builder) {
       keypair);
 
   auto sig = proto_tx.add_signature();
-  sig->set_pubkey(keypair.publicKey().blob());
-  sig->set_signature(signedProto.blob());
+  sig->set_pubkey(keypair.publicKey().str());
+  sig->set_signature(signedProto.str());
 
   auto tx = shared_model::proto::TransactionBuilder()
                 .txCounter(tx_counter)

--- a/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
@@ -22,6 +22,7 @@
 
 using namespace iroha;
 using namespace shared_model::proto;
+using shared_model::crypto::toBinaryString;
 
 /**
  * @given some protobuf object
@@ -33,6 +34,6 @@ TEST(UtilTest, StringFromMakeBlob) {
   base.set_created_time(100);
   auto blob = make_blob(base);
 
-  ASSERT_TRUE(deserialized.ParseFromString(blob.str()));
+  ASSERT_TRUE(deserialized.ParseFromString(toBinaryString(blob)));
   ASSERT_EQ(deserialized.created_time(), base.created_time());
 }

--- a/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
@@ -32,7 +32,7 @@ using shared_model::crypto::toBinaryString;
 TEST(UtilTest, StringFromMakeBlob) {
   protocol::Header base, deserialized;
   base.set_created_time(100);
-  auto blob = make_blob(base);
+  auto blob = makeBlob(base);
 
   ASSERT_TRUE(deserialized.ParseFromString(toBinaryString(blob)));
   ASSERT_EQ(deserialized.created_time(), base.created_time());

--- a/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_util_test.cpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/protobuf/util.hpp"
+#include "block.pb.h"
+
+#include <gtest/gtest.h>
+
+using namespace iroha;
+using namespace shared_model::proto;
+
+/**
+ * @given some protobuf object
+ * @when making a blob from it
+ * @then make sure that the deserialized from string is the same
+ */
+TEST(UtilTest, StringFromMakeBlob) {
+  protocol::Header base, deserialized;
+  base.set_created_time(100);
+  auto blob = make_blob(base);
+
+  ASSERT_TRUE(deserialized.ParseFromString(blob.str()));
+  ASSERT_EQ(deserialized.created_time(), base.created_time());
+}

--- a/test/module/shared_model/cryptography/blob_test.cpp
+++ b/test/module/shared_model/cryptography/blob_test.cpp
@@ -19,8 +19,9 @@
 #include <gtest/gtest.h>
 
 using namespace shared_model::crypto;
+using namespace std::literals::string_literals;
 
-auto data = "Hello World";
+auto data = "Hello \0World"s;
 
 /**
  * @given arbitrary string and known its hex representation
@@ -30,7 +31,7 @@ auto data = "Hello World";
 TEST(BlobTest, HexConversionTest) {
   Blob blob(data);
   auto hex = blob.hex();
-  ASSERT_EQ("48656c6c6f20576f726c64", hex);
+  ASSERT_EQ("48656c6c6f2000576f726c64", hex);
 }
 
 /**

--- a/test/module/shared_model/cryptography/blob_test.cpp
+++ b/test/module/shared_model/cryptography/blob_test.cpp
@@ -41,12 +41,12 @@ TEST(BlobTest, HexConversionTest) {
  */
 TEST(BlobTest, BlobIsString) {
   Blob blob(data);
-  auto str = blob.str();
+  auto bin_str = toBinaryString(blob);
   auto binary = blob.blob();
   size_t sz = binary.size();
 
-  ASSERT_EQ(str.size(), sz);
+  ASSERT_EQ(bin_str.size(), sz);
   for (size_t i = 0; i < sz; ++i) {
-    ASSERT_EQ(binary[i], str[i]);
+    ASSERT_EQ(binary[i], bin_str[i]);
   }
 }

--- a/test/module/shared_model/cryptography/blob_test.cpp
+++ b/test/module/shared_model/cryptography/blob_test.cpp
@@ -15,19 +15,37 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
 #include "cryptography/blob.hpp"
+#include <gtest/gtest.h>
 
 using namespace shared_model::crypto;
+
+auto data = "Hello World";
 
 /**
  * @given arbitrary string and known its hex representation
  * @when conversion of this string to hex is done
  * @then conversion is done right
  */
-TEST(BlobTest, HexConversionTest){
-  auto data = "Hello World";
+TEST(BlobTest, HexConversionTest) {
   Blob blob(data);
   auto hex = blob.hex();
   ASSERT_EQ("48656c6c6f20576f726c64", hex);
+}
+
+/**
+ * @given arbitrary string
+ * @when making a blob from it
+ * @then make sure that the blob's blob stores the same data as string
+ */
+TEST(BlobTest, BlobIsString) {
+  Blob blob(data);
+  auto str = blob.str();
+  auto binary = blob.blob();
+  size_t sz = binary.size();
+
+  ASSERT_EQ(str.size(), sz);
+  for (size_t i = 0; i < sz; ++i) {
+    ASSERT_EQ(binary[i], str[i]);
+  }
 }

--- a/test/module/shared_model/cryptography/blob_test.cpp
+++ b/test/module/shared_model/cryptography/blob_test.cpp
@@ -17,21 +17,25 @@
 
 #include "cryptography/blob.hpp"
 #include <gtest/gtest.h>
+#include <memory>
 
 using namespace shared_model::crypto;
 using namespace std::literals::string_literals;
 
-auto data = "Hello \0World"s;
+class BlobMock : public ::testing::Test {
+ public:
+  void SetUp() override { blob = std::make_shared<Blob>(data); }
+  std::shared_ptr<Blob> blob;
+  std::string data = "Hello \0World"s;
+};
 
 /**
  * @given arbitrary string and known its hex representation
  * @when conversion of this string to hex is done
  * @then conversion is done right
  */
-TEST(BlobTest, HexConversionTest) {
-  Blob blob(data);
-  auto hex = blob.hex();
-  ASSERT_EQ("48656c6c6f2000576f726c64", hex);
+TEST_F(BlobMock, HexConversionTest) {
+  ASSERT_EQ("48656c6c6f2000576f726c64", blob->hex());
 }
 
 /**
@@ -39,10 +43,9 @@ TEST(BlobTest, HexConversionTest) {
  * @when making a blob from it
  * @then make sure that the blob's blob stores the same data as string
  */
-TEST(BlobTest, BlobIsString) {
-  Blob blob(data);
-  auto bin_str = toBinaryString(blob);
-  auto binary = blob.blob();
+TEST_F(BlobMock, BlobIsString) {
+  auto bin_str = toBinaryString(*blob);
+  auto binary = blob->blob();
   size_t sz = binary.size();
 
   ASSERT_EQ(bin_str.size(), sz);

--- a/test/module/shared_model/validators/commands_validator_test.cpp
+++ b/test/module/shared_model/validators/commands_validator_test.cpp
@@ -49,7 +49,7 @@ TEST(commandsValidatorTest, EmptyTransactionTest) {
   tx.mutable_payload()->set_created_time(iroha::time::now());
   shared_model::validation::CommandsValidator commands_validator;
   auto answer = commands_validator.validate(
-      detail::make_polymorphic<proto::Transaction>(tx));
+      detail::makePolymorphic<proto::Transaction>(tx));
   ASSERT_EQ(answer.getReasonsMap().size(), 1);
 }
 
@@ -96,9 +96,9 @@ TEST(CommandsValidatorTest, StatelessValidTest) {
   auto setEnum = setField(&google::protobuf::Reflection::SetEnumValue);
 
   // List all used fields in commands
-  std::unordered_map<std::string,
-                     std::function<void(
-                         const google::protobuf::Reflection *,
+  std::unordered_map<
+      std::string,
+      std::function<void(const google::protobuf::Reflection *,
                          google::protobuf::Message *,
                          const google::protobuf::FieldDescriptor *)>>
       field_setters;
@@ -156,7 +156,7 @@ TEST(CommandsValidatorTest, StatelessValidTest) {
 
   shared_model::validation::CommandsValidator commands_validator;
   auto answer = commands_validator.validate(
-      detail::make_polymorphic<proto::Transaction>(tx));
+      detail::makePolymorphic<proto::Transaction>(tx));
 
   ASSERT_FALSE(answer.hasErrors());
 }
@@ -186,7 +186,7 @@ TEST(CommandsValidatorTest, StatelessInvalidTest) {
 
   shared_model::validation::CommandsValidator commands_validator;
   auto answer = commands_validator.validate(
-      detail::make_polymorphic<proto::Transaction>(tx));
+      detail::makePolymorphic<proto::Transaction>(tx));
 
   // in total there should be number_of_commands + 1 reasons of bad answer:
   // number_of_commands for each command + 1 for transaction metadata


### PR DESCRIPTION
## What is this pull request?
This pr is changes the iterface of `Blob::blob()` from `std::string` to `std::vector<uint8_t>`

## Why do you implement it? Why do we need this pull request?
There're issues with the swig string conversions, binary data is basically converted incorrectly


Also note, that this way is more or less bad in terms of efficiency (there's can be redundant copies in debug builds). I think it should be optimized: all binary data should be stored in the `std::vector<uint8_t>`. But that requires significant amount of work, so maybe there's some better approaches