### PR TITLE
Fix Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,16 +18,16 @@ jobs:
     docker:
       - image: hyperledger/iroha-docker-develop:v1
       - image: postgres:9.5
-      - image: redis:3.2.8
     steps:
       - checkout
       - run: echo $(eval echo "$IROHA_VERSION")
       - restore_cache:
           keys:
-            - v1-build-cache-debug-{{ arch }}-{{ .Branch }}-
-            - v1-build-cache-debug-{{ arch }}-
+            - build-linux-debug-{{ arch }}-{{ .Branch }}-
+            - build-linux-debug-{{ arch }}-
+            - build-linux-debug-
           paths:
-            - .ccache
+            - ~/.ccache
 
       - run:
           name: ccache setup
@@ -35,7 +35,7 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=5G
+            ccache --max-size=2G
       - run:
           name: cmake
           command: >
@@ -51,9 +51,9 @@ jobs:
             cmake --build $IROHA_BUILD -- -j3
       - run: ccache --show-stats
       - save_cache:
-          key: v1-build-cache-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - .ccache
+            - ~/.ccache
       - run:
           name: unit tests, generate xunit-*.xml
           command: cmake --build $IROHA_BUILD --target test
@@ -83,17 +83,18 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-build-cache-release-{{ arch }}-{{ .Branch }}-
-            - v1-build-cache-release-{{ arch }}-
+            - build-linux-release-{{ arch }}-{{ .Branch }}-
+            - build-linux-release-{{ arch }}-
+            - build-linux-release-
           paths:
-            - .ccache
+            - ~/.ccache
       - run:
           name: ccache setup
           command: |
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=5G
+            ccache --max-size=2G
       - run:
           name: cmake
           command: >
@@ -112,9 +113,9 @@ jobs:
             cmake --build $IROHA_BUILD --target package -- -j3
       - run: ccache --show-stats
       - save_cache:
-          key: v1-build-cache-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-linux-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - .ccache
+            - ~/.ccache
       - run:
           name: copy deb file
           command: |
@@ -188,7 +189,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-sonar-
+            - sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -210,9 +211,9 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: v1-sonar-{{ epoch }}
+          key: sonar-{{ epoch }}
           paths:
-            - .sonar
+            - ~/.sonar
 
 
   # executed only for develop, master and release branches
@@ -225,7 +226,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-sonar-
+            - sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -242,9 +243,9 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: v1-sonar-{{ epoch }}
+          key: sonar-{{ epoch }}
           paths:
-            - .sonar
+            - ~/.sonar
 
 
   build-macos-release:
@@ -255,25 +256,28 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-brew-{{ arch }}
+            - brew-
           paths:
-            - Library/Caches/Homebrew
+            - ~/Library/Caches/Homebrew
       - run:
           name: install dev dependencies
           command: brew install cmake boost postgres grpc autoconf automake libtool ccache
       - save_cache:
-          key: brew-{{ arch }}-{{ epoch }}
+          key: brew-{{ epoch }}
           paths:
-            - Library/Caches/Homebrew
+            - ~/Library/Caches/Homebrew
       - restore_cache:
           keys:
-            - v1-build-cache-{{ arch }}-{{ .Branch }}
+            - build-mac-release-{{ arch }}-{{ .Branch }}-
+            - build-mac-release-{{ arch }}-
+            - build-mac-release-
           paths:
-            - .ccache
+            - ~/.ccache
       - restore_cache:
           keys:
-            - v1-external-{{ arch }}-{{ .Branch }}
-            - v1-external-{{ arch }}
+            - mac-external-{{ arch }}-{{ .Branch }}-
+            - mac-external-{{ arch }}-
+            - mac-external-
           paths:
             - external
       - run:
@@ -298,11 +302,11 @@ jobs:
             cmake --build build --target package -- -j$(sysctl -n hw.ncpu)
       - run: ccache --show-stats
       - save_cache:
-          key: v1-build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: build-mac-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - .ccache
+            - ~/.ccache
       - save_cache:
-          key: v1-external-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: mac-external-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - external
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: make and package
           command: |
-            cmake --build $IROHA_BUILD --target package -- -j3
+            cmake --build $IROHA_BUILD --target package -- -j4
       - run: ccache --show-stats
       - save_cache:
           key: build-linux-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
@@ -191,7 +191,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - sonar-
+            - v1-sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -213,7 +213,7 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: sonar-{{ epoch }}
+          key: v1-sonar-{{ epoch }}
           paths:
             - ~/.sonar
           when: always
@@ -229,7 +229,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - sonar-
+            - v1-sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -246,7 +246,7 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: sonar-{{ epoch }}
+          key: v1-sonar-{{ epoch }}
           paths:
             - ~/.sonar
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=2G
+            # debug/coverage builds produce 2G cache
+            ccache --max-size=5G
       - run:
           name: cmake
           command: >
@@ -94,7 +95,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=2G
+            # release builds produce cache <100M
+            ccache --max-size=500M
       - run:
           name: cmake
           command: >
@@ -290,7 +292,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=5G
+            # release build produces <20M cache per build
+            ccache --max-size=100M
       - run:
           name: cmake
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ defaults: &defaults
   environment:
     IROHA_HOME: /opt/iroha
     IROHA_BUILD: /opt/iroha/build
-    SONAR_DIR: /opt/.sonar
 
 
 defaults: &version
@@ -213,7 +212,7 @@ jobs:
       - save_cache:
           key: v1-sonar-{{ epoch }}
           paths:
-            - $SONAR_DIR
+            - .sonar
 
 
   # executed only for develop, master and release branches
@@ -245,7 +244,7 @@ jobs:
       - save_cache:
           key: v1-sonar-{{ epoch }}
           paths:
