### PR TITLE
Fix naming for propagateTransaction in ordering gate

### DIFF
--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -29,7 +29,7 @@ namespace iroha {
     void PeerCommunicationServiceImpl::propagate_transaction(
         std::shared_ptr<const model::Transaction> transaction) {
       log_->info("propagate tx");
-      ordering_gate_->propagate_transaction(transaction);
+      ordering_gate_->propagateTransaction(transaction);
     }
 
     rxcpp::observable<model::Proposal>

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -34,7 +34,7 @@ namespace iroha {
        * Propagate a signed transaction for further processing
        * @param transaction
        */
-      virtual void propagate_transaction(
+      virtual void propagateTransaction(
           std::shared_ptr<const model::Transaction> transaction) = 0;
 
       /**

--- a/irohad/network/ordering_gate_transport.hpp
+++ b/irohad/network/ordering_gate_transport.hpp
@@ -57,7 +57,7 @@ namespace iroha {
        * Propagates transaction over network
        * @param transaction : transaction to be propagated
        */
-      virtual void propagate_transaction(
+      virtual void propagateTransaction(
           std::shared_ptr<const model::Transaction> transaction) = 0;
 
       virtual ~OrderingGateTransport() = default;

--- a/irohad/ordering/impl/ordering_gate_impl.cpp
+++ b/irohad/ordering/impl/ordering_gate_impl.cpp
@@ -24,13 +24,13 @@ namespace iroha {
         std::shared_ptr<iroha::network::OrderingGateTransport> transport)
         : transport_(transport), log_(logger::log("OrderingGate")) {}
 
-    void OrderingGateImpl::propagate_transaction(
+    void OrderingGateImpl::propagateTransaction(
         std::shared_ptr<const model::Transaction> transaction) {
       log_->info("propagate tx, tx_counter: "
                  + std::to_string(transaction->tx_counter)
                  + " account_id: " + transaction->creator_account_id);
 
-      transport_->propagate_transaction(transaction);
+      transport_->propagateTransaction(transaction);
     }
 
     rxcpp::observable<model::Proposal> OrderingGateImpl::on_proposal() {

--- a/irohad/ordering/impl/ordering_gate_impl.hpp
+++ b/irohad/ordering/impl/ordering_gate_impl.hpp
@@ -40,7 +40,7 @@ namespace iroha {
       explicit OrderingGateImpl(
           std::shared_ptr<iroha::network::OrderingGateTransport> transport);
 
-      void propagate_transaction(
+      void propagateTransaction(
           std::shared_ptr<const model::Transaction> transaction) override;
 
       rxcpp::observable<model::Proposal> on_proposal() override;

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -48,7 +48,7 @@ OrderingGateTransportGrpc::OrderingGateTransportGrpc(
           server_address, grpc::InsecureChannelCredentials()))),
       log_(logger::log("OrderingGate")) {}
 
-void OrderingGateTransportGrpc::propagate_transaction(
+void OrderingGateTransportGrpc::propagateTransaction(
     std::shared_ptr<const model::Transaction> transaction) {
   log_->info("Propagate tx (on transport)");
   auto call = new AsyncClientCall;

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
@@ -38,7 +38,7 @@ namespace iroha {
                               const protocol::Proposal *request,
                               ::google::protobuf::Empty *response) override;
 
-      void propagate_transaction(
+      void propagateTransaction(
           std::shared_ptr<const model::Transaction> transaction) override;
 
       void subscribe(std::shared_ptr<iroha::network::OrderingGateNotification>

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -49,7 +49,7 @@ namespace iroha {
 
     class MockOrderingGate : public OrderingGate {
      public:
-      MOCK_METHOD1(propagate_transaction,
+      MOCK_METHOD1(propagateTransaction,
                    void(std::shared_ptr<const model::Transaction> transaction));
 
       MOCK_METHOD0(on_proposal, rxcpp::observable<model::Proposal>());

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -99,7 +99,7 @@ class OrderingGateServiceTest : public ::testing::Test {
   void send_transaction(size_t i) {
     auto tx = std::make_shared<Transaction>();
     tx->tx_counter = i;
-    gate->propagate_transaction(tx);
+    gate->propagateTransaction(tx);
     // otherwise tx may come unordered
     std::this_thread::sleep_for(20ms);
   }

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -107,7 +107,7 @@ TEST_F(OrderingGateTest, TransactionReceivedByServerWhenSent) {
       }));
 
   for (size_t i = 0; i < 5; ++i) {
-    gate_impl->propagate_transaction(std::make_shared<Transaction>());
+    gate_impl->propagateTransaction(std::make_shared<Transaction>());
   }
 
   std::unique_lock<std::mutex> lock(m);


### PR DESCRIPTION
### Description of the Change
Fix of naming notation for ordering gate

### Benefits
Code cleanup.
