### PR TITLE
Improve bindings interface

### DIFF
--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -43,6 +43,10 @@ shared_model::interface::Query::QueryVariantType load_query(Archive &&ar) {
   if (not ar.has_payload()) {
     throw std::invalid_argument("Query missing payload");
   }
+  if (ar.payload().query_case()
+      == iroha::protocol::Query_Payload::QueryCase::QUERY_NOT_SET) {
+    throw std::invalid_argument("Missing concrete query");
+  }
   int which = ar.payload()
                   .GetDescriptor()
                   ->FindFieldByNumber(ar.payload().query_case())
@@ -101,7 +105,9 @@ namespace shared_model {
 
       Query(Query &&o) noexcept : Query(std::move(o.proto_)) {}
 
-      const Query::QueryVariantType &get() const override { return *variant_; }
+      const Query::QueryVariantType &get() const override {
+        return *variant_;
+      }
 
       const interface::types::AccountIdType &creatorAccountId() const override {
         return proto_->payload().creator_account_id();
@@ -111,9 +117,13 @@ namespace shared_model {
         return proto_->payload().query_counter();
       }
 
-      const Query::BlobType &blob() const override { return *blob_; }
+      const Query::BlobType &blob() const override {
+        return *blob_;
+      }
 
-      const Query::BlobType &payload() const override { return *payload_; }
+      const Query::BlobType &payload() const override {
+        return *payload_;
+      }
 
       // ------------------------| Signable override  |-------------------------
       const Query::SignatureSetType &signatures() const override {

--- a/shared_model/bindings/model_query_builder.cpp
+++ b/shared_model/bindings/model_query_builder.cpp
@@ -19,12 +19,8 @@
 
 namespace shared_model {
   namespace bindings {
-    void ModelQueryBuilder::setDefaultValues() {
-      *this = creatorAccountId("").createdTime(0).queryCounter(0);
-    }
-
     ModelQueryBuilder::ModelQueryBuilder() {
-      setDefaultValues();
+      *this = creatorAccountId("").createdTime(0).queryCounter(0);
     }
 
     ModelQueryBuilder ModelQueryBuilder::createdTime(

--- a/shared_model/bindings/model_query_builder.cpp
+++ b/shared_model/bindings/model_query_builder.cpp
@@ -19,6 +19,14 @@
 
 namespace shared_model {
   namespace bindings {
+    void ModelQueryBuilder::setDefaultValues() {
+      *this = creatorAccountId("").createdTime(0).queryCounter(0);
+    }
+
+    ModelQueryBuilder::ModelQueryBuilder() {
+      setDefaultValues();
+    }
+
     ModelQueryBuilder ModelQueryBuilder::createdTime(
         interface::types::TimestampType created_time) {
       return ModelQueryBuilder(builder_.createdTime(created_time));

--- a/shared_model/bindings/model_query_builder.hpp
+++ b/shared_model/bindings/model_query_builder.hpp
@@ -33,8 +33,6 @@ namespace shared_model {
       explicit ModelQueryBuilder(const proto::TemplateQueryBuilder<Sp> &o)
           : builder_(o) {}
 
-      void setDefaultValues();
-
      public:
       ModelQueryBuilder();
 

--- a/shared_model/bindings/model_query_builder.hpp
+++ b/shared_model/bindings/model_query_builder.hpp
@@ -33,8 +33,10 @@ namespace shared_model {
       explicit ModelQueryBuilder(const proto::TemplateQueryBuilder<Sp> &o)
           : builder_(o) {}
 
+      void setDefaultValues();
+
      public:
-      ModelQueryBuilder() = default;
+      ModelQueryBuilder();
 
       /**
        * Sets time of query creation (Unix time in milliseconds)

--- a/shared_model/bindings/model_transaction_builder.cpp
+++ b/shared_model/bindings/model_transaction_builder.cpp
@@ -19,6 +19,14 @@
 
 namespace shared_model {
   namespace bindings {
+    void ModelTransactionBuilder::setDefaultValues() {
+      *this = creatorAccountId("").createdTime(0).txCounter(0);
+    }
+
+    ModelTransactionBuilder::ModelTransactionBuilder() {
+      setDefaultValues();
+    }
+
     ModelTransactionBuilder ModelTransactionBuilder::creatorAccountId(
         const interface::types::AccountIdType &account_id) {
       return ModelTransactionBuilder(builder_.creatorAccountId(account_id));

--- a/shared_model/bindings/model_transaction_builder.cpp
+++ b/shared_model/bindings/model_transaction_builder.cpp
@@ -19,12 +19,8 @@
 
 namespace shared_model {
   namespace bindings {
-    void ModelTransactionBuilder::setDefaultValues() {
-      *this = creatorAccountId("").createdTime(0).txCounter(0);
-    }
-
     ModelTransactionBuilder::ModelTransactionBuilder() {
-      setDefaultValues();
+      *this = creatorAccountId("").createdTime(0).txCounter(0);
     }
 
     ModelTransactionBuilder ModelTransactionBuilder::creatorAccountId(

--- a/shared_model/bindings/model_transaction_builder.hpp
+++ b/shared_model/bindings/model_transaction_builder.hpp
@@ -35,8 +35,6 @@ namespace shared_model {
           const proto::TemplateTransactionBuilder<Sp> &o)
           : builder_(o) {}
 
-      void setDefaultValues();
-
      public:
       ModelTransactionBuilder();
 

--- a/shared_model/bindings/model_transaction_builder.hpp
+++ b/shared_model/bindings/model_transaction_builder.hpp
@@ -35,8 +35,10 @@ namespace shared_model {
           const proto::TemplateTransactionBuilder<Sp> &o)
           : builder_(o) {}
 
+      void setDefaultValues();
+
      public:
-      ModelTransactionBuilder() = default;
+      ModelTransactionBuilder();
 
       /**
        * Sets id of account creator

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -164,15 +164,21 @@ namespace shared_model {
           reason.second.push_back(boost::str(
               boost::format(
                   "timestamp broken: send from future (%llu, now %llu)")
-              % timestamp
-              % now));
+              % timestamp % now));
         }
 
         if (now - timestamp > MAX_DELAY) {
           reason.second.push_back(boost::str(
               boost::format("timestamp broken: too old (%llu, now %llu)")
-              % timestamp
-              % now));
+              % timestamp % now));
+        }
+      }
+
+      void validateCounter(ReasonsGroupType &reason,
+                           const interface::types::CounterType &counter) const {
+        if (counter == 0) {
+          reason.second.push_back(
+              boost::str(boost::format("Counter should be > 0")));
         }
       }
 

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -164,6 +164,7 @@ namespace shared_model {
         field_validator_.validateCreatorAccountId(qry_reason,
                                                   qry->creatorAccountId());
         field_validator_.validateCreatedTime(qry_reason, qry->createdTime());
+        field_validator_.validateCounter(qry_reason, qry->queryCounter());
 
         if (not qry_reason.second.empty()) {
           answer.addReason(std::move(qry_reason));

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -261,6 +261,7 @@ namespace shared_model {
         field_validator_.validateCreatorAccountId(tx_reason,
                                                   tx->creatorAccountId());
         field_validator_.validateCreatedTime(tx_reason, tx->createdTime());
+        field_validator_.validateCounter(tx_reason, tx->transactionCounter());
 
         if (not tx_reason.second.empty()) {
           answer.addReason(std::move(tx_reason));

--- a/test/module/shared_model/validators/query_validator_test.cpp
+++ b/test/module/shared_model/validators/query_validator_test.cpp
@@ -36,6 +36,7 @@ TEST_F(QueryValidatorTest, StatelessValidTest) {
   iroha::protocol::Query qry;
   qry.mutable_payload()->set_creator_account_id(valid_account_id);
   qry.mutable_payload()->set_created_time(valid_created_time);
+  qry.mutable_payload()->set_query_counter(valid_counter);
   auto payload = qry.mutable_payload();
 
   // Iterate through all query types, filling query fields with valid values

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -120,6 +120,7 @@ class ValidatorsTest : public ::testing::Test {
   }
 
   size_t public_key_size = 32, hash_size = 32;
+  uint64_t valid_counter = 1048576;
   std::string valid_account_id = "account@domain", valid_asset_name = "asset",
               valid_asset_id = "asset#domain",
               valid_address_localhost = "localhost:65535",
@@ -139,9 +140,9 @@ class ValidatorsTest : public ::testing::Test {
   decltype(iroha::time::now()) valid_created_time;
 
   // List all used fields in commands
-  std::unordered_map<std::string,
-                     std::function<void(
-                         const google::protobuf::Reflection *,
+  std::unordered_map<
+      std::string,
+      std::function<void(const google::protobuf::Reflection *,
                          google::protobuf::Message *,
                          const google::protobuf::FieldDescriptor *)>>
       field_setters;


### PR DESCRIPTION
## What is this pull request?
It solves problem when bindings users can forget to set one ore more mandatory fields for queries and transactions (like tx_counter) and still pass validation.

## Details/Features
- Add validator for query and tx counters
- Set mandatory fields for query and tx to invalid values
- Fix bug in load_query
