### PR TITLE
Fix irohad failing on stopped postgres

### DIFF
--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -83,11 +83,12 @@ namespace iroha {
         std::unique_ptr<shared_model::interface::Proposal> proposal) {
       std::vector<std::string> peers;
 
-      auto lst = wsv_->getLedgerPeers().value();
-      for (const auto &peer : lst) {
-        peers.push_back(peer->address());
-      }
-      transport_->publishProposal(std::move(proposal), peers);
+      wsv_->getLedgerPeers() | [&](auto &lst) {
+        for (const auto &peer : lst) {
+          peers.push_back(peer->address());
+        }
+        transport_->publishProposal(std::move(proposal), peers);
+      };
     }
 
     void OrderingServiceImpl::updateTimer() {

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -74,9 +74,9 @@ namespace iroha {
 
       // Save proposal height to the persistent storage.
       // In case of restart it reloads state.
-      persistent_state_->saveProposalHeight(proposal_height);
-
-      publishProposal(std::move(proposal));
+      if (persistent_state_->saveProposalHeight(proposal_height)) {
+        publishProposal(std::move(proposal));
+      }
     }
 
     void OrderingServiceImpl::publishProposal(

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -76,7 +76,7 @@ namespace iroha {
 
       // Save proposal height to the persistent storage.
       // In case of restart it reloads state.
-      if (not persistent_state_->saveProposalHeight(proposal_height)) {
+      if (persistent_state_->saveProposalHeight(proposal_height)) {
         publishProposal(std::move(proposal));
       } else {
         // TODO(@l4l) 23/03/18: publish proposal independant of psql status

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -79,6 +79,8 @@ namespace iroha {
       if (not persistent_state_->saveProposalHeight(proposal_height)) {
         publishProposal(std::move(proposal));
       } else {
+        // TODO(@l4l) 23/03/18: publish proposal independant of psql status
+        // IR-1162
         log_->warn(
             "Proposal height cannot be saved. Skipping proposal publish");
       }

--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -38,7 +38,8 @@ namespace iroha {
           max_size_(max_size),
           delay_milliseconds_(delay_milliseconds),
           transport_(transport),
-          persistent_state_(persistent_state) {
+          persistent_state_(persistent_state),
+          is_finished(false) {
       updateTimer();
       log_ = logger::log("OrderingServiceImpl");
 
@@ -103,6 +104,10 @@ namespace iroha {
     }
 
     void OrderingServiceImpl::updateTimer() {
+      std::lock_guard<std::mutex> lock(m);
+      if (is_finished) {
+        return;
+      }
       if (not queue_.empty()) {
         this->generateProposal();
       }
@@ -113,6 +118,8 @@ namespace iroha {
     }
 
     OrderingServiceImpl::~OrderingServiceImpl() {
+      std::lock_guard<std::mutex> lock(m);
+      is_finished = true;
       handle.unsubscribe();
     }
   }  // namespace ordering

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -20,6 +20,7 @@
 
 #include <tbb/concurrent_queue.h>
 #include <memory>
+#include <mutex>
 #include <rxcpp/rx.hpp>
 
 #include "logger/logger.hpp"
@@ -122,6 +123,16 @@ namespace iroha {
        * the ledger + 1.
        */
       size_t proposal_height;
+
+      /**
+       * Mutex for proper quit handling
+       */
+      std::mutex m;
+
+      /**
+       * Set after destruction
+       */
+      bool is_finished;
 
       logger::Logger log_;
     };

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -25,18 +25,16 @@
 
 #include "ametsuchi/ordering_service_persistent_state.hpp"
 #include "backend/protobuf/common_objects/peer.hpp"
-#include "mock_ordering_service_persistent_state.hpp"
 #include "builders/common_objects/peer_builder.hpp"
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
+#include "mock_ordering_service_persistent_state.hpp"
+#include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "ordering/impl/ordering_gate_impl.hpp"
 #include "ordering/impl/ordering_gate_transport_grpc.hpp"
 #include "ordering/impl/ordering_service_impl.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
 #include "validators/field_validator.hpp"
-
-#include "builders/protobuf/common_objects/proto_peer_builder.hpp"
-#include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
-#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 
 using namespace iroha;
 using namespace iroha::ordering;
@@ -45,12 +43,12 @@ using namespace iroha::network;
 using namespace iroha::ametsuchi;
 using namespace std::chrono_literals;
 
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
+using ::testing::_;
 
 using wPeer = std::shared_ptr<shared_model::interface::Peer>;
 
@@ -136,8 +134,9 @@ TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
   const size_t max_proposal = 5;
   const size_t commit_delay = 1000;
 
-  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_)).Times(2);
-
+  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
+      .Times(2)
+      .WillRepeatedly(Return(true));
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
@@ -175,8 +174,9 @@ TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
 TEST_F(OrderingServiceTest, ValidWhenTimerStrategy) {
   // Init => proposal timer 400 ms => 10 tx by 50 ms => 2 proposals in 1 second
 
-  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_)).Times(2);
-
+  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
+      .Times(2)
+      .WillRepeatedly(Return(true));
   shared_model::proto::PeerBuilder builder;
 
   auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());


### PR DESCRIPTION
### Description of the Change

If psql is stopped during irohad, the last one may cause sigsegv, abort or smth else.
This pr introduces few checks for db activeness

### Benefits

Stability

### Usage Examples or Tests

These steps will cause irohad failing:

1. start postgres
2. start irohad
3. stop postgres
4. send something via iroha-cli

With that fixes it doesn't do anything

### Alternate Designs

Maybe call `std::abort` with meaningful error?
