### PR TITLE
Clean postgres in ametsuchi test in SetUp

### DIFF
--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -97,7 +97,7 @@ namespace iroha {
       std::string block_store_path = "/tmp/block_store";
 
       // TODO(warchant): IR-1019 hide SQLs under some interface
-      const auto drop_ = R"(
+      const std::string drop_ = R"(
 DROP TABLE IF EXISTS account_has_signatory;
 DROP TABLE IF EXISTS account_has_asset;
 DROP TABLE IF EXISTS role_has_permissions;

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -56,7 +56,19 @@ namespace iroha {
       }
 
      protected:
-      virtual void SetUp() {
+      virtual void clear() {
+        pqxx::work txn(*connection);
+        txn.exec(drop_);
+        txn.commit();
+
+        iroha::remove_all(block_store_path);
+      }
+
+      virtual void disconnect() {
+        connection->disconnect();
+      }
+
+      virtual void connect() {
         connection = std::make_shared<pqxx::lazyconnection>(pgopt_);
         try {
           connection->activate();
@@ -64,8 +76,28 @@ namespace iroha {
           FAIL() << "Connection to PostgreSQL broken: " << e.what();
         }
       }
-      virtual void TearDown() {
-        const auto drop = R"(
+
+      void SetUp() override {
+        connect();
+        clear();
+      }
+
+      void TearDown() override {
+        clear();
+        disconnect();
+      }
+
+      std::shared_ptr<pqxx::lazyconnection> connection;
+
+      model::generators::CommandGenerator cmd_gen;
+
+      std::string pgopt_ =
+          "host=localhost port=5432 user=postgres password=mysecretpassword";
+
+      std::string block_store_path = "/tmp/block_store";
+
+      // TODO(warchant): IR-1019 hide SQLs under some interface
+      const auto drop_ = R"(
 DROP TABLE IF EXISTS account_has_signatory;
 DROP TABLE IF EXISTS account_has_asset;
 DROP TABLE IF EXISTS role_has_permissions;
@@ -82,23 +114,6 @@ DROP TABLE IF EXISTS height_by_account_set;
 DROP TABLE IF EXISTS index_by_creator_height;
 DROP TABLE IF EXISTS index_by_id_height_asset;
 )";
-
-        pqxx::work txn(*connection);
-        txn.exec(drop);
-        txn.commit();
-        connection->disconnect();
-
-        iroha::remove_all(block_store_path);
-      }
-
-      std::shared_ptr<pqxx::lazyconnection> connection;
-
-      model::generators::CommandGenerator cmd_gen;
-
-      std::string pgopt_ =
-          "host=localhost port=5432 user=postgres password=mysecretpassword";
-
-      std::string block_store_path = "/tmp/block_store";
 
       const std::string init_ = R"(
 CREATE TABLE IF NOT EXISTS role (


### PR DESCRIPTION
Clean postgres in ametsuchi test in SetUp step, right after connection.

When test dies with SIGSEGV or other error, TearDown is not executed and postgres remains tables and rows, which lead to double insertion of the same primary key (peer id and others).

This PR fixes this.

Example:

```
      Start 95: transfer_asset_inter_domain_test
95/95 Test #95: transfer_asset_inter_domain_test .......***Exception: SegFault  5.05 sec
Running main() from gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TransferAssetInterDomainTest
[ RUN      ] TransferAssetInterDomainTest.TransferAssetInterDomainTest
[2018-02-24 09:50:54.746092543][th:3866][info] IROHAD created
[2018-02-24 09:50:54.746217649][th:3866][info] StorageImpl:initConnection Start storage creation
[2018-02-24 09:50:54.746605656][th:3866][info] StorageImpl:initConnection block store created
[2018-02-24 09:50:54.748557187][th:3866][info] StorageImpl:initConnection connection to PostgreSQL completed
[2018-02-24 09:50:54.748599812][th:3866][info] StorageImpl:initConnection transaction to PostgreSQL initialized
[2018-02-24 09:50:54.750228915][th:3866][info] IROHAD [Init] => storage
[2018-02-24 09:50:54.750261342][th:3866][info] StorageImpl create mutable storage
[2018-02-24 09:50:54.755920033][th:3866][error] MutableStorage AddPeer: failed to insert peer, public key: 'db69d9c43e1a8fcaf0822abba1de92800e99dde0a48e1385c27cfece8882e7ec', address: '0.0.0.0:10001'
ERROR:  duplicate key value violates unique constraint "peer_address_key"
DETAIL:  Key (address)=(0.0.0.0:10001) already exists.

[2018-02-24 09:50:54.756037086][th:3866][info] StorageImpl block inserted: false
[2018-02-24 09:50:54.756666212][th:3866][info] IROHAD [Init] => peer query
[2018-02-24 09:50:54.756697814][th:3866][info] IROHAD [Init] => crypto provider
[2018-02-24 09:50:54.756826837][th:3866][info] IROHAD [Init] => validators
[2018-02-24 09:50:54.759077262][th:3866][info] OrderingGate Subscribe
[2018-02-24 09:50:54.759109049][th:3866][info] IROHAD [Init] => init ordering gate - [true]
[2018-02-24 09:50:54.759385684][th:3866][info] IROHAD [Init] => init simulator
[2018-02-24 09:50:54.759571451][th:3866][info] IROHAD [Init] => block loader
[2018-02-24 09:50:54.760167276][th:3866][info] IROHAD [Init] => consensus gate
[2018-02-24 09:50:54.760404027][th:3866][info] IROHAD [Init] => synchronizer
[2018-02-24 09:50:54.760618522][th:3866][info] IROHAD [Init] => pcs
[2018-02-24 09:50:54.761022210][th:3866][info] IROHAD [Init] => command service
[2018-02-24 09:50:54.761260134][th:3866][info] IROHAD [Init] => query service
[2018-02-24 09:50:54.766015364][th:3866][info] IROHAD ===> iroha initialized
[2018-02-24 09:50:54.778357628][th:3866][info] TxProcessor handle transaction
[2018-02-24 09:50:54.778684447][th:3866][info] PCS propagate tx
[2018-02-24 09:50:54.778714065][th:3866][info] OrderingGate propagate tx, tx_counter: 1 account_id: nba@usabnk
[2018-02-24 09:50:54.778724958][th:3866][info] OrderingGate Propagate tx (on transport)
[2018-02-24 09:50:54.779137467][th:3866][info] TxProcessor stateless validated
``` 