### PR TITLE
Add feature for custom genesis block gen

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <gflags/gflags.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/rapidjson.h>
 #include <boost/filesystem.hpp>
 #include <fstream>
 #include <iostream>
@@ -55,6 +57,9 @@ DEFINE_string(json_query, "", "Query in json format");
 DEFINE_bool(genesis_block,
             false,
             "Generate genesis block for new Iroha network");
+DEFINE_string(genesis_transaction,
+              "",
+              "File with transaction in json format for the genesis");
 DEFINE_string(peers_address,
               "",
               "File with peers address for new Iroha network");
@@ -76,19 +81,36 @@ int main(int argc, char *argv[]) {
   // Generate new genesis block now Iroha network
   if (FLAGS_genesis_block) {
     BlockGenerator generator;
-
-    if (FLAGS_peers_address.empty()) {
-      logger->error("--peers_address is empty");
-      return EXIT_FAILURE;
+    iroha::model::Transaction transaction;
+    if (FLAGS_genesis_transaction == "") {
+      if (FLAGS_peers_address.empty()) {
+        logger->error("--peers_address is empty");
+        return EXIT_FAILURE;
+      }
+      std::ifstream file(FLAGS_peers_address);
+      std::vector<std::string> peers_address;
+      std::copy(std::istream_iterator<std::string>(file),
+                std::istream_iterator<std::string>(),
+                std::back_inserter(peers_address));
+      // Generate genesis block
+      transaction = TransactionGenerator().generateGenesisTransaction(
+          0, std::move(peers_address));
+    } else {
+      rapidjson::Document doc;
+      std::ifstream file(FLAGS_genesis_transaction);
+      rapidjson::IStreamWrapper isw(file);
+      doc.ParseStream(isw);
+      auto some_tx = JsonTransactionFactory{}.deserialize(doc);
+      if (some_tx) {
+        transaction = *some_tx;
+      } else {
+        logger->error(
+            "Cannot deserialize genesis transaction (problem with file reading "
+            "or illformed json?)");
+        return EXIT_FAILURE;
+      }
     }
-    std::ifstream file(FLAGS_peers_address);
-    std::vector<std::string> peers_address;
-    std::copy(std::istream_iterator<std::string>(file),
-              std::istream_iterator<std::string>(),
-              std::back_inserter(peers_address));
-    // Generate genesis block
-    auto transaction = TransactionGenerator().generateGenesisTransaction(
-        0, std::move(peers_address));
+
     auto block = generator.generateGenesisBlock(0, {transaction});
     // Convert to json
     JsonBlockFactory json_factory;

--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -59,14 +59,13 @@ DEFINE_bool(genesis_block,
             "Generate genesis block for new Iroha network");
 DEFINE_string(genesis_transaction,
               "",
-              "File with transaction in json format for the genesis");
+              "File with transaction in json format for the genesis block");
 DEFINE_string(peers_address,
               "",
               "File with peers address for new Iroha network");
 
 // Run iroha-cli in interactive mode
 DEFINE_bool(interactive, true, "Run iroha-cli in interactive mode");
-
 
 using namespace iroha::protocol;
 using namespace iroha::model::generators;
@@ -82,7 +81,7 @@ int main(int argc, char *argv[]) {
   if (FLAGS_genesis_block) {
     BlockGenerator generator;
     iroha::model::Transaction transaction;
-    if (FLAGS_genesis_transaction == "") {
+    if (FLAGS_genesis_transaction.empty()) {
       if (FLAGS_peers_address.empty()) {
         logger->error("--peers_address is empty");
         return EXIT_FAILURE;


### PR DESCRIPTION
### Description of the Change

Allow transaction loading for genesis block generation in cli. I know it is going to be rewritten but that small fix enable that vial feature.

### Benefits

Configuration of the genesis block

### Usage Examples or Tests *[optional]*

1. Generate transaction in json
2. Launch `iroha-cli --genesis_block --genesis_transaction <your_file>`
