### PR TITLE
Revert "Pass compiler generator and launchers to dependencies"

### DIFF
--- a/cmake/Modules/Findbenchmark.cmake
+++ b/cmake/Modules/Findbenchmark.cmake
@@ -12,32 +12,17 @@ find_package_handle_standard_args(benchmark DEFAULT_MSG
     benchmark_LIBRARY
     )
 
-iroha_get_lib_name(BENCHLIB benchmark STATIC)
-
 if (NOT benchmark_FOUND)
   externalproject_add(google_benchmark
       GIT_REPOSITORY https://github.com/google/benchmark
       GIT_TAG v1.2.0
-      CMAKE_ARGS
-          -G${CMAKE_GENERATOR}
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-      BUILD_BYPRODUCTS
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${BENCHLIB}
-      INSTALL_COMMAND  "" # remove install step
-      TEST_COMMAND     "" # remove test step
-      UPDATE_COMMAND   "" # remove update step
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(google_benchmark source_dir binary_dir)
   set(benchmark_INCLUDE_DIR ${source_dir}/include)
-
-  set(benchmark_LIBRARY ${CMAKE_BINARY_DIR}${XCODE_EXT}/${BENCHLIB})
-
+  set(benchmark_LIBRARY ${binary_dir}/src/libbenchmark.a)
   file(MAKE_DIRECTORY ${benchmark_INCLUDE_DIR})
 
   add_dependencies(benchmark google_benchmark)

--- a/cmake/Modules/Finded25519.cmake
+++ b/cmake/Modules/Finded25519.cmake
@@ -15,28 +15,11 @@ set(URL https://github.com/hyperledger/iroha-ed25519)
 set(VERSION e7188b8393dbe5ac54378610d53630bd4a180038)
 set_target_description(ed25519 "Digital signature algorithm" ${URL} ${VERSION})
 
-iroha_get_lib_name(EDLIB ed25519 STATIC)
-
 if (NOT ed25519_FOUND)
   externalproject_add(hyperledger_ed25519
       GIT_REPOSITORY ${URL}
       GIT_TAG        ${VERSION}
-      CMAKE_ARGS
-          -DEDIMPL=ref10
-          -DHASH=sha3_brainhub
-          -DRANDOM=dev_urandom
-
-          -DTESTING=OFF
-          -DBUILD_TESTING=OFF
-          -DBUILD=STATIC
-
-          -G${CMAKE_GENERATOR}
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-      BUILD_BYPRODUCTS
-          ${EP_PREFIX}/src/hyperledger_ed25519-build${XCODE_EXT}/${EDLIB}
+      CMAKE_ARGS     -DTESTING=OFF -DBUILD=STATIC
       INSTALL_COMMAND "" # remove install step
       TEST_COMMAND    "" # remove test step
       UPDATE_COMMAND  "" # remove update step
@@ -44,8 +27,9 @@ if (NOT ed25519_FOUND)
   externalproject_get_property(hyperledger_ed25519 binary_dir)
   externalproject_get_property(hyperledger_ed25519 source_dir)
   set(ed25519_INCLUDE_DIR ${source_dir}/include)
-  set(ed25519_LIBRARY     ${binary_dir}${XCODE_EXT}/${EDLIB})
+  set(ed25519_LIBRARY ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}ed25519${CMAKE_STATIC_LIBRARY_SUFFIX})
   file(MAKE_DIRECTORY ${ed25519_INCLUDE_DIR})
+  link_directories(${binary_dir})
 
   add_dependencies(ed25519 hyperledger_ed25519)
 endif ()
@@ -54,3 +38,7 @@ set_target_properties(ed25519 PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${ed25519_INCLUDE_DIR}
     IMPORTED_LOCATION ${ed25519_LIBRARY}
     )
+
+if(ENABLE_LIBS_PACKAGING)
+  add_install_step_for_lib(${ed25519_LIBRARY})
+endif()

--- a/cmake/Modules/Findgflags.cmake
+++ b/cmake/Modules/Findgflags.cmake
@@ -15,32 +15,19 @@ set(URL https://github.com/gflags/gflags.git)
 set(VERSION f8a0efe03aa69b3336d8e228b37d4ccb17324b88)
 set_target_description(gflags "Flag parsing engine" ${URL} ${VERSION})
 
-iroha_get_lib_name(GFLAGSLIB gflags STATIC)
 
 if (NOT gflags_FOUND)
   externalproject_add(gflags_gflags
-      GIT_REPOSITORY   ${URL}
-      GIT_TAG          ${VERSION}
-      CMAKE_ARGS
-          -G${CMAKE_GENERATOR}
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-      BUILD_BYPRODUCTS
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GFLAGSLIB}
-      INSTALL_COMMAND  "" # remove install step
-      TEST_COMMAND     "" # remove test step
-      UPDATE_COMMAND   "" # remove update step
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/gflags_gflags-build/lib/libgflags.a
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(gflags_gflags binary_dir)
   set(gflags_INCLUDE_DIR ${binary_dir}/include)
-
-  set(gflags_LIBRARY ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GFLAGSLIB})
-
+  set(gflags_LIBRARY ${binary_dir}/lib/libgflags.a)
   file(MAKE_DIRECTORY ${gflags_INCLUDE_DIR})
 
   add_dependencies(gflags gflags_gflags)

--- a/cmake/Modules/Findgrpc.cmake
+++ b/cmake/Modules/Findgrpc.cmake
@@ -1,5 +1,6 @@
 add_library(grpc UNKNOWN IMPORTED)
 add_library(grpc++ UNKNOWN IMPORTED)
+add_library(grpc++_reflection UNKNOWN IMPORTED)
 add_library(gpr UNKNOWN IMPORTED)
 add_executable(grpc_cpp_plugin IMPORTED)
 
@@ -12,6 +13,9 @@ mark_as_advanced(grpc_LIBRARY)
 find_library(grpc_grpc++_LIBRARY grpc++)
 mark_as_advanced(grpc_grpc++_LIBRARY)
 
+find_library(grpc_grpc++_reflection_LIBRARY grpc++_reflection)
+mark_as_advanced(grpc_grpc++_reflection_LIBRARY)
+
 find_library(gpr_LIBRARY gpr)
 mark_as_advanced(gpr_LIBRARY)
 
@@ -22,6 +26,7 @@ find_package_handle_standard_args(grpc DEFAULT_MSG
     grpc_LIBRARY
     grpc_INCLUDE_DIR
     gpr_LIBRARY
+    grpc_grpc++_reflection_LIBRARY
     grpc_CPP_PLUGIN
     )
 
@@ -29,52 +34,34 @@ set(URL https://github.com/grpc/grpc)
 set(VERSION bfcbad3b86c7912968dc8e64f2121c920dad4dfb)
 set_target_description(grpc "Remote Procedure Call library" ${URL} ${VERSION})
 
-iroha_get_lib_name(GPRLIB       gpr               SHARED)
-iroha_get_lib_name(GRPCLIB      grpc              SHARED)
-iroha_get_lib_name(GRPCPPLIB    grpc++            SHARED)
-
 if (NOT grpc_FOUND)
   find_package(Git REQUIRED)
   externalproject_add(grpc_grpc
       GIT_REPOSITORY ${URL}
       GIT_TAG        ${VERSION}
-      CMAKE_ARGS
-          -DgRPC_PROTOBUF_PROVIDER=package
-          -DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG
-          -DProtobuf_DIR=${EP_PREFIX}/src/google_protobuf-build/lib/cmake/protobuf
-          -DgRPC_ZLIB_PROVIDER=package
-          -DBUILD_SHARED_LIBS=ON
-          -G${CMAKE_GENERATOR}
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-      PATCH_COMMAND
-          ${GIT_EXECUTABLE} apply ${PROJECT_SOURCE_DIR}/patch/fix-protobuf-package-include.patch || true
-      BUILD_BYPRODUCTS
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/grpc_cpp_plugin
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GPRLIB}
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GRPCLIB}
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GRPCPPLIB}
+      CMAKE_ARGS -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG -DProtobuf_DIR=${EP_PREFIX}/src/google_protobuf-build/lib/cmake/protobuf -DgRPC_ZLIB_PROVIDER=package -DBUILD_SHARED_LIBS=ON
+      PATCH_COMMAND ${GIT_EXECUTABLE} apply ${PROJECT_SOURCE_DIR}/patch/fix-protobuf-package-include.patch || true
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/grpc_grpc-build/grpc_cpp_plugin
+                       ${EP_PREFIX}/src/grpc_grpc-build/${CMAKE_SHARED_LIBRARY_PREFIX}grpc${CMAKE_SHARED_LIBRARY_SUFFIX}
+                       ${EP_PREFIX}/src/grpc_grpc-build/${CMAKE_SHARED_LIBRARY_PREFIX}grpc++${CMAKE_SHARED_LIBRARY_SUFFIX}
+                       ${EP_PREFIX}/src/grpc_grpc-build/${CMAKE_SHARED_LIBRARY_PREFIX}grpc++_reflection${CMAKE_SHARED_LIBRARY_SUFFIX}
       INSTALL_COMMAND "" # remove install step
-      TEST_COMMAND    "" # remove test step
-      UPDATE_COMMAND  "" # remove update step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(grpc_grpc source_dir binary_dir)
-  set(grpc_INCLUDE_DIR               ${source_dir}/include)
-  set(gpr_LIBRARY                    ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GPRLIB})
-  set(grpc_LIBRARY                   ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GRPCLIB})
-  set(grpc_grpc++_LIBRARY            ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GRPCPPLIB})
-  set(grpc_CPP_PLUGIN                ${CMAKE_BINARY_DIR}${XCODE_EXT}/grpc_cpp_plugin)
-
+  set(grpc_INCLUDE_DIR ${source_dir}/include)
+  set(grpc_LIBRARY ${binary_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}grpc${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(grpc_grpc++_LIBRARY ${binary_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}grpc++${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(grpc_grpc++_reflection_LIBRARY ${binary_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}grpc++_reflection${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(grpc_CPP_PLUGIN ${binary_dir}/grpc_cpp_plugin)
   file(MAKE_DIRECTORY ${grpc_INCLUDE_DIR})
+  link_directories(${binary_dir})
 
   add_dependencies(grpc_grpc protobuf)
   add_dependencies(grpc grpc_grpc)
   add_dependencies(grpc++ grpc_grpc)
+  add_dependencies(grpc++_reflection grpc_grpc)
   add_dependencies(grpc_cpp_plugin grpc_grpc protoc)
 endif ()
 
@@ -90,6 +77,12 @@ set_target_properties(grpc++ PROPERTIES
     IMPORTED_LOCATION ${grpc_grpc++_LIBRARY}
     )
 
+set_target_properties(grpc++_reflection PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${grpc_INCLUDE_DIR}
+    INTERFACE_LINK_LIBRARIES grpc++
+    IMPORTED_LOCATION ${grpc_grpc++_reflection_LIBRARY}
+    )
+
 set_target_properties(grpc_cpp_plugin PROPERTIES
     IMPORTED_LOCATION ${grpc_CPP_PLUGIN}
     )
@@ -99,7 +92,7 @@ set_target_properties(gpr PROPERTIES
 	)
 
 if(ENABLE_LIBS_PACKAGING)
-  add_install_step_for_lib(${gpr_LIBRARY})
   add_install_step_for_lib(${grpc_LIBRARY})
   add_install_step_for_lib(${grpc_grpc++_LIBRARY})
+  add_install_step_for_lib(${gpr_LIBRARY})
 endif()

--- a/cmake/Modules/Findgtest.cmake
+++ b/cmake/Modules/Findgtest.cmake
@@ -33,44 +33,31 @@ set(VERSION ec44c6c1675c25b9827aacd08c02433cccde7780)
 set_target_description(gtest "Unit testing library" ${URL} ${VERSION})
 set_target_description(gmock "Mocking library" ${URL} ${VERSION})
 
-iroha_get_lib_name(GTESTMAINLIB gtest_main STATIC)
-iroha_get_lib_name(GTESTLIB     gtest      STATIC)
-iroha_get_lib_name(GMOCKMAINLIB gmock_main STATIC)
-iroha_get_lib_name(GMOCKLIB     gmock      STATIC)
-
 if (NOT gtest_FOUND)
   ExternalProject_Add(google_test
       GIT_REPOSITORY ${URL}
       GIT_TAG        ${VERSION}
-      CMAKE_ARGS
-          -Dgtest_force_shared_crt=ON
-          -Dgtest_disable_pthreads=OFF
-          -G${CMAKE_GENERATOR}
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-      BUILD_BYPRODUCTS
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GTESTMAINLIB}
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GTESTLIB}
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GMOCKMAINLIB}
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GMOCKLIB}
+      CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -Dgtest_force_shared_crt=ON
+      -Dgtest_disable_pthreads=OFF
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/google_test-build/googlemock/gtest/libgtest_main.a
+                       ${EP_PREFIX}/src/google_test-build/googlemock/gtest/libgtest.a
+                       ${EP_PREFIX}/src/google_test-build/googlemock/libgmock_main.a
+                       ${EP_PREFIX}/src/google_test-build/googlemock/libgmock.a
       INSTALL_COMMAND "" # remove install step
-      UPDATE_COMMAND  "" # remove update step
-      TEST_COMMAND    "" # remove test step
+      UPDATE_COMMAND "" # remove update step
+      TEST_COMMAND "" # remove test step
       )
   ExternalProject_Get_Property(google_test source_dir binary_dir)
   set(gtest_INCLUDE_DIR ${source_dir}/googletest/include)
   set(gmock_INCLUDE_DIR ${source_dir}/googlemock/include)
 
-  set(gtest_MAIN_LIBRARY ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GTESTMAINLIB})
-  set(gtest_LIBRARY      ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GTESTLIB})
+  set(gtest_MAIN_LIBRARY ${binary_dir}/googlemock/gtest/libgtest_main.a)
+  set(gtest_LIBRARY ${binary_dir}/googlemock/gtest/libgtest.a)
 
