### PR TITLE
Fix artifacts uploading on unsuccessful build

### DIFF
--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -1,7 +1,7 @@
 def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
-      if (currentBuild.result != "UNSTABLE" && BRANCH_NAME ==~ /(master|develop)/) {
+      if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"
         def commit = env.GIT_COMMIT
         def platform = sh(script: 'uname -m', returnStdout: true).trim()

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -1,7 +1,7 @@
 def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
-      if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
+      if (currentBuild.currentResult == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"
         def commit = env.GIT_COMMIT
         def platform = sh(script: 'uname -m', returnStdout: true).trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,7 +218,7 @@ pipeline {
               """
               def testExitCode = sh(script: 'IROHA_POSTGRES_HOST=localhost IROHA_POSTGRES_PORT=5433 cmake --build build --target test', returnStatus: true)
               if (testExitCode != 0) {
-                currentBuild.result = "UNSTABLE"
+                currentBuild.currentResult = "UNSTABLE"
               }
               if ( coverageEnabled ) {
                 sh "cmake --build build --target cppcheck"
@@ -249,7 +249,7 @@ pipeline {
               script {
                 timeout(time: 600, unit: "SECONDS") {
                   try {
-                    if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
+                    if (currentBuild.currentResult == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]
@@ -345,7 +345,7 @@ pipeline {
               script {
                 timeout(time: 600, unit: "SECONDS") {
                   try {
-                    if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
+                    if (currentBuild.currentResult == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,22 +248,20 @@ pipeline {
             always {
               script {
                 timeout(time: 600, unit: "SECONDS") {
-                  if (currentBuild.result != "UNSTABLE") {
-                    if (BRANCH_NAME ==~ /(master|develop)/) {
-                      try {
-                        def artifacts = load ".jenkinsci/artifacts.groovy"
-                        def commit = env.GIT_COMMIT
-                        filePaths = [ '\$(pwd)/build/*.tar.gz' ]
-                        artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [BRANCH_NAME, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))                        
-                      }
-                      finally {
-                        cleanWs()
-                        sh """
-                          pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ stop && \
-                          rm -rf /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/
-                        """
-                      }
+                  try {
+                    if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
+                      def artifacts = load ".jenkinsci/artifacts.groovy"
+                      def commit = env.GIT_COMMIT
+                      filePaths = [ '\$(pwd)/build/*.tar.gz' ]
+                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [BRANCH_NAME, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))                        
                     }
+                  }
+                  finally {
+                    cleanWs()
+                    sh """
+                      pg_ctl -D /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/ stop && \
+                      rm -rf /var/jenkins/${GIT_COMMIT}-${BUILD_NUMBER}/
+                    """
                   }
                 }
               }
@@ -346,16 +344,16 @@ pipeline {
             always {
               script {
                 timeout(time: 600, unit: "SECONDS") {
-                  if (BRANCH_NAME ==~ /(master|develop)/) {
-                    try {
+                  try {
+                    if (currentBuild.result == "SUCCESS" && BRANCH_NAME ==~ /(master|develop)/) {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]
-                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [BRANCH_NAME, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))                        
+                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [BRANCH_NAME, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
                     }
-                    finally {
-                      cleanWs()
-                    }
+                  }
+                  finally {
+                    cleanWs()
                   }
                 }
               }


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
This PR fixes the case, when CI build artifacts could have been uploaded on unsuccessful build or not uploaded at all (e.g., build was aborted and artifacts were not generated)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
More stable and consistent process of uploading artifacts
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
