### PR TITLE
Changed ios build script to use https for all git clone operations (f…

### DIFF
--- a/shared_model/packages/android/android-build.sh
+++ b/shared_model/packages/android/android-build.sh
@@ -92,7 +92,7 @@ LDFLAGS="-llog -landroid" cmake "${ANDROID_TOOLCHAIN_ARGS[@]}" "${INSTALL_ARGS[@
 VERBOSE=1 cmake --build ./protobuf/.build --target install -- -j"$CORES"
 
 # ed25519
-git clone git://github.com/hyperledger/iroha-ed25519
+git clone https://github.com/hyperledger/iroha-ed25519.git
 (cd ./iroha-ed25519 ; git checkout e7188b8393dbe5ac54378610d53630bd4a180038)
 cmake "${ANDROID_TOOLCHAIN_ARGS[@]}" "${INSTALL_ARGS[@]}" -DTESTING=OFF -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DBUILD=STATIC -H./iroha-ed25519 -B./iroha-ed25519/build
 VERBOSE=1 cmake --build ./iroha-ed25519/build --target install -- -j"$CORES"

--- a/shared_model/packages/ios/ios-build.sh
+++ b/shared_model/packages/ios/ios-build.sh
@@ -90,7 +90,7 @@ cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${IOS_TOOLCHAIN_ARGS[@]}" "${INSTALL_ARG
 VERBOSE=1 cmake --build ./protobuf/.build --target install -- -j"$CORES"
 
 # ed25519
-git clone git://github.com/hyperledger/iroha-ed25519
+git clone https://github.com/hyperledger/iroha-ed25519.git
 (cd ./iroha-ed25519;
 git checkout e7188b8393dbe5ac54378610d53630bd4a180038)
 cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${IOS_TOOLCHAIN_ARGS[@]}" "${INSTALL_ARGS[@]}" -DTESTING=OFF -DBUILD=STATIC -H./iroha-ed25519 -B./iroha-ed25519/build


### PR DESCRIPTION
Changed ios build script to use https for all git clone operations (fixed issue with connection timeout)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Just a small improvement for ios-build bash script - on local machines it's safer to use https URL for clone operations. Currently, the script contains "git:" schema which may cause connection timeout while executing it. 
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Solves issue with "connection timeout" for iroha-ed25519
Code style - all other script parts use https URL to clone repositories

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

There are no impacts - it's a common way to clone git repositories

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

Launch script from the terminal with options for platform and mode like:

ios-build.sh SIMULATOR64 Debug
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

None
<!-- Explain what other alternates were considered and why the proposed version was selected -->
