### PR TITLE
Fix: Remove proto lazy fields 

### DIFF
--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -42,9 +42,10 @@ namespace shared_model {
       template <class BlockType>
       explicit Block(BlockType &&block)
           : CopyableProto(std::forward<BlockType>(block)),
+            payload_(proto_->payload()),
             transactions_([this] {
               std::vector<w<interface::Transaction>> txs;
-              for (const auto &tx : proto_->payload().transactions()) {
+              for (const auto &tx : payload_.transactions()) {
                 auto tmp = detail::makePolymorphic<proto::Transaction>(tx);
                 txs.emplace_back(tmp);
               }
@@ -62,9 +63,7 @@ namespace shared_model {
               }
               return sigs;
             }),
-            payload_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Block::payload)),
-            payload_blob_([this] { return makeBlob(*payload_); })
+            payload_blob_([this] { return makeBlob(payload_); })
 
       {}
 
@@ -77,7 +76,7 @@ namespace shared_model {
       }
 
       interface::types::HeightType height() const override {
-        return payload_->height();
+        return payload_.height();
       }
 
       const HashType &prevHash() const override {
@@ -106,11 +105,11 @@ namespace shared_model {
       }
 
       interface::types::TimestampType createdTime() const override {
-        return payload_->created_time();
+        return payload_.created_time();
       }
 
       TransactionsNumberType txsNumber() const override {
-        return payload_->tx_number();
+        return payload_.tx_number();
       }
 
       const typename Hashable<Block, iroha::model::Block>::BlobType &payload()
@@ -122,12 +121,11 @@ namespace shared_model {
       // lazy
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
-
+      const iroha::protocol::Block::Payload &payload_;
       const Lazy<std::vector<w<interface::Transaction>>> transactions_;
       const Lazy<BlobType> blob_;
       const Lazy<HashType> prev_hash_;
       const Lazy<SignatureSetType> signatures_;
-      const Lazy<const iroha::protocol::Block::Payload &> payload_;
       const Lazy<BlobType> payload_blob_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -36,10 +36,9 @@ namespace shared_model {
       template <typename CommandType>
       explicit AddAssetQuantity(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            add_asset_quantity_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::add_asset_quantity)),
+            add_asset_quantity_(proto_->add_asset_quantity()),
             amount_([this] {
-              return proto::Amount(add_asset_quantity_->amount());
+              return proto::Amount(add_asset_quantity_.amount());
             }) {}
 
       AddAssetQuantity(const AddAssetQuantity &o)
@@ -49,11 +48,11 @@ namespace shared_model {
           : AddAssetQuantity(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return add_asset_quantity_->account_id();
+        return add_asset_quantity_.account_id();
       }
 
       const interface::types::AssetIdType &assetId() const override {
-        return add_asset_quantity_->asset_id();
+        return add_asset_quantity_.asset_id();
       }
 
       const interface::Amount &amount() const override {
@@ -65,7 +64,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::AddAssetQuantity &> add_asset_quantity_;
+      const iroha::protocol::AddAssetQuantity &add_asset_quantity_;
 
       const Lazy<proto::Amount> amount_;
     };

--- a/shared_model/backend/protobuf/commands/proto_add_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_peer.hpp
@@ -33,7 +33,7 @@ namespace shared_model {
       explicit AddPeer(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
             add_peer_(proto_->add_peer()),
-            peer_([this] { return proto::Peer(add_peer_->peer()); }) {}
+            peer_([this] { return proto::Peer(add_peer_.peer()); }) {}
 
 
       AddPeer(const AddPeer &o) : AddPeer(o.proto_) {}

--- a/shared_model/backend/protobuf/commands/proto_add_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_peer.hpp
@@ -32,9 +32,9 @@ namespace shared_model {
       template <typename CommandType>
       explicit AddPeer(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            add_peer_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::add_peer)),
+            add_peer_(proto_->add_peer()),
             peer_([this] { return proto::Peer(add_peer_->peer()); }) {}
+
 
       AddPeer(const AddPeer &o) : AddPeer(o.proto_) {}
 
@@ -49,7 +49,7 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const Lazy<const iroha::protocol::AddPeer &> add_peer_;
+      const iroha::protocol::AddPeer &add_peer_;
       const Lazy<proto::Peer> peer_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
@@ -29,10 +29,9 @@ namespace shared_model {
       template <typename CommandType>
       explicit AddSignatory(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            add_signatory_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::add_signatory)),
+            add_signatory_(proto_->add_signatory()),
             pubkey_([this] {
-              return interface::types::PubkeyType(add_signatory_->public_key());
+              return interface::types::PubkeyType(add_signatory_.public_key());
             }) {}
 
       AddSignatory(const AddSignatory &o) : AddSignatory(o.proto_) {}
@@ -41,7 +40,7 @@ namespace shared_model {
           : AddSignatory(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return add_signatory_->account_id();
+        return add_signatory_.account_id();
       }
 
       const interface::types::PubkeyType &pubkey() const override {
@@ -53,7 +52,7 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const Lazy<const iroha::protocol::AddSignatory &> add_signatory_;
+      const iroha::protocol::AddSignatory &add_signatory_;
 
       const Lazy<interface::types::PubkeyType> pubkey_;
     };

--- a/shared_model/backend/protobuf/commands/proto_append_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_append_role.hpp
@@ -30,25 +30,22 @@ namespace shared_model {
       template <typename CommandType>
       explicit AppendRole(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            append_role_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::append_role)) {}
+            append_role_(proto_->append_role()) {}
 
       AppendRole(const AppendRole &o) : AppendRole(o.proto_) {}
 
       AppendRole(AppendRole &&o) noexcept : AppendRole(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return append_role_->account_id();
+        return append_role_.account_id();
       }
 
       const interface::types::RoleIdType &roleName() const override {
-        return append_role_->role_name();
+        return append_role_.role_name();
       }
 
      private:
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-      const Lazy<const iroha::protocol::AppendRole &> append_role_;
+      const iroha::protocol::AppendRole &append_role_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_account.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_account.hpp
@@ -30,11 +30,10 @@ namespace shared_model {
       template <typename CommandType>
       explicit CreateAccount(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            create_account_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::create_account)),
+            create_account_(proto_->create_account()),
             pubkey_([this] {
               return interface::types::PubkeyType(
-                  create_account_->main_pubkey());
+                  create_account_.main_pubkey());
             }) {}
 
       CreateAccount(const CreateAccount &o) : CreateAccount(o.proto_) {}
@@ -47,11 +46,11 @@ namespace shared_model {
       }
 
       const interface::types::AccountNameType &accountName() const override {
-        return create_account_->account_name();
+        return create_account_.account_name();
       }
 
       const interface::types::DomainIdType &domainId() const override {
-        return create_account_->domain_id();
+        return create_account_.domain_id();
       }
 
      private:
@@ -59,7 +58,7 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const Lazy<const iroha::protocol::CreateAccount &> create_account_;
+      const iroha::protocol::CreateAccount &create_account_;
       const Lazy<interface::types::PubkeyType> pubkey_;
     };
 

--- a/shared_model/backend/protobuf/commands/proto_create_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_asset.hpp
@@ -30,9 +30,8 @@ namespace shared_model {
       template <typename CommandType>
       explicit CreateAsset(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            create_asset_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::create_asset)),
-            precision_([this] { return create_asset_->precision(); }) {}
+            create_asset_(proto_->create_asset()),
+            precision_([this] { return create_asset_.precision(); }) {}
 
       CreateAsset(const CreateAsset &o) : CreateAsset(o.proto_) {}
 
@@ -40,11 +39,11 @@ namespace shared_model {
           : CreateAsset(std::move(o.proto_)) {}
 
       const interface::types::AssetNameType &assetName() const override {
-        return create_asset_->asset_name();
+        return create_asset_.asset_name();
       }
 
       const interface::types::DomainIdType &domainId() const override {
-        return create_asset_->domain_id();
+        return create_asset_.domain_id();
       }
 
       const PrecisionType &precision() const override {
@@ -55,7 +54,7 @@ namespace shared_model {
       // lazy
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
-      const Lazy<const iroha::protocol::CreateAsset &> create_asset_;
+      const iroha::protocol::CreateAsset &create_asset_;
       const Lazy<PrecisionType> precision_;
     };
 

--- a/shared_model/backend/protobuf/commands/proto_create_domain.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_domain.hpp
@@ -30,8 +30,7 @@ namespace shared_model {
       template <typename CommandType>
       explicit CreateDomain(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            create_domain_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::create_domain)) {}
+            create_domain_(proto_->create_domain()) {}
 
       CreateDomain(const CreateDomain &o) : CreateDomain(o.proto_) {}
 
@@ -39,19 +38,15 @@ namespace shared_model {
           : CreateDomain(std::move(o.proto_)) {}
 
       const interface::types::DomainIdType &domainId() const override {
-        return create_domain_->domain_id();
+        return create_domain_.domain_id();
       }
 
       const interface::types::RoleIdType &userDefaultRole() const override {
-        return create_domain_->default_role();
+        return create_domain_.default_role();
       }
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
-      const Lazy<const iroha::protocol::CreateDomain &> create_domain_;
+      const iroha::protocol::CreateDomain &create_domain_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_role.hpp
@@ -30,11 +30,10 @@ namespace shared_model {
       template <typename CommandType>
       explicit CreateRole(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            create_role_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::create_role)),
+            create_role_(proto_->create_role()),
             role_permissions_([this] {
               return boost::accumulate(
-                  create_role_->permissions(),
+                  create_role_.permissions(),
                   PermissionsType{},
                   [](auto &&acc, const auto &perm) {
                     acc.insert(iroha::protocol::RolePermission_Name(
@@ -48,7 +47,7 @@ namespace shared_model {
       CreateRole(CreateRole &&o) noexcept : CreateRole(std::move(o.proto_)) {}
 
       const interface::types::RoleIdType &roleName() const override {
-        return create_role_->role_name();
+        return create_role_.role_name();
       }
 
       const PermissionsType &rolePermissions() const override {
@@ -59,7 +58,7 @@ namespace shared_model {
       // lazy
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
-      const Lazy<const iroha::protocol::CreateRole &> create_role_;
+      const iroha::protocol::CreateRole &create_role_;
       const Lazy<PermissionsType> role_permissions_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_detach_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_detach_role.hpp
@@ -30,25 +30,22 @@ namespace shared_model {
       template <typename CommandType>
       explicit DetachRole(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            detach_role_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::detach_role)) {}
+            detach_role_(proto_->detach_role()) {}
 
       DetachRole(const DetachRole &o) : DetachRole(o.proto_) {}
 
       DetachRole(DetachRole &&o) noexcept : DetachRole(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return detach_role_->account_id();
+        return detach_role_.account_id();
       }
 
       const interface::types::RoleIdType &roleName() const override {
-        return detach_role_->role_name();
+        return detach_role_.role_name();
       }
 
      private:
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-      const Lazy<const iroha::protocol::DetachRole &> detach_role_;
+      const iroha::protocol::DetachRole &detach_role_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
@@ -31,8 +31,7 @@ namespace shared_model {
       template <typename CommandType>
       explicit GrantPermission(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            grant_permission_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::grant_permission)) {}
+            grant_permission_(proto_->grant_permission()) {}
 
       GrantPermission(const GrantPermission &o) : GrantPermission(o.proto_) {}
 
@@ -40,20 +39,17 @@ namespace shared_model {
           : GrantPermission(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return grant_permission_->account_id();
+        return grant_permission_.account_id();
       }
 
       const interface::types::PermissionNameType &permissionName()
           const override {
         return iroha::protocol::GrantablePermission_Name(
-            grant_permission_->permission());
+            grant_permission_.permission());
       }
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-      const Lazy<const iroha::protocol::GrantPermission &> grant_permission_;
+      const iroha::protocol::GrantPermission &grant_permission_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
@@ -31,11 +31,10 @@ namespace shared_model {
       template <typename CommandType>
       explicit RemoveSignatory(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            remove_signatory_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::remove_sign)),
+            remove_signatory_(proto_->remove_sign()),
             pubkey_([this] {
               return interface::types::PubkeyType(
-                  remove_signatory_->public_key());
+                  remove_signatory_.public_key());
             }) {}
 
       RemoveSignatory(const RemoveSignatory &o) : RemoveSignatory(o.proto_) {}
@@ -44,7 +43,7 @@ namespace shared_model {
           : RemoveSignatory(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return remove_signatory_->account_id();
+        return remove_signatory_.account_id();
       }
 
       const interface::types::PubkeyType &pubkey() const override {
@@ -56,7 +55,7 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const Lazy<const iroha::protocol::RemoveSignatory &> remove_signatory_;
+      const iroha::protocol::RemoveSignatory &remove_signatory_;
 
       const Lazy<interface::types::PubkeyType> pubkey_;
     };

--- a/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
@@ -30,8 +30,7 @@ namespace shared_model {
       template <typename CommandType>
       explicit RevokePermission(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            revoke_permission_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::revoke_permission)) {}
+            revoke_permission_(proto_->revoke_permission()) {}
 
       RevokePermission(const RevokePermission &o)
           : RevokePermission(o.proto_) {}
@@ -40,21 +39,17 @@ namespace shared_model {
           : RevokePermission(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return revoke_permission_->account_id();
+        return revoke_permission_.account_id();
       }
 
       const interface::types::PermissionNameType &permissionName()
           const override {
         return iroha::protocol::GrantablePermission_Name(
-            revoke_permission_->permission());
+            revoke_permission_.permission());
       }
 
      private:
-      // lazy
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::RevokePermission &> revoke_permission_;
+      const iroha::protocol::RevokePermission &revoke_permission_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
@@ -35,8 +35,7 @@ namespace shared_model {
       template <typename CommandType>
       explicit SetAccountDetail(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            set_account_detail_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::set_account_detail)) {}
+            set_account_detail_(proto_->set_account_detail()) {}
 
       SetAccountDetail(const SetAccountDetail &o)
           : SetAccountDetail(o.proto_) {}
@@ -45,23 +44,19 @@ namespace shared_model {
           : SetAccountDetail(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return set_account_detail_->account_id();
+        return set_account_detail_.account_id();
       }
 
       const AccountDetailKeyType &key() const override {
-        return set_account_detail_->key();
+        return set_account_detail_.key();
       }
 
       const AccountDetailValueType &value() const override {
-        return set_account_detail_->value();
+        return set_account_detail_.value();
       }
 
      private:
-      // lazy
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::SetAccountDetail &> set_account_detail_;
+      const iroha::protocol::SetAccountDetail &set_account_detail_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
@@ -29,16 +29,15 @@ namespace shared_model {
       template <typename CommandType>
       explicit SetQuorum(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            set_quorum_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::set_quorum)),
-            new_quorum_([this] { return set_quorum_->quorum(); }) {}
+            set_quorum_(proto_->set_quorum()),
+            new_quorum_([this] { return set_quorum_.quorum(); }) {}
 
       SetQuorum(const SetQuorum &o) : SetQuorum(o.proto_) {}
 
       SetQuorum(SetQuorum &&o) noexcept : SetQuorum(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return set_quorum_->account_id();
+        return set_quorum_.account_id();
       }
 
       const interface::types::QuorumType &newQuorum() const override {
@@ -50,7 +49,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::SetAccountQuorum &> set_quorum_;
+      const iroha::protocol::SetAccountQuorum &set_quorum_;
       const Lazy<const interface::types::QuorumType> new_quorum_;
     };
 

--- a/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
@@ -36,10 +36,9 @@ namespace shared_model {
       template <typename CommandType>
       explicit SubtractAssetQuantity(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            subtract_asset_quantity_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::subtract_asset_quantity)),
+            subtract_asset_quantity_(proto_->subtract_asset_quantity()),
             amount_([this] {
-              return proto::Amount(subtract_asset_quantity_->amount());
+              return proto::Amount(subtract_asset_quantity_.amount());
             }) {}
 
       SubtractAssetQuantity(const SubtractAssetQuantity &o)
@@ -49,11 +48,11 @@ namespace shared_model {
           : SubtractAssetQuantity(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return subtract_asset_quantity_->account_id();
+        return subtract_asset_quantity_.account_id();
       }
 
       const interface::types::AssetIdType &assetId() const override {
-        return subtract_asset_quantity_->asset_id();
+        return subtract_asset_quantity_.asset_id();
       }
 
       const interface::Amount &amount() const override {
@@ -65,8 +64,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::SubtractAssetQuantity &>
-          subtract_asset_quantity_;
+      const iroha::protocol::SubtractAssetQuantity &subtract_asset_quantity_;
 
       const Lazy<proto::Amount> amount_;
     };

--- a/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
@@ -30,10 +30,9 @@ namespace shared_model {
       template <typename CommandType>
       explicit TransferAsset(CommandType &&command)
           : CopyableProto(std::forward<CommandType>(command)),
-            transfer_asset_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Command::transfer_asset)),
+            transfer_asset_(proto_->transfer_asset()),
             amount_(
-                [this] { return proto::Amount(transfer_asset_->amount()); }) {}
+                [this] { return proto::Amount(transfer_asset_.amount()); }) {}
 
       TransferAsset(const TransferAsset &o) : TransferAsset(o.proto_) {}
 
@@ -45,19 +44,19 @@ namespace shared_model {
       }
 
       const interface::types::AssetIdType &assetId() const override {
-        return transfer_asset_->asset_id();
+        return transfer_asset_.asset_id();
       }
 
       const interface::types::AccountIdType &srcAccountId() const override {
-        return transfer_asset_->src_account_id();
+        return transfer_asset_.src_account_id();
       }
 
       const interface::types::AccountIdType &destAccountId() const override {
-        return transfer_asset_->dest_account_id();
+        return transfer_asset_.dest_account_id();
       }
 
       const MessageType &message() const override {
-        return transfer_asset_->description();
+        return transfer_asset_.description();
       }
 
      private:
@@ -65,7 +64,7 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const Lazy<const iroha::protocol::TransferAsset &> transfer_asset_;
+      const iroha::protocol::TransferAsset &transfer_asset_;
       const Lazy<proto::Amount> amount_;
     };
 

--- a/shared_model/backend/protobuf/queries/proto_get_account.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account.hpp
@@ -33,23 +33,19 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAccount(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-
-            account_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_account)) {}
+            account_(proto_->payload().get_account()) {}
 
       GetAccount(const GetAccount &o) : GetAccount(o.proto_) {}
 
       GetAccount(GetAccount &&o) noexcept : GetAccount(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_->account_id();
+        return account_.account_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
-      const detail::LazyInitializer<const iroha::protocol::GetAccount &>
-          account_;
+      const iroha::protocol::GetAccount &account_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -34,10 +34,8 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAccountAssetTransactions(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            account_asset_transactions_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::
-                    get_account_asset_transactions)) {}
+            account_asset_transactions_(
+                proto_->payload().get_account_asset_transactions()) {}
 
       GetAccountAssetTransactions(const GetAccountAssetTransactions &o)
           : GetAccountAssetTransactions(o.proto_) {}
@@ -46,21 +44,18 @@ namespace shared_model {
           : GetAccountAssetTransactions(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_asset_transactions_->account_id();
+        return account_asset_transactions_.account_id();
       }
 
       const interface::types::AssetIdType &assetId() const override {
-        return account_asset_transactions_->asset_id();
+        return account_asset_transactions_.asset_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
 
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetAccountAssetTransactions &>
-          account_asset_transactions_;
+      const iroha::protocol::GetAccountAssetTransactions
+          &account_asset_transactions_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
@@ -34,9 +34,7 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAccountAssets(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            account_assets_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_account_assets)) {}
+            account_assets_(proto_->payload().get_account_assets()) {}
 
       GetAccountAssets(const GetAccountAssets &o)
           : GetAccountAssets(o.proto_) {}
@@ -45,20 +43,17 @@ namespace shared_model {
           : GetAccountAssets(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_assets_->account_id();
+        return account_assets_.account_id();
       }
 
       const interface::types::AssetIdType &assetId() const override {
-        return account_assets_->asset_id();
+        return account_assets_.asset_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
 
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetAccountAssets &> account_assets_;
+      const iroha::protocol::GetAccountAssets &account_assets_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
@@ -34,9 +34,7 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAccountDetail(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            account_detail_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_account_detail)) {}
+            account_detail_(proto_->payload().get_account_detail()) {}
 
       GetAccountDetail(const GetAccountDetail &o)
           : GetAccountDetail(o.proto_) {}
@@ -45,20 +43,17 @@ namespace shared_model {
           : GetAccountDetail(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_detail_->account_id();
+        return account_detail_.account_id();
       }
 
       const interface::types::DetailType &detail() const override {
-        return account_detail_->detail();
+        return account_detail_.detail();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
 
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetAccountDetail &> account_detail_;
+      const iroha::protocol::GetAccountDetail &account_detail_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
@@ -34,9 +34,8 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAccountTransactions(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            account_transactions_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_account_transactions)) {}
+            account_transactions_(
+                proto_->payload().get_account_transactions()) {}
 
       GetAccountTransactions(const GetAccountTransactions &o)
           : GetAccountTransactions(o.proto_) {}
@@ -45,17 +44,13 @@ namespace shared_model {
           : GetAccountTransactions(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_transactions_->account_id();
+        return account_transactions_.account_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
 
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetAccountTransactions &>
-          account_transactions_;
+      const iroha::protocol::GetAccountTransactions &account_transactions_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
@@ -33,9 +33,7 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetAssetInfo(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            asset_info_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_asset_info)) {}
+            asset_info_(proto_->payload().get_asset_info()) {}
 
       GetAssetInfo(const GetAssetInfo &o) : GetAssetInfo(o.proto_) {}
 
@@ -43,13 +41,12 @@ namespace shared_model {
           : GetAssetInfo(std::move(o.proto_)) {}
 
       const interface::types::AssetIdType &assetId() const override {
-        return asset_info_->asset_id();
+        return asset_info_.asset_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
-      const detail::LazyInitializer<const iroha::protocol::GetAssetInfo &>
-          asset_info_;
+      const iroha::protocol::GetAssetInfo &asset_info_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
@@ -34,9 +34,7 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetRolePermissions(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            role_permissions_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_role_permissions)) {}
+            role_permissions_(proto_->payload().get_role_permissions()) {}
 
       GetRolePermissions(const GetRolePermissions &o)
           : GetRolePermissions(o.proto_) {}
@@ -45,13 +43,12 @@ namespace shared_model {
           : GetRolePermissions(std::move(o.proto_)) {}
 
       const interface::types::RoleIdType &roleId() const override {
-        return role_permissions_->role_id();
+        return role_permissions_.role_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
-      const detail::LazyInitializer<const iroha::protocol::GetRolePermissions &>
-          role_permissions_;
+      const iroha::protocol::GetRolePermissions &role_permissions_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
@@ -33,9 +33,7 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetSignatories(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            account_signatories_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_account_signatories)) {}
+            account_signatories_(proto_->payload().get_account_signatories()) {}
 
       GetSignatories(const GetSignatories &o) : GetSignatories(o.proto_) {}
 
@@ -43,16 +41,13 @@ namespace shared_model {
           : GetSignatories(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &accountId() const override {
-        return account_signatories_->account_id();
+        return account_signatories_.account_id();
       }
 
      private:
       // ------------------------------| fields |-------------------------------
 
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetSignatories &> account_signatories_;
+      const iroha::protocol::GetSignatories &account_signatories_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
@@ -34,12 +34,10 @@ namespace shared_model {
       template <typename QueryType>
       explicit GetTransactions(QueryType &&query)
           : CopyableProto(std::forward<QueryType>(query)),
-            get_transactions_(detail::makeReferenceGenerator(
-                &proto_->payload(),
-                &iroha::protocol::Query::Payload::get_transactions)),
+            get_transactions_(proto_->payload().get_transactions()),
             transaction_hashes_([this] {
               return boost::accumulate(
-                  get_transactions_->tx_hashes(),
+                  get_transactions_.tx_hashes(),
                   TransactionHashesType{},
                   [](auto &&acc, const auto &hash) {
                     acc.emplace_back(hash);
@@ -59,10 +57,10 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
+      const iroha::protocol::GetTransactions &get_transactions_;
+
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::GetTransactions &> get_transactions_;
 
       const Lazy<TransactionHashesType> transaction_hashes_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -35,11 +35,9 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit AccountAssetResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            accountAssetResponse_(detail::makeReferenceGenerator(
-                proto_,
-                &iroha::protocol::QueryResponse::account_assets_response)),
+            accountAssetResponse_(proto_->account_assets_response()),
             accountAsset_([this] {
-              return AccountAsset(accountAssetResponse_->account_asset());
+              return AccountAsset(accountAssetResponse_.account_asset());
             }) {}
 
       AccountAssetResponse(const AccountAssetResponse &o)
@@ -56,8 +54,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::AccountAssetResponse &>
-          accountAssetResponse_;
+      const iroha::protocol::AccountAssetResponse &accountAssetResponse_;
       const Lazy<AccountAsset> accountAsset_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
@@ -35,10 +35,7 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit AccountDetailResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            account_detail_response_(detail::makeReferenceGenerator(
-                proto_,
-                &iroha::protocol::QueryResponse::account_detail_response)),
-            detail_([this] { return account_detail_response_->detail(); }) {}
+            account_detail_response_(proto_->account_detail_response()){}
 
       AccountDetailResponse(const AccountDetailResponse &o)
           : AccountDetailResponse(o.proto_) {}
@@ -47,16 +44,11 @@ namespace shared_model {
           : AccountDetailResponse(std::move(o.proto_)) {}
 
       const DetailType &detail() const override {
-        return *detail_;
+        return account_detail_response_.detail();
       }
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      const Lazy<const iroha::protocol::AccountDetailResponse &>
-          account_detail_response_;
-      const Lazy<std::string> detail_;
+      const iroha::protocol::AccountDetailResponse &account_detail_response_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
@@ -37,18 +37,17 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit AccountResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            accountResponse_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::QueryResponse::account_response)),
+            accountResponse_(proto_->account_response()),
             accountRoles_([this] {
               return boost::accumulate(
-                  accountResponse_->account_roles(),
-                  SetRoleIdType{},
+                  accountResponse_.account_roles(),
+                  AccountRolesIdType{},
                   [](auto &&roles, const auto &role) {
                     roles.push_back(interface::types::RoleIdType(role));
                     return std::move(roles);
                   });
             }),
-            account_([this] { return Account(accountResponse_->account()); }) {}
+            account_([this] { return Account(accountResponse_.account()); }) {}
 
       AccountResponse(const AccountResponse &o) : AccountResponse(o.proto_) {}
 
@@ -59,7 +58,7 @@ namespace shared_model {
         return *account_;
       }
 
-      const SetRoleIdType &roles() const override {
+      const AccountRolesIdType &roles() const override {
         return *accountRoles_;
       }
 
@@ -67,8 +66,8 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::AccountResponse &> accountResponse_;
-      const Lazy<SetRoleIdType> accountRoles_;
+      const iroha::protocol::AccountResponse &accountResponse_;
+      const Lazy<AccountRolesIdType> accountRoles_;
       const Lazy<shared_model::proto::Account> account_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
@@ -35,9 +35,8 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit AssetResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            assetResponse_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::QueryResponse::asset_response)),
-            asset_([this] { return Asset(assetResponse_->asset()); }) {}
+            assetResponse_(proto_->asset_response()),
+            asset_([this] { return Asset(assetResponse_.asset()); }) {}
 
       AssetResponse(const AssetResponse &o) : AssetResponse(o.proto_) {}
 
@@ -51,7 +50,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::AssetResponse &> assetResponse_;
+      const iroha::protocol::AssetResponse &assetResponse_;
       const Lazy<Asset> asset_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
@@ -34,12 +34,10 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit RolePermissionsResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            rolePermissionsResponse_(detail::makeReferenceGenerator(
-                proto_,
-                &iroha::protocol::QueryResponse::role_permissions_response)),
+            rolePermissionsResponse_(proto_->role_permissions_response()),
             rolePermissions_([this] {
               return boost::accumulate(
-                  rolePermissionsResponse_->permissions(),
+                  rolePermissionsResponse_.permissions(),
                   PermissionNameCollectionType{},
                   [](auto &&permissions, const auto &permission) {
                     permissions.emplace_back(permission);
@@ -61,8 +59,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::RolePermissionsResponse &>
-          rolePermissionsResponse_;
+      const iroha::protocol::RolePermissionsResponse &rolePermissionsResponse_;
       const Lazy<PermissionNameCollectionType> rolePermissions_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
@@ -34,10 +34,9 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit RolesResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            rolesResponse_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::QueryResponse::roles_response)),
+            rolesResponse_(proto_->roles_response()),
             roles_([this] {
-              return boost::accumulate(rolesResponse_->roles(),
+              return boost::accumulate(rolesResponse_.roles(),
                                        RolesIdType{},
                                        [](auto &&roles, const auto &role) {
                                          roles.emplace_back(role);
@@ -57,7 +56,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::RolesResponse &> rolesResponse_;
+      const iroha::protocol::RolesResponse &rolesResponse_;
       const Lazy<RolesIdType> roles_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
@@ -34,11 +34,10 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit SignatoriesResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            signatoriesResponse_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::QueryResponse::signatories_response)),
+            signatoriesResponse_(proto_->signatories_response()),
             keys_([this] {
               return boost::accumulate(
-                  signatoriesResponse_->keys(),
+                  signatoriesResponse_.keys(),
                   interface::types::PublicKeyCollectionType{},
                   [](auto &&acc, const auto &key) {
                     acc.emplace_back(new interface::types::PubkeyType(key));
@@ -60,8 +59,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::SignatoriesResponse &>
-          signatoriesResponse_;
+      const iroha::protocol::SignatoriesResponse &signatoriesResponse_;
       const Lazy<interface::types::PublicKeyCollectionType> keys_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
@@ -35,11 +35,9 @@ namespace shared_model {
       template <typename QueryResponseType>
       explicit TransactionsResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            transactionResponse_(detail::makeReferenceGenerator(
-                proto_,
-                &iroha::protocol::QueryResponse::transactions_response)),
+            transactionResponse_(proto_->transactions_response()),
             transactions_([this] {
-              return boost::accumulate(transactionResponse_->transactions(),
+              return boost::accumulate(transactionResponse_.transactions(),
                                        TransactionsCollectionType{},
                                        [](auto &&txs, const auto &tx) {
                                          txs.emplace_back(new Transaction(tx));
@@ -61,8 +59,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::TransactionsResponse &>
-          transactionResponse_;
+      const iroha::protocol::TransactionsResponse &transactionResponse_;
       const Lazy<TransactionsCollectionType> transactions_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -36,11 +36,10 @@ namespace shared_model {
       template <typename TransactionType>
       explicit Transaction(TransactionType &&transaction)
           : CopyableProto(std::forward<TransactionType>(transaction)),
-            payload_(detail::makeReferenceGenerator(
-                proto_, &iroha::protocol::Transaction::payload)),
+            payload_(proto_->payload()),
             commands_([this] {
               return boost::accumulate(
-                  payload_->commands(),
+                  payload_.commands(),
                   CommandsType{},
                   [](auto &&acc, const auto &cmd) {
                     acc.emplace_back(new Command(cmd));
@@ -48,7 +47,7 @@ namespace shared_model {
                   });
             }),
             blob_([this] { return makeBlob(*proto_); }),
-            blobTypePayload_([this] { return makeBlob(*payload_); }),
+            blobTypePayload_([this] { return makeBlob(payload_); }),
             signatures_([this] {
               return boost::accumulate(
                   proto_->signature(),
@@ -66,11 +65,11 @@ namespace shared_model {
           : Transaction(std::move(o.proto_)) {}
 
       const interface::types::AccountIdType &creatorAccountId() const override {
-        return payload_->creator_account_id();
+        return payload_.creator_account_id();
       }
 
       interface::types::CounterType transactionCounter() const override {
-        return payload_->tx_counter();
+        return payload_.tx_counter();
       }
 
       const Transaction::CommandsType &commands() const override {
@@ -106,7 +105,7 @@ namespace shared_model {
       }
 
       interface::types::TimestampType createdTime() const override {
-        return payload_->created_time();
+        return payload_.created_time();
       }
 
      private:
@@ -114,7 +113,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<const iroha::protocol::Transaction::Payload &> payload_;
+      const iroha::protocol::Transaction::Payload &payload_;
 
       const Lazy<CommandsType> commands_;
 

--- a/shared_model/interfaces/query_responses/account_response.hpp
+++ b/shared_model/interfaces/query_responses/account_response.hpp
@@ -37,7 +37,7 @@ namespace shared_model {
     class AccountResponse : public PRIMITIVE(AccountResponse) {
      public:
       /// Collection of role_id types
-      using SetRoleIdType = std::vector<types::RoleIdType>;
+      using AccountRolesIdType = std::vector<types::RoleIdType>;
 
       /**
        * @return the fetched account.
@@ -47,7 +47,7 @@ namespace shared_model {
       /**
        * @return roles attached to the account
        */
-      virtual const SetRoleIdType &roles() const = 0;
+      virtual const AccountRolesIdType &roles() const = 0;
 
       /**
        * Stringify the data.

--- a/shared_model/utils/lazy_initializer.hpp
+++ b/shared_model/utils/lazy_initializer.hpp
@@ -82,34 +82,6 @@ namespace shared_model {
       using targetType = decltype(generator());
       return LazyInitializer<targetType>(std::forward<Generator>(generator));
     }
-
-    /**
-     * Create lambda which will return reference to value returned by function f
-     * lvalue reference specialization
-     * @tparam T object type
-     * @tparam F pointer to member function type
-     * @param t object to invoke method on
-     * @param f method to be invoked
-     * @return specified lambda
-     */
-    template <typename T, typename F>
-    auto makeReferenceGenerator(T &t, F &&f) {
-      return [&t, f]() -> decltype(auto) { return ((*t.*f)()); };
-    }
-
-    /**
-     * Create lambda which will return reference to value returned by function f
-     * rvalue reference specialization
-     * @tparam T object type
-     * @tparam F pointer to member function type
-     * @param t object to invoke method on
-     * @param f method to be invoked
-     * @return specified lambda
-     */
-    template <typename T, typename F>
-    auto makeReferenceGenerator(T &&t, F &&f) {
-      return [t{std::move(t)}, f]() -> decltype(auto) { return ((*t.*f)()); };
-    }
   }  // namespace detail
 }  // namespace shared_model
 #endif  // IROHA_LAZY_INITIALIZER_HPP


### PR DESCRIPTION
### Description of the Change

Small re-factoring to simplify the shared model protobuf implementation: 
 - Remove private lazy const reference fields 
 - Remove reference generator
 - Minor name renaming 

### Benefits

Simpler implementation 

### Possible Drawbacks 
None
