### PR TITLE
CreateRole acceptance tests

### DIFF
--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -29,6 +29,7 @@ namespace shared_model {
           asset_id_pattern_(R"([a-z]{1,9}\#[a-z]{1,9})"),
           name_pattern_(R"([a-z]{1,9})"),
           detail_key_pattern_(R"([A-Za-z0-9_]{1,})"),
+          role_id_pattern_(R"([A-Za-z0-9_]{1,7})"),
           future_gap_(future_gap) {}
 
     void FieldValidator::validateAccountId(
@@ -100,7 +101,7 @@ namespace shared_model {
     void FieldValidator::validateRoleId(
         ReasonsGroupType &reason,
         const interface::types::RoleIdType &role_id) const {
-      if (not std::regex_match(role_id, name_pattern_)) {
+      if (not std::regex_match(role_id, role_id_pattern_)) {
         auto message =
             (boost::format("Wrongly formed role_id, passed value: '%s'")
              % role_id)

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -112,6 +112,7 @@ namespace shared_model {
       std::regex asset_id_pattern_;
       std::regex name_pattern_;
       std::regex detail_key_pattern_;
+      std::regex role_id_pattern_;
       // gap for future transactions
       time_t future_gap_;
       // max-delay between tx creation and validation

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -23,6 +23,14 @@ target_link_libraries(get_transactions_test
   shared_model_stateless_validation
   )
 
+addtest(create_role_test create_role_test.cpp)
+target_link_libraries(create_role_test
+  application
+  integration_framework
+  shared_model_proto_builders
+  shared_model_stateless_validation
+  )
+
 addtest(invalid_fields_test invalid_fields_test.cpp)
 target_link_libraries(invalid_fields_test
   application

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -124,15 +124,14 @@ TEST_F(CreateRole, HaveNoPerms) {
  *       (aka skipProposal throws)
  */
 TEST_F(CreateRole, EmptyRole) {
-  ASSERT_ANY_THROW(
-      IntegrationTestFramework()
-          .setInitialState(kAdminKeypair)
-          .sendTx(makeUserWithPerms(
-              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
-          .skipProposal()
-          .skipBlock()
-          .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, "")))
-          .skipProposal());
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, "")));
+  ASSERT_ANY_THROW(itf.skipProposal());
 }
 
 /**
@@ -142,15 +141,14 @@ TEST_F(CreateRole, EmptyRole) {
  *       (aka skipProposal throws)
  */
 TEST_F(CreateRole, EmptyPerms) {
-  ASSERT_ANY_THROW(
-      IntegrationTestFramework()
-          .setInitialState(kAdminKeypair)
-          .sendTx(makeUserWithPerms(
-              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
-          .skipProposal()
-          .skipBlock()
-          .sendTx(completeTx(baseTx({}, kRole)))
-          .skipProposal());
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({}, kRole)));
+  ASSERT_ANY_THROW(itf.skipProposal());
 }
 
 /**
@@ -160,16 +158,15 @@ TEST_F(CreateRole, EmptyPerms) {
  *       (aka skipProposal throws)
  */
 TEST_F(CreateRole, LongRoleName) {
-  ASSERT_ANY_THROW(
-      IntegrationTestFramework()
-          .setInitialState(kAdminKeypair)
-          .sendTx(makeUserWithPerms(
-              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
-          .skipProposal()
-          .skipBlock()
-          .sendTx(completeTx(
-              baseTx({iroha::model::can_get_my_txs}, std::string(8, 'a'))))
-          .skipProposal());
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(
+          baseTx({iroha::model::can_get_my_txs}, std::string(8, 'a'))));
+  ASSERT_ANY_THROW(itf.skipProposal());
 }
 
 /**
@@ -199,15 +196,14 @@ TEST_F(CreateRole, MaxLenRoleName) {
  *       (aka skipProposal throws)
  */
 TEST_F(CreateRole, DISABLED_InexistentPerm) {
-  ASSERT_ANY_THROW(
-      IntegrationTestFramework()
-          .setInitialState(kAdminKeypair)
-          .sendTx(makeUserWithPerms(
-              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
-          .skipProposal()
-          .skipBlock()
-          .sendTx(completeTx(baseTx({"this_permission_doesnt_exist"}, kRole)))
-          .skipProposal());
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({"this_permission_doesnt_exist"}, kRole)));
+  ASSERT_ANY_THROW(itf.skipProposal());
 }
 
 /**
@@ -216,13 +212,12 @@ TEST_F(CreateRole, DISABLED_InexistentPerm) {
  * @then there is an empty verified proposal
  */
 TEST_F(CreateRole, DISABLED_ExistingRole) {
-  ASSERT_ANY_THROW(
-      IntegrationTestFramework()
-          .setInitialState(kAdminKeypair)
-          .sendTx(makeUserWithPerms(
-              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
-          .skipProposal()
-          .skipBlock()
-          .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, kRole)))
-          .skipProposal());
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, kRole)));
+  ASSERT_ANY_THROW(itf.skipProposal());
 }

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -1,0 +1,228 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "backend/protobuf/transaction.hpp"
+#include "builders/protobuf/queries.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "datetime/time.hpp"
+#include "framework/base_tx.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "model/permissions.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "utils/query_error_response_visitor.hpp"
+
+using namespace std::string_literals;
+using namespace integration_framework;
+using namespace shared_model;
+
+class CreateRole : public ::testing::Test {
+ public:
+  /**
+   * Creates the transaction with the user creation commands
+   * @param perms are the permissions of the user
+   * @return built tx and a hash of its payload
+   */
+  auto makeUserWithPerms(const std::vector<std::string> &perms) {
+    auto new_perms = perms;
+    new_perms.push_back(iroha::model::can_set_quorum);
+    return framework::createUserWithPerms(
+               kUser, kUserKeypair.publicKey(), kNewRole, new_perms)
+        .build()
+        .signAndAddSignature(kAdminKeypair);
+  }
+
+  /**
+   * Create valid base pre-build transaction with CreateRole command
+   * @param perms is a permission list
+   * @param role_name is a name of the role
+   * @return pre-build tx
+   */
+  auto baseTx(const std::vector<std::string> &perms,
+              const std::string role_name) {
+    return TestUnsignedTransactionBuilder()
+        .createRole(role_name, perms)
+        .txCounter(1)
+        .creatorAccountId(kUserId)
+        .createdTime(iroha::time::now());
+  }
+
+  /**
+   * Completes pre-build transaction
+   * @param builder is a pre-built tx
+   * @return built tx
+   */
+  template <typename TestTransactionBuilder>
+  auto completeTx(TestTransactionBuilder builder) {
+    return builder.build().signAndAddSignature(kUserKeypair);
+  }
+
+  const std::string kRole = "role"s;
+  const std::string kUser = "user"s;
+  const std::string kNewRole = "rl"s;
+  const std::string kUserId = kUser + "@test";
+  const crypto::Keypair kAdminKeypair =
+      crypto::DefaultCryptoAlgorithmType::generateKeypair();
+  const crypto::Keypair kUserKeypair =
+      crypto::DefaultCryptoAlgorithmType::generateKeypair();
+};
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command
+ * @then there is the tx in proposal
+ */
+TEST_F(CreateRole, Basic) {
+  IntegrationTestFramework()
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, kRole)))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
+ * @given some user without can_create_role permission
+ * @when execute tx with CreateRole command
+ * @then there is an empty verified proposal
+ */
+TEST_F(CreateRole, HaveNoPerms) {
+  IntegrationTestFramework()
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, kRole)))
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .done();
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with empty role
+ * @then the tx hasn't passed stateless validation
+ *       (aka skipProposal throws)
+ */
+TEST_F(CreateRole, EmptyRole) {
+  ASSERT_ANY_THROW(
+      IntegrationTestFramework()
+          .setInitialState(kAdminKeypair)
+          .sendTx(makeUserWithPerms(
+              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+          .skipProposal()
+          .skipBlock()
+          .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, "")))
+          .skipProposal());
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with empty permission
+ * @then the tx hasn't passed stateless validation
+ *       (aka skipProposal throws)
+ */
+TEST_F(CreateRole, EmptyPerms) {
+  ASSERT_ANY_THROW(
+      IntegrationTestFramework()
+          .setInitialState(kAdminKeypair)
+          .sendTx(makeUserWithPerms(
+              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+          .skipProposal()
+          .skipBlock()
+          .sendTx(completeTx(baseTx({}, kRole)))
+          .skipProposal());
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with too long role name
+ * @then the tx hasn't passed stateless validation
+ *       (aka skipProposal throws)
+ */
+TEST_F(CreateRole, DISABLED_LongRoleName) {
+  ASSERT_ANY_THROW(
+      IntegrationTestFramework()
+          .setInitialState(kAdminKeypair)
+          .sendTx(makeUserWithPerms(
+              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+          .skipProposal()
+          .skipBlock()
+          .sendTx(completeTx(
+              baseTx({iroha::model::can_get_my_txs}, std::string(8, 'a'))))
+          .skipProposal());
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with maximal role name size
+ * @then the tx is comitted
+ */
+TEST_F(CreateRole, MaxLenRoleName) {
+  IntegrationTestFramework()
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(
+          baseTx({iroha::model::can_get_my_txs}, std::string(7, 'a'))))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with inexistent permission name
+ * @then the tx hasn't passed stateless validation
+ *       (aka skipProposal throws)
+ */
+TEST_F(CreateRole, InexistentPerm) {
+  ASSERT_ANY_THROW(
+      IntegrationTestFramework()
+          .setInitialState(kAdminKeypair)
+          .sendTx(makeUserWithPerms(
+              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+          .skipProposal()
+          .skipBlock()
+          .sendTx(completeTx(baseTx({"this_permission_doesnt_exist"}, kRole)))
+          .skipProposal());
+}
+
+/**
+ * @given some user with can_create_role permission
+ * @when execute tx with CreateRole command with existent role name
+ * @then there is an empty verified proposal
+ */
+TEST_F(CreateRole, DISABLED_ExistingRole) {
+  ASSERT_ANY_THROW(
+      IntegrationTestFramework()
+          .setInitialState(kAdminKeypair)
+          .sendTx(makeUserWithPerms(
+              {iroha::model::can_get_my_txs, iroha::model::can_create_role}))
+          .skipProposal()
+          .skipBlock()
+          .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, kRole)))
+          .skipProposal());
+}

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -198,7 +198,7 @@ TEST_F(CreateRole, MaxLenRoleName) {
  * @then the tx hasn't passed stateless validation
  *       (aka skipProposal throws)
  */
-TEST_F(CreateRole, InexistentPerm) {
+TEST_F(CreateRole, DISABLED_InexistentPerm) {
   ASSERT_ANY_THROW(
       IntegrationTestFramework()
           .setInitialState(kAdminKeypair)

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -159,7 +159,7 @@ TEST_F(CreateRole, EmptyPerms) {
  * @then the tx hasn't passed stateless validation
  *       (aka skipProposal throws)
  */
-TEST_F(CreateRole, DISABLED_LongRoleName) {
+TEST_F(CreateRole, LongRoleName) {
   ASSERT_ANY_THROW(
       IntegrationTestFramework()
           .setInitialState(kAdminKeypair)


### PR DESCRIPTION
### Description of the Change

Adds acceptance tests for CreateRole command

Disabled test:
- **InexistentPerm** - issue at serialization for hashing [here](url), should work after moving tx processor to the new model
- **ExistingRole** - deadlock due to multiple insertions, doesn't seem obvious

### Benefits

Coverage, stability

### Possible Drawbacks 

~2 min of test execution time, itf issue?
