### PR TITLE
Stateless_invalid response contains error message

### DIFF
--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -113,6 +113,7 @@ namespace torii {
                   shared_model::crypto::toBinaryString(tx_hash));
               response.set_tx_status(
                   iroha::protocol::TxStatus::STATELESS_VALIDATION_FAILED);
+              response.set_error_message(std::move(error.error));
             });
 
     cache_->addItem(tx_hash, response);

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -77,6 +77,7 @@ namespace torii {
                   shared_model::crypto::toBinaryString(hash));
               response.mutable_error_response()->set_reason(
                   iroha::protocol::ErrorResponse::STATELESS_INVALID);
+              response.mutable_error_response()->set_message(std::move(error.error));
             });
   }
 

--- a/schema/endpoint.proto
+++ b/schema/endpoint.proto
@@ -20,6 +20,7 @@ enum TxStatus {
 message ToriiResponse {
   TxStatus tx_status = 1;
   bytes tx_hash = 2;
+  string error_message = 3;
 }
 
 message TxStatusRequest{

--- a/schema/responses.proto
+++ b/schema/responses.proto
@@ -67,6 +67,7 @@ message ErrorResponse {
     NO_ROLES = 8;           // when there are no roles defined in the system
   }
   Reason reason = 1;
+  string message = 2;
 }
 
 message SignatoriesResponse {

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -210,6 +210,7 @@ TEST_F(ClientServerTest, SendQueryWhenStatelessInvalid) {
   ASSERT_TRUE(res.answer.has_error_response());
   ASSERT_EQ(res.answer.error_response().reason(),
             iroha::model::ErrorResponse::STATELESS_INVALID);
+  ASSERT_NE(res.answer.error_response().message().size(), 0);
 }
 
 TEST_F(ClientServerTest, SendQueryWhenValid) {

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -42,10 +42,10 @@
 constexpr const char *Ip = "0.0.0.0";
 constexpr int Port = 50051;
 
+using ::testing::_;
 using ::testing::A;
 using ::testing::AtLeast;
 using ::testing::Return;
-using ::testing::_;
 
 using namespace iroha::ametsuchi;
 using namespace iroha::network;
@@ -167,10 +167,11 @@ TEST_F(ClientServerTest, SendTxWhenStatelessInvalid) {
   ASSERT_EQ(iroha_cli::CliClient(Ip, Port).sendTx(*old_tx).answer,
             iroha_cli::CliClient::OK);
   auto tx_hash = shm_tx.hash();
-  ASSERT_EQ(iroha_cli::CliClient(Ip, Port)
-                .getTxStatus(shared_model::crypto::toBinaryString(tx_hash))
-                .answer.tx_status(),
+  auto res = iroha_cli::CliClient(Ip, Port).getTxStatus(
+      shared_model::crypto::toBinaryString(tx_hash));
+  ASSERT_EQ(res.answer.tx_status(),
             iroha::protocol::TxStatus::STATELESS_VALIDATION_FAILED);
+  ASSERT_NE(res.answer.error_message().size(), 0);
 }
 
 TEST_F(ClientServerTest, SendQueryWhenInvalidJson) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Added error message to response, if stateless validation has failed. Now ErrorResponse and Torii response will have information from the stateless validator.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Clients can now see what went wrong with if their transactions or queries do not pass stateless validation
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Size of the response is increased in some cases.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->