### PR TITLE
Query service update to sh-m

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -81,7 +81,6 @@ Irohad::~Irohad() {
  * Initializing iroha daemon
  */
 void Irohad::init() {
-  initProtoFactories();
   initPeerQuery();
   initCryptoProvider();
   initValidators();
@@ -118,17 +117,6 @@ void Irohad::initStorage() {
       });
 
   log_->info("[Init] => storage", logger::logBool(storage));
-}
-
-/**
- * Creating transaction, query and query response factories
- */
-void Irohad::initProtoFactories() {
-  pb_tx_factory = std::make_shared<PbTransactionFactory>();
-  pb_query_factory = std::make_shared<PbQueryFactory>();
-  pb_query_response_factory = std::make_shared<PbQueryResponseFactory>();
-
-  log_->info("[Init] => converters");
 }
 
 /**
@@ -235,7 +223,7 @@ void Irohad::initPeerCommunicationService() {
  */
 void Irohad::initTransactionCommandService() {
   auto tx_processor =
-      std::make_shared<TransactionProcessorImpl>(pcs, stateless_validator);
+      std::make_shared<TransactionProcessorImpl>(pcs);
 
   command_service = std::make_unique<::torii::CommandService>(
       pb_tx_factory, tx_processor, storage, proposal_delay_);
@@ -251,10 +239,9 @@ void Irohad::initQueryService() {
       storage->getWsvQuery(), storage->getBlockQuery());
 
   auto query_processor = std::make_shared<QueryProcessorImpl>(
-      std::move(query_processing_factory), stateless_validator);
+      std::move(query_processing_factory));
 
