### PR TITLE
Allow to query all account JSON data

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -26,7 +26,6 @@ namespace iroha {
     using shared_model::interface::types::AssetIdType;
     using shared_model::interface::types::JsonType;
     using shared_model::interface::types::RoleIdType;
-    using shared_model::interface::types::DetailType;
     using shared_model::interface::types::PubkeyType;
 
     const std::string kRoleId = "role_id";
@@ -39,8 +38,7 @@ namespace iroha {
     PostgresWsvQuery::PostgresWsvQuery(pqxx::nontransaction &transaction)
         : transaction_(transaction),
           log_(logger::log("PostgresWsvQuery")),
-          execute_{makeExecuteOptional
-                       (transaction_, log_)} {}
+          execute_{makeExecuteOptional(transaction_, log_)} {}
 
     bool PostgresWsvQuery::hasAccountGrantablePermission(
         const AccountIdType &permitee_account_id,
@@ -104,13 +102,9 @@ namespace iroha {
       };
     }
 
-    nonstd::optional<DetailType> PostgresWsvQuery::getAccountDetail(
-        const AccountIdType &account_id,
-        const AccountIdType &creator_account_id,
-        const DetailType &detail) {
-      return execute_("SELECT data#>>"
-                      + transaction_.quote("{" + creator_account_id + ", "
-                                           + detail + "}")
+    nonstd::optional<std::string> PostgresWsvQuery::getAccountDetail(
+        const std::string &account_id) {
+      return execute_("SELECT data#>>" + transaction_.quote("{}")
                       + " FROM account WHERE account_id = "
                       + transaction_.quote(account_id) + ";")
                  | [&](const auto &result) -> nonstd::optional<std::string> {

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -39,12 +39,9 @@ namespace iroha {
       nonstd::optional<std::shared_ptr<shared_model::interface::Account>>
       getAccount(const shared_model::interface::types::AccountIdType
                      &account_id) override;
-      nonstd::optional<shared_model::interface::types::DetailType>
-      getAccountDetail(
-          const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::AccountIdType
-              &creator_account_id,
-          const shared_model::interface::types::DetailType &detail) override;
+      nonstd::optional<std::string> getAccountDetail(
+          const shared_model::interface::types::AccountIdType &account_id)
+          override;
       nonstd::optional<std::vector<shared_model::interface::types::PubkeyType>>
       getSignatories(const shared_model::interface::types::AccountIdType
                          &account_id) override;

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -23,9 +23,6 @@
 #include <vector>
 #include "common/types.hpp"
 
-#include <nonstd/optional.hpp>
-
-#include "common/types.hpp"
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/account_asset.hpp"
 #include "interfaces/common_objects/asset.hpp"
@@ -106,17 +103,11 @@ namespace iroha {
 
       /**
        * Get accounts information from its key-value storage
-       * @param account_id
-       * @param creator_account_id
-       * @param detail
-       * @return
+       * @param account_id - account to get details about
+       * @return optional of account details
        */
-      virtual nonstd::optional<shared_model::interface::types::DetailType>
-      getAccountDetail(
-          const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::AccountIdType
-              &creator_account_id,
-          const shared_model::interface::types::DetailType &detail) = 0;
+      virtual nonstd::optional<std::string> getAccountDetail(
+          const std::string &account_id) = 0;
 
       /**
        * Get signatories of account by user account_id

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -124,8 +124,7 @@ namespace iroha {
           const Value &obj_query) {
         auto des = makeFieldDeserializer(obj_query);
         return make_optional_ptr<GetAccountDetail>()
-            | des.String(&GetAccountDetail::account_id, "account_id")
-            | des.String(&GetAccountDetail::detail, "detail") | toQuery;
+            | des.String(&GetAccountDetail::account_id, "account_id") | toQuery;
       }
 
       optional_ptr<Query> JsonQueryFactory::deserializeGetTransactions(
@@ -210,7 +209,6 @@ namespace iroha {
         auto casted_query =
             std::static_pointer_cast<const GetAccountDetail>(query);
         json_doc.AddMember("account_id", casted_query->account_id, allocator);
-        json_doc.AddMember("detail", casted_query->detail, allocator);
       }
 
       void JsonQueryFactory::serializeGetSignatories(

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -79,11 +79,10 @@ namespace iroha {
               break;
             }
             case Query_Payload::QueryCase::kGetAccountDetail: {
-              // Convert to get Account Asset
+              // Convert to get Account Detail
               const auto &pb_cast = pl.get_account_detail();
               auto query = GetAccountDetail();
               query.account_id = pb_cast.account_id();
-              query.detail = pb_cast.detail();
               val = std::make_shared<model::GetAccountDetail>(query);
               break;
             }
@@ -213,7 +212,6 @@ namespace iroha {
         auto pb_query_mut =
             pb_query.mutable_payload()->mutable_get_account_detail();
         pb_query_mut->set_account_id(tmp->account_id);
-        pb_query_mut->set_detail(tmp->detail);
         return pb_query;
       }
 

--- a/irohad/model/generators/impl/query_generator.cpp
+++ b/irohad/model/generators/impl/query_generator.cpp
@@ -64,15 +64,13 @@ namespace iroha {
                                                std::string creator,
                                                uint64_t query_counter,
                                                std::string account_id,
-                                               std::string creator_account_id,
-                                               std::string detail) {
+                                               std::string creator_account_id) {
         auto query = std::make_shared<GetAccountDetail>();
         query->created_ts = timestamp;
         query->creator_account_id = creator;
         query->query_counter = query_counter;
         query->account_id = account_id;
         query->creator_account_id = creator_account_id;
-        query->detail = detail;
         return query;
       }
 

--- a/irohad/model/generators/query_generator.hpp
+++ b/irohad/model/generators/query_generator.hpp
@@ -49,8 +49,7 @@ namespace iroha {
             std::string creator,
             uint64_t query_counter,
             std::string account_id,
-            std::string creator_account_id,
-            std::string detail);
+            std::string creator_account_id);
 
         std::shared_ptr<GetSignatories> generateGetSignatories(
             ts64_t timestamp,

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -257,8 +257,7 @@ std::shared_ptr<QueryResponse> QueryProcessingFactory::executeGetAccountAssets(
 std::shared_ptr<iroha::model::QueryResponse>
 iroha::model::QueryProcessingFactory::executeGetAccountDetail(
     const model::GetAccountDetail &query) {
-  auto acct_detail = _wsvQuery->getAccountDetail(
-      query.account_id, query.creator_account_id, query.detail);
+  auto acct_detail = _wsvQuery->getAccountDetail(query.account_id);
   if (!acct_detail.has_value()) {
     iroha::model::ErrorResponse response;
     response.query_hash = iroha::hash(query);
@@ -309,7 +308,8 @@ iroha::model::QueryProcessingFactory::executeGetTransactions(
   std::vector<iroha::model::Transaction> transactions;
   txs.subscribe([&transactions](auto const &tx_opt) {
     if (tx_opt) {
-      transactions.push_back(*std::unique_ptr<iroha::model::Transaction>((*tx_opt)->makeOldModel()));
+      transactions.push_back(*std::unique_ptr<iroha::model::Transaction>(
+          (*tx_opt)->makeOldModel()));
     }
   });
   iroha::model::TransactionsResponse response;

--- a/irohad/model/queries/get_account_detail.hpp
+++ b/irohad/model/queries/get_account_detail.hpp
@@ -28,7 +28,6 @@ namespace iroha {
      */
     struct GetAccountDetail : Query {
       std::string account_id{};
-      std::string detail{};
     };
   }  // namespace model
 }  // namespace iroha

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -31,7 +31,6 @@ message GetAccountAssets {
 
 message GetAccountDetail {
   string account_id = 1;
-  string detail = 2;
 }
 
 message GetAssetInfo {

--- a/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
@@ -45,10 +45,6 @@ namespace shared_model {
         return account_detail_.account_id();
       }
 
-      const interface::types::DetailType &detail() const override {
-        return account_detail_.detail();
-      }
-
      private:
       // ------------------------------| fields |-------------------------------
 

--- a/shared_model/bindings/model_query_builder.cpp
+++ b/shared_model/bindings/model_query_builder.cpp
@@ -86,9 +86,8 @@ namespace shared_model {
     }
 
     ModelQueryBuilder ModelQueryBuilder::getAccountDetail(
-        const interface::types::AccountIdType &account_id,
-        const interface::types::DetailType &detail) {
-      return ModelQueryBuilder(builder_.getAccountDetail(account_id, detail));
+        const interface::types::AccountIdType &account_id) {
+      return ModelQueryBuilder(builder_.getAccountDetail(account_id));
     }
 
     proto::UnsignedWrapper<proto::Query> ModelQueryBuilder::build() {

--- a/shared_model/bindings/model_query_builder.hpp
+++ b/shared_model/bindings/model_query_builder.hpp
@@ -141,8 +141,7 @@ namespace shared_model {
        * @return builder with getAccountDetail query inside
        */
       ModelQueryBuilder getAccountDetail(
-          const interface::types::AccountIdType &account_id,
-          const interface::types::DetailType &detail);
+          const interface::types::AccountIdType &account_id);
 
       /**
        * Builds result with all appended fields

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -153,12 +153,10 @@ namespace shared_model {
         });
       }
 
-      auto getAccountDetail(const interface::types::AccountIdType &account_id,
-                            const interface::types::DetailType &detail) {
+      auto getAccountDetail(const interface::types::AccountIdType &account_id) {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_detail();
           query->set_account_id(account_id);
-          query->set_detail(detail);
         });
       }
 

--- a/shared_model/interfaces/queries/get_account_detail.hpp
+++ b/shared_model/interfaces/queries/get_account_detail.hpp
@@ -36,16 +36,11 @@ namespace shared_model {
        * @return account identifier
        */
       virtual const types::AccountIdType &accountId() const = 0;
-      /**
-       * @return asset identifier
-       */
-      virtual const types::DetailType &detail() const = 0;
 
 #ifndef DISABLE_BACKWARD
       OldModelType *makeOldModel() const override {
         auto oldModel = new iroha::model::GetAccountDetail;
         oldModel->account_id = accountId();
-        oldModel->detail = detail();
         return oldModel;
       }
 
@@ -53,14 +48,13 @@ namespace shared_model {
 
       std::string toString() const override {
         return detail::PrettyStringBuilder()
-            .init("GetAccountAssets")
+            .init("GetAccountDetail")
             .append("account_id", accountId())
-            .append("detail", detail())
             .finalize();
       }
 
       bool operator==(const ModelType &rhs) const override {
-        return accountId() == rhs.accountId() and detail() == rhs.detail();
+        return accountId() == rhs.accountId();
       }
     };
   }  // namespace interface

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -109,7 +109,6 @@ namespace shared_model {
         reason.first = "GetAccountDetail";
 
         validator_.validateAccountId(reason, qry->accountId());
-        validator_.validateAccountDetailKey(reason, qry->detail());
 
         return reason;
       }

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -75,9 +75,8 @@ class ClientServerTest : public testing::Test {
     wsv_query = std::make_shared<MockWsvQuery>();
     block_query = std::make_shared<MockBlockQuery>();
 
-    rxcpp::subjects::subject<
-          std::shared_ptr<shared_model::interface::Proposal>>
-          prop_notifier;
+    rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Proposal>>
+        prop_notifier;
     rxcpp::subjects::subject<iroha::Commit> commit_notifier;
 
     EXPECT_CALL(*pcsMock, on_proposal())
@@ -96,15 +95,15 @@ class ClientServerTest : public testing::Test {
     auto qpf = std::make_unique<iroha::model::QueryProcessingFactory>(
         wsv_query, block_query);
 
-      auto qpi = std::make_shared<iroha::torii::QueryProcessorImpl>(
-          std::move(qpf));
+    auto qpi =
+        std::make_shared<iroha::torii::QueryProcessorImpl>(std::move(qpf));
 
-      //----------- Server run ----------------
-      runner
-          ->append(std::make_unique<torii::CommandService>( tx_processor, block_query, proposal_delay))
-          .append(std::make_unique<torii::QueryService>(qpi))
-          .run();
-
+    //----------- Server run ----------------
+    runner
+        ->append(std::make_unique<torii::CommandService>(
+            tx_processor, block_query, proposal_delay))
+        .append(std::make_unique<torii::QueryService>(qpi))
+        .run();
 
     runner->waitForServersReady();
   }
@@ -228,14 +227,14 @@ TEST_F(ClientServerTest, SendQueryWhenValid) {
                   "admin@test", "test@test", can_get_my_acc_detail))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*wsv_query, getAccountDetail("test@test", "admin@test", "key"))
+  EXPECT_CALL(*wsv_query, getAccountDetail("test@test"))
       .WillOnce(Return(nonstd::make_optional<std::string>("value")));
 
   auto query = QueryBuilder()
                    .createdTime(iroha::time::now())
                    .creatorAccountId("admin@test")
                    .queryCounter(1)
-                   .getAccountDetail("test@test", "key")
+                   .getAccountDetail("test@test")
                    .build()
                    .signAndAddSignature(
                        shared_model::crypto::DefaultCryptoAlgorithmType::
@@ -263,7 +262,7 @@ TEST_F(ClientServerTest, SendQueryWhenStatefulInvalid) {
                    .createdTime(iroha::time::now())
                    .creatorAccountId("admin@test")
                    .queryCounter(1)
-                   .getAccountDetail("test@test", "key")
+                   .getAccountDetail("test@test")
                    .build()
                    .signAndAddSignature(
                        shared_model::crypto::DefaultCryptoAlgorithmType::

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -45,11 +45,9 @@ namespace iroha {
       MOCK_METHOD1(getAccountRoles,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &account_id));
-      MOCK_METHOD3(
+      MOCK_METHOD1(
           getAccountDetail,
-          nonstd::optional<std::string>(const std::string &account_id,
-                                        const std::string &creator_account_id,
-                                        const std::string &detail));
+          nonstd::optional<std::string>(const std::string &account_id));
       MOCK_METHOD1(getRolePermissions,
                    nonstd::optional<std::vector<std::string>>(
                        const std::string &role_name));

--- a/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
@@ -17,12 +17,12 @@
 
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
+#include "framework/result_fixture.hpp"
 #include "model/account.hpp"
+#include "model/asset.hpp"
 #include "model/domain.hpp"
 #include "model/peer.hpp"
-#include "model/asset.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
-#include "framework/result_fixture.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -56,8 +56,6 @@ namespace iroha {
 
         wsv_transaction->exec(init_);
       }
-
-
 
       std::string role = "role", permission = "permission";
       model::Account account;
@@ -210,8 +208,7 @@ namespace iroha {
      * @then getAccountDetail will return nullopt
      */
     TEST_F(AccountTest, GetAccountDetailInvalidWhenNotFound) {
-      EXPECT_FALSE(query->getAccountDetail(
-          "invalid account id", "invalid_creator", "invalid_detail"));
+      EXPECT_FALSE(query->getAccountDetail("invalid account id"));
     }
 
     class AccountRoleTest : public WsvQueryCommandTest {
@@ -322,7 +319,7 @@ namespace iroha {
       ASSERT_NO_THROW(checkValueCase(command->insertAccountGrantablePermission(
           permittee_account.account_id, account.account_id, permission)));
 
-          ASSERT_TRUE(query->hasAccountGrantablePermission(
+      ASSERT_TRUE(query->hasAccountGrantablePermission(
           permittee_account.account_id, account.account_id, permission));
     }
 
@@ -348,7 +345,7 @@ namespace iroha {
 
     TEST_F(AccountGrantablePermissionTest,
            DeleteAccountGrantablePermissionWhenAccountsPermissionExist) {
-ASSERT_NO_THROW(checkValueCase(command->deleteAccountGrantablePermission(
+      ASSERT_NO_THROW(checkValueCase(command->deleteAccountGrantablePermission(
           permittee_account.account_id, account.account_id, permission)));
 
       ASSERT_FALSE(query->hasAccountGrantablePermission(

--- a/test/module/irohad/model/converters/json_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/json_query_factory_test.cpp
@@ -123,15 +123,13 @@ TEST(QuerySerializerTest, DeserializeGetAccountDetailWhenValid) {
     "creator_account_id":"123",
     "query_counter":0,
     "query_type":"GetAccountDetail",
-    "account_id":"test@test",
-    "detail":"key"
+    "account_id":"test@test"
   })";
   auto res = querySerializer.deserialize(json_query);
   ASSERT_TRUE(res.has_value());
   auto casted =
       std::static_pointer_cast<iroha::model::GetAccountDetail>(res.value());
   ASSERT_EQ("test@test", casted->account_id);
-  ASSERT_EQ("key", casted->detail);
 }
 
 TEST(QuerySerializerTest, DeserializeWhenUnknownType) {

--- a/test/module/irohad/model/converters/pb_query_factory_test.cpp
+++ b/test/module/irohad/model/converters/pb_query_factory_test.cpp
@@ -90,8 +90,8 @@ TEST(PbQueryFactoryTest, SerializeGetAccountAssets) {
 TEST(PbQueryFactoryTest, SerializeGetAccountDetail) {
   PbQueryFactory query_factory;
   QueryGenerator query_generator;
-  auto query = query_generator.generateGetAccountDetail(
-      0, "123", 0, "test", "test2", "key");
+  auto query =
+      query_generator.generateGetAccountDetail(0, "123", 0, "test", "test2");
   auto pb_query = query_factory.serialize(query);
   ASSERT_TRUE(pb_query.has_value());
   auto res_query = query_factory.deserialize(pb_query.value());

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -158,7 +158,7 @@ public class QueryTest {
 
     @Test
     void getAccountDetail() {
-        UnsignedQuery query = builder.getAccountDetail("user@test", "hello").build();
+        UnsignedQuery query = builder.getAccountDetail("user@test").build();
         assertTrue(checkProtoQuery(proto(query)));
     }
 }

--- a/test/module/shared_model/bindings/query-test.py
+++ b/test/module/shared_model/bindings/query-test.py
@@ -89,7 +89,7 @@ class BuilderTest(unittest.TestCase):
     self.assertTrue(self.check_proto_query(self.proto(query)))
 
   def test_get_account_detail(self):
-    query = self.builder.getAccountDetail("user@test", "hello").build()
+    query = self.builder.getAccountDetail("user@test").build()
     self.assertTrue(self.check_proto_query(self.proto(query)))
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
At the moment getAccountDetail query unable to request details added by users different from query creator. This pull request changes behaviour of getAccountDetail - now it returns all account details (in JSON format).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Possibility to request detail data added from other accounts. Also retrieving a whole details JSON in a single request could be more convenient to clients than to do a request for every key.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Behaviour of query was changed so old code which uses getAccountDetail becomes broken.

### Usage Examples or Tests *[optional]*
Check kv_storage_test. Also simple example for Java:
In genesis block:
```
{
 "command_type": "SetAccountDetail",
 "account_id": "admin@test",
 "key": "pog",
 "value": "champ"
 }
```
In some .java file:
```
...
UnsignedTx utx = txBuilder.creatorAccountId("admin@test")
            .createdTime(BigInteger.valueOf(currentTime))
            .txCounter(BigInteger.valueOf(startTxCounter))
            .setAccountDetail("admin@test", "lol", "kek")
            .setAccountDetail("admin@test", "kek", "lol")
            .build();
...
UnsignedQuery uquery = queryBuilder.creatorAccountId(creator)
            .queryCounter(BigInteger.valueOf(startQueryCounter))
            .createdTime(BigInteger.valueOf(currentTime))
            .getAccountDetail("admin@test")
            .build();
...
```
Expected result:
```
Query responsed:
Detail = {"genesis": {"pog": "champ"}, "admin@test": {"kek": "lol", "lol": "kek"}}
```
