### PR TITLE
Cmake coverage target

### DIFF
--- a/.jenkinsci/bindings.groovy
+++ b/.jenkinsci/bindings.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 def doBindings() {
-
   def cmake_options = ""
   if (params.JavaBindings) {
     cmake_options += " -DSWIG_JAVA=ON "
@@ -10,7 +9,7 @@ def doBindings() {
     cmake_options += " -DSWIG_PYTHON=ON "
   }
   // In case language specific options were not set,
-  // build for every language
+  // build for each language
   if (!params.JavaBindings && !params.PythonBindings) {
     cmake_options += " -DSWIG_JAVA=ON -DSWIG_PYTHON=ON "
   }
@@ -21,8 +20,8 @@ def doBindings() {
       -DCMAKE_BUILD_TYPE=Release \
       ${cmake_options}
   """
+  sh "cmake --build build --target python_tests"
   sh "cd build; make -j${params.PARALLELISM} irohajava irohapy"
-  archive(includes: 'build/shared_model/bindings/')
 }
 
 return this

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -19,13 +19,13 @@ def doDebugBuild(coverageEnabled=false) {
   // speeds up consequent image builds as we simply tag them 
   sh "docker pull ${DOCKER_BASE_IMAGE_DEVELOP}"
   if (env.BRANCH_NAME == 'develop') {
-    iC = docker.build("hyperledger/iroha:${GIT_COMMIT}-${BUILD_NUMBER}", "--build-arg PARALLELISM=${parallelism} -f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT}")
+    iC = docker.build("hyperledger/iroha:${GIT_COMMIT}-${BUILD_NUMBER}", "--build-arg PARALLELISM=${env.parallelism} -f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT}")
     docker.withRegistry('https://registry.hub.docker.com', 'docker-hub-credentials') {
       iC.push("${platform}-develop")
     }
   }
   else {
-    iC = docker.build("hyperledger/iroha-workflow:${GIT_COMMIT}-${BUILD_NUMBER}", "-f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT} --build-arg PARALLELISM=${parallelism}")
+    iC = docker.build("hyperledger/iroha-workflow:${GIT_COMMIT}-${BUILD_NUMBER}", "-f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT} --build-arg PARALLELISM=${env.parallelism}")
   }
   iC.inside(""
     + " -e IROHA_POSTGRES_HOST=${env.IROHA_POSTGRES_HOST}"
@@ -36,6 +36,10 @@ def doDebugBuild(coverageEnabled=false) {
     + " -v /var/jenkins/ccache:${CCACHE_DIR}") {
 
     def scmVars = checkout scm
+    def cmakeOptions = ""
+    if ( coverageEnabled ) {
+      cmakeOptions = " -DCOVERAGE=ON "
+    }
     env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
     env.IROHA_HOME = "/opt/iroha"
     env.IROHA_BUILD = "${env.IROHA_HOME}/build"
@@ -48,16 +52,22 @@ def doDebugBuild(coverageEnabled=false) {
     """  
     sh """
       cmake \
-        -DCOVERAGE=ON \
         -DTESTING=ON \
         -H. \
         -Bbuild \
         -DCMAKE_BUILD_TYPE=Debug \
-        -DIROHA_VERSION=${env.IROHA_VERSION}
+        -DIROHA_VERSION=${env.IROHA_VERSION} \
+        ${cmakeOptions}
     """
-    sh "cmake --build build -- -j${parallelism}"
+    sh "cmake --build build -- -j${env.parallelism}"
     sh "ccache --show-stats"
-    sh "cmake --build build --target test"
+    if ( coverageEnabled ) {
+      sh "cmake --build build --target coverage.init.info"
+    }
+    def testExitCode = sh(script: 'cmake --build build --target test', returnStatus: true)
+    if (testExitCode != 0) {
+      currentBuild.result = "UNSTABLE"
+    }
     sh "cmake --build build --target cppcheck"
 
     if ( coverageEnabled ) {
@@ -75,9 +85,8 @@ def doDebugBuild(coverageEnabled=false) {
         """
       }
 
-      sh "lcov --capture --directory build --config-file .lcovrc --output-file build/reports/coverage_full.info"
-      sh "lcov --remove build/reports/coverage_full.info '/usr/*' 'schema/*' --config-file .lcovrc -o build/reports/coverage_full_filtered.info"
-      sh "python /tmp/lcov_cobertura.py build/reports/coverage_full_filtered.info -o build/reports/coverage.xml"                
+      sh "cmake --build build --target coverage.info"
+      sh "python /tmp/lcov_cobertura.py build/reports/coverage.info -o build/reports/coverage.xml"
       cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/build/reports/coverage.xml', conditionalCoverageTargets: '75, 50, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '75, 50, 0', maxNumberOfBuilds: 50, methodCoverageTargets: '75, 50, 0', onlyStable: false, zoomCoverageChart: false
     }
 

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -5,7 +5,7 @@ def doDebugBuild(coverageEnabled=false) {
   if ("arm7" in env.NODE_NAME) {
     parallelism = 1
   }
-  sh "docker network create ${env.IROHA_NETWORK}"
+  sh "docker network create ${env.IROHA_NETWORK} || true"
 
   docker.image('postgres:9.5').run(""
     + " -e POSTGRES_USER=${env.IROHA_POSTGRES_USER}"

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -68,9 +68,8 @@ def doDebugBuild(coverageEnabled=false) {
     if (testExitCode != 0) {
       currentBuild.result = "UNSTABLE"
     }
-    sh "cmake --build build --target cppcheck"
-
     if ( coverageEnabled ) {
+      sh "cmake --build build --target cppcheck"
       // Sonar
       if (env.CHANGE_ID != null) {
         sh """

--- a/.jenkinsci/release-build.groovy
+++ b/.jenkinsci/release-build.groovy
@@ -10,7 +10,7 @@ def doReleaseBuild() {
   // pull docker image for building release package of Iroha
   // speeds up consequent image builds as we simply tag them 
   sh "docker pull ${DOCKER_BASE_IMAGE_DEVELOP}"
-  iC = docker.build("hyperledger/iroha:${GIT_COMMIT}-${BUILD_NUMBER}", "--build-arg PARALLELISM=${parallelism} -f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT}")
+  iC = docker.build("hyperledger/iroha:${GIT_COMMIT}-${BUILD_NUMBER}", "--build-arg PARALLELISM=${env.parallelism} -f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT}")
 
   sh "mkdir /tmp/${env.GIT_COMMIT}-${BUILD_NUMBER} || true"
   iC.inside(""
@@ -39,7 +39,7 @@ def doReleaseBuild() {
         -DCOVERAGE=OFF \
         -DTESTING=OFF
     """
-    sh "cmake --build build --target package -- -j${parallelism}"
+    sh "cmake --build build --target package -- -j${env.parallelism}"
     sh "ccache --show-stats"
 
     // copy build package to the volume

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,15 @@ SET(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 SET(CMAKE_INSTALL_RPATH "../lib")
 
 if(COVERAGE)
+  find_program(LCOV_PROGRAM lcov)
+  if(NOT LCOV_PROGRAM)
+    message(FATAL_ERROR "lcov not found! Aborting...")
+  endif()
+  find_file(LCOV_CONFIG_FILE .lcovrc ${PROJECT_SOURCE_DIR})
+  if(NOT LCOV_CONFIG_FILE)
+    message(FATAL_ERROR "lcov config file not found in project root! Aborting...")
+  endif()
+  message(STATUS "lcov enabled (${LCOV_PROGRAM})")
   # remove -g flag to reduce binary size
   list(REMOVE_ITEM CMAKE_CXX_FLAGS -g)
   set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
@@ -23,7 +32,14 @@ if(COVERAGE)
   set(CMAKE_C_FLAGS "--coverage ${CMAKE_C_FLAGS}")
   set(CMAKE_SHARED_LINKER_FLAGS "--coverage ${CMAKE_SHARED_LINKER_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
-
+  add_custom_target(coverage.init.info
+      COMMAND ${LCOV_PROGRAM} --config-file ${LCOV_CONFIG_FILE} -o ${PROJECT_BINARY_DIR}/reports/coverage.init.info -c -i -d ${PROJECT_BINARY_DIR}
+      )
+  add_custom_target(coverage.info
+      COMMAND ${LCOV_PROGRAM} --config-file ${LCOV_CONFIG_FILE} -o ${PROJECT_BINARY_DIR}/reports/coverage.info -c -d ${PROJECT_BINARY_DIR}
+      COMMAND ${LCOV_PROGRAM} --config-file ${LCOV_CONFIG_FILE} -o ${PROJECT_BINARY_DIR}/reports/coverage.info -a ${PROJECT_BINARY_DIR}/reports/coverage.init.info -a ${PROJECT_BINARY_DIR}/reports/coverage.info
+      COMMAND ${LCOV_PROGRAM} --config-file ${LCOV_CONFIG_FILE} -o ${PROJECT_BINARY_DIR}/reports/coverage.info -r ${PROJECT_BINARY_DIR}/reports/coverage.info '/usr*' '${CMAKE_SOURCE_DIR}/external/*'
+      )
   set(REPORT_DIR ${CMAKE_BINARY_DIR}/reports)
   file(MAKE_DIRECTORY ${REPORT_DIR})
   include(cmake/analysis.cmake)
@@ -122,6 +138,3 @@ if (FUZZING)
     message(Fuzzing with compilers other than clang does not supported yet)
   endif()
 endif()
-
-
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,15 @@
 // Overall pipeline looks like the following
 //         
 //   |--Linux-----|----Debug
-//   |      |----Release 
-//   |  OR
-//   |       
+//   |            |----Release 
+//   |    OR
+//   |           
 //-- |--Linux ARM-|----Debug
-//   |      |----Release
-//   |  OR
+//   |            |----Release
+//   |    OR
 //   |
 //   |--MacOS-----|----Debug
-//   |      |----Release
+//   |            |----Release
 properties([parameters([
   choice(choices: 'Debug\nRelease', description: '', name: 'BUILD_TYPE'),
   booleanParam(defaultValue: true, description: '', name: 'Linux'),
@@ -81,9 +81,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }
@@ -109,9 +111,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }
@@ -137,9 +141,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }
@@ -150,8 +156,10 @@ pipeline {
           steps {
             script {
               def coverageEnabled = false
+              def cmakeOptions = ""
               if (!params.Linux) {
                 coverageEnabled = true
+                cmakeOptions = " -DCOVERAGE=ON "
               }
               def scmVars = checkout scm
               env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
@@ -159,38 +167,44 @@ pipeline {
               env.IROHA_BUILD = "${env.IROHA_HOME}/build"
 
               sh """
-                /usr/local/bin/ccache --version
-                /usr/local/bin/ccache --show-stats
-                /usr/local/bin/ccache --zero-stats
-                /usr/local/bin/ccache --max-size=5G
+                ccache --version
+                ccache --show-stats
+                ccache --zero-stats
+                ccache --max-size=5G
               """
               sh """
-                /usr/local/bin/cmake \
-                  -DCOVERAGE=ON \
+                cmake \
                   -DTESTING=ON \
                   -H. \
                   -Bbuild \
                   -DCMAKE_BUILD_TYPE=${params.BUILD_TYPE} \
-                  -DIROHA_VERSION=${env.IROHA_VERSION}
+                  -DIROHA_VERSION=${env.IROHA_VERSION} \
+                  ${cmakeOptions}
               """
-              sh "/usr/local/bin/cmake --build build -- -j${params.PARALLELISM}"
-              sh "/usr/local/bin/ccache --show-stats"
+              sh "cmake --build build -- -j${params.PARALLELISM}"
+              sh "ccache --show-stats"
+              if ( coverageEnabled ) {
+                sh "cmake --build build --target coverage.init.info"
+              }
               sh """
                 export IROHA_POSTGRES_PASSWORD=${IROHA_POSTGRES_PASSWORD}; \
                 export IROHA_POSTGRES_USER=${IROHA_POSTGRES_USER}; \
                 mkdir -p /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}; \
-                /usr/local/bin/initdb -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ -U ${IROHA_POSTGRES_USER} --pwfile=<(echo ${IROHA_POSTGRES_PASSWORD}); \
-                /usr/local/bin/pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ -o '-p 5433' -l /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/events.log start; \
-                /usr/local/bin/psql -h localhost -d postgres -p 5433 -U ${IROHA_POSTGRES_USER} --file=<(echo create database ${IROHA_POSTGRES_USER};)
+                initdb -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ -U ${IROHA_POSTGRES_USER} --pwfile=<(echo ${IROHA_POSTGRES_PASSWORD}); \
+                pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ -o '-p 5433' -l /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/events.log start; \
+                psql -h localhost -d postgres -p 5433 -U ${IROHA_POSTGRES_USER} --file=<(echo create database ${IROHA_POSTGRES_USER};)
               """
-              sh "IROHA_POSTGRES_HOST=localhost IROHA_POSTGRES_PORT=5433 /usr/local/bin/cmake --build build --target test"
-              sh "/usr/local/bin/cmake --build build --target cppcheck"
+              def testExitCode = sh(script: 'IROHA_POSTGRES_HOST=localhost IROHA_POSTGRES_PORT=5433 cmake --build build --target test', returnStatus: true)
+              if (testExitCode != 0) {
+                currentBuild.result = "UNSTABLE"
+              }
+              sh "cmake --build build --target cppcheck"
 
               if ( coverageEnabled ) {
                 // Sonar
                 if (env.CHANGE_ID != null) {
                   sh """
-                    /usr/local/bin/sonar-scanner \
+                    sonar-scanner \
                       -Dsonar.github.disableInlineComments \
                       -Dsonar.github.repository='hyperledger/iroha' \
                       -Dsonar.analysis.mode=preview \
@@ -199,11 +213,9 @@ pipeline {
                       -Dsonar.github.oauth=${SORABOT_TOKEN}
                   """
                 }
-                sh "/usr/local/bin/lcov --capture --directory build --config-file .lcovrc --output-file build/reports/coverage_full.info"
-                sh "/usr/local/bin/lcov --remove build/reports/coverage_full.info '/usr/*' 'schema/*' --config-file .lcovrc -o build/reports/coverage_full_filtered.info"
-                sh "python /usr/local/bin/lcov_cobertura.py build/reports/coverage_full_filtered.info -o build/reports/coverage.xml"                
+                sh "cmake --build build --target coverage.info"
+                sh "python /usr/local/bin/lcov_cobertura.py build/reports/coverage.info -o build/reports/coverage.xml"
                 cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/build/reports/coverage.xml', conditionalCoverageTargets: '75, 50, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '75, 50, 0', maxNumberOfBuilds: 50, methodCoverageTargets: '75, 50, 0', onlyStable: false, zoomCoverageChart: false
-
               }
               
               // TODO: replace with upload to artifactory server
@@ -216,11 +228,13 @@ pipeline {
           post {
             always {
               script {
-                cleanWs()
-                sh """
-                  /usr/local/bin/pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ stop && \
-                  rm -rf /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/
-                """
+                timeout(time: 60, unit: "SECONDS") {
+                  cleanWs()
+                  sh """
+                    pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ stop && \
+                    rm -rf /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/
+                  """
+                }
               }
             }
           }
@@ -247,9 +261,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }
@@ -266,9 +282,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }            
@@ -285,9 +303,11 @@ pipeline {
           post {
             always {
               script {
-                def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-                cleanup.doDockerCleanup()
-                cleanWs()
+                timeout(time: 60, unit: "SECONDS") {
+                  def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+                  cleanup.doDockerCleanup()
+                  cleanWs()
+                }
               }
             }
           }            
@@ -300,23 +320,22 @@ pipeline {
               env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
               env.IROHA_HOME = "/opt/iroha"
               env.IROHA_BUILD = "${env.IROHA_HOME}/build"
-              env.CCACHE_DIR = "${env.IROHA_HOME}/.ccache"
 
               sh """
-                /usr/local/bin/ccache --version
-                /usr/local/bin/ccache --show-stats
-                /usr/local/bin/ccache --zero-stats
-                /usr/local/bin/ccache --max-size=5G
+                ccache --version
+                ccache --show-stats
+                ccache --zero-stats
+                ccache --max-size=5G
               """  
               sh """
-                /usr/local/bin/cmake \
+                cmake \
                   -H. \
                   -Bbuild \
                   -DCMAKE_BUILD_TYPE=${params.BUILD_TYPE} \
                   -DIROHA_VERSION=${env.IROHA_VERSION}
               """
-              sh "/usr/local/bin/cmake --build build -- -j${params.PARALLELISM}"
-              sh "/usr/local/bin/ccache --show-stats"
+              sh "cmake --build build -- -j${params.PARALLELISM}"
+              sh "ccache --show-stats"
               
               // TODO: replace with upload to artifactory server
               // only develop branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,9 +198,8 @@ pipeline {
               if (testExitCode != 0) {
                 currentBuild.result = "UNSTABLE"
               }
-              sh "cmake --build build --target cppcheck"
-
               if ( coverageEnabled ) {
+                sh "cmake --build build --target cppcheck"
                 // Sonar
                 if (env.CHANGE_ID != null) {
                   sh """


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
#### Jenkinsfile
- Coverage step is now a separate Cmake target instead of plain scripting
- Fix ccache not being used during builds on MacOS
- Fix full path to binaries being used instead of relative ones on MacOS. Jenkins now complements PATH with additional lookup paths
- Fix post step may stuck forever on random builds. It now has a timeout. Post step will be forcibly terminated after a certain timeout (60s)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Increase stability of CI pipeline. Improve Jenkinsfile readability.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
