### PR TITLE
Reduce parallelism and add cache cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
+            # cleanup cache (not clear!) - removes old cache
+            ccache --cleanup
             # debug/coverage builds produce 2G cache
             ccache --max-size=2G
       - run:
@@ -95,6 +97,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
+            # cleanup cache (not clear!) - removes old cache
+            ccache --cleanup
             # release builds produce cache <100M
             ccache --max-size=500M
       - run:
@@ -112,7 +116,7 @@ jobs:
       - run:
           name: make and package
           command: |
-            cmake --build $IROHA_BUILD --target package -- -j$(nproc --all)
+            cmake --build $IROHA_BUILD --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
           key: build-linux-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
@@ -292,6 +296,8 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
+            # cleanup cache (not clear!) - removes old cache
+            ccache --cleanup
             # release build produces <20M cache per build
             ccache --max-size=100M
       - run:
@@ -306,7 +312,7 @@ jobs:
       - run:
           name: make
           command: |
-            cmake --build build --target package -- -j$(sysctl -n hw.ncpu)
+            cmake --build build --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
           key: build-mac-release-{{ arch }}-{{ .Branch }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            # cleanup cache (not clear!) - removes old cache
             ccache --cleanup
             # debug/coverage builds produce 2G cache
             ccache --max-size=2G
@@ -97,7 +96,6 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            # cleanup cache (not clear!) - removes old cache
             ccache --cleanup
             # release builds produce cache <100M
             ccache --max-size=500M
@@ -296,7 +294,6 @@ jobs:
             ccache --version
             ccache --show-stats
             ccache --zero-stats
-            # cleanup cache (not clear!) - removes old cache
             ccache --cleanup
             # release build produces <20M cache per build
             ccache --max-size=100M


### PR DESCRIPTION
Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Reduce parallelism and add cache cleanup.

### Benefits

<!-- What benefits will be realized by the code change? -->

+ old cache is removed, thanks to `--cleanup`
+ reduce parallelism to 2 in release builds, because `$(nproc --all)` may return 16, but circle ci in fact gives us only 2 and -j16 may be slower than -j2

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None.