### PR TITLE
Command Executor returns error message on execute()

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -56,7 +56,7 @@ namespace iroha {
                   *command, *wsv_, *executor_, transaction.creator_account_id);
           return result.match(
               [](expected::Value<void> v) { return true; },
-              [](expected::Error<std::string> e) { return false; });
+              [](expected::Error<iroha::model::ExecutionError> e) { return false; });
         };
         return std::all_of(transaction.commands.begin(),
                            transaction.commands.end(),

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -51,8 +51,12 @@ namespace iroha {
             function) {
       auto execute_transaction = [this](auto &transaction) {
         auto execute_command = [this, &transaction](auto command) {
-          return command_executors_->getCommandExecutor(command)->execute(
-              *command, *wsv_, *executor_, transaction.creator_account_id);
+          auto result =
+              command_executors_->getCommandExecutor(command)->execute(
+                  *command, *wsv_, *executor_, transaction.creator_account_id);
+          return result.match(
+              [](expected::Value<void> v) { return true; },
+              [](expected::Error<std::string> e) { return false; });
         };
         return std::all_of(transaction.commands.begin(),
                            transaction.commands.end(),

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -18,14 +18,14 @@
 #ifndef IROHA_MUTABLE_STORAGE_IMPL_HPP
 #define IROHA_MUTABLE_STORAGE_IMPL_HPP
 
-#include "ametsuchi/mutable_storage.hpp"
-
 #include <cpp_redis/cpp_redis>
 #include <pqxx/connection>
 #include <pqxx/nontransaction>
 #include <unordered_map>
 
 #include "ametsuchi/impl/block_index.hpp"
+#include "ametsuchi/mutable_storage.hpp"
+#include "logger/logger.hpp"
 #include "model/execution/command_executor_factory.hpp"
 
 namespace iroha {
@@ -63,6 +63,8 @@ namespace iroha {
       std::shared_ptr<model::CommandExecutorFactory> command_executors_;
 
       bool committed;
+
+      logger::Logger log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -43,7 +43,7 @@ namespace iroha {
       auto execute_command = [this, &tx_creator](auto command) {
         auto executor = command_executors_->getCommandExecutor(command);
         auto account = wsv_->getAccount(tx_creator).value();
-        if (!executor->validate(*command, *wsv_, tx_creator)) {
+        if (not executor->validate(*command, *wsv_, tx_creator)) {
           return false;
         }
         auto result =

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -67,7 +67,7 @@ namespace iroha {
         transaction_->exec("ROLLBACK TO SAVEPOINT savepoint_;");
       }
       return result;
-    }  // namespace ametsuchi
+    }
 
     TemporaryWsvImpl::~TemporaryWsvImpl() {
       transaction_->exec("ROLLBACK;");

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -49,7 +49,7 @@ namespace iroha {
             executor->execute(*command, *wsv_, *executor_, tx_creator);
         return result.match(
             [](expected::Value<void> &v) { return true; },
-            [this](expected::Error<std::string> &e) { return false; });
+            [this](expected::Error<iroha::model::ExecutionError> &e) { return false; });
       };
 
       transaction_->exec("SAVEPOINT savepoint_;");

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -22,6 +22,7 @@
 #include <pqxx/nontransaction>
 
 #include "ametsuchi/temporary_wsv.hpp"
+#include "logger/logger.hpp"
 #include "model/execution/command_executor_factory.hpp"
 
 namespace iroha {
@@ -45,6 +46,8 @@ namespace iroha {
       std::unique_ptr<WsvQuery> wsv_;
       std::unique_ptr<WsvCommand> executor_;
       std::shared_ptr<model::CommandExecutorFactory> command_executors_;
+
+      logger::Logger log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(command_execution
 target_link_libraries(command_execution
     common_execution
     validator
+    boost
     )
 
 add_library(model

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -64,7 +64,8 @@ namespace iroha {
        * @param command - command to be executed
        * @param queries - world state view query interface
        * @param commands - world state view command interface
-       * @return true, if execution is successful
+       * @return Result, which will contain error with ExecutionError if execute
+       * is not successful or void Value otherwise
        */
       virtual ExecutionResult execute(
           const Command &command,

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -22,6 +22,9 @@
 #include "ametsuchi/wsv_query.hpp"
 #include "logger/logger.hpp"
 #include "model/command.hpp"
+#include "common/result.hpp"
+
+using ExecutionResult = iroha::expected::Result<void, std::string>;
 
 namespace iroha {
   namespace model {
@@ -50,7 +53,7 @@ namespace iroha {
        * @param commands - world state view command interface
        * @return true, if execution is successful
        */
-      virtual bool execute(const Command &command,
+      virtual ExecutionResult execute(const Command &command,
                            ametsuchi::WsvQuery &queries,
                            ametsuchi::WsvCommand &commands,
                            const std::string &creator_account_id) = 0;
@@ -85,7 +88,7 @@ namespace iroha {
     class AppendRoleExecutor : public CommandExecutor {
      public:
       AppendRoleExecutor();
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -103,7 +106,7 @@ namespace iroha {
     class DetachRoleExecutor : public CommandExecutor {
      public:
       DetachRoleExecutor();
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -121,7 +124,7 @@ namespace iroha {
     class CreateRoleExecutor : public CommandExecutor {
      public:
       CreateRoleExecutor();
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -139,7 +142,7 @@ namespace iroha {
     class GrantPermissionExecutor : public CommandExecutor {
      public:
       GrantPermissionExecutor();
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -157,7 +160,7 @@ namespace iroha {
     class RevokePermissionExecutor : public CommandExecutor {
      public:
       RevokePermissionExecutor();
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -176,7 +179,7 @@ namespace iroha {
      public:
       AddAssetQuantityExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -195,7 +198,7 @@ namespace iroha {
      public:
       SubtractAssetQuantityExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -214,7 +217,7 @@ namespace iroha {
      public:
       AddPeerExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -233,7 +236,7 @@ namespace iroha {
      public:
       AddSignatoryExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -252,7 +255,7 @@ namespace iroha {
      public:
       CreateAccountExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -271,7 +274,7 @@ namespace iroha {
      public:
       CreateAssetExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -290,7 +293,7 @@ namespace iroha {
      public:
       CreateDomainExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -309,7 +312,7 @@ namespace iroha {
      public:
       RemoveSignatoryExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -328,7 +331,7 @@ namespace iroha {
      public:
       SetAccountDetailExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -347,7 +350,7 @@ namespace iroha {
      public:
       SetQuorumExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;
@@ -366,7 +369,7 @@ namespace iroha {
      public:
       TransferAssetExecutor();
 
-      bool execute(const Command &command,
+      ExecutionResult execute(const Command &command,
                    ametsuchi::WsvQuery &queries,
                    ametsuchi::WsvCommand &commands,
                    const std::string &creator_account_id) override;

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -111,6 +111,14 @@ namespace iroha {
       expected::Error<ExecutionError> makeExecutionError(
           const std::string &error_message) const noexcept;
 
+      /**
+       * Return execution result with an error with given message if predicate
+       * is false
+       * @param predicate - condition which determines result state
+       * @param error_message - string which will be part of the error
+       * @return ExecutionResult with empty value if predicate is true, Error
+       * with error message otherwise
+       */
       ExecutionResult errorIfNot(bool predicate,
                                  const std::string &error_message) const
           noexcept;

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -24,23 +24,22 @@
 #include "ametsuchi/wsv_query.hpp"
 #include "common/result.hpp"
 #include "model/command.hpp"
+#include "model/execution/execution_error.hpp"
 
 namespace iroha {
   namespace model {
 
     /**
-     * Error message contains command name, as well as what went wrong
-     * it may be validation error, or database error
+     * ExecutionResult is a return type of all execute functions.
+     * If execute is successful, result will not contain anything (void value),
+     * because execute does not return any value.
+     * If execution is not successful, ExecutionResult will contain Execution
+     * error with explanation
+     *
+     * Result is used because it allows for clear distinction between two states
+     * - value and error. If we just returned error, it would be confusing, what
+     * value of an error to consider as a successful state of execution
      */
-    struct ExecutionError {
-      std::string command_name;
-      std::string error_message;
-
-      std::string toString() const {
-        return (boost::format("%s: %s") % command_name % error_message).str();
-      }
-    };
-
     using ExecutionResult = expected::Result<void, ExecutionError>;
 
     /**
@@ -114,12 +113,12 @@ namespace iroha {
       /**
        * Return execution result with an error with given message if predicate
        * is false
-       * @param predicate - condition which determines result state
+       * @param condition - boolean value which determines result state
        * @param error_message - string which will be part of the error
        * @return ExecutionResult with empty value if predicate is true, Error
        * with error message otherwise
        */
-      ExecutionResult errorIfNot(bool predicate,
+      ExecutionResult errorIfNot(bool condition,
                                  const std::string &error_message) const
           noexcept;
     };

--- a/irohad/model/execution/command_executor.hpp
+++ b/irohad/model/execution/command_executor.hpp
@@ -23,7 +23,6 @@
 #include "ametsuchi/wsv_command.hpp"
 #include "ametsuchi/wsv_query.hpp"
 #include "common/result.hpp"
-#include "logger/logger.hpp"
 #include "model/command.hpp"
 
 namespace iroha {

--- a/irohad/model/execution/execution_error.hpp
+++ b/irohad/model/execution/execution_error.hpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_EXECUTION_ERROR_HPP
+#define IROHA_EXECUTION_ERROR_HPP
+
+#include <boost/format.hpp>
+
+namespace iroha {
+  namespace model {
+
+    /**
+     * Error for command execution.
+     * Contains command name, as well as an error message
+     */
+    struct ExecutionError {
+      std::string command_name;
+      std::string error_message;
+
+      std::string toString() const {
+        return (boost::format("%s: %s") % command_name % error_message).str();
+      }
+    };
+  }  // namespace model
+}  // namespace iroha
+
+#endif  // IROHA_EXECUTION_ERROR_HPP

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -30,9 +30,6 @@
 #include "model/commands/remove_signatory.hpp"
 #include "model/commands/revoke_permission.hpp"
 #include "model/commands/set_account_detail.hpp"
-
-
-
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/subtract_asset_quantity.hpp"
 #include "model/commands/transfer_asset.hpp"
@@ -50,8 +47,8 @@ namespace iroha {
     // TODO: 30.01.2018 nickaleks make db calls return result to eliminate need
     // for this function IR-775
     ExecutionResult CommandExecutor::errorIfNot(
-        bool predicate, const std::string &error_message) const noexcept {
-      if (not predicate) {
+        bool condition, const std::string &error_message) const noexcept {
+      if (not condition) {
         return makeExecutionError(error_message);
       }
       return {};
@@ -450,7 +447,6 @@ namespace iroha {
     bool AddPeerExecutor::isValid(const Command &command,
                                   ametsuchi::WsvQuery &queries,
                                   const std::string &creator_account_id) {
-      // TODO: check that address is formed right
       return true;
     }
 

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -41,14 +41,14 @@
 using namespace iroha::ametsuchi;
 using iroha::expected::makeError;
 
-
 namespace iroha {
   namespace model {
 
-    // TODO: Make db calls return result to eliminate need for this function IR-775
-    ExecutionResult CommandExecutor::errorIfNot(bool predicate,
-                               const std::string &error_message) const noexcept {
-      if (!predicate) {
+    // TODO: 30.01.2018 nickaleks make db calls return result to eliminate need
+    // for this function IR-775
+    ExecutionResult CommandExecutor::errorIfNot(
+        bool predicate, const std::string &error_message) const noexcept {
+      if (not predicate) {
         return makeExecutionError(error_message);
       }
       return {};
@@ -164,9 +164,9 @@ namespace iroha {
         const std::string &creator_account_id) {
       auto cmd_value = static_cast<const CreateRole &>(command);
 
-      if (!commands.insertRole(cmd_value.role_name)) {
+      if (not commands.insertRole(cmd_value.role_name)) {
         return makeExecutionError("failed to insert role: "
-                         + cmd_value.role_name);
+                                  + cmd_value.role_name);
       }
 
       return errorIfNot(commands.insertRolePermissions(cmd_value.role_name,
@@ -302,13 +302,12 @@ namespace iroha {
       }
       if (not queries.getAccount(add_asset_quantity.account_id).has_value()) {
         return makeExecutionError((boost::format("account %s is absent")
-                          % add_asset_quantity.account_id)
-                             .str());
+                                   % add_asset_quantity.account_id)
+                                      .str());
       }
       auto account_asset = queries.getAccountAsset(
           add_asset_quantity.account_id, add_asset_quantity.asset_id);
       if (not account_asset.has_value()) {
-
         account_asset = AccountAsset();
         account_asset->asset_id = add_asset_quantity.asset_id;
         account_asset->account_id = add_asset_quantity.account_id;
@@ -366,8 +365,8 @@ namespace iroha {
       auto asset = queries.getAsset(subtract_asset_quantity.asset_id);
       if (not asset) {
         return makeExecutionError((boost::format("asset %s is absent")
-                          % subtract_asset_quantity.asset_id)
-                             .str());
+                                   % subtract_asset_quantity.asset_id)
+                                      .str());
       }
       auto precision = asset.value().precision;
 
@@ -378,9 +377,9 @@ namespace iroha {
           subtract_asset_quantity.account_id, subtract_asset_quantity.asset_id);
       if (not account_asset.has_value()) {
         return makeExecutionError((boost::format("%s do not have %s")
-                          % subtract_asset_quantity.account_id
-                          % subtract_asset_quantity.asset_id)
-                             .str());
+                                   % subtract_asset_quantity.account_id
+                                   % subtract_asset_quantity.asset_id)
+                                      .str());
       }
       auto account_asset_value = account_asset.value();
 
@@ -459,7 +458,7 @@ namespace iroha {
         const std::string &creator_account_id) {
       auto add_signatory = static_cast<const AddSignatory &>(command);
 
-      if (!commands.insertSignatory(add_signatory.pubkey)) {
+      if (not commands.insertSignatory(add_signatory.pubkey)) {
         return makeExecutionError("failed to insert signatory");
       }
       return errorIfNot(commands.insertAccountSignatory(
@@ -517,14 +516,14 @@ namespace iroha {
                 .str());
       }
       // TODO: remove insert signatory from here ?
-      if (!commands.insertSignatory(create_account.pubkey)) {
+      if (not commands.insertSignatory(create_account.pubkey)) {
         return makeExecutionError("failed to insert signatory");
       }
-      if (!commands.insertAccount(account)) {
+      if (not commands.insertAccount(account)) {
         return makeExecutionError("failed to insert account");
       }
-      if (!commands.insertAccountSignatory(account.account_id,
-                                           create_account.pubkey)) {
+      if (not commands.insertAccountSignatory(account.account_id,
+                                              create_account.pubkey)) {
         return makeExecutionError("failed to insert account signatory");
       }
       return errorIfNot(commands.insertAccountRole(account.account_id,
@@ -570,7 +569,7 @@ namespace iroha {
           create_asset.asset_name + "#" + create_asset.domain_id;
       new_asset.domain_id = create_asset.domain_id;
       new_asset.precision = create_asset.precision;
-      // The insert will fail if asset already exist
+      // The insert will fail if asset already exists
       return errorIfNot(commands.insertAsset(new_asset),
                         "failed to insert asset");
     }
@@ -656,8 +655,8 @@ namespace iroha {
       auto remove_signatory = static_cast<const RemoveSignatory &>(command);
 
       // Delete will fail if account signatory doesn't exist
-      if (!commands.deleteAccountSignatory(remove_signatory.account_id,
-                                           remove_signatory.pubkey)) {
+      if (not commands.deleteAccountSignatory(remove_signatory.account_id,
+                                              remove_signatory.pubkey)) {
         return makeExecutionError("failed to delete account signatory");
       }
       return errorIfNot(commands.deleteSignatory(remove_signatory.pubkey),
@@ -814,11 +813,10 @@ namespace iroha {
       auto src_account_asset = queries.getAccountAsset(
           transfer_asset.src_account_id, transfer_asset.asset_id);
       if (not src_account_asset.has_value()) {
-
         return makeExecutionError((boost::format("asset %s is absent of %s")
-                          % transfer_asset.asset_id
-                          % transfer_asset.src_account_id)
-                             .str());
+                                   % transfer_asset.asset_id
+                                   % transfer_asset.src_account_id)
+                                      .str());
       }
 
       AccountAsset dest_AccountAsset;
@@ -827,9 +825,9 @@ namespace iroha {
       auto asset = queries.getAsset(transfer_asset.asset_id);
       if (not asset.has_value()) {
         return makeExecutionError((boost::format("asset %s is absent of %s")
-                          % transfer_asset.asset_id
-                          % transfer_asset.dest_account_id)
-                             .str());
+                                   % transfer_asset.asset_id
+                                   % transfer_asset.dest_account_id)
+                                      .str());
       }
       // Precision for both wallets
       auto precision = asset.value().precision;
@@ -870,7 +868,7 @@ namespace iroha {
         dest_AccountAsset.balance = dest_balance;
       }
 
-      if (!commands.upsertAccountAsset(dest_AccountAsset)) {
+      if (not commands.upsertAccountAsset(dest_AccountAsset)) {
         return makeExecutionError("failed to upsert destination balance");
       }
       return errorIfNot(commands.upsertAccountAsset(src_account_asset.value()),

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -30,6 +30,9 @@
 #include "model/commands/remove_signatory.hpp"
 #include "model/commands/revoke_permission.hpp"
 #include "model/commands/set_account_detail.hpp"
+
+
+
 #include "model/commands/set_quorum.hpp"
 #include "model/commands/subtract_asset_quantity.hpp"
 #include "model/commands/transfer_asset.hpp"
@@ -327,7 +330,6 @@ namespace iroha {
         account_asset->balance = new_balance.value();
       }
 
-      // accountAsset.value().balance += amount;
       return errorIfNot(commands.upsertAccountAsset(account_asset.value()),
                         "failed to update account asset");
     }
@@ -397,7 +399,6 @@ namespace iroha {
       }
       account_asset->balance = new_balance.value();
 
-      // accountAsset.value().balance -= amount;
       return errorIfNot(commands.upsertAccountAsset(account_asset.value()),
                         "Failed to upsert account asset");
     }

--- a/irohad/model/execution/impl/command_executor.cpp
+++ b/irohad/model/execution/impl/command_executor.cpp
@@ -82,7 +82,7 @@ namespace iroha {
 
       return errorIfNot(
           commands.insertAccountRole(cmd_value.account_id, cmd_value.role_name),
-          "failed to insert account");
+          "failed to insert account role");
     }
 
     bool AppendRoleExecutor::hasPermissions(
@@ -298,8 +298,12 @@ namespace iroha {
       auto precision = asset.value().precision;
 
       if (add_asset_quantity.amount.getPrecision() != precision) {
-        return makeExecutionError("amount is wrongly formed");
+        return makeExecutionError(
+            (boost::format("precision mismatch: expected %d, but got %d")
+             % precision % add_asset_quantity.amount.getPrecision())
+                .str());
       }
+
       if (not queries.getAccount(add_asset_quantity.account_id).has_value()) {
         return makeExecutionError((boost::format("account %s is absent")
                                    % add_asset_quantity.account_id)
@@ -371,7 +375,10 @@ namespace iroha {
       auto precision = asset.value().precision;
 
       if (subtract_asset_quantity.amount.getPrecision() != precision) {
-        return makeExecutionError("amount is wrongly formed");
+        return makeExecutionError(
+            (boost::format("precision mismatch: expected %d, but got %d")
+             % precision % subtract_asset_quantity.amount.getPrecision())
+                .str());
       }
       auto account_asset = queries.getAccountAsset(
           subtract_asset_quantity.account_id, subtract_asset_quantity.asset_id);

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -75,6 +75,9 @@ namespace iroha {
       using variant_type::variant_type;  // inherit constructors
 
      public:
+      using ValueType = Value<V>;
+      using ErrorType = Error<E>;
+
       /**
        * match is a function which allows working with result's underlying
        * types, you must provide 2 functions to cover success and failure cases.

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -50,10 +50,6 @@ using namespace iroha::model;
 
 class CommandValidateExecuteTest : public ::testing::Test {
  public:
-  CommandValidateExecuteTest() {
-    spdlog::set_level(spdlog::level::off);
-  }
-
   void SetUp() override {
     factory = CommandExecutorFactory::create().value();
 
@@ -78,7 +74,9 @@ class CommandValidateExecuteTest : public ::testing::Test {
       auto result = executor->execute(
           *command, *wsv_query, *wsv_command, creator.account_id);
       return result.match([](expected::Value<void> v) { return true; },
-                          [](expected::Error<iroha::model::ExecutionError> e) { return false; });
+                          [](expected::Error<iroha::model::ExecutionError> e) {
+                            return false;
+                          });
     }
     return false;
   }
@@ -87,8 +85,9 @@ class CommandValidateExecuteTest : public ::testing::Test {
     auto executor = factory->getCommandExecutor(command);
     auto result = executor->execute(
         *command, *wsv_query, *wsv_command, creator.account_id);
-    return result.match([](expected::Value<void> v) { return true; },
-                        [](expected::Error<iroha::model::ExecutionError> e) { return false; });
+    return result.match(
+        [](expected::Value<void> v) { return true; },
+        [](expected::Error<iroha::model::ExecutionError> e) { return false; });
   }
 
   Amount max_amount{

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -74,15 +74,21 @@ class CommandValidateExecuteTest : public ::testing::Test {
 
   bool validateAndExecute() {
     auto executor = factory->getCommandExecutor(command);
-    return executor->validate(*command, *wsv_query, creator.account_id)
-        and executor->execute(
-                *command, *wsv_query, *wsv_command, creator.account_id);
+    if (executor->validate(*command, *wsv_query, creator.account_id)) {
+      auto result = executor->execute(
+          *command, *wsv_query, *wsv_command, creator.account_id);
+      return result.match([](expected::Value<void> v) { return true; },
+                          [](expected::Error<std::string> e) { return false; });
+    }
+    return false;
   }
 
   bool execute() {
     auto executor = factory->getCommandExecutor(command);
-    return executor->execute(
+    auto result = executor->execute(
         *command, *wsv_query, *wsv_command, creator.account_id);
+    return result.match([](expected::Value<void> v) { return true; },
+                        [](expected::Error<std::string> e) { return false; });
   }
 
   Amount max_amount{

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -84,12 +84,12 @@ class CommandValidateExecuteTest : public ::testing::Test {
         *command, *wsv_query, *wsv_command, creator.account_id);
   }
 
-  // Throws exception if result does not contain value
+  /// Throws exception if result does not contain value
   void checkValueCase(const ExecutionResult &result) {
     boost::get<ExecutionResult::ValueType>(result);
   }
 
-  // Returns error from result or throws error in case result contains value
+  /// Returns error from result or throws error in case result contains value
   ExecutionResult::ErrorType checkErrorCase(const ExecutionResult &result) {
     return boost::get<ExecutionResult::ErrorType>(result);
   }

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -78,7 +78,7 @@ class CommandValidateExecuteTest : public ::testing::Test {
       auto result = executor->execute(
           *command, *wsv_query, *wsv_command, creator.account_id);
       return result.match([](expected::Value<void> v) { return true; },
-                          [](expected::Error<std::string> e) { return false; });
+                          [](expected::Error<iroha::model::ExecutionError> e) { return false; });
     }
     return false;
   }
@@ -88,7 +88,7 @@ class CommandValidateExecuteTest : public ::testing::Test {
     auto result = executor->execute(
         *command, *wsv_query, *wsv_command, creator.account_id);
     return result.match([](expected::Value<void> v) { return true; },
-                        [](expected::Error<std::string> e) { return false; });
+                        [](expected::Error<iroha::model::ExecutionError> e) { return false; });
   }
 
   Amount max_amount{


### PR DESCRIPTION
### Description of the Change

This pull request modifies execute() method in command_executor, to return Result instead of bool. This means, that if for some reason, execution of the command has failed, a caller of the executor will know the reason why. This allows for better informativeness of error messages.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
1. Command executor now returns meaningful error message
2. Returned error contains command name

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
1. Validate still returns bool, so it is impossible to know if the database has failed during validation.
2. Because database operations still return boolean, or optional, a lot of code needs to be added to transform it into the result, in the future, it will be simplified.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
Mutable storage and temporary wsv both output error message from command_executor into the log. This is the simplest use, and they can return a result as well, to tell components up in the chain what happened.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->