### PR TITLE
Cover Redis BlockQuery with tests

### DIFF
--- a/irohad/ametsuchi/impl/flat_file/flat_file.hpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.hpp
@@ -31,34 +31,6 @@ namespace iroha {
   namespace ametsuchi {
 
     /**
-     * Type of storage key
-     */
-    using Identifier = uint32_t;
-
-    /**
-     * Convert id to a string representation. The string representation is
-     * always DIGIT_CAPACITY-character width regardless of the value of `id`. If
-     * the length of the string representation of `id` is less than
-     * DIGIT_CAPACITY, then the returned value is filled with leading zeros.
-     *
-     * For example, if str_rep(`id`) is "123", then the returned value is
-     * "0000000000000123".
-     *
-     * @param id - for conversion
-     * @return string repr of identifier
-     */
-    std::string id_to_name(Identifier id);
-
-    /**
-     * Checking consistency of storage for provided folder
-     * If some block in the middle is missing all blocks following it are
-     * deleted
-     * @param dump_dir - folder of storage
-     * @return - last available identifier
-     */
-    nonstd::optional<Identifier> check_consistency(const std::string &dump_dir);
-
-    /**
      * Solid storage based on raw files
      */
     class FlatFile {
@@ -71,7 +43,26 @@ namespace iroha {
      public:
       // ----------| public API |----------
 
+      /**
+       * Type of storage key
+       */
+      using Identifier = uint32_t;
+
       static const uint32_t DIGIT_CAPACITY = 16;
+
+      /**
+       * Convert id to a string representation. The string representation is
+       * always DIGIT_CAPACITY-character width regardless of the value of `id`.
+       * If the length of the string representation of `id` is less than
+       * DIGIT_CAPACITY, then the returned value is filled with leading zeros.
+       *
+       * For example, if str_rep(`id`) is "123", then the returned value is
+       * "0000000000000123".
+       *
+       * @param id - for conversion
+       * @return string repr of identifier
+       */
+      static std::string id_to_name(Identifier id);
 
       /**
        * Create storage in paths
@@ -104,6 +95,16 @@ namespace iroha {
        * @return maximal not null key
        */
       Identifier last_id() const;
+
+      /**
+       * Checking consistency of storage for provided folder
+       * If some block in the middle is missing all blocks following it are
+       * deleted
+       * @param dump_dir - folder of storage
+       * @return - last available identifier
+       */
+      static nonstd::optional<Identifier> check_consistency(
+          const std::string &dump_dir);
 
       void dropAll();
 

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -27,12 +27,12 @@ namespace iroha {
 
     rxcpp::observable<model::Block> RedisBlockQuery::getBlocks(uint32_t height,
                                                                uint32_t count) {
-      auto to = height + count;
       auto last_id = block_store_.last_id();
-      to = std::min(to, last_id);
-      if (height > to) {
+      auto to = std::min(last_id, height + count - 1);
+      if (height > to or count == 0) {
         return rxcpp::observable<>::empty<model::Block>();
       }
+
       return rxcpp::observable<>::range(height, to).flat_map([this](auto i) {
         auto bytes = block_store_.get(i);
         return rxcpp::observable<>::create<model::Block>([this, bytes](auto s) {

--- a/irohad/ametsuchi/impl/redis_block_query.cpp
+++ b/irohad/ametsuchi/impl/redis_block_query.cpp
@@ -154,13 +154,10 @@ namespace iroha {
 
             for (auto block_id : block_ids) {
               // create key for querying redis
-              std::string account_assets_key;
-              account_assets_key.append(account_id);
-              account_assets_key.append(":");
-              account_assets_key.append(std::to_string(block_id));
-              account_assets_key.append(":");
-              account_assets_key.append(asset_id);
-              client_.lrange(account_assets_key,
+              std::stringstream account_assets_key;
+              account_assets_key << account_id << ':' << block_id << ':'
+                                 << asset_id;
+              client_.lrange(account_assets_key.str(),
                              0,
                              -1,
                              this->callbackToLrange(subscriber, block_id));

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -175,7 +175,7 @@ namespace framework {
     }
 
     /**
-     * CallExact check invariant that subscriber called exact number of timers
+     * CallExact check invariant that subscriber called exact number of times
      * @tparam T - observable parameter
      */
     template <typename T>

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -336,3 +336,22 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetBlockButItIsInvalidBlock) {
 
   ASSERT_TRUE(wrapper.validate());
 }
+
+/**
+ * @given block store with 2 blocks totally containing 3 txs created by
+ * user1@test AND 1 tx created by user2@test
+ * @when get top 2 blocks
+ * @then last 2 blocks returned with correct height
+ */
+TEST_F(BlockQueryTest, BlockQuery_GetTopBlocks) {
+  size_t blocks_n = 2; // top 2 blocks
+  auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getTopBlocks(blocks_n), blocks_n);
+
+  size_t counter = this->blocks_total - blocks_n + 1;
+  wrapper.subscribe([this, &counter](Block b) {
+    ASSERT_EQ(b.height, counter++);
+  });
+
+  ASSERT_TRUE(wrapper.validate());
+}

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -236,9 +236,6 @@ TEST_F(BlockQueryTest, GetNonExistentBlock) {
  * user1@test AND 1 tx created by user2@test
  * @when height=1, count=1
  * @then returned exactly 1 block
- *
- * @note test for bug, when <total_blocks=2, height=1, count=1>, then
- * min(1+1, 2)=2, and it reads from 1 to 2 (2 blocks).
  */
 TEST_F(BlockQueryTest, GetExactlyOneBlock) {
   auto wrapper = make_test_subscriber<CallExact>(

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -221,10 +221,10 @@ TEST_F(BlockQueryTest, GetTransactionsWithInvalidTxAndValidTx) {
 /**
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test
- * @when get non-existent 1000 block
+ * @when get non-existent 1000th block
  * @then nothing is returned
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetNonExistentBlock) {
+TEST_F(BlockQueryTest, GetNonExistentBlock) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(1000, 1), 0);
   wrapper.subscribe();
@@ -240,7 +240,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetNonExistentBlock) {
  * @note test for bug, when <total_blocks=2, height=1, count=1>, then
  * min(1+1, 2)=2, and it reads from 1 to 2 (2 blocks).
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetExactlyOneBlock) {
+TEST_F(BlockQueryTest, GetExactlyOneBlock) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(1, 1), 1);
   wrapper.subscribe();
@@ -251,9 +251,9 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetExactlyOneBlock) {
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test
  * @when count=0
- * @then returned empty block
+ * @then no blocks returned
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetCountZero) {
+TEST_F(BlockQueryTest, GetBlocks_Count0) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(1, 0), 0);
   wrapper.subscribe();
@@ -264,9 +264,9 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetCountZero) {
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test
  * @when get zero block
- * @then returned empty block
+ * @then no blocks returned
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetZeroBlock) {
+TEST_F(BlockQueryTest, GetZeroBlock) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(0, 1), 0);
   wrapper.subscribe();
@@ -279,7 +279,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetZeroBlock) {
  * @when get all blocks starting from 1
  * @then returned all blocks (2)
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetAllBlocksFrom1) {
+TEST_F(BlockQueryTest, GetBlocksFrom1) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocksFrom(1), this->blocks_total);
   size_t counter = 1;
@@ -295,9 +295,9 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetAllBlocksFrom1) {
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test. Block #1 is filled with trash data (NOT JSON).
  * @when read block #1
- * @then get no blocks / error
+ * @then get no blocks
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsNotJSON) {
+TEST_F(BlockQueryTest, GetBlockButItIsNotJSON) {
   namespace fs = boost::filesystem;
   size_t block_n = 1;
 
@@ -310,11 +310,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsNotJSON) {
 
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(block_n, 1), 0);
-  wrapper.subscribe([this, block_n](Block block) {
-    FAIL() << "should not get here"
-           << "received height " << block.height
-           << ", expected height: " << block_n;
-  });
+  wrapper.subscribe();
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -323,9 +319,9 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsNotJSON) {
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test. Block #1 is filled with trash data (NOT JSON).
  * @when read block #1
- * @then get no blocks / error
+ * @then get no blocks
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsInvalidBlock) {
+TEST_F(BlockQueryTest, GetBlockButItIsInvalidBlock) {
   namespace fs = boost::filesystem;
   size_t block_n = 1;
 
@@ -341,11 +337,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsInvalidBlock) {
 
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocks(block_n, 1), 0);
-  wrapper.subscribe([this, block_n](Block block) {
-    FAIL() << "should not get here"
-           << "received height " << block.height
-           << ", expected height: " << block_n;
-  });
+  wrapper.subscribe();
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -356,7 +348,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsInvalidBlock) {
  * @when get top 2 blocks
  * @then last 2 blocks returned with correct height
  */
-TEST_F(BlockQueryTest, BlockQuery_GetTopBlocks) {
+TEST_F(BlockQueryTest, GetTop2Blocks) {
   size_t blocks_n = 2; // top 2 blocks
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getTopBlocks(blocks_n), blocks_n);

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -283,7 +283,7 @@ TEST_F(BlockQueryTest, GetBlocksFrom1) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getBlocksFrom(1), this->blocks_total);
   size_t counter = 1;
-  wrapper.subscribe([this, &counter](Block b) {
+  wrapper.subscribe([&counter](Block b) {
     // wrapper returns blocks 1 and 2
     ASSERT_EQ(b.height, counter++)
         << "block height: " << b.height << "counter: " << counter;
@@ -354,7 +354,7 @@ TEST_F(BlockQueryTest, GetTop2Blocks) {
       blocks->getTopBlocks(blocks_n), blocks_n);
 
   size_t counter = this->blocks_total - blocks_n + 1;
-  wrapper.subscribe([this, &counter](Block b) {
+  wrapper.subscribe([&counter](Block b) {
     ASSERT_EQ(b.height, counter++);
   });
 

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -76,7 +76,7 @@ class BlockQueryTest : public AmetsuchiTest {
       file->add(b.height, iroha::stringToBytes(converters::jsonToString(
           converters::JsonBlockFactory().serialize(b))));
       index->index(b);
-      this->blocks_total++;
+      blocks_total++;
     }
   }
 
@@ -150,10 +150,10 @@ TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
     subs_cnt++;
     if (subs_cnt == 1) {
       EXPECT_TRUE(tx);
-      EXPECT_EQ(this->tx_hashes[1], iroha::hash(*tx));
+      EXPECT_EQ(tx_hashes[1], iroha::hash(*tx));
     } else {
       EXPECT_TRUE(tx);
-      EXPECT_EQ(this->tx_hashes[3], iroha::hash(*tx));
+      EXPECT_EQ(tx_hashes[3], iroha::hash(*tx));
     }
   });
   ASSERT_TRUE(wrapper.validate());
@@ -212,7 +212,7 @@ TEST_F(BlockQueryTest, GetTransactionsWithInvalidTxAndValidTx) {
       EXPECT_EQ(boost::none, tx);
     } else {
       EXPECT_TRUE(tx);
-      EXPECT_EQ(this->tx_hashes[0], iroha::hash(*tx));
+      EXPECT_EQ(tx_hashes[0], iroha::hash(*tx));
     }
   });
   ASSERT_TRUE(wrapper.validate());
@@ -281,7 +281,7 @@ TEST_F(BlockQueryTest, GetZeroBlock) {
  */
 TEST_F(BlockQueryTest, GetBlocksFrom1) {
   auto wrapper = make_test_subscriber<CallExact>(
-      blocks->getBlocksFrom(1), this->blocks_total);
+      blocks->getBlocksFrom(1), blocks_total);
   size_t counter = 1;
   wrapper.subscribe([&counter](Block b) {
     // wrapper returns blocks 1 and 2
@@ -302,7 +302,7 @@ TEST_F(BlockQueryTest, GetBlockButItIsNotJSON) {
   size_t block_n = 1;
 
   // write something that is NOT JSON to block #1
-  auto block_path = fs::path{this->block_store_path} / FlatFile::id_to_name(block_n);
+  auto block_path = fs::path{block_store_path} / FlatFile::id_to_name(block_n);
   fs::ofstream block_file(block_path);
   std::string content = R"(this is definitely not json)";
   block_file << content;
@@ -326,7 +326,7 @@ TEST_F(BlockQueryTest, GetBlockButItIsInvalidBlock) {
   size_t block_n = 1;
 
   // write bad block instead of block #1
-  auto block_path = fs::path{this->block_store_path} / FlatFile::id_to_name(block_n);
+  auto block_path = fs::path{block_store_path} / FlatFile::id_to_name(block_n);
   fs::ofstream block_file(block_path);
   std::string content = R"({
   "testcase": [],
@@ -353,7 +353,7 @@ TEST_F(BlockQueryTest, GetTop2Blocks) {
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getTopBlocks(blocks_n), blocks_n);
 
-  size_t counter = this->blocks_total - blocks_n + 1;
+  size_t counter = blocks_total - blocks_n + 1;
   wrapper.subscribe([&counter](Block b) {
     ASSERT_EQ(b.height, counter++);
   });

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -263,6 +263,19 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetCountZero) {
 /**
  * @given block store with 2 blocks totally containing 3 txs created by
  * user1@test AND 1 tx created by user2@test
+ * @when get zero block
+ * @then returned empty block
+ */
+TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetZeroBlock) {
+  auto wrapper = make_test_subscriber<CallExact>(
+      blocks->getBlocks(0, 1), 0);
+  wrapper.subscribe();
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @given block store with 2 blocks totally containing 3 txs created by
+ * user1@test AND 1 tx created by user2@test
  * @when get all blocks starting from 1
  * @then returned all blocks (2)
  */
@@ -284,7 +297,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetAllBlocksFrom1) {
  * @when read block #1
  * @then get no blocks / error
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetBlockButItIsNotJSON) {
+TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsNotJSON) {
   namespace fs = boost::filesystem;
   size_t block_n = 1;
 
@@ -312,7 +325,7 @@ TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetBlockButItIsNotJSON) {
  * @when read block #1
  * @then get no blocks / error
  */
-TEST_F(BlockQueryTest, BlockQuery_GetBlocksFrom_GetBlockButItIsInvalidBlock) {
+TEST_F(BlockQueryTest, BlockQuery_GetBlocks_GetBlockButItIsInvalidBlock) {
   namespace fs = boost::filesystem;
   size_t block_n = 1;
 

--- a/test/module/irohad/ametsuchi/flat_file_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_test.cpp
@@ -27,6 +27,7 @@
 #include "logger/logger.hpp"
 
 using namespace iroha::ametsuchi;
+using Identifier = FlatFile::Identifier;
 
 static logger::Logger log_ = logger::testLog("BlockStore");
 
@@ -138,7 +139,7 @@ TEST_F(BlStore_Test, BlockStoreInitializationFromNonemptyFolder) {
  * @then check consistency fails
  */
 TEST_F(BlStore_Test, EmptyDumpDir) {
-  auto res = check_consistency("");
+  auto res = FlatFile::check_consistency("");
   ASSERT_FALSE(res);
 }
 
@@ -180,7 +181,7 @@ TEST_F(BlStore_Test, GetDeniedBlock) {
   auto id = 1u;
   bl_store->add(id, block);
 
-  auto filename = boost::filesystem::path{block_store_path} / id_to_name(id);
+  auto filename = boost::filesystem::path{block_store_path} / FlatFile::id_to_name(id);
 
   using perms = boost::filesystem::perms;
 
@@ -200,7 +201,7 @@ TEST_F(BlStore_Test, AddExistingId) {
   auto bl_store = std::move(*store);
   auto id = 1u;
   const auto file_name =
-      boost::filesystem::path{block_store_path} / id_to_name(id);
+      boost::filesystem::path{block_store_path} / FlatFile::id_to_name(id);
   std::ofstream fout(file_name.string());
   fout.close();
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

- [x] move `check_consistency`, `Identifier`, `id_to_name` to class FlatFile as static members, instead of free members. I did this at least because I needed `id_to_name` in `FlatFile` interface.
- [x] Fix bug in https://github.com/hyperledger/iroha/blob/develop/irohad/ametsuchi/impl/redis_block_query.cpp#L30-L35 . Test for bug + description is at https://github.com/hyperledger/iroha/compare/develop...feature/cover-redis-negative-cases?expand=1#diff-c855aee60870118507c2cd5177c150eaR241
- [x] Increase coverage of `BlockQuery`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Bugfixes, increase coverage

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
None.
