### PR TITLE
Refactor constructors in shared_model/protobuf

### DIFF
--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -108,10 +108,12 @@ namespace shared_model {
         return txs;
       }};
 
-      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
 
-      const Lazy<interface::types::HashType> prev_hash_{
-          [this] { return interface::types::HashType(proto_->payload().prev_block_hash()); }};
+      const Lazy<interface::types::HashType> prev_hash_{[this] {
+        return interface::types::HashType(proto_->payload().prev_block_hash());
+      }};
 
       const Lazy<interface::SignatureSetType> signatures_{[this] {
         interface::SignatureSetType sigs;
@@ -122,7 +124,8 @@ namespace shared_model {
         return sigs;
       }};
 
-      const Lazy<interface::types::BlobType> payload_blob_{[this] { return makeBlob(payload_); }};
+      const Lazy<interface::types::BlobType> payload_blob_{
+          [this] { return makeBlob(payload_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -41,31 +41,7 @@ namespace shared_model {
      public:
       template <class BlockType>
       explicit Block(BlockType &&block)
-          : CopyableProto(std::forward<BlockType>(block)),
-            payload_(proto_->payload()),
-            transactions_([this] {
-              std::vector<w<interface::Transaction>> txs;
-              for (const auto &tx : payload_.transactions()) {
-                auto tmp = detail::makePolymorphic<proto::Transaction>(tx);
-                txs.emplace_back(tmp);
-              }
-              return txs;
-            }),
-            blob_([this] { return makeBlob(*proto_); }),
-            prev_hash_([this] {
-              return interface::types::HashType(proto_->payload().prev_block_hash());
-            }),
-            signatures_([this] {
-              interface::SignatureSetType sigs;
-              for (const auto &sig : proto_->signatures()) {
-                auto curr = detail::makePolymorphic<proto::Signature>(sig);
-                sigs.insert(curr);
-              }
-              return sigs;
-            }),
-            payload_blob_([this] { return makeBlob(payload_); })
-
-      {}
+          : CopyableProto(std::forward<BlockType>(block)) {}
 
       Block(const Block &o) : Block(o.proto_) {}
 
@@ -120,12 +96,33 @@ namespace shared_model {
       // lazy
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
-      const iroha::protocol::Block::Payload &payload_;
-      const Lazy<std::vector<w<interface::Transaction>>> transactions_;
-      const Lazy<interface::types::BlobType> blob_;
-      const Lazy<interface::types::HashType> prev_hash_;
-      const Lazy<interface::SignatureSetType> signatures_;
-      const Lazy<interface::types::BlobType> payload_blob_;
+
+      const iroha::protocol::Block::Payload &payload_{proto_->payload()};
+
+      const Lazy<std::vector<w<interface::Transaction>>> transactions_{[this] {
+        std::vector<w<interface::Transaction>> txs;
+        for (const auto &tx : payload_.transactions()) {
+          auto tmp = detail::makePolymorphic<proto::Transaction>(tx);
+          txs.emplace_back(tmp);
+        }
+        return txs;
+      }};
+
+      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+
+      const Lazy<interface::types::HashType> prev_hash_{
+          [this] { return interface::types::HashType(proto_->payload().prev_block_hash()); }};
+
+      const Lazy<interface::SignatureSetType> signatures_{[this] {
+        interface::SignatureSetType sigs;
+        for (const auto &sig : proto_->signatures()) {
+          auto curr = detail::makePolymorphic<proto::Signature>(sig);
+          sigs.insert(curr);
+        }
+        return sigs;
+      }};
+
+      const Lazy<interface::types::BlobType> payload_blob_{[this] { return makeBlob(payload_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -35,11 +35,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit AddAssetQuantity(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            add_asset_quantity_(proto_->add_asset_quantity()),
-            amount_([this] {
-              return proto::Amount(add_asset_quantity_.amount());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       AddAssetQuantity(const AddAssetQuantity &o)
           : AddAssetQuantity(o.proto_) {}
@@ -64,9 +60,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::AddAssetQuantity &add_asset_quantity_;
+      const iroha::protocol::AddAssetQuantity &add_asset_quantity_{
+          proto_->add_asset_quantity()};
 
-      const Lazy<proto::Amount> amount_;
+      const Lazy<proto::Amount> amount_{
+          [this] { return proto::Amount(add_asset_quantity_.amount()); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_add_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_peer.hpp
@@ -31,10 +31,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit AddPeer(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            add_peer_(proto_->add_peer()),
-            peer_([this] { return proto::Peer(add_peer_.peer()); }) {}
-
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       AddPeer(const AddPeer &o) : AddPeer(o.proto_) {}
 
@@ -49,8 +46,9 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const iroha::protocol::AddPeer &add_peer_;
-      const Lazy<proto::Peer> peer_;
+      const iroha::protocol::AddPeer &add_peer_{proto_->add_peer()};
+      const Lazy<proto::Peer> peer_{
+          [this] { return proto::Peer(add_peer_.peer()); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
@@ -28,11 +28,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit AddSignatory(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            add_signatory_(proto_->add_signatory()),
-            pubkey_([this] {
-              return interface::types::PubkeyType(add_signatory_.public_key());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       AddSignatory(const AddSignatory &o) : AddSignatory(o.proto_) {}
 
@@ -52,9 +48,12 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const iroha::protocol::AddSignatory &add_signatory_;
+      const iroha::protocol::AddSignatory &add_signatory_{
+          proto_->add_signatory()};
 
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const Lazy<interface::types::PubkeyType> pubkey_{[this] {
+        return interface::types::PubkeyType(add_signatory_.public_key());
+      }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_append_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_append_role.hpp
@@ -29,8 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit AppendRole(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            append_role_(proto_->append_role()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       AppendRole(const AppendRole &o) : AppendRole(o.proto_) {}
 
@@ -45,7 +44,7 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::AppendRole &append_role_;
+      const iroha::protocol::AppendRole &append_role_{proto_->append_role()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -92,10 +92,7 @@ namespace shared_model {
 
       template <typename CommandType>
       explicit Command(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            variant_(
-                [this] { return loadCommand<ProtoCommandListType>(*proto_); }),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       Command(const Command &o) : Command(o.proto_) {}
 
@@ -111,9 +108,11 @@ namespace shared_model {
 
      private:
       // lazy
-      const LazyVariantType variant_;
+      const LazyVariantType variant_{
+          [this] { return loadCommand<ProtoCommandListType>(*proto_); }};
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_create_account.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_account.hpp
@@ -29,12 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit CreateAccount(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            create_account_(proto_->create_account()),
-            pubkey_([this] {
-              return interface::types::PubkeyType(
-                  create_account_.main_pubkey());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       CreateAccount(const CreateAccount &o) : CreateAccount(o.proto_) {}
 
@@ -58,8 +53,12 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const iroha::protocol::CreateAccount &create_account_;
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const iroha::protocol::CreateAccount &create_account_{
+          proto_->create_account()};
+
+      const Lazy<interface::types::PubkeyType> pubkey_{[this] {
+        return interface::types::PubkeyType(create_account_.main_pubkey());
+      }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_asset.hpp
@@ -29,14 +29,12 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit CreateAsset(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            create_asset_(proto_->create_asset()),
-            precision_([this] { return create_asset_.precision(); }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       CreateAsset(const CreateAsset &o) : CreateAsset(o.proto_) {}
 
-      CreateAsset(CreateAsset &&o) noexcept
-          : CreateAsset(std::move(o.proto_)) {}
+      CreateAsset(CreateAsset &&o) noexcept : CreateAsset(std::move(o.proto_)) {
+      }
 
       const interface::types::AssetNameType &assetName() const override {
         return create_asset_.asset_name();
@@ -54,8 +52,11 @@ namespace shared_model {
       // lazy
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
-      const iroha::protocol::CreateAsset &create_asset_;
-      const Lazy<PrecisionType> precision_;
+
+      const iroha::protocol::CreateAsset &create_asset_{proto_->create_asset()};
+
+      const Lazy<PrecisionType> precision_{
+          [this] { return create_asset_.precision(); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_domain.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_domain.hpp
@@ -29,8 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit CreateDomain(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            create_domain_(proto_->create_domain()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       CreateDomain(const CreateDomain &o) : CreateDomain(o.proto_) {}
 
@@ -46,7 +45,8 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::CreateDomain &create_domain_;
+      const iroha::protocol::CreateDomain &create_domain_{
+          proto_->create_domain()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_role.hpp
@@ -29,18 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit CreateRole(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            create_role_(proto_->create_role()),
-            role_permissions_([this] {
-              return boost::accumulate(
-                  create_role_.permissions(),
-                  PermissionsType{},
-                  [](auto &&acc, const auto &perm) {
-                    acc.insert(iroha::protocol::RolePermission_Name(
-                        static_cast<iroha::protocol::RolePermission>(perm)));
-                    return std::forward<decltype(acc)>(acc);
-                  });
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       CreateRole(const CreateRole &o) : CreateRole(o.proto_) {}
 
@@ -58,8 +47,19 @@ namespace shared_model {
       // lazy
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
-      const iroha::protocol::CreateRole &create_role_;
-      const Lazy<PermissionsType> role_permissions_;
+
+      const iroha::protocol::CreateRole &create_role_{proto_->create_role()};
+
+      const Lazy<PermissionsType> role_permissions_{[this] {
+        return boost::accumulate(
+            create_role_.permissions(),
+            PermissionsType{},
+            [](auto &&acc, const auto &perm) {
+              acc.insert(iroha::protocol::RolePermission_Name(
+                  static_cast<iroha::protocol::RolePermission>(perm)));
+              return std::forward<decltype(acc)>(acc);
+            });
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_detach_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_detach_role.hpp
@@ -29,8 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit DetachRole(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            detach_role_(proto_->detach_role()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       DetachRole(const DetachRole &o) : DetachRole(o.proto_) {}
 
@@ -45,7 +44,7 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::DetachRole &detach_role_;
+      const iroha::protocol::DetachRole &detach_role_{proto_->detach_role()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
@@ -30,8 +30,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit GrantPermission(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            grant_permission_(proto_->grant_permission()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       GrantPermission(const GrantPermission &o) : GrantPermission(o.proto_) {}
 
@@ -49,7 +48,8 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::GrantPermission &grant_permission_;
+      const iroha::protocol::GrantPermission &grant_permission_{
+          proto_->grant_permission()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
@@ -30,12 +30,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit RemoveSignatory(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            remove_signatory_(proto_->remove_sign()),
-            pubkey_([this] {
-              return interface::types::PubkeyType(
-                  remove_signatory_.public_key());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       RemoveSignatory(const RemoveSignatory &o) : RemoveSignatory(o.proto_) {}
 
@@ -55,9 +50,12 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const iroha::protocol::RemoveSignatory &remove_signatory_;
+      const iroha::protocol::RemoveSignatory &remove_signatory_{
+          proto_->remove_sign()};
 
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const Lazy<interface::types::PubkeyType> pubkey_{[this] {
+        return interface::types::PubkeyType(remove_signatory_.public_key());
+      }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
@@ -29,8 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit RevokePermission(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            revoke_permission_(proto_->revoke_permission()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       RevokePermission(const RevokePermission &o)
           : RevokePermission(o.proto_) {}
@@ -49,7 +48,8 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::RevokePermission &revoke_permission_;
+      const iroha::protocol::RevokePermission &revoke_permission_{
+          proto_->revoke_permission()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
@@ -34,8 +34,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit SetAccountDetail(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            set_account_detail_(proto_->set_account_detail()) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       SetAccountDetail(const SetAccountDetail &o)
           : SetAccountDetail(o.proto_) {}
@@ -56,7 +55,8 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::SetAccountDetail &set_account_detail_;
+      const iroha::protocol::SetAccountDetail &set_account_detail_{
+          proto_->set_account_detail()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
@@ -28,9 +28,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit SetQuorum(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            set_quorum_(proto_->set_quorum()),
-            new_quorum_([this] { return set_quorum_.quorum(); }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       SetQuorum(const SetQuorum &o) : SetQuorum(o.proto_) {}
 
@@ -49,8 +47,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::SetAccountQuorum &set_quorum_;
-      const Lazy<const interface::types::QuorumType> new_quorum_;
+      const iroha::protocol::SetAccountQuorum &set_quorum_{
+          proto_->set_quorum()};
+
+      const Lazy<const interface::types::QuorumType> new_quorum_{
+          [this] { return set_quorum_.quorum(); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
@@ -35,11 +35,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit SubtractAssetQuantity(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            subtract_asset_quantity_(proto_->subtract_asset_quantity()),
-            amount_([this] {
-              return proto::Amount(subtract_asset_quantity_.amount());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       SubtractAssetQuantity(const SubtractAssetQuantity &o)
           : SubtractAssetQuantity(o.proto_) {}
@@ -64,9 +60,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::SubtractAssetQuantity &subtract_asset_quantity_;
+      const iroha::protocol::SubtractAssetQuantity &subtract_asset_quantity_{
+          proto_->subtract_asset_quantity()};
 
-      const Lazy<proto::Amount> amount_;
+      const Lazy<proto::Amount> amount_{
+          [this] { return proto::Amount(subtract_asset_quantity_.amount()); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
@@ -29,10 +29,7 @@ namespace shared_model {
      public:
       template <typename CommandType>
       explicit TransferAsset(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            transfer_asset_(proto_->transfer_asset()),
-            amount_(
-                [this] { return proto::Amount(transfer_asset_.amount()); }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}
 
       TransferAsset(const TransferAsset &o) : TransferAsset(o.proto_) {}
 
@@ -64,8 +61,11 @@ namespace shared_model {
       template <typename Value>
       using Lazy = detail::LazyInitializer<Value>;
 
-      const iroha::protocol::TransferAsset &transfer_asset_;
-      const Lazy<proto::Amount> amount_;
+      const iroha::protocol::TransferAsset &transfer_asset_{
+          proto_->transfer_asset()};
+
+      const Lazy<proto::Amount> amount_{
+          [this] { return proto::Amount(transfer_asset_.amount()); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/account.hpp
+++ b/shared_model/backend/protobuf/common_objects/account.hpp
@@ -33,8 +33,7 @@ namespace shared_model {
      public:
       template <typename AccountType>
       explicit Account(AccountType &&account)
-          : CopyableProto(std::forward<AccountType>(account)),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<AccountType>(account)) {}
 
       Account(const Account &o) : Account(o.proto_) {}
 
@@ -64,7 +63,8 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/account_asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/account_asset.hpp
@@ -35,9 +35,7 @@ namespace shared_model {
      public:
       template <typename AccountAssetType>
       explicit AccountAsset(AccountAssetType &&accountAssetType)
-          : CopyableProto(std::forward<AccountAssetType>(accountAssetType)),
-            balance_([this] { return Amount(proto_->balance()); }),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<AccountAssetType>(accountAssetType)) {}
 
       AccountAsset(const AccountAsset &o) : AccountAsset(o.proto_) {}
 
@@ -64,9 +62,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<Amount> balance_;
+      const Lazy<Amount> balance_{
+          [this] { return Amount(proto_->balance()); }};
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/account_asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/account_asset.hpp
@@ -62,8 +62,7 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<Amount> balance_{
-          [this] { return Amount(proto_->balance()); }};
+      const Lazy<Amount> balance_{[this] { return Amount(proto_->balance()); }};
 
       const Lazy<interface::types::BlobType> blob_{
           [this] { return makeBlob(*proto_); }};

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -71,7 +71,7 @@ namespace shared_model {
       }};
 
       const Lazy<interface::types::BlobType> blob_{
-        [this] { return makeBlob(*proto_); }};
+          [this] { return makeBlob(*proto_); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/amount.hpp
+++ b/shared_model/backend/protobuf/common_objects/amount.hpp
@@ -35,19 +35,7 @@ namespace shared_model {
      public:
       template <typename AmountType>
       explicit Amount(AmountType &&amount)
-          : CopyableProto(std::forward<AmountType>(amount)),
-            multiprecision_repr_([this] {
-              const auto offset = 64u;
-              auto times = 3u;
-              const auto &value = proto_->value();
-              boost::multiprecision::uint256_t result;
-              result |= value.first() << offset * times--;
-              result |= value.second() << offset * times--;
-              result |= value.third() << offset * times--;
-              result |= value.fourth() << offset * times--;
-              return result;
-            }),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<AmountType>(amount)) {}
 
       Amount(const Amount &o) : Amount(o.proto_) {}
 
@@ -70,9 +58,20 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<boost::multiprecision::uint256_t> multiprecision_repr_;
+      const Lazy<boost::multiprecision::uint256_t> multiprecision_repr_{[this] {
+        const auto offset = 64u;
+        auto times = 3u;
+        const auto &value = proto_->value();
+        boost::multiprecision::uint256_t result;
+        result |= value.first() << offset * times--;
+        result |= value.second() << offset * times--;
+        result |= value.third() << offset * times--;
+        result |= value.fourth() << offset * times--;
+        return result;
+      }};
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{
+        [this] { return makeBlob(*proto_); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/asset.hpp
@@ -33,8 +33,7 @@ namespace shared_model {
      public:
       template <typename AssetType>
       explicit Asset(AssetType &&account)
-          : CopyableProto(std::forward<AssetType>(account)),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<AssetType>(account)) {}
 
       Asset(const Asset &o) : Asset(o.proto_) {}
 
@@ -60,7 +59,8 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{
+        [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/asset.hpp
+++ b/shared_model/backend/protobuf/common_objects/asset.hpp
@@ -60,7 +60,7 @@ namespace shared_model {
       using Lazy = detail::LazyInitializer<T>;
 
       const Lazy<interface::types::BlobType> blob_{
-        [this] { return makeBlob(*proto_); }};
+          [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/peer.hpp
+++ b/shared_model/backend/protobuf/common_objects/peer.hpp
@@ -31,10 +31,7 @@ namespace shared_model {
      public:
       template <typename PeerType>
       explicit Peer(PeerType &&peer)
-          : CopyableProto(std::forward<PeerType>(peer)),
-            public_key_([this] {
-              return interface::types::PubkeyType(proto_->peer_key());
-            }) {}
+          : CopyableProto(std::forward<PeerType>(peer)) {}
 
       Peer(const Peer &o) : Peer(o.proto_) {}
 
@@ -53,7 +50,8 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<interface::types::PubkeyType> public_key_;
+      const Lazy<interface::types::PubkeyType> public_key_{
+          [this] { return interface::types::PubkeyType(proto_->peer_key()); }};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/signature.hpp
+++ b/shared_model/backend/protobuf/common_objects/signature.hpp
@@ -30,9 +30,7 @@ namespace shared_model {
      public:
       template <typename SignatureType>
       explicit Signature(SignatureType &&signature)
-          : CopyableProto(std::forward<SignatureType>(signature)),
-            public_key_([this] { return PublicKeyType(proto_->pubkey()); }),
-            signed_([this] { return SignedType(proto_->signature()); }) {}
+          : CopyableProto(std::forward<SignatureType>(signature)) {}
 
       Signature(const Signature &o) : Signature(o.proto_) {}
 
@@ -51,9 +49,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<PublicKeyType> public_key_;
+      const Lazy<PublicKeyType> public_key_{
+          [this] { return PublicKeyType(proto_->pubkey()); }};
 
-      const Lazy<SignedType> signed_;
+      const Lazy<SignedType> signed_{
+          [this] { return SignedType(proto_->signature()); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/from_old_model.hpp
+++ b/shared_model/backend/protobuf/from_old_model.hpp
@@ -24,8 +24,8 @@
 #include "backend/protobuf/block.hpp"
 #include "backend/protobuf/proposal.hpp"
 #include "backend/protobuf/queries/proto_query.hpp"
-#include "backend/protobuf/transaction.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/proposal.hpp"
 #include "model/converters/pb_block_factory.hpp"
 #include "model/converters/pb_query_factory.hpp"
@@ -68,8 +68,9 @@ namespace shared_model {
     inline static shared_model::proto::QueryResponse from_old(
         std::shared_ptr<iroha::model::QueryResponse> queryResponse) {
       auto sshash = queryResponse->query_hash.to_hexstring();
-      auto proto_resp = *iroha::model::converters::PbQueryResponseFactory().serialize(
-          queryResponse);
+      auto proto_resp =
+          *iroha::model::converters::PbQueryResponseFactory().serialize(
+              queryResponse);
       auto res = shared_model::proto::QueryResponse(std::move(proto_resp));
       auto hash = res.queryHash();
       return shared_model::proto::QueryResponse(

--- a/shared_model/backend/protobuf/impl.cpp
+++ b/shared_model/backend/protobuf/impl.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
+#include "backend/protobuf/block.hpp"
 #include "backend/protobuf/commands/proto_command.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
-#include "backend/protobuf/block.hpp"

--- a/shared_model/backend/protobuf/proposal.hpp
+++ b/shared_model/backend/protobuf/proposal.hpp
@@ -34,10 +34,9 @@
 namespace shared_model {
 
   namespace proto {
-    class Proposal final
-        : public CopyableProto<interface::Proposal,
-                               iroha::protocol::Proposal,
-                               Proposal> {
+    class Proposal final : public CopyableProto<interface::Proposal,
+                                                iroha::protocol::Proposal,
+                                                Proposal> {
       template <class T>
       using w = detail::PolymorphicWrapper<T>;
       using TransactionContainer = std::vector<w<interface::Transaction>>;
@@ -45,17 +44,7 @@ namespace shared_model {
      public:
       template <class ProposalType>
       explicit Proposal(ProposalType &&proposal)
-          : CopyableProto(std::forward<ProposalType>(proposal)),
-            transactions_([this] {
-              return boost::accumulate(
-                  proto_->transactions(),
-                  TransactionContainer{},
-                  [](auto &&vec, const auto &tx) {
-                    vec.emplace_back(new proto::Transaction(tx));
-                    return std::forward<decltype(vec)>(vec);
-                  });
-            }),
-            blob_([this] { return makeBlob(*proto_); }) {}
+          : CopyableProto(std::forward<ProposalType>(proposal)) {}
 
       Proposal(const Proposal &o) : Proposal(o.proto_) {}
 
@@ -82,8 +71,16 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const Lazy<TransactionContainer> transactions_;
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<TransactionContainer> transactions_{[this] {
+        return boost::accumulate(proto_->transactions(),
+                                 TransactionContainer{},
+                                 [](auto &&vec, const auto &tx) {
+                                   vec.emplace_back(new proto::Transaction(tx));
+                                   return std::forward<decltype(vec)>(vec);
+                                 });
+      }};
+
+      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/proposal.hpp
+++ b/shared_model/backend/protobuf/proposal.hpp
@@ -80,7 +80,8 @@ namespace shared_model {
                                  });
       }};
 
-      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_account.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account.hpp
@@ -44,7 +44,8 @@ namespace shared_model {
 
      private:
       // ------------------------------| fields |-------------------------------
-      const iroha::protocol::GetAccount &account_{proto_->payload().get_account()};
+      const iroha::protocol::GetAccount &account_{
+          proto_->payload().get_account()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account.hpp
@@ -32,8 +32,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAccount(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_(proto_->payload().get_account()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAccount(const GetAccount &o) : GetAccount(o.proto_) {}
 
@@ -45,7 +44,7 @@ namespace shared_model {
 
      private:
       // ------------------------------| fields |-------------------------------
-      const iroha::protocol::GetAccount &account_;
+      const iroha::protocol::GetAccount &account_{proto_->payload().get_account()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -33,9 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAccountAssetTransactions(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_asset_transactions_(
-                proto_->payload().get_account_asset_transactions()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAccountAssetTransactions(const GetAccountAssetTransactions &o)
           : GetAccountAssetTransactions(o.proto_) {}
@@ -55,7 +53,8 @@ namespace shared_model {
       // ------------------------------| fields |-------------------------------
 
       const iroha::protocol::GetAccountAssetTransactions
-          &account_asset_transactions_;
+          &account_asset_transactions_{
+              proto_->payload().get_account_asset_transactions()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
@@ -33,8 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAccountAssets(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_assets_(proto_->payload().get_account_assets()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAccountAssets(const GetAccountAssets &o)
           : GetAccountAssets(o.proto_) {}
@@ -53,7 +52,8 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
-      const iroha::protocol::GetAccountAssets &account_assets_;
+      const iroha::protocol::GetAccountAssets &account_assets_{
+          proto_->payload().get_account_assets()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
@@ -33,8 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAccountDetail(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_detail_(proto_->payload().get_account_detail()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAccountDetail(const GetAccountDetail &o)
           : GetAccountDetail(o.proto_) {}
@@ -53,7 +52,8 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
-      const iroha::protocol::GetAccountDetail &account_detail_;
+      const iroha::protocol::GetAccountDetail &account_detail_{
+          proto_->payload().get_account_detail()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
@@ -33,9 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAccountTransactions(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_transactions_(
-                proto_->payload().get_account_transactions()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAccountTransactions(const GetAccountTransactions &o)
           : GetAccountTransactions(o.proto_) {}
@@ -50,7 +48,8 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
-      const iroha::protocol::GetAccountTransactions &account_transactions_;
+      const iroha::protocol::GetAccountTransactions &account_transactions_{
+          proto_->payload().get_account_transactions()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
@@ -32,8 +32,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetAssetInfo(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            asset_info_(proto_->payload().get_asset_info()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetAssetInfo(const GetAssetInfo &o) : GetAssetInfo(o.proto_) {}
 
@@ -46,7 +45,8 @@ namespace shared_model {
 
      private:
       // ------------------------------| fields |-------------------------------
-      const iroha::protocol::GetAssetInfo &asset_info_;
+      const iroha::protocol::GetAssetInfo &asset_info_{
+          proto_->payload().get_asset_info()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
@@ -33,8 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetRolePermissions(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            role_permissions_(proto_->payload().get_role_permissions()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetRolePermissions(const GetRolePermissions &o)
           : GetRolePermissions(o.proto_) {}
@@ -48,7 +47,8 @@ namespace shared_model {
 
      private:
       // ------------------------------| fields |-------------------------------
-      const iroha::protocol::GetRolePermissions &role_permissions_;
+      const iroha::protocol::GetRolePermissions &role_permissions_{
+          proto_->payload().get_role_permissions()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
@@ -32,8 +32,7 @@ namespace shared_model {
      public:
       template <typename QueryType>
       explicit GetSignatories(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            account_signatories_(proto_->payload().get_account_signatories()) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       GetSignatories(const GetSignatories &o) : GetSignatories(o.proto_) {}
 
@@ -47,7 +46,8 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
-      const iroha::protocol::GetSignatories &account_signatories_;
+      const iroha::protocol::GetSignatories &account_signatories_{
+          proto_->payload().get_account_signatories()};
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -152,7 +152,8 @@ namespace shared_model {
       const LazyVariantType variant_{
           [this] { return loadQuery<ProtoQueryListType>(*proto_); }};
 
-      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
 
       const Lazy<interface::types::BlobType> payload_{
           [this] { return makeBlob(proto_->payload()); }};

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -52,9 +52,9 @@ shared_model::interface::Query::QueryVariantType loadQuery(Archive &&ar) {
                   .GetDescriptor()
                   ->FindFieldByNumber(ar.payload().query_case())
                   ->index_in_oneof();
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::Query::QueryVariantType>(
-      std::forward<Archive>(ar), which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::Query::QueryVariantType>(
+          std::forward<Archive>(ar), which);
 }
 
 namespace shared_model {
@@ -92,17 +92,7 @@ namespace shared_model {
 
       template <typename QueryType>
       explicit Query(QueryType &&query)
-          : CopyableProto(std::forward<QueryType>(query)),
-            variant_([this] { return loadQuery<ProtoQueryListType>(*proto_); }),
-            blob_([this] { return makeBlob(*proto_); }),
-            payload_([this] { return makeBlob(proto_->payload()); }),
-            signatures_([this] {
-              interface::SignatureSetType set;
-              if (proto_->has_signature()) {
-                set.emplace(new Signature(proto_->signature()));
-              }
-              return set;
-            }) {}
+          : CopyableProto(std::forward<QueryType>(query)) {}
 
       Query(const Query &o) : Query(o.proto_) {}
 
@@ -159,11 +149,21 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
       // lazy
-      const LazyVariantType variant_;
+      const LazyVariantType variant_{
+          [this] { return loadQuery<ProtoQueryListType>(*proto_); }};
 
-      const Lazy<interface::types::BlobType> blob_;
-      const Lazy<interface::types::BlobType> payload_;
-      const Lazy<interface::SignatureSetType> signatures_;
+      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+
+      const Lazy<interface::types::BlobType> payload_{
+          [this] { return makeBlob(proto_->payload()); }};
+
+      const Lazy<interface::SignatureSetType> signatures_{[this] {
+        interface::SignatureSetType set;
+        if (proto_->has_signature()) {
+          set.emplace(new Signature(proto_->signature()));
+        }
+        return set;
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -34,11 +34,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit AccountAssetResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            accountAssetResponse_(proto_->account_assets_response()),
-            accountAsset_([this] {
-              return AccountAsset(accountAssetResponse_.account_asset());
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       AccountAssetResponse(const AccountAssetResponse &o)
           : AccountAssetResponse(o.proto_) {}
@@ -54,8 +50,12 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::AccountAssetResponse &accountAssetResponse_;
-      const Lazy<AccountAsset> accountAsset_;
+      const iroha::protocol::AccountAssetResponse &accountAssetResponse_{
+          proto_->account_assets_response()};
+
+      const Lazy<AccountAsset> accountAsset_{[this] {
+        return AccountAsset(accountAssetResponse_.account_asset());
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
@@ -34,8 +34,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit AccountDetailResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            account_detail_response_(proto_->account_detail_response()){}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       AccountDetailResponse(const AccountDetailResponse &o)
           : AccountDetailResponse(o.proto_) {}
@@ -48,7 +47,8 @@ namespace shared_model {
       }
 
      private:
-      const iroha::protocol::AccountDetailResponse &account_detail_response_;
+      const iroha::protocol::AccountDetailResponse &account_detail_response_{
+          proto_->account_detail_response()};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
@@ -34,9 +34,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit AssetResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            assetResponse_(proto_->asset_response()),
-            asset_([this] { return Asset(assetResponse_.asset()); }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       AssetResponse(const AssetResponse &o) : AssetResponse(o.proto_) {}
 
@@ -50,8 +48,11 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::AssetResponse &assetResponse_;
-      const Lazy<Asset> asset_;
+      const iroha::protocol::AssetResponse &assetResponse_{
+          proto_->asset_response()};
+
+      const Lazy<Asset> asset_{
+          [this] { return Asset(assetResponse_.asset()); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -33,9 +33,10 @@ auto loadErrorResponse(Archive &&ar) {
                        ->enum_type()
                        ->FindValueByNumber(ar.reason())
                        ->index();
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::ErrorQueryResponse::
-          QueryErrorResponseVariantType>(std::forward<Archive>(ar), which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::ErrorQueryResponse::
+                        QueryErrorResponseVariantType>(
+          std::forward<Archive>(ar), which);
 }
 
 namespace shared_model {
@@ -74,11 +75,7 @@ namespace shared_model {
 
       template <typename QueryResponseType>
       explicit ErrorQueryResponse(QueryResponseType &&response)
-          : CopyableProto(std::forward<QueryResponseType>(response)),
-            variant_([this] {
-              return loadErrorResponse<ProtoQueryErrorResponseListType>(
-                  proto_->error_response());
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(response)) {}
 
       ErrorQueryResponse(const ErrorQueryResponse &o)
           : ErrorQueryResponse(o.proto_) {}
@@ -91,7 +88,10 @@ namespace shared_model {
       }
 
      private:
-      const LazyVariantType variant_;
+      const LazyVariantType variant_{[this] {
+        return loadErrorResponse<ProtoQueryErrorResponseListType>(
+            proto_->error_response());
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -39,9 +39,10 @@ template <typename... T, typename Archive>
 auto loadQueryResponse(Archive &&ar) {
   int which =
       ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::QueryResponse::QueryResponseVariantType>(
-      std::forward<Archive>(ar), which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::QueryResponse::
+                        QueryResponseVariantType>(std::forward<Archive>(ar),
+                                                  which);
 }
 
 namespace shared_model {
@@ -76,13 +77,7 @@ namespace shared_model {
 
       template <typename QueryResponseType>
       explicit QueryResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            variant_([this] {
-              return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
-            }),
-            hash_([this] {
-              return interface::types::HashType(proto_->query_hash());
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       QueryResponse(const QueryResponse &o) : QueryResponse(o.proto_) {}
 
@@ -98,8 +93,12 @@ namespace shared_model {
       }
 
      private:
-      const LazyVariantType variant_;
-      const Lazy<interface::types::HashType> hash_;
+      const LazyVariantType variant_{[this] {
+        return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
+      }};
+
+      const Lazy<interface::types::HashType> hash_{
+          [this] { return interface::types::HashType(proto_->query_hash()); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
@@ -33,17 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit RolePermissionsResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            rolePermissionsResponse_(proto_->role_permissions_response()),
-            rolePermissions_([this] {
-              return boost::accumulate(
-                  rolePermissionsResponse_.permissions(),
-                  PermissionNameCollectionType{},
-                  [](auto &&permissions, const auto &permission) {
-                    permissions.emplace_back(permission);
-                    return std::move(permissions);
-                  });
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       RolePermissionsResponse(const RolePermissionsResponse &o)
           : RolePermissionsResponse(o.proto_) {}
@@ -59,8 +49,18 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::RolePermissionsResponse &rolePermissionsResponse_;
-      const Lazy<PermissionNameCollectionType> rolePermissions_;
+      const iroha::protocol::RolePermissionsResponse &rolePermissionsResponse_{
+          proto_->role_permissions_response()};
+
+      const Lazy<PermissionNameCollectionType> rolePermissions_{[this] {
+        return boost::accumulate(
+            rolePermissionsResponse_.permissions(),
+            PermissionNameCollectionType{},
+            [](auto &&permissions, const auto &permission) {
+              permissions.emplace_back(permission);
+              return std::move(permissions);
+            });
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
@@ -33,16 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit RolesResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            rolesResponse_(proto_->roles_response()),
-            roles_([this] {
-              return boost::accumulate(rolesResponse_.roles(),
-                                       RolesIdType{},
-                                       [](auto &&roles, const auto &role) {
-                                         roles.emplace_back(role);
-                                         return std::move(roles);
-                                       });
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       RolesResponse(const RolesResponse &o) : RolesResponse(o.proto_) {}
 
@@ -56,8 +47,17 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::RolesResponse &rolesResponse_;
-      const Lazy<RolesIdType> roles_;
+      const iroha::protocol::RolesResponse &rolesResponse_{
+          proto_->roles_response()};
+
+      const Lazy<RolesIdType> roles_{[this] {
+        return boost::accumulate(rolesResponse_.roles(),
+                                 RolesIdType{},
+                                 [](auto &&roles, const auto &role) {
+                                   roles.emplace_back(role);
+                                   return std::move(roles);
+                                 });
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
@@ -33,17 +33,7 @@ namespace shared_model {
      public:
       template <typename QueryResponseType>
       explicit SignatoriesResponse(QueryResponseType &&queryResponse)
-          : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-            signatoriesResponse_(proto_->signatories_response()),
-            keys_([this] {
-              return boost::accumulate(
-                  signatoriesResponse_.keys(),
-                  interface::types::PublicKeyCollectionType{},
-                  [](auto &&acc, const auto &key) {
-                    acc.emplace_back(new interface::types::PubkeyType(key));
-                    return std::move(acc);
-                  });
-            }) {}
+          : CopyableProto(std::forward<QueryResponseType>(queryResponse)) {}
 
       SignatoriesResponse(const SignatoriesResponse &o)
           : SignatoriesResponse(o.proto_) {}
@@ -59,8 +49,18 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::SignatoriesResponse &signatoriesResponse_;
-      const Lazy<interface::types::PublicKeyCollectionType> keys_;
+      const iroha::protocol::SignatoriesResponse &signatoriesResponse_{
+          proto_->signatories_response()};
+
+      const Lazy<interface::types::PublicKeyCollectionType> keys_{[this] {
+        return boost::accumulate(
+            signatoriesResponse_.keys(),
+            interface::types::PublicKeyCollectionType{},
+            [](auto &&acc, const auto &key) {
+              acc.emplace_back(new interface::types::PubkeyType(key));
+              return std::move(acc);
+            });
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -102,7 +102,8 @@ namespace shared_model {
                                  });
       }};
 
-      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
+      const Lazy<interface::types::BlobType> blob_{
+          [this] { return makeBlob(*proto_); }};
 
       const Lazy<interface::types::BlobType> blobTypePayload_{
           [this] { return makeBlob(payload_); }};

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -35,34 +35,12 @@ namespace shared_model {
      public:
       template <typename TransactionType>
       explicit Transaction(TransactionType &&transaction)
-          : CopyableProto(std::forward<TransactionType>(transaction)),
-            payload_(proto_->payload()),
-            commands_([this] {
-              return boost::accumulate(
-                  payload_.commands(),
-                  CommandsType{},
-                  [](auto &&acc, const auto &cmd) {
-                    acc.emplace_back(new Command(cmd));
-                    return std::forward<decltype(acc)>(acc);
-                  });
-            }),
-            blob_([this] { return makeBlob(*proto_); }),
-            blobTypePayload_([this] { return makeBlob(payload_); }),
-            signatures_([this] {
-              return boost::accumulate(
-                  proto_->signature(),
-                  interface::SignatureSetType{},
-                  [](auto &&acc, const auto &sig) {
-                    acc.emplace(new Signature(sig));
-                    return std::forward<decltype(acc)>(acc);
-                  });
-            }),
-            txhash_([this] { return HashProviderType::makeHash(payload()); }) {}
+          : CopyableProto(std::forward<TransactionType>(transaction)) {}
 
       Transaction(const Transaction &o) : Transaction(o.proto_) {}
 
-      Transaction(Transaction &&o) noexcept
-          : Transaction(std::move(o.proto_)) {}
+      Transaction(Transaction &&o) noexcept : Transaction(std::move(o.proto_)) {
+      }
 
       const interface::types::AccountIdType &creatorAccountId() const override {
         return payload_.creator_account_id();
@@ -113,17 +91,33 @@ namespace shared_model {
       template <typename T>
       using Lazy = detail::LazyInitializer<T>;
 
-      const iroha::protocol::Transaction::Payload &payload_;
+      const iroha::protocol::Transaction::Payload &payload_{proto_->payload()};
 
-      const Lazy<CommandsType> commands_;
+      const Lazy<CommandsType> commands_{[this] {
+        return boost::accumulate(payload_.commands(),
+                                 CommandsType{},
+                                 [](auto &&acc, const auto &cmd) {
+                                   acc.emplace_back(new Command(cmd));
+                                   return std::forward<decltype(acc)>(acc);
+                                 });
+      }};
 
-      const Lazy<interface::types::BlobType> blob_;
+      const Lazy<interface::types::BlobType> blob_{[this] { return makeBlob(*proto_); }};
 
-      const Lazy<interface::types::BlobType> blobTypePayload_;
+      const Lazy<interface::types::BlobType> blobTypePayload_{
+          [this] { return makeBlob(payload_); }};
 
-      const Lazy<interface::SignatureSetType> signatures_;
+      const Lazy<interface::SignatureSetType> signatures_{[this] {
+        return boost::accumulate(proto_->signature(),
+                                 interface::SignatureSetType{},
+                                 [](auto &&acc, const auto &sig) {
+                                   acc.emplace(new Signature(sig));
+                                   return std::forward<decltype(acc)>(acc);
+                                 });
+      }};
 
-      const Lazy<interface::types::HashType> txhash_;
+      const Lazy<interface::types::HashType> txhash_{
+          [this] { return HashProviderType::makeHash(payload()); }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
+++ b/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
@@ -32,9 +32,10 @@ auto loadTxResponse(Archive &&ar) {
                        ->index();
   constexpr unsigned last = boost::mpl::size<T...>::type::value - 1;
 
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::TransactionResponse::ResponseVariantType>(
-      std::forward<Archive>(ar), which > last ? last : which);
+  return shared_model::detail::variant_impl<T...>::
+      template load<shared_model::interface::TransactionResponse::
+                        ResponseVariantType>(std::forward<Archive>(ar),
+                                             which > last ? last : which);
 }
 
 namespace shared_model {
@@ -65,11 +66,7 @@ namespace shared_model {
 
       template <typename TxResponse>
       explicit TransactionResponse(TxResponse &&ref)
-          : CopyableProto(std::forward<TxResponse>(ref)),
-            variant_(detail::makeLazyInitializer([this] {
-              return loadTxResponse<ProtoResponseListType>(*proto_);
-            })),
-            hash_([this] { return crypto::Hash(this->proto_->tx_hash()); }) {}
+          : CopyableProto(std::forward<TxResponse>(ref)) {}
 
       TransactionResponse(const TransactionResponse &r)
           : TransactionResponse(r.proto_) {}
@@ -99,10 +96,12 @@ namespace shared_model {
       using LazyVariantType = Lazy<ResponseVariantType>;
 
       // lazy
-      const LazyVariantType variant_;
+      const LazyVariantType variant_{detail::makeLazyInitializer(
+          [this] { return loadTxResponse<ProtoResponseListType>(*proto_); })};
 
       // stub hash
-      const Lazy<crypto::Hash> hash_;
+      const Lazy<crypto::Hash> hash_{
+          [this] { return crypto::Hash(this->proto_->tx_hash()); }};
     };
   }  // namespace  proto
 }  // namespace shared_model


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Change all constructors in `shared_model/protobuf/*`:

```patch
       explicit AddAssetQuantity(CommandType &&command)
-          : CopyableProto(std::forward<CommandType>(command)),
-            add_asset_quantity_(proto_->add_asset_quantity()),
-            amount_([this] {
-              return proto::Amount(add_asset_quantity_.amount());
-            }) {}
+          : CopyableProto(std::forward<CommandType>(command)) {}

-      const iroha::protocol::AddAssetQuantity &add_asset_quantity_;
+      const iroha::protocol::AddAssetQuantity &add_asset_quantity_{
+          proto_->add_asset_quantity()};
 
-      const Lazy<proto::Amount> amount_;
+      const Lazy<proto::Amount> amount_{
+          [this] { return proto::Amount(add_asset_quantity_.amount()); }};
```

Because of the initialization order:
1) constructors of base classes
2) constructors of derived class
3) members 

It is better to move callbacks to lazy initializers as `non-static data member with initializer`.

It allows to make constructors simpler.

### Benefits

<!-- What benefits will be realized by the code change? -->

This allows me to remove templated constructors (https://soramitsu.atlassian.net/browse/IR-1020) in further optimizations.

All constructors in `shared_model/protobuf/*` now look like
```
template <typename CommandType>
explicit AddAssetQuantity(CommandType &&command)
: CopyableProto(std::forward<CommandType>(command)) {}
``` 

and they can  be easily changed to accept according protocol objects.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None.
