### PR TITLE
Fix internal compiler error forever

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: make
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -d $((3*1024*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
             cmake --build $IROHA_BUILD -- -j2
       - run: ccache --show-stats
       - run:
@@ -115,7 +115,7 @@ jobs:
           name: make and package
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -d $((3*1024*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
             cmake --build $IROHA_BUILD --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
@@ -243,6 +243,7 @@ jobs:
             if [ ! -z "$SONAR_TOKEN" ] && \
               [ ! -z "$CIRCLE_BUILD_NUM" ] && \
               [ ! -z "$CIRCLE_BRANCH" ]; then
+              ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
               sonar-scanner \
                 -Dsonar.login="${SONAR_TOKEN}" \
                 -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
@@ -311,7 +312,7 @@ jobs:
           name: make
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -d $((3*1024*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
             cmake --build build --target package -- -j2
       - run: ccache --show-stats
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       - run:
           name: make
           command: |
+            # set limit for memory consumption, 3 GB
+            ulimit -d $((3*1024*1024*1024))
             cmake --build $IROHA_BUILD -- -j2
       - run: ccache --show-stats
       - run:
@@ -112,7 +114,9 @@ jobs:
       - run:
           name: make and package
           command: |
-            cmake --build $IROHA_BUILD --target package -- -j$(nproc --all)
+            # set limit for memory consumption, 3 GB
+            ulimit -d $((3*1024*1024*1024))
+            cmake --build $IROHA_BUILD --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
           key: build-linux-release-{{ arch }}-{{ .Branch }}-{{ epoch }}
@@ -306,7 +310,9 @@ jobs:
       - run:
           name: make
           command: |
-            cmake --build build --target package -- -j$(sysctl -n hw.ncpu)
+            # set limit for memory consumption, 3 GB
+            ulimit -d $((3*1024*1024*1024))
+            cmake --build build --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
           key: build-mac-release-{{ arch }}-{{ .Branch }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: make
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024)) -m $((3*1024*1024))
             cmake --build $IROHA_BUILD -- -j2
       - run: ccache --show-stats
       - run:
@@ -115,7 +115,7 @@ jobs:
           name: make and package
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024)) -m $((3*1024*1024))
             cmake --build $IROHA_BUILD --target package -- -j2
       - run: ccache --show-stats
       - save_cache:
@@ -243,7 +243,7 @@ jobs:
             if [ ! -z "$SONAR_TOKEN" ] && \
               [ ! -z "$CIRCLE_BUILD_NUM" ] && \
               [ ! -z "$CIRCLE_BRANCH" ]; then
-              ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
+              ulimit -v $((3*1024*1024)) -d $((3*1024*1024)) -m $((3*1024*1024))
               sonar-scanner \
                 -Dsonar.login="${SONAR_TOKEN}" \
                 -Dsonar.projectVersion="${CIRCLE_BUILD_NUM}" \
@@ -312,7 +312,7 @@ jobs:
           name: make
           command: |
             # set limit for memory consumption, 3 GB
-            ulimit -v $((3*1024*1024)) -d $((3*1024*1024))
+            ulimit -v $((3*1024*1024)) -d $((3*1024*1024)) -m $((3*1024*1024))
             cmake --build build --target package -- -j2
       - run: ccache --show-stats
       - save_cache:


### PR DESCRIPTION
- set `data seg size` to 3 GB max per terminal
- set `max memory size` to 3 GB max per terminal
- set `virtual memory` to 3 GB  max  per terminal
- set maximum parallelism to 2. Currently we use [`resource_class: medium`](https://circleci.com/docs/2.0/configuration-reference/#resource_class), which is 2 CPUs, 4 GB. 

>Note: A paid account is required to access this feature. Customers on paid plans can request access by opening a support ticket. If resource_class is not specified or an invalid class is specified, the default resource_class: medium will be used. The resource_class key is currently only available for use with the docker executor. 
>Java, Erlang and any other languages that introspect the /proc directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.

So in this PR I specifically limit parallelism to 2.

3 GB per terminal is selected because I leave 1 GB for OS needs. You can check numbers with `ulimit -a`

Reference: http://www.network-theory.co.uk/docs/gccintro/gccintro_77.html