-  query_service = std::make_unique<::torii::QueryService>(
-      pb_query_factory, pb_query_response_factory, query_processor);
+  query_service = std::make_unique<::torii::QueryService>(query_processor);
 
   log_->info("[Init] => query service");
 }

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -141,8 +141,6 @@ void Irohad::initCryptoProvider() {
  * Initializing validators
  */
 void Irohad::initValidators() {
-  stateless_validator =
-      std::make_shared<StatelessValidatorImpl>(crypto_verifier);
   stateful_validator = std::make_shared<StatefulValidatorImpl>();
   chain_validator = std::make_shared<ChainValidatorImpl>();
 
@@ -222,11 +220,10 @@ void Irohad::initPeerCommunicationService() {
  * Initializing transaction command service
  */
 void Irohad::initTransactionCommandService() {
-  auto tx_processor =
-      std::make_shared<TransactionProcessorImpl>(pcs);
+  auto tx_processor = std::make_shared<TransactionProcessorImpl>(pcs);
 
   command_service = std::make_unique<::torii::CommandService>(
-      pb_tx_factory, tx_processor, storage, proposal_delay_);
+      tx_processor, storage, proposal_delay_);
 
   log_->info("[Init] => command service");
 }
@@ -238,8 +235,8 @@ void Irohad::initQueryService() {
   auto query_processing_factory = std::make_unique<QueryProcessingFactory>(
       storage->getWsvQuery(), storage->getBlockQuery());
 
-  auto query_processor = std::make_shared<QueryProcessorImpl>(
-      std::move(query_processing_factory));
+  auto query_processor =
+      std::make_shared<QueryProcessorImpl>(std::move(query_processing_factory));
 
   query_service = std::make_unique<::torii::QueryService>(query_processor);
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -96,8 +96,6 @@ class Irohad {
 
   virtual void initStorage();
 
-  virtual void initProtoFactories();
-
   virtual void initPeerQuery();
 
   virtual void initCryptoProvider();
@@ -134,9 +132,6 @@ class Irohad {
 
   // converter factories
   std::shared_ptr<iroha::model::converters::PbTransactionFactory> pb_tx_factory;
-  std::shared_ptr<iroha::model::converters::PbQueryFactory> pb_query_factory;
-  std::shared_ptr<iroha::model::converters::PbQueryResponseFactory>
-      pb_query_response_factory;
 
   // crypto provider
   std::shared_ptr<iroha::model::ModelCryptoProvider> crypto_verifier;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -130,14 +130,10 @@ class Irohad {
 
   // ------------------------| internal dependencies |-------------------------
 
-  // converter factories
-  std::shared_ptr<iroha::model::converters::PbTransactionFactory> pb_tx_factory;
-
   // crypto provider
   std::shared_ptr<iroha::model::ModelCryptoProvider> crypto_verifier;
 
   // validators
-  std::shared_ptr<iroha::validation::StatelessValidator> stateless_validator;
   std::shared_ptr<iroha::validation::StatefulValidator> stateful_validator;
   std::shared_ptr<iroha::validation::ChainValidator> chain_validator;
 

--- a/irohad/model/converters/impl/pb_query_response_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_response_factory.cpp
@@ -83,6 +83,9 @@ namespace iroha {
                       *query_response)));
         }
 
+        if (response.has_value()) {
+          response->set_query_hash(query_response->query_hash.to_string());
+        }
         return response;
       }
 

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -225,6 +225,7 @@ std::shared_ptr<QueryResponse> QueryProcessingFactory::executeGetAccount(
   response.account = acc.value();
   response.roles = roles.value();
   response.query_hash = iroha::hash(query);
+  auto ss = iroha::hash(query).to_hexstring();
   return std::make_shared<AccountResponse>(response);
 }
 

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -225,7 +225,6 @@ std::shared_ptr<QueryResponse> QueryProcessingFactory::executeGetAccount(
   response.account = acc.value();
   response.roles = roles.value();
   response.query_hash = iroha::hash(query);
-  auto ss = iroha::hash(query).to_hexstring();
   return std::make_shared<AccountResponse>(response);
 }
 

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -44,8 +44,6 @@ namespace torii {
      * @param proposal_delay - time of a one proposal propagation.
      */
     CommandService(
-        std::shared_ptr<iroha::model::converters::PbTransactionFactory>
-            pb_factory,
         std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
         std::shared_ptr<iroha::ametsuchi::Storage> storage,
         std::chrono::milliseconds proposal_delay);

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -34,13 +34,10 @@ using namespace std::chrono_literals;
 namespace torii {
 
   CommandService::CommandService(
-      std::shared_ptr<iroha::model::converters::PbTransactionFactory>
-          pb_factory,
       std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
       std::shared_ptr<iroha::ametsuchi::Storage> storage,
       std::chrono::milliseconds proposal_delay)
-      : pb_factory_(pb_factory),
-        tx_processor_(tx_processor),
+      : tx_processor_(tx_processor),
         storage_(storage),
         proposal_delay_(proposal_delay),
         start_tx_processing_duration_(1s),

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -43,8 +43,6 @@ namespace torii {
 
   void QueryService::Find(iroha::protocol::Query const &request,
                           iroha::protocol::QueryResponse &response) {
-    using iroha::operator|;
-
     //    shared_model::proto::QueryResponse model_response(response);
     shared_model::crypto::Hash hash;
     shared_model::proto::TransportBuilder<

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -55,7 +55,7 @@ namespace torii {
             [this, &hash, &response](
                 const iroha::expected::Value<shared_model::proto::Query>
                     &query) {
-              auto hash = query.value.hash();
+              hash = query.value.hash();
               if (cache_.findItem(hash)) {
                 // Query was already processed
 
@@ -69,8 +69,7 @@ namespace torii {
                         response));
                 // Send query to iroha
                 query_processor_->queryHandle(
-                    shared_model::detail::makePolymorphic<
-                        shared_model::proto::Query>(query.value));
+                    std::make_shared<shared_model::proto::Query>(query.value));
               }
 
               auto result_response = cache_.findItem(hash).value();

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -17,62 +17,78 @@
 
 #include "torii/query_service.hpp"
 #include "backend/protobuf/from_old_model.hpp"
+#include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 #include "common/types.hpp"
 #include "model/sha3_hash.hpp"
 
 namespace torii {
 
   QueryService::QueryService(
-      std::shared_ptr<iroha::model::converters::PbQueryFactory>
-          pb_query_factory,
-      std::shared_ptr<iroha::model::converters::PbQueryResponseFactory>
-          pb_query_response_factory,
       std::shared_ptr<iroha::torii::QueryProcessor> query_processor)
-      : pb_query_factory_(pb_query_factory),
-        pb_query_response_factory_(pb_query_response_factory),
-        query_processor_(query_processor) {
-    // Subscribe on result from iroha
-    query_processor_->queryNotifier().subscribe([this](auto iroha_response) {
-      // Find client to respond
-      auto old_reponse = iroha_response->makeOldModel();
-      auto res = handler_map_.find(old_reponse->query_hash.to_string());
-      // Serialize to proto an return to response
-      res->second =
-          pb_query_response_factory_
-              ->serialize(
-                  std::shared_ptr<iroha::model::QueryResponse>(old_reponse))
-              .value();
+      : query_processor_(query_processor) {
+    //    Subscribe on result from iroha
+    query_processor_->queryNotifier().subscribe(
+        [this](const std::shared_ptr<shared_model::interface::QueryResponse>
+                   &iroha_response) {
+          // Find client to respond
+          auto hash = iroha_response->queryHash();
+          auto res = cache_.findItem(hash);
 
-    });
+          if (res) {
+            cache_.addItem(hash, iroha_response);
+          }
+
+        });
   }
 
   void QueryService::Find(iroha::protocol::Query const &request,
                           iroha::protocol::QueryResponse &response) {
     using iroha::operator|;
-    auto deserializedRequest = pb_query_factory_->deserialize(request);
-    deserializedRequest | [&](const auto &query) {
-      auto hash = iroha::hash(*query).to_string();
-      if (handler_map_.count(hash) > 0) {
-        // Query was already processed
-        response.mutable_error_response()->set_reason(
-            iroha::protocol::ErrorResponse::STATELESS_INVALID);
-      }
 
-      else {
-        // Query - response relationship
-        handler_map_.emplace(hash, response);
-        // Send query to iroha
-        query_processor_->queryHandle(
-            std::make_shared<shared_model::proto::Query>(
-                shared_model::proto::from_old(*query)));
-      }
-      response.set_query_hash(hash);
-    };
+    //    shared_model::proto::QueryResponse model_response(response);
+    shared_model::crypto::Hash hash;
+    shared_model::proto::TransportBuilder<
+        shared_model::proto::Query,
+        shared_model::validation::DefaultQueryValidator>()
+        .build(request)
+        .match(
+            [this, &hash, &response](
+                const iroha::expected::Value<shared_model::proto::Query>
+                    &query) {
+              auto hash = query.value.hash();
+              if (cache_.findItem(hash)) {
+                // Query was already processed
 
-    if (not deserializedRequest) {
-      response.mutable_error_response()->set_reason(
-          iroha::protocol::ErrorResponse::NOT_SUPPORTED);
-    }
+                response.mutable_error_response()->set_reason(
+                    iroha::protocol::ErrorResponse::STATELESS_INVALID);
+              } else {
+                // Query - response relationship
+                cache_.addItem(
+                    hash,
+                    std::make_shared<shared_model::proto::QueryResponse>(
+                        response));
+                // Send query to iroha
+                query_processor_->queryHandle(
+                    shared_model::detail::makePolymorphic<
+                        shared_model::proto::Query>(query.value));
+              }
+
+              auto result_response = cache_.findItem(hash).value();
+              response = static_cast<shared_model::proto::QueryResponse &>(
+                             *result_response)
+                             .getTransport();
+            },
+            [&hash, &request, &response](
+                const iroha::expected::Error<std::string> &error) {
+              auto blobPayload =
+                  shared_model::proto::makeBlob(request.payload());
+              hash = shared_model::proto::Query::HashProviderType::makeHash(
+                  blobPayload);
+              response.set_query_hash(
+                  shared_model::crypto::toBinaryString(hash));
+              response.mutable_error_response()->set_reason(
+                  iroha::protocol::ErrorResponse::STATELESS_INVALID);
+            });
   }
 
   grpc::Status QueryService::Find(grpc::ServerContext *context,

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -30,9 +30,8 @@ namespace iroha {
     using validation::StatelessValidator;
 
     TransactionProcessorImpl::TransactionProcessorImpl(
-        std::shared_ptr<PeerCommunicationService> pcs,
-        std::shared_ptr<StatelessValidator> validator)
-        : pcs_(std::move(pcs)), validator_(std::move(validator)) {
+        std::shared_ptr<PeerCommunicationService> pcs)
+        : pcs_(std::move(pcs)) {
       log_ = logger::log("TxProcessor");
 
       // insert all txs from proposal to proposal set
@@ -97,17 +96,11 @@ namespace iroha {
       model::TransactionResponse response;
       response.tx_hash = hash(*transaction).to_string();
       response.current_status =
-          model::TransactionResponse::Status::STATELESS_VALIDATION_FAILED;
+          model::TransactionResponse::Status::STATELESS_VALIDATION_SUCCESS;
 
-      if (validator_->validate(*transaction)) {
-        response.current_status =
-            TransactionResponse::Status::STATELESS_VALIDATION_SUCCESS;
-        pcs_->propagate_transaction(transaction);
-      }
-      log_->info(
-          "stateless validation status: {}",
-          response.current_status
-              == TransactionResponse::Status::STATELESS_VALIDATION_SUCCESS);
+      pcs_->propagate_transaction(transaction);
+
+      log_->info("stateless validated");
       notifier_.get_subscriber().on_next(
           std::make_shared<model::TransactionResponse>(response));
     }

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -47,8 +47,8 @@ namespace iroha {
        * Subscribe for query responses
        * @return observable with query responses
        */
-      virtual rxcpp::observable<std::shared_ptr<
-          shared_model::interface::QueryResponse>>
+      virtual rxcpp::observable<
+          std::shared_ptr<shared_model::interface::QueryResponse>>
       queryNotifier() = 0;
 
       virtual ~QueryProcessor(){};

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -31,8 +31,7 @@ namespace iroha {
     class QueryProcessorImpl : public QueryProcessor {
      public:
       explicit QueryProcessorImpl(
-          std::unique_ptr<model::QueryProcessingFactory> qpf,
-          std::shared_ptr<validation::StatelessValidator> stateless_validator);
+          std::unique_ptr<model::QueryProcessingFactory> qpf);
 
       /**
        * Register client query
@@ -50,11 +49,10 @@ namespace iroha {
       queryNotifier() override;
 
      private:
-      rxcpp::subjects::subject<std::shared_ptr<
-          shared_model::interface::QueryResponse>>
+      rxcpp::subjects::subject<
+          std::shared_ptr<shared_model::interface::QueryResponse>>
           subject_;
       std::unique_ptr<model::QueryProcessingFactory> qpf_;
-      std::shared_ptr<validation::StatelessValidator> validator_;
     };
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -33,8 +33,7 @@ namespace iroha {
        * @param validator - perform stateless validation
        */
       TransactionProcessorImpl(
-          std::shared_ptr<network::PeerCommunicationService> pcs,
-          std::shared_ptr<validation::StatelessValidator> validator);
+          std::shared_ptr<network::PeerCommunicationService> pcs);
 
       void transactionHandle(
           std::shared_ptr<model::Transaction> transaction) override;
@@ -47,8 +46,6 @@ namespace iroha {
       std::shared_ptr<network::PeerCommunicationService> pcs_;
 
       // processing
-      std::shared_ptr<validation::StatelessValidator> validator_;
-
       std::unordered_set<std::string> proposal_set_;
       std::unordered_set<std::string> candidate_set_;
 

--- a/shared_model/backend/protobuf/from_old_model.hpp
+++ b/shared_model/backend/protobuf/from_old_model.hpp
@@ -67,6 +67,11 @@ namespace shared_model {
 
     inline static shared_model::proto::QueryResponse from_old(
         std::shared_ptr<iroha::model::QueryResponse> queryResponse) {
+      auto sshash = queryResponse->query_hash.to_hexstring();
+      auto proto_resp = *iroha::model::converters::PbQueryResponseFactory().serialize(
+          queryResponse);
+      auto res = shared_model::proto::QueryResponse(std::move(proto_resp));
+      auto hash = res.queryHash();
       return shared_model::proto::QueryResponse(
           *iroha::model::converters::PbQueryResponseFactory().serialize(
               queryResponse));

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -98,7 +98,9 @@ namespace shared_model {
             payload_([this] { return makeBlob(proto_->payload()); }),
             signatures_([this] {
               interface::SignatureSetType set;
-              set.emplace(new Signature(proto_->signature()));
+              if (proto_->has_signature()) {
+                set.emplace(new Signature(proto_->signature()));
+              }
               return set;
             }) {}
 
@@ -124,6 +126,13 @@ namespace shared_model {
 
       const Query::BlobType &payload() const override {
         return *payload_;
+      }
+
+      const HashType &hash() const override {
+        if (hash_ == boost::none) {
+          hash_.emplace(HashProviderType::makeHash(payload()));
+        }
+        return *hash_;
       }
 
       // ------------------------| Signable override  |-------------------------

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -83,7 +83,9 @@ namespace shared_model {
             variant_([this] {
               return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
             }),
-            hash_([this] { return QueryHashType(proto_->query_hash()); }) {}
+            hash_([this] {
+              return QueryHashType(proto_->query_hash());
+            }) {}
 
       QueryResponse(const QueryResponse &o) : QueryResponse(o.proto_) {}
 

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -95,8 +95,7 @@ class ClientServerTest : public testing::Test {
 
       //----------- Server run ----------------
       runner
-          ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, proposal_delay))
+          ->append(std::make_unique<torii::CommandService>( tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(qpi))
           .run();
     });

--- a/test/module/irohad/torii/processor/CMakeLists.txt
+++ b/test/module/irohad/torii/processor/CMakeLists.txt
@@ -2,7 +2,8 @@
 addtest(transaction_processor_test transaction_processor_test.cpp)
 target_link_libraries(transaction_processor_test
     processors
-)
+    shared_model_stateless_validation
+    )
 
 # Testing of query processor
 addtest(query_processor_test query_processor_test.cpp)

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -65,11 +65,7 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
   auto qpf = std::make_unique<model::QueryProcessingFactory>(wsv_queries,
                                                              block_queries);
 
-  auto validation = std::make_shared<MockStatelessValidator>();
-  EXPECT_CALL(*validation, validate(A<const model::Query &>()))
-      .WillOnce(Return(true));
-
-  iroha::torii::QueryProcessorImpl qpi(std::move(qpf), validation);
+  iroha::torii::QueryProcessorImpl qpi(std::move(qpf));
 
   auto query = TestUnsignedQueryBuilder()
                    .createdTime(created_time)

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "torii/query_service.hpp"
+#include "builders/protobuf/queries.hpp"
 #include "generator/generator.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
 
@@ -23,7 +24,6 @@ using namespace torii;
 
 using namespace iroha;
 using namespace iroha::torii;
-using namespace iroha::model::converters;
 
 using namespace shared_model::detail;
 using namespace shared_model::interface;
@@ -34,37 +34,34 @@ class QueryServiceTest : public ::testing::Test {
  public:
   void SetUp() override {
     query_processor = std::make_shared<MockQueryProcessor>();
-    query_factory = std::make_shared<PbQueryFactory>();
-    query_response_factory = std::make_shared<PbQueryResponseFactory>();
     // any query
-    auto val = query.mutable_payload()->mutable_get_account();
-
-    // just random hex strings (same seed every time is ok here)
-    query.mutable_signature()->set_pubkey(
-        generator::random_blob<16>(0).to_hexstring());
-    query.mutable_signature()->set_signature(
-        generator::random_blob<32>(0).to_hexstring());
+    query = shared_model::proto::QueryBuilder()
+                .creatorAccountId("user@domain")
+                .createdTime(iroha::time::now())
+                .queryCounter(1)
+                .getAccountTransactions("user@domain")
+                .build()
+                .signAndAddSignature(
+                    shared_model::crypto::DefaultCryptoAlgorithmType::
+                        generateKeypair())
+                .getTransport();
   }
 
   void init() {
-    query_service = std::make_shared<QueryService>(
-        query_factory, query_response_factory, query_processor);
+    query_service = std::make_shared<QueryService>(query_processor);
   }
 
   protocol::Query query;
   protocol::QueryResponse response;
   std::shared_ptr<QueryService> query_service;
   std::shared_ptr<MockQueryProcessor> query_processor;
-  std::shared_ptr<PbQueryFactory> query_factory;
-  std::shared_ptr<PbQueryResponseFactory> query_response_factory;
-
 };
 
 TEST_F(QueryServiceTest, SubscribeQueryProcessorWhenInit) {
   // query service is subscribed to query processor
   EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(Return(
-          rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
+      .WillOnce(
+          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
 
   init();
 }
@@ -72,8 +69,8 @@ TEST_F(QueryServiceTest, SubscribeQueryProcessorWhenInit) {
 TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
   // unique query => query handled by query processor
   EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(Return(
-          rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
+      .WillOnce(
+          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
   EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
   init();
 
@@ -83,8 +80,8 @@ TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
 TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   // two same queries => only first query handled by query processor
   EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(Return(
-          rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
+      .WillOnce(
+          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
   EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
 
   init();

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -31,6 +31,10 @@ limitations under the License.
 #include "torii/query_client.hpp"
 #include "torii/query_service.hpp"
 
+#include "builders/protobuf/queries.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "module/shared_model/builders/protobuf/test_query_builder.hpp"
+
 constexpr const char *Ip = "0.0.0.0";
 constexpr int Port = 50051;
 
@@ -57,7 +61,6 @@ class ToriiQueriesTest : public testing::Test {
     th = std::thread([this] {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<MockPeerCommunicationService>();
-      statelessValidatorMock = std::make_shared<MockStatelessValidator>();
       wsv_query = std::make_shared<MockWsvQuery>();
       block_query = std::make_shared<MockBlockQuery>();
       storageMock = std::make_shared<MockStorage>();
@@ -72,8 +75,7 @@ class ToriiQueriesTest : public testing::Test {
           .WillRepeatedly(Return(commit_notifier.get_observable()));
 
       auto tx_processor =
-          std::make_shared<iroha::torii::TransactionProcessorImpl>(
-              pcsMock, statelessValidatorMock);
+          std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock);
       auto pb_tx_factory =
           std::make_shared<iroha::model::converters::PbTransactionFactory>();
 
@@ -82,20 +84,14 @@ class ToriiQueriesTest : public testing::Test {
       auto qpf = std::make_unique<iroha::model::QueryProcessingFactory>(
           wsv_query, block_query);
 
-      auto qpi = std::make_shared<iroha::torii::QueryProcessorImpl>(
-          std::move(qpf), statelessValidatorMock);
-
-      auto pb_query_factory =
-          std::make_shared<iroha::model::converters::PbQueryFactory>();
-      auto pb_query_resp_factory =
-          std::make_shared<iroha::model::converters::PbQueryResponseFactory>();
+      auto qpi =
+          std::make_shared<iroha::torii::QueryProcessorImpl>(std::move(qpf));
 
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
               pb_tx_factory, tx_processor, storageMock, proposal_delay))
-          .append(std::make_unique<torii::QueryService>(
-              pb_query_factory, pb_query_resp_factory, qpi))
+          .append(std::make_unique<torii::QueryService>(qpi))
           .run();
     });
 
@@ -112,7 +108,6 @@ class ToriiQueriesTest : public testing::Test {
   std::thread th;
 
   std::shared_ptr<MockPeerCommunicationService> pcsMock;
-  std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
   std::shared_ptr<MockStorage> storageMock;
 
   std::shared_ptr<MockWsvQuery> wsv_query;
@@ -156,10 +151,6 @@ TEST_F(ToriiQueriesTest, QueryClient) {
  */
 
 TEST_F(ToriiQueriesTest, FindWhenResponseInvalid) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(false));
-
   iroha::protocol::QueryResponse response;
   auto query = iroha::protocol::Query();
 
@@ -181,13 +172,10 @@ TEST_F(ToriiQueriesTest, FindWhenResponseInvalid) {
  */
 
 TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
+  // TODO: kamilsa 19.02.2017 remove old model
   iroha::model::Account account;
-  account.account_id = "accountB";
-  auto creator = "accountA";
+  account.account_id = "b@domain";
+  auto creator = "a@domain";
 
   // TODO: refactor this to use stateful validation mocks
   EXPECT_CALL(*wsv_query,
@@ -200,32 +188,35 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccount(account.account_id)
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account()->set_account_id("accountB");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
 
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
   ASSERT_TRUE(stat.ok());
 
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
+  auto creator = "a@domain";
 
-  auto creator = "accountA";
-
+  // TODO: kamilsa 19.02.2017 remove old model
   iroha::model::Account accountB;
-  accountB.account_id = "accountB";
+  accountB.account_id = "b@domain";
 
   // TODO: refactor this to use stateful validation mocks
   EXPECT_CALL(*wsv_query,
@@ -242,34 +233,38 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccount(accountB.account_id)
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account()->set_account_id("accountB");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
-
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
-  ASSERT_EQ(response.account_response().account().account_id(), "accountB");
+  ASSERT_EQ(response.account_response().account().account_id(),
+            accountB.account_id);
   ASSERT_EQ(response.account_response().account_roles().size(), 1);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
+  // TODO 19.02.2018 kamilsa remove old model
   iroha::model::Account account;
-  account.account_id = "accountA";
+  account.account_id = "a";
+  account.quorum = 2;
+  account.domain_id = "domain";
 
-  // Should be called once when stateful validation is in progress
-  EXPECT_CALL(*wsv_query, getAccount("accountA")).WillOnce(Return(account));
+  auto creator = "a@domain";
+  EXPECT_CALL(*wsv_query, getAccount(creator)).WillOnce(Return(account));
   // TODO: refactor this to use stateful validation mocks
-  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillRepeatedly(Return(roles));
@@ -278,19 +273,28 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccount(creator)
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account()->set_account_id("accountA");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
-
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
-  ASSERT_EQ(response.account_response().account().account_id(), "accountA");
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  //  ASSERT_EQ(response.account_detail_response().detail(), "value");
+  ASSERT_EQ(response.account_response().account().account_id(),
+            account.account_id);
+  ASSERT_EQ(response.account_response().account().domain_id(),
+            account.domain_id);
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 /**
@@ -298,30 +302,13 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
  */
 
 TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
-  iroha::model::Account account;
-  account.account_id = "accountB";
-
-  iroha::model::AccountAsset account_asset;
-  account_asset.account_id = "accountB";
-  account_asset.asset_id = "usd";
-  iroha::Amount amount(100, 2);
-  account_asset.balance = amount;
-
-  iroha::model::Asset asset;
-  asset.asset_id = "usd";
-  asset.domain_id = "USA";
-  asset.precision = 2;
-
-  auto creator = "accountA";
+  auto creator = "a@domain";
+  auto accountb_id = "b@domain";
 
   // TODO: refactor this to use stateful validation mocks
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  creator, account.account_id, can_get_my_acc_ast))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(creator, accountb_id, can_get_my_acc_ast))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(nonstd::nullopt));
@@ -331,45 +318,37 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccountAssets(accountb_id, "usd#domain")
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account_assets()->set_account_id(
-      "accountB");
-  query.mutable_payload()->mutable_get_account_assets()->set_asset_id("usd");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
-
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account asset
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
-  iroha::model::Account account;
-  account.account_id = "accountA";
-
+  // TODO 19.02.2018 kamilsa remove old model
   iroha::model::AccountAsset account_asset;
-  account_asset.account_id = "accountA";
+  account_asset.account_id = "a";
   account_asset.asset_id = "usd";
   iroha::Amount amount(100, 2);
   account_asset.balance = amount;
 
-  iroha::model::Asset asset;
-  asset.asset_id = "usd";
-  asset.domain_id = "USA";
-  asset.precision = 2;
-
   // TODO: refactor this to use stateful validation mocks
-  auto creator = "accountA";
+  auto creator = "a@domain";
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_acc_ast};
@@ -379,15 +358,21 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account_assets()->set_account_id(
-      "accountA");
-  query.mutable_payload()->mutable_get_account_assets()->set_asset_id("usd");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccountAssets(creator, "usd#domain")
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
+
+  auto hash = response.query_hash();
+
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
@@ -400,7 +385,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   auto iroha_amount_asset = iroha::model::converters::deserializeAmount(
       response.account_assets_response().account_asset().balance());
   ASSERT_EQ(iroha_amount_asset, account_asset.balance);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 /**
@@ -408,23 +394,16 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
  */
 
 TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
-  iroha::model::Account account;
-  account.account_id = "accountB";
-
   iroha::pubkey_t pubkey;
   std::fill(pubkey.begin(), pubkey.end(), 0x1);
   std::vector<iroha::pubkey_t> keys;
   keys.push_back(pubkey);
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator = "accountA";
+  auto creator = "a@domain";
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  creator, account.account_id, can_get_my_signatories))
+                  creator, "b@domain", can_get_my_signatories))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(nonstd::nullopt));
@@ -432,54 +411,54 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account_signatories()->set_account_id(
-      "accountB");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId(creator)
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getSignatories("b@domain")
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account
   ASSERT_EQ(response.error_response().reason(),
             iroha::model::ErrorResponse::STATEFUL_INVALID);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
-  iroha::model::Account account;
-  account.account_id = "accountA";
-
+  // TODO: refactor this to use stateful validation mocks
   iroha::pubkey_t pubkey;
   std::fill(pubkey.begin(), pubkey.end(), 0x1);
   std::vector<iroha::pubkey_t> keys;
   keys.push_back(pubkey);
 
-  // TODO: refactor this to use stateful validation mocks
-  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles("a@domain")).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_signatories};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*wsv_query, getSignatories(_)).WillOnce(Return(keys));
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId("a@domain")
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getSignatories("a@domain")
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id("accountA");
-  query.mutable_payload()->mutable_get_account_signatories()->set_account_id(
-      "accountA");
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
-
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   /// Should not return Error Response because tx is stateless and stateful
   /// valid
@@ -489,7 +468,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   decltype(pubkey) response_pubkey;
   std::copy(signatory.begin(), signatory.end(), response_pubkey.begin());
   ASSERT_EQ(response_pubkey, pubkey);
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 /**
@@ -497,10 +477,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
  */
 
 TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(true));
-
+  // TODO 19.02.2018 kamilsa remove old model
   iroha::model::Account account;
   account.account_id = "accountA";
 
@@ -516,25 +493,27 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   }());
 
   // TODO: refactor this to use stateful validation mocks
-  auto creator = "accountA";
   std::vector<std::string> roles = {"test"};
-  EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
+  EXPECT_CALL(*wsv_query, getAccountRoles("a@domain")).WillOnce(Return(roles));
   std::vector<std::string> perm = {can_get_my_acc_txs};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
-  EXPECT_CALL(*block_query, getAccountTransactions(account.account_id))
+  EXPECT_CALL(*block_query, getAccountTransactions("a@domain"))
       .WillOnce(Return(txs_observable));
 
   iroha::protocol::QueryResponse response;
 
-  auto query = iroha::protocol::Query();
+  auto model_query = shared_model::proto::QueryBuilder()
+                         .creatorAccountId("a@domain")
+                         .queryCounter(1)
+                         .createdTime(iroha::time::now())
+                         .getAccountTransactions("a@domain")
+                         .build()
+                         .signAndAddSignature(
+                             shared_model::crypto::DefaultCryptoAlgorithmType::
+                                 generateKeypair());
 
-  query.mutable_payload()->set_creator_account_id(account.account_id);
-  query.mutable_payload()->mutable_get_account_transactions()->set_account_id(
-      account.account_id);
-  query.mutable_signature()->set_pubkey(pubkey_test);
-  query.mutable_signature()->set_signature(signature_test);
-
-  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(query, response);
+  auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
+      model_query.getTransport(), response);
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
@@ -549,31 +528,30 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
         response.transactions_response().transactions(i).payload().tx_counter(),
         i);
   }
-  ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+  ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+            response.query_hash());
 }
 
 TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Query &>()))
-      .WillOnce(Return(false));
-
   auto client = torii_utils::QuerySyncClient(Ip, Port);
 
   for (size_t i = 0; i < TimesFind; ++i) {
     iroha::protocol::QueryResponse response;
-    auto query = iroha::protocol::Query();
 
-    query.mutable_payload()->set_creator_account_id("accountA");
-    query.mutable_payload()->mutable_get_account()->set_account_id("accountB");
-    query.mutable_payload()->set_query_counter(i);
-    query.mutable_signature()->set_pubkey(pubkey_test);
-    query.mutable_signature()->set_signature(signature_test);
+    // stateless invalid query
+    auto model_query = TestQueryBuilder()
+                           .creatorAccountId("a@domain")
+                           .queryCounter(i)
+                           .createdTime(iroha::time::now())
+                           .getAccountTransactions("a@2domain")
+                           .build();
 
-    auto stat = client.Find(query, response);
+    auto stat = client.Find(model_query.getTransport(), response);
     ASSERT_TRUE(stat.ok());
     // Must return Error Response
     ASSERT_EQ(response.error_response().reason(),
               iroha::model::ErrorResponse::STATELESS_INVALID);
-    ASSERT_EQ(iroha::hash(query).to_string(), response.query_hash());
+    ASSERT_EQ(iroha::hash(model_query.getTransport()).to_string(),
+              response.query_hash());
   }
 }

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -20,9 +20,6 @@ limitations under the License.
 #include "module/irohad/validation/validation_mocks.hpp"
 // to compare pb amount and iroha amount
 #include "model/converters/pb_common.hpp"
-#include "model/converters/pb_query_factory.hpp"
-#include "model/converters/pb_query_response_factory.hpp"
-#include "model/converters/pb_transaction_factory.hpp"
 
 #include "main/server_runner.hpp"
 #include "model/permissions.hpp"
@@ -76,8 +73,6 @@ class ToriiQueriesTest : public testing::Test {
 
       auto tx_processor =
           std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock);
-      auto pb_tx_factory =
-          std::make_shared<iroha::model::converters::PbTransactionFactory>();
 
       //----------- Query Service ----------
 
@@ -90,7 +85,7 @@ class ToriiQueriesTest : public testing::Test {
       //----------- Server run ----------------
       runner
           ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, proposal_delay))
+              tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(qpi))
           .run();
     });

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -82,14 +82,12 @@ class ToriiServiceTest : public testing::Test {
       // ----------- Command Service --------------
       pcsMock = std::make_shared<CustomPeerCommunicationServiceMock>(
           prop_notifier_, commit_notifier_);
-      statelessValidatorMock = std::make_shared<MockStatelessValidator>();
       wsv_query = std::make_shared<MockWsvQuery>();
       storageMock = std::make_shared<MockStorage>();
       block_query = std::make_shared<MockBlockQuery>();
 
       auto tx_processor =
-          std::make_shared<iroha::torii::TransactionProcessorImpl>(
-              pcsMock, statelessValidatorMock);
+          std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock);
       auto pb_tx_factory =
           std::make_shared<iroha::model::converters::PbTransactionFactory>();
 
@@ -97,13 +95,8 @@ class ToriiServiceTest : public testing::Test {
       auto qpf = std::make_unique<iroha::model::QueryProcessingFactory>(
           wsv_query, block_query);
 
-      auto qpi = std::make_shared<iroha::torii::QueryProcessorImpl>(
-          std::move(qpf), statelessValidatorMock);
-
-      auto pb_query_factory =
-          std::make_shared<iroha::model::converters::PbQueryFactory>();
-      auto pb_query_resp_factory =
-          std::make_shared<iroha::model::converters::PbQueryResponseFactory>();
+      auto qpi =
+          std::make_shared<iroha::torii::QueryProcessorImpl>(std::move(qpf));
 
       EXPECT_CALL(*storageMock, getBlockQuery())
           .WillRepeatedly(Return(block_query));
@@ -114,8 +107,7 @@ class ToriiServiceTest : public testing::Test {
       runner
           ->append(std::make_unique<torii::CommandService>(
               pb_tx_factory, tx_processor, storageMock, proposal_delay))
-          .append(std::make_unique<torii::QueryService>(
-              pb_query_factory, pb_query_resp_factory, qpi))
+          .append(std::make_unique<torii::QueryService>(qpi))
           .run();
     });
 
@@ -139,7 +131,6 @@ class ToriiServiceTest : public testing::Test {
   rxcpp::subjects::subject<Commit> commit_notifier_;
 
   std::shared_ptr<CustomPeerCommunicationServiceMock> pcsMock;
-  std::shared_ptr<MockStatelessValidator> statelessValidatorMock;
 };
 
 /**
@@ -217,11 +208,6 @@ TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {
            then STATEFUL_VALIDATION_FAILED
  */
 TEST_F(ToriiServiceTest, StatusWhenBlocking) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Transaction &>()))
