### PR TITLE
Update CMakeLists for swig

### DIFF
--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -35,7 +35,7 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP)
 
     set(CMAKE_SWIG_FLAGS "")
     if (SHARED_MODEL_DISABLE_COMPATIBILITY)
-        set(CMAKE_SWIG_FLAGS "-DDISABLE_BACKWARD")
+        set(CMAKE_SWIG_FLAGS "-DDISABLE_BACKWARD" -package bindings)
     endif()
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     set_source_files_properties(bindings.i PROPERTIES CPLUSPLUS ON)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Binding interfaces now placed in a default package, therefore, classes placed in packages cannot use these interfaces (it is impossible to import a class from default package https://stackoverflow.com/questions/7849421/is-the-use-of-javas-default-package-a-bad-practice).
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
This flag will add bindings package to generated interfaces so you can import them into project
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
none
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
