### PR TITLE
Change namespace for permissions

### DIFF
--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -36,6 +36,7 @@
 #include "parser/parser.hpp"  // for parser::ParseValue
 
 using namespace iroha::model;
+using namespace shared_model::permissions;
 
 namespace iroha_cli {
   namespace interactive {

--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -21,8 +21,8 @@
 
 #include "execution/common_executor.hpp"
 #include "interfaces/commands/command.hpp"
-#include "validators/permissions.hpp"
 #include "utils/amount_utils.hpp"
+#include "validators/permissions.hpp"
 
 namespace iroha {
 
@@ -362,8 +362,8 @@ namespace iroha {
               .str(),
           command_name);
     }
-    auto account_asset = queries->getAccountAsset(
-        command->accountId(), command->assetId());
+    auto account_asset =
+        queries->getAccountAsset(command->accountId(), command->assetId());
     if (not account_asset) {
       return makeExecutionError((boost::format("%s do not have %s")
                                  % command->accountId() % command->assetId())
@@ -506,7 +506,9 @@ namespace iroha {
     // any asset
     return creator_account_id == command.accountId()
         and checkAccountRolePermission(
-                creator_account_id, queries, model::can_add_asset_qty);
+                creator_account_id,
+                queries,
+                shared_model::permissions::can_add_asset_qty);
   }
 
   bool CommandValidator::hasPermissions(
@@ -514,7 +516,7 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_add_peer);
+        creator_account_id, queries, shared_model::permissions::can_add_peer);
   }
 
   bool CommandValidator::hasPermissions(
@@ -526,11 +528,15 @@ namespace iroha {
         // account and he has permission CanAddSignatory
         (command.accountId() == creator_account_id
          and checkAccountRolePermission(
-                 creator_account_id, queries, model::can_add_signatory))
+                 creator_account_id,
+                 queries,
+                 shared_model::permissions::can_add_signatory))
         or
         // Case 2. Creator has granted permission for it
         (queries.hasAccountGrantablePermission(
-            creator_account_id, command.accountId(), model::can_add_signatory));
+            creator_account_id,
+            command.accountId(),
+            shared_model::permissions::can_add_signatory));
   }
 
   bool CommandValidator::hasPermissions(
@@ -538,7 +544,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_append_role);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_append_role);
   }
 
   bool CommandValidator::hasPermissions(
@@ -546,7 +554,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_create_account);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_create_account);
   }
 
   bool CommandValidator::hasPermissions(
@@ -554,7 +564,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_create_asset);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_create_asset);
   }
 
   bool CommandValidator::hasPermissions(
@@ -562,7 +574,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_create_domain);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_create_domain);
   }
 
   bool CommandValidator::hasPermissions(
@@ -570,7 +584,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_create_role);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_create_role);
   }
 
   bool CommandValidator::hasPermissions(
@@ -578,7 +594,9 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return checkAccountRolePermission(
-        creator_account_id, queries, model::can_detach_role);
+        creator_account_id,
+        queries,
+        shared_model::permissions::can_detach_role);
   }
 
   bool CommandValidator::hasPermissions(
@@ -588,7 +606,7 @@ namespace iroha {
     return checkAccountRolePermission(
         creator_account_id,
         queries,
-        model::can_grant + command.permissionName());
+        shared_model::permissions::can_grant + command.permissionName());
   }
 
   bool CommandValidator::hasPermissions(
@@ -600,11 +618,14 @@ namespace iroha {
         // permission on it
         (creator_account_id == command.accountId()
          and checkAccountRolePermission(
-                 creator_account_id, queries, model::can_remove_signatory))
+                 creator_account_id,
+                 queries,
+                 shared_model::permissions::can_remove_signatory))
         // 2. Creator has granted permission on removal
