### PR TITLE
Fix -Wreturn-type

### DIFF
--- a/shared_model/utils/variant_deserializer.hpp
+++ b/shared_model/utils/variant_deserializer.hpp
@@ -20,6 +20,8 @@
 
 #include <boost/serialization/variant.hpp>
 
+#define NORETURN [[noreturn]]
+
 namespace shared_model {
   namespace detail {
     /**
@@ -40,8 +42,9 @@ namespace shared_model {
          * @tparam Archive container type
          */
         template <class V, class T = typename V::types, class Archive>
-        static V invoke(Archive &&, int) {
+        NORETURN static V invoke(Archive &&, int) {
           BOOST_ASSERT_MSG(false, "Required type not found");
+          std::abort();
         }
       };
 


### PR DESCRIPTION
Because function returns `template V` (some object) and does not return anything, it caused warning, which in turn, with -Werror resulted in compilation error.

UPD: when you use BOOST_ASSERT in such function, and program is compiled with -DNDEBUG (any release mode), it actually disables BOOST_ASSERT and warning `-Wreturn-type` appears.