### PR TITLE
Use rxcpp for OrderingServiceImpl proposal timeout

### DIFF
--- a/irohad/main/impl/ordering_init.cpp
+++ b/irohad/main/impl/ordering_init.cpp
@@ -38,7 +38,7 @@ namespace iroha {
       return std::make_shared<ordering::OrderingServiceImpl>(
           wsv,
           max_size,
-          delay_milliseconds.count(),
+          rxcpp::observable<>::timer(delay_milliseconds),
           transport,
           persistent_state);
     }

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -42,17 +42,18 @@ namespace iroha {
      * Allows receiving transactions concurrently from multiple peers by using
      * concurrent queue
      * Sends proposal by given timer interval and proposal size
-     * @param delay_milliseconds timer delay
+     * @param proposal_timeout timer delay
      * @param max_size proposal size
      * @param persistent_state - storage for persistent state of ordering
      * service
      */
     class OrderingServiceImpl : public network::OrderingService {
      public:
+      using Rep = std::chrono::milliseconds::rep;
       OrderingServiceImpl(
           std::shared_ptr<ametsuchi::PeerQuery> wsv,
           size_t max_size,
-          size_t delay_milliseconds,
+          rxcpp::observable<Rep> proposal_timeout,
           std::shared_ptr<network::OrderingServiceTransport> transport,
           std::shared_ptr<ametsuchi::OrderingServicePersistentState>
               persistent_state);
@@ -83,15 +84,10 @@ namespace iroha {
       void generateProposal() override;
 
       /**
-       * Method update peers for sending proposal
-       */
-
-      /**
-       * Update the timer to be called after delay_milliseconds_
+       * Update the timer to be called at proposal timeout
        */
       void updateTimer();
 
-      rxcpp::observable<long> timer;
       rxcpp::composite_subscription handle;
       std::shared_ptr<ametsuchi::PeerQuery> wsv_;
 
@@ -104,10 +100,6 @@ namespace iroha {
        */
       const size_t max_size_;
 
-      /**
-       *  wait for specified time if queue is empty
-       */
-      const size_t delay_milliseconds_;
       std::shared_ptr<network::OrderingServiceTransport> transport_;
 
       /**

--- a/test/module/irohad/ordering/ordering_gate_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_service_test.cpp
@@ -20,6 +20,7 @@
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "framework/test_subscriber.hpp"
+#include "logger/logger.hpp"
 #include "mock_ordering_service_persistent_state.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
@@ -41,6 +42,37 @@ using testing::_;
 using testing::Return;
 
 using wPeer = std::shared_ptr<shared_model::interface::Peer>;
+
+logger::Logger logger_ = logger::log("OrderingServiceImpl");
+
+class OrderingServiceImplProxy : public OrderingServiceImpl {
+ public:
+  using OrderingServiceImpl::OrderingServiceImpl;
+
+  void init() {
+    tx_awaiter_ = tx_await_.get_observable();
+  }
+
+  void onTransaction(
+      std::shared_ptr<shared_model::interface::Transaction> tx) override {
+    OrderingServiceImpl::onTransaction(tx);
+    logger_->info("tx_await_ notify");
+    tx_await_.get_subscriber().on_next(0);
+  }
+
+  template <typename T>
+  void waitTransaction(T t) {
+    try {
+      tx_awaiter_.take(1).as_blocking().count();
+    } catch (std::exception &e) {
+      logger_->warn("Exception at waitTransaction: {}", e.what());
+    }
+  }
+
+ private:
+  rxcpp::subjects::subject<int> tx_await_;
+  rxcpp::observable<int> tx_awaiter_;
+};
 
 // TODO: refactor services to allow dynamic port binding IR-741
 class OrderingGateServiceTest : public ::testing::Test {
@@ -103,7 +135,12 @@ class OrderingGateServiceTest : public ::testing::Test {
   }
 
   TestSubscriber<std::shared_ptr<shared_model::interface::Proposal>> init(
-      size_t times) {
+      std::shared_ptr<OrderingServiceImplProxy> service, size_t times) {
+    service->init();
+    service_transport->subscribe(service);
+
+    start();
+
     auto wrapper = make_test_subscriber<CallExact>(gate->on_proposal(), times);
     gate->on_proposal().subscribe([this](auto proposal) {
       proposal_counter++;
@@ -116,6 +153,7 @@ class OrderingGateServiceTest : public ::testing::Test {
               TestBlockBuilder().build());
       commit_subject_.get_subscriber().on_next(
           rxcpp::observable<>::just(block));
+      logger_->info("on_proposal");
       cv.notify_one();
     });
     wrapper.subscribe();
@@ -137,30 +175,30 @@ class OrderingGateServiceTest : public ::testing::Test {
             .signAndAddSignature(
                 shared_model::crypto::DefaultCryptoAlgorithmType::
                     generateKeypair()));
+    // network may change tx order, so wait until recieving
     gate->propagateTransaction(tx);
-    // otherwise tx may come unordered
-    std::this_thread::sleep_for(20ms);
+    service->waitTransaction(1s);
+    logger_->info("tx_awaiter_ passed");
   }
 
-  void timeoutTick() {
+  void waitProposal(size_t proposal_num) {
     proposal_timeout.get_subscriber().on_next(0);
-  }
-
-  void waitForGate() {
-    std::mutex mtx;
-    std::unique_lock<std::mutex> lock(mtx);
-    cv.wait_for(lock, 1s);
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait_for(lock, 1s, [this, proposal_num] {
+      return proposal_counter == proposal_num;
+    });
   }
 
   std::string address{"0.0.0.0:50051"};
   std::shared_ptr<OrderingGateImpl> gate;
-  std::shared_ptr<OrderingServiceImpl> service;
+  std::shared_ptr<OrderingServiceImplProxy> service;
 
   /// Peer Communication Service and commit subject are required to emulate
   /// commits for Ordering Service
   std::shared_ptr<MockPeerCommunicationService> pcs_;
   rxcpp::subjects::subject<Commit> commit_subject_;
-  rxcpp::subjects::subject<OrderingServiceImpl::Rep> proposal_timeout;
+  rxcpp::subjects::subject<OrderingServiceImplProxy::Rep> proposal_timeout;
 
   std::vector<std::shared_ptr<shared_model::interface::Proposal>> proposals;
   std::atomic<size_t> proposal_counter;
@@ -188,6 +226,7 @@ TEST_F(OrderingGateServiceTest, SplittingBunchTransactions) {
       .WillRepeatedly(Return(std::vector<wPeer>{peer}));
 
   const size_t max_proposal = 100;
+  const size_t proposal_num = 2;
 
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
@@ -200,31 +239,26 @@ TEST_F(OrderingGateServiceTest, SplittingBunchTransactions) {
       .Times(1)
       .WillOnce(Return(true));
 
-  service =
-      std::make_shared<OrderingServiceImpl>(wsv,
-                                            max_proposal,
-                                            proposal_timeout.get_observable(),
-                                            service_transport,
-                                            fake_persistent_state);
-  service_transport->subscribe(service);
-
-  start();
-  auto wrapper = init(2);
+  service = std::make_shared<OrderingServiceImplProxy>(
+      wsv,
+      max_proposal,
+      proposal_timeout.get_observable(),
+      service_transport,
+      fake_persistent_state);
+  auto wrapper = init(service, proposal_num);
 
   for (size_t i = 0; i < 8; ++i) {
     send_transaction(i + 1);
   }
 
-  timeoutTick();
+  waitProposal(1);
   send_transaction(9);
   send_transaction(10);
-  timeoutTick();
+  waitProposal(2);
 
-  waitForGate();
-  ASSERT_EQ(proposals.size(), 2);
+  ASSERT_EQ(proposals.size(), proposal_num);
   ASSERT_EQ(proposals.at(0)->transactions().size(), 8);
   ASSERT_EQ(proposals.at(1)->transactions().size(), 2);
-  ASSERT_EQ(proposal_counter, 2);
   ASSERT_TRUE(wrapper.validate());
 
   size_t i = 1;
@@ -247,6 +281,7 @@ TEST_F(OrderingGateServiceTest, ProposalsReceivedWhenProposalSize) {
       .WillRepeatedly(Return(std::vector<wPeer>{peer}));
 
   const size_t max_proposal = 5;
+  const size_t proposal_num = 2;
 
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
@@ -259,27 +294,22 @@ TEST_F(OrderingGateServiceTest, ProposalsReceivedWhenProposalSize) {
       .Times(1)
       .WillOnce(Return(true));
 
-  service =
-      std::make_shared<OrderingServiceImpl>(wsv,
-                                            max_proposal,
-                                            proposal_timeout.get_observable(),
-                                            service_transport,
-                                            fake_persistent_state);
-  service_transport->subscribe(service);
-
-  start();
-  auto wrapper = init(2);
+  service = std::make_shared<OrderingServiceImplProxy>(
+      wsv,
+      max_proposal,
+      proposal_timeout.get_observable(),
+      service_transport,
+      fake_persistent_state);
+  auto wrapper = init(service, proposal_num);
 
   for (size_t i = 0; i < 10; ++i) {
     send_transaction(i + 1);
   }
 
-  timeoutTick();
+  waitProposal(2);
 
-  waitForGate();
   ASSERT_TRUE(wrapper.validate());
-  ASSERT_EQ(proposals.size(), 2);
-  ASSERT_EQ(proposal_counter, 2);
+  ASSERT_EQ(proposals.size(), proposal_num);
 
   size_t i = 1;
   for (auto &&proposal : proposals) {
@@ -300,7 +330,8 @@ TEST_F(OrderingGateServiceTest, BatchOfSingleTxProposal) {
       .WillRepeatedly(Return(std::vector<wPeer>{peer}));
 
   const size_t max_proposal = 1;
-  const size_t times = 100;
+  const size_t times = 10;
+  const size_t proposal_num = times / max_proposal;
 
   int height_cnt = 2;
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
@@ -309,27 +340,22 @@ TEST_F(OrderingGateServiceTest, BatchOfSingleTxProposal) {
   EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
       .WillRepeatedly(Return(true));
 
-  service =
-      std::make_shared<OrderingServiceImpl>(wsv,
-                                            max_proposal,
-                                            proposal_timeout.get_observable(),
-                                            service_transport,
-                                            fake_persistent_state);
-  service_transport->subscribe(service);
-
-  start();
-  auto wrapper = init(times);
+  service = std::make_shared<OrderingServiceImplProxy>(
+      wsv,
+      max_proposal,
+      proposal_timeout.get_observable(),
+      service_transport,
+      fake_persistent_state);
+  auto wrapper = init(service, proposal_num);
 
   for (size_t i = 0; i < times; ++i) {
     send_transaction(i + 1);
   }
 
-  timeoutTick();
+  waitProposal(proposal_num);
 
-  waitForGate();
   ASSERT_TRUE(wrapper.validate());
-  ASSERT_EQ(proposals.size(), times);
-  ASSERT_EQ(proposal_counter, times);
+  ASSERT_EQ(proposals.size(), proposal_num);
 
   size_t i = 1;
   for (auto &&proposal : proposals) {

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -19,6 +19,7 @@
 
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
+#include "builders/protobuf/transaction.hpp"
 #include "logger/logger.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
@@ -27,7 +28,6 @@
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "ordering/impl/ordering_service_impl.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
-#include "builders/protobuf/transaction.hpp"
 
 using namespace iroha;
 using namespace iroha::ordering;
@@ -35,14 +35,14 @@ using namespace iroha::network;
 using namespace iroha::ametsuchi;
 using namespace std::chrono_literals;
 
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-using ::testing::_;
 
-static logger::Logger log_ = logger::testLog("OrderingService");
+static logger::Logger log_ = logger::testLog("OrderingServiceTest");
 
 class MockOrderingServiceTransport : public network::OrderingServiceTransport {
  public:
@@ -81,54 +81,74 @@ class OrderingServiceTest : public ::testing::Test {
         std::make_shared<MockOrderingServicePersistentState>();
   }
 
-  auto getTx() {
+  auto createTx() {
     return std::make_shared<shared_model::proto::Transaction>(
         shared_model::proto::TransactionBuilder()
-        .txCounter(2)
-        .createdTime(iroha::time::now())
-        .creatorAccountId("admin@ru")
-        .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-        .build()
-        .signAndAddSignature(
-            shared_model::crypto::DefaultCryptoAlgorithmType::
-            generateKeypair()));
+            .txCounter(2)
+            .createdTime(iroha::time::now())
+            .creatorAccountId("admin@ru")
+            .addAssetQuantity("admin@tu", "coin#coin", "1.0")
+            .build()
+            .signAndAddSignature(
+                shared_model::crypto::DefaultCryptoAlgorithmType::
+                    generateKeypair()));
+  }
+
+  void timeoutTick() {
+    log_->info("proposal timeout tick");
+    proposal_timeout.get_subscriber().on_next(0);
   }
 
   std::shared_ptr<MockOrderingServiceTransport> fake_transport;
   std::shared_ptr<MockOrderingServicePersistentState> fake_persistent_state;
-  std::condition_variable cv;
-  std::mutex m;
   std::string address{"0.0.0.0:50051"};
   std::shared_ptr<shared_model::interface::Peer> peer;
   std::shared_ptr<MockPeerQuery> wsv;
+  rxcpp::subjects::subject<OrderingServiceImpl::Rep> proposal_timeout;
 };
 
-TEST_F(OrderingServiceTest, SimpleTest) {
-  // Direct publishProposal call, used for basic case test and for debug
-  // simplicity
-
+/**
+ * @given OrderingService and MockOrderingServiceTransport
+ * @when publishProposal is called at transport
+ * @then publishProposalProxy is called
+ */
+TEST_F(OrderingServiceTest, PublishProxy) {
   const size_t max_proposal = 5;
-  const size_t commit_delay = 1000;
 
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service =
+      std::make_shared<OrderingServiceImpl>(wsv,
+                                            max_proposal,
+                                            proposal_timeout.get_observable(),
+                                            fake_transport,
+                                            fake_persistent_state);
   fake_transport->subscribe(ordering_service);
 
   EXPECT_CALL(*fake_transport, publishProposalProxy(_, _)).Times(1);
 
   fake_transport->publishProposal(
       std::make_unique<shared_model::proto::Proposal>(
-          TestProposalBuilder().height(1).createdTime(iroha::time::now()).build()),
+          TestProposalBuilder()
+              .height(1)
+              .createdTime(iroha::time::now())
+              .build()),
       {});
 }
 
+/**
+ * @given OrderingService with max_proposal==5 and only self peer
+ *        and MockOrderingServiceTransport
+ *        and MockOrderingServicePersistentState
+ * @when OrderingService::onTransaction called 10 times
+ * @then publishProposalProxy called twice
+ *       and proposal height was loaded once and saved twice
+ */
 TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
   const size_t max_proposal = 5;
-  const size_t commit_delay = 1000;
+  const size_t tx_num = 10;
 
   EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
       .Times(2)
@@ -136,88 +156,78 @@ TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
-
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
-  fake_transport->subscribe(ordering_service);
-
-  // Init => proposal size 5 => 2 proposals after 10 transactions
-  size_t call_count = 0;
-  EXPECT_CALL(*fake_transport, publishProposalProxy(_, _))
-      .Times(2)
-      .WillRepeatedly(InvokeWithoutArgs([&] {
-        ++call_count;
-        cv.notify_one();
-      }));
-
-  shared_model::proto::PeerBuilder builder;
-
-  auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
-  auto tmp = builder.address(peer->address()).pubkey(key).build();
-
   EXPECT_CALL(*wsv, getLedgerPeers())
       .WillRepeatedly(Return(std::vector<decltype(peer)>{peer}));
 
-  for (size_t i = 0; i < 10; ++i) {
-    ordering_service->onTransaction(getTx());
-  }
-
-  std::unique_lock<std::mutex> lock(m);
-  cv.wait_for(lock, 10s, [&] { return call_count == 2; });
-}
-
-TEST_F(OrderingServiceTest, ValidWhenTimerStrategy) {
-  // Init => proposal timer 400 ms => 10 tx by 50 ms => 2 proposals in 1 second
-
-  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
-      .Times(2)
-      .WillRepeatedly(Return(true));
-  shared_model::proto::PeerBuilder builder;
-
-  auto key = shared_model::crypto::PublicKey(peer->pubkey().toString());
-  auto tmp = builder.address(peer->address()).pubkey(key).build();
-
-  EXPECT_CALL(*wsv, getLedgerPeers())
-      .WillRepeatedly(Return(std::vector<decltype(peer)>{peer}));
-
-  const size_t max_proposal = 100;
-  const size_t commit_delay = 400;
-
-  EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
-      .Times(1)
-      .WillOnce(Return(boost::optional<size_t>(2)));
-
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service =
+      std::make_shared<OrderingServiceImpl>(wsv,
+                                            max_proposal,
+                                            proposal_timeout.get_observable(),
+                                            fake_transport,
+                                            fake_persistent_state);
   fake_transport->subscribe(ordering_service);
 
   EXPECT_CALL(*fake_transport, publishProposalProxy(_, _))
-      .Times(2)
-      .WillRepeatedly(InvokeWithoutArgs([&] {
-        log_->info("Proposal send to grpc");
-        cv.notify_one();
-      }));
+      .Times(tx_num / max_proposal);
 
-  for (size_t i = 0; i < 8; ++i) {
-    ordering_service->onTransaction(getTx());
+  for (size_t i = 0; i < tx_num; ++i) {
+    ordering_service->onTransaction(createTx());
   }
-
-  std::unique_lock<std::mutex> lk(m);
-  cv.wait_for(lk, 10s);
-
-  ordering_service->onTransaction(getTx());
-  ordering_service->onTransaction(getTx());
-  cv.wait_for(lk, 10s);
 }
 
 /**
- * @given Ordering service and the persistent state that cannot save proposals
+ * @given OrderingService with big enough max_proposal and only self peer
+ *        and MockOrderingServiceTransport
+ *        and MockOrderingServicePersistentState
+ * @when OrderingService::onTransaction called 8 times
+ *       and after triggered timeout
+ *       and then repeat with 2 onTransaction calls
+ * @then publishProposalProxy called twice
+ *       and proposal height was loaded once and saved twice
+ */
+TEST_F(OrderingServiceTest, ValidWhenTimerStrategy) {
+  const size_t max_proposal = 100;
+
+  EXPECT_CALL(*fake_persistent_state, saveProposalHeight(_))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
+      .Times(1)
+      .WillOnce(Return(boost::optional<size_t>(2)));
+  EXPECT_CALL(*wsv, getLedgerPeers())
+      .WillRepeatedly(Return(std::vector<decltype(peer)>{peer}));
+
+  auto ordering_service =
+      std::make_shared<OrderingServiceImpl>(wsv,
+                                            max_proposal,
+                                            proposal_timeout.get_observable(),
+                                            fake_transport,
+                                            fake_persistent_state);
+  fake_transport->subscribe(ordering_service);
+
+  EXPECT_CALL(*fake_transport, publishProposalProxy(_, _))
+      .Times(2)
+      .WillRepeatedly(
+          InvokeWithoutArgs([&] { log_->info("Proposal send to grpc"); }));
+
+  for (size_t i = 0; i < 8; ++i) {
+    ordering_service->onTransaction(createTx());
+  }
+
+  timeoutTick();
+  ordering_service->onTransaction(createTx());
+  ordering_service->onTransaction(createTx());
+  timeoutTick();
+}
+
+/**
+ * @given Ordering service and the persistent state that cannot save
+ proposals
  * @when onTransaction is called
  * @then no published proposal
  */
 TEST_F(OrderingServiceTest, BrokenPersistentState) {
   const size_t max_proposal = 1;
-  const size_t commit_delay = 100;
   EXPECT_CALL(*fake_persistent_state, loadProposalHeight())
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(1)));
@@ -225,10 +235,12 @@ TEST_F(OrderingServiceTest, BrokenPersistentState) {
       .Times(1)
       .WillRepeatedly(Return(false));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
-  ordering_service->onTransaction(getTx());
-
-  std::unique_lock<std::mutex> lk(m);
-  cv.wait_for(lk, 2s);
+  auto ordering_service =
+      std::make_shared<OrderingServiceImpl>(wsv,
+                                            max_proposal,
+                                            proposal_timeout.get_observable(),
+                                            fake_transport,
+                                            fake_persistent_state);
+  ordering_service->onTransaction(createTx());
+  timeoutTick();
 }


### PR DESCRIPTION
### Description of the Change

Previously OrderingService and OrderingGate tests was using timeouts for handling its cases. That way is pretty bad as long as tests may occasionally fail.
That pr reworks OrderingServiceImpl to use rxcpp::observable for handling proposal timeouts.

### Benefits

More stable (and probably faster) ordering tests, simpler OrderingServiceImpl structure

