### PR TITLE
IR-652 Replace nonstd::optional with boost::variant in StorageResult

### DIFF
--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "consensus/yac/yac.hpp"
+#include "common/inplace_visitor.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -136,7 +137,9 @@ namespace iroha {
         }
       }
 
-      void Yac::closeRound() { timer_->deny(); }
+      void Yac::closeRound() {
+        timer_->deny();
+      }
 
       nonstd::optional<model::Peer> Yac::findPeer(const VoteMessage &vote) {
         auto peers = cluster_order_.getPeers();
@@ -157,15 +160,15 @@ namespace iroha {
           auto proposal_hash = getProposalHash(commit.votes).value();
           auto already_processed =
               vote_storage_.getProcessingState(proposal_hash);
-
           if (not already_processed) {
-            answer.commit | [&](const auto &commit) {
-              notifier_.get_subscriber().on_next(commit);
-            };
-            answer.reject | [&](const auto &reject) {
-              log_->warn("reject case");
-              // TODO 14/08/17 Muratov: work on reject case IR-497
-            };
+            visit_in_place(answer.result,
+                           [&](const CommitMessage &commit) {
+                             notifier_.get_subscriber().on_next(commit);
+                           },
+                           [&](const RejectMessage &reject) {
+                             log_->warn("reject case");
+                             // TODO 14/08/17 Muratov: work on reject case IR-497
+                           });
             vote_storage_.markAsProcessedState(proposal_hash);
           }
           this->closeRound();
@@ -199,37 +202,38 @@ namespace iroha {
               vote_storage_.getProcessingState(proposal_hash);
 
           if (not already_processed) {
-            answer.commit | [&](const auto &commit) {
-              // propagate for all
-
-              log_->info("Propagate commit {} to whole network",
-                         vote.hash.block_hash);
-
-              this->propagateCommit(commit);
-            };
-            answer.reject | [&](const auto &reject) {
-              log_->info("Reject case on hash {} achieved", proposal_hash);
-
-              // propagate reject for all
-              this->propagateReject(reject);
-            };
+            visit_in_place(answer.result,
+                           [&](const CommitMessage &commit) {
+                             // propagate for all
+                             log_->info("Propagate commit {} to whole network",
+                                        vote.hash.block_hash);
+                             this->propagateCommit(
+                                 boost::get<CommitMessage>(answer.result));
+                           },
+                           [&](const RejectMessage &reject) {
+                             // propagate reject for all
+                             log_->info("Reject case on hash {} achieved",
+                                        proposal_hash);
+                             this->propagateReject(
+                                 boost::get<RejectMessage>(answer.result));
+                           });
           } else {
             from | [&](const auto &from) {
-              answer.commit | [&](const auto &commit) {
-                // propagate directly
-
-                log_->info("Propagate commit {} directly to {}",
-                           vote.hash.block_hash,
-                           from.address);
-
-                this->propagateCommitDirectly(from, commit);
-              };
-              answer.reject | [&](const auto &reject) {
-                log_->info("Reject case on hash {} achieved", proposal_hash);
-
-                // propagate directly
-                this->propagateRejectDirectly(from, reject);
-              };
+              visit_in_place(
+                  answer.result,
+                  [&](const CommitMessage &commit) {
+                    log_->info("Propagate commit {} directly to {}",
+                               vote.hash.block_hash,
+                               from.address);
+                    this->propagateCommitDirectly(
+                        from, boost::get<CommitMessage>(answer.result));
+                  },
+                  [&](const RejectMessage &reject) {
+                    log_->info("Reject case on hash {} achieved",
+                               proposal_hash);
+                    this->propagateRejectDirectly(
+                        from, boost::get<RejectMessage>(answer.result));
+                  });
             };
           }
         };

--- a/irohad/consensus/yac/storage/impl/storage_result.cpp
+++ b/irohad/consensus/yac/storage/impl/storage_result.cpp
@@ -22,9 +22,8 @@ namespace iroha {
     namespace yac {
 
       bool Answer::operator==(const Answer &rhs) const {
-        return this->commit == rhs.commit and
-            this->reject == rhs.reject;
+        return this->result == rhs.result;
       }
-    } // namespace yac
-  } // namespace consensus
-} // namespace iroha
+    }  // namespace yac
+  }    // namespace consensus
+}  // namespace iroha

