### PR TITLE
Fix/extract literals

### DIFF
--- a/iroha-cli/impl/grpc_response_handler.cpp
+++ b/iroha-cli/impl/grpc_response_handler.cpp
@@ -34,7 +34,6 @@ namespace iroha_cli {
     handler_map_[FAILED_PRECONDITION] = "FAILED_PRECONDITION";
     handler_map_[ABORTED] = "ABORTED";
     handler_map_[OUT_OF_RANGE] = "OUT_OF_RANGE";
-    handler_map_[UNIMPLEMENTED] = "UNIMPLEMENTED";
     handler_map_[INTERNAL] = "INTERNAL";
     handler_map_[UNIMPLEMENTED] = "UNIMPLEMENTED";
     handler_map_[UNAVAILABLE] = "Server is unavailable";

--- a/iroha-cli/impl/query_response_handler.cpp
+++ b/iroha-cli/impl/query_response_handler.cpp
@@ -65,6 +65,31 @@ namespace iroha_cli {
     }
   }
 
+  enum PrefixId {
+    kAccountId,
+    kAssetId,
+    kAmount,
+    kDomainId,
+    kSignatories,
+    kPrecision,
+    kRoles,
+    kJsonData,
+    kCreatorId,
+    kDefault,
+  };
+
+  const std::map<PrefixId, const char *> prefix{
+      {kAccountId, "-Account Id:- {}"},
+      {kAssetId, "-Asset Id- {}"},
+      {kAmount, "-Balance- {}"},
+      {kDomainId, "-Domain- {}"},
+      {kSignatories, "-Signatory- {}"},
+      {kPrecision, "-Precision- {}"},
+      {kRoles, "-Roles-: "},
+      {kJsonData, "-Data-: {}"},
+      {kCreatorId, "-Creator Id- {}"},
+      {kDefault, " {} "}};
+
   void QueryResponseHandler::handleErrorResponse(
       const iroha::protocol::QueryResponse &response) {
     auto it = error_handler_map_.find((response.error_response().reason()));
@@ -81,29 +106,30 @@ namespace iroha_cli {
       const iroha::protocol::QueryResponse &response) {
     auto account = response.account_response().account();
     log_->info("[Account]:");
-    log_->info("-Id:- {}", account.account_id());
-    log_->info("-Domain- {}", account.domain_id());
+    log_->info(prefix.at(kAccountId), account.account_id());
+    log_->info(prefix.at(kDomainId), account.domain_id());
 
-    log_->info("-Roles-: ");
+    log_->info(prefix.at(kRoles));
     auto roles = response.account_response().account_roles();
-    std::for_each(roles.begin(), roles.end(), [](auto role){
-      std::cout << " " << role;
+    std::for_each(roles.begin(), roles.end(), [this](auto role) {
+      log_->info(prefix.at(kDefault), role);
     });
-    log_->info("-Data-: {}", account.json_data());
+    log_->info(prefix.at(kJsonData), account.json_data());
   }
 
   void QueryResponseHandler::handleRolesResponse(
       const iroha::protocol::QueryResponse &response) {
     auto roles = response.roles_response().roles();
     std::for_each(roles.begin(), roles.end(), [this](auto role) {
-      log_->info(" {} ", role);
+      log_->info(prefix.at(kDefault), role);
     });
   }
 
-  void QueryResponseHandler::handleRolePermissionsResponse(const iroha::protocol::QueryResponse &response) {
+  void QueryResponseHandler::handleRolePermissionsResponse(
+      const iroha::protocol::QueryResponse &response) {
     auto perms = response.role_permissions_response().permissions();
     std::for_each(perms.begin(), perms.end(), [this](auto perm) {
-      log_->info(" {} ", perm);
+      log_->info(prefix.at(kDefault), perm);
     });
   }
 
@@ -111,11 +137,11 @@ namespace iroha_cli {
       const iroha::protocol::QueryResponse &response) {
     auto acc_assets = response.account_assets_response().account_asset();
     log_->info("[Account Assets]");
-    log_->info("-Account Id- {}", acc_assets.account_id());
-    log_->info("-Asset Id- {}", acc_assets.asset_id());
+    log_->info(prefix.at(kAccountId), acc_assets.account_id());
+    log_->info(prefix.at(kAssetId), acc_assets.asset_id());
     auto balance =
         iroha::model::converters::deserializeAmount(acc_assets.balance());
-    log_->info("-Balance- {}", balance.to_string());
+    log_->info(prefix.at(kAmount), balance.to_string());
   }
 
   void QueryResponseHandler::handleSignatoriesResponse(
@@ -124,25 +150,25 @@ namespace iroha_cli {
     log_->info("[Signatories]");
     std::for_each(
         signatories.begin(), signatories.end(), [this](auto signatory) {
-          log_->info("-Signatory- {}", signatory);
+          log_->info(prefix.at(kSignatories), signatory);
         });
   }
 
-  void QueryResponseHandler::handleAssetResponse(const iroha::protocol::QueryResponse &response) {
+  void QueryResponseHandler::handleAssetResponse(
+      const iroha::protocol::QueryResponse &response) {
     auto asset = response.asset_response().asset();
     log_->info("[Asset]");
-    log_->info("-Asset Id- {}", asset.asset_id());
-    log_->info("-Domain Id- {}", asset.domain_id());
-    log_->info("-Precision- {}", asset.precision());
+    log_->info(prefix.at(kAssetId), asset.asset_id());
+    log_->info(prefix.at(kDomainId), asset.domain_id());
+    log_->info(prefix.at(kPrecision), asset.precision());
   }
 
   void QueryResponseHandler::handleTransactionsResponse(
       const iroha::protocol::QueryResponse &response) {
     auto txs = response.transactions_response().transactions();
-    log_->info("[Transactions]");
     std::for_each(txs.begin(), txs.end(), [this](auto tx) {
-      log_->info("-[tx]-");
-      log_->info("--[Creator Id] -- {}", tx.payload().creator_account_id());
+      log_->info("[Transaction]");
+      log_->info(prefix.at(kCreatorId), tx.payload().creator_account_id());
       // TODO 13/09/17 grimadas: add other fields: tx head, tx body IR-507
     });
   }

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -22,9 +22,9 @@
 
 #include "byteutils.hpp"
 #include "client.hpp"
+#include "crypto/keys_manager_impl.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
-#include "crypto/keys_manager_impl.hpp"
 #include "datetime/time.hpp"
 #include "grpc_response_handler.hpp"
 #include "model/converters/json_query_factory.hpp"
@@ -131,6 +131,8 @@ namespace iroha_cli {
           case RESULT:
             is_parsing = parseResult(line);
             break;
+          default:
+            BOOST_ASSERT_MSG(false, "not implemented");
         }
       }
     }
@@ -181,14 +183,15 @@ namespace iroha_cli {
     InteractiveQueryCli::parseGetTransactions(QueryParams params) {
       // Parser definition: hash1 hash2 ...
       GetTransactions::TxHashCollectionType tx_hashes;
-      std::for_each(params.begin(), params.end(), [&tx_hashes](auto const& hex_hash){
-        if (auto opt =
-          iroha::hexstringToArray<GetTransactions::TxHashType::size()>(hex_hash)) {
-          tx_hashes.push_back(*opt);
-        }
-      });
+      std::for_each(
+          params.begin(), params.end(), [&tx_hashes](auto const &hex_hash) {
+            if (auto opt = iroha::hexstringToArray<
+                    GetTransactions::TxHashType::size()>(hex_hash)) {
+              tx_hashes.push_back(*opt);
+            }
+          });
       return generator_.generateGetTransactions(
-        local_time_, creator_, counter_, tx_hashes);
+          local_time_, creator_, counter_, tx_hashes);
     }
 
     std::shared_ptr<iroha::model::Query>
@@ -202,7 +205,8 @@ namespace iroha_cli {
         QueryParams params) {
       auto asset_id = params[0];
       auto query = std::make_shared<GetAssetInfo>(asset_id);
-      //TODO 26/09/17 grimadas: remove duplicated code and move setQueryMetaData calls to private method IR-508 #goodfirstissue
+      // TODO 26/09/17 grimadas: remove duplicated code and move
+      // setQueryMetaData calls to private method IR-508 #goodfirstissue
       generator_.setQueryMetaData(query, local_time_, creator_, counter_);
       return query;
     }

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -108,11 +108,15 @@ namespace iroha_cli {
       create_result_menu();
     }
 
+    void printMenu(const MenuPoints &menu) {
+      printMenu("Choose query: ", menu);
+    }
+
     void InteractiveQueryCli::run() {
       std::string line;
       bool is_parsing = true;
       current_context_ = MAIN;
-      printMenu("Choose query: ", menu_points_);
+      printMenu(menu_points_);
       // Creating a new query, increment local counter
       ++counter_;
       // Init timestamp for a new query
@@ -223,7 +227,7 @@ namespace iroha_cli {
         // Give up the last query and start a new one
         current_context_ = MAIN;
         printEnd();
-        printMenu("Choose query: ", menu_points_);
+        printMenu(menu_points_);
         // Continue parsing
         return true;
       }

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -152,6 +152,9 @@ namespace iroha {
 
       // ------|Apply data|------
 
+      const char *kRejectMsg = "reject case";
+      const char *kRejectOnHashMsg = "Reject case on hash {} achieved";
+
       void Yac::applyCommit(nonstd::optional<model::Peer> from,
                             CommitMessage commit) {
         auto answer =
@@ -167,7 +170,7 @@ namespace iroha {
                              notifier_.get_subscriber().on_next(commit);
                            },
                            [&](const RejectMessage &reject) {
-                             log_->warn("reject case");
+                             log_->warn(kRejectMsg);
                              // TODO 14/08/17 Muratov: work on reject case
                              // IR-497
                            });
@@ -189,7 +192,7 @@ namespace iroha {
             vote_storage_.markAsProcessedState(proposal_hash);
             visit_in_place(answer,
                            [&](const RejectMessage &reject) {
-                             log_->warn("reject case");
+                             log_->warn(kRejectMsg);
                              // TODO 14/08/17 Muratov: work on reject case
                              // IR-497
                            },
@@ -234,8 +237,7 @@ namespace iroha {
                            },
                            [&](const RejectMessage &reject) {
                              // propagate reject for all
-                             log_->info("Reject case on hash {} achieved",
-                                        proposal_hash);
+                             log_->info(kRejectOnHashMsg, proposal_hash);
                              this->propagateReject(reject);
                            });
           } else {
@@ -248,8 +250,7 @@ namespace iroha {
                                this->propagateCommitDirectly(from, commit);
                              },
                              [&](const RejectMessage &reject) {
-                               log_->info("Reject case on hash {} achieved",
-                                          proposal_hash);
+                               log_->info(kRejectOnHashMsg, proposal_hash);
                                this->propagateRejectDirectly(from, reject);
                              });
             };

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -260,13 +260,14 @@ void Irohad::initQueryService() {
  */
 void Irohad::run() {
   // Initializing torii server
+  std::string ip = "0.0.0.0";
   torii_server =
-      std::make_unique<ServerRunner>("0.0.0.0:" + std::to_string(torii_port_));
+      std::make_unique<ServerRunner>(ip + ":" + std::to_string(torii_port_));
 
   // Initializing internal server
   grpc::ServerBuilder builder;
   int port = 0;
-  builder.AddListeningPort("0.0.0.0:" + std::to_string(internal_port_),
+  builder.AddListeningPort(ip + ":" + std::to_string(internal_port_),
                            grpc::InsecureServerCredentials(),
                            &port);
   builder.RegisterService(ordering_init.ordering_gate_transport.get());

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -18,79 +18,84 @@
 #ifndef IROHA_CONF_LOADER_HPP
 #define IROHA_CONF_LOADER_HPP
 
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/rapidjson.h>
 #include <fstream>
 #include <string>
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/istreamwrapper.h>
 #include "common/assert_config.hpp"
 
 namespace config_members {
-  const char* BlockStorePath = "block_store_path";
-  const char* ToriiPort = "torii_port";
-  const char* InternalPort = "internal_port";
-  const char* KeyPairPath = "key_pair_path";
-  const char* PgOpt = "pg_opt";
-  const char* RedisHost = "redis_host";
-  const char* RedisPort = "redis_port";
-  const char* MaxProposalSize = "max_proposal_size";
-  const char* ProposalDelay = "proposal_delay";
-  const char* VoteDelay = "vote_delay";
-  const char* LoadDelay = "load_delay";
+  const char *BlockStorePath = "block_store_path";
+  const char *ToriiPort = "torii_port";
+  const char *InternalPort = "internal_port";
+  const char *KeyPairPath = "key_pair_path";
+  const char *PgOpt = "pg_opt";
+  const char *RedisHost = "redis_host";
+  const char *RedisPort = "redis_port";
+  const char *MaxProposalSize = "max_proposal_size";
+  const char *ProposalDelay = "proposal_delay";
+  const char *VoteDelay = "vote_delay";
+  const char *LoadDelay = "load_delay";
 }  // namespace config_members
 
 /**
  * parse and assert trusted peers json in `iroha.conf`
- * @param iroha_conf_path
- * @return rapidjson::Document
+ * @param conf_path is a path to iroha's config
+ * @return rapidjson::Document is a parsed equivalent of that file
  */
-inline rapidjson::Document parse_iroha_config(std::string const& iroha_conf_path) {
+inline rapidjson::Document parse_iroha_config(const std::string &conf_path) {
   using namespace assert_config;
   namespace mbr = config_members;
   rapidjson::Document doc;
-  std::ifstream ifs_iroha(iroha_conf_path);
+  std::ifstream ifs_iroha(conf_path);
   rapidjson::IStreamWrapper isw(ifs_iroha);
+  const std::string kStrType = "string";
+  const std::string kUintType = "uint";
   doc.ParseStream(isw);
-  assert_fatal(not doc.HasParseError(), "JSON parse error: " + iroha_conf_path);
+  assert_fatal(not doc.HasParseError(), "JSON parse error: " + conf_path);
 
   assert_fatal(doc.HasMember(mbr::BlockStorePath),
                no_member_error(mbr::BlockStorePath));
   assert_fatal(doc[mbr::BlockStorePath].IsString(),
-               type_error(mbr::BlockStorePath, "string"));
+               type_error(mbr::BlockStorePath, kStrType));
 
   assert_fatal(doc.HasMember(mbr::ToriiPort), no_member_error(mbr::ToriiPort));
   assert_fatal(doc[mbr::ToriiPort].IsUint(),
-               type_error(mbr::ToriiPort, "uint"));
+               type_error(mbr::ToriiPort, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::InternalPort), no_member_error(mbr::InternalPort));
+  assert_fatal(doc.HasMember(mbr::InternalPort),
+               no_member_error(mbr::InternalPort));
   assert_fatal(doc[mbr::InternalPort].IsUint(),
-               type_error(mbr::InternalPort, "uint"));
+               type_error(mbr::InternalPort, kUintType));
 
   assert_fatal(doc.HasMember(mbr::PgOpt), no_member_error(mbr::PgOpt));
-  assert_fatal(doc[mbr::PgOpt].IsString(), type_error(mbr::PgOpt, "string"));
+  assert_fatal(doc[mbr::PgOpt].IsString(), type_error(mbr::PgOpt, kStrType));
 
   assert_fatal(doc.HasMember(mbr::RedisHost), no_member_error(mbr::RedisHost));
   assert_fatal(doc[mbr::RedisHost].IsString(),
-               type_error(mbr::RedisHost, "string"));
+               type_error(mbr::RedisHost, kStrType));
 
   assert_fatal(doc.HasMember(mbr::RedisPort), no_member_error(mbr::RedisPort));
   assert_fatal(doc[mbr::RedisPort].IsUint(),
-               type_error(mbr::RedisPort, "uint"));
+               type_error(mbr::RedisPort, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::MaxProposalSize), no_member_error(mbr::MaxProposalSize));
+  assert_fatal(doc.HasMember(mbr::MaxProposalSize),
+               no_member_error(mbr::MaxProposalSize));
   assert_fatal(doc[mbr::MaxProposalSize].IsUint(),
-               type_error(mbr::MaxProposalSize, "uint"));
+               type_error(mbr::MaxProposalSize, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::ProposalDelay), no_member_error(mbr::ProposalDelay));
+  assert_fatal(doc.HasMember(mbr::ProposalDelay),
+               no_member_error(mbr::ProposalDelay));
   assert_fatal(doc[mbr::ProposalDelay].IsUint(),
-               type_error(mbr::ProposalDelay, "uint"));
+               type_error(mbr::ProposalDelay, kUintType));
 
   assert_fatal(doc.HasMember(mbr::VoteDelay), no_member_error(mbr::VoteDelay));
   assert_fatal(doc[mbr::VoteDelay].IsUint(),
-               type_error(mbr::VoteDelay, "uint"));
+               type_error(mbr::VoteDelay, kUintType));
 
   assert_fatal(doc.HasMember(mbr::LoadDelay), no_member_error(mbr::LoadDelay));
   assert_fatal(doc[mbr::LoadDelay].IsUint(),
-               type_error(mbr::LoadDelay, "uint"));
+               type_error(mbr::LoadDelay, kUintType));
   return doc;
 }
 

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -44,7 +44,7 @@ namespace config_members {
  * @return rapidjson::Document is a parsed equivalent of that file
  */
 inline rapidjson::Document parse_iroha_config(const std::string &conf_path) {
-  using namespace assert_config;
+  namespace ac = assert_config;
   namespace mbr = config_members;
   rapidjson::Document doc;
   std::ifstream ifs_iroha(conf_path);
@@ -52,50 +52,56 @@ inline rapidjson::Document parse_iroha_config(const std::string &conf_path) {
   const std::string kStrType = "string";
   const std::string kUintType = "uint";
   doc.ParseStream(isw);
-  assert_fatal(not doc.HasParseError(), "JSON parse error: " + conf_path);
+  ac::assert_fatal(not doc.HasParseError(), "JSON parse error: " + conf_path);
 
-  assert_fatal(doc.HasMember(mbr::BlockStorePath),
-               no_member_error(mbr::BlockStorePath));
-  assert_fatal(doc[mbr::BlockStorePath].IsString(),
-               type_error(mbr::BlockStorePath, kStrType));
+  ac::assert_fatal(doc.HasMember(mbr::BlockStorePath),
+                   ac::no_member_error(mbr::BlockStorePath));
+  ac::assert_fatal(doc[mbr::BlockStorePath].IsString(),
+                   ac::type_error(mbr::BlockStorePath, kStrType));
 
-  assert_fatal(doc.HasMember(mbr::ToriiPort), no_member_error(mbr::ToriiPort));
-  assert_fatal(doc[mbr::ToriiPort].IsUint(),
-               type_error(mbr::ToriiPort, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::ToriiPort),
+                   ac::no_member_error(mbr::ToriiPort));
+  ac::assert_fatal(doc[mbr::ToriiPort].IsUint(),
+                   ac::type_error(mbr::ToriiPort, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::InternalPort),
-               no_member_error(mbr::InternalPort));
-  assert_fatal(doc[mbr::InternalPort].IsUint(),
-               type_error(mbr::InternalPort, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::InternalPort),
+                   ac::no_member_error(mbr::InternalPort));
+  ac::assert_fatal(doc[mbr::InternalPort].IsUint(),
+                   ac::type_error(mbr::InternalPort, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::PgOpt), no_member_error(mbr::PgOpt));
-  assert_fatal(doc[mbr::PgOpt].IsString(), type_error(mbr::PgOpt, kStrType));
+  ac::assert_fatal(doc.HasMember(mbr::PgOpt), ac::no_member_error(mbr::PgOpt));
+  ac::assert_fatal(doc[mbr::PgOpt].IsString(),
+                   ac::type_error(mbr::PgOpt, kStrType));
 
-  assert_fatal(doc.HasMember(mbr::RedisHost), no_member_error(mbr::RedisHost));
-  assert_fatal(doc[mbr::RedisHost].IsString(),
-               type_error(mbr::RedisHost, kStrType));
+  ac::assert_fatal(doc.HasMember(mbr::RedisHost),
+                   ac::no_member_error(mbr::RedisHost));
+  ac::assert_fatal(doc[mbr::RedisHost].IsString(),
+                   ac::type_error(mbr::RedisHost, kStrType));
 
-  assert_fatal(doc.HasMember(mbr::RedisPort), no_member_error(mbr::RedisPort));
-  assert_fatal(doc[mbr::RedisPort].IsUint(),
-               type_error(mbr::RedisPort, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::RedisPort),
+                   ac::no_member_error(mbr::RedisPort));
+  ac::assert_fatal(doc[mbr::RedisPort].IsUint(),
+                   ac::type_error(mbr::RedisPort, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::MaxProposalSize),
-               no_member_error(mbr::MaxProposalSize));
-  assert_fatal(doc[mbr::MaxProposalSize].IsUint(),
-               type_error(mbr::MaxProposalSize, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::MaxProposalSize),
+                   ac::no_member_error(mbr::MaxProposalSize));
+  ac::assert_fatal(doc[mbr::MaxProposalSize].IsUint(),
+                   ac::type_error(mbr::MaxProposalSize, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::ProposalDelay),
-               no_member_error(mbr::ProposalDelay));
-  assert_fatal(doc[mbr::ProposalDelay].IsUint(),
-               type_error(mbr::ProposalDelay, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::ProposalDelay),
+                   ac::no_member_error(mbr::ProposalDelay));
+  ac::assert_fatal(doc[mbr::ProposalDelay].IsUint(),
+                   ac::type_error(mbr::ProposalDelay, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::VoteDelay), no_member_error(mbr::VoteDelay));
-  assert_fatal(doc[mbr::VoteDelay].IsUint(),
-               type_error(mbr::VoteDelay, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::VoteDelay),
+                   ac::no_member_error(mbr::VoteDelay));
+  ac::assert_fatal(doc[mbr::VoteDelay].IsUint(),
+                   ac::type_error(mbr::VoteDelay, kUintType));
 
-  assert_fatal(doc.HasMember(mbr::LoadDelay), no_member_error(mbr::LoadDelay));
-  assert_fatal(doc[mbr::LoadDelay].IsUint(),
-               type_error(mbr::LoadDelay, kUintType));
+  ac::assert_fatal(doc.HasMember(mbr::LoadDelay),
+                   ac::no_member_error(mbr::LoadDelay));
+  ac::assert_fatal(doc[mbr::LoadDelay].IsUint(),
+                   ac::type_error(mbr::LoadDelay, kUintType));
   return doc;
 }
 

--- a/irohad/torii/command_client.cpp
+++ b/irohad/torii/command_client.cpp
@@ -20,15 +20,19 @@ limitations under the License.
 
 namespace torii {
 
-  using iroha::protocol::Transaction;
   using iroha::protocol::ToriiResponse;
+  using iroha::protocol::Transaction;
 
   CommandSyncClient::CommandSyncClient(std::string ip, int port)
       : stub_(iroha::protocol::CommandService::NewStub(
             grpc::CreateChannel(ip + ":" + std::to_string(port),
                                 grpc::InsecureChannelCredentials()))) {}
 
-  CommandSyncClient::~CommandSyncClient() { completionQueue_.Shutdown(); }
+  CommandSyncClient::~CommandSyncClient() {
+    completionQueue_.Shutdown();
+  }
+
+  const char *kQueueNextError = "CompletionQueue::Next() returns error";
 
   /**
    * requests tx to a torii server and returns response (blocking, sync)
@@ -36,51 +40,52 @@ namespace torii {
    * @param response - returns ToriiResponse if succeeded
    * @return grpc::Status - returns connection is success or not.
    */
-  grpc::Status CommandSyncClient::Torii(const Transaction& tx) {
+  grpc::Status CommandSyncClient::Torii(const Transaction &tx) {
     auto rpc = stub_->AsyncTorii(&context_, tx, &completionQueue_);
 
     using State = network::UntypedCall<torii::ToriiServiceHandler>::State;
 
     google::protobuf::Empty empty;
-    rpc->Finish(&empty, &status_, (void*)static_cast<int>(State::ResponseSent));
+    rpc->Finish(
+        &empty, &status_, (void *)static_cast<int>(State::ResponseSent));
 
-    void* got_tag;
+    void *got_tag;
     bool ok = false;
 
     /**
      * pulls a new rpc response. If no response, blocks this thread.
      */
     if (!completionQueue_.Next(&got_tag, &ok)) {
-      throw std::runtime_error("CompletionQueue::Next() returns error");
+      throw std::runtime_error(kQueueNextError);
     }
 
-    assert(got_tag == (void*)static_cast<int>(State::ResponseSent));
+    assert(got_tag == (void *)static_cast<int>(State::ResponseSent));
     assert(ok);
 
     return status_;
   }
 
   grpc::Status CommandSyncClient::Status(
-      const iroha::protocol::TxStatusRequest& request,
-      iroha::protocol::ToriiResponse& response) {
+      const iroha::protocol::TxStatusRequest &request,
+      iroha::protocol::ToriiResponse &response) {
     auto rpc = stub_->AsyncStatus(&context_, request, &completionQueue_);
 
     using State = network::UntypedCall<torii::ToriiServiceHandler>::State;
 
-    rpc->Finish(&response, &status_,
-                (void*)static_cast<int>(State::ResponseSent));
+    rpc->Finish(
+        &response, &status_, (void *)static_cast<int>(State::ResponseSent));
 
-    void* got_tag;
+    void *got_tag;
     bool ok = false;
 
     /**
      * pulls a new rpc response. If no response, blocks this thread.
      */
     if (!completionQueue_.Next(&got_tag, &ok)) {
-      throw std::runtime_error("CompletionQueue::Next() returns error");
+      throw std::runtime_error(kQueueNextError);
     }
 
-    assert(got_tag == (void*)static_cast<int>(State::ResponseSent));
+    assert(got_tag == (void *)static_cast<int>(State::ResponseSent));
     assert(ok);
 
     return status_;
@@ -123,29 +128,29 @@ namespace torii {
    * @return grpc::Status
    */
   grpc::Status CommandAsyncClient::Torii(
-      const Transaction& tx,
-      const std::function<void(google::protobuf::Empty& response)>& callback) {
+      const Transaction &tx,
+      const std::function<void(google::protobuf::Empty &response)> &callback) {
     auto call = new ToriiAsyncClientCall;
     call->callback = callback;
     call->responseReader =
         stub_->AsyncTorii(&call->context, tx, &completionQueue_);
-    call->responseReader->Finish(&call->response, &call->status, (void*)call);
+    call->responseReader->Finish(&call->response, &call->status, (void *)call);
     return call->status;
   }
 
-/**
- * @param tx_request contains hash of requested tx
- * @param callback callback to process obtained status
- * @return grpc::Status determining if connection was successful
- */
+  /**
+   * @param tx_request contains hash of requested tx
+   * @param callback callback to process obtained status
+   * @return grpc::Status determining if connection was successful
+   */
   grpc::Status CommandAsyncClient::Status(
-      const iroha::protocol::TxStatusRequest& tx_request,
-      const StatusCallback& callback) {
+      const iroha::protocol::TxStatusRequest &tx_request,
+      const StatusCallback &callback) {
     auto call = new StatusAsyncClientCall;
     call->callback = callback;
     call->responseReader =
         stub_->AsyncStatus(&call->context, tx_request, &completionQueue_);
-    call->responseReader->Finish(&call->response, &call->status, (void*)call);
+    call->responseReader->Finish(&call->response, &call->status, (void *)call);
     return call->status;
   }
 
@@ -154,7 +159,7 @@ namespace torii {
    * @param ip
    * @param port
    */
-  CommandAsyncClient::CommandAsyncClient(const std::string& ip, const int port)
+  CommandAsyncClient::CommandAsyncClient(const std::string &ip, const int port)
       : stub_(iroha::protocol::CommandService::NewStub(
             grpc::CreateChannel(ip + ":" + std::to_string(port),
                                 grpc::InsecureChannelCredentials()))) {
@@ -175,7 +180,7 @@ namespace torii {
      * server.
      * ok - true if a regular event, otherwise false (e.g. grpc::Alarm)
      */
-    void* got_tag;
+    void *got_tag;
     bool ok = false;
 
     /**
@@ -186,14 +191,14 @@ namespace torii {
       if (!got_tag || !ok) {
         break;
       }
-      auto call = static_cast<AsyncClientCall*>(got_tag);
+      auto call = static_cast<AsyncClientCall *>(got_tag);
 
-      if (ToriiAsyncClientCall* torii_call =
-              dynamic_cast<ToriiAsyncClientCall*>(call)) {
+      if (ToriiAsyncClientCall *torii_call =
+              dynamic_cast<ToriiAsyncClientCall *>(call)) {
         torii_call->callback(torii_call->response);
       }
-      if (StatusAsyncClientCall* status_call =
-              dynamic_cast<StatusAsyncClientCall*>(call)) {
+      if (StatusAsyncClientCall *status_call =
+              dynamic_cast<StatusAsyncClientCall *>(call)) {
         status_call->callback(status_call->response);
       }
       delete call;

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -74,8 +74,8 @@ namespace iroha {
     std::string pub_key;
     std::string priv_key;
 
-    if (!loadFile(account_name_ + ".pub", pub_key)
-        || !loadFile(account_name_ + ".priv", priv_key))
+    if (!loadFile(account_name_ + kPubExt, pub_key)
+        || !loadFile(account_name_ + kPrivExt, priv_key))
       return nonstd::nullopt;
 
     return nonstd::make_optional<iroha::keypair_t>()
@@ -91,8 +91,8 @@ namespace iroha {
     auto seed = iroha::create_seed(pass_phrase);
     auto key_pairs = iroha::create_keypair(seed);
 
-    std::ofstream pub_file(account_name_ + ".pub");
-    std::ofstream priv_file(account_name_ + ".priv");
+    std::ofstream pub_file(account_name_ + kPubExt);
+    std::ofstream priv_file(account_name_ + kPrivExt);
     if (not pub_file or not priv_file) {
       return false;
     }
@@ -101,4 +101,6 @@ namespace iroha {
     return true;
   }
 
+  const std::string KeysManagerImpl::kPubExt = ".pub";
+  const std::string KeysManagerImpl::kPrivExt = ".priv";
 }  // namespace iroha

--- a/libs/crypto/keys_manager_impl.hpp
+++ b/libs/crypto/keys_manager_impl.hpp
@@ -32,6 +32,9 @@ namespace iroha {
 
     bool createKeys(const std::string &pass_phrase) override;
 
+    static const std::string kPubExt;
+    static const std::string kPrivExt;
+
    private:
     /**
      * Check if keypair provides valid signature

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -17,15 +17,15 @@ limitations under the License.
 #include "logger/logger.hpp"
 
 namespace logger {
+  const std::string end = "\033[0m";
+
   std::string red(const std::string &string) {
     const std::string red_start = "\033[31m";
-    const std::string end = "\033[0m";
     return red_start + string + end;
   }
 
   std::string yellow(const std::string &string) {
     const std::string yellow_start = "\033[33m";
-    const std::string end = "\033[0m";
     return yellow_start + string + end;
   }
 
@@ -33,7 +33,9 @@ namespace logger {
     return yellow("---> " + string);
   }
 
-  std::string input(const std::string &string) { return red("<--- " + string); }
+  std::string input(const std::string &string) {
+    return red("<--- " + string);
+  }
 
   void setGlobalPattern() {
     spdlog::set_pattern("[%H:%M:%S][th: %t][%l] [%n] << %v");
@@ -52,7 +54,7 @@ namespace logger {
     return logger;
   }
 
-  Logger testLog(const std::string &tag){
+  Logger testLog(const std::string &tag) {
     return log(tag);
   }
 


### PR DESCRIPTION
### Description of the Change

Extract some literals to the constant variables. Note that it doesn't cover irohad/model directory at all, affected files are below

iroha-cli:
- impl/grpc_response_handler.cpp
- impl/query_response_handler.cpp
- interactive/impl/interactive_query_cli.cpp

irohad/ametsuchi:
- /impl/postgres_wsv_query.cpp
- /impl/storage_impl.cpp

irohad/consensus:
- yac/impl/yac.cpp

irohad/main:
- application.cpp
- iroha_conf_loader.hpp

irohad/network:
- impl/block_loader_impl.cpp

irohad/torii:
- command_client.cpp

irohad/validation:
- impl/stateless_validator_impl.cpp

libs:
- crypto/keys_manager_impl.cpp
- crypto/keys_manager_impl.hpp
- logger/logger.cpp


### Benefits

Easier fixing, cleaner code

### Possible Drawbacks 

None
