### PR TITLE
Fix error query response deserialization, add missing query error resp

### DIFF
--- a/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
@@ -20,6 +20,7 @@
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/error_responses/no_account_assets_error_response.hpp"
+#include "interfaces/query_responses/error_responses/no_account_detail_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_asset_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_roles_error_response.hpp"
@@ -42,6 +43,9 @@ namespace shared_model {
                      iroha::protocol::ErrorResponse>;
     using NoAccountAssetsErrorResponse =
         TrivialProto<interface::NoAccountAssetsErrorResponse,
+                     iroha::protocol::ErrorResponse>;
+    using NoAccountDetailErrorResponse =
+        TrivialProto<interface::NoAccountDetailErrorResponse,
                      iroha::protocol::ErrorResponse>;
     using NoSignatoriesErrorResponse =
         TrivialProto<interface::NoSignatoriesErrorResponse,

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -28,7 +28,11 @@
 
 template <typename... T, typename Archive>
 auto loadErrorResponse(Archive &&ar) {
-  int which = ar.GetDescriptor()->FindFieldByNumber(ar.reason())->index();
+  unsigned which = ar.GetDescriptor()
+                       ->FindFieldByName("reason")
+                       ->enum_type()
+                       ->FindValueByNumber(ar.reason())
+                       ->index();
   return shared_model::detail::variant_impl<T...>::template load<
       shared_model::interface::ErrorQueryResponse::
           QueryErrorResponseVariantType>(std::forward<Archive>(ar), which);
@@ -58,6 +62,7 @@ namespace shared_model {
                StatefulFailedErrorResponse,
                NoAccountErrorResponse,
                NoAccountAssetsErrorResponse,
+               NoAccountDetailErrorResponse,
                NoSignatoriesErrorResponse,
                NotSupportedErrorResponse,
                NoAssetErrorResponse,

--- a/shared_model/interfaces/query_responses/error_query_response.hpp
+++ b/shared_model/interfaces/query_responses/error_query_response.hpp
@@ -21,6 +21,7 @@
 #include <boost/variant.hpp>
 #include "interfaces/base/primitive.hpp"
 #include "interfaces/query_responses/error_responses/no_account_assets_error_response.hpp"
+#include "interfaces/query_responses/error_responses/no_account_detail_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_asset_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_roles_error_response.hpp"
@@ -50,6 +51,7 @@ namespace shared_model {
                                               StatefulFailedErrorResponse,
                                               NoAccountErrorResponse,
                                               NoAccountAssetsErrorResponse,
+                                              NoAccountDetailErrorResponse,
                                               NoSignatoriesErrorResponse,
                                               NotSupportedErrorResponse,
                                               NoAssetErrorResponse,

--- a/shared_model/interfaces/query_responses/error_responses/no_account_detail_error_response.hpp
+++ b/shared_model/interfaces/query_responses/error_responses/no_account_detail_error_response.hpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_SHARED_MODEL_NO_ACCOUNT_DETAIL_ERROR_REPONSE_HPP
+#define IROHA_SHARED_MODEL_NO_ACCOUNT_DETAIL_ERROR_REPONSE_HPP
+
+#include "interfaces/common_objects/types.hpp"
+#include "interfaces/query_responses/error_responses/abstract_error_response.hpp"
+#include "utils/string_builder.hpp"
+
+namespace shared_model {
+  namespace interface {
+    /**
+     * Error response of broken query, account has no specified account detail.
+     */
+    class NoAccountDetailErrorResponse
+        : public AbstractErrorResponse<NoAccountDetailErrorResponse> {
+     private:
+      std::string reason() const override {
+        return "NoAccountDetailErrorResponse";
+      }
+
+#ifndef DISABLE_BACKWARD
+      iroha::model::ErrorResponse::Reason oldModelReason() const override {
+        return iroha::model::ErrorResponse::Reason::NO_ACCOUNT_DETAIL;
+      }
+
+#endif
+    };
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_SHARED_MODEL_NO_ACCOUNT_DETAIL_ERROR_REPONSE_HPP

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -23,7 +23,7 @@
 #include "cryptography/hash.hpp"
 
 /**
- * @given protobuf's QueryResponse with different tx_statuses and some hash
+ * @given protobuf's QueryResponse with different responses and some hash
  * @when converting to shared model
  * @then ensure that status and hash remain the same
  */
@@ -44,4 +44,37 @@ TEST(QueryResponse, QueryResponseLoad) {
     ASSERT_EQ(i, shared_response.get().which());
     ASSERT_EQ(shared_response.queryHash(), shared_model::crypto::Hash(hash));
   });
+}
+
+/**
+ * @given protobuf's ErrorResponse with different reasons and some hash
+ * @when converting to shared model
+ * @then ensure that reason and hash remain the same
+ */
+TEST(QueryResponse, ErrorResponseLoad) {
+  iroha::protocol::QueryResponse response;
+  const std::string hash = "123";
+  response.set_query_hash(hash);
+  auto error_resp = response.mutable_error_response();
+  auto refl = error_resp->GetReflection();
+  auto desc = error_resp->GetDescriptor();
+  auto resp_reason = desc->FindFieldByName("reason");
+  ASSERT_NE(nullptr, resp_reason);
+  auto resp_reason_enum = resp_reason->enum_type();
+  ASSERT_NE(nullptr, resp_reason_enum);
+
+  boost::for_each(
+      boost::irange(0, resp_reason_enum->value_count()), [&](auto i) {
+        refl->SetEnumValue(
+            error_resp, resp_reason, resp_reason_enum->value(i)->number());
+        auto shared_response = shared_model::proto::QueryResponse(response);
+        ASSERT_EQ(i,
+                  boost::get<shared_model::detail::PolymorphicWrapper<
+                      shared_model::interface::ErrorQueryResponse>>(
+                      shared_response.get())
+                      ->get()
+                      .which());
+        ASSERT_EQ(shared_response.queryHash(),
+                  shared_model::crypto::Hash(hash));
+      });
 }


### PR DESCRIPTION
Signed-off-by: Andrei Lebedev <lebdron@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix error query response deserialization - wrong protobuf methods were previously used.
Add missing error query reason - no account detail reason was not present in shared model.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Integration test framework `sendQuery(const Query &, Lambda)` works as expected.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
https://github.com/hyperledger/iroha/blob/aca94010a0a1d31eb9a65bb558423f5cb4115925/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp#L54-L80
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->