### PR TITLE
fix names of grant permissions in protobuf and old model

### DIFF
--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -113,13 +113,13 @@ namespace iroha {
             (protocol::RolePermission::can_get_all_txs, can_get_all_txs)
 
             // Can grant set quorum
-            (protocol::RolePermission::can_grant_set_quorum,
+            (protocol::RolePermission::can_grant_can_set_quorum,
              can_grant + can_set_quorum)
             // Can grant add signatory
-            (protocol::RolePermission::can_grant_add_signatory,
+            (protocol::RolePermission::can_grant_can_add_signatory,
              can_grant + can_add_signatory)
             // Can grant remove signatory
-            (protocol::RolePermission::can_grant_remove_signatory,
+            (protocol::RolePermission::can_grant_can_remove_signatory,
              can_grant + can_remove_signatory)
             // Can grant can_transfer
             (protocol::RolePermission::can_grant_can_transfer,

--- a/schema/primitive.proto
+++ b/schema/primitive.proto
@@ -65,9 +65,9 @@ enum RolePermission {
   can_get_all_txs = 36;
 
   // Grant permissions
-  can_grant_set_quorum = 37;
-  can_grant_add_signatory = 38;
-  can_grant_remove_signatory = 39;
+  can_grant_can_set_quorum = 37;
+  can_grant_can_add_signatory = 38;
+  can_grant_can_remove_signatory = 39;
   can_grant_can_transfer = 40;
   can_grant_can_set_detail = 41;
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix strings for protobuf can_grant_ permissions and old model strings.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Now it is possible to convert from new to old and vice versa.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
no
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