-            - $SONAR_DIR
+            - .sonar
 
 
   build-macos-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ defaults: &defaults
   environment:
     IROHA_HOME: /opt/iroha
     IROHA_BUILD: /opt/iroha/build
-    CCACHE_DIR: /opt/.ccache
     SONAR_DIR: /opt/.sonar
 
 
@@ -29,7 +28,7 @@ jobs:
             - v1-build-cache-debug-{{ arch }}-{{ .Branch }}-
             - v1-build-cache-debug-{{ arch }}-
           paths:
-            - $CCACHE_DIR
+            - .ccache
 
       - run:
           name: ccache setup
@@ -37,7 +36,7 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=1G
+            ccache --max-size=5G
       - run:
           name: cmake
           command: >
@@ -50,16 +49,12 @@ jobs:
       - run:
           name: make
           command: |
-            cmake --build $IROHA_BUILD -- -j4
-      - run:
-          name: ccache teardown
-          command: |
-            ccache --cleanup
-            ccache --show-stats
+            cmake --build $IROHA_BUILD -- -j3
+      - run: ccache --show-stats
       - save_cache:
           key: v1-build-cache-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - $CCACHE_DIR
+            - .ccache
       - run:
           name: unit tests, generate xunit-*.xml
           command: cmake --build $IROHA_BUILD --target test
@@ -92,14 +87,14 @@ jobs:
             - v1-build-cache-release-{{ arch }}-{{ .Branch }}-
             - v1-build-cache-release-{{ arch }}-
           paths:
-            - $CCACHE_DIR
+            - .ccache
       - run:
           name: ccache setup
           command: |
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=1G
+            ccache --max-size=5G
       - run:
           name: cmake
           command: >
@@ -115,16 +110,12 @@ jobs:
       - run:
           name: make and package
           command: |
-            cmake --build $IROHA_BUILD --target package -- -j4
-      - run:
-          name: ccache teardown
-          command: |
-            ccache --cleanup
-            ccache --show-stats
+            cmake --build $IROHA_BUILD --target package -- -j3
+      - run: ccache --show-stats
       - save_cache:
           key: v1-build-cache-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - $CCACHE_DIR
+            - .ccache
       - run:
           name: copy deb file
           command: |
@@ -279,7 +270,7 @@ jobs:
           keys:
             - v1-build-cache-{{ arch }}-{{ .Branch }}
           paths:
-            - $CCACHE_DIR
+            - .ccache
       - restore_cache:
           keys:
             - v1-external-{{ arch }}-{{ .Branch }}
@@ -292,7 +283,7 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size=1G
+            ccache --max-size=5G
       - run:
           name: cmake
           command: >
@@ -306,20 +297,15 @@ jobs:
           name: make
           command: |
             cmake --build build --target package -- -j$(sysctl -n hw.ncpu)
-      - run:
-          name: ccache teardown
-          command: |
-            ccache --cleanup
-            ccache --show-stats
+      - run: ccache --show-stats
       - save_cache:
           key: v1-build-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
-            - $CCACHE_DIR
+            - .ccache
       - save_cache:
           key: v1-external-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - external
-      - run: ccache --show-stats
       - run:
           name: rename artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
           key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+          when: always
       - run:
           name: unit tests, generate xunit-*.xml
           command: cmake --build $IROHA_BUILD --target test
@@ -116,6 +117,7 @@ jobs:
           key: build-linux-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+          when: always
       - run:
           name: copy deb file
           command: |
@@ -214,6 +216,7 @@ jobs:
           key: sonar-{{ epoch }}
           paths:
             - ~/.sonar
+          when: always
 
 
   # executed only for develop, master and release branches
@@ -246,6 +249,7 @@ jobs:
           key: sonar-{{ epoch }}
           paths:
             - ~/.sonar
+          when: always
 
 
   build-macos-release:
@@ -266,6 +270,7 @@ jobs:
           key: brew-{{ epoch }}
           paths:
             - ~/Library/Caches/Homebrew
+          when: always
       - restore_cache:
           keys:
             - build-mac-release-{{ arch }}-{{ .Branch }}-
@@ -305,10 +310,12 @@ jobs:
           key: build-mac-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+          when: always
       - save_cache:
           key: mac-external-{{ arch }}-{{ .Branch }}-{{ epoch }}
           paths:
             - external
+          when: always
       - run:
           name: rename artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ defaults: &defaults
     IROHA_HOME: /opt/iroha
     IROHA_BUILD: /opt/iroha/build
 
-
 defaults: &version
   environment:
     IROHA_VERSION: ${CIRCLE_TAG:-0x$CIRCLE_SHA1}
@@ -191,7 +190,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-sonar-
+            - v3-sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -213,7 +212,7 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: v1-sonar-{{ epoch }}
+          key: v3-sonar-{{ epoch }}
           paths:
             - ~/.sonar
           when: always
@@ -229,7 +228,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-sonar-
+            - v3-sonar-
       - attach_workspace:
           at: /opt/iroha/build
       - run:
@@ -246,7 +245,7 @@ jobs:
               echo "required env vars not found"
             fi
       - save_cache:
-          key: v1-sonar-{{ epoch }}
+          key: v3-sonar-{{ epoch }}
           paths:
             - ~/.sonar
           when: always


### PR DESCRIPTION
This PR fixes three issues in Circle CI:
- Internal  compiler error
- Ccache will work correctly after this PR
    - Cache sizes: Debug (1 build ~2G), Release Linux (~100M), Release Mac (~30M)
    - circle ci can not evaluate $CCACHE_DIR variable in yaml file and it resulted in disabling ccache
- circle ci can not evaluate $SONAR_DIR in yaml, and it resulted in cache miss