### PR TITLE
Edit dev dockerfile: Add libcurl with ssl, set cmake v to 3.7.2

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -23,7 +23,7 @@ RUN set -e; \
     apt-get -y --no-install-recommends install build-essential python-software-properties \
         automake libtool \
         # dev dependencies
-        libssl-dev zlib1g-dev libc6-dbg golang \
+        libssl-dev zlib1g-dev libcurl4-openssl-dev libc6-dbg golang \
         # CircleCI dependencies
         git ssh tar gzip ca-certificates python python-pip python-setuptools \
         # code coverage
@@ -33,11 +33,11 @@ RUN set -e; \
         gcovr cppcheck doxygen graphviz graphviz-dev; \
     apt-get -y clean
 
-# install cmake 3.5.1
+# install cmake 3.7.2
 RUN set -e; \
     git clone https://gitlab.kitware.com/cmake/cmake.git /tmp/cmake; \
-    (cd /tmp/cmake ; git checkout 64130a7e793483e24c1d68bdd234f81d5edb2d51); \
-    (cd /tmp/cmake ; /tmp/cmake/bootstrap --parallel=${PARALLELISM} --enable-ccache); \
+    (cd /tmp/cmake ; git checkout 35413bf2c1b33980afd418030af27f184872af6b); \
+    (cd /tmp/cmake ; /tmp/cmake/bootstrap --system-curl --parallel=${PARALLELISM} --enable-ccache); \
     make -j${PARALLELISM} -C /tmp/cmake; \
     make -C /tmp/cmake install; \
     ldconfig; \


### PR DESCRIPTION
Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

We compile cmake manually in dev docker, it uses internal libcurl without SSL. Because of this, #1070 build step on circle ci fails with `log: Protocol "https" not supported or disabled in libcurl`.

To fix this I:
- install `libcurl` with `openssl` support.
- I compile cmake with `--system-curl` option, to force cmake use libcurl with ssl cupport

Also, since we use SWIG and it requires cmake 3.7+, I update cmake version to 3.7.2.

### Benefits

<!-- What benefits will be realized by the code change? -->

- this will let us to use hunter in circle ci (build will not fail in #1070)

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None.


### NOTES

Because both changes (curl + cmake version) are made in a single dockerfile, it is hard for me to do 2 separate PRs for these changes, because each change requires full `hyperledger/iroha-docker-develop:v1` rebuild -- and this process is very slow, so for me it is better to build that image once.