### PR TITLE
Feature/add custom findswig module

### DIFF
--- a/cmake/Modules/Findswig.cmake
+++ b/cmake/Modules/Findswig.cmake
@@ -1,0 +1,44 @@
+add_executable(swig IMPORTED)
+
+find_program(SWIG_EXECUTABLE NAMES swig3.0 swig2.0 swig)
+
+find_package_handle_standard_args(SWIG DEFAULT_MSG
+  SWIG_EXECUTABLE
+  )
+
+if(NOT SWIG_EXECUTABLE)
+  find_package(Git REQUIRED)
+
+  set(URL https://github.com/swig/swig)
+  set(VERSION fbeb566014a1d320df972aef965daf042db7db36) # Tag origin/rel-3.0.12
+  set_target_description(swig "Simplified Wrapper and Interface Generator (SWIG)" ${URL} ${VERSION})
+
+  ExternalProject_Add(swig_swig
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
+      GIT_PROGRESS   ON
+      PATCH_COMMAND ${GIT_EXECUTABLE} apply ${PROJECT_SOURCE_DIR}/patch/add-nodejs8-support-to-swig.patch || true
+      # We should install SWIG to properly access SWIG lib
+      CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --without-pcre --prefix=${EP_PREFIX}/src/swig_swig
+      BUILD_IN_SOURCE ON
+      BUILD_COMMAND $(MAKE) swig
+      TEST_COMMAND "" # remove test step
+      )
+  ExternalProject_Get_Property(swig_swig source_dir)
+
+  # Predefined vars for local installed SWIG
+  set(SWIG_EXECUTABLE ${source_dir}/swig)
+  set(SWIG_DIR ${source_dir})
+
+  add_dependencies(swig swig_swig)
+
+  message(STATUS "Installed package SWIG not found. It will be pulled to " ${SWIG_DIR} " at compile time.")
+endif()
+
+set(SWIG_USE_FILE ${CMAKE_ROOT}/Modules/UseSWIG.cmake)
+
+set_target_properties(swig PROPERTIES
+    IMPORTED_LOCATION ${SWIG_EXECUTABLE}
+    )
+
+mark_as_advanced(SWIG_DIR)

--- a/patch/add-nodejs8-support-to-swig.patch
+++ b/patch/add-nodejs8-support-to-swig.patch
@@ -1,0 +1,541 @@
+From f08d7a63a92a3ba89d97bdfcc206e1e1c4804c0f Mon Sep 17 00:00:00 2001
+From: Patrick Schneider <patrick.schneider@meetnow.eu>
+Date: Thu, 13 Apr 2017 15:02:53 +0200
+Subject: [PATCH 1/2] Add Node 7.x aka V8 5.2+ support
+
+* Use WeakCallbackInfo instead of WeakCallbackData
+* Use GetPrivate instead of GetHiddenValue
+* Adopted new signature for SetWeak to support destructor calling
+* SetAccessor deprecation fixed
+* Proper version checks where applicable
+---
+ Lib/javascript/v8/javascriptcode.swg    | 27 +++++++++++++++++-----
+ Lib/javascript/v8/javascripthelpers.swg | 29 +++++++++++++++++++++---
+ Lib/javascript/v8/javascriptinit.swg    | 16 +++++++++++--
+ Lib/javascript/v8/javascriptrun.swg     | 40 ++++++++++++++++++++++++++++-----
+ 4 files changed, 95 insertions(+), 17 deletions(-)
+
+diff --git a/Lib/javascript/v8/javascriptcode.swg b/Lib/javascript/v8/javascriptcode.swg
+index fb7d55c2ad..b8c5089816 100644
+--- a/Lib/javascript/v8/javascriptcode.swg
++++ b/Lib/javascript/v8/javascriptcode.swg
+@@ -133,10 +133,13 @@ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Value> object, v
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Object> *object, SWIGV8_Proxy *proxy) {
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SWIGV8_Proxy *proxy = data.GetParameter();
++#else
++  static void $jswrapper(const v8::WeakCallbackInfo<SWIGV8_Proxy> &data) {
++  SWIGV8_Proxy *proxy = data.GetParameter();
+ #endif
+ 
+   if(proxy->swigCMemOwn && proxy->swigCObject) {
+@@ -147,7 +150,9 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+   }
+   delete proxy;
+ 
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   object.Clear();
++#endif
+   
+ #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031710)
+   object.Dispose();
+@@ -155,7 +160,7 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+   object.Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032100)
+   object->Dispose(isolate);
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   object->Dispose();
+ #endif
+ }
+@@ -177,10 +182,13 @@ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Value> object, v
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ static void $jswrapper(v8::Isolate *isolate, v8::Persistent< v8::Object> *object, SWIGV8_Proxy *proxy) {
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SWIGV8_Proxy *proxy = data.GetParameter();
++#else
++static void $jswrapper(const v8::WeakCallbackInfo<SWIGV8_Proxy> &data) {
++  SWIGV8_Proxy *proxy = data.GetParameter();
+ #endif
+ 
+   if(proxy->swigCMemOwn && proxy->swigCObject) {
+@@ -197,7 +205,7 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+   object->Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   object->Dispose();
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   object.Clear();
+ #endif
+ }
+@@ -211,7 +219,11 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+  * ----------------------------------------------------------------------------- */
+ %fragment("js_getter", "templates")
+ %{
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ static SwigV8ReturnValue $jswrapper(v8::Local<v8::String> property, const SwigV8PropertyCallbackInfo &info) {
++#else
++static SwigV8ReturnValue $jswrapper(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
++#endif
+   SWIGV8_HANDLESCOPE();
+   
+   v8::Handle<v8::Value> jsresult;
+@@ -233,8 +245,11 @@ fail:
+  * ----------------------------------------------------------------------------- */
+ %fragment("js_setter", "templates")
+ %{
+-static void $jswrapper(v8::Local<v8::String> property, v8::Local<v8::Value> value,
+-  const SwigV8PropertyCallbackInfoVoid &info) {
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++static void $jswrapper(v8::Local<v8::String> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
++#else
++static void $jswrapper(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
++#endif
+   SWIGV8_HANDLESCOPE();
+   
+   $jslocals
+diff --git a/Lib/javascript/v8/javascripthelpers.swg b/Lib/javascript/v8/javascripthelpers.swg
+index 091467df4d..74610793af 100644
+--- a/Lib/javascript/v8/javascripthelpers.swg
++++ b/Lib/javascript/v8/javascripthelpers.swg
+@@ -6,11 +6,16 @@ typedef v8::InvocationCallback  SwigV8FunctionCallback;
+ typedef v8::AccessorGetter      SwigV8AccessorGetterCallback;
+ typedef v8::AccessorSetter      SwigV8AccessorSetterCallback;
+ typedef v8::AccessorInfo        SwigV8PropertyCallbackInfoVoid;
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ typedef v8::FunctionCallback            SwigV8FunctionCallback;
+ typedef v8::AccessorGetterCallback      SwigV8AccessorGetterCallback;
+ typedef v8::AccessorSetterCallback      SwigV8AccessorSetterCallback;
+ typedef v8::PropertyCallbackInfo<void>  SwigV8PropertyCallbackInfoVoid;
++#else
++typedef v8::FunctionCallback            SwigV8FunctionCallback;
++typedef v8::AccessorNameGetterCallback  SwigV8AccessorGetterCallback;
++typedef v8::AccessorNameSetterCallback  SwigV8AccessorSetterCallback;
++typedef v8::PropertyCallbackInfo<void>  SwigV8PropertyCallbackInfoVoid;
+ #endif
+ 
+ /**
+@@ -65,18 +70,36 @@ SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Handle<v8::Object> obj, const char
+  */
+ SWIGRUNTIME void SWIGV8_AddStaticVariable(v8::Handle<v8::Object> obj, const char* symbol,
+   SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   obj->SetAccessor(SWIGV8_SYMBOL_NEW(symbol), getter, setter);
++#else
++  obj->SetAccessor(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), getter, setter);
++#endif
+ }
+ 
+-SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::String> property, v8::Local<v8::Value> value,
+-  const SwigV8PropertyCallbackInfoVoid& info)
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::String> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid& info)
++#else
++SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid& info)
++#endif
+ {
+     char buffer[256];
+     char msg[512];
+     int res;
+ 
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+     property->WriteUtf8(buffer, 256);
+     res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
++#else
++    v8::Local<v8::String> sproperty;
++    if (property->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocal(&sproperty)) {
++      sproperty->WriteUtf8(buffer, 256);
++      res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
++    }
++    else {
++      res = -1;
++    }
++#endif
+ 
+     if(res<0) {
+       SWIG_exception(SWIG_ERROR, "Tried to write read-only variable.");
+diff --git a/Lib/javascript/v8/javascriptinit.swg b/Lib/javascript/v8/javascriptinit.swg
+index 34befa7ce7..86008d927f 100644
+--- a/Lib/javascript/v8/javascriptinit.swg
++++ b/Lib/javascript/v8/javascriptinit.swg
+@@ -7,15 +7,27 @@ SWIG_V8_SetModule(void *, swig_module_info *swig_module) {
+   v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
+   v8::Local<v8::External> mod = SWIGV8_EXTERNAL_NEW(swig_module);
+   assert(!mod.IsEmpty());
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   global_obj->SetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"), mod);
++#else
++  v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
++  global_obj->SetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey, mod);
++#endif
+ }
+ 
+ SWIGRUNTIME swig_module_info *
+ SWIG_V8_GetModule(void *) {
+   v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   v8::Local<v8::Value> moduleinfo = global_obj->GetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"));
++#else
++  v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
++  v8::Local<v8::Value> moduleinfo;
++  if (!global_obj->GetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey).ToLocal(&moduleinfo))
++    return 0;
++#endif
+ 
+-  if (moduleinfo.IsEmpty())
++  if (moduleinfo.IsEmpty() || moduleinfo->IsNull() || moduleinfo->IsUndefined())
+   {
+     // It's not yet loaded
+     return 0;
+@@ -23,7 +35,7 @@ SWIG_V8_GetModule(void *) {
+ 
+   v8::Local<v8::External> moduleinfo_extern = v8::Local<v8::External>::Cast(moduleinfo);
+ 
+-  if (moduleinfo_extern.IsEmpty())
++  if (moduleinfo_extern.IsEmpty() || moduleinfo_extern->IsNull() || moduleinfo_extern->IsUndefined())
+   {
+     // Something's not right
+     return 0;
+diff --git a/Lib/javascript/v8/javascriptrun.swg b/Lib/javascript/v8/javascriptrun.swg
+index 5ac52a51dc..30002c02a3 100644
+--- a/Lib/javascript/v8/javascriptrun.swg
++++ b/Lib/javascript/v8/javascriptrun.swg
+@@ -193,8 +193,10 @@ public:
+   void (*dtor) (v8::Isolate *isolate, v8::Persistent< v8::Value> object, void *parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   void (*dtor) (v8::Isolate *isolate, v8::Persistent< v8::Object > *object, SWIGV8_Proxy *proxy);
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   void (*dtor) (const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data);
++#else
++  void (*dtor) (const v8::WeakCallbackInfo<SWIGV8_Proxy> &data);
+ #endif
+ };
+ 
+@@ -241,9 +243,12 @@ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(v8::Isolate *, v8::Persistent< v8::Val
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(v8::Isolate *, v8::Persistent< v8::Object > *object, SWIGV8_Proxy *proxy) {
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   SWIGV8_Proxy *proxy = data.GetParameter();
++#else
++SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(const v8::WeakCallbackInfo<SWIGV8_Proxy> &data) {
++  SWIGV8_Proxy *proxy = data.GetParameter();
+ #endif
+ 
+   delete proxy;
+@@ -312,12 +317,18 @@ SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Handle<v8::Object> obj, void *ptr, sw
+   } else {
+     cdata->handle.MakeWeak(cdata, SWIGV8_Proxy_DefaultDtor);
+   }
+-#else
++#elifif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   if(cdata->swigCMemOwn && (SWIGV8_ClientData*)info->clientdata) {
+     cdata->handle.SetWeak(cdata, ((SWIGV8_ClientData*)info->clientdata)->dtor);
+   } else {
+     cdata->handle.SetWeak(cdata, SWIGV8_Proxy_DefaultDtor);
+   }
++#else
++  if(cdata->swigCMemOwn && (SWIGV8_ClientData*)info->clientdata) {
++    cdata->handle.SetWeak(cdata, ((SWIGV8_ClientData*)info->clientdata)->dtor, v8::WeakCallbackType::kParameter);
++  } else {
++    cdata->handle.SetWeak(cdata, SWIGV8_Proxy_DefaultDtor, v8::WeakCallbackType::kParameter);
++  }
+ #endif
+ 
+ #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031710)
+@@ -470,7 +481,14 @@ int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
+   
+   v8::Handle<v8::Object> objRef = valRef->ToObject();
+   if(objRef->InternalFieldCount() < 1) return false;
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   v8::Handle<v8::Value> flag = objRef->GetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"));
++#else
++  v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("__swig__packed_data__"));
++  v8::Local<v8::Value> flag;
++  if (!objRef->GetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey).ToLocal(&flag))
++    return false;
++#endif
+   return (flag->IsBoolean() && flag->BooleanValue());
+ }
+ 
+@@ -519,10 +537,13 @@ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persist
+   SwigV8PackedData *cdata = static_cast<SwigV8PackedData *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persistent<v8::Object> *object, SwigV8PackedData *cdata) {
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackData<v8::Object, SwigV8PackedData> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SwigV8PackedData *cdata = data.GetParameter();
++#else
++SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackInfo<SwigV8PackedData> &data) {
++  SwigV8PackedData *cdata = data.GetParameter();
+ #endif
+ 
+   delete cdata;
+@@ -537,7 +558,7 @@ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackData<v8::Ob
+   object->Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   object->Dispose();
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   object.Clear();
+ #endif
+ }
+@@ -550,7 +571,12 @@ v8::Handle<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_inf
+ //  v8::Handle<v8::Object> obj = SWIGV8_OBJECT_NEW();
+   v8::Local<v8::Object> obj = SWIGV8_OBJECT_NEW();
+ 
++#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   obj->SetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"), SWIGV8_BOOLEAN_NEW(true));
++#else
++  v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("__swig__packed_data__"));
++  obj->SetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey, SWIGV8_BOOLEAN_NEW(true));
++#endif
+ 
+ #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031511)
+   obj->SetPointerInInternalField(0, cdata);
+@@ -573,9 +599,11 @@ v8::Handle<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_inf
+   cdata->handle.MakeWeak(v8::Isolate::GetCurrent(), cdata, _wrap_SwigV8PackedData_delete);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   cdata->handle.MakeWeak(cdata, _wrap_SwigV8PackedData_delete);
+-#else
++#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+   cdata->handle.SetWeak(cdata, _wrap_SwigV8PackedData_delete);
+ //  v8::V8::SetWeak(&cdata->handle, cdata, _wrap_SwigV8PackedData_delete);
++#else
++  cdata->handle.SetWeak(cdata, _wrap_SwigV8PackedData_delete, v8::WeakCallbackType::kParameter);
+ #endif
+ 
+ #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031710)
+
+From 9ce8d7e7c99e75163318428aeff6e60d398fcdca Mon Sep 17 00:00:00 2001
+From: Patrick Schneider <patrick.schneider@meetnow.eu>
+Date: Thu, 13 Apr 2017 19:39:44 +0200
+Subject: [PATCH 2/2] Remove warnings on Node 6.x aka V8 5.0 and 5.1
+
+The proposed changes targetted at 5.2 (or 5.4 to be more precise, since there is no Node release with V8 5.2 or 5.3) work for lower versions as well and bust the deprecation warnings there.
+---
+ Lib/javascript/v8/javascriptcode.swg    | 14 +++++++-------
+ Lib/javascript/v8/javascripthelpers.swg |  8 ++++----
+ Lib/javascript/v8/javascriptinit.swg    |  4 ++--
+ Lib/javascript/v8/javascriptrun.swg     | 16 ++++++++--------
+ 4 files changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/Lib/javascript/v8/javascriptcode.swg b/Lib/javascript/v8/javascriptcode.swg
+index b8c5089816..c4aaf3db0c 100644
+--- a/Lib/javascript/v8/javascriptcode.swg
++++ b/Lib/javascript/v8/javascriptcode.swg
+@@ -133,7 +133,7 @@ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Value> object, v
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Object> *object, SWIGV8_Proxy *proxy) {
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SWIGV8_Proxy *proxy = data.GetParameter();
+@@ -150,7 +150,7 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+   }
+   delete proxy;
+ 
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   object.Clear();
+ #endif
+   
+@@ -160,7 +160,7 @@ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &dat
+   object.Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032100)
+   object->Dispose(isolate);
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   object->Dispose();
+ #endif
+ }
+@@ -182,7 +182,7 @@ static void $jswrapper(v8::Isolate *isolate, v8::Persistent<v8::Value> object, v
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ static void $jswrapper(v8::Isolate *isolate, v8::Persistent< v8::Object> *object, SWIGV8_Proxy *proxy) {
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+ static void $jswrapper(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SWIGV8_Proxy *proxy = data.GetParameter();
+@@ -205,7 +205,7 @@ static void $jswrapper(const v8::WeakCallbackInfo<SWIGV8_Proxy> &data) {
+   object->Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   object->Dispose();
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   object.Clear();
+ #endif
+ }
+@@ -219,7 +219,7 @@ static void $jswrapper(const v8::WeakCallbackInfo<SWIGV8_Proxy> &data) {
+  * ----------------------------------------------------------------------------- */
+ %fragment("js_getter", "templates")
+ %{
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+ static SwigV8ReturnValue $jswrapper(v8::Local<v8::String> property, const SwigV8PropertyCallbackInfo &info) {
+ #else
+ static SwigV8ReturnValue $jswrapper(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+@@ -245,7 +245,7 @@ fail:
+  * ----------------------------------------------------------------------------- */
+ %fragment("js_setter", "templates")
+ %{
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+ static void $jswrapper(v8::Local<v8::String> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
+ #else
+ static void $jswrapper(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
+diff --git a/Lib/javascript/v8/javascripthelpers.swg b/Lib/javascript/v8/javascripthelpers.swg
+index 74610793af..7b8a5ec237 100644
+--- a/Lib/javascript/v8/javascripthelpers.swg
++++ b/Lib/javascript/v8/javascripthelpers.swg
+@@ -6,7 +6,7 @@ typedef v8::InvocationCallback  SwigV8FunctionCallback;
+ typedef v8::AccessorGetter      SwigV8AccessorGetterCallback;
+ typedef v8::AccessorSetter      SwigV8AccessorSetterCallback;
+ typedef v8::AccessorInfo        SwigV8PropertyCallbackInfoVoid;
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+ typedef v8::FunctionCallback            SwigV8FunctionCallback;
+ typedef v8::AccessorGetterCallback      SwigV8AccessorGetterCallback;
+ typedef v8::AccessorSetterCallback      SwigV8AccessorSetterCallback;
+@@ -70,14 +70,14 @@ SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Handle<v8::Object> obj, const char
+  */
+ SWIGRUNTIME void SWIGV8_AddStaticVariable(v8::Handle<v8::Object> obj, const char* symbol,
+   SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   obj->SetAccessor(SWIGV8_SYMBOL_NEW(symbol), getter, setter);
+ #else
+   obj->SetAccessor(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), getter, setter);
+ #endif
+ }
+ 
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::String> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid& info)
+ #else
+ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid& info)
+@@ -87,7 +87,7 @@ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::Name> property, v8::Local<v8
+     char msg[512];
+     int res;
+ 
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+     property->WriteUtf8(buffer, 256);
+     res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
+ #else
+diff --git a/Lib/javascript/v8/javascriptinit.swg b/Lib/javascript/v8/javascriptinit.swg
+index 86008d927f..e83f478d9d 100644
+--- a/Lib/javascript/v8/javascriptinit.swg
++++ b/Lib/javascript/v8/javascriptinit.swg
+@@ -7,7 +7,7 @@ SWIG_V8_SetModule(void *, swig_module_info *swig_module) {
+   v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
+   v8::Local<v8::External> mod = SWIGV8_EXTERNAL_NEW(swig_module);
+   assert(!mod.IsEmpty());
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   global_obj->SetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"), mod);
+ #else
+   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
+@@ -18,7 +18,7 @@ SWIG_V8_SetModule(void *, swig_module_info *swig_module) {
+ SWIGRUNTIME swig_module_info *
+ SWIG_V8_GetModule(void *) {
+   v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   v8::Local<v8::Value> moduleinfo = global_obj->GetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"));
+ #else
+   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
+diff --git a/Lib/javascript/v8/javascriptrun.swg b/Lib/javascript/v8/javascriptrun.swg
+index 30002c02a3..0af9f4eb0a 100644
+--- a/Lib/javascript/v8/javascriptrun.swg
++++ b/Lib/javascript/v8/javascriptrun.swg
+@@ -193,7 +193,7 @@ public:
+   void (*dtor) (v8::Isolate *isolate, v8::Persistent< v8::Value> object, void *parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   void (*dtor) (v8::Isolate *isolate, v8::Persistent< v8::Object > *object, SWIGV8_Proxy *proxy);
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   void (*dtor) (const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data);
+ #else
+   void (*dtor) (const v8::WeakCallbackInfo<SWIGV8_Proxy> &data);
+@@ -243,7 +243,7 @@ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(v8::Isolate *, v8::Persistent< v8::Val
+   SWIGV8_Proxy *proxy = static_cast<SWIGV8_Proxy *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(v8::Isolate *, v8::Persistent< v8::Object > *object, SWIGV8_Proxy *proxy) {
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(const v8::WeakCallbackData<v8::Object, SWIGV8_Proxy> &data) {
+   SWIGV8_Proxy *proxy = data.GetParameter();
+ #else
+@@ -317,7 +317,7 @@ SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Handle<v8::Object> obj, void *ptr, sw
+   } else {
+     cdata->handle.MakeWeak(cdata, SWIGV8_Proxy_DefaultDtor);
+   }
+-#elifif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   if(cdata->swigCMemOwn && (SWIGV8_ClientData*)info->clientdata) {
+     cdata->handle.SetWeak(cdata, ((SWIGV8_ClientData*)info->clientdata)->dtor);
+   } else {
+@@ -481,7 +481,7 @@ int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
+   
+   v8::Handle<v8::Object> objRef = valRef->ToObject();
+   if(objRef->InternalFieldCount() < 1) return false;
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   v8::Handle<v8::Value> flag = objRef->GetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"));
+ #else
+   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("__swig__packed_data__"));
+@@ -537,7 +537,7 @@ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persist
+   SwigV8PackedData *cdata = static_cast<SwigV8PackedData *>(parameter);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persistent<v8::Object> *object, SwigV8PackedData *cdata) {
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackData<v8::Object, SwigV8PackedData> &data) {
+   v8::Local<v8::Object> object = data.GetValue();
+   SwigV8PackedData *cdata = data.GetParameter();
+@@ -558,7 +558,7 @@ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackInfo<SwigV8
+   object->Dispose(isolate);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   object->Dispose();
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   object.Clear();
+ #endif
+ }
+@@ -571,7 +571,7 @@ v8::Handle<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_inf
+ //  v8::Handle<v8::Object> obj = SWIGV8_OBJECT_NEW();
+   v8::Local<v8::Object> obj = SWIGV8_OBJECT_NEW();
+ 
+-#if (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#if (V8_MAJOR_VERSION-0) < 5
+   obj->SetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"), SWIGV8_BOOLEAN_NEW(true));
+ #else
+   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("__swig__packed_data__"));
+@@ -599,7 +599,7 @@ v8::Handle<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_inf
+   cdata->handle.MakeWeak(v8::Isolate::GetCurrent(), cdata, _wrap_SwigV8PackedData_delete);
+ #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < SWIGV8_SETWEAK_VERSION)
+   cdata->handle.MakeWeak(cdata, _wrap_SwigV8PackedData_delete);
+-#elif (V8_MAJOR_VERSION-0) < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
++#elif (V8_MAJOR_VERSION-0) < 5
+   cdata->handle.SetWeak(cdata, _wrap_SwigV8PackedData_delete);
+ //  v8::V8::SetWeak(&cdata->handle, cdata, _wrap_SwigV8PackedData_delete);
+ #else

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(bindings
 
 
 if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP)
-    find_package(SWIG 3.0.12 REQUIRED)
+    find_package(swig REQUIRED)
     include(${SWIG_USE_FILE})
 
     set(CMAKE_SWIG_FLAGS "")
@@ -40,6 +40,8 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     set_source_files_properties(bindings.i PROPERTIES CPLUSPLUS ON)
     set_property(GLOBAL PROPERTY SWIG_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_dependencies(bindings swig)
 endif()
 
 if (SWIG_PYTHON)


### PR DESCRIPTION
### Description of the Change
This PR introduced customized FindSWIG CMake module. It pulls and builds an appropriate version of SWIG and allow using it in the build system to generate bindings for a target language.

### Benefits
For now, if you want to compile any example or client library for target language you must clone, build, patch and install SWIG manually. Also, you need to choose a particular version of SWIG that supports by the client library. This PR adds more automatization to this process allowing don't have installed version before building the project by CMake.

### Possible Drawbacks 
Every customized module can be hard to maintain because their functionalities mostly based on existing find modules. Also, without tests coverage, it can be hard to check build success on different platforms.
Besides except SWIG library user must install additional dependencies for target language on his system. 

### Usage Examples or Tests
1. Set build configuration (e.g. for *python*)
```
cmake -H. -Bbuild -DSWIG_PYTHON=ON -DSHARED_MODEL_DISABLE_COMPATIBILITY=ON
```
2. Build project. It starts cloning and building SWIG
```
cmake --build build/ --target irohapy -- -j"$(getconf _NPROCESSORS_ONLN)"
```

### Additional Information
Local SWIG installed in `<project_root>/external/src/swig_swig`. We can use this installation in `prepare.sh` scripts of different examples.