### PR TITLE
Docker-related quickfixes for develop

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -194,11 +194,18 @@ RUN git clone git://github.com/warchant/ed25519.git /tmp/ed25519; \
     ldconfig; \
     rm -rf /tmp/ed25519
 
-RUN adduser --disabled-password  iroha-ci --uid 6535
+# non-interactive adduser
+#   -m = create home dir
+#   -s = set default shell
+#   iroha-ci = username
+#   -u = userid, default for Ubuntu is 1000
+#   -U = create a group same as username
+#   no password
+RUN useradd -ms /bin/bash iroha-ci -u 1000 -U
+
 WORKDIR /opt/iroha
 RUN chmod -R 777 /opt/iroha; \
     mkdir -p /tmp/ccache -m 777;
 
 USER iroha-ci
-
 CMD ["/bin/bash"]

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -194,7 +194,7 @@ RUN git clone git://github.com/warchant/ed25519.git /tmp/ed25519; \
     ldconfig; \
     rm -rf /tmp/ed25519
 
-RUN adduser iroha-ci
+RUN adduser --disabled-password  iroha-ci --uid 6535
 WORKDIR /opt/iroha
 RUN chmod -R 777 /opt/iroha; \
     mkdir -p /tmp/ccache -m 777;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - IROHA_REDIS_HOST=${COMPOSE_PROJECT_NAME}_redis_1
       - IROHA_REDIS_PORT=6379
       - CCACHE_DIR=/tmp/ccache
+    # export G_ID=$(id -g $(whoami))
+    # export U_ID=$(id -g $(whoami))
+    user: ${U_ID?define U_ID withuuser id}:${G_ID?define G_ID with user group id}
     depends_on:
       - redis
       - postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - CCACHE_DIR=/tmp/ccache
     # export G_ID=$(id -g $(whoami))
     # export U_ID=$(id -g $(whoami))
-    user: ${U_ID?define U_ID withuuser id}:${G_ID?define G_ID with user group id}
+    user: ${U_ID?define U_ID with user id}:${G_ID?define G_ID with user group id}
     depends_on:
       - redis
       - postgres

--- a/scripts/run-iroha-dev.sh
+++ b/scripts/run-iroha-dev.sh
@@ -3,10 +3,9 @@ CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname "${CURDIR}")"
 PROJECT=iroha${USERID}
 COMPOSE=${IROHA_HOME}/docker/docker-compose.yml
-USER=$(whoami)
 
-export G_ID=$(id -g $USER)
-export U_ID=$(id -u $USER)
+export G_ID=$(id -g)
+export U_ID=$(id -u)
 export COMPOSE_PROJECT_NAME=${PROJECT}
 
 docker-compose -f ${COMPOSE} up -d

--- a/scripts/run-iroha-dev.sh
+++ b/scripts/run-iroha-dev.sh
@@ -1,35 +1,13 @@
 #!/bin/bash
-
-USERID=$(id -u $(whoami))
-
-
-if [ "$USERID" == "0" ]; then
-    USER=root
-else
-    USER=iroha
-fi
-
 CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname "${CURDIR}")"
 PROJECT=iroha${USERID}
+COMPOSE=${IROHA_HOME}/docker/docker-compose.yml
+USER=$(whoami)
 
+export G_ID=$(id -g $USER)
+export U_ID=$(id -u $USER)
 export COMPOSE_PROJECT_NAME=${PROJECT}
 
-if [ ! "$(docker ps -q -f name=${PROJECT}_node_1)" ] # node already running
-then
-  docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml up -d
-
-  if [ "$USERID" != "0" ]; then
-      docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml exec \
-        --user root node adduser --disabled-password --gecos "" ${USER} --uid ${USERID}
-      docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml exec \
-        --user root node chown -R ${USER}:${USER} /tmp/ccache
-  fi
-
-  docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml exec \
-    --user ${USER} node /bin/bash
-  docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml down
-else
-  docker-compose -f ${IROHA_HOME}/docker/docker-compose.yml exec \
-    node /bin/bash
-fi
+docker-compose -f ${COMPOSE} up -d
+docker-compose -f ${COMPOSE} exec node /bin/bash

--- a/test/module/irohad/ametsuchi/flat_file_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_test.cpp
@@ -184,9 +184,7 @@ TEST_F(BlStore_Test, GetDeniedBlock) {
   auto filename =
       boost::filesystem::path{block_store_path} / FlatFile::id_to_name(id);
 
-  using perms = boost::filesystem::perms;
-
-  boost::filesystem::permissions(filename.string().data(), perms::no_perms);
+  boost::filesystem::remove(filename);
   auto res = bl_store->get(id);
   ASSERT_FALSE(res);
 }
