### PR TITLE
Feature/swig csharp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(PACKAGE_DEB  "Create DEB package"             OFF)
 option(ENABLE_LIBS_PACKAGING "Enable libs packaging" ON)
 option(SWIG_PYTHON  "Generate Swig Python bindings"  OFF)
 option(SWIG_JAVA    "Generate Swig Java bindings"    OFF)
+option(SWIG_CSHARP  "Generate Swig C# bindings"      OFF)
 
 if (NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Debug)
@@ -57,6 +58,7 @@ message(STATUS "-DPACKAGE_DEB=${PACKAGE_DEB}")
 message(STATUS "-DENABLE_LIBS_PACKAGING=${ENABLE_LIBS_PACKAGING}")
 message(STATUS "-DSWIG_PYTHON=${SWIG_PYTHON}")
 message(STATUS "-DSWIG_JAVA=${SWIG_JAVA}")
+message(STATUS "-DSWIG_CSHARP=${SWIG_CSHARP}")
 
 SET(IROHA_SCHEMA_DIR "${PROJECT_SOURCE_DIR}/schema")
 include_directories(

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(bindings
 
 
 
-if (SWIG_PYTHON OR SWIG_JAVA)
+if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP)
     find_package(SWIG 3.0.12 REQUIRED)
     include(${SWIG_USE_FILE})
 
@@ -57,4 +57,9 @@ if (SWIG_JAVA)
 
     swig_add_library(iroha LANGUAGE java SOURCES bindings.i)
     swig_link_libraries(iroha ${Java_LIBRARIES} bindings)
+endif()
+
+if (SWIG_CSHARP)
+    swig_add_library(libirohacs LANGUAGE csharp SOURCES bindings.i)
+    swig_link_libraries(libirohacs bindings)
 endif()


### PR DESCRIPTION
## What is this pull request?
Bindings for C#.
   
## Why do you implement it? Why do we need this pull request?
Mostly for usage with Xamarin but it's completely up to user.
  
## How to use the features provided in the pull request?
Build with cmake -DSWIG_CSHARP=ON option. Then you can use this example:
```
using System;
public class test {
    static void Main() {
        ModelTransactionBuilder builder = new ModelTransactionBuilder();
    	  ModelCrypto crypto = new ModelCrypto();
    	  Keypair me_kp = crypto.generateKeypair();
    	  Keypair peer_kp = crypto.generateKeypair();

    	  ulong time = 1513786459561;
    	  ulong startCounter = 1;
    	  String creator = "me@iroha";

    	  UnsignedTx utx = builder.txCounter(startCounter).creatorAccountId(creator).createdTime(time).addPeer("127.0.0.255", peer_kp.publicKey()).build();

    	  ModelProtoTransaction protoHelper = new ModelProtoTransaction();
      	Console.WriteLine(protoHelper.signAndAddSignature(utx, me_kp).toString());
     }
 }
 ```
Save as <anyname>.cs. Then go to build/shared_model/bindings and execute next commands:
```
mcs *.cs -out:test.exe
mono test.exe
```
Expected output should be something like that:
```
Blob: [0a460a31122f0a0b3132372e302e302e32353512209c1d900fa2d3d0f8000d083c172729ef3ece283164aec4c79acdc467fc0639fa12086d654069726f6861180120a98bd1a5872c12640a2015dbaf8e3a57869ff26fc1317c9ba79ca8fe5c831a1ab3840fd263d3a405bbbe12403aecb6f8f1ca860f3413e175ac610155cfec738922e219615a830b7f720f146e6039ff03308e14d1792c21d8379c9c8b18a9271b757eecbb16b11af364c99c0d ]
```
