### PR TITLE
update spdlog commit version for alpine

### DIFF
--- a/cmake/Modules/Findspdlog.cmake
+++ b/cmake/Modules/Findspdlog.cmake
@@ -9,7 +9,7 @@ find_package_handle_standard_args(spdlog DEFAULT_MSG
 
 
 set(URL https://github.com/gabime/spdlog.git)
-set(VERSION f85a08622e20b74bff34381cafcb8ef8167b29d0)
+set(VERSION ccd675a286f457068ee8c823f8207f13c2325b26)
 set_target_description(spdlog "Logging library" ${URL} ${VERSION})
 
 

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -90,7 +90,7 @@ RUN git clone https://github.com/google/googletest /tmp/googletest; \
     cmake --build /tmp/googletest/build --target install -- -j${PARALLELISM}; \
     rm -rf /tmp/googletest
 
-# install spdlog
+# install spdlog v0.16.3
 RUN git clone https://github.com/gabime/spdlog /tmp/spdlog; \
     (cd /tmp/spdlog ; git checkout ccd675a286f457068ee8c823f8207f13c2325b26); \
     cmake -DSPDLOG_BUILD_TESTING=OFF -H/tmp/spdlog -B/tmp/spdlog/build; \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -92,7 +92,7 @@ RUN git clone https://github.com/google/googletest /tmp/googletest; \
 
 # install spdlog
 RUN git clone https://github.com/gabime/spdlog /tmp/spdlog; \
-    (cd /tmp/spdlog ; git checkout f85a08622e20b74bff34381cafcb8ef8167b29d0); \
+    (cd /tmp/spdlog ; git checkout ccd675a286f457068ee8c823f8207f13c2325b26); \
     cmake -DSPDLOG_BUILD_TESTING=OFF -H/tmp/spdlog -B/tmp/spdlog/build; \
     cmake --build /tmp/spdlog/build --target install; \
     rm -rf /tmp/spdlog


### PR DESCRIPTION
Signed-off-by: satellitex <s.a.t.e.3.ths@gmail.com>
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
An error occurred while building shared_model using alpine.
```
In file included from /opt/iroha/external/src/gabime_spdlog/include/spdlog/details/log_msg.h:9:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/sink.h:9,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/base_sink.h:13,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/logger.h:15,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:14,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/opt/iroha/external/src/gabime_spdlog/include/spdlog/details/os.h: In function 'std::__cxx11::string spdlog::details::os::errno_str(int)':
/opt/iroha/external/src/gabime_spdlog/include/spdlog/details/os.h:389:58: error: no matching function for call to 'std::__cxx11::basic_string<char>::basic_string(int)'
     return std::string(strerror_r(err_num, buf, buf_size));
                                                          ^
In file included from /usr/include/c++/6.3.0/string:52:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/common.h:8,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:13,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/usr/include/c++/6.3.0/bits/basic_string.h:549:9: note: candidate: template<class _InputIterator, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(_InputIterator, _InputIterator, const _Alloc&)
         basic_string(_InputIterator __beg, _InputIterator __end,
         ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:549:9: note:   template argument deduction/substitution failed:
In file included from /opt/iroha/external/src/gabime_spdlog/include/spdlog/details/log_msg.h:9:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/sink.h:9,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/base_sink.h:13,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/logger.h:15,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:14,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/opt/iroha/external/src/gabime_spdlog/include/spdlog/details/os.h:389:58: note:   candidate expects 3 arguments, 1 provided
     return std::string(strerror_r(err_num, buf, buf_size));
                                                          ^
In file included from /usr/include/c++/6.3.0/string:52:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/common.h:8,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:13,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/usr/include/c++/6.3.0/bits/basic_string.h:511:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(basic_string&& __str, const _Alloc& __a)
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:511:7: note:   candidate expects 2 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:507:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(const basic_string& __str, const _Alloc& __a)
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:507:7: note:   candidate expects 2 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:503:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::initializer_list<_Tp>, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(initializer_list<_CharT> __l, const _Alloc& __a = _Alloc())
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:503:7: note:   no known conversion for argument 1 from 'int' to 'std::initializer_list<char>'
/usr/include/c++/6.3.0/bits/basic_string.h:476:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(basic_string&& __str) noexcept
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:476:7: note:   no known conversion for argument 1 from 'int' to 'std::__cxx11::basic_string<char>&&'
/usr/include/c++/6.3.0/bits/basic_string.h:464:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, _CharT, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]
       basic_string(size_type __n, _CharT __c, const _Alloc& __a = _Alloc())
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:464:7: note:   candidate expects 3 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:454:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>] <near match>
       basic_string(const _CharT* __s, const _Alloc& __a = _Alloc())
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:454:7: note:   conversion of argument 1 would be ill-formed:
In file included from /opt/iroha/external/src/gabime_spdlog/include/spdlog/details/log_msg.h:9:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/sink.h:9,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/sinks/base_sink.h:13,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/logger.h:15,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:14,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/opt/iroha/external/src/gabime_spdlog/include/spdlog/details/os.h:389:34: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
     return std::string(strerror_r(err_num, buf, buf_size));
                        ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/6.3.0/string:52:0,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/common.h:8,
                 from /opt/iroha/external/src/gabime_spdlog/include/spdlog/spdlog.h:13,
                 from /opt/iroha/libs/logger/logger.hpp:21,
                 from /opt/iroha/libs/logger/logger.cpp:17:
/usr/include/c++/6.3.0/bits/basic_string.h:444:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]
       basic_string(const _CharT* __s, size_type __n,
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:444:7: note:   candidate expects 3 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:426:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]
       basic_string(const basic_string& __str, size_type __pos,
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:426:7: note:   candidate expects 4 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:410:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]
       basic_string(const basic_string& __str, size_type __pos,
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:410:7: note:   candidate expects 3 arguments, 1 provided
/usr/include/c++/6.3.0/bits/basic_string.h:397:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(const basic_string& __str)
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:397:7: note:   no known conversion for argument 1 from 'int' to 'const std::__cxx11::basic_string<char>&'
/usr/include/c++/6.3.0/bits/basic_string.h:389:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string(const _Alloc& __a) _GLIBCXX_NOEXCEPT
       ^~~~~~~~~~~~
/usr/include/c++/6.3.0/bits/basic_string.h:389:7: note:   no known conversion for argument 1 from 'int' to 'const std::allocator<char>&'
/usr/include/c++/6.3.0/bits/basic_string.h:380:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
       basic_string()
       ^~~~~~~~~~~~
```
This error is a spdlog error.
This was solved with the following PR.
https://github.com/gabime/spdlog/pull/436

The version of spdlog in iroha docker / dependences does not follow this PR, so I fixed this.

### Benefits

<!-- What benefits will be realized by the code change? -->
Compiling spdlog in alpine environment becomes possible.
