### PR TITLE
Torii streaming

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -28,6 +28,8 @@ using namespace iroha::torii;
 using namespace iroha::model::converters;
 using namespace iroha::consensus::yac;
 
+using namespace std::chrono_literals;
+
 /**
  * Configuring iroha daemon
  */
@@ -234,7 +236,7 @@ void Irohad::initTransactionCommandService() {
       std::make_shared<TransactionProcessorImpl>(pcs, stateless_validator);
 
   command_service = std::make_unique<::torii::CommandService>(
-      pb_tx_factory, tx_processor, storage);
+      pb_tx_factory, tx_processor, storage, 1s, 10s);
 
   log_->info("[Init] => command service");
 }

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -236,7 +236,7 @@ void Irohad::initTransactionCommandService() {
       std::make_shared<TransactionProcessorImpl>(pcs, stateless_validator);
 
   command_service = std::make_unique<::torii::CommandService>(
-      pb_tx_factory, tx_processor, storage, 1s, 10s);
+      pb_tx_factory, tx_processor, storage, proposal_delay_);
 
   log_->info("[Init] => command service");
 }

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -29,13 +29,13 @@ namespace torii {
    */
   class CommandSyncClient {
    public:
-    CommandSyncClient(const std::string& ip, size_t port);
+    CommandSyncClient(const std::string &ip, size_t port);
 
-    CommandSyncClient(const CommandSyncClient&);
-    CommandSyncClient& operator=(CommandSyncClient);
+    CommandSyncClient(const CommandSyncClient &);
+    CommandSyncClient &operator=(CommandSyncClient);
 
-    CommandSyncClient(CommandSyncClient&&) noexcept ;
-    CommandSyncClient&operator=(CommandSyncClient&&) noexcept ;
+    CommandSyncClient(CommandSyncClient &&) noexcept;
+    CommandSyncClient &operator=(CommandSyncClient &&) noexcept;
 
     /**
      * requests tx to a torii server and returns response (blocking, sync)
@@ -52,13 +52,22 @@ namespace torii {
     grpc::Status Status(const iroha::protocol::TxStatusRequest &tx,
                         iroha::protocol::ToriiResponse &response) const;
 
+    /**
+     * Acquires stream of transaction statuses from the request
+     * moment until final.
+     * @param tx - transaction to send.
+     * @param response - vector of all statuses during tx pipeline.
+     */
+    void StatusStream(
+        const iroha::protocol::TxStatusRequest &tx,
+        std::vector<iroha::protocol::ToriiResponse> &response) const;
+
    private:
-    void swap(CommandSyncClient& lhs, CommandSyncClient& rhs);
+    void swap(CommandSyncClient &lhs, CommandSyncClient &rhs);
     std::string ip_;
     size_t port_;
     std::unique_ptr<iroha::protocol::CommandService::Stub> stub_;
   };
-
 
 }  // namespace torii
 

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -37,14 +37,21 @@ namespace torii {
     /**
      * Creates a new instance of CommandService
      * @param pb_factory - model->protobuf and vice versa converter
-     * @param txProcessor - processor of received transactions
+     * @param tx_processor - processor of received transactions
      * @param storage - storage to request transactions outside the cache
+     * @param start_tx_processing_duration - maximum time between getting a
+     * StatusStream request and receiving at least one status about processing
+     * of corresponding transaction
+     * @param finish_tx_processing_duration - maximum transaction processing
+     * time. Generally is should be a time of one proposal propagation.
      */
     CommandService(
         std::shared_ptr<iroha::model::converters::PbTransactionFactory>
             pb_factory,
-        std::shared_ptr<iroha::torii::TransactionProcessor> txProcessor,
-        std::shared_ptr<iroha::ametsuchi::Storage> storage);
+        std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
+        std::shared_ptr<iroha::ametsuchi::Storage> storage,
+        std::chrono::duration<uint64_t> start_tx_processing_duration,
+        std::chrono::duration<uint64_t> finish_tx_processing_duration);
 
     /**
      * Disable copying in any way to prevent potential issues with common
@@ -126,11 +133,11 @@ namespace torii {
     std::shared_ptr<iroha::model::converters::PbTransactionFactory> pb_factory_;
     std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor_;
     std::shared_ptr<iroha::ametsuchi::Storage> storage_;
+    std::chrono::duration<uint64_t> start_tx_processing_duration_;
+    std::chrono::duration<uint64_t> finish_tx_processing_duration_;
     std::shared_ptr<
         iroha::cache::Cache<std::string, iroha::protocol::ToriiResponse>>
         cache_;
-    std::mutex wait_subscription_;
-    std::condition_variable cv_;
   };
 
 }  // namespace torii

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -1,18 +1,19 @@
-/*
-Copyright 2017 Soramitsu Co., Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef TORII_COMMAND_SERVICE_HPP
 #define TORII_COMMAND_SERVICE_HPP
@@ -39,19 +40,14 @@ namespace torii {
      * @param pb_factory - model->protobuf and vice versa converter
      * @param tx_processor - processor of received transactions
      * @param storage - storage to request transactions outside the cache
-     * @param start_tx_processing_duration - maximum time between getting a
-     * StatusStream request and receiving at least one status about processing
-     * of corresponding transaction
-     * @param finish_tx_processing_duration - maximum transaction processing
-     * time. Generally is should be a time of one proposal propagation.
+     * @param proposal_delay - time of a one proposal propagation.
      */
     CommandService(
         std::shared_ptr<iroha::model::converters::PbTransactionFactory>
             pb_factory,
         std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
         std::shared_ptr<iroha::ametsuchi::Storage> storage,
-        std::chrono::duration<uint64_t> start_tx_processing_duration,
-        std::chrono::duration<uint64_t> finish_tx_processing_duration);
+        std::chrono::milliseconds proposal_delay);
 
     /**
      * Disable copying in any way to prevent potential issues with common
@@ -131,21 +127,21 @@ namespace torii {
 
    private:
     void checkCacheAndSend(
-        boost::optional<iroha::protocol::ToriiResponse> &resp,
+        const boost::optional<iroha::protocol::ToriiResponse> &resp,
         grpc::ServerWriter<iroha::protocol::ToriiResponse> &response_writer)
         const;
 
     iroha::protocol::TxStatus convertStatusToProto(
-        iroha::model::TransactionResponse::Status &status);
+        const iroha::model::TransactionResponse::Status &status);
 
-    bool isFinalStatus(iroha::protocol::TxStatus &status);
+    bool isFinalStatus(const iroha::protocol::TxStatus &status) const;
 
    private:
     std::shared_ptr<iroha::model::converters::PbTransactionFactory> pb_factory_;
     std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor_;
     std::shared_ptr<iroha::ametsuchi::Storage> storage_;
-    std::chrono::duration<uint64_t> start_tx_processing_duration_;
-    std::chrono::duration<uint64_t> finish_tx_processing_duration_;
+    std::chrono::milliseconds proposal_delay_;
+    std::chrono::milliseconds start_tx_processing_duration_;
     std::shared_ptr<
         iroha::cache::Cache<std::string, iroha::protocol::ToriiResponse>>
         cache_;

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -130,6 +130,17 @@ namespace torii {
         override;
 
    private:
+    void checkCacheAndSend(
+        boost::optional<iroha::protocol::ToriiResponse> &resp,
+        grpc::ServerWriter<iroha::protocol::ToriiResponse> &response_writer)
+        const;
+
+    iroha::protocol::TxStatus convertStatusToProto(
+        iroha::model::TransactionResponse::Status &status);
+
+    bool isFinalStatus(iroha::protocol::TxStatus &status);
+
+   private:
     std::shared_ptr<iroha::model::converters::PbTransactionFactory> pb_factory_;
     std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor_;
     std::shared_ptr<iroha::ametsuchi::Storage> storage_;

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -86,11 +86,9 @@ namespace torii {
         });
   }
 
-  void CommandService::Torii(iroha::protocol::Transaction const &request,
-                             google::protobuf::Empty &empty) {
-    auto iroha_tx = pb_factory_->deserialize(request);
-    auto tx_hash =
-        iroha::hash<iroha::protocol::Transaction>(request).to_string();
+  void CommandService::Torii(iroha::protocol::Transaction const &tx) {
+    auto iroha_tx = pb_factory_->deserialize(tx);
+    auto tx_hash = iroha::hash<iroha::protocol::Transaction>(tx).to_string();
 
     if (cache_->findItem(tx_hash)) {
       return;
@@ -109,7 +107,7 @@ namespace torii {
       grpc::ServerContext *context,
       const iroha::protocol::Transaction *request,
       google::protobuf::Empty *response) {
-    Torii(*request, *response);
+    Torii(*request);
     return grpc::Status::OK;
   }
 

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -50,6 +50,8 @@ using namespace iroha::validation;
 using namespace iroha::model::converters;
 using namespace iroha::model;
 
+using namespace std::chrono_literals;
+
 class ClientServerTest : public testing::Test {
  public:
   virtual void SetUp() {
@@ -95,7 +97,7 @@ class ClientServerTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock))
+              pb_tx_factory, tx_processor, storageMock, 1s, 10s))
           .append(std::make_unique<torii::QueryService>(
               pb_query_factory, pb_query_resp_factory, qpi))
           .run();

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -51,6 +51,7 @@ using namespace iroha::model::converters;
 using namespace iroha::model;
 
 using namespace std::chrono_literals;
+constexpr std::chrono::milliseconds proposal_delay = 10s;
 
 class ClientServerTest : public testing::Test {
  public:
@@ -97,7 +98,7 @@ class ClientServerTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, 1s, 10s))
+              pb_tx_factory, tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(
               pb_query_factory, pb_query_resp_factory, qpi))
           .run();

--- a/test/integration/pipeline/tx_pipeline_integration_test_fixture.hpp
+++ b/test/integration/pipeline/tx_pipeline_integration_test_fixture.hpp
@@ -198,8 +198,7 @@ class TxPipelineIntegrationTestFixture
     auto pb_tx =
         iroha::model::converters::PbTransactionFactory().serialize(transaction);
 
-    google::protobuf::Empty response;
-    irohad->getCommandService()->Torii(pb_tx, response);
+    irohad->getCommandService()->Torii(pb_tx);
   }
 };
 

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -87,8 +87,6 @@ TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
 
   init();
-
-  //TODO luckychess 03.02.2018 is this OK?
   query_service->Find(query, response);
   query_service->Find(query, response);
 }

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -88,6 +88,7 @@ TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
 
   init();
 
+  //TODO luckychess 03.02.2018 is this OK?
   query_service->Find(query, response);
   query_service->Find(query, response);
 }

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -46,6 +46,8 @@ using namespace iroha::validation;
 using namespace iroha::ametsuchi;
 using namespace iroha::model;
 
+using namespace std::chrono_literals;
+
 // TODO: allow dynamic port binding in ServerRunner IR-741
 class ToriiQueriesTest : public testing::Test {
  public:
@@ -90,7 +92,7 @@ class ToriiQueriesTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock))
+              pb_tx_factory, tx_processor, storageMock, 1s, 10s))
           .append(std::make_unique<torii::QueryService>(
               pb_query_factory, pb_query_resp_factory, qpi))
           .run();

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -47,6 +47,7 @@ using namespace iroha::ametsuchi;
 using namespace iroha::model;
 
 using namespace std::chrono_literals;
+constexpr std::chrono::milliseconds proposal_delay = 10s;
 
 // TODO: allow dynamic port binding in ServerRunner IR-741
 class ToriiQueriesTest : public testing::Test {
@@ -92,7 +93,7 @@ class ToriiQueriesTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, 1s, 10s))
+              pb_tx_factory, tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(
               pb_query_factory, pb_query_resp_factory, qpi))
           .run();

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -35,7 +35,6 @@ limitations under the License.
 
 constexpr const char *Ip = "0.0.0.0";
 constexpr int Port = 50051;
-
 constexpr size_t TimesToriiBlocking = 5;
 
 using ::testing::_;
@@ -48,6 +47,7 @@ using namespace iroha::validation;
 using namespace iroha::ametsuchi;
 
 using namespace std::chrono_literals;
+constexpr std::chrono::milliseconds proposal_delay = 10s;
 
 using Commit = rxcpp::observable<iroha::model::Block>;
 
@@ -113,7 +113,7 @@ class ToriiServiceTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, 1s, 10s))
+              pb_tx_factory, tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(
               pb_query_factory, pb_query_resp_factory, qpi))
           .run();

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -344,3 +344,79 @@ TEST_F(ToriiServiceTest, CheckHash) {
     ASSERT_EQ(toriiResponse.tx_hash(), hash);
   }
 }
+
+/**
+ * @given torii service and one valid transaction
+ * @when starting StatusStream and then sending transaction to Iroha
+ * @then ensure that response will have at least 3 statuses
+ * (it should contain STATELESS_VALIDATION_SUCCESS, STATEFUL_VALIDATION_SUCCESS
+ * and COMMITTED) and the last status should be COMMITTED
+ */
+TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
+  EXPECT_CALL(*statelessValidatorMock,
+              validate(A<const iroha::model::Transaction &>()))
+      .WillRepeatedly(Return(true));
+
+  iroha::model::converters::PbTransactionFactory tx_factory;
+  auto client = torii::CommandSyncClient(Ip, Port);
+
+  auto new_tx = iroha::protocol::Transaction();
+  auto payload = new_tx.mutable_payload();
+  payload->set_tx_counter(1);
+  payload->set_creator_account_id("accountA");
+
+  auto iroha_tx = tx_factory.deserialize(new_tx);
+  std::string txhash = iroha::hash(*iroha_tx).to_string();
+
+  std::vector<iroha::protocol::ToriiResponse> torii_response;
+  std::thread t([&]() {
+    iroha::protocol::TxStatusRequest tx_request;
+    tx_request.set_tx_hash(txhash);
+    client.StatusStream(tx_request, torii_response);
+  });
+
+  client.Torii(new_tx);
+
+  std::vector<iroha::model::Transaction> txs;
+  txs.push_back(*iroha_tx);
+  iroha::model::Proposal proposal(txs);
+  prop_notifier_.get_subscriber().on_next(proposal);
+
+  iroha::model::Block block;
+  block.transactions.push_back(*iroha_tx);
+
+  // create commit from block notifier's observable
+  rxcpp::subjects::subject<iroha::model::Block> block_notifier_;
+  Commit commit = block_notifier_.get_observable();
+
+  // invoke on next of commit_notifier by sending new block to commit
+  commit_notifier_.get_subscriber().on_next(commit);
+  block_notifier_.get_subscriber().on_next(block);
+
+  block_notifier_.get_subscriber().on_completed();
+  t.join();
+
+  ASSERT_GE(torii_response.size(), 3);
+  ASSERT_EQ(torii_response.back().tx_status(),
+            iroha::protocol::TxStatus::COMMITTED);
+}
+
+/**
+ * @given torii service and fake transaction hash
+ * @when sending streaming request for this hash
+ * @then ensure that response will have exactly 1 status - NOT_RECEIVED
+ */
+TEST_F(ToriiServiceTest, StreamingNoTx) {
+  auto client = torii::CommandSyncClient(Ip, Port);
+  std::vector<iroha::protocol::ToriiResponse> torii_response;
+  std::thread t([&]() {
+    iroha::protocol::TxStatusRequest tx_request;
+    tx_request.set_tx_hash("0123456789abcdef");
+    client.StatusStream(tx_request, torii_response);
+  });
+
+  t.join();
+  ASSERT_EQ(torii_response.size(), 1);
+  ASSERT_EQ(torii_response.at(0).tx_status(),
+            iroha::protocol::TxStatus::NOT_RECEIVED);
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Streaming grpc call for transaction statuses.

### Benefits

<!-- What benefits will be realized by the code change? -->
We want to have a push-based notifications for tx statuses so here we are.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Each streaming call can theoretically block one of grpc thread up to a second. This timeout can be decreased in a least 10 times but it allows to start streaming call before transaction sending.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
Two tests were added to torii_service_test.

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Two main possibilities were checked: use combined Torii request which will return stream of responses or use separate calls for that (the second one was actually implemented). The first approach was faced with thread-related difficulties (kick me and I explain details).