-  set(gmock_MAIN_LIBRARY ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GMOCKMAINLIB})
-  set(gmock_LIBRARY      ${CMAKE_BINARY_DIR}${XCODE_EXT}/${GMOCKLIB})
+  set(gmock_MAIN_LIBRARY ${binary_dir}/googlemock/libgmock_main.a)
+  set(gmock_LIBRARY ${binary_dir}/googlemock/libgmock.a)
 
   file(MAKE_DIRECTORY ${gtest_INCLUDE_DIR})
   file(MAKE_DIRECTORY ${gmock_INCLUDE_DIR})

--- a/cmake/Modules/Findoptional.cmake
+++ b/cmake/Modules/Findoptional.cmake
@@ -14,17 +14,17 @@ set_target_description(optional "Data structure for optional types" ${URL} ${VER
 
 if (NOT optional_FOUND)
   externalproject_add(martinmoene_optional
-      GIT_REPOSITORY    ${URL}
-      GIT_TAG           ${VERSION}
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
       CONFIGURE_COMMAND "" # remove configure step
-      BUILD_COMMAND     "" # remove build step
-      INSTALL_COMMAND   "" # remove install step
-      TEST_COMMAND      "" # remove test step
-      UPDATE_COMMAND    "" # remove update step
+      BUILD_COMMAND "" # remove build step
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(martinmoene_optional source_dir)
   set(optional_INCLUDE_DIR ${source_dir}/include)
-  file(MAKE_DIRECTORY      ${optional_INCLUDE_DIR})
+  file(MAKE_DIRECTORY ${optional_INCLUDE_DIR})
 
   add_dependencies(optional martinmoene_optional)
 endif ()

--- a/cmake/Modules/Findpq.cmake
+++ b/cmake/Modules/Findpq.cmake
@@ -25,33 +25,25 @@ set(URL https://git.postgresql.org/git/postgresql.git)
 set(VERSION 029386ccbddd0a33d481b94e511f5219b03e6636)
 set_target_description(pq "C postgres client library" ${URL} ${VERSION})
 
-iroha_get_lib_name(PQLIB pq STATIC)
 
 if (NOT pq_FOUND)
-  set(pqlib_path    ${EP_PREFIX}/src/postgres_postgres/src/interfaces/libpq/${PQLIB})
-  set(pqconfig_path ${EP_PREFIX}/src/postgres_postgres/src/bin/pq_config/pq_config)
-
   externalproject_add(postgres_postgres
       GIT_REPOSITORY  ${URL}
       GIT_TAG         ${VERSION}
-      CONFIGURE_COMMAND
-          ./configure --without-readline
+      CONFIGURE_COMMAND ./configure --without-readline
       BUILD_IN_SOURCE 1
-      BUILD_COMMAND
-          $(MAKE) -C ./src/bin/pg_config && $(MAKE) -C ./src/interfaces/libpq
-      BUILD_BYPRODUCTS
-          ${pqlib_path}
-          ${pqconfig_path}
+      BUILD_COMMAND $(MAKE) -C ./src/bin/pg_config && $(MAKE) -C ./src/interfaces/libpq
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/postgres_postgres/src/interfaces/libpq/libpq.a
       INSTALL_COMMAND "" # remove install step
-      TEST_COMMAND    "" # remove test step
-      UPDATE_COMMAND  "" # remove update step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(postgres_postgres source_dir)
   set(postgres_INCLUDE_DIR ${source_dir}/src/include)
-  set(pq_INCLUDE_DIR       ${source_dir}/src/interfaces/libpq)
-  set(pq_LIBRARY           ${pqlib_path})
-  set(pg_config_EXECUTABLE ${pqconfig_path})
-  file(MAKE_DIRECTORY      ${pq_INCLUDE_DIR} ${postgres_INCLUDE_DIR})
+  set(pq_INCLUDE_DIR ${source_dir}/src/interfaces/libpq)
+  set(pq_LIBRARY ${source_dir}/src/interfaces/libpq/libpq.a)
+  set(pg_config_EXECUTABLE ${source_dir}/src/bin/pg_config/pg_config)
+  file(MAKE_DIRECTORY ${pq_INCLUDE_DIR} ${postgres_INCLUDE_DIR})
 
   add_dependencies(pg_config postgres_postgres)
   add_dependencies(pq postgres_postgres pg_config)

--- a/cmake/Modules/Findpqxx.cmake
+++ b/cmake/Modules/Findpqxx.cmake
@@ -15,37 +15,27 @@ set(URL https://github.com/jtv/libpqxx.git)
 set(VERSION 5b17abce5ac2b1a2f8278718405b7ade8bb30ae9)
 set_target_description(pqxx "C++ bindings for postgres client library" ${URL} ${VERSION})
 
-iroha_get_lib_name(PQXX pqxx STATIC)
-
 if (NOT pqxx_FOUND)
   externalproject_add(jtv_libpqxx
       GIT_REPOSITORY ${URL}
       GIT_TAG        ${VERSION}
-      CONFIGURE_COMMAND
-          ${CMAKE_COMMAND} -E env
-          CPPFLAGS=-I${postgres_INCLUDE_DIR}
-          PG_CONFIG=${pg_config_EXECUTABLE}
-          ./configure
-          --disable-documentation
-          --with-postgres-include=${pq_INCLUDE_DIR}
-          --with-postgres-lib=${pq_INCLUDE_DIR}
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=${CMAKE_CXX_FLAGS} CPPFLAGS=-I${postgres_INCLUDE_DIR} PG_CONFIG=${pg_config_EXECUTABLE} ./configure --disable-documentation --with-postgres-include=${pq_INCLUDE_DIR} --with-postgres-lib=${pq_INCLUDE_DIR}
       BUILD_IN_SOURCE 1
       BUILD_COMMAND $(MAKE)
-      BUILD_BYPRODUCTS
-          ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/${PQXX}
-          ${EP_PREFIX}/src/jtv_libpqxx/src/libpqxx.la
-          ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.la
-          ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.lai
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.a
+                       ${EP_PREFIX}/src/jtv_libpqxx/src/libpqxx.la
+                       ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.la
+                       ${EP_PREFIX}/src/jtv_libpqxx/src/.libs/libpqxx.lai
       INSTALL_COMMAND "" # remove install step
-      TEST_COMMAND    "" # remove test step
-      UPDATE_COMMAND  "" # remove update step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(jtv_libpqxx source_dir)
   set(pqxx_INCLUDE_DIR ${source_dir}/include)
-  set(pqxx_LIBRARY     ${source_dir}/src/.libs/${PQXX})
-  file(MAKE_DIRECTORY  ${pqxx_INCLUDE_DIR})
+  set(pqxx_LIBRARY ${source_dir}/src/.libs/libpqxx.a)
+  file(MAKE_DIRECTORY ${pqxx_INCLUDE_DIR})
 
-  add_dependencies(jtv_libpqxx pq pg_config)
+  add_dependencies(jtv_libpqxx pq)
   add_dependencies(pqxx jtv_libpqxx)
 endif ()
 

--- a/cmake/Modules/Findprotobuf.cmake
+++ b/cmake/Modules/Findprotobuf.cmake
@@ -22,37 +22,23 @@ set(URL https://github.com/google/protobuf.git)
 set(VERSION 80a37e0782d2d702d52234b62dd4b9ec74fd2c95)
 set_target_description(protobuf "Protocol buffers library" ${URL} ${VERSION})
 
-iroha_get_lib_name(PROTOLIB protobuf SHARED)
-
 if (NOT protobuf_FOUND)
   externalproject_add(google_protobuf
       GIT_REPOSITORY  ${URL}
       GIT_TAG         ${VERSION}
-      CMAKE_ARGS
-          -G${CMAKE_GENERATOR}
-          -H${EP_PREFIX}/src/google_protobuf/cmake
-          -B${EP_PREFIX}/src/google_protobuf-build
-          -Dprotobuf_BUILD_TESTS=OFF
-          -Dprotobuf_BUILD_SHARED_LIBS=ON
-          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-          -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}
-      BUILD_BYPRODUCTS
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/protoc
-          ${CMAKE_BINARY_DIR}${XCODE_EXT}/${PROTOLIB}
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -H${EP_PREFIX}/src/google_protobuf/cmake -B${EP_PREFIX}/src/google_protobuf-build -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=ON
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/google_protobuf-build/protoc
+                       ${EP_PREFIX}/src/google_protobuf-build/${CMAKE_SHARED_LIBRARY_PREFIX}protobuf${CMAKE_SHARED_LIBRARY_SUFFIX}
       INSTALL_COMMAND ""
-      TEST_COMMAND    "" # remove test step
-      UPDATE_COMMAND  "" # remove update step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(google_protobuf source_dir binary_dir)
   set(protobuf_INCLUDE_DIR ${source_dir}/src)
-  set(protobuf_LIBRARY     ${CMAKE_BINARY_DIR}${XCODE_EXT}/${PROTOLIB})
-  set(protoc_EXECUTABLE    ${CMAKE_BINARY_DIR}${XCODE_EXT}/protoc)
-  file(MAKE_DIRECTORY      ${protobuf_INCLUDE_DIR})
+  set(protobuf_LIBRARY ${binary_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}protobuf${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(protoc_EXECUTABLE ${binary_dir}/protoc)
+  file(MAKE_DIRECTORY ${protobuf_INCLUDE_DIR})
+  link_directories(${binary_dir})
 
   add_dependencies(protoc google_protobuf)
   add_dependencies(protobuf google_protobuf protoc)

--- a/cmake/Modules/Findrapidjson.cmake
+++ b/cmake/Modules/Findrapidjson.cmake
@@ -13,13 +13,13 @@ set_target_description(rapidjson "JSON library" ${URL} ${VERSION})
 
 if (NOT rapidjson_FOUND)
   externalproject_add(miloyip_rapidjson
-      GIT_REPOSITORY    ${URL}
-      GIT_TAG           ${VERSION}
-      BUILD_COMMAND     "" # remove build step, header only lib
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
+      BUILD_COMMAND "" # remove build step, header only lib
       CONFIGURE_COMMAND "" # remove configure step
-      INSTALL_COMMAND   "" # remove install step
-      TEST_COMMAND      "" # remove test step
-      UPDATE_COMMAND    "" # remove update step
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(miloyip_rapidjson source_dir)
   set(rapidjson_INCLUDE_DIR "${source_dir}/include")

--- a/cmake/Modules/Findrxcpp.cmake
+++ b/cmake/Modules/Findrxcpp.cmake
@@ -15,13 +15,13 @@ set_target_description(rxcpp "Library for reactive programming" ${URL} ${VERSION
 
 if (NOT rxcpp_FOUND)
   externalproject_add(reactive_extensions_rxcpp
-      GIT_REPOSITORY    ${URL}
-      GIT_TAG           ${VERSION}
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
       CONFIGURE_COMMAND ""
-      BUILD_COMMAND     ""
-      INSTALL_COMMAND   "" # remove install step
-      UPDATE_COMMAND    "" # remove update step
-      TEST_COMMAND      "" # remove test step
+      BUILD_COMMAND ""
+      INSTALL_COMMAND "" # remove install step
+      UPDATE_COMMAND "" # remove update step
+      TEST_COMMAND "" # remove test step
       )
   externalproject_get_property(reactive_extensions_rxcpp source_dir)
   set(rxcpp_INCLUDE_DIR ${source_dir}/Rx/v2/src)

--- a/cmake/Modules/Findspdlog.cmake
+++ b/cmake/Modules/Findspdlog.cmake
@@ -15,13 +15,13 @@ set_target_description(spdlog "Logging library" ${URL} ${VERSION})
 
 if (NOT SPDLOG_FOUND)
   externalproject_add(gabime_spdlog
-      GIT_REPOSITORY    ${URL}
-      GIT_TAG           ${VERSION}
+      GIT_REPOSITORY  ${URL}
+      GIT_TAG         ${VERSION}
       CONFIGURE_COMMAND "" # remove configure step
-      BUILD_COMMAND     "" # remove build step
-      INSTALL_COMMAND   "" # remove install step
-      TEST_COMMAND      "" # remove test step
-      UPDATE_COMMAND    "" # remove update step
+      BUILD_COMMAND "" # remove build step
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   externalproject_get_property(gabime_spdlog source_dir)
   set(spdlog_INCLUDE_DIR ${source_dir}/include)

--- a/cmake/Modules/Findtbb.cmake
+++ b/cmake/Modules/Findtbb.cmake
@@ -16,37 +16,30 @@ set(URL https://github.com/01org/tbb.git)
 set(VERSION eb6336ad29450f2a64af5123ca1b9429ff6bc11d)
 set_target_description(tbb "Concurrent queue" ${URL} ${VERSION})
 
-iroha_get_lib_name(RLIB tbb       SHARED)
-iroha_get_lib_name(DLIB tbb_debug SHARED)
 
 if (NOT tbb_FOUND)
-  set(release_lib_path ${EP_PREFIX}/src/01org_tbb/build/build_release/${RLIB})
-  set(debug_lib_path   ${EP_PREFIX}/src/01org_tbb/build/build_debug/${DLIB})
-
   ExternalProject_Add(01org_tbb
-      GIT_REPOSITORY  ${URL}
-      GIT_TAG         ${VERSION}
+      GIT_REPOSITORY ${URL}
+      GIT_TAG        ${VERSION}
       BUILD_IN_SOURCE 1
-      BUILD_COMMAND
-          $(MAKE) info && $(MAKE) tbb_build_prefix=build
-      BUILD_BYPRODUCTS
-          ${release_lib_path}
-          ${debug_lib_path}
+      BUILD_COMMAND $(MAKE) tbb_build_prefix=build
+      BUILD_BYPRODUCTS ${EP_PREFIX}/src/01org_tbb/build/build_debug/${CMAKE_SHARED_LIBRARY_PREFIX}tbb_debug${CMAKE_SHARED_LIBRARY_SUFFIX}
+                       ${EP_PREFIX}/src/01org_tbb/build/build_release/${CMAKE_SHARED_LIBRARY_PREFIX}tbb${CMAKE_SHARED_LIBRARY_SUFFIX}
       CONFIGURE_COMMAND "" # remove configure step
-      INSTALL_COMMAND   "" # remove install step
-      TEST_COMMAND      "" # remove test step
-      UPDATE_COMMAND    "" # remove update step
+      INSTALL_COMMAND "" # remove install step
+      TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   ExternalProject_Get_Property(01org_tbb source_dir)
   set(tbb_INCLUDE_DIR ${source_dir}/include)
-
   if (CMAKE_BUILD_TYPE MATCHES Debug)
-    set(tbb_LIBRARY ${debug_lib_path})
+    set(tbb_LIBRARY ${source_dir}/build/build_debug/${CMAKE_SHARED_LIBRARY_PREFIX}tbb_debug${CMAKE_SHARED_LIBRARY_SUFFIX})
   else()
-    set(tbb_LIBRARY ${release_lib_path})
+    set(tbb_LIBRARY ${source_dir}/build/build_release/${CMAKE_SHARED_LIBRARY_PREFIX}tbb${CMAKE_SHARED_LIBRARY_SUFFIX})
   endif ()
-
   file(MAKE_DIRECTORY ${tbb_INCLUDE_DIR})
+  link_directories(${source_dir}/build/build_debug)
+  link_directories(${source_dir}/build/build_release)
 
   add_dependencies(tbb 01org_tbb)
 endif ()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -6,12 +6,6 @@ set_directory_properties(PROPERTIES
     EP_PREFIX ${EP_PREFIX}
     )
 
-if(CMAKE_GENERATOR MATCHES Xcode)
-  set(XCODE_EXT "/Debug")
-else()
-  set(XCODE_EXT "")
-endif()
-
 # Project dependencies.
 find_package(Threads REQUIRED)
 

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -130,21 +130,3 @@ macro(get_git_revision commit)
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
 endmacro()
-
-
-function(iroha_get_lib_name out lib type)
-  if(type STREQUAL "STATIC")
-    set(${out} ${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX} PARENT_SCOPE)
-  elseif(type STREQUAL "SHARED")
-    set(${out} ${CMAKE_SHARED_LIBRARY_PREFIX}${lib}${CMAKE_SHARED_LIBRARY_SUFFIX} PARENT_SCOPE)
-  else()
-    message(FATAL_ERROR "type can be either STATIC or SHARED")
-  endif()
-endfunction()
-
-
-function(JOIN VALUES GLUE OUTPUT)
-  string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
-  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
-  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
-endfunction()


### PR DESCRIPTION
.deb package build process is broken, since Circle CI is using shared library.