### PR TITLE
Fix flags in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,9 @@ endif()
 PROJECT(iroha C CXX)
 
 SET(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-SET(CMAKE_CXX_FLAGS "-std=c++1y -Wall")
-SET(CMAKE_CXX_FLAGS_RELEASE "-O3")
-SET(CMAKE_CXX_FLAGS_DEBUG   "-g -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -O0")
+SET(CMAKE_CXX_FLAGS "-std=c++1y -Wall" CACHE STRING "C++ flags for all configurations")
+SET(CMAKE_CXX_FLAGS_RELEASE "-O3" CACHE STRING "C++ flags for RELEASE")
+SET(CMAKE_CXX_FLAGS_DEBUG   "-g -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -O0" CACHE STRING "C++ fags for debug")
 SET(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 SET(CMAKE_INSTALL_RPATH "../lib")
 


### PR DESCRIPTION
This fix adds caching for default flags, so now it is possible to set them in cmake time.

Before:
```
cmake -DCMAKE_CXX_FLAGS="-O3" ..
```
will be overwritten with `set(CMAKE_CXX_FLAGS "...")

Now -- CMAKE_CXX_FLAGS will be cached from cmake arguments.