-        or (queries.hasAccountGrantablePermission(creator_account_id,
-                                                  command.accountId(),
-                                                  model::can_remove_signatory));
+        or (queries.hasAccountGrantablePermission(
+               creator_account_id,
+               command.accountId(),
+               shared_model::permissions::can_remove_signatory));
   }
 
   bool CommandValidator::hasPermissions(
@@ -624,7 +645,9 @@ namespace iroha {
         creator_account_id == command.accountId() or
         // Case 2. Creator has grantable permission to set account key/value
         queries.hasAccountGrantablePermission(
-            creator_account_id, command.accountId(), model::can_set_detail);
+            creator_account_id,
+            command.accountId(),
+            shared_model::permissions::can_set_detail);
   }
 
   bool CommandValidator::hasPermissions(
@@ -635,10 +658,14 @@ namespace iroha {
         // 1. Creator set quorum for his account -> must have permission
         (creator_account_id == command.accountId()
          and checkAccountRolePermission(
-                 creator_account_id, queries, model::can_set_quorum))
+                 creator_account_id,
+                 queries,
+                 shared_model::permissions::can_set_quorum))
         // 2. Creator has granted permission on it
         or (queries.hasAccountGrantablePermission(
-               creator_account_id, command.accountId(), model::can_set_quorum));
+               creator_account_id,
+               command.accountId(),
+               shared_model::permissions::can_set_quorum));
   }
 
   bool CommandValidator::hasPermissions(
@@ -647,7 +674,9 @@ namespace iroha {
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return creator_account_id == command.accountId()
         and checkAccountRolePermission(
-                creator_account_id, queries, model::can_subtract_asset_qty);
+                creator_account_id,
+                queries,
+                shared_model::permissions::can_subtract_asset_qty);
   }
 
   bool CommandValidator::hasPermissions(
@@ -660,15 +689,18 @@ namespace iroha {
                 and queries.hasAccountGrantablePermission(
                         creator_account_id,
                         command.srcAccountId(),
-                        model::can_transfer))
+                        shared_model::permissions::can_transfer))
                or
                // 2. Creator transfer from their account
                (creator_account_id == command.srcAccountId()
                 and checkAccountRolePermission(
-                        creator_account_id, queries, model::can_transfer)))
+                        creator_account_id,
+                        queries,
+                        shared_model::permissions::can_transfer)))
         // For both cases, dest_account must have can_receive
