### PR TITLE
Add CommandService logging

### DIFF
--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -26,6 +26,7 @@
 #include "cryptography/hash.hpp"
 #include "endpoint.grpc.pb.h"
 #include "endpoint.pb.h"
+#include "logger/logger.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
 #include "model/transaction_response.hpp"
 #include "torii/processor/transaction_processor.hpp"
@@ -146,6 +147,7 @@ namespace torii {
     std::chrono::milliseconds proposal_delay_;
     std::chrono::milliseconds start_tx_processing_duration_;
     std::shared_ptr<CacheType> cache_;
+    logger::Logger log_;
   };
 
 }  // namespace torii

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -207,12 +207,14 @@ namespace torii {
         response_writer.WriteLast(resp_none.getTransport(),
                                   grpc::WriteOptions());
       } else {
-        log_->info("Tx processing was started but unfinished, awaiting more");
+        log_->info(
+            "Tx processing was started but unfinished, awaiting more, hash: {}",
+            request.tx_hash());
         /// We give it 2*proposal_delay time until timeout.
         cv.wait_for(lock, 2 * proposal_delay_);
       }
     } else {
-      log_->warn("Command processing timeout");
+      log_->warn("Command processing timeout, hash: {}", request.tx_hash());
     }
   }
 
@@ -235,7 +237,8 @@ namespace torii {
       }
       response_writer.Write(*resp);
     } else {
-      log_->debug("Transaction not found in service cache");
+      log_->debug("Transaction not found in service cache, hash: {}",
+                  resp->tx_hash());
     }
   }
 


### PR DESCRIPTION
### Description of the Change

For now stateless validation fail cause no output, that may waste time at debugging stuff. This pr introduce logging such a case (and some other corner cases) in CommandService.

### Benefits

Resolves #803, better logging