--- a/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
@@ -71,7 +71,7 @@ namespace iroha {
           auto block_state = iter->insert(msg);
 
           if (block_state.has_value() and
-              block_state->commit.has_value()) {
+              block_state->result.type() == typeid(CommitMessage)) {
             // supermajority on block achieved
             current_state_ = std::move(block_state);
           } else {

--- a/irohad/consensus/yac/storage/storage_result.hpp
+++ b/irohad/consensus/yac/storage/storage_result.hpp
@@ -20,9 +20,10 @@
 
 #include <utility>
 
-#include "consensus/yac/storage/yac_common.hpp"
+#include <boost/variant.hpp>
 #include "consensus/yac/messages.hpp"
-#include <nonstd/optional.hpp>
+#include "consensus/yac/storage/yac_common.hpp"
+//#include <nonstd/optional.hpp>
 
 namespace iroha {
   namespace consensus {
@@ -33,30 +34,25 @@ namespace iroha {
        * Guarantee that at least one optional will be empty
        */
       struct Answer {
-        explicit Answer(CommitMessage cmt){
-          commit = std::move(cmt);
+        explicit Answer(CommitMessage cmt) {
+          result = std::move(cmt);
         }
 
-        explicit Answer(RejectMessage rjt){
-          reject = std::move(rjt);
+        explicit Answer(RejectMessage rjt) {
+          result = std::move(rjt);
         }
 
         Answer() = delete;
 
         /**
-         * Result contains commit if it available
+         * Result contains commit or reject.
          */
-        nonstd::optional<CommitMessage> commit;
-
-        /**
-         * Result contains reject if it available
-         */
-        nonstd::optional<RejectMessage> reject;
+        boost::variant<CommitMessage, RejectMessage> result;
 
         bool operator==(const Answer &rhs) const;
       };
 
-    } // namespace yac
-  } // namespace consensus
-} // namespace iroha
-#endif //IROHA_STORAGE_RESULT_HPP
+    }  // namespace yac
+  }    // namespace consensus
+}  // namespace iroha
+#endif  // IROHA_STORAGE_RESULT_HPP

--- a/libs/common/inplace_visitor.hpp
+++ b/libs/common/inplace_visitor.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_INPLACE_VISITOR_HPP
+#define IROHA_INPLACE_VISITOR_HPP
+
+#include <boost/hana.hpp>
+
+namespace iroha {
+
+  /**
+   * Inplace visitor for boost::variant.
+   * Usage:
+   *
+   *   boost::variant<int, std::string> value = "1234";
+   *   ...
+   *   visit_in_place(value,
+   *                  [](int v) { std::cout << "(int)" << v; },
+   *                  [](std::string v) { std::cout << "(string)" << v;}
+   *                  );
+   */
+  template <typename TVariant, typename... TVisitors>
+  inline auto visit_in_place(TVariant &&variant, TVisitors &&... visitors) {
+    return boost::apply_visitor(
+            boost::hana::overload(std::forward<TVisitors>(visitors)...),
+            std::forward<TVariant>(variant));
+  }
+
+}  // namespace iroha
+
+#endif //IROHA_INPLACE_VISITOR_HPP

--- a/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
@@ -18,8 +18,8 @@
 #include <gtest/gtest.h>
 #include <nonstd/optional.hpp>
 #include "consensus/yac/storage/yac_vote_storage.hpp"
-#include "module/irohad/consensus/yac/yac_mocks.hpp"
 #include "logger/logger.hpp"
+#include "module/irohad/consensus/yac/yac_mocks.hpp"
 
 using namespace iroha::consensus::yac;
 
@@ -36,14 +36,11 @@ class YacBlockStorageTest : public ::testing::Test {
     hash = YacHash("proposal", "commit");
     number_of_peers = 4;
     storage = YacBlockStorage(hash, number_of_peers);
-    valid_votes = {
-        create_vote(hash, "one"),
-        create_vote(hash, "two"),
-        create_vote(hash, "three"),
-        create_vote(hash, "four")
-    };
+    valid_votes = {create_vote(hash, "one"),
+                   create_vote(hash, "two"),
+                   create_vote(hash, "three"),
+                   create_vote(hash, "four")};
   }
-
 };
 
 TEST_F(YacBlockStorageTest, YacBlockStorageWhenNormalDataInput) {
@@ -57,15 +54,13 @@ TEST_F(YacBlockStorageTest, YacBlockStorageWhenNormalDataInput) {
 
   auto insert_3 = storage.insert(valid_votes.at(2));
   ASSERT_NE(nonstd::nullopt, insert_3);
-  ASSERT_NE(nonstd::nullopt, insert_3->commit);
-  ASSERT_EQ(3, insert_3->commit->votes.size());
-  ASSERT_EQ(nonstd::nullopt, insert_3->reject);
+  ASSERT_EQ(typeid(CommitMessage), insert_3->result.type());
+  ASSERT_EQ(3, boost::get<CommitMessage>(insert_3->result).votes.size());
 
   auto insert_4 = storage.insert(valid_votes.at(3));
   ASSERT_NE(nonstd::nullopt, insert_4);
-  ASSERT_NE(nonstd::nullopt, insert_4->commit);
-  ASSERT_EQ(4, insert_4->commit->votes.size());
-  ASSERT_EQ(nonstd::nullopt, insert_4->reject);
+  ASSERT_EQ(typeid(CommitMessage), insert_4->result.type());
+  ASSERT_EQ(4, boost::get<CommitMessage>(insert_4->result).votes.size());
 }
 
 TEST_F(YacBlockStorageTest, YacBlockStorageWhenNotCommittedAndCommitAcheive) {
@@ -74,11 +69,11 @@ TEST_F(YacBlockStorageTest, YacBlockStorageWhenNotCommittedAndCommitAcheive) {
   auto insert_1 = storage.insert(valid_votes.at(0));
   ASSERT_EQ(nonstd::nullopt, insert_1);
 
-  decltype(YacBlockStorageTest::valid_votes)
-      for_insert(valid_votes.begin() + 1, valid_votes.end());
+  decltype(YacBlockStorageTest::valid_votes) for_insert(valid_votes.begin() + 1,
+                                                        valid_votes.end());
   auto insert_commit = storage.insert(for_insert);
-  ASSERT_EQ(4, insert_commit->commit->votes.size());
-  ASSERT_EQ(nonstd::nullopt, insert_commit->reject);
+  ASSERT_EQ(typeid(CommitMessage), insert_commit->result.type());
+  ASSERT_EQ(4, boost::get<CommitMessage>(insert_commit->result).votes.size());
 }
 
 TEST_F(YacBlockStorageTest, YacBlockStorageWhenGetVotes) {
@@ -89,11 +84,12 @@ TEST_F(YacBlockStorageTest, YacBlockStorageWhenGetVotes) {
 }
 
 TEST_F(YacBlockStorageTest, YacBlockStorageWhenIsContains) {
-  log_->info("-----------| Init storage => "
-                 "verify ok and fail cases of contains |-----------");
+  log_->info(
+      "-----------| Init storage => "
+      "verify ok and fail cases of contains |-----------");
 
-  decltype(YacBlockStorageTest::valid_votes)
-      for_insert(valid_votes.begin(), valid_votes.begin() + 2);
+  decltype(YacBlockStorageTest::valid_votes) for_insert(
+      valid_votes.begin(), valid_votes.begin() + 2);
 
   storage.insert(for_insert);
 

--- a/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
+#include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include <gtest/gtest.h>
 #include <nonstd/optional.hpp>
-#include "consensus/yac/storage/yac_proposal_storage.hpp"
-#include "module/irohad/consensus/yac/yac_mocks.hpp"
 #include "logger/logger.hpp"
+#include "module/irohad/consensus/yac/yac_mocks.hpp"
 
 using namespace iroha::consensus::yac;
 
@@ -44,12 +44,12 @@ class YacProposalStorageTest : public ::testing::Test {
       return votes;
     }();
   }
-
 };
 
 TEST_F(YacProposalStorageTest, YacProposalStorageWhenCommitCase) {
-  log_->info("Init storage => insert unique votes => "
-                 "expected commit");
+  log_->info(
+      "Init storage => insert unique votes => "
+      "expected commit");
 
   for (auto i = 0u; i < 4; ++i) {
     ASSERT_EQ(nonstd::nullopt, storage.insert(valid_votes.at(i)));
@@ -58,17 +58,18 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenCommitCase) {
   for (auto i = 4u; i < 7; ++i) {
     auto commit = storage.insert(valid_votes.at(i));
     log_->info("Commit: {}", logger::opt_to_string(commit, [](auto answer) {
-      return "value";
-    }));
+                 return "value";
+               }));
     ASSERT_NE(nonstd::nullopt, commit);
-    ASSERT_EQ(i + 1, commit->commit->votes.size());
+    ASSERT_EQ(typeid(CommitMessage), commit->result.type());
+    ASSERT_EQ(i + 1, boost::get<CommitMessage>(commit->result).votes.size());
   }
-
 }
 
 TEST_F(YacProposalStorageTest, YacProposalStorageWhenInsertNotUnique) {
-  log_->info("Init storage => insert not-unique votes => "
-                 "expected absence of commit");
+  log_->info(
+      "Init storage => insert not-unique votes => "
+      "expected absence of commit");
 
   for (auto i = 0; i < 7; ++i) {
     auto fixed_index = 0;
@@ -77,8 +78,9 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenInsertNotUnique) {
 }
 
 TEST_F(YacProposalStorageTest, YacProposalStorageWhenRejectCase) {
-  log_->info("Init storage => insert votes for reject case => "
-                 "expected absence of commit");
+  log_->info(
+      "Init storage => insert votes for reject case => "
+      "expected absence of commit");
 
   // insert 3 vote for hash 1
   for (auto i = 0; i < 3; ++i) {
@@ -88,18 +90,15 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenRejectCase) {
   // insert 2 for other hash
   auto other_hash = YacHash(hash.proposal_hash, "other_commit");
   for (auto i = 0; i < 2; ++i) {
-    auto answer
-        = storage.insert(create_vote(other_hash,
-                                     std::to_string(valid_votes.size() +
-                                         1 + i)));
+    auto answer = storage.insert(
+        create_vote(other_hash, std::to_string(valid_votes.size() + 1 + i)));
     ASSERT_EQ(nonstd::nullopt, answer);
   }
 
   // insert more one for other hash
-  auto answer
-      = storage.insert(create_vote(other_hash,
-                                   std::to_string(2 * valid_votes.size() +
-                                       1)));
+  auto answer = storage.insert(
+      create_vote(other_hash, std::to_string(2 * valid_votes.size() + 1)));
   ASSERT_NE(nonstd::nullopt, answer);
-  ASSERT_EQ(6, answer->reject->votes.size());
+  ASSERT_EQ(typeid(RejectMessage), answer->result.type());
+  ASSERT_EQ(6, boost::get<RejectMessage>(answer->result).votes.size());
 }

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <utility>
+#include <gtest/gtest.h>
 #include <string>
-#include "module/irohad/consensus/yac/yac_mocks.hpp"
+#include <utility>
 #include "framework/test_subscriber.hpp"
+#include "module/irohad/consensus/yac/yac_mocks.hpp"
 
-#include <vector>
 #include <iostream>
+#include <vector>
 
 using ::testing::Return;
 using ::testing::_;
@@ -47,12 +47,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
   uint64_t wait_seconds = 10;
   delay = wait_seconds * 1000;
 
-  yac = Yac::create(YacVoteStorage(),
-                    network,
-                    crypto,
-                    timer,
-                    my_order,
-                    delay);
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -60,8 +55,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .Times(0);
+  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
   EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
   EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
 
@@ -86,12 +80,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   uint64_t wait_seconds = 10;
   delay = wait_seconds * 1000;
 
-  yac = Yac::create(YacVoteStorage(),
-                    network,
-                    crypto,
-                    timer,
-                    my_order,
-                    delay);
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -137,12 +126,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   delay = wait_seconds * 1000;
   EXPECT_CALL(*timer, deny()).Times(2);
 
-  yac = Yac::create(YacVoteStorage(),
-                    network,
-                    crypto,
-                    timer,
-                    my_order,
-                    delay);
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -181,7 +165,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
 
 TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
   cout << "-----------| Start => vote => propagate commit => receive commit "
-      "|-----------"
+          "|-----------"
        << endl;
 
   auto my_peers = std::vector<iroha::model::Peer>({default_peers.at(0)});
@@ -193,8 +177,7 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
   uint64_t wait_seconds = 10;
   delay = wait_seconds * 1000;
 
-  yac = Yac::create(YacVoteStorage(), network, crypto, timer,
-                    my_order, delay);
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -245,8 +228,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
   uint64_t wait_seconds = 10;
   delay = wait_seconds * 1000;
 
-  yac = Yac::create(YacVoteStorage(), network, crypto, timer,
-                    my_order, delay);
+  yac = Yac::create(YacVoteStorage(), network, crypto, timer, my_order, delay);
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Replace two nonstd::optional with one boost::variant.
Inplace visitor was added dued to visit boost::variant with neat code.
Also code was clang-format'ed.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