-        and checkAccountRolePermission(
-                command.destAccountId(), queries, model::can_receive);
+        and checkAccountRolePermission(command.destAccountId(),
+                                       queries,
+                                       shared_model::permissions::can_receive);
   }
 
   bool CommandValidator::isValid(
@@ -745,12 +777,12 @@ namespace iroha {
       const shared_model::interface::CreateRole &command,
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
-    return std::all_of(
-        command.rolePermissions().begin(),
-        command.rolePermissions().end(),
-        [&queries, &creator_account_id](auto perm) {
-          return checkAccountRolePermission(creator_account_id, queries, perm);
-        });
+    return std::all_of(command.rolePermissions().begin(),
+                       command.rolePermissions().end(),
+                       [&queries, &creator_account_id](auto perm) {
+                         return checkAccountRolePermission(
+                             creator_account_id, queries, perm);
+                       });
   }
 
   bool CommandValidator::isValid(
@@ -772,8 +804,7 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     auto account = queries.getAccount(command.accountId());
-    auto signatories =
-        queries.getSignatories(command.accountId());
+    auto signatories = queries.getSignatories(command.accountId());
 
     if (not(account and signatories)) {
       // No account or signatories found
@@ -803,8 +834,7 @@ namespace iroha {
       const shared_model::interface::SetQuorum &command,
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
-    auto signatories =
-        queries.getSignatories(command.accountId());
+    auto signatories = queries.getSignatories(command.accountId());
 
     if (not(signatories)) {
       // No  signatories of an account found

--- a/irohad/model/converters/impl/pb_command_factory.cpp
+++ b/irohad/model/converters/impl/pb_command_factory.cpp
@@ -21,6 +21,8 @@
 
 #include "model/converters/pb_common.hpp"
 
+using namespace shared_model::permissions;
+
 namespace iroha {
   namespace model {
     namespace converters {
@@ -85,19 +87,24 @@ namespace iroha {
             // Can get all account assets
             (protocol::RolePermission::can_get_all_acc_ast, can_get_all_acc_ast)
             // Can get domain account assets
-            (protocol::RolePermission::can_get_domain_acc_ast, can_get_domain_acc_ast)
+            (protocol::RolePermission::can_get_domain_acc_ast,
+             can_get_domain_acc_ast)
             // Can get my account detail
-            (protocol::RolePermission::can_get_my_acc_detail, can_get_my_acc_detail)
+            (protocol::RolePermission::can_get_my_acc_detail,
+             can_get_my_acc_detail)
             // Can get all account detail
-            (protocol::RolePermission::can_get_all_acc_detail, can_get_all_acc_detail)
+            (protocol::RolePermission::can_get_all_acc_detail,
+             can_get_all_acc_detail)
             // Can get domain account detail
-            (protocol::RolePermission::can_get_domain_acc_detail, can_get_domain_acc_detail)
+            (protocol::RolePermission::can_get_domain_acc_detail,
+             can_get_domain_acc_detail)
             // Can get my account transactions
             (protocol::RolePermission::can_get_my_acc_txs, can_get_my_acc_txs)
             // Can get all account transactions
             (protocol::RolePermission::can_get_all_acc_txs, can_get_all_acc_txs)
             // Can get domain account transactions
-            (protocol::RolePermission::can_get_domain_acc_txs, can_get_domain_acc_txs)
+            (protocol::RolePermission::can_get_domain_acc_txs,
+             can_get_domain_acc_txs)
             // Can get my account assets transactions
             (protocol::RolePermission::can_get_my_acc_ast_txs,
              can_get_my_acc_ast_txs)
@@ -142,7 +149,7 @@ namespace iroha {
              can_set_detail)
             // Can transfer my assets
             (protocol::GrantablePermission::can_transfer_my_assets,
-                can_transfer);
+             can_transfer);
       }
 
       // asset quantity

--- a/irohad/model/generators/impl/command_generator.cpp
+++ b/irohad/model/generators/impl/command_generator.cpp
@@ -32,6 +32,7 @@
 #include "validators/permissions.hpp"
 
 using namespace generator;
+using namespace shared_model::permissions;
 
 namespace iroha {
   namespace model {

--- a/irohad/model/impl/query_execution.cpp
+++ b/irohad/model/impl/query_execution.cpp
@@ -23,6 +23,7 @@
 #include "validators/permissions.hpp"
 
 using namespace iroha::model;
+using namespace shared_model::permissions;
 using namespace iroha::ametsuchi;
 
 // TODO: 28/03/2018 x3medima17 remove poly wrapper, IR-1011

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -18,8 +18,8 @@
 #include "validators/field_validator.hpp"
 #include <boost/algorithm/string_regex.hpp>
 #include <boost/format.hpp>
-#include "permissions.hpp"
 #include "cryptography/crypto_provider/crypto_verifier.hpp"
+#include "permissions.hpp"
 
 // TODO: 15.02.18 nickaleks Change structure to compositional IR-978
 
@@ -213,8 +213,8 @@ namespace shared_model {
     void FieldValidator::validatePermission(
         ReasonsGroupType &reason,
         const interface::types::PermissionNameType &permission_name) const {
-      if (iroha::model::all_perm_group.find(permission_name)
-          == iroha::model::all_perm_group.end()) {
+      if (shared_model::permissions::all_perm_group.find(permission_name)
+          == shared_model::permissions::all_perm_group.end()) {
         reason.second.push_back("Provided permission does not exist");
       }
     }
@@ -226,8 +226,8 @@ namespace shared_model {
         reason.second.push_back(
             "Permission set should contain at least one permission");
       }
-      if (not std::includes(iroha::model::role_perm_group.begin(),
-                            iroha::model::role_perm_group.end(),
+      if (not std::includes(shared_model::permissions::role_perm_group.begin(),
+                            shared_model::permissions::role_perm_group.end(),
                             permissions.begin(),
                             permissions.end())) {
         reason.second.push_back(

--- a/shared_model/validators/permissions.hpp
+++ b/shared_model/validators/permissions.hpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#ifndef IROHA_PERMISSIONS_HPP
-#define IROHA_PERMISSIONS_HPP
+#ifndef SHARED_MODEL_PERMISSIONS_HPP
+#define SHARED_MODEL_PERMISSIONS_HPP
 
 #include <set>
 #include <string>
 
-namespace iroha {
-  namespace model {
+namespace shared_model {
+  namespace permissions {
 
     /* ~~~~~~~~       Command-related permissions        ~~~~~~~~ */
 
@@ -252,7 +252,7 @@ namespace iroha {
         can_set_my_account_detail,
         can_transfer_my_assets};
 
-  }  // namespace model
-}  // namespace iroha
+  }  // namespace shared_model
+}  // namespace permissions
 
-#endif  // IROHA_PERMISSIONS_HPP
+#endif  // SHARED_MODEL_PERMISSIONS_HPP

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -75,12 +75,12 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
             .txCounter(1)
             .createdTime(iroha::time::now())
             .addPeer("0.0.0.0:50541", key.publicKey())
-            .createRole(
-                kDefaultRole,
-                // TODO (@l4l) IR-874 create more confort way for
-                // permssion-dependent proto building
-                std::vector<std::string>{iroha::model::role_perm_group.begin(),
-                                         iroha::model::role_perm_group.end()})
+            .createRole(kDefaultRole,
+                        // TODO (@l4l) IR-874 create more confort way for
+                        // permssion-dependent proto building
+                        std::vector<std::string>{
+                            shared_model::permissions::role_perm_group.begin(),
+                            shared_model::permissions::role_perm_group.end()})
             .createDomain(kDefaultDomain, kDefaultRole)
             .createAccount(kAdminName, kDefaultDomain, key.publicKey())
             .createAsset(kAssetName, kDefaultDomain, 1)

--- a/test/framework/test_block_generator.cpp
+++ b/test/framework/test_block_generator.cpp
@@ -22,11 +22,12 @@
 #include "model/commands/create_account.hpp"
 #include "model/commands/create_asset.hpp"
 #include "model/commands/create_domain.hpp"
-#include "validators/permissions.hpp"
 #include "model/sha3_hash.hpp"
+#include "validators/permissions.hpp"
 
 using namespace iroha;
 using namespace iroha::model;
+using namespace shared_model::permissions;
 
 namespace framework {
   namespace generator {

--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -21,8 +21,8 @@
 #include "datetime/time.hpp"
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -36,7 +36,7 @@ class AddAssetQuantity : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             iroha::model::can_add_asset_qty}) {
+                             shared_model::permissions::can_add_asset_qty}) {
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), "role"s, perms)
         .build()
@@ -100,7 +100,7 @@ TEST_F(AddAssetQuantity, Basic) {
 TEST_F(AddAssetQuantity, NoPermissions) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .skipProposal()
       .skipBlock()
       .sendTx(completeTx(baseTx().addAssetQuantity(kUserId, kAsset, kAmount)))
@@ -252,9 +252,9 @@ TEST_F(AddAssetQuantity, OtherDomain) {
               .creatorAccountId(
                   integration_framework::IntegrationTestFramework::kAdminId)
               .createdTime(iroha::time::now())
-              .createRole(
-                  kNewRole,
-                  std::vector<std::string>{iroha::model::can_get_my_txs})
+              .createRole(kNewRole,
+                          std::vector<std::string>{
+                              shared_model::permissions::can_get_my_txs})
               .createDomain(kNewDomain, kNewRole)
               .createAccount(
                   kNewUser,

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -21,8 +21,8 @@
 #include "datetime/time.hpp"
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -36,7 +36,7 @@ class CreateAccount : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             iroha::model::can_create_account}) {
+                             shared_model::permissions::can_create_account}) {
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), "role"s, perms)
         .build()
@@ -103,7 +103,7 @@ TEST_F(CreateAccount, Basic) {
 TEST_F(CreateAccount, NoPermissions) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .skipProposal()
       .skipBlock()
       .sendTx(completeTx(baseTx().createAccount(

--- a/test/integration/acceptance/create_domain_test.cpp
+++ b/test/integration/acceptance/create_domain_test.cpp
@@ -21,8 +21,8 @@
 #include "datetime/time.hpp"
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -36,7 +36,7 @@ class CreateDomain : public ::testing::Test {
    * @return built tx
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             iroha::model::can_create_domain}) {
+                             shared_model::permissions::can_create_domain}) {
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), kRole, perms)
         .build()
@@ -100,7 +100,7 @@ TEST_F(CreateDomain, Basic) {
 TEST_F(CreateDomain, NoPermissions) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .skipProposal()
       .skipBlock()
       .sendTx(completeTx(baseTx().createDomain(kNewDomain, kRole)))

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -21,8 +21,8 @@
 #include "datetime/time.hpp"
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -36,8 +36,8 @@ class CreateRole : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             iroha::model::can_get_my_txs,
-                             iroha::model::can_create_role}) {
+                             shared_model::permissions::can_get_my_txs,
+                             shared_model::permissions::can_create_role}) {
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), kNewRole, perms)
         .build()
@@ -60,7 +60,7 @@ class CreateRole : public ::testing::Test {
   }
 
   auto baseTx(const std::vector<std::string> &perms = {
-                  iroha::model::can_get_my_txs}) {
+                  shared_model::permissions::can_get_my_txs}) {
     return baseTx(perms, kRole);
   }
 
@@ -110,7 +110,7 @@ TEST_F(CreateRole, Basic) {
 TEST_F(CreateRole, HaveNoPerms) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .skipProposal()
       .skipBlock()
       .sendTx(completeTx(baseTx()))
@@ -131,7 +131,8 @@ TEST_F(CreateRole, EmptyRole) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(completeTx(baseTx({iroha::model::can_get_my_txs}, "")));
+      .sendTx(
+          completeTx(baseTx({shared_model::permissions::can_get_my_txs}, "")));
   ASSERT_ANY_THROW(itf.skipProposal());
 }
 
@@ -163,8 +164,8 @@ TEST_F(CreateRole, LongRoleName) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(completeTx(
-          baseTx({iroha::model::can_get_my_txs}, std::string(33, 'a'))));
+      .sendTx(completeTx(baseTx({shared_model::permissions::can_get_my_txs},
+                                std::string(33, 'a'))));
   ASSERT_ANY_THROW(itf.skipProposal());
 }
 
@@ -179,8 +180,8 @@ TEST_F(CreateRole, MaxLenRoleName) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(completeTx(
-          baseTx({iroha::model::can_get_my_txs}, std::string(32, 'a'))))
+      .sendTx(completeTx(baseTx({shared_model::permissions::can_get_my_txs},
+                                std::string(32, 'a'))))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -23,8 +23,8 @@
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "interfaces/utils/specified_visitor.hpp"
-#include "validators/permissions.hpp"
 #include "utils/query_error_response_visitor.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -39,7 +39,7 @@ class GetTransactions : public ::testing::Test {
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms) {
     auto new_perms = perms;
-    new_perms.push_back(iroha::model::can_set_quorum);
+    new_perms.push_back(shared_model::permissions::can_set_quorum);
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), kNewRole, new_perms)
         .build()
@@ -101,7 +101,7 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
   auto dummy_tx = dummyTx();
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_read_assets}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_read_assets}))
       .sendTx(dummy_tx)
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); })
@@ -127,7 +127,7 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_all_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_all_txs}))
       .sendTx(dummy_tx)
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); })
@@ -153,7 +153,7 @@ TEST_F(GetTransactions, HaveGetMyTx) {
 
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .sendTx(dummy_tx)
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); })
@@ -187,7 +187,7 @@ TEST_F(GetTransactions, InvalidSignatures) {
 
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .sendQuery(query, check)
       .done();
 }
