### PR TITLE
Add handling of empty query to load_query

### DIFF
--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -40,6 +40,9 @@
 
 template <typename... T, typename Archive>
 shared_model::interface::Query::QueryVariantType load_query(Archive &&ar) {
+  if (not ar.has_payload()) {
+    throw std::invalid_argument("Query missing payload");
+  }
   int which = ar.payload()
                   .GetDescriptor()
                   ->FindFieldByNumber(ar.payload().query_case())

--- a/test/module/shared_model/bindings/CMakeLists.txt
+++ b/test/module/shared_model/bindings/CMakeLists.txt
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+addtest(model_query_builder_test
+    model_query_builder_test.cpp
+    )
+target_link_libraries(model_query_builder_test
+    bindings
+    )
+
 if (SWIG_PYTHON OR SWIG_JAVA)
   get_property(SWIG_BUILD_DIR GLOBAL PROPERTY SWIG_BUILD_DIR)
 endif()

--- a/test/module/shared_model/bindings/model_query_builder_test.cpp
+++ b/test/module/shared_model/bindings/model_query_builder_test.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings/model_query_builder.hpp"
+
+#include <gtest/gtest.h>
+
+/**
+ * @given Model transaction builder
+ * @when build() is called on builder without set fields
+ * @then Exception is thrown
+ */
+TEST(ModelQueryBuilderTest, EmptyBuilder) {
+  auto query = shared_model::bindings::ModelQueryBuilder();
+
+  EXPECT_ANY_THROW(query.build());
+}


### PR DESCRIPTION
Calling build on empty simple query builder resulted in segmentation fault due to access to null pointer. This PR adds handling of such case by throwing an exception if query payload is not set.