### PR TITLE
Move HashType and BlobType out of Hashable

### DIFF
--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -22,6 +22,7 @@
 
 #include "common/wrapper.hpp"
 #include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {
@@ -47,9 +48,8 @@ namespace iroha {
        * TODO 14/02/17 (@l4l) IR-960 rework method with returning result
        */
       virtual nonstd::optional<Wrapper<shared_model::interface::Block>>
-      retrieveBlock(
-          const shared_model::crypto::PublicKey &peer_pubkey,
-          const shared_model::interface::Block::HashType &block_hash) = 0;
+      retrieveBlock(const shared_model::crypto::PublicKey &peer_pubkey,
+                    const shared_model::interface::types::HashType &block_hash) = 0;
 
       virtual ~BlockLoader() = default;
     };

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -93,7 +93,7 @@ rxcpp::observable<Wrapper<Block>> BlockLoaderImpl::retrieveBlocks(
 }
 
 nonstd::optional<Wrapper<Block>> BlockLoaderImpl::retrieveBlock(
-    const PublicKey &peer_pubkey, const Block::HashType &block_hash) {
+    const PublicKey &peer_pubkey, const types::HashType &block_hash) {
   auto peer = findPeer(peer_pubkey);
   if (not peer.has_value()) {
     log_->error(kPeerNotFound);

--- a/irohad/network/impl/block_loader_impl.hpp
+++ b/irohad/network/impl/block_loader_impl.hpp
@@ -42,7 +42,7 @@ namespace iroha {
 
       nonstd::optional<Wrapper<shared_model::interface::Block>> retrieveBlock(
           const shared_model::crypto::PublicKey &peer_pubkey,
-          const shared_model::interface::Block::HashType &block_hash) override;
+          const shared_model::interface::types::HashType &block_hash) override;
 
      private:
       /**

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -53,7 +53,7 @@ namespace shared_model {
             }),
             blob_([this] { return makeBlob(*proto_); }),
             prev_hash_([this] {
-              return HashType(proto_->payload().prev_block_hash());
+              return interface::types::HashType(proto_->payload().prev_block_hash());
             }),
             signatures_([this] {
               interface::SignatureSetType sigs;
@@ -79,11 +79,11 @@ namespace shared_model {
         return payload_.height();
       }
 
-      const HashType &prevHash() const override {
+      const interface::types::HashType &prevHash() const override {
         return *prev_hash_;
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -112,8 +112,7 @@ namespace shared_model {
         return payload_.tx_number();
       }
 
-      const typename Hashable<Block, iroha::model::Block>::BlobType &payload()
-          const override {
+      const interface::types::BlobType &payload() const override {
         return *payload_blob_;
       }
 
@@ -123,10 +122,10 @@ namespace shared_model {
       using Lazy = detail::LazyInitializer<T>;
       const iroha::protocol::Block::Payload &payload_;
       const Lazy<std::vector<w<interface::Transaction>>> transactions_;
-      const Lazy<BlobType> blob_;
-      const Lazy<HashType> prev_hash_;
+      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::HashType> prev_hash_;
       const Lazy<interface::SignatureSetType> signatures_;
-      const Lazy<BlobType> payload_blob_;
+      const Lazy<interface::types::BlobType> payload_blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -39,19 +39,21 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "backend/protobuf/util.hpp"
 #include "commands.pb.h"
+#include "interfaces/common_objects/types.hpp"
 #include "utils/lazy_initializer.hpp"
 #include "utils/variant_deserializer.hpp"
 
 template <typename... T, typename Archive>
 auto loadCommand(Archive &&ar) {
   int which = ar.GetDescriptor()->FindFieldByNumber(ar.command_case())->index();
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::Command::CommandVariantType>(
-      std::forward<Archive>(ar), which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::Command::CommandVariantType>(
+          std::forward<Archive>(ar), which);
 }
 
 namespace shared_model {
   namespace proto {
+
     class Command final : public CopyableProto<interface::Command,
                                                iroha::protocol::Command,
                                                Command> {
@@ -103,7 +105,7 @@ namespace shared_model {
         return *variant_;
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -111,7 +113,7 @@ namespace shared_model {
       // lazy
       const LazyVariantType variant_;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/account.hpp
+++ b/shared_model/backend/protobuf/common_objects/account.hpp
@@ -56,7 +56,7 @@ namespace shared_model {
         return proto_->json_data();
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -64,7 +64,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/account_asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/account_asset.hpp
@@ -56,7 +56,7 @@ namespace shared_model {
         return *balance_;
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -66,7 +66,7 @@ namespace shared_model {
 
       const Lazy<Amount> balance_;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -61,7 +61,7 @@ namespace shared_model {
         return proto_->precision();
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -72,7 +72,7 @@ namespace shared_model {
 
       const Lazy<boost::multiprecision::uint256_t> multiprecision_repr_;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/asset.hpp
@@ -52,7 +52,7 @@ namespace shared_model {
         return proto_->precision();
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -60,7 +60,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/proposal.hpp
+++ b/shared_model/backend/protobuf/proposal.hpp
@@ -73,7 +73,7 @@ namespace shared_model {
         return proto_->height();
       }
 
-      const BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
@@ -83,7 +83,7 @@ namespace shared_model {
       using Lazy = detail::LazyInitializer<T>;
 
       const Lazy<TransactionContainer> transactions_;
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -120,15 +120,15 @@ namespace shared_model {
         return proto_->payload().query_counter();
       }
 
-      const Query::BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
-      const Query::BlobType &payload() const override {
+      const interface::types::BlobType &payload() const override {
         return *payload_;
       }
 
-      const HashType &hash() const override {
+      const interface::types::HashType &hash() const override {
         if (hash_ == boost::none) {
           hash_.emplace(HashProviderType::makeHash(payload()));
         }
@@ -161,8 +161,8 @@ namespace shared_model {
       // lazy
       const LazyVariantType variant_;
 
-      const Lazy<BlobType> blob_;
-      const Lazy<BlobType> payload_;
+      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> payload_;
       const Lazy<interface::SignatureSetType> signatures_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -74,9 +74,6 @@ namespace shared_model {
       /// list of types in variant
       using ProtoQueryResponseListType = ProtoQueryResponseVariantType::types;
 
-      /// Type of query hash
-      using QueryHashType = interface::Query::HashType;
-
       template <typename QueryResponseType>
       explicit QueryResponse(QueryResponseType &&queryResponse)
           : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
@@ -84,7 +81,7 @@ namespace shared_model {
               return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
             }),
             hash_([this] {
-              return QueryHashType(proto_->query_hash());
+              return interface::types::HashType(proto_->query_hash());
             }) {}
 
       QueryResponse(const QueryResponse &o) : QueryResponse(o.proto_) {}
@@ -96,13 +93,13 @@ namespace shared_model {
         return *variant_;
       }
 
-      const QueryHashType &queryHash() const override {
+      const interface::types::HashType &queryHash() const override {
         return *hash_;
       }
 
      private:
       const LazyVariantType variant_;
-      const Lazy<QueryHashType> hash_;
+      const Lazy<interface::types::HashType> hash_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -76,15 +76,15 @@ namespace shared_model {
         return *commands_;
       }
 
-      const Transaction::BlobType &blob() const override {
+      const interface::types::BlobType &blob() const override {
         return *blob_;
       }
 
-      const Transaction::BlobType &payload() const override {
+      const interface::types::BlobType &payload() const override {
         return *blobTypePayload_;
       }
 
-      const Transaction::HashType &hash() const override {
+      const interface::types::HashType &hash() const override {
         return *txhash_;
       }
 
@@ -117,13 +117,13 @@ namespace shared_model {
 
       const Lazy<CommandsType> commands_;
 
-      const Lazy<BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_;
 
-      const Lazy<BlobType> blobTypePayload_;
+      const Lazy<interface::types::BlobType> blobTypePayload_;
 
       const Lazy<interface::SignatureSetType> signatures_;
 
-      const Lazy<HashType> txhash_;
+      const Lazy<interface::types::HashType> txhash_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
+++ b/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
@@ -80,9 +80,9 @@ namespace shared_model {
       /**
        * @return hash of corresponding transaction
        */
-      const interface::Transaction::HashType &transactionHash() const override {
+      const interface::types::HashType &transactionHash() const override {
         return *hash_;
-      };
+      }
 
       /**
        * @return attached concrete tx response

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -29,13 +29,13 @@ namespace shared_model {
   namespace proto {
 
     /**
-       * Template query builder for creating new types of query builders by
-       * means of replacing template parameters
-       * @tparam S -- field counter for checking that all required fields are
+     * Template query builder for creating new types of query builders by
+     * means of replacing template parameters
+     * @tparam S -- field counter for checking that all required fields are
      * set
-       * @tparam SV -- stateless validator called when build method is invoked
-       * @tparam BT -- build type of built object returned by build method
-       */
+     * @tparam SV -- stateless validator called when build method is invoked
+     * @tparam BT -- build type of built object returned by build method
+     */
     template <int S = 0,
               typename SV = validation::DefaultQueryValidator,
               typename BT = UnsignedWrapper<Query>>

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -28,17 +28,20 @@
 namespace shared_model {
   namespace proto {
 
-  /**
-     * Template query builder for creating new types of query builders by
-     * means of replacing template parameters
-     * @tparam S -- field counter for checking that all required fields are set
-     * @tparam SV -- stateless validator called when build method is invoked
-     * @tparam BT -- build type of built object returned by build method
-     */
-    template <int S = 0, typename SV = validation::DefaultQueryValidator, typename BT = UnsignedWrapper<Query>>
+    /**
+       * Template query builder for creating new types of query builders by
+       * means of replacing template parameters
+       * @tparam S -- field counter for checking that all required fields are
+     * set
+       * @tparam SV -- stateless validator called when build method is invoked
+       * @tparam BT -- build type of built object returned by build method
+       */
+    template <int S = 0,
+              typename SV = validation::DefaultQueryValidator,
+              typename BT = UnsignedWrapper<Query>>
     class TemplateQueryBuilder {
      private:
-      template <int, typename, typename >
+      template <int, typename, typename>
       friend class TemplateQueryBuilder;
 
       enum RequiredFields {
@@ -190,8 +193,7 @@ namespace shared_model {
       }
 
       auto getTransactions(
-          std::initializer_list<interface::Transaction::HashType> hashes)
-          const {
+          std::initializer_list<interface::types::HashType> hashes) const {
         return getTransactions(hashes);
       }
 

--- a/shared_model/cryptography/hash_providers/sha3_256.hpp
+++ b/shared_model/cryptography/hash_providers/sha3_256.hpp
@@ -20,6 +20,7 @@
 
 #include "common/types.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
+#include "cryptography/hash.hpp"
 
 namespace shared_model {
   namespace crypto {

--- a/shared_model/interfaces/base/hashable.hpp
+++ b/shared_model/interfaces/base/hashable.hpp
@@ -20,9 +20,9 @@
 
 #include <boost/optional.hpp>
 
-#include "interfaces/common_objects/types.hpp"
 #include "cryptography/hash_providers/sha3_256.hpp"
 #include "interfaces/base/primitive.hpp"
+#include "interfaces/common_objects/types.hpp"
 #include "utils/lazy_initializer.hpp"
 
 #ifdef DISABLE_BACKWARD

--- a/shared_model/interfaces/base/hashable.hpp
+++ b/shared_model/interfaces/base/hashable.hpp
@@ -19,7 +19,8 @@
 #define IROHA_HASHABLE_HPP
 
 #include <boost/optional.hpp>
-#include "cryptography/hash.hpp"
+
+#include "interfaces/common_objects/types.hpp"
 #include "cryptography/hash_providers/sha3_256.hpp"
 #include "interfaces/base/primitive.hpp"
 #include "utils/lazy_initializer.hpp"
@@ -45,17 +46,12 @@ namespace shared_model {
 #endif
     {
      public:
-      /// Type of hash
-      using HashType = crypto::Hash;
-
-      using BlobType = crypto::Blob;
-
       using HashProviderType = HashProvider;
 
       /**
        * @return hash of object.
        */
-      virtual const HashType &hash() const {
+      virtual const types::HashType &hash() const {
         if (hash_ == boost::none) {
           hash_.emplace(HashProvider::makeHash(blob()));
         }
@@ -65,7 +61,7 @@ namespace shared_model {
       /**
        * @return blob representation of object
        */
-      virtual const BlobType &blob() const = 0;
+      virtual const types::BlobType &blob() const = 0;
 
       /**
        * Overriding operator== with equality hash semantics:
@@ -78,7 +74,7 @@ namespace shared_model {
       }
 
      protected:
-      mutable boost::optional<HashType> hash_;
+      mutable boost::optional<types::HashType> hash_;
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -20,11 +20,11 @@
 
 #include <boost/functional/hash.hpp>
 #include "interfaces/base/hashable.hpp"
+#include "interfaces/common_objects/signable_hash.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "utils/polymorphic_wrapper.hpp"
 #include "utils/string_builder.hpp"
-#include "interfaces/common_objects/signable_hash.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -50,7 +50,6 @@ namespace shared_model {
     class Signable : public Hashable<Model> {
 #endif
      public:
-
       /**
        * @return attached signatures
        */
@@ -68,15 +67,10 @@ namespace shared_model {
        */
       virtual types::TimestampType createdTime() const = 0;
 
-/**
- * @return object payload (everything except signatures)
- */
-#ifndef DISABLE_BACKWARD
-      virtual const typename Hashable<Model, OldModel>::BlobType &payload()
-#else
-      virtual const typename Hashable<Model>::BlobType &payload()
-#endif
-          const = 0;
+      /**
+       * @return object payload (everything except signatures)
+       */
+      virtual const types::BlobType &payload() const = 0;
 
       /**
        * Provides comparison based on equality of objects and signatures.

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -19,6 +19,7 @@
 #define IROHA_SIGNABLE_HPP
 
 #include <boost/functional/hash.hpp>
+
 #include "interfaces/base/hashable.hpp"
 #include "interfaces/common_objects/signable_hash.hpp"
 #include "interfaces/common_objects/signature.hpp"

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -22,14 +22,20 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "utils/polymorphic_wrapper.hpp"
+#include "cryptography/hash.hpp"
 
 namespace shared_model {
 
   namespace interface {
     namespace types {
+      /// Type of hash
+      using HashType = crypto::Hash;
+      /// Blob type
+      using BlobType = crypto::Blob;
       /// Type of account id
       using AccountIdType = std::string;
       /// Type of precision

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -23,10 +23,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cryptography/hash.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "utils/polymorphic_wrapper.hpp"
-#include "cryptography/hash.hpp"
 
 namespace shared_model {
 

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -43,7 +43,7 @@ namespace shared_model {
       /**
        * @return hash of a previous block
        */
-      virtual const HashType &prevHash() const = 0;
+      virtual const types::HashType &prevHash() const = 0;
 
       /// Type of a number of transactions in block
       using TransactionsNumberType = uint16_t;

--- a/shared_model/interfaces/queries/get_transactions.hpp
+++ b/shared_model/interfaces/queries/get_transactions.hpp
@@ -33,7 +33,7 @@ namespace shared_model {
     class GetTransactions : public PRIMITIVE(GetTransactions) {
      public:
       /// type of hashes collection
-      using TransactionHashesType = std::vector<Transaction::HashType>;
+      using TransactionHashesType = std::vector<interface::types::HashType>;
 
       /**
        * @return Hashes of transactions to fetch

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -71,7 +71,7 @@ namespace shared_model {
       /**
        * @return hash of corresponding query
        */
-      virtual const Query::HashType &queryHash() const = 0;
+      virtual const interface::types::HashType &queryHash() const = 0;
 
       // ------------------------| Primitive override |-------------------------
 

--- a/shared_model/interfaces/transaction_responses/tx_response.hpp
+++ b/shared_model/interfaces/transaction_responses/tx_response.hpp
@@ -60,7 +60,7 @@ namespace shared_model {
       /**
        * @return hash of corresponding transaction
        */
-      virtual const Transaction::HashType &transactionHash() const = 0;
+      virtual const interface::types::HashType &transactionHash() const = 0;
 
       /**
        * @return attached concrete tx response

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -44,7 +44,7 @@ namespace iroha {
       MOCK_METHOD2(retrieveBlock,
                    nonstd::optional<Wrapper<shared_model::interface::Block>>(
                        const shared_model::crypto::PublicKey &,
-                       const shared_model::interface::Block::HashType &));
+                       const shared_model::interface::types::HashType &));
     };
 
     class MockOrderingGate : public OrderingGate {


### PR DESCRIPTION
Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Move `HashType` and `BlobType` from `Hashable` to `common_objects/types.hpp`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Because Hashable is a template, you need weird constructions like https://github.com/hyperledger/iroha/pull/1022/files#diff-f5da1abc9499e5ab936bf6172f85dbb6L71 to actually access the type. Also, what if you want to access this type from some other type, which does not have Hashable as its base class? You simply can't.

Now you can just include header and use it.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None.