@@ -208,7 +208,7 @@ TEST_F(GetTransactions, InexistentHash) {
 
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(makeQuery(crypto::Hash(std::string(32, '0'))), check)
@@ -230,7 +230,7 @@ TEST_F(GetTransactions, DISABLED_OtherUserTx) {
     ASSERT_EQ(resp.value()->transactions().size(), 0);
   };
 
-  auto tx = makeUserWithPerms({iroha::model::can_get_my_txs});
+  auto tx = makeUserWithPerms({shared_model::permissions::can_get_my_txs});
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
       .sendTx(tx)

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -21,8 +21,8 @@
 #include "datetime/time.hpp"
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -36,8 +36,8 @@ class SubtractAssetQuantity : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             iroha::model::can_subtract_asset_qty,
-                             iroha::model::can_add_asset_qty}) {
+                             shared_model::permissions::can_subtract_asset_qty,
+                             shared_model::permissions::can_add_asset_qty}) {
     return framework::createUserWithPerms(
                kUser, kUserKeypair.publicKey(), "role"s, perms)
         .build()
@@ -131,7 +131,7 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
 TEST_F(SubtractAssetQuantity, NoPermissions) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({iroha::model::can_add_asset_qty}))
+      .sendTx(makeUserWithPerms({shared_model::permissions::can_add_asset_qty}))
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -25,9 +25,9 @@
 #include "framework/base_tx.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "interfaces/utils/specified_visitor.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "utils/query_error_response_visitor.hpp"
