### PR TITLE
Fix problem with overloaded method unavailability

### DIFF
--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -26,8 +26,9 @@ namespace shared_model {
       return crypto::CryptoProviderEd25519Sha3::generateKeypair();
     }
 
-    crypto::Keypair ModelCrypto::generateKeypair(const std::string &seed) {
-      auto byte_string = iroha::hexstringToBytestring(seed);
+    crypto::Keypair ModelCrypto::fromPrivateKey(
+        const std::string &private_key) {
+      auto byte_string = iroha::hexstringToBytestring(private_key);
       if (not byte_string) {
         throw std::runtime_error("invalid seed");
       }

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -36,16 +36,16 @@ namespace shared_model {
       crypto::Keypair generateKeypair();
 
       /**
-       * Generates new keypair (ed25519) based on user-provided seed
-       * the seed should be 32 byte hex-encoded string
-       * @return generated keypair
+       * Creates keypair (ed25519) from provided private key
+       * @param private_key - ed25519 hex-encoded private key
+       * @return created keypair
        */
-      crypto::Keypair generateKeypair(const std::string &seed);
+      crypto::Keypair fromPrivateKey(const std::string &private_key);
 
       /**
        * Retrieves Keypair object (ed25519) from existing keypair.
-       * @param publicKey - ed25519 hex-encoded public key
-       * @param privateKey - ed25519 hex-encoded private key
+       * @param public_key - ed25519 hex-encoded public key
+       * @param private_key - ed25519 hex-encoded private key
        * @return keypair from provided keys
        */
       crypto::Keypair convertFromExisting(const std::string &public_key,

--- a/test/module/shared_model/bindings/model_crypto_test.cpp
+++ b/test/module/shared_model/bindings/model_crypto_test.cpp
@@ -25,9 +25,9 @@
  * @then assertion is not thrown on keypair generation
  */
 TEST(ModelCryptoTest, GenerateKeypair) {
-  ASSERT_NO_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_NO_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(64, 'a')););
-  ASSERT_NO_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_NO_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(64, 'A')););
 }
 /**
@@ -36,12 +36,12 @@ TEST(ModelCryptoTest, GenerateKeypair) {
  * @then assertion is thrown
  */
 TEST(ModelCryptoTest, GenerateKeypairInvalidSeed) {
-  ASSERT_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(64, 'g'));, std::runtime_error);
-  ASSERT_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(63, 'a'));, std::runtime_error);
-  ASSERT_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(65, 'a'));, std::runtime_error);
-  ASSERT_THROW(shared_model::bindings::ModelCrypto().generateKeypair(
+  ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(32, 'a'));, std::invalid_argument);
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This pull request eliminates overloading of generateKeypair() function (renames one of overloads to fromPrivateKey).

### Benefits

<!-- What benefits will be realized by the code change? -->
For languages which don't support function overload (like Javascript) behaviour is unspecified in general. In case of Javascript it resulted in impossibility to access generateKeypair(seed). Swig does not contain any documented ways to deal with this issue.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Client libraries should be rebuilt.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
  let keypairFromSeed = crypto.fromPrivateKey(...)
