### PR TITLE
Remove poly wrapper from shared_model::validator

### DIFF
--- a/shared_model/builders/protobuf/builder_templates/block_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/block_template.hpp
@@ -123,12 +123,12 @@ namespace shared_model {
 
       BT build() {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-        auto answer = stateless_validator_.validate(
-            detail::makePolymorphic<Block>(block_));
+        auto result = Block(iroha::protocol::Block(block_));
+        auto answer = stateless_validator_.validate(result);
         if (answer.hasErrors()) {
           throw std::invalid_argument(answer.reason());
         }
-        return BT(Block(iroha::protocol::Block(block_)));
+        return BT(std::move(result));
       }
 
       static const int total = RequiredFields::TOTAL;

--- a/shared_model/builders/protobuf/builder_templates/proposal_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/proposal_template.hpp
@@ -92,12 +92,12 @@ namespace shared_model {
 
       Proposal build() {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-        auto answer = stateless_validator_.validate(
-            detail::makePolymorphic<Proposal>(proposal_));
+        auto result = Proposal(iroha::protocol::Proposal(proposal_));
+        auto answer = stateless_validator_.validate(result);
         if (answer.hasErrors()) {
           throw std::invalid_argument(answer.reason());
         }
-        return Proposal(iroha::protocol::Proposal(proposal_));
+        return result;
       }
 
       static const int total = RequiredFields::TOTAL;

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -204,12 +204,12 @@ namespace shared_model {
 
       auto build() const {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-        auto answer = stateless_validator_.validate(
-            detail::makePolymorphic<Query>(query_));
+        auto result = Query(iroha::protocol::Query(query_));
+        auto answer = stateless_validator_.validate(result);
         if (answer.hasErrors()) {
           throw std::invalid_argument(answer.reason());
         }
-        return BT(Query(iroha::protocol::Query(query_)));
+        return BT(std::move(result));
       }
 
       static const int total = RequiredFields::TOTAL;

--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -65,7 +65,8 @@ namespace shared_model {
       using ProtoCommand = iroha::protocol::Command;
 
       template <int Sp>
-      TemplateTransactionBuilder(const TemplateTransactionBuilder<Sp, SV, BT> &o)
+      TemplateTransactionBuilder(
+          const TemplateTransactionBuilder<Sp, SV, BT> &o)
           : transaction_(o.transaction_),
             stateless_validator_(o.stateless_validator_) {}
 
@@ -312,13 +313,12 @@ namespace shared_model {
 
       auto build() const {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
-
-        auto answer = stateless_validator_.validate(
-            detail::makePolymorphic<Transaction>(transaction_));
+        auto result = Transaction(iroha::protocol::Transaction(transaction_));
+        auto answer = stateless_validator_.validate(result);
         if (answer.hasErrors()) {
           throw std::invalid_argument(answer.reason());
         }
-        return BT(Transaction(iroha::protocol::Transaction(transaction_)));
+        return BT(std::move(result));
       }
 
       static const int total = RequiredFields::TOTAL;

--- a/shared_model/builders/protobuf/transport_builder.hpp
+++ b/shared_model/builders/protobuf/transport_builder.hpp
@@ -42,8 +42,8 @@ namespace shared_model {
        */
       iroha::expected::Result<T, std::string> build(
           typename T::TransportType transport) {
-        auto answer = stateless_validator_.validate(
-            detail::makePolymorphic<T>(transport));
+        auto result = T(transport);
+        auto answer = stateless_validator_.validate(result);
         if (answer.hasErrors()) {
           return iroha::expected::makeError(answer.reason());
         }

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -128,7 +128,7 @@ namespace shared_model {
       std::string hex_;
     };
 
-    static inline std::string toBinaryString(const Blob &b) {
+    static inline std::string   toBinaryString(const Blob &b) {
       return std::string(b.blob().begin(), b.blob().end());
     }
   }  // namespace crypto

--- a/shared_model/utils/polymorphic_wrapper.hpp
+++ b/shared_model/utils/polymorphic_wrapper.hpp
@@ -121,6 +121,22 @@ namespace shared_model {
         return ptr_.get();
       }
 
+      /**
+       * Mutable wrapped object
+       * @return pointer for wrapped object
+       */
+      WrappedType &operator*() {
+        return *ptr_;
+      }
+
+      /**
+       * Immutable wraped object
+       * @return pointer for wrapped object
+       */
+      const WrappedType &operator*() const {
+        return *ptr_;
+      }
+
      private:
       /// pointer with wrapped value
       std::shared_ptr<WrappedType> ptr_;

--- a/shared_model/validators/block_validator.hpp
+++ b/shared_model/validators/block_validator.hpp
@@ -20,9 +20,9 @@
 
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/iroha_internal/block.hpp"
 #include "utils/polymorphic_wrapper.hpp"
 #include "validators/answer.hpp"
-#include "interfaces/iroha_internal/block.hpp"
 
 // TODO 22/01/2018 x3medima17: write stateless validator IR-837
 
@@ -39,8 +39,7 @@ namespace shared_model {
        * @param block
        * @return Answer containing found error if any
        */
-      Answer validate(
-          detail::PolymorphicWrapper<interface::Block> block) const {
+      Answer validate(const interface::Block &block) const {
         return Answer();
       }
 

--- a/shared_model/validators/default_validator.hpp
+++ b/shared_model/validators/default_validator.hpp
@@ -36,14 +36,14 @@ namespace shared_model {
 
     using DefaultBlockValidator = BlockValidator;
 
-    using DefaultSignableTransactionValidator = SignableModelValidator<
-        DefaultTransactionValidator,
-        detail::PolymorphicWrapper<interface::Transaction>,
-        FieldValidator>;
+    using DefaultSignableTransactionValidator =
+        SignableModelValidator<DefaultTransactionValidator,
+                               const interface::Transaction &,
+                               FieldValidator>;
 
     using DefaultSignableQueryValidator =
         SignableModelValidator<DefaultQueryValidator,
-                               detail::PolymorphicWrapper<interface::Query>,
+                               const interface::Query &,
                                FieldValidator>;
 
   }  // namespace validation

--- a/shared_model/validators/proposal_validator.hpp
+++ b/shared_model/validators/proposal_validator.hpp
@@ -22,7 +22,6 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 #include "validators/answer.hpp"
 
 // TODO 22/01/2018 x3medima17: write stateless validator IR-836
@@ -37,8 +36,7 @@ namespace shared_model {
      private:
       void validateTransaction(
           ReasonsGroupType &reason,
-          const detail::PolymorphicWrapper<interface::Transaction> &transaction)
-          const {
+          const interface::Transaction &transaction) const {
         // TODO 22/01/2018 x3medima17: add stateless validator IR-837
       }
 
@@ -53,16 +51,15 @@ namespace shared_model {
        * @param proposal
        * @return Answer containing found error if any
        */
-      Answer validate(
-          detail::PolymorphicWrapper<interface::Proposal> prop) const {
+      Answer validate(const interface::Proposal &prop) const {
         Answer answer;
         // TODO 22/01/2018 x3medima17: add stateless validator IR-837
         ReasonsGroupType reason;
         reason.first = "Proposal";
 
-        validateHeight(reason, prop->height());
-        for (const auto &tx : prop->transactions()) {
-          validateTransaction(reason, tx);
+        validateHeight(reason, prop.height());
+        for (const auto &tx : prop.transactions()) {
+          validateTransaction(reason, *tx);
         }
         if (not reason.second.empty()) {
           answer.addReason(std::move(reason));

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -167,21 +167,21 @@ namespace shared_model {
        * @param qry - query to validate
        * @return Answer containing found error if any
        */
-      Answer validate(detail::PolymorphicWrapper<interface::Query> qry) const {
+      Answer validate(const interface::Query &qry) const {
         Answer answer;
         std::string qry_reason_name = "Query";
         ReasonsGroupType qry_reason(qry_reason_name, GroupedReasons());
 
         field_validator_.validateCreatorAccountId(qry_reason,
-                                                  qry->creatorAccountId());
-        field_validator_.validateCreatedTime(qry_reason, qry->createdTime());
-        field_validator_.validateCounter(qry_reason, qry->queryCounter());
+                                                  qry.creatorAccountId());
+        field_validator_.validateCreatedTime(qry_reason, qry.createdTime());
+        field_validator_.validateCounter(qry_reason, qry.queryCounter());
 
         if (not qry_reason.second.empty()) {
           answer.addReason(std::move(qry_reason));
         }
 
-        auto reason = boost::apply_visitor(query_field_validator_, qry->get());
+        auto reason = boost::apply_visitor(query_field_validator_, qry.get());
         if (not reason.second.empty()) {
           answer.addReason(std::move(reason));
         }

--- a/shared_model/validators/signable_validator.hpp
+++ b/shared_model/validators/signable_validator.hpp
@@ -33,7 +33,7 @@ namespace shared_model {
         std::string reason_name = "Signature";
         ReasonsGroupType reason(reason_name, GroupedReasons());
         FieldValidator().validateSignatures(
-            reason, model->signatures(), model->payload());
+            reason, model.signatures(), model.payload());
         if (not reason.second.empty()) {
           answer.addReason(std::move(reason));
         }

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -256,27 +256,26 @@ namespace shared_model {
        * @param tx - transaction to validate
        * @return Answer containing found error if any
        */
-      Answer validate(
-          detail::PolymorphicWrapper<interface::Transaction> tx) const {
+      Answer validate(const interface::Transaction &tx) const {
         Answer answer;
         std::string tx_reason_name = "Transaction";
         ReasonsGroupType tx_reason(tx_reason_name, GroupedReasons());
 
-        if (tx->commands().empty()) {
+        if (tx.commands().empty()) {
           tx_reason.second.push_back(
               "Transaction should contain at least one command");
         }
 
         field_validator_.validateCreatorAccountId(tx_reason,
-                                                  tx->creatorAccountId());
-        field_validator_.validateCreatedTime(tx_reason, tx->createdTime());
-        field_validator_.validateCounter(tx_reason, tx->transactionCounter());
+                                                  tx.creatorAccountId());
+        field_validator_.validateCreatedTime(tx_reason, tx.createdTime());
+        field_validator_.validateCounter(tx_reason, tx.transactionCounter());
 
         if (not tx_reason.second.empty()) {
           answer.addReason(std::move(tx_reason));
         }
 
-        for (const auto &command : tx->commands()) {
+        for (const auto &command : tx.commands()) {
           auto reason =
               boost::apply_visitor(command_validator_, command->get());
           if (not reason.second.empty()) {

--- a/test/module/shared_model/validators/query_validator_test.cpp
+++ b/test/module/shared_model/validators/query_validator_test.cpp
@@ -57,8 +57,8 @@ TEST_F(QueryValidatorTest, StatelessValidTest) {
         }
       },
       [&] {
-        auto answer = query_validator.validate(
-            detail::makePolymorphic<proto::Query>(qry));
+        auto result = proto::Query(iroha::protocol::Query(qry));
+        auto answer = query_validator.validate(result);
 
         ASSERT_FALSE(answer.hasErrors()) << answer.reason();
       });
@@ -88,8 +88,8 @@ TEST_F(QueryValidatorTest, StatelessInvalidTest) {
         // Note that no fields are set
       },
       [&] {
-        auto answer = query_validator.validate(
-            detail::makePolymorphic<proto::Query>(qry));
+        auto result = proto::Query(iroha::protocol::Query(qry));
+        auto answer = query_validator.validate(result);
 
         ASSERT_TRUE(answer.hasErrors());
       });

--- a/test/module/shared_model/validators/transaction_validator_test.cpp
+++ b/test/module/shared_model/validators/transaction_validator_test.cpp
@@ -52,8 +52,9 @@ TEST_F(TransactionValidatorTest, EmptyTransactionTest) {
   auto tx = generateEmptyTransaction();
   tx.mutable_payload()->set_created_time(created_time);
   shared_model::validation::DefaultTransactionValidator transaction_validator;
-  auto answer = transaction_validator.validate(
-      detail::makePolymorphic<proto::Transaction>(tx));
+  auto result = proto::Transaction(iroha::protocol::Transaction(tx));
+  auto answer =
+      transaction_validator.validate(result);
   ASSERT_EQ(answer.getReasonsMap().size(), 1);
 }
 
@@ -85,8 +86,9 @@ TEST_F(TransactionValidatorTest, StatelessValidTest) {
                    [] {});
 
   shared_model::validation::DefaultTransactionValidator transaction_validator;
-  auto answer = transaction_validator.validate(
-      detail::makePolymorphic<proto::Transaction>(tx));
+  auto result = proto::Transaction(iroha::protocol::Transaction(tx));
+  auto answer =
+      transaction_validator.validate(result);
 
   ASSERT_FALSE(answer.hasErrors()) << answer.reason();
 }
@@ -120,8 +122,9 @@ TEST_F(TransactionValidatorTest, StatelessInvalidTest) {
                    [] {});
 
   shared_model::validation::DefaultTransactionValidator transaction_validator;
-  auto answer = transaction_validator.validate(
-      detail::makePolymorphic<proto::Transaction>(tx));
+  auto result = proto::Transaction(iroha::protocol::Transaction(tx));
+  auto answer =
+      transaction_validator.validate(result);
 
   // in total there should be number_of_commands + 1 reasons of bad answer:
   // number_of_commands for each command + 1 for transaction metadata

--- a/test/module/shared_model/validators/validators.hpp
+++ b/test/module/shared_model/validators/validators.hpp
@@ -24,15 +24,15 @@
 namespace shared_model {
   namespace validation {
 
-  //TODO: kamilsa 01.02.2018 IR-873 Replace all these validators with mock classes
+    // TODO: kamilsa 01.02.2018 IR-873 Replace all these validators with mock
+    // classes
 
     /**
      * Tx validator which always returns answer with no errors.
      */
     class TransactionAlwaysValidValidator {
      public:
-      Answer validate(
-          detail::PolymorphicWrapper<interface::Transaction>) const {
+      Answer validate(const interface::Transaction &) const {
         return Answer();
       }
     };
@@ -42,7 +42,7 @@ namespace shared_model {
      */
     class QueryAlwaysValidValidator {
      public:
-      Answer validate(detail::PolymorphicWrapper<interface::Query>) const {
+      Answer validate(const interface::Query &) const {
         return Answer();
       }
     };


### PR DESCRIPTION
Signed-off-by: Moonraker <ssolonets@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Currently, validator interface requires `poly_wrapper` for command and query validation. This is a redundant and not convenient way for the interface.

The pr reworks interface of stateless validators for queries and commands with const ref.

### Benefits

no need to wrap object before passing

### Possible Drawbacks 

none