### PR TITLE
Prohibit TransferAsset with source equals destination

### DIFF
--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -216,6 +216,11 @@ namespace shared_model {
         ReasonsGroupType reason;
         addInvalidCommand(reason, "TransferAsset");
 
+        if (ta->srcAccountId() == ta->destAccountId()) {
+          reason.second.push_back(
+              "Source and destination accounts cannot be the same");
+        }
+
         validator_.validateAccountId(reason, ta->srcAccountId());
         validator_.validateAccountId(reason, ta->destAccountId());
         validator_.validateAssetId(reason, ta->assetId());

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -366,3 +366,22 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
+
+/**
+ * @given some user with all required permissions
+ * @when execute tx with TransferAsset command where the source and destination
+ * accounts are the same
+ * @then the tx hasn't passed stateless validation
+ *       (aka skipProposal throws)
+ */
+TEST_F(TransferAsset, SourceIsDest) {
+  IntegrationTestFramework itf;
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
+      .sendTx(addAssets(kUser1, kUser1Keypair))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(completeTx(
+          baseTx().transferAsset(kUser1Id, kUser1Id, kAsset, kDesc, kAmount)));
+  ASSERT_ANY_THROW(itf.skipProposal());
+}

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -44,7 +44,7 @@ class ValidatorsTest : public ::testing::Test {
     auto addEnum = setField(&google::protobuf::Reflection::AddEnumValue);
     auto setEnum = setField(&google::protobuf::Reflection::SetEnumValue);
 
-    for (const auto &id : {"account_id", "src_account_id", "dest_account_id"}) {
+    for (const auto &id : {"account_id", "src_account_id"}) {
       field_setters[id] = setString(account_id);
     }
     for (const auto &id : {"public_key", "main_pubkey"}) {
@@ -53,6 +53,7 @@ class ValidatorsTest : public ::testing::Test {
     for (const auto &id : {"role_name", "default_role", "role_id"}) {
       field_setters[id] = setString(role_name);
     }
+    field_setters["dest_account_id"] = setString(dest_id);
     field_setters["asset_id"] = setString(asset_id);
     field_setters["account_name"] = setString(account_name);
     field_setters["domain_id"] = setString(domain_id);
@@ -125,6 +126,7 @@ class ValidatorsTest : public ::testing::Test {
     hash_size = 32;
     counter = 1048576;
     account_id = "account@domain";
+    dest_id = "dest@domain";
     asset_name = "asset";
     asset_id = "asset#domain";
     address_localhost = "localhost:65535";
@@ -148,6 +150,7 @@ class ValidatorsTest : public ::testing::Test {
   size_t hash_size{0};
   uint64_t counter{0};
   std::string account_id;
+  std::string dest_id;
   std::string asset_name;
   std::string asset_id;
   std::string address_localhost;


### PR DESCRIPTION
### Description of the Change

The asset transfer can be performed to the same account who is creating transaction with asset transfer. That prs disables that feature via stateless check.
Also there is a test

### Benefits

Quite better attack resistance
