### PR TITLE
Use static linking for ed25519 library

### DIFF
--- a/cmake/Modules/Finded25519.cmake
+++ b/cmake/Modules/Finded25519.cmake
@@ -29,6 +29,7 @@ if (NOT ed25519_FOUND)
   set(ed25519_INCLUDE_DIR ${source_dir}/include)
   set(ed25519_LIBRARY ${binary_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}ed25519${CMAKE_SHARED_LIBRARY_SUFFIX})
   file(MAKE_DIRECTORY ${ed25519_INCLUDE_DIR})
+  link_directories(${binary_dir})
 
   add_dependencies(ed25519 warchant_ed25519)
 endif ()


### PR DESCRIPTION
## What is this pull request?
Ed25519 library is statically linked.
   
## Why do you implement it? Why do we need this pull request?
I've got a problem with new crypto library (I hope somebody else could also check it). Scenario is pretty simple:
1. Checkout actual develop branch.
2. Do clean.sh to ensure everything was cleaned.
3. Run cmake && make
This sequence gives me a stable problem when I try to run tests (or irohad, doesn't matter):
```
➜  build git:(develop) ctest
Test project /Users/konstantinmunichev/src/iroha/build
      Start  1: blob_converter_test
 1/77 Test  #1: blob_converter_test ....................   Passed    0.01 sec
      Start  2: block_insertion_test
 2/77 Test  #2: block_insertion_test ...................***Exception: Child aborted  0.01 sec
      Start  3: ametsuchi_test
 3/77 Test  #3: ametsuchi_test .........................***Exception: Child aborted  0.00 sec
.....
18% tests passed, 63 tests failed out of 77
```
The problem is ed25519 library (just an example):
```
➜  build git:(develop) test_bin/cache_test
dyld: Library not loaded: @rpath/libed25519.1.2.2.dylib
  Referenced from: /Users/konstantinmunichev/src/iroha/build/test_bin/cache_test
  Reason: image not found
```
The most interesting in this story is that rerunning build fixes the problem (e. g. touch CMakeLists.txt && make). Looks like shared lib wasn't created on the first passthrough but it actually did.

Looks like it should be fixed by setting rpath for this lib explicitly bit I tried and without success.