### PR TITLE
Remove ; to fix warning "unused-value"

### DIFF
--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -139,7 +139,7 @@ namespace iroha {
             (protocol::GrantablePermission::can_set_my_quorum, can_set_quorum)
             // Can write details to other accounts
             (protocol::GrantablePermission::can_set_my_account_detail,
-             can_set_detail);
+             can_set_detail)
             // Can transfer my assets
             (protocol::GrantablePermission::can_transfer_my_assets,
                 can_transfer);


### PR DESCRIPTION
Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Fixes bug:

```C++
boost::assign::insert(pb_grant_map_)
    // Can add my signatory
    (protocol::GrantablePermission::can_add_my_signatory,
     can_add_signatory)
    // Can remove my signatory
    (protocol::GrantablePermission::can_remove_my_signatory,
     can_remove_signatory)
    // Can set my quorum
    (protocol::GrantablePermission::can_set_my_quorum, can_set_quorum)
    // Can write details to other accounts
    (protocol::GrantablePermission::can_set_my_account_detail,
     can_set_detail) // ; <-- if ; is here, then next line(s) related to boost::assign::insert are ignored 
    // Can transfer my assets
    (protocol::GrantablePermission::can_transfer_my_assets,
        can_transfer);
```

### Benefits

<!-- What benefits will be realized by the code change? -->

Fix warning at:
```bash
/Users/bogdan/tools/iroha/irohad/model/converters/impl/pb_command_factory.cpp: In constructor 'iroha::model::converters::PbCommandFactory::PbCommandFactory()':
/Users/bogdan/tools/iroha/irohad/model/converters/impl/pb_command_factory.cpp:145:17: error: left operand of comma operator has no effect [-Werror=unused-value]
                 can_transfer);
                 ^~~~~~~~~~~~
```
