### PR TITLE
Feature/unique ptr in shm copy ir 1115

### DIFF
--- a/example/config.sample
+++ b/example/config.sample
@@ -8,3 +8,4 @@
   "vote_delay" : 5000,
   "load_delay" : 5000
 }
+

--- a/example/config.sample
+++ b/example/config.sample
@@ -8,4 +8,3 @@
   "vote_delay" : 5000,
   "load_delay" : 5000
 }
-

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -73,7 +73,7 @@ namespace iroha {
       if (result) {
         block_store_.insert(std::make_pair(
             block.height(),
-            std::unique_ptr<shared_model::interface::Block>(block.copy())));
+            clone(block)));
         block_index_->index(block);
 
         top_hash_ = block.hash();

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -125,7 +125,7 @@ namespace iroha {
             }),
             [&](auto x) {
               subscriber.on_next(PostgresBlockQuery::wTransaction(
-                  block->transactions().at(x)->copy()));
+                  clone(*block->transactions().at(x))));
             });
       };
     }
@@ -216,8 +216,7 @@ namespace iroha {
                            block.transactions().end(),
                            [&hash](auto tx) { return tx->hash() == hash; });
           if (it != block.transactions().end()) {
-            result = boost::optional<PostgresBlockQuery::wTransaction>(
-                PostgresBlockQuery::wTransaction((*it)->copy()));
+            result = boost::optional<PostgresBlockQuery::wTransaction>(clone(**it));
           }
           return result;
         };

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_CONF_LOADER_HPP
 #define IROHA_CONF_LOADER_HPP
 
+#include <rapidjson/error/en.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/rapidjson.h>
 #include <fstream>
