### PR TITLE
Add the packaging metadata to build the iroha snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4d8edb74d4954c76a4656a9e109dbc4e)](https://www.codacy.com/app/neewy/iroha?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=hyperledger/iroha&amp;utm_campaign=Badge_Grade)
 [![CircleCI](https://circleci.com/gh/hyperledger/iroha/tree/master.svg?style=svg)](https://circleci.com/gh/hyperledger/iroha/tree/master)
 [![codecov](https://codecov.io/gh/hyperledger/iroha/branch/master/graph/badge.svg)](https://codecov.io/gh/hyperledger/iroha)
+[![Snap Status](https://build.snapcraft.io/badge/hyperledger/iroha.svg)](https://build.snapcraft.io/user/hyperledger/iroha)
 
 [![Throughput Graph](https://graphs.waffle.io/hyperledger/iroha/throughput.svg)](https://waffle.io/hyperledger/iroha/metrics/throughput)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,18 +38,13 @@ parts:
       - gflags
       - c-ares
       - grpc
-      - gtest
       - spdlog
       - rxcpp
       - rapidjson
       - optional
       - libpq
       - pqxx
-      - cpp-redis
       - tbb
-      - sonar-scanner-cli
-      - sonar-build-wrapper
-      - valgrind
       - ed25519
   cmake:
     source: https://gitlab.kitware.com/cmake/cmake.git
@@ -95,11 +90,6 @@ parts:
      - -DgRPC_GFLAGS_PROVIDER=package
      - -DBUILD_SHARED_LIBS=ON
     after: [cmake, protobuf, c-ares]
-  gtest:
-    source: https://github.com/google/googletest.git
-    source-commit: ec44c6c1675c25b9827aacd08c02433cccde7780
-    plugin: cmake
-    after: [cmake]
   spdlog:
     source: https://github.com/gabime/spdlog.git
     source-commit: f85a08622e20b74bff34381cafcb8ef8167b29d0
@@ -117,10 +107,6 @@ parts:
     plugin: cmake
     configflags: [-DRAPIDJSON_BUILD_EXAMPLES=OFF]
     after: [cmake]
-    stage:
-      - -include/gtest/gtest.h
-      - -lib/libgtest.a
-      - -lib/libgtest_main.a
   optional:
     source: https://github.com/martinmoene/optional-lite.git
     source-commit: a0ddabb8b52e1eaaf0dd1515bb85698b747528e4
@@ -148,13 +134,6 @@ parts:
     plugin: autotools
     configflags: [--disable-documentation, --with-pic]
     after: [libpq]
-  cpp-redis:
-    source: https://github.com/Cylix/cpp_redis.git
-    source-commit: f390eef447a62dcb6da288fb1e91f25f8a9b838c
-    plugin: nil
-    build: cmake -H../src -B.
-    install: cmake --build . --target install
-    after: [cmake]
   tbb:
     source: https://github.com/01org/tbb.git
     source-commit: eb6336ad29450f2a64af5123ca1b9429ff6bc11d
@@ -168,25 +147,6 @@ parts:
       cp build/build_release/*.so* $SNAPCRAFT_PART_INSTALL/usr/local/lib
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local
       mv $SNAPCRAFT_PART_INSTALL/include $SNAPCRAFT_PART_INSTALL/usr/local/include
-  sonar-scanner-cli:
-    source: https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
-    plugin: nil
-    install: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/sonar
-      mv sonar-scanner-3.0.3.778-linux $SNAPCRAFT_PART_INSTALL/opt/sonar/scanner
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/bin/
-      ln -s -f ../../../opt/sonar/scanner/bin/sonar-scanner $SNAPCRAFT_PART_INSTALL/usr/local/bin/sonar-scanner
-  sonar-build-wrapper:
-    source: https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
-    plugin: nil
-    install: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/sonar
-      mv ../src/build-wrapper-linux-x86 $SNAPCRAFT_PART_INSTALL/opt/sonar/build-wrapper
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/bin/
-      ln -s -f ../../../opt/sonar/build-wrapper/build-wrapper-linux-x86-64 $SNAPCRAFT_PART_INSTALL/usr/local/bin/sonar-build-wrapper
-  valgrind:
-    source: git://sourceware.org/git/valgrind.git
-    plugin: autotools
   ed25519:
     source: https://github.com/hyperledger/iroha-ed25519.git
     source-commit: e7188b8393dbe5ac54378610d53630bd4a180038

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: iroha-elopio
+name: iroha
 version: git
 summary: A simple, decentralized ledger
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
     source: git://sourceware.org/git/valgrind.git
     plugin: autotools
   ed25519:
-    source: https://github.com/warchant/ed25519.git
-    source-commit: 56d926c4489aa7b2bb664a48294c5ee2d6e1c283
+    source: https://github.com/hyperledger/iroha-ed25519.git
+    source-commit: e7188b8393dbe5ac54378610d53630bd4a180038
     plugin: cmake
     configflags: [-DTESTING=OFF]
     after: [cmake]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,195 @@
+name: iroha-elopio
+version: git
+summary: A simple, decentralized ledger
+description: |
+  Blockchain platform Hyperledger Iroha is designed for simple creation and
+  management of assets. This is a distributed ledger of transactions.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  cli:
+    command: iroha-cli
+  daemon:
+    command: irohad
+
+build-packages:
+  - build-essential
+  - automake
+  - libtool
+  - libssl-dev
+  - zlib1g-dev
+  - libc6-dbg
+  - ccache
+  - gcc
+  - g++
+  - python
+
+parts:
+  iroha:
+    source: .
+    plugin: cmake
+    install: mv bin $SNAPCRAFT_PART_INSTALL/
+    after:
+      - cmake
+      - boost
+      - protobuf
+      - gflags
+      - c-ares
+      - grpc
+      - gtest
+      - spdlog
+      - rxcpp
+      - rapidjson
+      - optional
+      - libpq
+      - pqxx
+      - cpp-redis
+      - tbb
+      - sonar-scanner-cli
+      - sonar-build-wrapper
+      - valgrind
+      - ed25519
+  cmake:
+    source: https://gitlab.kitware.com/cmake/cmake.git
+    source-commit: 64130a7e793483e24c1d68bdd234f81d5edb2d51
+    plugin: make
+    prepare: ./bootstrap --enable-ccache
+  boost:
+    source: https://github.com/boostorg/boost.git
+    source-commit: 436ad1dfcfc7e0246141beddd11c8a4e9c10b146
+    plugin: nil
+    build: |
+      ./bootstrap.sh --with-libraries=system,filesystem
+      ./b2 headers
+      ./b2 cxxflags="-std=c++14" install
+  protobuf:
+    source: https://github.com/google/protobuf.git
+    source-commit: 80a37e0782d2d702d52234b62dd4b9ec74fd2c95
+    source-subdir: cmake
+    plugin: cmake
+    configflags: [-Dprotobuf_BUILD_TESTS=OFF, -Dprotobuf_BUILD_SHARED_LIBS=ON]
+    after: [cmake]
+  gflags:
+    source: https://github.com/gflags/gflags.git
+    source-commit: f8a0efe03aa69b3336d8e228b37d4ccb17324b88
+    plugin: cmake
+    configflags: [-DCMAKE_INSTALL_PREFIX=/]
+    after: [cmake]
+  c-ares:
+    source: https://github.com/c-ares/c-ares.git
+    source-commit: 3be1924221e1326df520f8498d704a5c4c8d0cce
+    plugin: cmake
+    configflags: [-DCMAKE_INSTALL_PREFIX=/]
+    after: [cmake]
+  grpc:
+    source: https://github.com/grpc/grpc.git
+    source-commit: bfcbad3b86c7912968dc8e64f2121c920dad4dfb
+    plugin: cmake
+    configflags:
+     - -DgRPC_ZLIB_PROVIDER=package
+     - -DgRPC_CARES_PROVIDER=package
+     - -DgRPC_SSL_PROVIDER=package
+     - -DgRPC_PROTOBUF_PROVIDER=package
+     - -DgRPC_GFLAGS_PROVIDER=package
+     - -DBUILD_SHARED_LIBS=ON
+    after: [cmake, protobuf, c-ares]
+  gtest:
+    source: https://github.com/google/googletest.git
+    source-commit: ec44c6c1675c25b9827aacd08c02433cccde7780
+    plugin: cmake
+    after: [cmake]
+  spdlog:
+    source: https://github.com/gabime/spdlog.git
+    source-commit: f85a08622e20b74bff34381cafcb8ef8167b29d0
+    plugin: cmake
+    configflags: [-DSPDLOG_BUILD_TESTING=OFF]
+    after: [cmake]
+  rxcpp:
+    source: https://github.com/Reactive-Extensions/RxCpp.git
+    source-commit: 1b2e0589f19cb34d8cd58803677701dcf2161876
+    plugin: cmake
+    after: [cmake]
+  rapidjson:
+    source: https://github.com/miloyip/rapidjson.git
+    source-commit: f54b0e47a08782a6131cc3d60f94d038fa6e0a51
+    plugin: cmake
+    configflags: [-DRAPIDJSON_BUILD_EXAMPLES=OFF]
+    after: [cmake]
+    stage:
+      - -include/gtest/gtest.h
+      - -lib/libgtest.a
+      - -lib/libgtest_main.a
+  optional:
+    source: https://github.com/martinmoene/optional-lite.git
+    source-commit: a0ddabb8b52e1eaaf0dd1515bb85698b747528e4
+    plugin: nil
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/include
+      cp -r include/nonstd $SNAPCRAFT_PART_INSTALL/usr/local/include
+  libpq:
+    source: https://git.postgresql.org/git/postgresql.git
+    source-commit: 029386ccbddd0a33d481b94e511f5219b03e6636
+    plugin: nil
+    build: |
+      ./configure --without-readline --prefix=
+      make -C src/bin/pg_config
+      make -C src/interfaces/libpq
+      make -C src/backend/utils fmgroids.h
+      ln -s $(pwd)/src/backend/utils/fmgroids.h src/include/utils/fmgroids.h
+    install: |
+      make -C src/bin/pg_config install DESTDIR=$SNAPCRAFT_PART_INSTALL
+      make -C src/interfaces/libpq install DESTDIR=$SNAPCRAFT_PART_INSTALL
+      make -C src/include install DESTDIR=$SNAPCRAFT_PART_INSTALL
+  pqxx:
+    source: https://github.com/jtv/libpqxx.git
+    source-commit: 5b17abce5ac2b1a2f8278718405b7ade8bb30ae9
+    plugin: autotools
+    configflags: [--disable-documentation, --with-pic]
+    after: [libpq]
+  cpp-redis:
+    source: https://github.com/Cylix/cpp_redis.git
+    source-commit: f390eef447a62dcb6da288fb1e91f25f8a9b838c
+    plugin: nil
+    build: cmake -H../src -B.
+    install: cmake --build . --target install
+    after: [cmake]
+  tbb:
+    source: https://github.com/01org/tbb.git
+    source-commit: eb6336ad29450f2a64af5123ca1b9429ff6bc11d
+    plugin: make
+    make-parameters: [tbb_build_prefix=build]
+    artifacts:
+      - include
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/lib
+      cp build/build_debug/*.so* $SNAPCRAFT_PART_INSTALL/usr/local/lib
+      cp build/build_release/*.so* $SNAPCRAFT_PART_INSTALL/usr/local/lib
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local
+      mv $SNAPCRAFT_PART_INSTALL/include $SNAPCRAFT_PART_INSTALL/usr/local/include
+  sonar-scanner-cli:
+    source: https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
+    plugin: nil
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/sonar
+      mv sonar-scanner-3.0.3.778-linux $SNAPCRAFT_PART_INSTALL/opt/sonar/scanner
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/bin/
+      ln -s -f ../../../opt/sonar/scanner/bin/sonar-scanner $SNAPCRAFT_PART_INSTALL/usr/local/bin/sonar-scanner
+  sonar-build-wrapper:
+    source: https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+    plugin: nil
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/sonar
+      mv ../src/build-wrapper-linux-x86 $SNAPCRAFT_PART_INSTALL/opt/sonar/build-wrapper
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/bin/
+      ln -s -f ../../../opt/sonar/build-wrapper/build-wrapper-linux-x86-64 $SNAPCRAFT_PART_INSTALL/usr/local/bin/sonar-build-wrapper
+  valgrind:
+    source: git://sourceware.org/git/valgrind.git
+    plugin: autotools
+  ed25519:
+    source: https://github.com/warchant/ed25519.git
+    source-commit: 56d926c4489aa7b2bb664a48294c5ee2d6e1c283
+    plugin: cmake
+    configflags: [-DTESTING=OFF]
+    after: [cmake]


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This package will let you publish the latest iroha binaries in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery. 
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
1-command installs, complete isolation when the snap is made strict, automatic updates, 4 channels with different levels of risks to make things easy and fun for your testers.

### Possible Drawbacks 

At this point, none. You can just give it a try in edge, and see if you like it before publishing it to stable. Once it's in stable, you will get users and will have to keep moving the releases from the edge channel when they are ready.
