### PR TITLE
Feature/grpc logging

### DIFF
--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -30,9 +30,9 @@ namespace iroha {
     namespace yac {
       // ----------| Public API |----------
 
-      NetworkImpl::NetworkImpl() {
-        log_ = logger::log("YacNetwork");
-      }
+      NetworkImpl::NetworkImpl()
+          : network::AsyncGrpcClient<google::protobuf::Empty>(
+                logger::log("YacNetwork")) {}
 
       void NetworkImpl::subscribe(
           std::shared_ptr<YacNetworkNotifications> handler) {

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -101,11 +101,6 @@ namespace iroha {
          * Subscriber of network messages
          */
         std::weak_ptr<YacNetworkNotifications> handler_;
-
-        /**
-         * Internal logger
-         */
-        logger::Logger log_;
       };
 
     }  // namespace yac

--- a/irohad/main/impl/ordering_init.cpp
+++ b/irohad/main/impl/ordering_init.cpp
@@ -55,6 +55,7 @@ namespace iroha {
             "Ledger don't have peers. Do you set correct genesis block?");
       }
       auto network_address = ledger_peers->front()->address();
+      log_->info("Ordering gate is at {}", network_address);
       ordering_gate_transport =
           std::make_shared<iroha::ordering::OrderingGateTransportGrpc>(
               network_address);

--- a/irohad/network/impl/async_grpc_client.hpp
+++ b/irohad/network/impl/async_grpc_client.hpp
@@ -32,7 +32,9 @@ namespace iroha {
     template <typename Response>
     class AsyncGrpcClient {
      public:
-      AsyncGrpcClient() : thread_(&AsyncGrpcClient::asyncCompleteRpc, this) {}
+      AsyncGrpcClient(logger::Logger &&log)
+          : thread_(&AsyncGrpcClient::asyncCompleteRpc, this),
+            log_(std::move(log)) {}
 
       /**
        * Listen to gRPC server responses
@@ -42,7 +44,9 @@ namespace iroha {
         auto ok = false;
         while (cq_.Next(&got_tag, &ok)) {
           auto call = static_cast<AsyncClientCall *>(got_tag);
-
+          if (!call->status.ok()) {
+            log_->warn("RPC failed: {}", call->status.error_message());
+          }
           delete call;
         }
       }
@@ -56,6 +60,7 @@ namespace iroha {
 
       grpc::CompletionQueue cq_;
       std::thread thread_;
+      logger::Logger log_;
 
       /**
        * State and data information of gRPC call

--- a/irohad/network/impl/async_grpc_client.hpp
+++ b/irohad/network/impl/async_grpc_client.hpp
@@ -32,7 +32,7 @@ namespace iroha {
     template <typename Response>
     class AsyncGrpcClient {
      public:
-      AsyncGrpcClient(logger::Logger &&log)
+      explicit AsyncGrpcClient(logger::Logger &&log)
           : thread_(&AsyncGrpcClient::asyncCompleteRpc, this),
             log_(std::move(log)) {}
 

--- a/irohad/network/impl/async_grpc_client.hpp
+++ b/irohad/network/impl/async_grpc_client.hpp
@@ -44,7 +44,7 @@ namespace iroha {
         auto ok = false;
         while (cq_.Next(&got_tag, &ok)) {
           auto call = static_cast<AsyncClientCall *>(got_tag);
-          if (!call->status.ok()) {
+          if (not call->status.ok()) {
             log_->warn("RPC failed: {}", call->status.error_message());
           }
           delete call;

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -52,9 +52,10 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
 
 OrderingGateTransportGrpc::OrderingGateTransportGrpc(
     const std::string &server_address)
-    : client_(proto::OrderingServiceTransportGrpc::NewStub(grpc::CreateChannel(
-          server_address, grpc::InsecureChannelCredentials()))),
-      log_(logger::log("OrderingGate")) {}
+    : network::AsyncGrpcClient<google::protobuf::Empty>(
+          logger::log("OrderingGate")),
+      client_(proto::OrderingServiceTransportGrpc::NewStub(grpc::CreateChannel(
+          server_address, grpc::InsecureChannelCredentials()))) {}
 
 void OrderingGateTransportGrpc::propagateTransaction(
     std::shared_ptr<const shared_model::interface::Transaction> transaction) {
@@ -64,6 +65,7 @@ void OrderingGateTransportGrpc::propagateTransaction(
   auto transaction_transport =
       static_cast<const shared_model::proto::Transaction &>(*transaction)
           .getTransport();
+  log_->debug("Propagating: '{}'", transaction_transport.DebugString());
   call->response_reader =
       client_->AsynconTransaction(&call->context, transaction_transport, &cq_);
 

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
@@ -53,7 +53,6 @@ namespace iroha {
      private:
       std::weak_ptr<iroha::network::OrderingGateNotification> subscriber_;
       std::unique_ptr<proto::OrderingServiceTransportGrpc::Stub> client_;
-      logger::Logger log_;
     };
 
   }  // namespace ordering

--- a/irohad/ordering/impl/ordering_service_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.cpp
@@ -30,6 +30,7 @@ grpc::Status OrderingServiceTransportGrpc::onTransaction(
     ::grpc::ServerContext *context,
     const iroha::protocol::Transaction *request,
     ::google::protobuf::Empty *response) {
+  log_->info("OrderingServiceTransportGrpc::onTransaction");
   if (subscriber_.expired()) {
     log_->error("No subscriber");
   } else {
@@ -44,6 +45,7 @@ grpc::Status OrderingServiceTransportGrpc::onTransaction(
 void OrderingServiceTransportGrpc::publishProposal(
     std::unique_ptr<shared_model::interface::Proposal> proposal,
     const std::vector<std::string> &peers) {
+  log_->info("OrderingServiceTransportGrpc::publishProposal");
   std::unordered_map<std::string,
                      std::unique_ptr<proto::OrderingGateTransportGrpc::Stub>>
       peers_map;
@@ -57,6 +59,8 @@ void OrderingServiceTransportGrpc::publishProposal(
     auto call = new AsyncClientCall;
 
     auto proto = static_cast<shared_model::proto::Proposal *>(proposal.get());
+    log_->debug("Publishing proposal: '{}'",
+                proto->getTransport().DebugString());
     call->response_reader = peer.second->AsynconProposal(
         &call->context, proto->getTransport(), &cq_);
 
@@ -65,4 +69,5 @@ void OrderingServiceTransportGrpc::publishProposal(
 }
 
 OrderingServiceTransportGrpc::OrderingServiceTransportGrpc()
-    : log_(logger::testLog("OrderingServiceTransportGrpc")) {}
+    : network::AsyncGrpcClient<google::protobuf::Empty>(
+          logger::log("OrderingServiceTransportGrpc")) {}

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -50,7 +50,6 @@ namespace iroha {
 
      private:
       std::weak_ptr<iroha::network::OrderingServiceNotification> subscriber_;
-      logger::Logger log_;
     };
 
   }  // namespace ordering


### PR DESCRIPTION
### Description of the Change

RPC errors are not logged, the pr changes that by moving logger from children of `AsyncGrpcClient` to the parent. Also adds some additional logging.

Note, that grpc errors can be observed via **GRPC_TRACE**/**GRPC_VERBOSITY** env variables, but they mostly are not human-friendly

### Benefits

More logging

### Possible Drawbacks 

None