@@ -50,7 +51,10 @@ inline rapidjson::Document parse_iroha_config(const std::string &conf_path) {
   const std::string kStrType = "string";
   const std::string kUintType = "uint";
   doc.ParseStream(isw);
-  ac::assert_fatal(not doc.HasParseError(), "JSON parse error: " + conf_path);
+  ac::assert_fatal(
+      not doc.HasParseError(),
+      "JSON parse error [" + conf_path + "]: "
+          + std::string(rapidjson::GetParseError_En(doc.GetParseError())));
 
   ac::assert_fatal(doc.HasMember(mbr::BlockStorePath),
                    ac::no_member_error(mbr::BlockStorePath));

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_CONF_LOADER_HPP
 #define IROHA_CONF_LOADER_HPP
 
-#include <rapidjson/error/en.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/rapidjson.h>
 #include <fstream>
@@ -51,10 +50,7 @@ inline rapidjson::Document parse_iroha_config(const std::string &conf_path) {
   const std::string kStrType = "string";
   const std::string kUintType = "uint";
   doc.ParseStream(isw);
-  ac::assert_fatal(
-      not doc.HasParseError(),
-      "JSON parse error [" + conf_path + "]: "
-          + std::string(rapidjson::GetParseError_En(doc.GetParseError())));
+  ac::assert_fatal(not doc.HasParseError(), "JSON parse error: " + conf_path);
 
   ac::assert_fatal(doc.HasMember(mbr::BlockStorePath),
                    ac::no_member_error(mbr::BlockStorePath));

--- a/libs/common/cloneable.hpp
+++ b/libs/common/cloneable.hpp
@@ -21,21 +21,18 @@
 #include <memory>
 
 /**
- * Functions and interface to create cloneable classes with
+ * Functions and interface for creation cloneable classes with
  * smart pointers.
  *
  * Usage:
- * struct Base : object::cloneable<Base>
- * {
+ * struct Base : object::cloneable<Base> {
  *   // ... other methods
  * };
  *
- * struct Derived : Base
- * {
+ * struct Derived : Base {
  *   // ... other methods
  * protected:
- *   Derived* clone() const override
- *   {
+ *   Derived* clone() const override {
  *     return new Derived(*this);
  *   }
  * };
@@ -45,7 +42,7 @@
  */
 
 /**
- * Function to clone Cloneable.
+ * Function to clone from Cloneable.
  * @tparam T - derived from Cloneable
  * @param object - object to clone
  * @return clone of object
@@ -85,7 +82,7 @@ class Cloneable {
   /**
    * Polymorphic clone constructor.
    * Method guarantees deep-copy.
-   * @return pointer to clone object
+   * @return pointer to cloned object
    */
   virtual T *clone() const = 0;
 

--- a/libs/common/cloneable.hpp
+++ b/libs/common/cloneable.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
  * http://soramitsu.co.jp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ std::unique_ptr<T> clone(const T &object) {
  * @return clone of object
  */
 template <typename T>
-auto clone(T *object) -> decltype(clone(*object)) {
+auto clone(T *object) {
   return clone(*object);
 }
 

--- a/libs/common/cloneable.hpp
+++ b/libs/common/cloneable.hpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
+ * http://soramitsu.co.jp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IROHA_CLONEABLE_HPP
+#define IROHA_CLONEABLE_HPP
+
+#include <memory>
+
+/**
+ * Functions and interface to create cloneable classes with
+ * smart pointers.
+ *
+ * Usage:
+ * struct Base : object::cloneable<Base>
+ * {
+ *   // ... other methods
+ * };
+ *
+ * struct Derived : Base
+ * {
+ *   // ... other methods
+ * protected:
+ *   Derived* clone() const override
+ *   {
+ *     return new Derived(*this);
+ *   }
+ * };
+ *
+ * Derived derived;
+ * auto c1 = clone(derived);
+ */
+
+/**
+ * Function to clone Cloneable.
+ * @tparam T - derived from Cloneable
+ * @param object - object to clone
+ * @return clone of object
+ */
+template <typename T>
+std::unique_ptr<T> clone(const T &object) {
+  using base_type = typename T::base_type;
+  static_assert(std::is_base_of<base_type, T>::value,
+                "T object has to derived from T::base_type");
+  auto ptr = static_cast<const base_type &>(object).clone();
+  return std::unique_ptr<T>(static_cast<T *>(ptr));
+}
+
+/**
+ * Helper function to copy from pointer to Cloneable.
+ * @tparam T - derived from Cloneable
+ * @param object - object to clone
+ * @return clone of object
+ */
+template <typename T>
+auto clone(T *object) -> decltype(clone(*object)) {
+  return clone(*object);
+}
+
+/**
+ * Interface for cloneable classes.
+ * @tparam T
+ */
+template <typename T>
+class Cloneable {
+ public:
+  using base_type = T;
+
+  virtual ~Cloneable() = default;
+
+ protected:
+  /**
+   * Polymorphic clone constructor.
+   * Method guarantees deep-copy.
+   * @return pointer to clone object
+   */
+  virtual T *clone() const = 0;
+
+  template <typename X>
+  friend std::unique_ptr<X> clone(const X &);
+};
+
+#endif  // IROHA_CLONEABLE_HPP

--- a/shared_model/backend/protobuf/common_objects/trivial_proto.hpp
+++ b/shared_model/backend/protobuf/common_objects/trivial_proto.hpp
@@ -38,7 +38,8 @@ namespace shared_model {
       explicit TrivialProto(ProtoLoader &&ref)
           : proto_(std::forward<ProtoLoader>(ref)) {}
 
-      typename Iface::ModelType *copy() const override {
+     protected:
+      typename Iface::ModelType *clone() const override {
         return new TrivialProto(Proto(*proto_));
       }
 
@@ -63,10 +64,6 @@ namespace shared_model {
       explicit CopyableProto(ProtoLoader &&ref)
           : proto_(std::forward<ProtoLoader>(ref)) {}
 
-      typename Iface::ModelType *copy() const override final {
-        return new Impl(Proto(*proto_));
-      }
-
       using TransportType = Proto;
 
       const Proto &getTransport() const {
@@ -74,6 +71,9 @@ namespace shared_model {
       }
 
      protected:
+      typename Iface::ModelType *clone() const override final {
+        return new Impl(Proto(*proto_));
+      }
       detail::ReferenceHolder<Proto> proto_;
     };
   }  // namespace proto

--- a/shared_model/builders/common_objects/common.hpp
+++ b/shared_model/builders/common_objects/common.hpp
@@ -53,7 +53,8 @@ namespace shared_model {
        * why object construction is unsuccessful.
        */
       BuilderResult<ModelType> build() {
-        auto model_impl = std::shared_ptr<ModelType>(builder_.build().copy());
+        std::shared_ptr<ModelType> model_impl =
+            std::move(clone(builder_.build()));
 
         auto reasons = validate(*model_impl);
         reasons.first = builderName();

--- a/shared_model/builders/transaction_responses/transaction_status_builder.hpp
+++ b/shared_model/builders/transaction_responses/transaction_status_builder.hpp
@@ -34,8 +34,7 @@ namespace shared_model {
     class TransactionStatusBuilder {
      public:
       std::shared_ptr<shared_model::interface::TransactionResponse> build() {
-        return std::shared_ptr<shared_model::interface::TransactionResponse>(
-            builder_.build().copy());
+        return clone(builder_.build());
       }
 
       TransactionStatusBuilder statelessValidationSuccess() {

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -82,8 +82,6 @@ namespace shared_model {
 
       bool operator==(const Blob &rhs) const override;
 
-      Blob *copy() const override;
-
 #ifndef DISABLE_BACKWARD
       /**
        * Method perform transforming object to old-fashion blob_t format
@@ -98,6 +96,9 @@ namespace shared_model {
         return BlobType::from_string(toBinaryString(*this));
       }
 #endif
+
+     protected:
+      Blob *clone() const override;
 
      private:
       // TODO: 17/11/2017 luckychess use improved Lazy with references support

--- a/shared_model/cryptography/keypair.hpp
+++ b/shared_model/cryptography/keypair.hpp
@@ -66,7 +66,8 @@ namespace shared_model {
 
 #endif
 
-      Keypair *copy() const override;
+     private:
+      Keypair *clone() const override;
 
      private:
       PublicKey public_key_;

--- a/shared_model/cryptography/model_impl/blob.cpp
+++ b/shared_model/cryptography/model_impl/blob.cpp
@@ -36,7 +36,7 @@ namespace shared_model {
       hex_ = iroha::bytestringToHexstring(toBinaryString(*this));
     }
 
-    Blob *Blob::copy() const {
+    Blob *Blob::clone() const {
       return new Blob(blob());
     }
 

--- a/shared_model/cryptography/model_impl/keypair.cpp
+++ b/shared_model/cryptography/model_impl/keypair.cpp
@@ -43,7 +43,7 @@ namespace shared_model {
           .finalize();
     }
 
-    Keypair *Keypair::copy() const {
+    Keypair *Keypair::clone() const {
       return new Keypair(publicKey(), privateKey());
     }
 

--- a/shared_model/cryptography/model_impl/public_key.cpp
+++ b/shared_model/cryptography/model_impl/public_key.cpp
@@ -33,7 +33,7 @@ namespace shared_model {
           .finalize();
     }
 
-    PublicKey *PublicKey::copy() const {
+    PublicKey *PublicKey::clone() const {
       return new PublicKey(crypto::toBinaryString(*this));
     }
 

--- a/shared_model/cryptography/public_key.hpp
+++ b/shared_model/cryptography/public_key.hpp
@@ -37,7 +37,8 @@ namespace shared_model {
 
       std::string toString() const override;
 
-      PublicKey *copy() const override;
+     protected:
+      PublicKey *clone() const override;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/interfaces/base/model_primitive.hpp
+++ b/shared_model/interfaces/base/model_primitive.hpp
@@ -19,6 +19,7 @@
 #define IROHA_MODEL_PRIMITIVE_HPP
 
 #include "utils/string_builder.hpp"
+#include "common/cloneable.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -29,7 +30,7 @@ namespace shared_model {
      * @tparam Model - your new style model
      */
     template <typename Model>
-    class ModelPrimitive {
+    class ModelPrimitive : public Cloneable<ModelPrimitive<Model>> {
      public:
       /**
        * Reference for model type.
@@ -52,16 +53,6 @@ namespace shared_model {
       virtual bool operator!=(const ModelType &rhs) const {
         return not(*this == rhs);
       }
-
-      /**
-       * Polymorphic copy constructor.
-       * Method guarantees deep-copy.
-       * @return pointer to copied object
-       * discussion note: this method possible to rework with in-place pointer
-       * as parameter. such as: copy(T* ptr=nullptr), on nullptr allocate object
-       * on heap, otherwise in passed pointer
-       */
-      virtual ModelType *copy() const = 0;
 
       virtual ~ModelPrimitive() = default;
     };

--- a/shared_model/utils/polymorphic_wrapper.hpp
+++ b/shared_model/utils/polymorphic_wrapper.hpp
@@ -46,7 +46,7 @@ namespace shared_model {
        * @param rhs - another wrapped value
        */
       PolymorphicWrapper(const PolymorphicWrapper &rhs)
-          : ptr_(rhs.ptr_->copy()) {}
+          : ptr_(std::move(clone(*rhs.ptr_))) {}
 
       /**
        * Move constructor
@@ -67,7 +67,7 @@ namespace shared_model {
       template <typename Y,
                 typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
       PolymorphicWrapper(const PolymorphicWrapper<Y> &rhs)
-          : ptr_(rhs.ptr_->copy()) {}
+          : ptr_(std::move(clone(*rhs.ptr_))) {}
 
       template <typename Y,
                 typename = std::enable_if_t<std::is_base_of<T, Y>::value>>
@@ -82,7 +82,7 @@ namespace shared_model {
        * @return *this
        */
       PolymorphicWrapper &operator=(const PolymorphicWrapper &rhs) {
-        ptr_ = rhs.ptr_->copy();
+        ptr_ = std::move(clone(*rhs.ptr_));
         return *this;
       }
 

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -19,13 +19,13 @@
 
 #include <endpoint.pb.h>
 
+#include "builders/protobuf/common_objects/proto_account_builder.hpp"
 #include "model/sha3_hash.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
-#include "builders/protobuf/common_objects/proto_account_builder.hpp"
 
 #include "client.hpp"
 
@@ -218,9 +218,8 @@ TEST_F(ClientServerTest, SendQueryWhenValid) {
   auto account_admin = iroha::model::Account();
   account_admin.account_id = "admin@test";
 
-  auto account_test = std::shared_ptr<shared_model::interface::Account>(
-      shared_model::proto::AccountBuilder().accountId("test@test").build().copy()
-  );
+  std::shared_ptr<shared_model::interface::Account> account_test = clone(
+      shared_model::proto::AccountBuilder().accountId("test@test").build());
 
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(

--- a/test/module/irohad/consensus/yac/peer_orderer_test.cpp
+++ b/test/module/irohad/consensus/yac/peer_orderer_test.cpp
@@ -58,9 +58,12 @@ class YacPeerOrdererTest : public ::testing::Test {
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers = [] {
     std::vector<std::shared_ptr<shared_model::interface::Peer>> result;
     for (size_t i = 1; i <= N_PEERS; ++i) {
-      auto peer = std::shared_ptr<shared_model::interface::Peer>(shared_model::proto::PeerBuilder()
-                      .address(std::to_string(i)).pubkey(shared_model::interface::types::PubkeyType(std::string(32, '0')))
-                      .build().copy());
+      auto peer = std::shared_ptr<shared_model::interface::Peer>(
+          clone(shared_model::proto::PeerBuilder()
+                    .address(std::to_string(i))
+                    .pubkey(shared_model::interface::types::PubkeyType(
+                        std::string(32, '0')))
+                    .build()));
       result.push_back(peer);
     }
     return result;
@@ -76,7 +79,7 @@ class YacPeerOrdererTest : public ::testing::Test {
       auto key = shared_model::crypto::PublicKey(tmp.pubkey.to_string());
       auto peer = builder.address(tmp.address).pubkey(key).build();
 
-      result.emplace_back(peer.copy());
+      result.emplace_back(clone(peer));
     }
     return result;
   }();
@@ -93,7 +96,8 @@ TEST_F(YacPeerOrdererTest, PeerOrdererInitialOrderWhenInvokeNormalCase) {
   auto old_peers = [this] {
     std::vector<iroha::model::Peer> result;
     for (auto &peer : s_peers) {
-      result.push_back(*std::unique_ptr<iroha::model::Peer>(peer->makeOldModel()));
+      result.push_back(
+          *std::unique_ptr<iroha::model::Peer>(peer->makeOldModel()));
     }
     return result;
   }();

--- a/test/module/irohad/consensus/yac/peer_orderer_test.cpp
+++ b/test/module/irohad/consensus/yac/peer_orderer_test.cpp
@@ -58,12 +58,12 @@ class YacPeerOrdererTest : public ::testing::Test {
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers = [] {
     std::vector<std::shared_ptr<shared_model::interface::Peer>> result;
     for (size_t i = 1; i <= N_PEERS; ++i) {
-      auto peer = std::shared_ptr<shared_model::interface::Peer>(
+      std::shared_ptr<shared_model::interface::Peer> peer =
           clone(shared_model::proto::PeerBuilder()
                     .address(std::to_string(i))
                     .pubkey(shared_model::interface::types::PubkeyType(
                         std::string(32, '0')))
-                    .build()));
+                    .build());
       result.push_back(peer);
     }
     return result;

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -109,7 +109,7 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
           shared_model::proto::from_old(expected_block));
   EXPECT_CALL(*block_creator, on_block())
       .WillOnce(Return(rxcpp::observable<>::just(block).map([](auto &&x) {
-        return std::shared_ptr<shared_model::interface::Block>(x.copy());
+        return std::shared_ptr<shared_model::interface::Block>(clone(x));
       })));
   expected_block = *std::unique_ptr<iroha::model::Block>(block.makeOldModel());
 
@@ -143,7 +143,7 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
           shared_model::proto::from_old(expected_block));
   EXPECT_CALL(*block_creator, on_block())
       .WillOnce(Return(rxcpp::observable<>::just(block).map([](auto &&x) {
-        return std::shared_ptr<shared_model::interface::Block>(x.copy());
+        return std::shared_ptr<shared_model::interface::Block>(clone(x));
       })));
 
   init();
@@ -157,7 +157,7 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommit) {
       shared_model::proto::from_old(expected_block));
   EXPECT_CALL(*block_creator, on_block())
       .WillOnce(Return(rxcpp::observable<>::just(block).map([](auto &&x) {
-        return std::shared_ptr<shared_model::interface::Block>(x.copy());
+        return std::shared_ptr<shared_model::interface::Block>(clone(x));
       })));
 
   // make hash from block

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -90,11 +90,10 @@ class CommandValidateExecuteTest : public ::testing::Test {
               FAIL() << *e.error;
             });
 
-    default_domain = std::shared_ptr<shared_model::interface::Domain>(
-        clone(shared_model::proto::DomainBuilder()
-                  .domainId(domain_id)
-                  .defaultRole(admin_role)
-                  .build()));
+    default_domain = clone(shared_model::proto::DomainBuilder()
+                            .domainId(domain_id)
+                            .defaultRole(admin_role)
+                            .build());
   }
 
   ExecutionResult validateAndExecute() {
@@ -1155,32 +1154,28 @@ class TransferAssetTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    asset = std::shared_ptr<shared_model::interface::Asset>(
-        clone(shared_model::proto::AssetBuilder()
-            .assetId(asset_id)
-            .domainId(domain_id)
-            .precision(2)
-            .build()));
+    asset = clone(shared_model::proto::AssetBuilder()
+                  .assetId(asset_id)
+                  .domainId(domain_id)
+                  .precision(2)
+                  .build());
 
-    balance = std::shared_ptr<shared_model::interface::Amount>(
-        clone(shared_model::proto::AmountBuilder()
-            .intValue(150)
-            .precision(2)
-            .build()));
+    balance = clone(shared_model::proto::AmountBuilder()
+                  .intValue(150)
+                  .precision(2)
+                  .build());
 
-    src_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
-        clone(shared_model::proto::AccountAssetBuilder()
-            .assetId(asset_id)
-            .accountId(admin_id)
-            .balance(*balance)
-            .build()));
+    src_wallet = clone(shared_model::proto::AccountAssetBuilder()
+                  .assetId(asset_id)
+                  .accountId(admin_id)
+                  .balance(*balance)
+                  .build());
 
-    dst_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
-        clone(shared_model::proto::AccountAssetBuilder()
-            .assetId(asset_id)
-            .accountId(account_id)
-            .balance(*balance)
-            .build()));
+    dst_wallet = clone(shared_model::proto::AccountAssetBuilder()
+                  .assetId(asset_id)
+                  .accountId(account_id)
+                  .balance(*balance)
+                  .build());
 
     transfer_asset = std::make_shared<TransferAsset>();
     transfer_asset->src_account_id = admin_id;
@@ -1481,19 +1476,18 @@ TEST_F(TransferAssetTest, InvalidWhenWrongPrecisionDuringExecute) {
  * @then execute fails and returns false
  */
 TEST_F(TransferAssetTest, InvalidWhenAmountOverflow) {
-  auto max_balance = std::shared_ptr<shared_model::interface::Amount>(
-      clone(shared_model::proto::AmountBuilder()
+  std::shared_ptr<shared_model::interface::Amount> max_balance = clone(
+      shared_model::proto::AmountBuilder()
           .intValue(
               std::numeric_limits<boost::multiprecision::uint256_t>::max())
           .precision(2)
-          .build()));
+          .build());
 
-  src_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
-      clone(shared_model::proto::AccountAssetBuilder()
-          .assetId(src_wallet->assetId())
-          .accountId(src_wallet->accountId())
-          .balance(*max_balance)
-          .build()));
+  src_wallet = clone(shared_model::proto::AccountAssetBuilder()
+                .assetId(src_wallet->assetId())
+                .accountId(src_wallet->accountId())
+                .balance(*max_balance)
+                .build());
 
   EXPECT_CALL(*wsv_query, getAsset(transfer_asset->asset_id))
       .WillOnce(Return(asset));
@@ -1506,7 +1500,7 @@ TEST_F(TransferAssetTest, InvalidWhenAmountOverflow) {
                               transfer_asset->asset_id))
       .WillOnce(Return(dst_wallet));
 
-  // More than account balance)
+  // More than account balance
   transfer_asset->amount = (max_amount - Amount(100, 2)).value();
 
   ASSERT_NO_THROW(checkErrorCase(execute()));

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -94,8 +94,7 @@ class CommandValidateExecuteTest : public ::testing::Test {
         shared_model::proto::DomainBuilder()
             .domainId(domain_id)
             .defaultRole(admin_role)
-            .build()
-            .copy());
+            .build());
   }
 
   ExecutionResult validateAndExecute() {
@@ -1162,31 +1161,27 @@ class TransferAssetTest : public CommandValidateExecuteTest {
             .assetId(asset_id)
             .domainId(domain_id)
             .precision(2)
-            .build()
-            .copy());
+            .build());
 
     balance = std::shared_ptr<shared_model::interface::Amount>(
         shared_model::proto::AmountBuilder()
             .intValue(150)
             .precision(2)
-            .build()
-            .copy());
+            .build());
 
     src_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
         shared_model::proto::AccountAssetBuilder()
             .assetId(asset_id)
             .accountId(admin_id)
             .balance(*balance)
-            .build()
-            .copy());
+            .build());
 
     dst_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
         shared_model::proto::AccountAssetBuilder()
             .assetId(asset_id)
             .accountId(account_id)
             .balance(*balance)
-            .build()
-            .copy());
+            .build());
 
     transfer_asset = std::make_shared<TransferAsset>();
     transfer_asset->src_account_id = admin_id;
@@ -1492,16 +1487,14 @@ TEST_F(TransferAssetTest, InvalidWhenAmountOverflow) {
           .intValue(
               std::numeric_limits<boost::multiprecision::uint256_t>::max())
           .precision(2)
-          .build()
-          .copy());
+          .build());
 
   src_wallet = std::shared_ptr<shared_model::interface::AccountAsset>(
       shared_model::proto::AccountAssetBuilder()
           .assetId(src_wallet->assetId())
           .accountId(src_wallet->accountId())
           .balance(*max_balance)
-          .build()
-          .copy());
+          .build());
 
   EXPECT_CALL(*wsv_query, getAsset(transfer_asset->asset_id))
       .WillOnce(Return(asset));

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -122,14 +122,13 @@ TEST_F(BlockLoaderTest, ValidWhenSameTopBlock) {
       shared_model::proto::PeerBuilder()
           .pubkey(peer->pubkey())
           .address(peer->address())
-          .build()
-          .copy());
+          .build());
 
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{w_peer}));
   EXPECT_CALL(*storage, getTopBlocks(1))
       .WillOnce(Return(rxcpp::observable<>::just(block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   EXPECT_CALL(*storage, getBlocksFrom(block.height() + 1))
       .WillOnce(Return(rxcpp::observable<>::empty<wBlock>()));
   auto wrapper = make_test_subscriber<CallExact>(
@@ -163,10 +162,10 @@ TEST_F(BlockLoaderTest, ValidWhenOneBlock) {
       .WillOnce(Return(std::vector<wPeer>{w_peer}));
   EXPECT_CALL(*storage, getTopBlocks(1))
       .WillOnce(Return(rxcpp::observable<>::just(block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   EXPECT_CALL(*storage, getBlocksFrom(block.height() + 1))
       .WillOnce(Return(rxcpp::observable<>::just(top_block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   auto wrapper =
       make_test_subscriber<CallExact>(loader->retrieveBlocks(peer_key), 1);
   wrapper.subscribe(
@@ -190,7 +189,7 @@ TEST_F(BlockLoaderTest, ValidWhenMultipleBlocks) {
   std::vector<wBlock> blocks;
   for (auto i = next_height; i < next_height + num_blocks; ++i) {
     auto blk = getBaseBlockBuilder().height(i).build();
-    blocks.emplace_back(blk.copy());
+    blocks.emplace_back(clone(blk));
   }
 
   EXPECT_CALL(*provider, verify(A<const iroha::model::Block &>()))
@@ -208,7 +207,7 @@ TEST_F(BlockLoaderTest, ValidWhenMultipleBlocks) {
       .WillOnce(Return(std::vector<wPeer>{w_peer}));
   EXPECT_CALL(*storage, getTopBlocks(1))
       .WillOnce(Return(rxcpp::observable<>::just(block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   EXPECT_CALL(*storage, getBlocksFrom(next_height))
       .WillOnce(Return(rxcpp::observable<>::iterate(blocks)));
   auto wrapper = make_test_subscriber<CallExact>(
@@ -242,7 +241,7 @@ TEST_F(BlockLoaderTest, ValidWhenBlockPresent) {
       .WillOnce(Return(std::vector<wPeer>{w_peer}));
   EXPECT_CALL(*storage, getBlocksFrom(1))
       .WillOnce(Return(rxcpp::observable<>::just(requested).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   auto block = loader->retrieveBlock(peer_key, requested.hash());
 
   ASSERT_TRUE(block);
@@ -269,7 +268,7 @@ TEST_F(BlockLoaderTest, ValidWhenBlockMissing) {
       .WillOnce(Return(std::vector<wPeer>{w_peer}));
   EXPECT_CALL(*storage, getBlocksFrom(1))
       .WillOnce(Return(rxcpp::observable<>::just(present).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
   auto block = loader->retrieveBlock(peer_key, Hash(std::string(32, '0')));
 
   ASSERT_FALSE(block);

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -47,10 +47,10 @@ using wPeer = std::shared_ptr<shared_model::interface::Peer>;
 class OrderingGateServiceTest : public ::testing::Test {
  public:
   OrderingGateServiceTest() {
-    peer = std::shared_ptr<shared_model::interface::Peer>(shared_model::proto::PeerBuilder()
+    peer = clone(shared_model::proto::PeerBuilder()
         .address(address)
         .pubkey(shared_model::interface::types::PubkeyType(std::string(32, '0')))
-        .build().copy());
+        .build());
     pcs_ = std::make_shared<MockPeerCommunicationService>();
     EXPECT_CALL(*pcs_, on_commit())
         .WillRepeatedly(Return(commit_subject_.get_observable()));
@@ -61,6 +61,8 @@ class OrderingGateServiceTest : public ::testing::Test {
 
     service_transport = std::make_shared<OrderingServiceTransportGrpc>();
     counter = 2;
+
+    wsv = std::make_shared<MockPeerQuery>();
   }
 
   void SetUp() override {
@@ -153,6 +155,7 @@ class OrderingGateServiceTest : public ::testing::Test {
   std::shared_ptr<OrderingGateTransportGrpc> gate_transport;
   std::shared_ptr<OrderingServiceTransportGrpc> service_transport;
   std::shared_ptr<MockOrderingServicePersistentState> fake_persistent_state;
+  std::shared_ptr<MockPeerQuery> wsv;
 };
 
 /**
@@ -164,18 +167,8 @@ class OrderingGateServiceTest : public ::testing::Test {
  */
 TEST_F(OrderingGateServiceTest, SplittingBunchTransactions) {
   // 8 transaction -> proposal -> 2 transaction -> proposal
-
-  std::shared_ptr<MockPeerQuery> wsv = std::make_shared<MockPeerQuery>();
-
-  shared_model::proto::PeerBuilder builder;
-
-  auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
-  auto tmp = builder.address(peer->address()).pubkey(key).build();
-
-  wPeer w_peer(tmp.copy());
-
   EXPECT_CALL(*wsv, getLedgerPeers())
-      .WillRepeatedly(Return(std::vector<wPeer>{w_peer}));
+      .WillRepeatedly(Return(std::vector<wPeer>{peer}));
 
   const size_t max_proposal = 100;
   const size_t commit_delay = 400;
@@ -234,17 +227,8 @@ TEST_F(OrderingGateServiceTest, SplittingBunchTransactions) {
 TEST_F(OrderingGateServiceTest, ProposalsReceivedWhenProposalSize) {
   // commits on the fulfilling proposal queue
   // 10 transaction -> proposal with 5 -> proposal with 5
-
-  std::shared_ptr<MockPeerQuery> wsv = std::make_shared<MockPeerQuery>();
-
-  shared_model::proto::PeerBuilder builder;
-
-  auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
-  auto tmp = builder.address(peer->address()).pubkey(key).build();
-
-  wPeer w_peer(tmp.copy());
   EXPECT_CALL(*wsv, getLedgerPeers())
-      .WillRepeatedly(Return(std::vector<wPeer>{w_peer}));
+      .WillRepeatedly(Return(std::vector<wPeer>{peer}));
 
   const size_t max_proposal = 5;
   const size_t commit_delay = 1000;

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -51,8 +51,6 @@ using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 
-using wPeer = std::shared_ptr<shared_model::interface::Peer>;
-
 static logger::Logger log_ = logger::testLog("OrderingService");
 
 class MockOrderingServiceTransport : public network::OrderingServiceTransport {
@@ -83,8 +81,7 @@ class OrderingServiceTest : public ::testing::Test {
             .address(address)
             .pubkey(shared_model::interface::types::PubkeyType(
                 std::string(32, '0')))
-            .build()
-            .copy());
+            .build());
   }
 
   void SetUp() override {
@@ -159,7 +156,6 @@ TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
   auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
   auto tmp = builder.address(peer->address()).pubkey(key).build();
 
-  wPeer w_peer(tmp.copy());
   EXPECT_CALL(*wsv, getLedgerPeers())
       .WillRepeatedly(Return(std::vector<decltype(peer)>{peer}));
 
@@ -181,7 +177,6 @@ TEST_F(OrderingServiceTest, ValidWhenTimerStrategy) {
   auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
   auto tmp = builder.address(peer->address()).pubkey(key).build();
 
-  wPeer w_peer(tmp.copy());
   EXPECT_CALL(*wsv, getLedgerPeers())
       .WillRepeatedly(Return(std::vector<decltype(peer)>{peer}));
 

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -76,12 +76,11 @@ class MockOrderingServiceTransport : public network::OrderingServiceTransport {
 class OrderingServiceTest : public ::testing::Test {
  public:
   OrderingServiceTest() {
-    peer = std::shared_ptr<shared_model::interface::Peer>(
-        clone(shared_model::proto::PeerBuilder()
+    peer = clone(shared_model::proto::PeerBuilder()
             .address(address)
             .pubkey(shared_model::interface::types::PubkeyType(
                 std::string(32, '0')))
-            .build()));
+            .build());
   }
 
   void SetUp() override {

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -77,11 +77,11 @@ class OrderingServiceTest : public ::testing::Test {
  public:
   OrderingServiceTest() {
     peer = std::shared_ptr<shared_model::interface::Peer>(
-        shared_model::proto::PeerBuilder()
+        clone(shared_model::proto::PeerBuilder()
             .address(address)
             .pubkey(shared_model::interface::types::PubkeyType(
                 std::string(32, '0')))
-            .build());
+            .build()));
   }
 
   void SetUp() override {

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -97,7 +97,7 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(1);
   EXPECT_CALL(*query, getTopBlocks(1))
       .WillOnce(Return(rxcpp::observable<>::just(block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
 
   EXPECT_CALL(*validator, validate(_, _)).WillOnce(Return(proposal));
 
@@ -170,7 +170,7 @@ TEST_F(SimulatorTest, FailWhenSameAsProposalHeight) {
 
   EXPECT_CALL(*query, getTopBlocks(1))
       .WillOnce(Return(rxcpp::observable<>::just(block).map(
-          [](auto &&x) { return wBlock(x.copy()); })));
+          [](auto &&x) { return wBlock(clone(x)); })));
 
   EXPECT_CALL(*validator, validate(_, _)).Times(0);
 

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -81,9 +81,9 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
   account.account_id = account_id;
   qry_resp->account = account;
   auto shared_account = std::shared_ptr<shared_model::interface::Account>(
-      shared_model::proto::AccountBuilder()
+      clone(shared_model::proto::AccountBuilder()
           .accountId(account_id)
-          .build());
+          .build()));
   auto role = "admin";
   std::vector<std::string> roles = {role};
   std::vector<std::string> perms = {iroha::model::can_get_my_account};

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -36,9 +36,9 @@ using namespace iroha::ametsuchi;
 using namespace iroha::validation;
 using namespace framework::test_subscriber;
 
-using ::testing::_;
 using ::testing::A;
 using ::testing::Return;
+using ::testing::_;
 
 class QueryProcessorTest : public ::testing::Test {
  public:
@@ -80,15 +80,14 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
   auto account = model::Account();
   account.account_id = account_id;
   qry_resp->account = account;
-  auto shared_account = std::shared_ptr<shared_model::interface::Account>(
-      clone(shared_model::proto::AccountBuilder()
-          .accountId(account_id)
-          .build()));
+  std::shared_ptr<shared_model::interface::Account> shared_account = clone(
+      shared_model::proto::AccountBuilder().accountId(account_id).build());
   auto role = "admin";
   std::vector<std::string> roles = {role};
   std::vector<std::string> perms = {iroha::model::can_get_my_account};
 
-  EXPECT_CALL(*wsv_queries, getAccount(account_id)).WillOnce(Return(shared_account));
+  EXPECT_CALL(*wsv_queries, getAccount(account_id))
+      .WillOnce(Return(shared_account));
   EXPECT_CALL(*wsv_queries, getAccountRoles(account_id))
       .Times(2)
       .WillRepeatedly(Return(roles));

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -83,8 +83,7 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
   auto shared_account = std::shared_ptr<shared_model::interface::Account>(
       shared_model::proto::AccountBuilder()
           .accountId(account_id)
-          .build()
-          .copy());
+          .build());
   auto role = "admin";
   std::vector<std::string> roles = {role};
   std::vector<std::string> perms = {iroha::model::can_get_my_account};

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -28,8 +28,8 @@ using namespace iroha::network;
 using namespace iroha::torii;
 using namespace framework::test_subscriber;
 
-using ::testing::_;
 using ::testing::Return;
+using ::testing::_;
 
 class TransactionProcessorTest : public ::testing::Test {
  public:
@@ -224,7 +224,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
 
   for (const auto &tx : txs) {
     tp->transactionHandle(
-        std::shared_ptr<shared_model::interface::Transaction>(clone(tx));
+        std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
   }
 
   // 1. Create proposal and notify transaction processor about it

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -116,7 +116,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
 
   for (const auto &tx : txs) {
     tp->transactionHandle(
-        std::shared_ptr<shared_model::interface::Transaction>(tx.copy()));
+        std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
   }
 
   // create proposal and notify about it
@@ -160,7 +160,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
 
   for (const auto &tx : txs) {
     tp->transactionHandle(
-        std::shared_ptr<shared_model::interface::Transaction>(tx.copy()));
+        std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
   }
 
   // 1. Create proposal and notify transaction processor about it
@@ -184,7 +184,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
   commit_notifier.get_subscriber().on_next(blocks_notifier.get_observable());
 
   blocks_notifier.get_subscriber().on_next(
-      std::shared_ptr<shared_model::interface::Block>(block.copy()));
+      std::shared_ptr<shared_model::interface::Block>(clone(block)));
   // Note blocks_notifier hasn't invoked on_completed, so
   // transactions are not commited
 
@@ -224,7 +224,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
 
   for (const auto &tx : txs) {
     tp->transactionHandle(
-        std::shared_ptr<shared_model::interface::Transaction>(tx.copy()));
+        std::shared_ptr<shared_model::interface::Transaction>(clone(tx));
   }
 
   // 1. Create proposal and notify transaction processor about it
@@ -243,7 +243,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
 
   // 2. Create block and notify transaction processor about it
   Commit single_commit = rxcpp::observable<>::just(
-      std::shared_ptr<shared_model::interface::Block>(block.copy()));
+      std::shared_ptr<shared_model::interface::Block>(clone(block)));
   commit_notifier.get_subscriber().on_next(single_commit);
 
   ASSERT_TRUE(wrapper.validate());
@@ -311,7 +311,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
                    .build();
 
   Commit single_commit = rxcpp::observable<>::just(
-      std::shared_ptr<shared_model::interface::Block>(block.copy()));
+      std::shared_ptr<shared_model::interface::Block>(clone(block)));
   commit_notifier.get_subscriber().on_next(single_commit);
   ASSERT_TRUE(wrapper.validate());
 

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -183,8 +183,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
 TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   auto creator = "a@domain";
 
-  auto accountB = std::shared_ptr<shared_model::interface::Account>(
-      shared_model::proto::AccountBuilder()
+  std::shared_ptr<shared_model::interface::Account> accountB =
+      clone(shared_model::proto::AccountBuilder()
           .accountId("b@domain")
           .build());
 
@@ -227,11 +227,10 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
-  auto account = std::shared_ptr<shared_model::interface::Account>(
-      shared_model::proto::AccountBuilder()
+  std::shared_ptr<shared_model::interface::Account> account =
+      clone(shared_model::proto::AccountBuilder()
           .accountId("accountA")
           .build());
-  ;
 
   auto creator = "a@domain";
   EXPECT_CALL(*wsv_query, getAccount(creator)).WillOnce(Return(account));
@@ -317,8 +316,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   auto amount =
       shared_model::proto::AmountBuilder().intValue(100).precision(2).build();
 
-  auto account_asset = std::shared_ptr<shared_model::interface::AccountAsset>(
-      shared_model::proto::AccountAssetBuilder()
+  std::shared_ptr<shared_model::interface::AccountAsset> account_asset =
+      clone(shared_model::proto::AccountAssetBuilder()
           .accountId("accountA")
           .assetId("usd")
           .balance(amount)
@@ -471,10 +470,11 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   auto txs_observable = rxcpp::observable<>::iterate([account] {
     std::vector<wTransaction> result;
     for (size_t i = 0; i < 3; ++i) {
-      auto current = wTransaction(TestTransactionBuilder()
-                                      .creatorAccountId(account.account_id)
-                                      .txCounter(i)
-                                      .build());
+      std::shared_ptr<shared_model::interface::Transaction> current =
+          clone(TestTransactionBuilder()
+                    .creatorAccountId(account.account_id)
+                    .txCounter(i)
+                    .build());
       result.push_back(current);
     }
     return result;

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -186,8 +186,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   auto accountB = std::shared_ptr<shared_model::interface::Account>(
       shared_model::proto::AccountBuilder()
           .accountId("b@domain")
-          .build()
-          .copy());
+          .build());
 
   // TODO: refactor this to use stateful validation mocks
   EXPECT_CALL(
@@ -231,8 +230,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   auto account = std::shared_ptr<shared_model::interface::Account>(
       shared_model::proto::AccountBuilder()
           .accountId("accountA")
-          .build()
-          .copy());
+          .build());
   ;
 
   auto creator = "a@domain";
@@ -324,8 +322,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
           .accountId("accountA")
           .assetId("usd")
           .balance(amount)
-          .build()
-          .copy());
+          .build());
 
   auto asset = shared_model::proto::AssetBuilder()
                    .assetId("usd")
@@ -477,8 +474,7 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
       auto current = wTransaction(TestTransactionBuilder()
                                       .creatorAccountId(account.account_id)
                                       .txCounter(i)
-                                      .build()
-                                      .copy());
+                                      .build());
       result.push_back(current);
     }
     return result;

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -140,7 +140,7 @@ TEST_F(ChainValidationTest, ValidWhenValidateChainFromOnePeer) {
   auto block = getBlockBuilder().build();
   rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       block_observable = rxcpp::observable<>::just(block).map([](auto &&x) {
-        return std::shared_ptr<shared_model::interface::Block>(x.copy());
+        return std::shared_ptr<shared_model::interface::Block>(clone(x));
       });
 
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -42,11 +42,11 @@
 #include "model/query_execution.hpp"
 #include "validators/field_validator.hpp"
 
-using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::StrictMock;
+using ::testing::_;
 
 using namespace iroha::ametsuchi;
 using namespace iroha::model;
@@ -66,23 +66,19 @@ class QueryValidateExecuteTest : public ::testing::Test {
     EXPECT_CALL(*wsv_query, hasAccountGrantablePermission(_, _, _))
         .WillRepeatedly(Return(false));
 
-    creator = std::shared_ptr<shared_model::interface::Account>(
-        shared_model::proto::AccountBuilder()
-            .accountId(admin_id)
-            .domainId(domain_id)
-            .jsonData("{}")
-            .quorum(1)
-            .build()
-            .copy());
+    creator = clone(shared_model::proto::AccountBuilder()
+                        .accountId(admin_id)
+                        .domainId(domain_id)
+                        .jsonData("{}")
+                        .quorum(1)
+                        .build());
 
-    account = std::shared_ptr<shared_model::interface::Account>(
-        shared_model::proto::AccountBuilder()
-            .accountId(account_id)
-            .domainId(domain_id)
-            .jsonData("{}")
-            .quorum(1)
-            .build()
-            .copy());
+    account = clone(shared_model::proto::AccountBuilder()
+                        .accountId(account_id)
+                        .domainId(domain_id)
+                        .jsonData("{}")
+                        .quorum(1)
+                        .build());
   }
 
   std::shared_ptr<QueryResponse> validateAndExecute() {
@@ -96,11 +92,10 @@ class QueryValidateExecuteTest : public ::testing::Test {
    * @return wrapper with created transaction
    */
   wTransaction makeTransaction(int counter, std::string creator) {
-    return wTransaction(TestTransactionBuilder()
-                            .creatorAccountId(creator)
-                            .txCounter(counter)
-                            .build()
-                            .copy());
+    return clone(TestTransactionBuilder()
+                     .creatorAccountId(creator)
+                     .txCounter(counter)
+                     .build());
   }
 
   /**
@@ -427,13 +422,11 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
  */
 TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
   get_account_assets->account_id = account_id;
-  accountAsset = std::shared_ptr<shared_model::interface::AccountAsset>(
-      shared_model::proto::AccountAssetBuilder()
-          .assetId(accountAsset->assetId())
-          .accountId(account_id)
-          .balance(accountAsset->balance())
-          .build()
-          .copy());
+  accountAsset = clone(shared_model::proto::AccountAssetBuilder()
+                           .assetId(accountAsset->assetId())
+                           .accountId(account_id)
+                           .balance(accountAsset->balance())
+                           .build());
   role_permissions = {};
 
   EXPECT_CALL(*wsv_query, getAccountRoles(admin_id))
@@ -1029,12 +1022,11 @@ class GetAssetInfoTest : public QueryValidateExecuteTest {
     qry->creator_account_id = admin_id;
     query = qry;
     role_permissions = {can_read_assets};
-    asset = std::shared_ptr<shared_model::interface::Asset>(
-        shared_model::proto::AssetBuilder()
-            .assetId(asset_id)
-            .domainId("test")
-            .precision(2)
-            .build().copy());
+    asset = clone(shared_model::proto::AssetBuilder()
+                      .assetId(asset_id)
+                      .domainId("test")
+                      .precision(2)
+                      .build());
   }
   std::shared_ptr<shared_model::interface::Asset> asset;
   std::shared_ptr<GetAssetInfo> qry;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
This PR introduces Cloneable interface and clone() function that returns unique_ptr described here (https://github.com/CppCodeReviewers/Covariant-Return-Types-and-Smart-Pointers) to replace shared_model *copy() method that returns raw pointer.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Safety with unique_ptr.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
no
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
```
 // Inherit from clonable with CRTP
 struct Base : object::cloneable<Base>
 {
   // ... other methods
 };

 // override clone() where it is needed
 struct Derived : Base
 {
   // ... other methods
 protected:
   Derived* clone() const override
   {
     return new Derived(*this);
   }
 };

 // and clone with function clone(obj) or clone(obj *)
 Derived derived;
 auto c1 = clone(derived);
 auto c2 = clone(&derived);
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
1. Just override copy() - this approach will hide base.
2. copy() returns unique_ptr<Base> - static_cast needed every time.
3. The same as implemented, but use method instead of function - less general and need to hide base method in every class in hierarchy of shared_model.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
