### PR TITLE
Remove -g flag if coverage is enabled to reduce binary size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ SET(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 SET(CMAKE_INSTALL_RPATH "../lib")
 
 if(COVERAGE)
+  # remove -g flag to reduce binary size
+  list(REMOVE_ITEM CMAKE_CXX_FLAGS -g)
   set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
   set(CMAKE_CXX_FLAGS "--coverage ${CMAKE_CXX_FLAGS}")
   set(CMAKE_C_FLAGS "--coverage ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Signed-off-by: Andrei Lebedev <lebdron@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
As it was pointed out in https://github.com/hyperledger/iroha/pull/983 , `-g` flag increases binary size, which leads to CircleCI container running out of memory. This pull request removes `-g` flag from coverage builds, allowing CircleCI to pass compilation.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
CircleCI does not crash with memory error
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Debugging (for example with gdb) in coverage build is probably not possible due to missing debug information
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->


<!-- Explain what other alternates were considered and why the proposed version was selected -->
