### PR TITLE
Fix memory leak related to Torii

### DIFF
--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -24,7 +24,7 @@
 ServerRunner::ServerRunner(const std::string &address)
     : serverAddress_(address) {}
 
-ServerRunner::~ServerRunner() { toriiServiceHandler_->shutdown(); }
+ServerRunner::~ServerRunner() {}
 
 void ServerRunner::run(std::unique_ptr<torii::CommandService> command_service,
                        std::unique_ptr<torii::QueryService> query_service) {

--- a/irohad/network/grpc_call.hpp
+++ b/irohad/network/grpc_call.hpp
@@ -144,10 +144,10 @@ namespace network {
      * @param requestMethod
      * @param rpcHandler
      */
-    static CallType *enqueueRequest(AsyncService *asyncService,
-                                    ::grpc::ServerCompletionQueue *cq,
-                                    RequestMethodType requestMethod,
-                                    RpcHandlerType rpcHandler) {
+    static auto *enqueueRequest(AsyncService *asyncService,
+                                ::grpc::ServerCompletionQueue *cq,
+                                RequestMethodType requestMethod,
+                                RpcHandlerType rpcHandler) {
       auto call = new CallType(rpcHandler);
 
       (asyncService->*requestMethod)(&call->ctx_,

--- a/irohad/torii/torii_service_handler.cpp
+++ b/irohad/torii/torii_service_handler.cpp
@@ -52,9 +52,9 @@ namespace torii {
       // wait until completion queue shuts down
     }
 
-    torii_owner_->responseSent();
-    status_owner_->responseSent();
-    find_owner_->responseSent();
+    torii_last_call_->responseSent();
+    status_last_call_->responseSent();
+    find_last_call_->responseSent();
   }
 
   /**
@@ -62,24 +62,24 @@ namespace torii {
    */
   void ToriiServiceHandler::handleRpcs() {
     // CommandService::Torii()
-    torii_owner_ = enqueueRequest<prot::CommandService::AsyncService,
-                                  prot::Transaction,
-                                  google::protobuf::Empty>(
+    torii_last_call_ = enqueueRequest<prot::CommandService::AsyncService,
+                                      prot::Transaction,
+                                      google::protobuf::Empty>(
         &prot::CommandService::AsyncService::RequestTorii,
         &ToriiServiceHandler::ToriiHandler,
         commandAsyncService_);
 
-    status_owner_ = enqueueRequest<prot::CommandService::AsyncService,
-                                   prot::TxStatusRequest,
-                                   prot::ToriiResponse>(
+    status_last_call_ = enqueueRequest<prot::CommandService::AsyncService,
+                                       prot::TxStatusRequest,
+                                       prot::ToriiResponse>(
         &prot::CommandService::AsyncService::RequestStatus,
         &ToriiServiceHandler::StatusHandler,
         commandAsyncService_);
 
     // QueryService::Find()
-    find_owner_ = enqueueRequest<prot::QueryService::AsyncService,
-                                 prot::Query,
-                                 prot::QueryResponse>(
+    find_last_call_ = enqueueRequest<prot::QueryService::AsyncService,
+                                     prot::Query,
+                                     prot::QueryResponse>(
         &prot::QueryService::AsyncService::RequestFind,
         &ToriiServiceHandler::QueryFindHandler,
         queryAsyncService_);
@@ -123,9 +123,9 @@ namespace torii {
     call->sendResponse(grpc::Status::OK);
 
     // Spawn a new Call instance to serve an another client.
-    torii_owner_ = enqueueRequest<prot::CommandService::AsyncService,
-                                  prot::Transaction,
-                                  google::protobuf::Empty>(
+    torii_last_call_ = enqueueRequest<prot::CommandService::AsyncService,
+                                      prot::Transaction,
+                                      google::protobuf::Empty>(
         &prot::CommandService::AsyncService::RequestTorii,
         &ToriiServiceHandler::ToriiHandler,
         commandAsyncService_);
@@ -137,9 +137,9 @@ namespace torii {
     command_service_->StatusAsync(call->request(), call->response());
     call->sendResponse(grpc::Status::OK);
 
-    status_owner_ = enqueueRequest<prot::CommandService::AsyncService,
-                                   prot::TxStatusRequest,
-                                   iroha::protocol::ToriiResponse>(
+    status_last_call_ = enqueueRequest<prot::CommandService::AsyncService,
+                                       prot::TxStatusRequest,
+                                       iroha::protocol::ToriiResponse>(
         &prot::CommandService::AsyncService::RequestStatus,
         &ToriiServiceHandler::StatusHandler,
         commandAsyncService_);
@@ -152,9 +152,9 @@ namespace torii {
     call->sendResponse(grpc::Status::OK);
 
     // Spawn a new Call instance to serve an another client.
-    find_owner_ = enqueueRequest<prot::QueryService::AsyncService,
-                                 prot::Query,
-                                 prot::QueryResponse>(
+    find_last_call_ = enqueueRequest<prot::QueryService::AsyncService,
+                                     prot::Query,
+                                     prot::QueryResponse>(
         &prot::QueryService::AsyncService::RequestFind,
         &ToriiServiceHandler::QueryFindHandler,
         queryAsyncService_);

--- a/irohad/torii/torii_service_handler.hpp
+++ b/irohad/torii/torii_service_handler.hpp
@@ -133,11 +133,11 @@ namespace torii {
     std::unique_ptr<torii::QueryService> query_service_;
 
     CommandServiceCall<iroha::protocol::Transaction, google::protobuf::Empty>
-        *torii_owner_;
+        *torii_last_call_;
     CommandServiceCall<iroha::protocol::TxStatusRequest,
-                       iroha::protocol::ToriiResponse> *status_owner_;
+                       iroha::protocol::ToriiResponse> *status_last_call_;
     QueryServiceCall<iroha::protocol::Query, iroha::protocol::QueryResponse>
-        *find_owner_;
+        *find_last_call_;
   };
 }  // namespace torii
 


### PR DESCRIPTION
Signed-off-by: luckychess <toobwn@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
This pull request fixes memory leaks in torii_service_test, torii_queries_test and client_test.

### Benefits

<!-- What benefits will be realized by the code change? -->
Well, leaks are bad ;)

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Probably none (I hope)

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
Build project with ```-fsanitize=address``` and run tests as ```ASAN_OPTIONS=detect_leaks=1 ctest```:
```
90% tests passed, 8 tests failed out of 78

Total Test time (real) =  39.61 sec

The following tests FAILED:
	  3 - ametsuchi_test (Child aborted)
	  4 - wsv_query_command_test (Failed)
	 15 - yac_timer_test (Child aborted)
	 47 - ordering_service_test (Child aborted)
	 49 - ordering_gate_service_test (Child aborted)
	 73 - field_validator_test (Failed)
	 77 - tx_pipeline_integration_test (Child aborted)
	 78 - transfer_asset_inter_domain_test (Child aborted)
```
Without current fix 11 tests will fail.

### P.S.
Please note change in ServerRunner destructor - it doesn't call shutdown for toriiServiceHandler anymore. The reason for that is possible double delete problem because ServerRunner::shutdown also also calls shutdown for toriiServiceHandler.
