### PR TITLE
Remove ccache from Findswig.cmake

### DIFF
--- a/cmake/Modules/Findswig.cmake
+++ b/cmake/Modules/Findswig.cmake
@@ -16,7 +16,7 @@ if(NOT SWIG_EXECUTABLE)
       URL_HASH SHA256=7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d
       PATCH_COMMAND patch -p1 < ${PROJECT_SOURCE_DIR}/../patch/add-nodejs8-support-to-swig.patch || true
       # We should install SWIG to properly access SWIG lib
-      CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --without-pcre --prefix=${EP_PREFIX}/src/swig_swig
+      CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --without-pcre --disable-ccache --prefix=${EP_PREFIX}/src/swig_swig
       BUILD_IN_SOURCE ON
       BUILD_COMMAND ${MAKE} swig
       TEST_COMMAND "" # remove test step


### PR DESCRIPTION

### Description of the Change
Disable ccache on SWIG compilation.

### Benefits
Fix build of **iroha-lib** NPM package, because CMake running under GYP doesn't want to compile SWIG with ccache enabled.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Slightly increases build time and **ccache-swig** tool will not be built.
