### PR TITLE
Fix build errors related to unused lambda captures

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -55,7 +55,7 @@ namespace iroha {
             function) {
       auto execute_transaction = [this](auto &transaction) {
         command_executor_->setCreatorAccountId(transaction->creatorAccountId());
-        auto execute_command = [this, &transaction](auto command) {
+        auto execute_command = [this](auto command) {
           auto result =
               boost::apply_visitor(*command_executor_, command->get());
           return result.match([](expected::Value<void> &v) { return true; },

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -51,7 +51,7 @@ namespace iroha {
               shared_model::proto::from_old(block_old));
         };
         return rxcpp::observable<>::create<PostgresBlockQuery::wBlock>(
-            [this, block{std::move(block)}](auto s) {
+            [block{std::move(block)}](auto s) {
               if (block) {
                 s.on_next(block);
               }
@@ -120,7 +120,7 @@ namespace iroha {
                   *model::converters::stringToJson(bytesToString(bytes)))));
         };
         boost::for_each(
-            result | boost::adaptors::transformed([&block](const auto &x) {
+            result | boost::adaptors::transformed([](const auto &x) {
               return x.at("index").template as<size_t>();
             }),
             [&](auto x) {
@@ -198,7 +198,7 @@ namespace iroha {
         const shared_model::crypto::Hash &hash) {
       return getBlockId(hash) |
           [this](auto blockId) { return block_store_.get(blockId); } |
-          [this](auto bytes) {
+          [](auto bytes) {
             // TODO IR-975 victordrobny 12.02.2018 convert directly to
             // shared_model::proto::Block after FlatFile will be reworked to new
             // model

--- a/irohad/ametsuchi/ordering_service_persistent_state.hpp
+++ b/irohad/ametsuchi/ordering_service_persistent_state.hpp
@@ -44,6 +44,8 @@ namespace iroha {
        * Reset storage to default state
        */
       virtual bool resetState() = 0;
+
+      virtual ~OrderingServicePersistentState() = default;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -88,7 +88,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
               .build(block)
               .match(
                   // success case
-                  [this, &context, &subscriber](
+                  [&subscriber](
                       const iroha::expected::Value<shared_model::proto::Block>
                           &result) {
                     subscriber.on_next(

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -169,7 +169,7 @@ TEST_F(GetTransactions, HaveGetMyTx) {
  */
 TEST_F(GetTransactions, InvalidSignatures) {
   auto dummy_tx = dummyTx();
-  auto check = [&dummy_tx](auto &status) {
+  auto check = [](auto &status) {
     auto resp = boost::get<shared_model::detail::PolymorphicWrapper<
         interface::ErrorQueryResponse>>(status.get());
     ASSERT_NO_THROW(boost::get<shared_model::detail::PolymorphicWrapper<

--- a/test/module/libs/common/result_test.cpp
+++ b/test/module/libs/common/result_test.cpp
@@ -166,6 +166,7 @@ class Base {
   virtual int getNumber() {
     return 0;
   }
+  virtual ~Base() = default;
 };
 
 class Derived : public Base {

--- a/test/module/shared_model/cryptography/crypto_usage_test.cpp
+++ b/test/module/shared_model/cryptography/crypto_usage_test.cpp
@@ -70,8 +70,7 @@ class CryptoUsageTest : public ::testing::Test {
         and std::all_of(
                 signable.signatures().begin(),
                 signable.signatures().end(),
-                [this,
-                 &signable](const shared_model::detail::PolymorphicWrapper<
+                [&signable](const shared_model::detail::PolymorphicWrapper<
                             shared_model::interface::Signature> &signature) {
                   return shared_model::crypto::CryptoVerifier<>::verify(
                       signature->signedData(),


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Build failed with clang version 5.0.1 (tags/RELEASE_501/final) due to tests being built with warnings treated as errors. This pull request removed unused captures.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Project builds with clang 5.0.1
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->