### PR TITLE
Fix consensus getting locked due to synchronous subscribers

### DIFF
--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -210,8 +210,8 @@ namespace iroha {
                              // IR-497
                            },
                            [&](const CommitMessage &commit) {
-                             notifier_.get_subscriber().on_next(commit);
                              this->propagateCommit(commit);
+                             notifier_.get_subscriber().on_next(commit);
                            });
           }
           this->closeRound();
@@ -246,8 +246,8 @@ namespace iroha {
                              // propagate for all
                              log_->info("Propagate commit {} to whole network",
                                         vote.hash.block_hash);
-                             notifier_.get_subscriber().on_next(commit);
                              this->propagateCommit(commit);
+                             notifier_.get_subscriber().on_next(commit);
                            },
                            [&](const RejectMessage &reject) {
                              // propagate reject for all


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Consensus was getting locked on two nodes because commit was sent to network after performing synchronous actions of subscribers to commit notification. Sending commit to network before notification fixes this issue.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Less locks due to consensus subscribers.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
It is hard to test at the moment, because it requires integration test with 2+ nodes.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->