### PR TITLE
Fix simulator getting locked when triggered by OrderingGate queue

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -67,7 +67,6 @@ void Irohad::init() {
   initWsvRestorer();
   restoreWsv();
 
-  initPeerQuery();
   initCryptoProvider();
   initValidators();
   initOrderingGate();
@@ -124,15 +123,6 @@ bool Irohad::restoreWsv() {
 }
 
 /**
- * Initializing peer query interface
- */
-void Irohad::initPeerQuery() {
-  wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery());
-
-  log_->info("[Init] => peer query");
-}
-
-/**
  * Initializing crypto provider
  */
 void Irohad::initCryptoProvider() {
@@ -158,7 +148,10 @@ void Irohad::initValidators() {
  */
 void Irohad::initOrderingGate() {
   ordering_gate = ordering_init.initOrderingGate(
-      wsv, max_proposal_size_, proposal_delay_, ordering_service_storage_);
+      std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery()),
+      max_proposal_size_,
+      proposal_delay_,
+      ordering_service_storage_);
   log_->info("[Init] => init ordering gate - [{}]",
              logger::logBool(ordering_gate));
 }
@@ -180,7 +173,9 @@ void Irohad::initSimulator() {
  * Initializing block loader
  */
 void Irohad::initBlockLoader() {
-  block_loader = loader_init.initBlockLoader(wsv, storage->getBlockQuery());
+  block_loader = loader_init.initBlockLoader(
+      std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery()),
+      storage->getBlockQuery());
 
   log_->info("[Init] => block loader");
 }
@@ -190,7 +185,7 @@ void Irohad::initBlockLoader() {
  */
 void Irohad::initConsensusGate() {
   consensus_gate = yac_init.initConsensusGate(
-      wsv,
+      std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery()),
       simulator,
       block_loader,
       keypair,

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -112,8 +112,6 @@ class Irohad {
 
   virtual void initStorage();
 
-  virtual void initPeerQuery();
-
   virtual void initCryptoProvider();
 
   virtual void initValidators();
@@ -157,9 +155,6 @@ class Irohad {
   // validators
   std::shared_ptr<iroha::validation::StatefulValidator> stateful_validator;
   std::shared_ptr<iroha::validation::ChainValidator> chain_validator;
-
-  // peer query
-  std::shared_ptr<iroha::ametsuchi::PeerQuery> wsv;
 
   // WSV restorer
   std::shared_ptr<iroha::ametsuchi::WsvRestorer> wsv_restorer_;

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -31,7 +31,8 @@ namespace iroha {
         std::shared_ptr<validation::StatefulValidator> statefulValidator,
         std::shared_ptr<ametsuchi::TemporaryFactory> factory,
         std::shared_ptr<ametsuchi::BlockQuery> blockQuery,
-        std::shared_ptr<shared_model::crypto::CryptoModelSigner<>> crypto_signer)
+        std::shared_ptr<shared_model::crypto::CryptoModelSigner<>>
+            crypto_signer)
         : validator_(std::move(statefulValidator)),
           ametsuchi_factory_(std::move(factory)),
           block_queries_(std::move(blockQuery)),
@@ -65,8 +66,10 @@ namespace iroha {
         const shared_model::interface::Proposal &proposal) {
       log_->info("process proposal");
       // Get last block from local ledger
-      block_queries_->getTopBlocks(1).as_blocking().subscribe(
-          [this](auto block) { last_block = block; });
+      block_queries_->getTopBlocks(1)
+          .subscribe_on(rxcpp::observe_on_new_thread())
+          .as_blocking()
+          .subscribe([this](auto block) { last_block = block; });
       if (not last_block) {
         log_->warn("Could not fetch last block");
         return;
@@ -97,8 +100,8 @@ namespace iroha {
         const shared_model::interface::Proposal &proposal) {
       log_->info("process verified proposal");
 
-      // TODO: Alexey Chernyshov IR-1011 2018-03-08 rework BlockBuilder logic, so
-      // that this cast will not be needed
+      // TODO: Alexey Chernyshov IR-1011 2018-03-08 rework BlockBuilder logic,
+      // so that this cast will not be needed
       auto proto_txs =
           proposal.transactions()
           | boost::adaptors::transformed([](const auto &polymorphic_tx) {

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -145,6 +145,14 @@ namespace framework {
         return strategy_->validate();
       }
 
+      /**
+       * Failure reason
+       * @return reason string if validation is unsuccessful
+       */
+      std::string what() {
+        return strategy_->invalidate_reason_;
+      }
+
      private:
       rxcpp::observable<T> unwrapped_;
       std::unique_ptr<VerificationStrategy<T>> strategy_;

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -105,12 +105,10 @@ TEST(PipelineIntegrationTest, SendTx) {
 TEST(PipelineIntegrationTest, SendMultipleTx) {
   auto keypair =
       shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  shared_model::interface::types::CounterType counter = 1;
   auto getTx = [&] {
     return shared_model::proto::TransactionBuilder()
         .createdTime(iroha::time::now())
         .creatorAccountId(kUser)
-        .txCounter(counter++)
         .addAssetQuantity(kUser, kAsset, "1.0")
         .build()
         .signAndAddSignature(keypair);

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -92,10 +92,6 @@ class OrderingGateServiceTest : public ::testing::Test {
       size_t times) {
     auto wrapper = make_test_subscriber<CallExact>(gate->on_proposal(), times);
     wrapper.subscribe();
-    gate->on_proposal().subscribe([this](auto) {
-      counter--;
-      cv.notify_one();
-    });
     gate->on_proposal().subscribe([this](auto proposal) {
       proposals.push_back(proposal);
 
@@ -106,6 +102,10 @@ class OrderingGateServiceTest : public ::testing::Test {
               TestBlockBuilder().build());
       commit_subject_.get_subscriber().on_next(
           rxcpp::observable<>::just(block));
+    });
+    gate->on_proposal().subscribe([this](auto) {
+      counter--;
+      cv.notify_one();
     });
     return wrapper;
   }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Simulator is getting locked in `getTopBlocks` call, possibly due to incorrect RxCpp usage.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No lock in Simulator.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Solution looks like a crutch, so it requires additional study of RxCpp.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
