### PR TITLE
Fix/on absent genesis block

### DIFF
--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -154,6 +154,17 @@ int main(int argc, char *argv[]) {
               block.value()->transactions().size());
   }
 
+  // check if at least one block is available in the ledger
+  auto blocks_exist = false;
+  irohad.storage->getBlockQuery()->getTopBlocks(1).subscribe(
+      [&blocks_exist](auto block) { blocks_exist = true; });
+
+  if (not blocks_exist) {
+    log->error(
+        "There are no blocks in the ledger. Use --genesis_block parameter.");
+    return EXIT_FAILURE;
+  }
+
   // init pipeline components
   irohad.init();
 

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -32,4 +32,7 @@ target_link_libraries(integration_framework
 target_include_directories(integration_framework PUBLIC ${PROJECT_SOURCE_DIR}/test)
 
 add_library(integration_framework_config_helper config_helper.cpp)
+target_link_libraries(integration_framework_config_helper
+    logger
+    )
 target_include_directories(integration_framework_config_helper PUBLIC ${PROJECT_SOURCE_DIR}/test)

--- a/test/framework/config_helper.cpp
+++ b/test/framework/config_helper.cpp
@@ -17,8 +17,8 @@
 
 #include "framework/config_helper.hpp"
 
-#include <cstdlib>
 #include <sstream>
+#include "logger/logger.hpp"
 
 namespace integration_framework {
   std::string getPostgresCredsOrDefault(const std::string &default_conn) {
@@ -32,6 +32,7 @@ namespace integration_framework {
       std::stringstream ss;
       ss << "host=" << pg_host << " port=" << pg_port << " user=" << pg_user
          << " password=" << pg_pass;
+      logger::log("ITF")->info("Postgres credentials: {}", ss.str());
       return ss.str();
     }
   }


### PR DESCRIPTION
### Description of the Change
Fix segfault when the ledger doesn't contain blocks.

### Benefits
Minus one segfault in the project.
Also, bring little fix plus improvement for `itf::config_helper`: remove redundant include and logging for pg credentials.

### Possible Drawbacks 
Absent test for checking the new behavior. And I don't see a theoretical opportunity to write it.
So, reviewers should check it manually.
