### PR TITLE
Fix std::string constructor arguments in tests

### DIFF
--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -402,8 +402,8 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
   ASSERT_TRUE(storage);
   auto wsv = storage->getWsvQuery();
 
-  shared_model::crypto::PublicKey pubkey1(std::string("1", 32));
-  shared_model::crypto::PublicKey pubkey2(std::string("2", 32));
+  shared_model::crypto::PublicKey pubkey1(std::string(32, '1'));
+  shared_model::crypto::PublicKey pubkey2(std::string(32, '2'));
 
   auto user1id = "userone@domain";
   auto user2id = "usertwo@domain";
@@ -691,8 +691,8 @@ TEST_F(AmetsuchiTest, FindTxByHashTest) {
   ASSERT_TRUE(storage);
   auto blocks = storage->getBlockQuery();
 
-  shared_model::crypto::PublicKey pubkey1(std::string("1", 32));
-  shared_model::crypto::PublicKey pubkey2(std::string("2", 32));
+  shared_model::crypto::PublicKey pubkey1(std::string(32, '1'));
+  shared_model::crypto::PublicKey pubkey2(std::string(32, '2'));
 
   auto txn1 =
       TestTransactionBuilder()

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -104,7 +104,7 @@ class BlockQueryTest : public AmetsuchiTest {
   std::string creator1 = "user1@test";
   std::string creator2 = "user2@test";
   std::size_t blocks_total{0};
-  std::string zero_string = std::string("0", 32);
+  std::string zero_string = std::string(32, '0');
 };
 
 /**
@@ -186,7 +186,7 @@ TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
  */
 TEST_F(BlockQueryTest, GetTransactionsIncludesNonExistingTxHashes) {
   shared_model::crypto::Hash invalid_tx_hash_1(zero_string),
-      invalid_tx_hash_2(std::string("9", 32));
+      invalid_tx_hash_2(std::string(32, '9'));
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getTransactions({invalid_tx_hash_1, invalid_tx_hash_2}), 2);
   wrapper.subscribe(

--- a/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
@@ -77,7 +77,7 @@ namespace iroha {
       std::string asset = "coin#test";
     };
 
-    auto zero_string = std::string("0", 32);
+    auto zero_string = std::string(32, '0');
     auto fake_hash = shared_model::crypto::Hash(zero_string);
 
     /**

--- a/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
@@ -22,8 +22,8 @@
 #include "consensus/yac/messages.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
 
-const auto pubkey = std::string('0', 32);
-const auto signed_data = std::string('1', 32);
+const auto pubkey = std::string(32, '0');
+const auto signed_data = std::string(32, '1');
 namespace iroha {
   namespace consensus {
     namespace yac {

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -77,7 +77,7 @@ shared_model::proto::Block makeBlock(int height) {
   return TestBlockBuilder()
       .transactions(std::vector<shared_model::proto::Transaction>())
       .height(height)
-      .prevHash(shared_model::crypto::Hash(std::string("0", 32)))
+      .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
       .build();
 }
 

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -127,7 +127,7 @@ class ToriiServiceTest : public testing::Test {
  */
 TEST_F(ToriiServiceTest, CommandClient) {
   iroha::protocol::TxStatusRequest tx_request;
-  tx_request.set_tx_hash(std::string('1', 32));
+  tx_request.set_tx_hash(std::string(32, '1'));
   iroha::protocol::ToriiResponse toriiResponse;
 
   auto client1 = torii::CommandSyncClient(Ip, Port);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix `std::string` constructor calls with implicitly converted arguments, which lead to address sanitizer errors.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No sanitizer errors in ametsuchi_test, and other tests changed in pull request.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
This looks like a temporary solution, because these kinds of errors could repeat in the future.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
