### PR TITLE
Conform old model perms with the shared_model

### DIFF
--- a/irohad/model/permissions.hpp
+++ b/irohad/model/permissions.hpp
@@ -24,55 +24,51 @@
 namespace iroha {
   namespace model {
 
-    const std::string can_append_role = "CanAppendRole";
-    const std::string can_create_role = "CanCreateRole";
-    const std::string can_detach_role = "CanDetachRole";
-    const std::string can_add_asset_qty = "CanAddAssetQuantity";
-    const std::string can_subtract_asset_qty = "CanSubtractAssetQuantity";
-    const std::string can_add_peer = "CanAddPeer";
-    const std::string can_add_signatory = "CanAddSignatory";
-    const std::string can_create_account = "CanCreateAccount";
-    const std::string can_create_asset = "CanCreateAsset";
-    const std::string can_create_domain = "CanCreateDomain";
-    const std::string can_remove_signatory = "CanRemoveSignatory";
-    const std::string can_set_quorum = "CanSetQuorum";
-    const std::string can_transfer = "CanTransfer";
-    const std::string can_receive = "CanReceive";
-    const std::string can_set_detail = "CanSetAccountInfo";
+    const std::string can_append_role = "can_append_role";
+    const std::string can_create_role = "can_create_role";
+    const std::string can_detach_role = "can_detach_role";
+    const std::string can_add_asset_qty = "can_add_asset_qty";
+    const std::string can_subtract_asset_qty = "can_subtract_asset_qty";
+    const std::string can_add_peer = "can_add_peer";
+    const std::string can_add_signatory = "can_add_signatory";
+    const std::string can_create_account = "can_create_account";
+    const std::string can_create_asset = "can_create_asset";
+    const std::string can_create_domain = "can_create_domain";
+    const std::string can_remove_signatory = "can_remove_signatory";
+    const std::string can_set_quorum = "can_set_quorum";
+    const std::string can_transfer = "can_transfer";
+    const std::string can_receive = "can_receive";
+    const std::string can_set_detail = "can_set_detail";
 
     // ---------|Query permissions|-------------
-    const std::string can_read_assets = "CanReadAssets";
-    const std::string can_get_roles = "CanGetRoles";
+    const std::string can_read_assets = "can_read_assets";
+    const std::string can_get_roles = "can_get_roles";
 
-    const std::string can_get_my_account = "CanGetMyAccount";
-    const std::string can_get_all_accounts = "CanGetAllAccounts";
-    const std::string can_get_domain_accounts = "CanGetDomainAccounts";
+    const std::string can_get_my_account = "can_get_my_account";
+    const std::string can_get_all_accounts = "can_get_all_accounts";
+    const std::string can_get_domain_accounts = "can_get_domain_accounts";
 
-    const std::string can_get_my_signatories = "CanGetMySignatories";
-    const std::string can_get_all_signatories = "CanGetAllSignatories";
-    const std::string can_get_domain_signatories = "CanGetDomainSignatories";
+    const std::string can_get_my_signatories = "can_get_my_signatories";
+    const std::string can_get_all_signatories = "can_get_all_signatories";
+    const std::string can_get_domain_signatories = "can_get_domain_signatories";
 
-    const std::string can_get_my_acc_ast = "CanGetMyAccountAssets";
-    const std::string can_get_all_acc_ast = "CanGetAllAccountAssets";
-    const std::string can_get_domain_acc_ast = "CanGetDomainAccountAssets";
-    const std::string can_get_my_acc_detail = "CanGetMyAccountDetail";
-    const std::string can_get_all_acc_detail = "CanGetAllAccountDetail";
-    const std::string can_get_domain_acc_detail = "CanGetDomainAccountDetail";
+    const std::string can_get_my_acc_ast = "can_get_my_acc_ast";
+    const std::string can_get_all_acc_ast = "can_get_all_acc_ast";
+    const std::string can_get_domain_acc_ast = "can_get_domain_acc_ast";
+    const std::string can_get_my_acc_detail = "can_get_my_acc_detail";
+    const std::string can_get_all_acc_detail = "can_get_all_acc_detail";
+    const std::string can_get_domain_acc_detail = "can_get_domain_acc_detail";
 
-    const std::string can_get_my_acc_txs = "CanGetMyAccountTransactions";
-    const std::string can_get_all_acc_txs = "CanGetAllAccountTransactions";
-    const std::string can_get_domain_acc_txs =
-        "CanGetDomainAccountTransactions";
+    const std::string can_get_my_acc_txs = "can_get_my_acc_txs";
+    const std::string can_get_all_acc_txs = "can_get_all_acc_txs";
+    const std::string can_get_domain_acc_txs = "can_get_domain_acc_txs";
 
-    const std::string can_get_my_acc_ast_txs =
-        "CanGetMyAccountAssetsTransactions";
-    const std::string can_get_all_acc_ast_txs =
-        "CanGetAllAccountAssetsTransactions";
-    const std::string can_get_domain_acc_ast_txs =
-        "CanGetDomainAccountAssetsTransactions";
+    const std::string can_get_my_acc_ast_txs = "can_get_my_acc_ast_txs";
+    const std::string can_get_all_acc_ast_txs = "can_get_all_acc_ast_txs";
+    const std::string can_get_domain_acc_ast_txs = "can_get_domain_acc_ast_txs";
 
-    const std::string can_get_my_txs = "CanGetMyTransactions";
-    const std::string can_get_all_txs = "CanGetAllTransactions";
+    const std::string can_get_my_txs = "can_get_my_txs";
+    const std::string can_get_all_txs = "can_get_all_txs";
 
     const std::set<std::string> read_self_group = {can_get_my_account,
                                                    can_get_my_acc_ast,
@@ -98,7 +94,7 @@ namespace iroha {
                                                      can_get_domain_signatories,
                                                      can_get_my_acc_detail};
 
-    const std::string can_grant = "CanGrant";
+    const std::string can_grant = "can_grant_";
     const std::set<std::string> grant_group = {can_grant + can_set_quorum,
                                                can_grant + can_add_signatory,
                                                can_grant + can_remove_signatory,

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -38,11 +38,11 @@
 #include "model/execution/command_executor_factory.hpp"
 #include "model/permissions.hpp"
 
-using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::StrictMock;
+using ::testing::_;
 
 using namespace iroha;
 using namespace iroha::ametsuchi;
@@ -1610,9 +1610,10 @@ class GrantPermissionTest : public CommandValidateExecuteTest {
  public:
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
-    exact_command = std::make_shared<GrantPermission>("yoda", "CanTeach");
+    const auto perm = "can_teach";
+    exact_command = std::make_shared<GrantPermission>("yoda", perm);
     command = exact_command;
-    role_permissions = {"CanGrantCanTeach"};
+    role_permissions = {can_grant + perm};
   }
   std::shared_ptr<GrantPermission> exact_command;
 };

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -36,6 +36,7 @@
 #include "model/commands/subtract_asset_quantity.hpp"
 #include "model/commands/transfer_asset.hpp"
 #include "model/converters/json_command_factory.hpp"
+#include "model/permissions.hpp"
 
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 
@@ -285,7 +286,7 @@ TEST_F(JsonCommandTest, detach_role) {
 
 TEST_F(JsonCommandTest, create_role) {
   std::set<std::string> perms = {
-      "CanGetMyAccount", "CanCreateAsset", "CanAddPeer"};
+      can_get_my_account, can_create_asset, can_add_peer};
   auto orig_command = std::make_shared<CreateRole>("master", perms);
   auto json_command = factory.serializeCreateRole(orig_command);
   auto serial_command = factory.deserializeCreateRole(json_command);


### PR DESCRIPTION
### Description of the Change

As @motxx noticed here's the shared_model permission converting:

https://github.com/hyperledger/iroha/blob/4e58f7780b8c918e56328231ec8f5a9fd67bb429/shared_model/builders/protobuf/transaction.hpp#L211-L215

That's pr updates old model permission string names, so it may work with the shared_model as well.

### Possible Drawbacks 

?

### Alternate Designs

As an additional way of fixing that is converting permissions and leaving the old model as is. Imo that not really good because it requires update such strings in multiple places.
