### PR TITLE
Restrict swig targets includes

### DIFF
--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -37,7 +37,6 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
     if (SHARED_MODEL_DISABLE_COMPATIBILITY)
         set(CMAKE_SWIG_FLAGS "-DDISABLE_BACKWARD")
     endif()
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     set_source_files_properties(bindings.i PROPERTIES CPLUSPLUS ON)
     set_property(GLOBAL PROPERTY SWIG_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -51,9 +50,6 @@ if (SWIG_PYTHON)
         find_package(PythonLibs 3.6 REQUIRED)
     endif()
 
-    # path to where Python.h is found
-    include_directories(${PYTHON_INCLUDE_DIRS})
-
     if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
         set(MAC_OPTS "-flat_namespace -undefined suppress")
     endif()
@@ -61,18 +57,22 @@ if (SWIG_PYTHON)
     swig_add_library(iroha LANGUAGE python SOURCES bindings.i)
     swig_link_libraries(iroha ${Python_LIBRARIES} bindings ${MAC_OPTS})
     add_custom_target(irohapy DEPENDS ${SWIG_MODULE_iroha_REAL_NAME})
-
+    # path to where Python.h is found
+    target_include_directories(${SWIG_MODULE_iroha_REAL_NAME} PUBLIC
+        ${PYTHON_INCLUDE_DIRS}
+        )
 endif()
 
 if (SWIG_JAVA)
     find_package(JNI REQUIRED)
-    # the include path to jni.h
-    include_directories(${JAVA_INCLUDE_PATH})
-    # the include path to jni_md.h
-    include_directories(${JAVA_INCLUDE_PATH2})
 
     swig_add_library(irohajava LANGUAGE java SOURCES bindings.i)
     swig_link_libraries(irohajava ${Java_LIBRARIES} bindings)
+    # the include path to jni.h and jni_md.h
+    target_include_directories(${SWIG_MODULE_irohajava_REAL_NAME} PUBLIC
+        ${JAVA_INCLUDE_PATH}
+        ${JAVA_INCLUDE_PATH2}
+        )
 endif()
 
 if (SWIG_CSHARP)
@@ -83,10 +83,6 @@ endif()
 
 if (SWIG_NODE)
     find_package (nodejs REQUIRED)
-    include_directories (
-            ${NODEJS_INCLUDE_DIRS}
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
-            )
 
     set (V8_VERSION_HEX 0x0${V8_VERSION_MAJOR}${V8_VERSION_MINOR}${V8_VERSION_PATCH})
     string (LENGTH "${V8_VERSION_HEX}" V8_VERSION_HEX_length)
@@ -110,4 +106,7 @@ if (SWIG_NODE)
         )
     set_target_properties(irohanode PROPERTIES PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX})
     target_link_libraries(irohanode bindings ${MAC_OPTS})
+    target_include_directories(${SWIG_MODULE_irohanode_REAL_NAME} PUBLIC
+        ${NODEJS_INCLUDE_DIRS}
+        )
 endif()


### PR DESCRIPTION
Signed-off-by: Andrei Lebedev <lebdron@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Includes from `python` were polluting `javascript` environment with `node.h`, which has the same name in `javascript` includes. Changes make include directories local to target, so `javascript` target does not include `python` includes.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Python and Javascript bindings can be compiled at the same time.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