@@ -231,10 +229,9 @@ TEST_F(BlStore_Test, WriteDeniedFolder) {
   auto bl_store = std::move(*store);
   auto id = 1u;
 
-  using perms = boost::filesystem::perms;
   auto path = boost::filesystem::path(block_store_path);
 
-  boost::filesystem::permissions(path, perms::owner_read | perms::owner_exe);
+  boost::filesystem::remove(path);
   auto res = bl_store->add(id, block);
   ASSERT_FALSE(res);
 }

--- a/test/module/libs/crypto/keys_manager_test.cpp
+++ b/test/module/libs/crypto/keys_manager_test.cpp
@@ -56,6 +56,7 @@ class KeyManager : public ::testing::Test {
       "36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80"s;
   KeysManagerImpl manager = KeysManagerImpl(filepath);
   const std::string passphrase = "test";
+  const std::string inexistent = "/tmp/path/that/does/not/exist/100/percent";
 };
 
 TEST_F(KeyManager, LoadNonExistentKeyFile) {
@@ -100,27 +101,23 @@ TEST_F(KeyManager, CreateAndLoad) {
 TEST_F(KeyManager, LoadInaccessiblePubkey) {
   create_file(pub_key_path, pubkey);
   create_file(pri_key_path, prikey);
-  permissions(pub_key_path, no_perms);
+  remove(pub_key_path);
   ASSERT_FALSE(manager.loadKeys());
 }
 
 TEST_F(KeyManager, LoadInaccessiblePrikey) {
   create_file(pub_key_path, pubkey);
   create_file(pri_key_path, prikey);
-  permissions(pri_key_path, no_perms);
+  remove(pri_key_path);
   ASSERT_FALSE(manager.loadKeys());
 }
 
 TEST_F(KeyManager, CreateInaccessiblePubkey) {
-  create_file(pub_key_path, "");
-  create_file(pri_key_path, "");
-  permissions(pub_key_path, no_perms);
+  KeysManagerImpl manager = KeysManagerImpl(inexistent);
   ASSERT_FALSE(manager.createKeys(passphrase));
 }
 
 TEST_F(KeyManager, CreateInaccessiblePrikey) {
-  create_file(pub_key_path, "");
-  create_file(pri_key_path, "");
-  permissions(pri_key_path, no_perms);
+  KeysManagerImpl manager = KeysManagerImpl(inexistent);
   ASSERT_FALSE(manager.createKeys(passphrase));
 }

--- a/test/module/libs/crypto/keys_manager_test.cpp
+++ b/test/module/libs/crypto/keys_manager_test.cpp
@@ -112,12 +112,7 @@ TEST_F(KeyManager, LoadInaccessiblePrikey) {
   ASSERT_FALSE(manager.loadKeys());
 }
 
-TEST_F(KeyManager, CreateInaccessiblePubkey) {
-  KeysManagerImpl manager = KeysManagerImpl(nonexistent);
-  ASSERT_FALSE(manager.createKeys(passphrase));
-}
-
-TEST_F(KeyManager, CreateInaccessiblePrikey) {
+TEST_F(KeyManager, CreateKeypairInNonexistentDir) {
   KeysManagerImpl manager = KeysManagerImpl(nonexistent);
   ASSERT_FALSE(manager.createKeys(passphrase));
 }

--- a/test/module/libs/crypto/keys_manager_test.cpp
+++ b/test/module/libs/crypto/keys_manager_test.cpp
@@ -56,7 +56,7 @@ class KeyManager : public ::testing::Test {
       "36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80"s;
   KeysManagerImpl manager = KeysManagerImpl(filepath);
   const std::string passphrase = "test";
-  const std::string inexistent = "/tmp/path/that/does/not/exist/100/percent";
+  const std::string nonexistent = "/tmp/path/that/does/not/exist/100/percent";
 };
 
 TEST_F(KeyManager, LoadNonExistentKeyFile) {
@@ -113,11 +113,11 @@ TEST_F(KeyManager, LoadInaccessiblePrikey) {
 }
 
 TEST_F(KeyManager, CreateInaccessiblePubkey) {
-  KeysManagerImpl manager = KeysManagerImpl(inexistent);
+  KeysManagerImpl manager = KeysManagerImpl(nonexistent);
   ASSERT_FALSE(manager.createKeys(passphrase));
 }
 
 TEST_F(KeyManager, CreateInaccessiblePrikey) {
-  KeysManagerImpl manager = KeysManagerImpl(inexistent);
+  KeysManagerImpl manager = KeysManagerImpl(nonexistent);
   ASSERT_FALSE(manager.createKeys(passphrase));
 }


### PR DESCRIPTION
Signed-off-by: dumitru <dimasavva17@gmail.com>

UPD: @warchant


### Description of the Change
- [x] fix issue with permissions in some tests: when run as user - pass, as root - fail. Now it is user-independent. **Note**: please, do not use chmod in tests. Use non-existent paths or remove files/dirs.
- [x] change adduser to useradd (non-interactive)
- [x] add advanced user mapping inside `run-iroha-dev.sh`. It allows to map current UID:GID inside docker-develop without necessity of user creation, which simplifies script.