### PR TITLE
Remove proposal builder from OS; fix ITF destructor

### DIFF
--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -20,6 +20,7 @@
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/proposal.hpp"
 #include "logger/logger.hpp"
+#include "proposal.pb.h"
 
 namespace iroha {
   namespace ordering {
@@ -54,20 +55,22 @@ namespace iroha {
     }
 
     void OrderingServiceImpl::generateProposal() {
-      std::vector<shared_model::proto::Transaction> fetched_txs;
-        log_->info("Start proposal generation");
+      // TODO 05/03/2018 andrei IR-1046 Server-side shared model object
+      // factories with move semantics
+      iroha::protocol::Proposal proto_proposal;
+      proto_proposal.set_height(proposal_height++);
+      proto_proposal.set_created_time(iroha::time::now());
+      log_->info("Start proposal generation");
       for (std::shared_ptr<shared_model::interface::Transaction> tx;
-           fetched_txs.size() < max_size_ and queue_.try_pop(tx);) {
-        fetched_txs.emplace_back(
-            std::move(static_cast<shared_model::proto::Transaction &>(*tx)));
+           static_cast<size_t>(proto_proposal.transactions_size()) < max_size_
+           and queue_.try_pop(tx);) {
+        *proto_proposal.add_transactions() = std::move(
+            std::static_pointer_cast<shared_model::proto::Transaction>(tx)
+                ->getTransport());
       }
 
       auto proposal = std::make_unique<shared_model::proto::Proposal>(
-          shared_model::proto::ProposalBuilder()
-              .height(proposal_height++)
-              .createdTime(iroha::time::now())
-              .transactions(fetched_txs)
-              .build());
+          std::move(proto_proposal));
 
       // Save proposal height to the persistent storage.
       // In case of restart it reloads state.

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -103,10 +103,10 @@ namespace integration_framework {
                         const std::string &error_reason);
 
    protected:
-    std::shared_ptr<IrohaInstance> iroha_instance_ =
-        std::make_shared<IrohaInstance>();
     tbb::concurrent_queue<ProposalType> proposal_queue_;
     tbb::concurrent_queue<BlockType> block_queue_;
+    std::shared_ptr<IrohaInstance> iroha_instance_ =
+        std::make_shared<IrohaInstance>();
 
     // config area
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Remove Proposal builder from OS method to avoid redundant copies
Fix destructor order in ITF - queues were destroyed before iroha instance, and iroha instance was writing proposals to nonexistent queues
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Proposal generation time with 1000 transactions
Before: Elapsed time for generateProposal: 3165786mus
After: Elapsed time for generateProposal: 6114mus
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Raw protobuf objects usage in implementation
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->