### PR TITLE
Feature/improve run iroha dev

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   node:
     image: hyperledger/iroha-docker-develop:v1
     ports:
-      - "50051:50051"
-      - "20000:20000"
+      - "${IROHA_PORT}:50051"
+      - "${DEBUGGER_PORT}:20000"
     environment:
       - IROHA_POSTGRES_HOST=${COMPOSE_PROJECT_NAME}_postgres_1
       - IROHA_POSTGRES_PORT=5432

--- a/scripts/run-iroha-dev.sh
+++ b/scripts/run-iroha-dev.sh
@@ -22,7 +22,7 @@ then
 
     docker-compose -f ${COMPOSE} up -d
 else
-    IROHA_DBG_PORTS="$(docker port ${PROJECT}_node_1 | sed 's/\(.*\)://' | sort -r | sed -e :a -e N -e 's/\n/:/' -e ta)"
+    IROHA_DBG_PORTS="$(docker port ${PROJECT}_node_1 | sed 's/\(.*\)://' | sort -r | sed -e :a -e N -e 's/\n/:/p' -e ta)"
     export IROHA_PORT="$(echo ${IROHA_DBG_PORTS} | sed 's/:.*//')"
     export DEBUGGER_PORT="$(echo ${IROHA_DBG_PORTS} | sed 's/.*://')"
 fi

--- a/scripts/run-iroha-dev.sh
+++ b/scripts/run-iroha-dev.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+function next_free_port {
+for port in $(seq $1 $2);
+    do echo -ne "\035" | nc 127.0.0.1 $port > /dev/null 2>&1; [ $? -eq 1 ] && echo "$port" && break;
+done
+}
+
 CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname "${CURDIR}")"
 PROJECT=iroha${UID}
@@ -8,5 +15,19 @@ export G_ID=$(id -g)
 export U_ID=$(id -u)
 export COMPOSE_PROJECT_NAME=${PROJECT}
 
-docker-compose -f ${COMPOSE} up -d
+if [ $(docker ps -q -f name=${PROJECT}_node_1 | wc -c) -eq 0 ];
+then
+    export IROHA_PORT="$(next_free_port 50051 50101)"
+    export DEBUGGER_PORT="$(next_free_port 20000 20100)"
+
+    docker-compose -f ${COMPOSE} up -d
+else
+    IROHA_DBG_PORTS="$(docker port ${PROJECT}_node_1 | sed 's/\(.*\)://' | sort -r | sed -e :a -e N -e 's/\n/:/' -e ta)"
+    export IROHA_PORT="$(echo ${IROHA_DBG_PORTS} | sed 's/:.*//')"
+    export DEBUGGER_PORT="$(echo ${IROHA_DBG_PORTS} | sed 's/.*://')"
+fi
+echo ""
+echo "Iroha is mapped to host port ${IROHA_PORT}"
+echo "Debugger is mapped to host port ${DEBUGGER_PORT}"
+echo ""
 docker-compose -f ${COMPOSE} exec node /bin/bash

--- a/scripts/run-iroha-dev.sh
+++ b/scripts/run-iroha-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname "${CURDIR}")"
-PROJECT=iroha${USERID}
+PROJECT=iroha${UID}
 COMPOSE=${IROHA_HOME}/docker/docker-compose.yml
 
 export G_ID=$(id -g)

--- a/scripts/stop-iroha-dev.sh
+++ b/scripts/stop-iroha-dev.sh
@@ -4,4 +4,8 @@ IROHA_HOME="$(dirname "${CURDIR}")"
 PROJECT=iroha${UID}
 COMPOSE=${IROHA_HOME}/docker/docker-compose.yml
 
+# actual values of are not needed here, but variables need to be defined
+export IROHA_PORT=1
+export DEBUGGER_PORT=2
+
 docker-compose -f ${COMPOSE} -p ${PROJECT} down

--- a/scripts/stop-iroha-dev.sh
+++ b/scripts/stop-iroha-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+CURDIR="$(cd "$(dirname "$0")"; pwd)"
+IROHA_HOME="$(dirname "${CURDIR}")"
+PROJECT=iroha${UID}
+COMPOSE=${IROHA_HOME}/docker/docker-compose.yml
+
+docker-compose -f ${COMPOSE} -p ${PROJECT} down


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR changes the behavior of **run-iroha-dev.sh** and introduces **stop-iroha-dev.sh**.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Managment of container environment comes more clear and intuitive.

#### Each user within a system can run own docker container
Now `${UID}` is actually attached to containers' and network names as it was initially designed.
Moreover, there will be no collision between ports which are used on a host system by different containers. The script `run-iroha-dev.sh` now automatically chooses free port from predefined ranges - 50051-50101 for Iroha and 20000-20100 for a debugger.

#### Introduced script for full shutdown of container environment - stop-iroha-dev.sh
If you want to reinitialize or just shutdown container environment, then you can run stop-iroha-dev.sh and script will stop Iroha and Postgres containers, remove them and the network.
_Note that containers of other users will be left untouched._

#### Now it is possible to reenter into the container without its recreation
Launching of run-iroha-dev.sh several times in a row will lead to the creation of container environment at the first time and enter into it, all the next launches will lead only to reentering into the existing environment.

#### run-iroha-dev.sh reports ports used on the host system for Iroha and debugger

You will be provided with the information what ports are used for Iroha and debugger when you enter the container via launching run-iroha-dev.sh. This information will be shown in both cases - environment creation or just reentering into an existing environment.

### Possible Drawbacks 

The scripts need to be tested on macOS. There should be no issues, but development was done on Linux host.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

`./scripts/run-iroha-dev.sh` - for environment creation and enter into it. If environment already exists you will be just attached to its bash console.

`./scripts/stop-iroha-dev.sh` - stop Iroha and Postgres containers, destroy them, and destroy the network that was established for the environment.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
