### PR TITLE
Fix find_path for libpq on Ubuntu

### DIFF
--- a/cmake/Modules/Findpq.cmake
+++ b/cmake/Modules/Findpq.cmake
@@ -1,10 +1,10 @@
 add_library(pq UNKNOWN IMPORTED)
 add_executable(pg_config IMPORTED)
 
-find_path(pq_INCLUDE_DIR libpq-fe.h)
+find_path(pq_INCLUDE_DIR libpq-fe.h PATH_SUFFIXES postgresql)
 mark_as_advanced(pq_INCLUDE_DIR)
 
-find_path(postgres_INCLUDE_DIR postgres_ext.h)
+find_path(postgres_INCLUDE_DIR postgres_ext.h PATH_SUFFIXES postgresql)
 mark_as_advanced(postgres_INCLUDE_DIR)
 
 find_library(pq_LIBRARY pq)


### PR DESCRIPTION
### Description of the Change
Add additional subdirectory search for find_path in Findpq.cmake
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Enables usage of libpq-dev installed by apt in Ubuntu.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
