### PR TITLE
Fix build error when no spdlog installed

### DIFF
--- a/test/module/shared_model/cryptography/crypto_usage_test.cpp
+++ b/test/module/shared_model/cryptography/crypto_usage_test.cpp
@@ -20,7 +20,6 @@
 #include "cryptography/crypto_provider/crypto_signer.hpp"
 #include "cryptography/crypto_provider/crypto_verifier.hpp"
 #include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
-#include "logger/logger.hpp"
 
 using namespace shared_model::crypto;
 


### PR DESCRIPTION
This PR fixes build error, when spdlog is not installed in the system.