### PR TITLE
Feature/refactor cli default peer

### DIFF
--- a/iroha-cli/interactive/impl/interactive_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_cli.cpp
@@ -43,7 +43,7 @@ namespace iroha_cli {
     InteractiveCli::InteractiveCli(
         const std::string &account_name,
         const std::string &default_peer_ip,
-        const int &default_port,
+        int default_port,
         uint64_t tx_counter,
         uint64_t qry_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)

--- a/iroha-cli/interactive/impl/interactive_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_cli.cpp
@@ -42,12 +42,17 @@ namespace iroha_cli {
 
     InteractiveCli::InteractiveCli(
         const std::string &account_name,
+        const std::string &default_peer_ip,
+        const int &default_port,
         uint64_t tx_counter,
         uint64_t qry_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)
         : creator_(account_name),
-          tx_cli_(creator_, tx_counter, provider),
-          query_cli_(creator_, qry_counter, provider) {
+          tx_cli_(
+              creator_, default_peer_ip, default_port, tx_counter, provider),
+          query_cli_(
+              creator_, default_peer_ip, default_port, qry_counter, provider),
+          statusCli_(default_peer_ip, default_port) {
       assign_main_handlers();
     }
 

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -31,11 +31,14 @@ namespace iroha_cli {
       };
     }
 
-    ParamsMap getCommonParamsMap() {
+    ParamsMap getCommonParamsMap(const std::string &default_ip,
+                                 const int &default_port) {
       return {
           // commonParamsMap
           {SAVE_CODE, {"Path to save json file"}},
-          {SEND_CODE, {"Peer address", "Peer port"}}
+          {SEND_CODE,
+           {"Peer address (" + default_ip + ")",
+            "Peer port (" + std::to_string(default_port) + ")"}}
           // commonParamsMap
       };
     }
@@ -89,10 +92,13 @@ namespace iroha_cli {
     }
 
     nonstd::optional<std::pair<std::string, uint16_t>> parseIrohaPeerParams(
-        ParamsDescription params) {
-      auto address = params[0];
-      auto port = parser::parseValue<uint16_t>(params[1]);
-      if (not port.has_value()) {
+        ParamsDescription params,
+        const std::string &default_ip,
+        const int &default_port) {
+      auto address = params[0].empty() ? default_ip : params[0];
+      auto port = params[1].empty() ? default_port
+                                    : parser::parseValue<uint16_t>(params[1]);
+      if (not params.empty() and not port.has_value()) {
         std::cout << "Port has wrong format" << std::endl;
         // Continue parsing
         return nonstd::nullopt;

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -32,7 +32,7 @@ namespace iroha_cli {
     }
 
     ParamsMap getCommonParamsMap(const std::string &default_ip,
-                                 const int &default_port) {
+                                 int default_port) {
       return {
           // commonParamsMap
           {SAVE_CODE, {"Path to save json file"}},
@@ -94,8 +94,8 @@ namespace iroha_cli {
     nonstd::optional<std::pair<std::string, uint16_t>> parseIrohaPeerParams(
         ParamsDescription params,
         const std::string &default_ip,
-        const int &default_port) {
-      auto address = params[0].empty() ? default_ip : params[0];
+        int default_port) {
+      const auto &address = params[0].empty() ? default_ip : params[0];
       auto port = params[1].empty() ? default_port
                                     : parser::parseValue<uint16_t>(params[1]);
       if (not params.empty() and not port.has_value()) {

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -87,7 +87,8 @@ namespace iroha_cli {
     void InteractiveQueryCli::create_result_menu() {
       result_handlers_ = {{SAVE_CODE, &InteractiveQueryCli::parseSaveFile},
                           {SEND_CODE, &InteractiveQueryCli::parseSendToIroha}};
-      result_params_descriptions_ = getCommonParamsMap();
+      result_params_descriptions_ =
+          getCommonParamsMap(default_peer_ip, default_port);
 
       result_points_ = formMenu(result_handlers_,
                                 result_params_descriptions_,
@@ -97,10 +98,14 @@ namespace iroha_cli {
 
     InteractiveQueryCli::InteractiveQueryCli(
         const std::string &account_name,
+        const std::string &default_peer_ip,
+        const int &default_port,
         uint64_t query_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)
         : current_context_(MAIN),
           creator_(account_name),
+          default_peer_ip(default_peer_ip),
+          default_port(default_port),
           counter_(query_counter),
           provider_(provider) {
       log_ = logger::log("InteractiveQueryCli");
@@ -248,7 +253,8 @@ namespace iroha_cli {
     }
 
     bool InteractiveQueryCli::parseSendToIroha(QueryParams params) {
-      auto address = parseIrohaPeerParams(params);
+      auto address =
+          parseIrohaPeerParams(params, default_peer_ip, default_port);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -88,7 +88,7 @@ namespace iroha_cli {
       result_handlers_ = {{SAVE_CODE, &InteractiveQueryCli::parseSaveFile},
                           {SEND_CODE, &InteractiveQueryCli::parseSendToIroha}};
       result_params_descriptions_ =
-          getCommonParamsMap(default_peer_ip, default_port);
+          getCommonParamsMap(default_peer_ip_, default_port_);
 
       result_points_ = formMenu(result_handlers_,
                                 result_params_descriptions_,
@@ -99,13 +99,13 @@ namespace iroha_cli {
     InteractiveQueryCli::InteractiveQueryCli(
         const std::string &account_name,
         const std::string &default_peer_ip,
-        const int &default_port,
+        int default_port,
         uint64_t query_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)
         : current_context_(MAIN),
           creator_(account_name),
-          default_peer_ip(default_peer_ip),
-          default_port(default_port),
+          default_peer_ip_(default_peer_ip),
+          default_port_(default_port),
           counter_(query_counter),
           provider_(provider) {
       log_ = logger::log("InteractiveQueryCli");
@@ -254,7 +254,7 @@ namespace iroha_cli {
 
     bool InteractiveQueryCli::parseSendToIroha(QueryParams params) {
       auto address =
-          parseIrohaPeerParams(params, default_peer_ip, default_port);
+          parseIrohaPeerParams(params, default_peer_ip_, default_port_);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -39,8 +39,8 @@ namespace iroha_cli {
              "Transaction was not found in the system."}};
 
     InteractiveStatusCli::InteractiveStatusCli(
-        const std::string &default_peer_ip, const int &default_port)
-        : default_peer_ip(default_peer_ip), default_port(default_port) {
+        const std::string &default_peer_ip, int default_port)
+        : default_peer_ip_(default_peer_ip), default_port_(default_port) {
       createActionsMenu();
       createResultMenu();
     }
@@ -61,7 +61,7 @@ namespace iroha_cli {
       resultHandlers_ = {{SEND_CODE, &InteractiveStatusCli::parseSendToIroha},
                          {SAVE_CODE, &InteractiveStatusCli::parseSaveFile}};
       resultParamsDescriptions_ =
-          getCommonParamsMap(default_peer_ip, default_port);
+          getCommonParamsMap(default_peer_ip_, default_port_);
 
       resultPoints_ = formMenu(resultHandlers_,
                                resultParamsDescriptions_,
@@ -127,7 +127,7 @@ namespace iroha_cli {
     }
 
     bool InteractiveStatusCli::parseSendToIroha(ActionParams line) {
-      auto address = parseIrohaPeerParams(line, default_peer_ip, default_port);
+      auto address = parseIrohaPeerParams(line, default_peer_ip_, default_port_);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -87,6 +87,10 @@ namespace iroha_cli {
           case RESULT:
             isParsing = parseResult(line.value());
             break;
+          default:
+            // shouldn't get here
+            BOOST_ASSERT_MSG(false, "not implemented");
+            break;
         }
       }
     }
@@ -127,7 +131,8 @@ namespace iroha_cli {
     }
 
     bool InteractiveStatusCli::parseSendToIroha(ActionParams line) {
-      auto address = parseIrohaPeerParams(line, default_peer_ip_, default_port_);
+      auto address =
+          parseIrohaPeerParams(line, default_peer_ip_, default_port_);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -38,7 +38,9 @@ namespace iroha_cli {
             {iroha::protocol::TxStatus::NOT_RECEIVED,
              "Transaction was not found in the system."}};
 
-    InteractiveStatusCli::InteractiveStatusCli() {
+    InteractiveStatusCli::InteractiveStatusCli(
+        const std::string &default_peer_ip, const int &default_port)
+        : default_peer_ip(default_peer_ip), default_port(default_port) {
       createActionsMenu();
       createResultMenu();
     }
@@ -58,7 +60,8 @@ namespace iroha_cli {
     void InteractiveStatusCli::createResultMenu() {
       resultHandlers_ = {{SEND_CODE, &InteractiveStatusCli::parseSendToIroha},
                          {SAVE_CODE, &InteractiveStatusCli::parseSaveFile}};
-      resultParamsDescriptions_ = getCommonParamsMap();
+      resultParamsDescriptions_ =
+          getCommonParamsMap(default_peer_ip, default_port);
 
       resultPoints_ = formMenu(resultHandlers_,
                                resultParamsDescriptions_,
@@ -124,7 +127,7 @@ namespace iroha_cli {
     }
 
     bool InteractiveStatusCli::parseSendToIroha(ActionParams line) {
-      auto address = parseIrohaPeerParams(line);
+      auto address = parseIrohaPeerParams(line, default_peer_ip, default_port);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -18,6 +18,7 @@
 #include "interactive/interactive_transaction_cli.hpp"
 
 #include <fstream>
+#include <utility>
 #include "client.hpp"
 #include "grpc_response_handler.hpp"
 #include "model/commands/append_role.hpp"
@@ -152,7 +153,8 @@ namespace iroha_cli {
       result_desciption.insert(
           {BACK_CODE, "Go back and start a new transaction"});
 
-      result_params_descriptions = getCommonParamsMap();
+      result_params_descriptions =
+          getCommonParamsMap(default_peer_ip, default_port);
 
       result_params_descriptions.insert({ADD_CMD, {}});
       result_params_descriptions.insert({BACK_CODE, {}});
@@ -171,10 +173,14 @@ namespace iroha_cli {
 
     InteractiveTransactionCli::InteractiveTransactionCli(
         const std::string &creator_account,
+        const std::string &default_peer_ip,
+        const int &default_port,
         uint64_t tx_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)
         : current_context_(MAIN),
           creator_(creator_account),
+          default_peer_ip(default_peer_ip),
+          default_port(default_port),
           tx_counter_(tx_counter),
           provider_(provider) {
       log_ = logger::log("InteractiveTransactionCli");
@@ -455,7 +461,8 @@ namespace iroha_cli {
 
     bool InteractiveTransactionCli::parseSendToIroha(
         std::vector<std::string> params) {
-      auto address = parseIrohaPeerParams(params);
+      auto address = parseIrohaPeerParams(
+          std::move(params), default_peer_ip, default_port);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -154,7 +154,7 @@ namespace iroha_cli {
           {BACK_CODE, "Go back and start a new transaction"});
 
       result_params_descriptions =
-          getCommonParamsMap(default_peer_ip, default_port);
+          getCommonParamsMap(default_peer_ip_, default_port_);
 
       result_params_descriptions.insert({ADD_CMD, {}});
       result_params_descriptions.insert({BACK_CODE, {}});
@@ -174,13 +174,13 @@ namespace iroha_cli {
     InteractiveTransactionCli::InteractiveTransactionCli(
         const std::string &creator_account,
         const std::string &default_peer_ip,
-        const int &default_port,
+        int default_port,
         uint64_t tx_counter,
         const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider)
         : current_context_(MAIN),
           creator_(creator_account),
-          default_peer_ip(default_peer_ip),
-          default_port(default_port),
+          default_peer_ip_(default_peer_ip),
+          default_port_(default_port),
           tx_counter_(tx_counter),
           provider_(provider) {
       log_ = logger::log("InteractiveTransactionCli");
@@ -462,7 +462,7 @@ namespace iroha_cli {
     bool InteractiveTransactionCli::parseSendToIroha(
         std::vector<std::string> params) {
       auto address = parseIrohaPeerParams(
-          std::move(params), default_peer_ip, default_port);
+          std::move(params), default_peer_ip_, default_port_);
       if (not address.has_value()) {
         return true;
       }

--- a/iroha-cli/interactive/interactive_cli.hpp
+++ b/iroha-cli/interactive/interactive_cli.hpp
@@ -40,7 +40,7 @@ namespace iroha_cli {
       InteractiveCli(
           const std::string &account_name,
           const std::string &default_peer_ip,
-          const int &default_port,
+          int default_port,
           uint64_t tx_counter,
           uint64_t qry_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);

--- a/iroha-cli/interactive/interactive_cli.hpp
+++ b/iroha-cli/interactive/interactive_cli.hpp
@@ -29,15 +29,23 @@ namespace iroha_cli {
     class InteractiveCli {
      public:
       /**
-       * @param account_id account id used as transaction or query creator
+       * Interactive command line client
+       * @param account_name registered in Iroha network
+       * @param default_peer_ip default peer ip to send transactions/query
+       * @param default_port default port of peer's Iroha Torii
+       * @param tx_counter synchronized nonce for sending transaction
+       * @param qry_counter synchronized nonce for sending queries
+       * @param provider crypto provider to make signatures
        */
       InteractiveCli(
           const std::string &account_name,
+          const std::string &default_peer_ip,
+          const int &default_port,
           uint64_t tx_counter,
           uint64_t qry_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);
       /**
-       * Run interactive cli. Print menu and parse command
+       * Run interactive cli. Print menu and parse commands
        */
       void run();
 

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -67,7 +67,8 @@ namespace iroha_cli {
      * Return mapping of Command_name to parameters descriptions
      * @return Map with parameters of common commands
      */
-    ParamsMap getCommonParamsMap();
+    ParamsMap getCommonParamsMap(const std::string &default_ip,
+                                 const int &default_port);
 
     /**
      * Handle error with empty command
@@ -184,7 +185,9 @@ namespace iroha_cli {
      * @return pair if ip and port if formed right, nullopt otherwise
      */
     nonstd::optional<std::pair<std::string, uint16_t>> parseIrohaPeerParams(
-        std::vector<std::string> params);
+        std::vector<std::string> params,
+        const std::string &default_ip,
+        const int &default_port);
 
     /**
      * Handle parsing routine:

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -68,7 +68,7 @@ namespace iroha_cli {
      * @return Map with parameters of common commands
      */
     ParamsMap getCommonParamsMap(const std::string &default_ip,
-                                 const int &default_port);
+                                 int default_port);
 
     /**
      * Handle error with empty command
@@ -187,7 +187,7 @@ namespace iroha_cli {
     nonstd::optional<std::pair<std::string, uint16_t>> parseIrohaPeerParams(
         std::vector<std::string> params,
         const std::string &default_ip,
-        const int &default_port);
+        int default_port);
 
     /**
      * Handle parsing routine:

--- a/iroha-cli/interactive/interactive_query_cli.hpp
+++ b/iroha-cli/interactive/interactive_query_cli.hpp
@@ -37,6 +37,8 @@ namespace iroha_cli {
        */
       InteractiveQueryCli(
           const std::string &account_id,
+          const std::string &default_peer_ip,
+          const int &default_port,
           uint64_t query_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);
       /**
@@ -131,6 +133,9 @@ namespace iroha_cli {
       // ------- Query data -----------
       // Creator account id
       std::string creator_;
+      // Default Iroha peer address
+      std::string default_peer_ip;
+      int default_port;
 
       // Local query counter of account creator_
       uint64_t counter_;

--- a/iroha-cli/interactive/interactive_query_cli.hpp
+++ b/iroha-cli/interactive/interactive_query_cli.hpp
@@ -31,14 +31,19 @@ namespace iroha_cli {
   namespace interactive {
     class InteractiveQueryCli {
      public:
+
       /**
-       * @param account_id creator's account identification
+       * Class to form and send Iroha queries  in interactive mode
+       * @param creator_account creator's account identification
+       * @param default_peer_ip of Iroha peer
+       * @param default_port of Iroha peer
        * @param query_counter counter associated with creator's account
+       * @param provider for signing queries
        */
       InteractiveQueryCli(
           const std::string &account_id,
           const std::string &default_peer_ip,
-          const int &default_port,
+          int default_port,
           uint64_t query_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);
       /**
@@ -134,8 +139,8 @@ namespace iroha_cli {
       // Creator account id
       std::string creator_;
       // Default Iroha peer address
-      std::string default_peer_ip;
-      int default_port;
+      std::string default_peer_ip_;
+      int default_port_;
 
       // Local query counter of account creator_
       uint64_t counter_;

--- a/iroha-cli/interactive/interactive_status_cli.hpp
+++ b/iroha-cli/interactive/interactive_status_cli.hpp
@@ -32,7 +32,7 @@ namespace iroha_cli {
     class InteractiveStatusCli {
      public:
       InteractiveStatusCli(const std::string &default_peer_ip,
-                           const int &default_port);
+                           int default_port);
       void run();
 
      private:
@@ -55,8 +55,8 @@ namespace iroha_cli {
 
       const std::string GET_TX_INFO = "get_tx_info";
 
-      std::string default_peer_ip;
-      int default_port;
+      std::string default_peer_ip_;
+      int default_port_;
 
       std::unordered_map<ActionName, ResultHandler> resultHandlers_;
       ParamsMap resultParamsDescriptions_;

--- a/iroha-cli/interactive/interactive_status_cli.hpp
+++ b/iroha-cli/interactive/interactive_status_cli.hpp
@@ -31,7 +31,8 @@ namespace iroha_cli {
      */
     class InteractiveStatusCli {
      public:
-      InteractiveStatusCli();
+      InteractiveStatusCli(const std::string &default_peer_ip,
+                           const int &default_port);
       void run();
 
      private:
@@ -53,6 +54,9 @@ namespace iroha_cli {
       std::string parseGetHash(ActionParams params);
 
       const std::string GET_TX_INFO = "get_tx_info";
+
+      std::string default_peer_ip;
+      int default_port;
 
       std::unordered_map<ActionName, ResultHandler> resultHandlers_;
       ParamsMap resultParamsDescriptions_;

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -31,11 +31,17 @@ namespace iroha_cli {
     class InteractiveTransactionCli {
      public:
       /**
-       * @param creator_account - Account of a creator
-       * @param tx_counter - local counter for transaction
+       *
+       * @param creator_account
+       * @param default_peer_ip
+       * @param default_port
+       * @param tx_counter synchronized with Iroha network
+       * @param provider for signing transactions
        */
       InteractiveTransactionCli(
           const std::string &creator_account,
+          const std::string &default_peer_ip,
+          const int &default_port,
           uint64_t tx_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);
       /**
@@ -166,6 +172,8 @@ namespace iroha_cli {
 
       //  Creator account id
       std::string creator_;
+      std::string default_peer_ip;
+      int default_port;
 
       //  Transaction counter specific for account creator
       uint64_t tx_counter_;

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -31,17 +31,17 @@ namespace iroha_cli {
     class InteractiveTransactionCli {
      public:
       /**
-       *
-       * @param creator_account
-       * @param default_peer_ip
-       * @param default_port
+       * Class to form and send Iroha transactions  in interactive mode
+       * @param creator_account user Iroha account
+       * @param default_peer_ip of Iroha peer
+       * @param default_port of Iroha peer
        * @param tx_counter synchronized with Iroha network
        * @param provider for signing transactions
        */
       InteractiveTransactionCli(
           const std::string &creator_account,
           const std::string &default_peer_ip,
-          const int &default_port,
+          int default_port,
           uint64_t tx_counter,
           const std::shared_ptr<iroha::model::ModelCryptoProvider> &provider);
       /**
@@ -172,8 +172,8 @@ namespace iroha_cli {
 
       //  Creator account id
       std::string creator_;
-      std::string default_peer_ip;
-      int default_port;
+      std::string default_peer_ip_;
+      int default_port_;
 
       //  Transaction counter specific for account creator
       uint64_t tx_counter_;

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -36,12 +36,12 @@
 DEFINE_bool(
     new_account,
     false,
-    "Create new account, generate and save locally public/private keys.");
+    "Generate and save locally new public/private keys");
 DEFINE_string(account_name,
               "",
               "Name of the account. Must be unique in iroha network");
-DEFINE_string(pass_phrase, "", "Account pass_phrase");
-DEFINE_string(key_path, ".", "Path to store user keys");
+DEFINE_string(pass_phrase, "", "Account pass-phrase");
+DEFINE_string(key_path, ".", "Path to user keys");
 
 // Iroha peer to connect with
 DEFINE_string(peer_ip, "0.0.0.0", "Address of the Iroha node");
@@ -62,6 +62,7 @@ DEFINE_string(peers_address,
 
 // Run iroha-cli in interactive mode
 DEFINE_bool(interactive, true, "Run iroha-cli in interactive mode");
+
 
 using namespace iroha::protocol;
 using namespace iroha::model::generators;

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -32,33 +32,36 @@
 #include "model/model_crypto_provider_impl.hpp"
 #include "validators.hpp"
 
-DEFINE_string(config, "", "Trusted peer's ip addresses");
-// DEFINE_validator(config, &iroha_cli::validate_config);
+// Account information
+DEFINE_bool(
+    new_account,
+    false,
+    "Create new account, generate and save locally public/private keys.");
+DEFINE_string(account_name,
+              "",
+              "Name of the account. Must be unique in iroha network");
+DEFINE_string(pass_phrase, "", "Account pass_phrase");
+DEFINE_string(key_path, ".", "Path to store user keys");
 
-// DEFINE_string(genesis_block, "", "Genesis block for sending network");
-// DEFINE_validator(genesis_block, &iroha_cli::validate_genesis_block);
+// Iroha peer to connect with
+DEFINE_string(peer_ip, "0.0.0.0", "Address of the Iroha node");
+DEFINE_int32(torii_port, 50051, "Port of Iroha's Torii");
 
-DEFINE_bool(new_account, false, "Choose if account does not exist");
-DEFINE_string(name, "", "Name of the account");
-DEFINE_string(pass_phrase, "", "Name of the account");
-DEFINE_string(key_path, ".", "Path to user keys");
-
-// Sending transaction to Iroha
-DEFINE_bool(grpc, false, "Send sample transaction to IrohaNetwork");
-DEFINE_string(address, "0.0.0.0", "Address of the Iroha node");
-DEFINE_int32(torii_port, 50051, "Port of iroha's Torii");
-// DEFINE_validator(torii_port, &iroha_cli::validate_port);
+// Send already signed and formed transaction to Iroha peer
 DEFINE_string(json_transaction, "", "Transaction in json format");
+// Send already signed and formed query to Iroha peer
 DEFINE_string(json_query, "", "Query in json format");
 
 // Genesis block generator:
 DEFINE_bool(genesis_block,
             false,
             "Generate genesis block for new Iroha network");
-DEFINE_string(peers_address, "", "File with peers address");
+DEFINE_string(peers_address,
+              "",
+              "File with peers address for new Iroha network");
 
-// Interactive
-DEFINE_bool(interactive, false, "Interactive cli");
+// Run iroha-cli in interactive mode
+DEFINE_bool(interactive, true, "Run iroha-cli in interactive mode");
 
 using namespace iroha::protocol;
 using namespace iroha::model::generators;
@@ -70,9 +73,33 @@ int main(int argc, char *argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   gflags::ShutDownCommandLineFlags();
   auto logger = logger::log("CLI-MAIN");
-  if (FLAGS_new_account) {
-    // Create new pub/priv key
-    auto keysManager = iroha::KeysManagerImpl(FLAGS_name);
+  // Generate new genesis block now Iroha network
+  if (FLAGS_genesis_block) {
+    BlockGenerator generator;
+
+    if (FLAGS_peers_address.empty()) {
+      logger->error("--peers_address is empty");
+      return EXIT_FAILURE;
+    }
+    std::ifstream file(FLAGS_peers_address);
+    std::vector<std::string> peers_address;
+    std::copy(std::istream_iterator<std::string>(file),
+              std::istream_iterator<std::string>(),
+              std::back_inserter(peers_address));
+    // Generate genesis block
+    auto transaction = TransactionGenerator().generateGenesisTransaction(
+        0, std::move(peers_address));
+    auto block = generator.generateGenesisBlock(0, {transaction});
+    // Convert to json
+    JsonBlockFactory json_factory;
+    auto doc = json_factory.serialize(block);
+    std::ofstream output_file("genesis.block");
+    output_file << jsonToString(doc);
+    logger->info("File saved to genesis.block");
+  }
+  // Create new pub/priv key, register in Iroha Network
+  else if (FLAGS_new_account) {
+    auto keysManager = iroha::KeysManagerImpl(FLAGS_account_name);
     if (not(FLAGS_pass_phrase.size() == 0
                 ? keysManager.createKeys()
                 : keysManager.createKeys(FLAGS_pass_phrase))) {
@@ -80,13 +107,15 @@ int main(int argc, char *argv[]) {
     } else {
       logger->info(
           "Public and private key has been generated in current directory");
-    };
-  } else if (FLAGS_grpc) {
-    iroha_cli::CliClient client(FLAGS_address, FLAGS_torii_port);
+    }
+  }
+  // Send to Iroha Peer json transaction/query
+  else if (not FLAGS_json_transaction.empty() or not FLAGS_json_query.empty()) {
+    iroha_cli::CliClient client(FLAGS_peer_ip, FLAGS_torii_port);
     iroha_cli::GrpcResponseHandler response_handler;
     if (not FLAGS_json_transaction.empty()) {
       logger->info(
-          "Send transaction to {}:{} ", FLAGS_address, FLAGS_torii_port);
+          "Send transaction to {}:{} ", FLAGS_peer_ip, FLAGS_torii_port);
       // Read from file
       std::ifstream file(FLAGS_json_transaction);
       std::string str((std::istreambuf_iterator<char>(file)),
@@ -104,7 +133,7 @@ int main(int argc, char *argv[]) {
       }
     }
     if (not FLAGS_json_query.empty()) {
-      logger->info("Send query to {}:{}", FLAGS_address, FLAGS_torii_port);
+      logger->info("Send query to {}:{}", FLAGS_peer_ip, FLAGS_torii_port);
       std::ifstream file(FLAGS_json_query);
       std::string str((std::istreambuf_iterator<char>(file)),
                       std::istreambuf_iterator<char>());
@@ -116,43 +145,19 @@ int main(int argc, char *argv[]) {
         response_handler.handle(client.sendQuery(query_opt.value()));
       }
     }
-
-  } else if (FLAGS_genesis_block) {
-    BlockGenerator generator;
-
-    if (FLAGS_peers_address.empty()) {
-      logger->error("--peers_address is empty");
+  }
+  // Run iroha-cli in interactive mode
+  else if (FLAGS_interactive) {
+    if (FLAGS_account_name.empty()) {
+      logger->error("Specify your account name");
       return EXIT_FAILURE;
     }
-
-    std::ifstream file(FLAGS_peers_address);
-    std::vector<std::string> peers_address;
-    std::copy(std::istream_iterator<std::string>(file),
-              std::istream_iterator<std::string>(),
-              std::back_inserter(peers_address));
-    // Generate genesis block
-    auto transaction = TransactionGenerator().generateGenesisTransaction(
-        0, std::move(peers_address));
-    auto block = generator.generateGenesisBlock(0, {transaction});
-
-    // Convert to json
-    JsonBlockFactory json_factory;
-    auto doc = json_factory.serialize(block);
-    std::ofstream output_file("genesis.block");
-    output_file << jsonToString(doc);
-    logger->info("File saved to genesis.block");
-  } else if (FLAGS_interactive) {
-    if (FLAGS_name.empty()) {
-      logger->error("Specify account name with --name flag");
-      return EXIT_FAILURE;
-    }
-
     fs::path path(FLAGS_key_path);
     if (not fs::exists(path)) {
-      logger->error("Path {} does not exist", path.string());
+      logger->error("Path {} not found.", path.string());
       return EXIT_FAILURE;
     }
-    iroha::KeysManagerImpl manager((path / FLAGS_name).string());
+    iroha::KeysManagerImpl manager((path / FLAGS_account_name).string());
     nonstd::optional<iroha::keypair_t> keypair;
     if (FLAGS_pass_phrase.size() != 0) {
       keypair = manager.loadKeys(FLAGS_pass_phrase);
@@ -162,16 +167,19 @@ int main(int argc, char *argv[]) {
     if (not keypair.has_value()) {
       logger->error(
           "Cannot load specified keypair, or keypair is invalid. Path: {}, "
-          "keypair name: {}\nMaybe wrong pass phrase (\"{}\")?",
+          "keypair name: {}. Use --key_path to path to your keypair. \nMaybe wrong pass phrase (\"{}\")?",
           path.string(),
-          FLAGS_name,
-          FLAGS_pass_phrase);
+          FLAGS_account_name,
+          FLAGS_pass_phrase
+      );
       return EXIT_FAILURE;
     }
     // TODO 13/09/17 grimadas: Init counters from Iroha, or read from disk?
     // IR-334
     InteractiveCli interactiveCli(
-        FLAGS_name,
+        FLAGS_account_name,
+        FLAGS_peer_ip,
+        FLAGS_torii_port,
         0,
         0,
         std::make_shared<iroha::model::ModelCryptoProviderImpl>(


### PR DESCRIPTION
### Description of the Change

Refactor iroha-cli by introducing a default peer. Add more verbose description to flags.  

### Benefits

Easier interaction with the system as you do not need to type in peer address every time.  
iroha-cli runs with peer_ip and torii_port flags (by default 0.0.0.0 and 50051). 
In interactive mode when sending to iroha default value will be displayed in parentheses.

### Possible Drawbacks 
None