+#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -103,9 +103,10 @@ class TransferAsset : public ::testing::Test {
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
   const crypto::Keypair kUser2Keypair =
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  const std::vector<std::string> kPerms{iroha::model::can_add_asset_qty,
-                                        iroha::model::can_transfer,
-                                        iroha::model::can_receive};
+  const std::vector<std::string> kPerms{
+      shared_model::permissions::can_add_asset_qty,
+      shared_model::permissions::can_transfer,
+      shared_model::permissions::can_receive};
 };
 
 /**
@@ -137,8 +138,10 @@ TEST_F(TransferAsset, Basic) {
 TEST_F(TransferAsset, WithOnlyCanTransferPerm) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(
-          kUser1, kUser1Keypair, {iroha::model::can_transfer}, kRole1))
+      .sendTx(makeUserWithPerms(kUser1,
+                                kUser1Keypair,
+                                {shared_model::permissions::can_transfer},
+                                kRole1))
       .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
       .sendTx(addAssets(kUser1, kUser1Keypair))
       .skipProposal()
@@ -160,8 +163,10 @@ TEST_F(TransferAsset, WithOnlyCanTransferPerm) {
 TEST_F(TransferAsset, WithOnlyCanReceivePerm) {
   IntegrationTestFramework()
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(
-          kUser1, kUser1Keypair, {iroha::model::can_receive}, kRole1))
+      .sendTx(makeUserWithPerms(kUser1,
+                                kUser1Keypair,
+                                {shared_model::permissions::can_receive},
+                                kRole1))
       .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
       .sendTx(addAssets(kUser1, kUser1Keypair))
       .skipProposal()
@@ -406,7 +411,8 @@ TEST_F(TransferAsset, InterDomain) {
                   integration_framework::IntegrationTestFramework::kAdminId)
               .createdTime(iroha::time::now())
               .createRole(kNewRole,
-                          std::vector<std::string>{iroha::model::can_receive})
+                          std::vector<std::string>{
+                              shared_model::permissions::can_receive})
               .createDomain(kNewDomain, kNewRole)
               .createAccount(
                   kUser2,

--- a/test/integration/client_test.cpp
+++ b/test/integration/client_test.cpp
@@ -58,6 +58,7 @@ using namespace iroha::validation;
 using namespace iroha::model::converters;
 using namespace iroha::model;
 using namespace shared_model::proto;
+using namespace shared_model::permissions;
 
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds proposal_delay = 10s;

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -24,10 +24,10 @@
 #include "ametsuchi/mutable_storage.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "framework/test_subscriber.hpp"
-#include "validators/permissions.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/permissions.hpp"
 
 using namespace iroha::ametsuchi;
 using namespace framework::test_subscriber;
@@ -195,9 +195,9 @@ TEST_F(AmetsuchiTest, SampleTest) {
                    .createRole(
                        "user",
                        shared_model::interface::types::PermissionSetType{
-                           iroha::model::can_add_peer,
-                           iroha::model::can_create_asset,
-                           iroha::model::can_get_my_account})
+                           shared_model::permissions::can_add_peer,
+                           shared_model::permissions::can_create_asset,
+                           shared_model::permissions::can_get_my_account})
                    .createDomain(domain, "user")
                    .createAccount(user1name, domain, fake_pubkey)
                    .build()}))
@@ -234,7 +234,7 @@ TEST_F(AmetsuchiTest, SampleTest) {
   // Block store tests
   auto hashes = {block1.hash(), block2.hash()};
   validateCalls(blocks->getBlocks(1, 2),
-                [i = 0, &hashes](auto eachBlock) mutable {
+                [ i = 0, &hashes ](auto eachBlock) mutable {
                   EXPECT_EQ(*(hashes.begin() + i), eachBlock->hash());
                   ++i;
                 },
@@ -293,9 +293,10 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
       TestTransactionBuilder()
           .creatorAccountId(admin)
           .createRole("user",
-                      std::set<std::string>{iroha::model::can_add_peer,
-                                            iroha::model::can_create_asset,
-                                            iroha::model::can_get_my_account})
+                      std::set<std::string>{
+                          shared_model::permissions::can_add_peer,
+                          shared_model::permissions::can_create_asset,
+                          shared_model::permissions::can_get_my_account})
           .createDomain(domain, "user")
           .createAccount(user1name, domain, fake_pubkey)
           .createAccount(user2name, domain, fake_pubkey)
@@ -376,7 +377,7 @@ TEST_F(AmetsuchiTest, queryGetAccountAssetTransactionsTest) {
   // Block store test
   auto hashes = {block1.hash(), block2.hash(), block3.hash()};
   validateCalls(blocks->getBlocks(1, 3),
-                [i = 0, &hashes](auto eachBlock) mutable {
+                [ i = 0, &hashes ](auto eachBlock) mutable {
                   EXPECT_EQ(*(hashes.begin() + i), eachBlock->hash());
                   ++i;
                 },
@@ -413,9 +414,10 @@ TEST_F(AmetsuchiTest, AddSignatoryTest) {
       TestTransactionBuilder()
           .creatorAccountId("adminone")
           .createRole("user",
-                      std::set<std::string>{iroha::model::can_add_peer,
-                                            iroha::model::can_create_asset,
-                                            iroha::model::can_get_my_account})
+                      std::set<std::string>{
+                          shared_model::permissions::can_add_peer,
+                          shared_model::permissions::can_create_asset,
+                          shared_model::permissions::can_get_my_account})
           .createDomain("domain", "user")
           .createAccount("userone", "domain", pubkey1)
           .build();
@@ -698,9 +700,10 @@ TEST_F(AmetsuchiTest, FindTxByHashTest) {
       TestTransactionBuilder()
           .creatorAccountId("admin1")
           .createRole("user",
-                      std::set<std::string>{iroha::model::can_add_peer,
-                                            iroha::model::can_create_asset,
-                                            iroha::model::can_get_my_account})
+                      std::set<std::string>{
+                          shared_model::permissions::can_add_peer,
+                          shared_model::permissions::can_create_asset,
+                          shared_model::permissions::can_get_my_account})
           .createDomain("domain", "user")
           .createAccount("userone", "domain", pubkey1)
           .build();
@@ -709,9 +712,10 @@ TEST_F(AmetsuchiTest, FindTxByHashTest) {
       TestTransactionBuilder()
           .creatorAccountId("admin1")
           .createRole("usertwo",
-                      std::set<std::string>{iroha::model::can_add_peer,
-                                            iroha::model::can_create_asset,
-                                            iroha::model::can_get_my_account})
+                      std::set<std::string>{
+                          shared_model::permissions::can_add_peer,
+                          shared_model::permissions::can_create_asset,
+                          shared_model::permissions::can_get_my_account})
           .createDomain("domaintwo", "user")
           .build();
 
@@ -866,12 +870,13 @@ TEST_F(AmetsuchiTest, TestRestoreWSV) {
           .txCounter(1)
           .createdTime(iroha::time::now())
           .createRole(default_role,
-                      std::vector<std::string>{iroha::model::can_create_domain,
-                                               iroha::model::can_create_account,
-                                               iroha::model::can_add_asset_qty,
-                                               iroha::model::can_add_peer,
-                                               iroha::model::can_receive,
-                                               iroha::model::can_transfer})
+                      std::vector<std::string>{
+                          shared_model::permissions::can_create_domain,
+                          shared_model::permissions::can_create_account,
+                          shared_model::permissions::can_add_asset_qty,
+                          shared_model::permissions::can_add_peer,
+                          shared_model::permissions::can_receive,
+                          shared_model::permissions::can_transfer})
           .createDomain(default_domain, default_role)
           .build()
           .signAndAddSignature(

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -24,9 +24,9 @@
 #include "ametsuchi/impl/storage_impl.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "model/block.hpp"
-#include "validators/permissions.hpp"
 #include "model/sha3_hash.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
+#include "validators/permissions.hpp"
 
 // TODO: 14-02-2018 Alexey Chernyshov remove this after relocation to
 // shared_model https://soramitsu.atlassian.net/browse/IR-887
@@ -61,9 +61,9 @@ class KVTest : public AmetsuchiTest {
 
     iroha::model::CreateRole createRole;
     createRole.role_name = "user";
-    createRole.permissions = {iroha::model::can_add_peer,
-                              iroha::model::can_create_asset,
-                              iroha::model::can_get_my_account};
+    createRole.permissions = {shared_model::permissions::can_add_peer,
+                              shared_model::permissions::can_create_asset,
+                              shared_model::permissions::can_get_my_account};
 
     // Create domain ru
     txn1_1.commands.push_back(

--- a/test/module/irohad/model/command_validate_execute_test.cpp
+++ b/test/module/irohad/model/command_validate_execute_test.cpp
@@ -49,6 +49,7 @@ using namespace iroha;
 using namespace iroha::ametsuchi;
 using namespace iroha::model;
 using namespace framework::expected;
+using namespace shared_model::permissions;
 
 class CommandValidateExecuteTest : public ::testing::Test {
  public:

--- a/test/module/irohad/model/converters/json_commands_test.cpp
+++ b/test/module/irohad/model/converters/json_commands_test.cpp
@@ -43,6 +43,7 @@ using namespace rapidjson;
 using namespace iroha;
 using namespace iroha::model;
 using namespace iroha::model::converters;
+using namespace shared_model::permissions;
 
 class JsonCommandTest : public ::testing::Test {
  public:

--- a/test/module/irohad/model/converters/pb_commands_test.cpp
+++ b/test/module/irohad/model/converters/pb_commands_test.cpp
@@ -37,6 +37,7 @@
 #include "validators/permissions.hpp"
 
 using namespace iroha::model;
+using namespace shared_model::permissions;
 
 void command_converter_test(iroha::model::Command &abstract_command) {
   auto factory = iroha::model::converters::PbCommandFactory();

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include "validators/permissions.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
+#include "validators/permissions.hpp"
 
 #include "framework/test_subscriber.hpp"
 #include "model/queries/responses/error_response.hpp"
@@ -91,7 +91,8 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
       shared_model::proto::AccountBuilder().accountId(account_id).build());
   auto role = "admin";
   std::vector<std::string> roles = {role};
-  std::vector<std::string> perms = {iroha::model::can_get_my_account};
+  std::vector<std::string> perms = {
+      shared_model::permissions::can_get_my_account};
 
   EXPECT_CALL(*storage, getWsvQuery()).WillRepeatedly(Return(wsv_queries));
   EXPECT_CALL(*storage, getBlockQuery()).WillRepeatedly(Return(block_queries));
@@ -147,7 +148,8 @@ TEST_F(QueryProcessorTest, QueryProcessorWithWrongKey) {
       shared_model::proto::AccountBuilder().accountId(account_id).build());
   auto role = "admin";
   std::vector<std::string> roles = {role};
-  std::vector<std::string> perms = {iroha::model::can_get_my_account};
+  std::vector<std::string> perms = {
+      shared_model::permissions::can_get_my_account};
 
   EXPECT_CALL(*storage, getWsvQuery()).WillRepeatedly(Return(wsv_queries));
   EXPECT_CALL(*storage, getBlockQuery()).WillRepeatedly(Return(block_queries));

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -27,10 +27,10 @@ limitations under the License.
 #include "model/converters/pb_common.hpp"
 
 #include "main/server_runner.hpp"
-#include "validators/permissions.hpp"
 #include "torii/processor/query_processor_impl.hpp"
 #include "torii/query_client.hpp"
 #include "torii/query_service.hpp"
+#include "validators/permissions.hpp"
 
 #include "builders/protobuf/queries.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
@@ -151,10 +151,11 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
   account.account_id = "b@domain";
   auto creator = "a@domain";
 
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          creator, account.account_id, iroha::model::can_get_my_account))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator,
+                  account.account_id,
+                  shared_model::permissions::can_get_my_account))
       .WillOnce(Return(false));
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
@@ -193,10 +194,11 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          creator, accountB->accountId(), iroha::model::can_get_my_account))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  creator,
+                  accountB->accountId(),
+                  shared_model::permissions::can_get_my_account))
       .WillOnce(Return(true));
 
   // Should be called once, after successful stateful validation
@@ -239,7 +241,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillRepeatedly(Return(roles));
-  std::vector<std::string> perm = {iroha::model::can_get_my_account};
+  std::vector<std::string> perm = {
+      shared_model::permissions::can_get_my_account};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
 
   iroha::protocol::QueryResponse response;
@@ -276,9 +279,10 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  creator, accountb_id, iroha::model::can_get_my_acc_ast))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          creator, accountb_id, shared_model::permissions::can_get_my_acc_ast))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(boost::none));
@@ -332,7 +336,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
       .WillRepeatedly(Return(signatories));
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
-  std::vector<std::string> perm = {iroha::model::can_get_my_acc_ast};
+  std::vector<std::string> perm = {
+      shared_model::permissions::can_get_my_acc_ast};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*wsv_query, getAccountAsset(_, _))
       .WillOnce(Return(account_asset));
@@ -386,7 +391,9 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
       .WillRepeatedly(Return(signatories));
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  creator, "b@domain", iroha::model::can_get_my_signatories))
+                  creator,
+                  "b@domain",
+                  shared_model::permissions::can_get_my_signatories))
       .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(boost::none));
@@ -425,7 +432,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
 
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
-  std::vector<std::string> perm = {iroha::model::can_get_my_signatories};
+  std::vector<std::string> perm = {
+      shared_model::permissions::can_get_my_signatories};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
 
   iroha::protocol::QueryResponse response;
@@ -482,7 +490,8 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
       .WillRepeatedly(Return(signatories));
   std::vector<std::string> roles = {"test"};
   EXPECT_CALL(*wsv_query, getAccountRoles(creator)).WillOnce(Return(roles));
-  std::vector<std::string> perm = {iroha::model::can_get_my_acc_txs};
+  std::vector<std::string> perm = {
+      shared_model::permissions::can_get_my_acc_txs};
   EXPECT_CALL(*wsv_query, getRolePermissions("test")).WillOnce(Return(perm));
   EXPECT_CALL(*block_query, getAccountTransactions(creator))
       .WillOnce(Return(txs_observable));

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -39,6 +39,7 @@ using ::testing::_;
 using namespace iroha::ametsuchi;
 using namespace iroha::model;
 using namespace framework::test_subscriber;
+using namespace shared_model::permissions;
 
 using wTransaction = std::shared_ptr<shared_model::interface::Transaction>;
 

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -29,10 +29,10 @@
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
-#include "validators/permissions.hpp"
 #include "module/shared_model/validators/validators_fixture.hpp"
 #include "utils/lazy_initializer.hpp"
 #include "validators/field_validator.hpp"
+#include "validators/permissions.hpp"
 
 using namespace shared_model;
 
@@ -516,14 +516,15 @@ class FieldValidatorTest : public ValidatorsTest {
           "too big quorum size", &FieldValidatorTest::quorum, 129, false, "")};
 
   std::vector<FieldTestCase> permissionTestCases() {
-    auto valid_cases = iroha::model::role_perm_group
+    auto valid_cases =
+        shared_model::permissions::role_perm_group
         | boost::adaptors::transformed([&](const auto &permission) {
-                         return this->makeTestCase(permission,
-                                             &FieldValidatorTest::permission,
-                                             permission,
-                                             true,
-                                             "");
-                       });
+            return this->makeTestCase(permission,
+                                      &FieldValidatorTest::permission,
+                                      permission,
+                                      true,
+                                      "");
+          });
     std::vector<FieldTestCase> invalid_cases = {
         makeInvalidCase("non existing permission",
                         "permission",


### PR DESCRIPTION


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Move permissions from iroha::model to shared_model::permissions

### Benefits

<!-- What benefits will be realized by the code change? -->
Permissions.hpp was moved to shared model but namespace still was old (iroha::model). Now it's fixed.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
None.


