### PR TITLE
Move cache step to the end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,6 @@ jobs:
           command: |
             cmake --build $IROHA_BUILD -- -j3
       - run: ccache --show-stats
-      - save_cache:
-          key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-          when: always
       - run:
           name: unit tests, generate xunit-*.xml
           command: cmake --build $IROHA_BUILD --target test
@@ -67,6 +62,11 @@ jobs:
       - run:
           name: codecov.io
           command: bash <(curl -s https://codecov.io/bash) -f $IROHA_BUILD/reports/gcovr.xml || echo "Codecov did not collect coverage reports"
+      - save_cache:
+          key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
+          when: always
       - persist_to_workspace:
           root: /opt/iroha/build
           paths:


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Move "save_cache" step in the end of "build" step.


### Benefits

<!-- What benefits will be realized by the code change? -->

When tests could potentially fail you typically push commit and wait until tests will succeed in CI. 
When save_cache is in the end, test step and analysis steps are executed earlier, so you, as a developer, can save 2-3 min. 
