### PR TITLE
Fixing redis dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,8 +281,8 @@ jobs:
             - ~/.ccache
       - restore_cache:
           keys:
-            - external-{{ arch }}-{{ .Branch }}
-            - external-{{ arch }}
+            - v0-external-{{ arch }}-{{ .Branch }}
+            - v0-external-{{ arch }}
           paths:
             - external
       - run:
@@ -315,7 +315,7 @@ jobs:
           paths:
             - ~/.ccache
       - save_cache:
-          key: external-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: v0-external-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - external
       - run: ccache --show-stats

--- a/cmake/Modules/Findcpp_redis.cmake
+++ b/cmake/Modules/Findcpp_redis.cmake
@@ -7,7 +7,7 @@ find_library(cpp_redis_LIBRARY cpp_redis)
 mark_as_advanced(cpp_redis_LIBRARY)
 
 find_library(tacopie_LIBRARY tacopie)
-mark_as_advanced(cpp_redis_LIBRARY)
+mark_as_advanced(tacopie_LIBRARY)
 
 find_package_handle_standard_args(cpp_redis DEFAULT_MSG
     cpp_redis_INCLUDE_DIR
@@ -15,50 +15,33 @@ find_package_handle_standard_args(cpp_redis DEFAULT_MSG
     tacopie_LIBRARY
     )
 
-set(URL1 https://github.com/Cylix/cpp_redis.git)
-set(VERSION1 f390eef447a62dcb6da288fb1e91f25f8a9b838c)
-set_target_description(cpp_redis "C++ redis client" ${URL1} ${VERSION1})
-
-set(URL2 https://github.com/Cylix/tacopie.git)
-set(VERSION2 4c551b8ff1c53c5fa63286371c9c884254fc9423)
-set_target_description(tacopie "C++ tcp library" ${URL2} ${VERSION2})
+set(URL https://github.com/Cylix/cpp_redis.git)
+set(VERSION f390eef447a62dcb6da288fb1e91f25f8a9b838c)
+set_target_description(cpp_redis "C++ redis client" ${URL} ${VERSION})
 
 if (NOT cpp_redis_FOUND)
   externalproject_add(cylix_cpp_redis
-      GIT_REPOSITORY ${URL1}
-      GIT_TAG        ${VERSION1}
-      CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-      BUILD_BYPRODUCTS ${EP_PREFIX}/src/cylix_cpp_redis-build/lib/libcpp_redis.a
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
+      BUILD_BYPRODUCTS
+        ${EP_PREFIX}/src/cylix_cpp_redis-build/lib/libcpp_redis.a
+        ${EP_PREFIX}/src/cylix_cpp_redis-build/lib/libtacopie.a
       INSTALL_COMMAND "" # remove install step
       UPDATE_COMMAND "" # remove update step
       TEST_COMMAND "" # remove test step
       )
   externalproject_get_property(cylix_cpp_redis source_dir binary_dir)
-  set(tacopie_SOURCE_DIR ${source_dir}/tacopie)
-  set(cpp_redis_INCLUDE_DIR ${source_dir}/includes)
+  set(cpp_redis_INCLUDE_DIRS "${source_dir}/tacopie/includes;${source_dir}/includes")
   set(cpp_redis_LIBRARY ${binary_dir}/lib/libcpp_redis.a)
   set(tacopie_LIBRARY ${binary_dir}/lib/libtacopie.a)
-  file(MAKE_DIRECTORY ${cpp_redis_INCLUDE_DIR})
+  file(MAKE_DIRECTORY ${source_dir}/tacopie/includes)
+  file(MAKE_DIRECTORY ${source_dir}/includes)
 
-  externalproject_add(cylix_tacopie
-      GIT_REPOSITORY  ${URL2}
-      GIT_TAG         ${VERSION2}
-      SOURCE_DIR ${tacopie_SOURCE_DIR}
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      BUILD_BYPRODUCTS ${EP_PREFIX}/src/cylix_cpp_redis-build/lib/libtacopie.a
-      INSTALL_COMMAND "" # remove install step
-      UPDATE_COMMAND "" # remove update step
-      TEST_COMMAND "" # remove test step
-      )
-
-  add_dependencies(cylix_cpp_redis cylix_tacopie)
   add_dependencies(cpp_redis cylix_cpp_redis)
 endif ()
 
 set_target_properties(cpp_redis PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES ${cpp_redis_INCLUDE_DIR}
+    INTERFACE_INCLUDE_DIRECTORIES "${cpp_redis_INCLUDE_DIRS}"
     IMPORTED_LOCATION ${cpp_redis_LIBRARY}
-    INTERFACE_LINK_LIBRARIES "${tacopie_LIBRARY};pthread"
+    INTERFACE_LINK_LIBRARIES "${tacopie_LIBRARY}"
     )

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -134,13 +134,10 @@ RUN git clone https://github.com/jtv/libpqxx /tmp/libpqxx; \
     make -C /tmp/libpqxx install; \
     rm -rf /tmp/libpqxx
 
-# install cpp_redis with tacopie
+# install cpp_redis 4.3.0
 RUN git clone https://github.com/Cylix/cpp_redis /tmp/cpp_redis; \
-    # v4.3.0
     (cd /tmp/cpp_redis ; git checkout f390eef447a62dcb6da288fb1e91f25f8a9b838c); \
-    git clone https://github.com/Cylix/tacopie /tmp/cpp_redis/tacopie; \
-     # v3.2.0
-    (cd /tmp/cpp_redis/tacopie ; git checkout 4c551b8ff1c53c5fa63286371c9c884254fc9423); \
+    (cd /tmp/cpp_redis ; git submodule update --init --recursive); \
     cmake -H/tmp/cpp_redis -B/tmp/cpp_redis/build; \
     cmake --build /tmp/cpp_redis/build --target install -- -j${PARALLELISM}; \
     rm -rf /tmp/cpp_redis


### PR DESCRIPTION
Mac's CI fails to build redis due to the include dir absence

This also set tacopie as the submodule