### PR TITLE
Feature/rework chain validator with new model

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "model/execution/command_executor_factory.hpp"
-
-#include "backend/protobuf/from_old_model.hpp"
 
 namespace iroha {
   namespace ametsuchi {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -18,9 +18,9 @@
 #ifndef IROHA_MUTABLE_STORAGE_IMPL_HPP
 #define IROHA_MUTABLE_STORAGE_IMPL_HPP
 
+#include <map>
 #include <pqxx/connection>
 #include <pqxx/nontransaction>
-#include <unordered_map>
 
 #include "ametsuchi/mutable_storage.hpp"
 #include "logger/logger.hpp"

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_MUTABLE_STORAGE_HPP
 #define IROHA_MUTABLE_STORAGE_HPP
 
-#include "common/types.hpp"  // for hash256_t
+#include <functional>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -28,11 +28,6 @@ namespace shared_model {
 }  // namespace shared_model
 
 namespace iroha {
-
-  namespace model {
-    struct Block;
-  }
-
   namespace ametsuchi {
 
     class WsvQuery;

--- a/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
@@ -17,14 +17,13 @@
 
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
 #include "interfaces/common_objects/peer.hpp"
-#include "model/peer.hpp"
 
 namespace iroha {
   namespace consensus {
     namespace yac {
 
       bool SupermajorityCheckerImpl::hasSupermajority(
-          const std::vector<model::Signature> &signatures,
+          const shared_model::interface::SignatureSetType &signatures,
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &peers) const {
         return checkSize(signatures.size(), peers.size())
@@ -41,7 +40,7 @@ namespace iroha {
       }
 
       bool SupermajorityCheckerImpl::peersSubset(
-          const std::vector<model::Signature> &signatures,
+          const shared_model::interface::SignatureSetType &signatures,
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &peers) const {
         return std::all_of(
@@ -51,14 +50,7 @@ namespace iroha {
                          peers.end(),
                          [&signature](const std::shared_ptr<
                                       shared_model::interface::Peer> &peer) {
-
-                           // TODO 14-02-2018 Alexey Chernyshov
-                           // remove after relocationn to shared_model
-                           shared_model::crypto::PublicKey signature_pubkey(
-                               {signature.pubkey.begin(),
-                                signature.pubkey.end()});
-
-                           return signature_pubkey == peer->pubkey();
+                           return signature->publicKey() == peer->pubkey();
                          })
                   != peers.end();
             });

--- a/irohad/consensus/yac/impl/supermajority_checker_impl.hpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.hpp
@@ -35,14 +35,14 @@ namespace iroha {
          * @return true on supermajority is achieved or false otherwise
          */
         virtual bool hasSupermajority(
-            const std::vector<model::Signature> &signatures,
+            const shared_model::interface::SignatureSetType &signatures,
             const std::vector<std::shared_ptr<shared_model::interface::Peer>> &peers)
             const override;
 
         virtual bool checkSize(uint64_t current, uint64_t all) const override;
 
         virtual bool peersSubset(
-            const std::vector<model::Signature> &signatures,
+            const shared_model::interface::SignatureSetType &signatures,
             const std::vector<std::shared_ptr<shared_model::interface::Peer>>
                 &peers) const override;
 

--- a/irohad/consensus/yac/supermajority_checker.hpp
+++ b/irohad/consensus/yac/supermajority_checker.hpp
@@ -50,7 +50,7 @@ namespace iroha {
          * @return true on supermajority is achieved or false otherwise
          */
         virtual bool hasSupermajority(
-            const std::vector<model::Signature> &signatures,
+            const shared_model::interface::SignatureSetType &signatures,
             const std::vector<std::shared_ptr<shared_model::interface::Peer>>
                 &peers) const = 0;
 
@@ -69,7 +69,7 @@ namespace iroha {
          * @return true if is subset or false otherwise
          */
         virtual bool peersSubset(
-            const std::vector<model::Signature> &signatures,
+            const shared_model::interface::SignatureSetType &signatures,
             const std::vector<std::shared_ptr<shared_model::interface::Peer>>
                 &peers) const = 0;
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -16,8 +16,6 @@
  */
 
 #include "main/application.hpp"
-#include <algorithm>
-#include <memory>
 #include "ametsuchi/impl/postgres_ordering_service_persistent_state.hpp"
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
 #include "ametsuchi/impl/wsv_restorer_impl.hpp"

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -17,7 +17,12 @@
 
 #include <utility>
 
+#include "ametsuchi/mutable_storage.hpp"
 #include "synchronizer/impl/synchronizer_impl.hpp"
+
+// TODO: 14-02-2018 Alexey Chernyshov remove this after relocation to
+// shared_model https://soramitsu.atlassian.net/browse/IR-903
+#include "backend/protobuf/from_old_model.hpp"
 
 namespace iroha {
   namespace synchronizer {
@@ -40,7 +45,8 @@ namespace iroha {
       subscription_.unsubscribe();
     }
 
-    void SynchronizerImpl::process_commit(iroha::model::Block commit_message) {
+    void SynchronizerImpl::process_commit(
+        iroha::model::Block old_commit_message) {
       log_->info("processing commit");
       auto storageResult = mutableFactory_->createMutableStorage();
       std::unique_ptr<ametsuchi::MutableStorage> storage;
@@ -54,18 +60,22 @@ namespace iroha {
       if (not storage) {
         return;
       }
+
+      // TODO: 14-02-2018 Alexey Chernyshov remove this after relocation to
+      // shared_model https://soramitsu.atlassian.net/browse/IR-903
+      auto commit_message = shared_model::proto::from_old(old_commit_message);
       if (validator_->validateBlock(commit_message, *storage)) {
         // Block can be applied to current storage
         // Commit to main Ametsuchi
         mutableFactory_->commit(std::move(storage));
 
-        auto single_commit = rxcpp::observable<>::just(commit_message);
+        auto single_commit = rxcpp::observable<>::just(old_commit_message);
 
         notifier_.get_subscriber().on_next(single_commit);
       } else {
         // Block can't be applied to current storage
         // Download all missing blocks
-        for (auto signature : commit_message.sigs) {
+        for (auto signature : old_commit_message.sigs) {
           auto storageResult = mutableFactory_->createMutableStorage();
           std::unique_ptr<ametsuchi::MutableStorage> storage;
           storageResult.match(
@@ -79,18 +89,18 @@ namespace iroha {
             return;
           }
           auto chain =
-              blockLoader_
-                  ->retrieveBlocks(shared_model::crypto::PublicKey(
-                      {signature.pubkey.begin(), signature.pubkey.end()}))
-                  .map([](auto block) {
-                    std::unique_ptr<iroha::model::Block> old_block(
-                        block->makeOldModel());
-                    return *old_block;
-                  });
+              blockLoader_->retrieveBlocks(shared_model::crypto::PublicKey(
+                  {signature.pubkey.begin(), signature.pubkey.end()}));
           if (validator_->validateChain(chain, *storage)) {
             // Peer send valid chain
             mutableFactory_->commit(std::move(storage));
-            notifier_.get_subscriber().on_next(chain);
+
+            //TODO Alexey Chernyshov move to shared_model
+            notifier_.get_subscriber().on_next(chain.map([](auto block) {
+              std::unique_ptr<iroha::model::Block> old_block(
+                  block->makeOldModel());
+              return *old_block;
+            }));
             // You are synchronized
             return;
           }

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -95,7 +95,8 @@ namespace iroha {
             // Peer send valid chain
             mutableFactory_->commit(std::move(storage));
 
-            //TODO Alexey Chernyshov move to shared_model
+            // TODO: 07-03-2018 Alexey Chernyshov remove this after relocation to
+            // shared_model https://soramitsu.atlassian.net/browse/IR-903
             notifier_.get_subscriber().on_next(chain.map([](auto block) {
               std::unique_ptr<iroha::model::Block> old_block(
                   block->makeOldModel());

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -18,12 +18,11 @@
 #define IROHA_SYNCHRONIZER_IMPL_HPP
 
 #include "ametsuchi/mutable_factory.hpp"
+#include "logger/logger.hpp"
 #include "network/block_loader.hpp"
 #include "network/consensus_gate.hpp"
 #include "synchronizer/synchronizer.hpp"
 #include "validation/chain_validator.hpp"
-
-#include "logger/logger.hpp"
 
 namespace iroha {
   namespace synchronizer {

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -20,11 +20,17 @@
 
 #include <rxcpp/rx-observable.hpp>
 
-#include "ametsuchi/mutable_storage.hpp"
-#include "model/block.hpp"
-#include "model/commit.hpp"
+namespace shared_model {
+  namespace interface {
+    class Block;
+  }
+}  // namespace shared_model
 
 namespace iroha {
+  namespace ametsuchi {
+    class MutableStorage;
+  }
+
   namespace validation {
 
     /**
@@ -46,8 +52,10 @@ namespace iroha {
        * @param storage - storage that may be modified during loading
        * @return true if commit is valid, false otherwise
        */
-      virtual bool validateChain(OldCommit commit,
-                                 ametsuchi::MutableStorage &storage) = 0;
+      virtual bool validateChain(
+          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+              commit,
+          ametsuchi::MutableStorage &storage) = 0;
 
       /**
        * Block validation will check if all signatures and meta-data are valid.
@@ -55,7 +63,7 @@ namespace iroha {
        * @param storage -  storage that may be modified during block appliance
        * @return true if block is valid and can be applied, false otherwise
        */
-      virtual bool validateBlock(const model::Block &block,
+      virtual bool validateBlock(const shared_model::interface::Block &block,
                                  ametsuchi::MutableStorage &storage) = 0;
     };
   }  // namespace validation

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -37,7 +37,7 @@ namespace iroha {
                  block.height(),
                  block.hash().hex());
       auto apply_block =
-          [&](const auto &block, auto &queries, const auto &top_hash) {
+          [this](const auto &block, auto &queries, const auto &top_hash) {
             auto peers = queries.getPeers();
             if (not peers.has_value()) {
               return false;

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "validation/impl/chain_validator_impl.hpp"
-#include "backend/protobuf/from_old_model.hpp"
 
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
+#include "ametsuchi/mutable_storage.hpp"
 #include "consensus/yac/supermajority_checker.hpp"
 
 namespace iroha {
@@ -30,40 +30,42 @@ namespace iroha {
       log_ = logger::log("ChainValidator");
     }
 
-    bool ChainValidatorImpl::validateBlock(const model::Block &block,
-                                           ametsuchi::MutableStorage &storage) {
+    bool ChainValidatorImpl::validateBlock(
+        const shared_model::interface::Block &block,
+        ametsuchi::MutableStorage &storage) {
       log_->info("validate block: height {}, hash {}",
-                 block.height,
-                 block.hash.to_hexstring());
+                 block.height(),
+                 block.hash().hex());
       auto apply_block =
-          [this](const auto &block, auto &queries, const auto &top_hash) {
+          [&](const auto &block, auto &queries, const auto &top_hash) {
             auto peers = queries.getPeers();
             if (not peers.has_value()) {
               return false;
             }
-            auto old_block = *std::unique_ptr<model::Block>(block.makeOldModel());
             return block.prevHash() == top_hash
-                and supermajority_checker_->hasSupermajority(old_block.sigs,
+                and supermajority_checker_->hasSupermajority(block.signatures(),
                                                              peers.value());
           };
 
       // Apply to temporary storage
-      auto old_block = shared_model::proto::from_old(block);
-      return storage.apply(old_block, apply_block);
+      return storage.apply(block, apply_block);
     }
 
-    bool ChainValidatorImpl::validateChain(OldCommit blocks,
-                                           ametsuchi::MutableStorage &storage) {
+    bool ChainValidatorImpl::validateChain(
+        rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+            blocks,
+        ametsuchi::MutableStorage &storage) {
       log_->info("validate chain...");
       return blocks
           .all([this, &storage](auto block) {
             log_->info("Validating block: height {}, hash {}",
-                       block.height,
-                       block.hash.to_hexstring());
-            return this->validateBlock(block, storage);
+                       block->height(),
+                       block->hash().hex());
+            return this->validateBlock(*block, storage);
           })
           .as_blocking()
           .first();
     }
+
   }  // namespace validation
 }  // namespace iroha

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include "logger/logger.hpp"
-#include "model/model_crypto_provider.hpp"
 #include "validation/chain_validator.hpp"
 
 namespace iroha {
@@ -37,10 +36,12 @@ namespace iroha {
       ChainValidatorImpl(std::shared_ptr<consensus::yac::SupermajorityChecker>
                              supermajority_checker);
 
-      bool validateChain(OldCommit blocks,
-                         ametsuchi::MutableStorage &storage) override;
+      bool validateChain(
+          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+              blocks,
+          ametsuchi::MutableStorage &storage) override;
 
-      bool validateBlock(const model::Block &block,
+      bool validateBlock(const shared_model::interface::Block &block,
                          ametsuchi::MutableStorage &storage) override;
 
      private:

--- a/shared_model/builders/common_objects/common.hpp
+++ b/shared_model/builders/common_objects/common.hpp
@@ -64,7 +64,8 @@ namespace shared_model {
         }
 
         if (answer) {
-          return iroha::expected::makeError(std::make_shared<std::string>(answer.reason()));
+          return iroha::expected::makeError(
+              std::make_shared<std::string>(answer.reason()));
         }
 
         return iroha::expected::makeValue(std::move(model_impl));

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -192,13 +192,13 @@ namespace iroha {
        public:
         MOCK_CONST_METHOD2(
             hasSupermajority,
-            bool(const std::vector<model::Signature> &signatures,
+            bool(const shared_model::interface::SignatureSetType &signatures,
                  const std::vector<
                      std::shared_ptr<shared_model::interface::Peer>> &peers));
         MOCK_CONST_METHOD2(checkSize, bool(uint64_t current, uint64_t all));
         MOCK_CONST_METHOD2(
             peersSubset,
-            bool(const std::vector<model::Signature> &signatures,
+            bool(const shared_model::interface::SignatureSetType &signatures,
                  const std::vector<
                      std::shared_ptr<shared_model::interface::Peer>> &peers));
         MOCK_CONST_METHOD3(

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -78,7 +78,9 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-  EXPECT_CALL(*chain_validator, validateBlock(test_block, _))
+// TODO: 14-02-2018 Alexey Chernyshov uncomment expected argument after relocation to
+// shared_model https://soramitsu.atlassian.net/browse/IR-903
+  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
@@ -114,7 +116,9 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(0);
 
-  EXPECT_CALL(*chain_validator, validateBlock(test_block, _)).Times(0);
+// TODO: 14-02-2018 Alexey Chernyshov replace with expected argument after relocation to
+// shared_model https://soramitsu.atlassian.net/browse/IR-903
+  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _)).Times(0);
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
 
@@ -144,7 +148,9 @@ TEST_F(SynchronizerTest, ValidWhenBlockValidationFailure) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-  EXPECT_CALL(*chain_validator, validateBlock(test_block, _))
+// TODO: 14-02-2018 Alexey Chernyshov replace with expected argument after relocation to
+// shared_model https://soramitsu.atlassian.net/browse/IR-903
+  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _))
       .WillOnce(Return(false));
   EXPECT_CALL(*chain_validator, validateChain(_, _)).WillOnce(Return(true));
 

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
-#include "module/irohad/network/network_mocks.hpp"
-#include "module/irohad/validation/validation_mocks.hpp"
-
 #include "backend/protobuf/block.hpp"
 #include "backend/protobuf/from_old_model.hpp"
 #include "framework/test_subscriber.hpp"
+#include "model/sha3_hash.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
+#include "module/irohad/network/network_mocks.hpp"
+#include "module/irohad/validation/validation_mocks.hpp"
 #include "synchronizer/impl/synchronizer_impl.hpp"
 #include "validation/chain_validator.hpp"
 
@@ -59,6 +59,16 @@ class SynchronizerTest : public ::testing::Test {
   std::shared_ptr<SynchronizerImpl> synchronizer;
 };
 
+// TODO: 14-02-2018 Alexey Chernyshov remove after
+// relocation to shared_model https://soramitsu.atlassian.net/browse/IR-903
+// hash of block should be initialised
+MATCHER_P(NewBlockMatcher,
+          block,
+          "is shared_model Block is equal to the old model Block ") {
+  std::unique_ptr<iroha::model::Block> old_block(arg.makeOldModel());
+  return *old_block == block;
+};
+
 TEST_F(SynchronizerTest, ValidWhenInitialized) {
   // synchronizer constructor => on_commit subscription called
   EXPECT_CALL(*consensus_gate, on_commit())
@@ -71,6 +81,7 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
   // commit from consensus => chain validation passed => commit successful
   Block test_block;
   test_block.height = 5;
+  test_block.hash = iroha::hash(test_block);
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
@@ -78,9 +89,10 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-// TODO: 14-02-2018 Alexey Chernyshov uncomment expected argument after relocation to
-// shared_model https://soramitsu.atlassian.net/browse/IR-903
-  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _))
+  // TODO: 14-02-2018 Alexey Chernyshov uncomment expected argument after
+  // relocation to shared_model https://soramitsu.atlassian.net/browse/IR-903
+  //  EXPECT_CALL(*chain_validator, validateBlock(testing::Ref(new_test_block), _))
+  EXPECT_CALL(*chain_validator, validateBlock(NewBlockMatcher(test_block), _))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
@@ -116,9 +128,7 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(0);
 
-// TODO: 14-02-2018 Alexey Chernyshov replace with expected argument after relocation to
-// shared_model https://soramitsu.atlassian.net/browse/IR-903
-  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _)).Times(0);
+  EXPECT_CALL(*chain_validator, validateBlock(_, _)).Times(0);
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
 
@@ -141,6 +151,7 @@ TEST_F(SynchronizerTest, ValidWhenBlockValidationFailure) {
   Block test_block;
   test_block.height = 5;
   test_block.sigs.emplace_back();
+  test_block.hash = iroha::hash(test_block);
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
@@ -148,10 +159,12 @@ TEST_F(SynchronizerTest, ValidWhenBlockValidationFailure) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-// TODO: 14-02-2018 Alexey Chernyshov replace with expected argument after relocation to
-// shared_model https://soramitsu.atlassian.net/browse/IR-903
-  EXPECT_CALL(*chain_validator, validateBlock(/* testing::Ref(new_test_block) */ _, _))
+  // TODO: 14-02-2018 Alexey Chernyshov replace with expected argument after
+  // relocation to shared_model https://soramitsu.atlassian.net/browse/IR-903
+//  EXPECT_CALL(*chain_validator, validateBlock(testing::Ref(new_test_block), _))
+  EXPECT_CALL(*chain_validator, validateBlock(NewBlockMatcher(test_block), _))
       .WillOnce(Return(false));
+
   EXPECT_CALL(*chain_validator, validateChain(_, _)).WillOnce(Return(true));
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_))

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -32,4 +32,5 @@ target_link_libraries(query_execution
 addtest(chain_validation_test chain_validation_test.cpp)
 target_link_libraries(chain_validation_test
     chain_validator
+    shared_model_stateless_validation
     )

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -56,8 +56,7 @@ class ChainValidationTest : public ::testing::Test {
         .transactions(std::vector<shared_model::proto::Transaction>{})
         .txNumber(0)
         .height(1)
-        .prevHash(hash)
-        .createdTime(iroha::time::now());
+        .prevHash(hash);
   }
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -152,9 +152,12 @@ TEST_F(ChainValidationTest, ValidWhenValidateChainFromOnePeer) {
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  // TODO: 14-02-2018 Alexey Chernyshov add argument to EXPECT_CALL after
-  // replacement with shared_model https://soramitsu.atlassian.net/browse/IR-903
-  EXPECT_CALL(*storage, apply(/* TODO block */ _, _))
+  EXPECT_CALL(
+      *storage,
+      apply(testing::Truly([&](const shared_model::interface::Block &rhs) {
+              return rhs == block;
+            }),
+            _))
       .WillOnce(InvokeArgument<1>(ByRef(block), ByRef(*query), ByRef(hash)));
 
   ASSERT_TRUE(validator->validateChain(block_observable, *storage));

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "backend/protobuf/from_old_model.hpp"
 #include "builders/common_objects/peer_builder.hpp"
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
@@ -42,19 +41,32 @@ auto fake_hash = shared_model::crypto::Hash(zero_string);
 class ChainValidationTest : public ::testing::Test {
  public:
   void SetUp() override {
-    validator = std::make_shared<ChainValidatorImpl>(supermajority_checker_);
+    validator = std::make_shared<ChainValidatorImpl>(supermajority_checker);
     storage = std::make_shared<MockMutableStorage>();
     query = std::make_shared<MockWsvQuery>();
+    peers = std::vector<std::shared_ptr<shared_model::interface::Peer>>();
+  }
+
+  /**
+   * Get block builder to build blocks for tests
+   * @return block builder
+   */
+  auto getBlockBuilder() const {
+    return TestBlockBuilder()
+        .transactions(std::vector<shared_model::proto::Transaction>{})
+        .txNumber(0)
+        .height(1)
+        .prevHash(hash)
+        .createdTime(iroha::time::now());
   }
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;
   Block block;
-  shared_model::interface::types::HashType hash{fake_hash};
 
   std::shared_ptr<iroha::consensus::yac::MockSupermajorityChecker>
-      supermajority_checker_ =
+      supermajority_checker =
           std::make_shared<iroha::consensus::yac::MockSupermajorityChecker>();
-
+  shared_model::crypto::Hash hash = shared_model::crypto::Hash("valid hash");
   std::shared_ptr<ChainValidatorImpl> validator;
   std::shared_ptr<MockMutableStorage> storage;
   std::shared_ptr<MockWsvQuery> query;
@@ -66,14 +78,17 @@ class ChainValidationTest : public ::testing::Test {
  * @then block is validated
  */
 TEST_F(ChainValidationTest, ValidCase) {
-  EXPECT_CALL(*supermajority_checker_, hasSupermajority(_, _))
+  // Valid previous hash, has supermajority, correct peers subset => valid
+  auto block = getBlockBuilder().build();
+
+  EXPECT_CALL(*supermajority_checker,
+              hasSupermajority(testing::Ref(block.signatures()), _))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  auto old_block = shared_model::proto::from_old(block);
-  EXPECT_CALL(*storage, apply(_, _))
-      .WillOnce(InvokeArgument<1>(ByRef(old_block), ByRef(*query), ByRef(hash)));
+  EXPECT_CALL(*storage, apply(testing::Ref(block), _))
+      .WillOnce(InvokeArgument<1>(ByRef(block), ByRef(*query), ByRef(hash)));
 
   ASSERT_TRUE(validator->validateBlock(block, *storage));
 }
@@ -84,14 +99,17 @@ TEST_F(ChainValidationTest, ValidCase) {
  * @then block is not validated
  */
 TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
-  hash = shared_model::interface::types::HashType(
-      std::string(1, block.prev_hash.size()));
+  // Invalid previous hash, has supermajority, correct peers subset => invalid
+  auto block = getBlockBuilder().build();
+
+  shared_model::crypto::Hash another_hash =
+      shared_model::crypto::Hash(std::string(32, '1'));
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  auto old_block = shared_model::proto::from_old(block);
-  EXPECT_CALL(*storage, apply(_, _))
-      .WillOnce(InvokeArgument<1>(ByRef(old_block), ByRef(*query), ByRef(hash)));
+  EXPECT_CALL(*storage, apply(testing::Ref(block), _))
+      .WillOnce(
+          InvokeArgument<1>(ByRef(block), ByRef(*query), ByRef(another_hash)));
 
   ASSERT_FALSE(validator->validateBlock(block, *storage));
 }
@@ -102,34 +120,43 @@ TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
  * @then block is not validated
  */
 TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
-  EXPECT_CALL(*supermajority_checker_, hasSupermajority(_, _))
+  // Valid previous hash, no supermajority, correct peers subset => invalid
+  auto block = getBlockBuilder().build();
+
+  EXPECT_CALL(*supermajority_checker,
+              hasSupermajority(testing::Ref(block.signatures()), _))
       .WillOnce(Return(false));
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  auto old_block = shared_model::proto::from_old(block);
-  EXPECT_CALL(*storage, apply(_, _))
-      .WillOnce(InvokeArgument<1>(ByRef(old_block), ByRef(*query), ByRef(hash)));
+  EXPECT_CALL(*storage, apply(testing::Ref(block), _))
+      .WillOnce(InvokeArgument<1>(ByRef(block), ByRef(*query), ByRef(hash)));
 
   ASSERT_FALSE(validator->validateBlock(block, *storage));
 }
 
 /**
- * @given valid block chain signed by peers
- * @when apply block chain
- * @then block chain is validated
+ * @given valid block signed by peer
+ * @when apply block
+ * @then block is validated via observer
  */
 TEST_F(ChainValidationTest, ValidWhenValidateChainFromOnePeer) {
-  EXPECT_CALL(*supermajority_checker_, hasSupermajority(_, _))
+  // Valid previous hash, has supermajority, correct peers subset => valid
+  auto block = getBlockBuilder().build();
+  rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+      block_observable = rxcpp::observable<>::just(block).map([](auto &&x) {
+        return std::shared_ptr<shared_model::interface::Block>(x.copy());
+      });
+
+  EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  auto block_observable = rxcpp::observable<>::just(block);
-
-  auto old_block = shared_model::proto::from_old(block);
-  EXPECT_CALL(*storage, apply(_, _))
-      .WillOnce(InvokeArgument<1>(ByRef(old_block), ByRef(*query), ByRef(hash)));
+  // TODO: 14-02-2018 Alexey Chernyshov add argument to EXPECT_CALL after
+  // replacement with shared_model https://soramitsu.atlassian.net/browse/IR-903
+  EXPECT_CALL(*storage, apply(/* TODO block */ _, _))
+      .WillOnce(InvokeArgument<1>(ByRef(block), ByRef(*query), ByRef(hash)));
 
   ASSERT_TRUE(validator->validateChain(block_observable, *storage));
 }

--- a/test/module/irohad/validation/validation_mocks.hpp
+++ b/test/module/irohad/validation/validation_mocks.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
  * http://soramitsu.co.jp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 #define IROHA_VALIDATION_MOCKS_HPP
 
 #include <gmock/gmock.h>
+
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "validation/chain_validator.hpp"
 #include "validation/stateful_validator.hpp"
@@ -42,10 +43,14 @@ namespace iroha {
 
     class MockChainValidator : public ChainValidator {
      public:
-      MOCK_METHOD2(validateChain, bool(OldCommit, ametsuchi::MutableStorage &));
+      MOCK_METHOD2(validateChain,
+                   bool(rxcpp::observable<
+                            std::shared_ptr<shared_model::interface::Block>>,
+                        ametsuchi::MutableStorage &));
 
       MOCK_METHOD2(validateBlock,
-                   bool(const model::Block &, ametsuchi::MutableStorage &));
+                   bool(const shared_model::interface::Block &,
+                        ametsuchi::MutableStorage &));
     };
   }  // namespace validation
 }  // namespace iroha

--- a/test/module/shared_model/builders/protobuf/test_block_builder.hpp
+++ b/test/module/shared_model/builders/protobuf/test_block_builder.hpp
@@ -25,7 +25,7 @@
  * and "required fields" check
  */
 using TestBlockBuilder =
-shared_model::proto::TemplateBlockBuilder<(1 << shared_model::proto::TemplateBlockBuilder<>::total) - 1,
-                                          shared_model::validation::DefaultBlockValidator,
-                                          shared_model::proto::Block>;
+    shared_model::proto::TemplateBlockBuilder<(1 << shared_model::proto::TemplateBlockBuilder<>::total) - 1,
+                         shared_model::validation::DefaultBlockValidator,
+                         shared_model::proto::Block>;
 #endif  // IROHA_TEST_BLOCK_BUILDER_HPP


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Move chain_validator to the new shared_model. There are a lot of TODOs and dependencies to be done in other tasks.
First commit fixes wrong protobuf permission string.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Chain validator moves to the new model.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Some tests checks were disabled until further part of shared_model is done.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
see tests
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
Move to new trunk?
<!-- Explain what other alternates were considered and why the proposed version was selected -->
