### PR TITLE
Use http and check hash after download for swig.

### DIFF
--- a/cmake/Modules/Findswig.cmake
+++ b/cmake/Modules/Findswig.cmake
@@ -9,11 +9,12 @@ find_package_handle_standard_args(SWIG DEFAULT_MSG
 if(NOT SWIG_EXECUTABLE)
   find_package(Git REQUIRED)
 
-  set(URL https://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz)
+  set(URL http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz)
   set_target_description(swig "Simplified Wrapper and Interface Generator (SWIG)" ${URL} 3.0.12)
 
   ExternalProject_Add(swig_swig
       URL ${URL}
+      URL_HASH SHA256=7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d
       PATCH_COMMAND patch -p1 < ${PROJECT_SOURCE_DIR}/../patch/add-nodejs8-support-to-swig.patch || true
       # We should install SWIG to properly access SWIG lib
       CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --without-pcre --prefix=${EP_PREFIX}/src/swig_swig


### PR DESCRIPTION
Signed-off-by: luckychess <toobwn@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Https can be not supported by cmake (it depends of does libcurl support ssl or not). This pr replaces https for http for swig package download and checks its hash after to prevent from downloading something malicious. 

### Benefits

<!-- What benefits will be realized by the code change? -->
More universal way to download swig with comparable level of security.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
None.


