### PR TITLE
Queue in ordering gate

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -220,6 +220,9 @@ void Irohad::initPeerCommunicationService() {
   pcs->on_commit().subscribe(
       [this](auto) { log_->info("~~~~~~~~~| COMMIT =^._.^= |~~~~~~~~~ "); });
 
+  // complete initialization of ordering gate
+  ordering_gate->setPcs(*pcs);
+
   log_->info("[Init] => pcs");
 }
 

--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -36,7 +36,7 @@ namespace iroha {
     }
 
     rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
-    PeerCommunicationServiceImpl::on_proposal() {
+    PeerCommunicationServiceImpl::on_proposal() const {
       return ordering_gate_->on_proposal().map(
           [](auto prop) -> std::shared_ptr<shared_model::interface::Proposal> {
             return std::make_shared<shared_model::proto::Proposal>(
@@ -44,7 +44,7 @@ namespace iroha {
           });
     }
 
-    rxcpp::observable<Commit> PeerCommunicationServiceImpl::on_commit() {
+    rxcpp::observable<Commit> PeerCommunicationServiceImpl::on_commit() const {
       return synchronizer_->on_commit_chain().map([](auto commit) -> Commit {
         return commit.map(
             [](auto block) -> std::shared_ptr<shared_model::interface::Block> {

--- a/irohad/network/impl/peer_communication_service_impl.hpp
+++ b/irohad/network/impl/peer_communication_service_impl.hpp
@@ -37,9 +37,9 @@ namespace iroha {
               transaction) override;
 
       rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
-      on_proposal() override;
+      on_proposal() const override;
 
-      rxcpp::observable<Commit> on_commit() override;
+      rxcpp::observable<Commit> on_commit() const override;
 
      private:
       std::shared_ptr<OrderingGate> ordering_gate_;

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -21,6 +21,7 @@
 #include <rxcpp/rx-observable.hpp>
 #include "model/proposal.hpp"
 #include "model/transaction.hpp"
+#include "network/peer_communication_service.hpp"
 
 namespace iroha {
   namespace network {
@@ -42,6 +43,15 @@ namespace iroha {
        * @return observable with notifications
        */
       virtual rxcpp::observable<model::Proposal> on_proposal() = 0;
+
+      /**
+       * Set peer communication service for commit notification
+       * @param pcs - const reference for PeerCommunicationService
+       * design notes: pcs passed by const reference because of cyclic linking
+       * between OG and PCS in the implementation. Same reasons to move the pcs
+       * dependency not in ctor but make the setter method.
+       */
+      virtual void setPcs(const PeerCommunicationService &pcs) = 0;
 
       virtual ~OrderingGate() = default;
     };

--- a/irohad/network/peer_communication_service.hpp
+++ b/irohad/network/peer_communication_service.hpp
@@ -55,7 +55,7 @@ namespace iroha {
        */
       virtual rxcpp::observable<
           std::shared_ptr<shared_model::interface::Proposal>>
-      on_proposal() = 0;
+      on_proposal() const = 0;
 
       /**
        * Event is triggered when commit block arrives.
@@ -64,7 +64,7 @@ namespace iroha {
        * But there are scenarios when consensus provide many blocks, e.g.
        * on peer startup - peer will get all actual blocks.
        */
-      virtual rxcpp::observable<Commit> on_commit() = 0;
+      virtual rxcpp::observable<Commit> on_commit() const = 0;
 
       virtual ~PeerCommunicationService() = default;
     };

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -28,12 +28,16 @@ namespace iroha {
   namespace network {
     class MockPeerCommunicationService : public PeerCommunicationService {
      public:
-      MOCK_METHOD1(propagate_transaction,
-                   void(std::shared_ptr<const shared_model::interface::Transaction>));
+      MOCK_METHOD1(
+          propagate_transaction,
+          void(std::shared_ptr<const shared_model::interface::Transaction>));
 
-      MOCK_METHOD0(on_proposal, rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>());
+      MOCK_CONST_METHOD0(
+          on_proposal,
+          rxcpp::observable<
+              std::shared_ptr<shared_model::interface::Proposal>>());
 
-      MOCK_METHOD0(on_commit, rxcpp::observable<Commit>());
+      MOCK_CONST_METHOD0(on_commit, rxcpp::observable<Commit>());
     };
 
     class MockBlockLoader : public BlockLoader {
@@ -53,6 +57,8 @@ namespace iroha {
                    void(std::shared_ptr<const model::Transaction> transaction));
 
       MOCK_METHOD0(on_proposal, rxcpp::observable<model::Proposal>());
+
+      MOCK_METHOD1(setPcs, void(const PeerCommunicationService &));
     };
 
     class MockConsensusGate : public ConsensusGate {

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include <gtest/gtest.h>
+
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
 #include "builders/common_objects/peer_builder.hpp"
@@ -22,18 +24,23 @@
 #include "mock_ordering_service_persistent_state.hpp"
 #include "model/asset.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
+#include "module/irohad/network/network_mocks.hpp"
 #include "ordering/impl/ordering_gate_impl.hpp"
 #include "ordering/impl/ordering_gate_transport_grpc.hpp"
 #include "ordering/impl/ordering_service_impl.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
 #include "validators/field_validator.hpp"
 
+#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+
+using namespace iroha;
 using namespace iroha::ordering;
 using namespace iroha::model;
 using namespace iroha::network;
 using namespace framework::test_subscriber;
 using namespace iroha::ametsuchi;
 using namespace std::chrono_literals;
+
 using ::testing::Return;
 
 using wPeer = std::shared_ptr<shared_model::interface::Peer>;
@@ -46,8 +53,12 @@ class OrderingGateServiceTest : public ::testing::Test {
         .address(address)
         .pubkey(shared_model::interface::types::PubkeyType(std::string(32, '0')))
         .build().copy());
+    pcs_ = std::make_shared<MockPeerCommunicationService>();
+    EXPECT_CALL(*pcs_, on_commit())
+        .WillRepeatedly(Return(commit_subject_.get_observable()));
     gate_transport = std::make_shared<OrderingGateTransportGrpc>(address);
     gate = std::make_shared<OrderingGateImpl>(gate_transport);
+    gate->setPcs(*pcs_);
     gate_transport->subscribe(gate);
 
     service_transport = std::make_shared<OrderingServiceTransportGrpc>();
@@ -93,14 +104,29 @@ class OrderingGateServiceTest : public ::testing::Test {
 
   TestSubscriber<iroha::model::Proposal> init(size_t times) {
     auto wrapper = make_test_subscriber<CallExact>(gate->on_proposal(), times);
-    wrapper.subscribe([this](auto proposal) { proposals.push_back(proposal); });
     gate->on_proposal().subscribe([this](auto) {
       counter--;
       cv.notify_one();
     });
+    gate->on_proposal().subscribe([this](auto proposal) {
+      proposals.push_back(proposal);
+
+      // emulate commit event after receiving the proposal to perform next
+      // round inside the peer.
+      std::shared_ptr<shared_model::interface::Block> block =
+          std::make_shared<shared_model::proto::Block>(
+              TestBlockBuilder().build());
+      commit_subject_.get_subscriber().on_next(
+          rxcpp::observable<>::just(block));
+    });
+    wrapper.subscribe();
     return wrapper;
   }
 
+  /**
+   * Send a stub transaction to OS
+   * @param i - number of transaction
+   */
   void send_transaction(size_t i) {
     auto tx = std::make_shared<Transaction>();
     tx->tx_counter = i;
@@ -112,6 +138,11 @@ class OrderingGateServiceTest : public ::testing::Test {
   std::string address{"0.0.0.0:50051"};
   std::shared_ptr<OrderingGateImpl> gate;
   std::shared_ptr<OrderingServiceImpl> service;
+
+  /// Peer Communication Service and commit subject are required to emulate
+  /// commits for Ordering Service
+  std::shared_ptr<MockPeerCommunicationService> pcs_;
+  rxcpp::subjects::subject<Commit> commit_subject_;
 
   std::vector<Proposal> proposals;
   std::atomic<size_t> counter;
@@ -127,9 +158,11 @@ class OrderingGateServiceTest : public ::testing::Test {
 };
 
 /**
- * @given ordering service
- * @when a bunch of transaction has arrived
- * @then proposal is sent
+ * @given Ordering service
+ * @when  Send 8 transactions
+ *        AND 2 transactions to OS
+ * @then  Received proposal with 8 transactions
+ *        AND proposal with 2 transactions
  */
 TEST_F(OrderingGateServiceTest, SplittingBunchTransactions) {
   // 8 transaction -> proposal -> 2 transaction -> proposal

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -64,10 +64,10 @@ class CustomPeerCommunicationServiceMock : public PeerCommunicationService {
       override {}
 
   rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
-  on_proposal() override {
+  on_proposal() const override {
     return prop_notifier_.get_observable();
   }
-  rxcpp::observable<Commit> on_commit() override {
+  rxcpp::observable<Commit> on_commit() const override {
     return commit_notifier_.get_observable();
   }
 


### PR DESCRIPTION
### Description of the Change
Add concurrent queue to the Ordering Gate.
Fix design bug in PeerCommunicationService: add const modifier for `on_proposal` and `on_commit`.

### Benefits
Solve back pressure issue from OS.

### Possible Drawbacks 
Increase test complexity where used Ordering Gate
