### PR TITLE
Sign everything with preliminary hashing

### DIFF
--- a/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
@@ -17,13 +17,14 @@
 
 #include "cryptography/ed25519_sha3_impl/signer.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
+#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 
 namespace shared_model {
   namespace crypto {
     Signed Signer::sign(const Blob &blob, const Keypair &keypair) {
       return Signed(
           iroha::sign(
-              crypto::toBinaryString(blob),
+              iroha::sha3_256(crypto::toBinaryString(blob)).to_string(),
               keypair.publicKey().makeOldModel<PublicKey::OldPublicKeyType>(),
               keypair.privateKey()
                   .makeOldModel<PrivateKey::OldPrivateKeyType>())

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
@@ -17,6 +17,7 @@
 
 #include "verifier.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
+#include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 
 namespace shared_model {
   namespace crypto {
@@ -24,7 +25,7 @@ namespace shared_model {
                           const Blob &orig,
                           const PublicKey &publicKey) {
       return iroha::verify(
-          crypto::toBinaryString(orig),
+          iroha::sha3_256(crypto::toBinaryString(orig)).to_string(),
           publicKey.makeOldModel<PublicKey::OldPublicKeyType>(),
           signedData.makeOldModel<Signed::OldSignatureType>());
     }


### PR DESCRIPTION
## What is this pull request?
Signing and verifying objects with preliminary hashing.
   
## Why do you implement it? Why do we need this pull request?
Old model uses hashing while new one does not. We should do the same approach in both.
  
## How to use the features provided in the pull request?
```
import iroha

import time
import block_pb2
import endpoint_pb2_grpc
import grpc

txbuilder = iroha.ModelTransactionBuilder()
queryBuilder = iroha.ModelQueryBuilder()
crypto = iroha.ModelCrypto()
protoTxHelper = iroha.ModelProtoTransaction()
protoQueryHelper = iroha.ModelProtoQuery()

me_kp = crypto.convertFromExisting("227a458045f8d7d520907fb400461ae3c9101a68af2851d56a85b96fd791911a", "1011098aebf697597a59151a0ba1bb34bcf081f5195fa8de551b9a2b52be864613aae9771f35df7318e0d7b8571f043cd54581a0b1c5cf36fb05ac8956d291fe")

print(me_kp.publicKey().hex())

peer_kp = crypto.generateKeypair()
signatory_kp = crypto.generateKeypair()
account_kp = crypto.generateKeypair()
time = int(round(time.time() * 1000))
startCounter = 1
creator = "me@iroha"
signatory = "fyodor@iroha"


tx = txbuilder.creatorAccountId(creator)\
    .createdTime(time)\
    .createDomain("ru", "user").build()

tx_blob = protoTxHelper.signAndAddSignature(tx, me_kp).blob()

proto_tx = block_pb2.Transaction()
proto_tx.ParseFromString(''.join(map(chr, tx_blob)))

channel = grpc.insecure_channel('127.0.0.1:50051')
stub = endpoint_pb2_grpc.CommandServiceStub(channel)

stub.Torii(proto_tx)

print("done!")
```
