### PR TITLE
Update query service

### DIFF
--- a/irohad/torii/query_service.hpp
+++ b/irohad/torii/query_service.hpp
@@ -23,11 +23,9 @@ limitations under the License.
 #include "responses.pb.h"
 
 #include "backend/protobuf/queries/proto_query.hpp"
-#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/transport_builder.hpp"
 #include "cache/cache.hpp"
 #include "torii/processor/query_processor.hpp"
-#include "validators/default_validator.hpp"
 
 #include "logger/logger.hpp"
 
@@ -60,7 +58,7 @@ namespace torii {
     std::shared_ptr<iroha::torii::QueryProcessor> query_processor_;
 
     iroha::cache::Cache<shared_model::crypto::Hash,
-                        std::shared_ptr<shared_model::interface::QueryResponse>,
+                        iroha::protocol::QueryResponse,
                         shared_model::crypto::Hash::Hasher>
         cache_;
 

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "torii/query_service.hpp"
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/queries.hpp"
-#include "generator/generator.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
 
 using namespace torii;
@@ -29,54 +29,116 @@ using namespace shared_model::detail;
 using namespace shared_model::interface;
 using ::testing::_;
 using ::testing::Return;
+using ::testing::Invoke;
+using ::testing::Truly;
 
 class QueryServiceTest : public ::testing::Test {
  public:
   void SetUp() override {
     query_processor = std::make_shared<MockQueryProcessor>();
     // any query
-    query = shared_model::proto::QueryBuilder()
-                .creatorAccountId("user@domain")
-                .createdTime(iroha::time::now())
-                .queryCounter(1)
-                .getAccountTransactions("user@domain")
-                .build()
-                .signAndAddSignature(
-                    shared_model::crypto::DefaultCryptoAlgorithmType::
-                        generateKeypair())
-                .getTransport();
+    query = std::make_shared<shared_model::proto::Query>(
+        shared_model::proto::QueryBuilder()
+            .creatorAccountId("user@domain")
+            .createdTime(iroha::time::now())
+            .queryCounter(1)
+            .getAccount("user@domain")
+            .build()
+            .signAndAddSignature(
+                shared_model::crypto::DefaultCryptoAlgorithmType::
+                    generateKeypair()));
+
+    // TODO: IR-1041 Update to query response builders (kamilsa, 04.03.2018)
+    protocol::QueryResponse response;
+    response.set_query_hash(
+        shared_model::crypto::toBinaryString(query->hash()));
+    auto account_response = response.mutable_account_response();
+    account_response->add_account_roles("user");
+    auto account = account_response->mutable_account();
+    account->set_domain_id("ru");
+    account->set_account_id("a");
+    account->set_quorum(2);
+
+    model_response = std::make_shared<shared_model::proto::QueryResponse>(
+        std::move(response));
   }
 
   void init() {
     query_service = std::make_shared<QueryService>(query_processor);
   }
 
-  protocol::Query query;
-  protocol::QueryResponse response;
+  std::shared_ptr<shared_model::proto::Query> query;
+  std::shared_ptr<shared_model::proto::QueryResponse> model_response;
   std::shared_ptr<QueryService> query_service;
   std::shared_ptr<MockQueryProcessor> query_processor;
 };
 
-TEST_F(QueryServiceTest, SubscribeQueryProcessorWhenInit) {
-  // query service is subscribed to query processor
-  EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(
-          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
-
-  init();
-}
-
+/**
+ * @given query and expected valid response
+ * @when query is sent to query service and query_processor processes query
+ * @then expected response is returned
+ */
 TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
   // unique query => query handled by query processor
+  rxcpp::subjects::subject<
+      std::shared_ptr<shared_model::interface::QueryResponse>>
+      notifier;
   EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(
-          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
-  EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
+      .WillOnce(Return(notifier.get_observable()));
+  EXPECT_CALL(
+      *query_processor,
+      queryHandle(
+          // match by shared_ptr's content
+          Truly([this](std::shared_ptr<shared_model::interface::Query> rhs) {
+            return *rhs == *query;
+          })))
+      .WillOnce(Invoke([this, &notifier](auto q) {
+        notifier.get_subscriber().on_next(model_response);
+      }));
   init();
 
-  query_service->Find(query, response);
+  protocol::QueryResponse response;
+  query_service->Find(query->getTransport(), response);
+  ASSERT_EQ(response.SerializeAsString(),
+            model_response->getTransport().SerializeAsString());
 }
 
+/**
+ * @given query and expected response
+ * @when query is sent to query service and query_processor does not process
+ * query
+ * @then NOT_SUPPORTED error response is returned
+ */
+TEST_F(QueryServiceTest, InvalidWhenUniqueHash) {
+  // unique query => query handled by query processor
+  rxcpp::subjects::subject<
+      std::shared_ptr<shared_model::interface::QueryResponse>>
+      notifier;
+  EXPECT_CALL(*query_processor, queryNotifier())
+      .WillOnce(Return(notifier.get_observable()));
+  EXPECT_CALL(
+      *query_processor,
+      queryHandle(
+          // match by shared_ptr's content
+          Truly([this](std::shared_ptr<shared_model::interface::Query> rhs) {
+            return *rhs == *query;
+          })))
+      .WillOnce(Return());
+  init();
+
+  protocol::QueryResponse response;
+  query_service->Find(query->getTransport(), response);
+  ASSERT_TRUE(response.has_error_response());
+  ASSERT_EQ(response.error_response().reason(),
+            protocol::ErrorResponse::NOT_SUPPORTED);
+}
+
+/**
+ * @given query
+ * @when query is sent to query service twice
+ * @then query processor will be invoked once and second response will have
+ * STATELESS_INVALID status
+ */
 TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   // two same queries => only first query handled by query processor
   EXPECT_CALL(*query_processor, queryNotifier())
@@ -85,6 +147,13 @@ TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
 
   init();
-  query_service->Find(query, response);
-  query_service->Find(query, response);
+
+  protocol::QueryResponse response;
+  query_service->Find(query->getTransport(), response);
+
+  // second call of the same query
+  query_service->Find(query->getTransport(), response);
+  ASSERT_TRUE(response.has_error_response());
+  ASSERT_EQ(response.error_response().reason(),
+            protocol::ErrorResponse::STATELESS_INVALID);
 }


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

QueryService performs redundant operations. Particularly, the following part of the code contained problems:

https://github.com/hyperledger/iroha/blob/def7bc4f7efdf0c2d1c3caecccd2cf3efe0c889e/irohad/torii/impl/query_service.cpp#L53-L77

1. Here on line 60 response's status is set to `STATELESS_INVALID` but this status is not put into cache, whereas response variable is overwritten on line 74 by previous response for the same query hash.
2. On line 64 empty response was put into cache.
3. On line 73 value of optional is taken without checking its existence
4. No tests reflected aforementioned issues
 
### Benefits

All problems above were fixed.

### Possible Drawbacks 

Now if after query is passed into `QueryProcessor::queryHandle` method, but afterwards corresponding query response is not in the cache(empty optional is returned from cache_), query service will return `NOT_SUPPORTED` status.

### Usage Examples or Tests

Tests, reflecting solution of above problems were introduced.