### PR TITLE
Generate key pair from hex string seed in bindings

### DIFF
--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -26,8 +26,13 @@ namespace shared_model {
     }
 
     crypto::Keypair ModelCrypto::generateKeypair(const std::string &seed) {
+      auto byte_string = iroha::hexstringToBytestring(seed);
+      if (not byte_string.has_value())
+      {
+        throw std::runtime_error("invalid seed");
+      }
       return crypto::CryptoProviderEd25519Sha3::generateKeypair(
-          crypto::Seed(seed));
+          crypto::Seed(*byte_string));
     }
 
     crypto::Keypair ModelCrypto::convertFromExisting(

--- a/test/module/shared_model/bindings/CMakeLists.txt
+++ b/test/module/shared_model/bindings/CMakeLists.txt
@@ -15,10 +15,17 @@
 addtest(model_query_builder_test
     model_query_builder_test.cpp
     )
+
 target_link_libraries(model_query_builder_test
     bindings
     )
 
+addtest(model_crypto_test
+    model_crypto_test.cpp
+    )
+target_link_libraries(model_crypto_test
+    bindings
+    )
 if (SWIG_PYTHON OR SWIG_JAVA)
   get_property(SWIG_BUILD_DIR GLOBAL PROPERTY SWIG_BUILD_DIR)
 endif()

--- a/test/module/shared_model/bindings/model_crypto_test.cpp
+++ b/test/module/shared_model/bindings/model_crypto_test.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings/model_crypto.hpp"
+
+#include <gtest/gtest.h>
+
+/**
+ * @given ModelCrypto module
+ * @when Receive 32 byte hex string
+ * @then assertion is not thrown
+ */
+TEST(ModelCryptoTest, GenerateKeypair) {
+  ASSERT_NO_THROW(
+  shared_model::bindings::ModelCrypto().generateKeypair(std::string(64, 'a'));
+  );
+  ASSERT_NO_THROW(
+      shared_model::bindings::ModelCrypto().generateKeypair(std::string(64, 'A'));
+  );
+}
+/**
+ * @given ModelCrypto module
+ * @when Receive invalid hex byte string
+ * @then assertion is thrown
+ */
+TEST(ModelCryptoTest, GenerateKeypairInvalidSeed) {
+  ASSERT_ANY_THROW(
+      shared_model::bindings::ModelCrypto().generateKeypair(std::string(64, 'g'));
+  );
+  ASSERT_ANY_THROW(
+      shared_model::bindings::ModelCrypto().generateKeypair(std::string(63, 'a'));
+  );
+  ASSERT_ANY_THROW(
+      shared_model::bindings::ModelCrypto().generateKeypair(std::string(65, 'a'));
+  );
+  ASSERT_ANY_THROW(
+      shared_model::bindings::ModelCrypto().generateKeypair(std::string(32, 'a'));
+  );
+}


### PR DESCRIPTION
Signed-off-by: Moonraker <ssolonets@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
shared_model::bindings::generateKeypair(const std::string &) takes a 32-byte binary string, which is not convenient for end users. Now it instead take a hex string which can be converted to 32-byte binary string.


### Benefits
more convenient for users?

### Possible Drawbacks 

None
