### PR TITLE
Fixes for shared_model classes (Block/Signature)

### DIFF
--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -21,6 +21,9 @@
 #include "interfaces/iroha_internal/block.hpp"
 
 #include <boost/range/numeric.hpp>
+#include "backend/protobuf/common_objects/signature.hpp"
+#include "backend/protobuf/transaction.hpp"
+#include "backend/protobuf/util.hpp"
 #include "common_objects/trivial_proto.hpp"
 #include "model/block.hpp"
 

--- a/shared_model/builders/protobuf/block.hpp
+++ b/shared_model/builders/protobuf/block.hpp
@@ -46,7 +46,6 @@ namespace shared_model {
         Height,
         PrevHash,
         CreatedTime,
-        Signatures,
         TOTAL
       };
 
@@ -79,9 +78,8 @@ namespace shared_model {
       auto transactions(const T &transactions) const {
         return transform<Transactions>([&](auto &block) {
           for (const auto &tx : transactions) {
-            iroha::protocol::Transaction proto_tx(tx->getTransport());
-            block.mutable_payload()->mutable_transactions()->Add(
-                std::move(proto_tx));
+            new (block.mutable_payload()->add_transactions())
+                iroha::protocol::Transaction(tx.getTransport());
           }
         });
       }
@@ -107,19 +105,6 @@ namespace shared_model {
       auto createdTime(interface::types::TimestampType time) const {
         return transform<CreatedTime>([&](auto &block) {
           block.mutable_payload()->set_created_time(time);
-        });
-      }
-
-      auto signatures(
-          const interface::Signable<interface::Block,
-                                    iroha::model::Block>::SignatureSetType
-              &signatures) const {
-        return transform<Signatures>([&](auto &block) {
-          for (const auto &signature : signatures) {
-            auto sig = block.add_signatures();
-            sig->set_pubkey(crypto::toBinaryString(signature->publicKey()));
-            sig->set_signature(crypto::toBinaryString(signature->signedData()));
-          }
         });
       }
 

--- a/shared_model/interfaces/common_objects/signature.hpp
+++ b/shared_model/interfaces/common_objects/signature.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_SHARED_MODEL_SIGNATURE_HPP
 #define IROHA_SHARED_MODEL_SIGNATURE_HPP
 
+#include "common/byteutils.hpp"
 #include "cryptography/blob.hpp"
 #include "cryptography/public_key.hpp"
 #include "cryptography/signed.hpp"
@@ -61,12 +62,11 @@ namespace shared_model {
       OldModelType *makeOldModel() const override {
         iroha::model::Signature *oldStyleSignature =
             new iroha::model::Signature();
-        oldStyleSignature->signature =
-            iroha::model::Signature::SignatureType::from_string(
-                signedData().toString());
+        oldStyleSignature->signature = *iroha::hexstringToArray<
+            iroha::model::Signature::SignatureType::size()>(signedData().hex());
         oldStyleSignature->pubkey =
-            iroha::model::Signature::KeyType::from_string(
-                publicKey().toString());
+            *iroha::hexstringToArray<iroha::model::Signature::KeyType::size()>(
+                publicKey().hex());
         return oldStyleSignature;
       }
 

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -18,9 +18,13 @@
 #ifndef IROHA_SHARED_MODEL_BLOCK_HPP
 #define IROHA_SHARED_MODEL_BLOCK_HPP
 
+#include <memory>
+#include "common/byteutils.hpp"
 #include "interfaces/base/signable.hpp"
 #include "interfaces/transaction.hpp"
 #include "model/block.hpp"
+#include "model/signature.hpp"
+#include "model/transaction.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -58,26 +62,28 @@ namespace shared_model {
       virtual const TransactionsCollectionType &transactions() const = 0;
 
       iroha::model::Block *makeOldModel() const override {
-        iroha::model::Block *oldStyleBlock = new iroha::model::Block();
-        oldStyleBlock->height = height();
-        oldStyleBlock->prev_hash =
-            iroha::model::Block::HashType::from_string(prevHash().toString());
-        oldStyleBlock->txs_number = txsNumber();
-        std::for_each(
-            transactions().begin(),
-            transactions().end(),
-            [oldStyleBlock](auto &tx) {
-              oldStyleBlock->transactions.emplace_back(*tx->makeOldModel());
-            });
-        oldStyleBlock->created_ts = createdTime();
-        oldStyleBlock->hash =
-            iroha::model::Block::HashType::from_string(hash().toString());
-        std::for_each(signatures().begin(),
-                      signatures().end(),
-                      [oldStyleBlock](auto &sig) {
-                        oldStyleBlock->sigs.emplace_back(*sig->makeOldModel());
+        iroha::model::Block *old_block = new iroha::model::Block();
+        old_block->height = height();
+        constexpr auto hash_size = iroha::model::Block::HashType::size();
+        old_block->prev_hash =
+            *iroha::hexstringToArray<hash_size>(prevHash().hex());
+        old_block->txs_number = txsNumber();
+        std::for_each(transactions().begin(),
+                      transactions().end(),
+                      [&old_block](auto &tx) {
+                        std::unique_ptr<iroha::model::Transaction> old_tx(
+                            tx->makeOldModel());
+                        old_block->transactions.emplace_back(*old_tx);
                       });
-        return oldStyleBlock;
+        old_block->created_ts = createdTime();
+        old_block->hash = *iroha::hexstringToArray<hash_size>(hash().hex());
+        std::for_each(
+            signatures().begin(), signatures().end(), [&old_block](auto &sig) {
+              std::unique_ptr<iroha::model::Signature> old_sig(
+                  sig->makeOldModel());
+              old_block->sigs.emplace_back(*old_sig);
+            });
+        return old_block;
       }
 
       std::string toString() const override {


### PR DESCRIPTION
### Description of the Change

Fixes for shared_model classes:
- Add missed includes
- Fix leaks and captures in block's `makeOldModel`
- Fix binary string conversion in block's & signature's `makeOldModel`
- Removed signatures from block's builder (as long as we sign builded object)
- Use placement new for adding txes in block (otherwise weird compile errors)

### Benefits

Lesser compile errors 

### Possible Drawbacks 

Hopefully none
