### PR TITLE
Rework OrderingService with new model

### DIFF
--- a/irohad/network/ordering_service.hpp
+++ b/irohad/network/ordering_service.hpp
@@ -34,7 +34,8 @@ namespace iroha {
        * Transform model proposal to transport object and send to peers
        * @param proposal - object for propagation
        */
-      virtual void publishProposal(model::Proposal &&proposal) = 0;
+      virtual void publishProposal(
+          shared_model::proto::Proposal &&proposal) = 0;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/ordering_service.hpp
+++ b/irohad/network/ordering_service.hpp
@@ -19,7 +19,6 @@
 #define IROHA_ORDERINGSERVICE_H
 
 #include "network/ordering_service_transport.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 
 namespace iroha {
   namespace network {

--- a/irohad/network/ordering_service.hpp
+++ b/irohad/network/ordering_service.hpp
@@ -19,6 +19,7 @@
 #define IROHA_ORDERINGSERVICE_H
 
 #include "network/ordering_service_transport.hpp"
+#include "utils/polymorphic_wrapper.hpp"
 
 namespace iroha {
   namespace network {
@@ -35,7 +36,8 @@ namespace iroha {
        * @param proposal - object for propagation
        */
       virtual void publishProposal(
-          shared_model::proto::Proposal &&proposal) = 0;
+          shared_model::detail::PolymorphicWrapper<
+              shared_model::interface::Proposal> proposal) = 0;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/ordering_service.hpp
+++ b/irohad/network/ordering_service.hpp
@@ -36,8 +36,7 @@ namespace iroha {
        * @param proposal - object for propagation
        */
       virtual void publishProposal(
-          shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::Proposal> proposal) = 0;
+          std::unique_ptr<shared_model::interface::Proposal> proposal) = 0;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/ordering_service_transport.hpp
+++ b/irohad/network/ordering_service_transport.hpp
@@ -17,9 +17,9 @@
 #ifndef IROHA_ORDERING_SERVICE_TRANSPORT_H
 #define IROHA_ORDERING_SERVICE_TRANSPORT_H
 
+#include <memory>
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/transaction.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 
 namespace iroha {
   namespace network {

--- a/irohad/network/ordering_service_transport.hpp
+++ b/irohad/network/ordering_service_transport.hpp
@@ -61,8 +61,7 @@ namespace iroha {
        * @param proposal : proposal to be published
        */
       virtual void publishProposal(
-          shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::Proposal> proposal,
+          std::unique_ptr<shared_model::interface::Proposal> proposal,
           const std::vector<std::string> &peers) = 0;
 
       virtual ~OrderingServiceTransport() = default;

--- a/irohad/network/ordering_service_transport.hpp
+++ b/irohad/network/ordering_service_transport.hpp
@@ -35,8 +35,8 @@ namespace iroha {
        * @param transaction - transaction object itself
        */
       virtual void onTransaction(
-          const shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::Transaction> transaction) = 0;
+          std::shared_ptr<shared_model::interface::Transaction>
+              transaction) = 0;
 
       virtual ~OrderingServiceNotification() = default;
     };

--- a/irohad/network/ordering_service_transport.hpp
+++ b/irohad/network/ordering_service_transport.hpp
@@ -17,9 +17,9 @@
 #ifndef IROHA_ORDERING_SERVICE_TRANSPORT_H
 #define IROHA_ORDERING_SERVICE_TRANSPORT_H
 
-#include "backend/protobuf/proposal.hpp"
-#include "backend/protobuf/transaction.hpp"
+#include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/transaction.hpp"
+#include "utils/polymorphic_wrapper.hpp"
 
 namespace iroha {
   namespace network {
@@ -35,7 +35,8 @@ namespace iroha {
        * @param transaction - transaction object itself
        */
       virtual void onTransaction(
-          const shared_model::proto::Transaction &transaction) = 0;
+          const shared_model::detail::PolymorphicWrapper<
+              shared_model::interface::Transaction> transaction) = 0;
 
       virtual ~OrderingServiceNotification() = default;
     };
@@ -59,8 +60,10 @@ namespace iroha {
        * Publishes proposal over network
        * @param proposal : proposal to be published
        */
-      virtual void publishProposal(shared_model::proto::Proposal &&proposal,
-                                   const std::vector<std::string> &peers) = 0;
+      virtual void publishProposal(
+          shared_model::detail::PolymorphicWrapper<
+              shared_model::interface::Proposal> proposal,
+          const std::vector<std::string> &peers) = 0;
 
       virtual ~OrderingServiceTransport() = default;
     };

--- a/irohad/network/ordering_service_transport.hpp
+++ b/irohad/network/ordering_service_transport.hpp
@@ -17,8 +17,9 @@
 #ifndef IROHA_ORDERING_SERVICE_TRANSPORT_H
 #define IROHA_ORDERING_SERVICE_TRANSPORT_H
 
-#include "model/proposal.hpp"
-#include "model/transaction.hpp"
+#include "backend/protobuf/proposal.hpp"
+#include "backend/protobuf/transaction.hpp"
+#include "interfaces/transaction.hpp"
 
 namespace iroha {
   namespace network {
@@ -33,7 +34,8 @@ namespace iroha {
        * Callback on receiving transaction
        * @param transaction - transaction object itself
        */
-      virtual void onTransaction(const model::Transaction &transaction) = 0;
+      virtual void onTransaction(
+          const shared_model::proto::Transaction &transaction) = 0;
 
       virtual ~OrderingServiceNotification() = default;
     };
@@ -57,7 +59,7 @@ namespace iroha {
        * Publishes proposal over network
        * @param proposal : proposal to be published
        */
-      virtual void publishProposal(model::Proposal &&proposal,
+      virtual void publishProposal(shared_model::proto::Proposal &&proposal,
                                    const std::vector<std::string> &peers) = 0;
 
       virtual ~OrderingServiceTransport() = default;

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -17,11 +17,10 @@
 #include "ordering_gate_transport_grpc.hpp"
 
 using namespace iroha::ordering;
-using namespace iroha::protocol;
 
 grpc::Status OrderingGateTransportGrpc::onProposal(
     ::grpc::ServerContext *context,
-    const protocol::Proposal *request,
+    const iroha::protocol::Proposal *request,
     ::google::protobuf::Empty *response) {
   log_->info("receive proposal");
 

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -35,10 +35,9 @@ namespace iroha {
     }
 
     void OrderingServiceImpl::onTransaction(
-        const shared_model::detail::PolymorphicWrapper<
-            shared_model::interface::Transaction> transaction) {
-      auto proto = static_cast<const shared_model::proto::Transaction *>(
-          transaction.operator->());
+        std::shared_ptr<shared_model::interface::Transaction> transaction) {
+      auto proto =
+          static_cast<shared_model::proto::Transaction *>(transaction.get());
       queue_.push(std::make_shared<shared_model::proto::Transaction>(*proto));
 
       if (queue_.unsafe_size() >= max_size_) {

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "ordering/impl/ordering_service_impl.hpp"
+#include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/proposal.hpp"
-#include "model/peer.hpp"
 
 namespace iroha {
   namespace ordering {

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -54,19 +54,17 @@ namespace iroha {
         fetched_txs.emplace_back(std::move(*tx));
       }
 
-      auto proposal =
-          shared_model::detail::makePolymorphic<shared_model::proto::Proposal>(
-              shared_model::proto::ProposalBuilder()
-                  .height(proposal_height++)
-                  .createdTime(iroha::time::now())
-                  .transactions(fetched_txs)
-                  .build());
+      auto proposal = std::make_unique<shared_model::proto::Proposal>(
+          shared_model::proto::ProposalBuilder()
+              .height(proposal_height++)
+              .createdTime(iroha::time::now())
+              .transactions(fetched_txs)
+              .build());
       publishProposal(std::move(proposal));
     }
 
     void OrderingServiceImpl::publishProposal(
-        shared_model::detail::PolymorphicWrapper<
-            shared_model::interface::Proposal> proposal) {
+        std::unique_ptr<shared_model::interface::Proposal> proposal) {
       std::vector<std::string> peers;
 
       auto lst = wsv_->getLedgerPeers().value();

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -98,7 +98,8 @@ namespace iroha {
       rxcpp::composite_subscription handle;
       std::shared_ptr<ametsuchi::PeerQuery> wsv_;
 
-      tbb::concurrent_queue<std::shared_ptr<shared_model::proto::Transaction>>
+      tbb::concurrent_queue<
+          std::shared_ptr<shared_model::interface::Transaction>>
           queue_;
 
       /**

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -77,8 +77,7 @@ namespace iroha {
        * @param proposal - object for propagation
        */
       void publishProposal(
-          shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::Proposal> proposal) override;
+          std::unique_ptr<shared_model::interface::Proposal> proposal) override;
 
      private:
       /**

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -35,6 +35,12 @@
 #include "network/impl/async_grpc_client.hpp"
 #include "ordering.grpc.pb.h"
 
+namespace shared_model {
+  namespace proto {
+    class Transaction;
+  }
+}  // namespace shared_model
+
 namespace iroha {
   namespace ordering {
 
@@ -60,7 +66,8 @@ namespace iroha {
        * @param transaction
        */
       void onTransaction(
-          const shared_model::proto::Transaction &transaction) override;
+          const shared_model::detail::PolymorphicWrapper<
+              shared_model::interface::Transaction> transaction) override;
 
       ~OrderingServiceImpl() override;
 
@@ -69,7 +76,9 @@ namespace iroha {
        * Transform model proposal to transport object and send to peers
        * @param proposal - object for propagation
        */
-      void publishProposal(shared_model::proto::Proposal &&proposal) override;
+      void publishProposal(
+          shared_model::detail::PolymorphicWrapper<
+              shared_model::interface::Proposal> proposal) override;
 
      private:
       /**

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -59,7 +59,8 @@ namespace iroha {
        * Enqueues transaction and publishes corresponding event
        * @param transaction
        */
-      void onTransaction(const model::Transaction &transaction) override;
+      void onTransaction(
+          const shared_model::proto::Transaction &transaction) override;
 
       ~OrderingServiceImpl() override;
 
@@ -68,7 +69,7 @@ namespace iroha {
        * Transform model proposal to transport object and send to peers
        * @param proposal - object for propagation
        */
-      void publishProposal(model::Proposal &&proposal) override;
+      void publishProposal(shared_model::proto::Proposal &&proposal) override;
 
      private:
       /**
@@ -90,7 +91,8 @@ namespace iroha {
       rxcpp::composite_subscription handle;
       std::shared_ptr<ametsuchi::PeerQuery> wsv_;
 
-      tbb::concurrent_queue<model::Transaction> queue_;
+      tbb::concurrent_queue<std::shared_ptr<shared_model::proto::Transaction>>
+          queue_;
 
       /**
        * max number of txs in proposal

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -65,9 +65,8 @@ namespace iroha {
        * Enqueues transaction and publishes corresponding event
        * @param transaction
        */
-      void onTransaction(
-          const shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::Transaction> transaction) override;
+      void onTransaction(std::shared_ptr<shared_model::interface::Transaction>
+                             transaction) override;
 
       ~OrderingServiceImpl() override;
 

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -20,26 +20,14 @@
 
 #include <tbb/concurrent_queue.h>
 #include <memory>
+#include <rxcpp/rx.hpp>
 #include <unordered_map>
 
+#include "ametsuchi/peer_query.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_service.hpp"
 #include "network/ordering_service_transport.hpp"
-
-#include "ametsuchi/peer_query.hpp"
 #include "ordering.grpc.pb.h"
-
-#include <rxcpp/rx.hpp>
-#include "model/converters/pb_transaction_factory.hpp"
-#include "model/proposal.hpp"
-#include "network/impl/async_grpc_client.hpp"
-#include "ordering.grpc.pb.h"
-
-namespace shared_model {
-  namespace proto {
-    class Transaction;
-  }
-}  // namespace shared_model
 
 namespace iroha {
   namespace ordering {

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -23,18 +23,15 @@
 #include "datetime/time.hpp"
 
 using namespace iroha::ordering;
-using namespace iroha::protocol;
-using namespace iroha::model;
-using namespace iroha::network;
 
 void OrderingServiceTransportGrpc::subscribe(
-    std::shared_ptr<OrderingServiceNotification> subscriber) {
+    std::shared_ptr<iroha::network::OrderingServiceNotification> subscriber) {
   subscriber_ = subscriber;
 }
 
 grpc::Status OrderingServiceTransportGrpc::onTransaction(
     ::grpc::ServerContext *context,
-    const protocol::Transaction *request,
+    const iroha::protocol::Transaction *request,
     ::google::protobuf::Empty *response) {
   if (subscriber_.expired()) {
     log_->error("No subscriber");

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
-
 #include "backend/protobuf/from_old_model.hpp"
+#include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/proposal.hpp"
-#include "datetime/time.hpp"
 
 using namespace iroha::ordering;
 

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -43,8 +43,7 @@ grpc::Status OrderingServiceTransportGrpc::onTransaction(
 }
 
 void OrderingServiceTransportGrpc::publishProposal(
-    shared_model::detail::PolymorphicWrapper<shared_model::interface::Proposal>
-        proposal,
+    std::unique_ptr<shared_model::interface::Proposal> proposal,
     const std::vector<std::string> &peers) {
   std::unordered_map<std::string,
                      std::unique_ptr<proto::OrderingGateTransportGrpc::Stub>>
@@ -58,8 +57,8 @@ void OrderingServiceTransportGrpc::publishProposal(
   for (const auto &peer : peers_map) {
     auto call = new AsyncClientCall;
 
-    auto proto = static_cast<const shared_model::proto::Proposal *>(
-        proposal.operator->());
+    auto proto =
+        static_cast<const shared_model::proto::Proposal *>(proposal.get());
     call->response_reader = peer.second->AsynconProposal(
         &call->context, proto->getTransport(), &cq_);
 

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -58,23 +58,11 @@ void OrderingServiceTransportGrpc::publishProposal(
         grpc::CreateChannel(peer, grpc::InsecureChannelCredentials()));
   }
 
-  auto pb_proposal =
-      shared_model::proto::ProposalBuilder()
-          .height(proposal.height())
-          .createdTime(iroha::time::now())
-          .transactions(proposal.transactions()
-                        | boost::adaptors::transformed([](auto iface_tx) {
-                            std::unique_ptr<iroha::model::Transaction> old_tx(
-                                iface_tx->makeOldModel());
-                            return shared_model::proto::from_old(*old_tx);
-                          }))
-          .build();
-
   for (const auto &peer : peers_map) {
     auto call = new AsyncClientCall;
 
     call->response_reader = peer.second->AsynconProposal(
-        &call->context, pb_proposal.getTransport(), &cq_);
+        &call->context, proposal.getTransport(), &cq_);
 
     call->response_reader->Finish(&call->reply, &call->status, call);
   }

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -35,8 +35,8 @@ grpc::Status OrderingServiceTransportGrpc::onTransaction(
     log_->error("No subscriber");
   } else {
     subscriber_.lock()->onTransaction(
-        shared_model::detail::makePolymorphic<shared_model::proto::Transaction>(
-            *request));
+        std::make_shared<shared_model::proto::Transaction>(
+            iroha::protocol::Transaction(*request)));
   }
 
   return ::grpc::Status::OK;
@@ -57,8 +57,7 @@ void OrderingServiceTransportGrpc::publishProposal(
   for (const auto &peer : peers_map) {
     auto call = new AsyncClientCall;
 
-    auto proto =
-        static_cast<const shared_model::proto::Proposal *>(proposal.get());
+    auto proto = static_cast<shared_model::proto::Proposal *>(proposal.get());
     call->response_reader = peer.second->AsynconProposal(
         &call->context, proto->getTransport(), &cq_);
 

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -39,7 +39,7 @@ namespace iroha {
           std::shared_ptr<iroha::network::OrderingServiceNotification>
               subscriber) override;
 
-      void publishProposal(model::Proposal &&proposal,
+      void publishProposal(shared_model::proto::Proposal &&proposal,
                            const std::vector<std::string> &peers) override;
 
       grpc::Status onTransaction(::grpc::ServerContext *context,

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -22,7 +22,6 @@
 #include "logger/logger.hpp"
 #include "ordering.grpc.pb.h"
 
-#include "model/converters/pb_transaction_factory.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_service_transport.hpp"
 
@@ -51,7 +50,6 @@ namespace iroha {
 
      private:
       std::weak_ptr<iroha::network::OrderingServiceNotification> subscriber_;
-      model::converters::PbTransactionFactory factory_;
       logger::Logger log_;
     };
 

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -39,7 +39,8 @@ namespace iroha {
           std::shared_ptr<iroha::network::OrderingServiceNotification>
               subscriber) override;
 
-      void publishProposal(shared_model::proto::Proposal &&proposal,
+      void publishProposal(shared_model::detail::PolymorphicWrapper<
+                               shared_model::interface::Proposal> proposal,
                            const std::vector<std::string> &peers) override;
 
       grpc::Status onTransaction(::grpc::ServerContext *context,

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -39,9 +39,9 @@ namespace iroha {
           std::shared_ptr<iroha::network::OrderingServiceNotification>
               subscriber) override;
 
-      void publishProposal(shared_model::detail::PolymorphicWrapper<
-                               shared_model::interface::Proposal> proposal,
-                           const std::vector<std::string> &peers) override;
+      void publishProposal(
+          std::unique_ptr<shared_model::interface::Proposal> proposal,
+          const std::vector<std::string> &peers) override;
 
       grpc::Status onTransaction(::grpc::ServerContext *context,
                                  const protocol::Transaction *request,

--- a/test/module/irohad/ordering/CMakeLists.txt
+++ b/test/module/irohad/ordering/CMakeLists.txt
@@ -15,6 +15,7 @@
 addtest(ordering_service_test ordering_service_test.cpp)
 target_link_libraries(ordering_service_test
     ordering_service
+    shared_model_stateless_validation
     )
 
 addtest(ordering_gate_test ordering_gate_test.cpp)

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -83,8 +83,8 @@ class OrderingServiceTest : public ::testing::Test {
   }
 
   auto empty_tx() {
-    return shared_model::detail::makePolymorphic<
-        shared_model::proto::Transaction>(TestTransactionBuilder().build());
+    return std::make_shared<shared_model::proto::Transaction>(
+        TestTransactionBuilder().build());
   }
 
   std::shared_ptr<MockOrderingServiceTransport> fake_transport;

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -28,12 +28,8 @@
 #include "ordering/impl/ordering_service_impl.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
 
-#include "builders/protobuf/proposal.hpp"
-#include "builders/protobuf/transaction.hpp"
 #include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
-#include "module/shared_model/validators//validators.hpp"
-#include "validators/default_validator.hpp"
 
 using namespace iroha;
 using namespace iroha::ordering;


### PR DESCRIPTION
### Description of the Change

Change OrderingServices' interfaces to the new shared model

### Issues

There's some issues that've been solved as simple as possible, though it's probably not really a good solution

#### iface -> proto

There's need to convert `proto::Proposal` to `protocol::Proposal`, it's pretty easy to set all the fields via builder but transactions. SM's proposal returns an interface, so there's no simple way to convert to protobuf, so I just use `makeOldModel` + `from_old`:

https://github.com/hyperledger/iroha/blob/5b711d1d7348f853ab8cda74e4b5b87207a24198/irohad/ordering/impl/ordering_service_transport_grpc.cpp#L61-L71

#### Pretty hard to create a simple tx

I guess the example is self-explainable

https://github.com/hyperledger/iroha/blob/5b711d1d7348f853ab8cda74e4b5b87207a24198/test/module/irohad/ordering/ordering_service_test.cpp#L82-L89

#### tbb queue wrapper

The tbb's concurrent queue can't work with interfaces (and even with `unique_ptr`), so I just used `shared_ptr` instead. Imo that can be a significant performance issue

https://github.com/hyperledger/iroha/blob/5b711d1d7348f853ab8cda74e4b5b87207a24198/irohad/ordering/impl/ordering_service_impl.hpp#L94