### PR TITLE
Replace make with $(MAKE) in cmake

### DIFF
--- a/cmake/Modules/Findpq.cmake
+++ b/cmake/Modules/Findpq.cmake
@@ -32,7 +32,7 @@ if (NOT pq_FOUND)
       GIT_TAG         ${VERSION}
       CONFIGURE_COMMAND ./configure --without-readline
       BUILD_IN_SOURCE 1
-      BUILD_COMMAND make -C ./src/bin/pg_config && make -C ./src/interfaces/libpq
+      BUILD_COMMAND $(MAKE) -C ./src/bin/pg_config && $(MAKE) -C ./src/interfaces/libpq
       BUILD_BYPRODUCTS ${EP_PREFIX}/src/postgres_postgres/src/interfaces/libpq/libpq.a
       INSTALL_COMMAND "" # remove install step
       TEST_COMMAND "" # remove test step

--- a/cmake/Modules/Findpqxx.cmake
+++ b/cmake/Modules/Findpqxx.cmake
@@ -21,7 +21,7 @@ if (NOT pqxx_FOUND)
       GIT_TAG        ${VERSION}
       CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=${CMAKE_CXX_FLAGS} CPPFLAGS=-I${postgres_INCLUDE_DIR} PG_CONFIG=${pg_config_EXECUTABLE} ./configure --disable-documentation --with-postgres-include=${pq_INCLUDE_DIR} --with-postgres-lib=${pq_INCLUDE_DIR}
       BUILD_IN_SOURCE 1
-      BUILD_COMMAND make
+      BUILD_COMMAND $(MAKE)
       BUILD_BYPRODUCTS ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.a
                        ${EP_PREFIX}/src/jtv_libpqxx/src/libpqxx.la
                        ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.la

--- a/cmake/Modules/Findtbb.cmake
+++ b/cmake/Modules/Findtbb.cmake
@@ -22,7 +22,7 @@ if (NOT tbb_FOUND)
       GIT_REPOSITORY ${URL}
       GIT_TAG        ${VERSION}
       BUILD_IN_SOURCE 1
-      BUILD_COMMAND make tbb_build_prefix=build
+      BUILD_COMMAND $(MAKE) tbb_build_prefix=build
       BUILD_BYPRODUCTS ${EP_PREFIX}/src/01org_tbb/build/build_debug/${CMAKE_SHARED_LIBRARY_PREFIX}tbb_debug${CMAKE_SHARED_LIBRARY_SUFFIX}
                        ${EP_PREFIX}/src/01org_tbb/build/build_release/${CMAKE_SHARED_LIBRARY_PREFIX}tbb${CMAKE_SHARED_LIBRARY_SUFFIX}
       CONFIGURE_COMMAND "" # remove configure step


### PR DESCRIPTION
`make -j<n>` leads to:

```
[ 28%] Performing build step for 'jtv_libpqxx'
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```

So this fix basically replaces `make` with with `$(MAKE)` in __cmake/Modules/Find*.cmake__ files according to [this discussion](http://cmake.3232098.n2.nabble.com/How-would-I-use-parallel-make-on-ExternalProjects-td5609078.html)