### PR TITLE
Add created_time in model::Proposal

### DIFF
--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -217,7 +217,8 @@ namespace iroha {
 
     /* Proposal */
     bool Proposal::operator==(const Proposal &rhs) const {
-      return rhs.height == height and rhs.transactions == transactions;
+      return rhs.height == height and rhs.created_time == created_time
+          and rhs.transactions == transactions;
     }
 
     /* Block */

--- a/irohad/model/proposal.hpp
+++ b/irohad/model/proposal.hpp
@@ -45,6 +45,11 @@ namespace iroha {
        */
       uint64_t height{};
 
+      /**
+       * Time when the proposal have been created
+       */
+      uint64_t created_time{};
+
       bool operator==(const Proposal &rhs) const;
       bool operator!=(const Proposal &rhs) const;
     };

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -33,6 +33,7 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
 
   model::Proposal proposal(transactions);
   proposal.height = request->height();
+  proposal.created_time = request->created_time();
   if (not subscriber_.expired()) {
     subscriber_.lock()->onProposal(std::move(proposal));
   } else {

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "ordering/impl/ordering_service_impl.hpp"
+#include "datetime/time.hpp"
 #include "model/peer.hpp"
 
 namespace iroha {
@@ -52,6 +53,7 @@ namespace iroha {
 
       model::Proposal proposal(txs);
       proposal.height = proposal_height++;
+      proposal.created_time = iroha::time::now();
 
       publishProposal(std::move(proposal));
     }

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
+#include "datetime/time.hpp"
 
 using namespace iroha::ordering;
 using namespace iroha::protocol;
@@ -52,6 +53,7 @@ void OrderingServiceTransportGrpc::publishProposal(
 
   protocol::Proposal pb_proposal;
   pb_proposal.set_height(proposal.height);
+  pb_proposal.set_created_time(iroha::time::now());
   for (const auto &tx : proposal.transactions) {
     new (pb_proposal.add_transactions())
         protocol::Transaction(factory_.serialize(tx));

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -71,8 +71,7 @@ namespace iroha {
       new_block.prev_hash = last_block.value().hash;
       new_block.transactions = proposal.transactions;
       new_block.txs_number = proposal.transactions.size();
-      new_block.created_ts = 0;  // TODO 14/08/17 Muratov set timestamp from
-                                 // proposal & for new model IR-501
+      new_block.created_ts = proposal.created_time;
       new_block.hash = hash(new_block);
       crypto_provider_->sign(new_block);
 

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -68,7 +68,7 @@ namespace iroha {
       model::Proposal validated_proposal(
           std::accumulate(txs.begin(), txs.end(), valid, filter));
       validated_proposal.height = proposal.height;
-      validated_proposal.height = iroha::time::now();
+      validated_proposal.created_time = iroha::time::now();
       log_->info("transactions in verified proposal: {}",
                  validated_proposal.transactions.size());
       return validated_proposal;

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-#include "validation/impl/stateful_validator_impl.hpp"
 #include <numeric>
 #include <set>
+
+#include "datetime/time.hpp"
 #include "model/account.hpp"
+#include "validation/impl/stateful_validator_impl.hpp"
 
 namespace iroha {
   namespace validation {
@@ -66,6 +68,7 @@ namespace iroha {
       model::Proposal validated_proposal(
           std::accumulate(txs.begin(), txs.end(), valid, filter));
       validated_proposal.height = proposal.height;
+      validated_proposal.height = iroha::time::now();
       log_->info("transactions in verified proposal: {}",
                  validated_proposal.transactions.size());
       return validated_proposal;

--- a/shared_model/backend/protobuf/from_old_model.hpp
+++ b/shared_model/backend/protobuf/from_old_model.hpp
@@ -53,6 +53,7 @@ namespace shared_model {
         const iroha::model::Proposal &proposal) {
       iroha::protocol::Proposal proto;
       proto.set_height(proposal.height);
+      proto.set_created_time(proposal.created_time);
       for (const auto &tx : proposal.transactions) {
         new (proto.add_transactions()) iroha::protocol::Transaction(
             iroha::model::converters::PbTransactionFactory().serialize(tx));


### PR DESCRIPTION
### Description of the Change

Add missing field `created_time` at the `model::Proposal`, also initializing that field where it possible, fixes ir-501 todo

### Possible Drawbacks and Alternate Designs

Can be a problem with block initialization here:
https://github.com/hyperledger/iroha/blob/92d329b3ec88ed7ebe6310fd9c34313c3d09bd18/irohad/simulator/impl/simulator.cpp#L74

Imo it's better use time::now() instead and remove the timestamp field from proposal completely