-      .Times(TimesToriiBlocking)
-      .WillRepeatedly(Return(true));
-
   std::vector<iroha::model::Transaction> txs;
   std::vector<std::string> tx_hashes;
 
@@ -363,10 +349,6 @@ TEST_F(ToriiServiceTest, CheckHash) {
  * and COMMITTED) and the last status should be COMMITTED
  */
 TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
-  EXPECT_CALL(*statelessValidatorMock,
-              validate(A<const iroha::model::Transaction &>()))
-      .WillRepeatedly(Return(true));
-
   iroha::model::converters::PbTransactionFactory tx_factory;
   auto client = torii::CommandSyncClient(Ip, Port);
 

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -105,8 +105,7 @@ class ToriiServiceTest : public testing::Test {
 
       //----------- Server run ----------------
       runner
-          ->append(std::make_unique<torii::CommandService>(
-              pb_tx_factory, tx_processor, storageMock, proposal_delay))
+          ->append(std::make_unique<torii::CommandService>(tx_processor, storageMock, proposal_delay))
           .append(std::make_unique<torii::QueryService>(qpi))
           .run();
     });


### PR DESCRIPTION
Removed stateless validation from query processor and transaction processor

Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Updates query service to use new model

### Benefits

Now stateless validation happens in query service

### Possible Drawbacks 

Big parts of code were affected

### Usage Examples or Tests

Old tests were updated and now demonstrate use of new model in query service