### PR TITLE
Fix/swig build

### DIFF
--- a/cmake/Modules/Findswig.cmake
+++ b/cmake/Modules/Findswig.cmake
@@ -20,12 +20,13 @@ if(NOT SWIG_EXECUTABLE)
       BUILD_IN_SOURCE ON
       BUILD_COMMAND ${MAKE} swig
       TEST_COMMAND "" # remove test step
+      UPDATE_COMMAND "" # remove update step
       )
   ExternalProject_Get_Property(swig_swig source_dir)
 
   # Predefined vars for local installed SWIG
   set(SWIG_EXECUTABLE ${source_dir}/swig)
-  set(SWIG_DIR ${source_dir})
+  set(SWIG_DIR ${source_dir}/share/swig/3.0.12)
 
   add_dependencies(swig swig_swig)
 

--- a/cmake/Modules/Findswig.cmake
+++ b/cmake/Modules/Findswig.cmake
@@ -8,8 +8,9 @@ find_package_handle_standard_args(SWIG DEFAULT_MSG
 
 if(NOT SWIG_EXECUTABLE)
   find_package(Git REQUIRED)
-  set(URL ftp://www.mirrorservice.org/sites/ftp.sourceforge.net/pub/sourceforge/s/sw/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz)
-  set_target_description(swig "Simplified Wrapper and Interface Generator (SWIG)" ${URL} 3.0.12)
+  set(SWIG_VERSION 3.0.12)
+  set(URL ftp://www.mirrorservice.org/sites/ftp.sourceforge.net/pub/sourceforge/s/sw/swig/swig/swig-${SWIG_VERSION}/swig-${SWIG_VERSION}.tar.gz)
+  set_target_description(swig "Simplified Wrapper and Interface Generator (SWIG)" ${URL} ${SWIG_VERSION})
 
   ExternalProject_Add(swig_swig
       URL ${URL}
@@ -26,7 +27,7 @@ if(NOT SWIG_EXECUTABLE)
 
   # Predefined vars for local installed SWIG
   set(SWIG_EXECUTABLE ${source_dir}/swig)
-  set(SWIG_DIR ${source_dir}/share/swig/3.0.12)
+  set(SWIG_DIR ${source_dir}/share/swig/${SWIG_VERSION})
 
   add_dependencies(swig swig_swig)
 

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -42,12 +42,16 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
 
     add_dependencies(bindings swig)
 
-    macro (myswig_add_library)
+    macro (myswig_add_library target)
         swig_add_library(${ARGV})
-        # workaround for CMake 3.11+
-        if (swig_gen_target)
-            add_dependencies (${swig_gen_target} swig)
-        endif()
+        # get internal dependencies
+        get_target_property(dependencies
+            ${SWIG_MODULE_${target}_REAL_NAME}
+            MANUALLY_ADDED_DEPENDENCIES)
+        # add external project dependency on internal targets
+        foreach (dependency IN LISTS dependencies)
+            add_dependencies(${dependency} swig)
+        endforeach()
     endmacro()
 endif()
 

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -41,6 +41,14 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
     set_property(GLOBAL PROPERTY SWIG_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
     add_dependencies(bindings swig)
+
+    macro (myswig_add_library)
+        swig_add_library(${ARGV})
+        # workaround for CMake 3.11+
+        if (swig_gen_target)
+            add_dependencies (${swig_gen_target} swig)
+        endif()
+    endmacro()
 endif()
 
 if (SWIG_PYTHON)
@@ -54,7 +62,7 @@ if (SWIG_PYTHON)
         set(MAC_OPTS "-flat_namespace -undefined suppress")
     endif()
 
-    swig_add_library(iroha LANGUAGE python SOURCES bindings.i)
+    myswig_add_library(iroha LANGUAGE python SOURCES bindings.i)
     swig_link_libraries(iroha ${Python_LIBRARIES} bindings ${MAC_OPTS})
     add_custom_target(irohapy DEPENDS ${SWIG_MODULE_iroha_REAL_NAME})
     # path to where Python.h is found
@@ -66,7 +74,7 @@ endif()
 if (SWIG_JAVA)
     find_package(JNI REQUIRED)
 
-    swig_add_library(irohajava LANGUAGE java SOURCES bindings.i)
+    myswig_add_library(irohajava LANGUAGE java SOURCES bindings.i)
     swig_link_libraries(irohajava ${Java_LIBRARIES} bindings)
     # the include path to jni.h and jni_md.h
     target_include_directories(${SWIG_MODULE_irohajava_REAL_NAME} PUBLIC
@@ -76,7 +84,7 @@ if (SWIG_JAVA)
 endif()
 
 if (SWIG_CSHARP)
-    swig_add_library(libirohacs LANGUAGE csharp SOURCES bindings.i)
+    myswig_add_library(libirohacs LANGUAGE csharp SOURCES bindings.i)
     swig_link_libraries(libirohacs bindings)
     add_custom_target(irohacs DEPENDS ${SWIG_MODULE_libirohacs_REAL_NAME})
 endif()
@@ -99,7 +107,7 @@ if (SWIG_NODE)
     set_property(SOURCE bindings.i PROPERTY SWIG_FLAGS "-node" "-DV8_VERSION=${V8_VERSION_HEX}")
 
     # Build SWIG library always statically for the subsequent assembly by GYP
-    swig_add_library(irohanode 
+    myswig_add_library(irohanode
         TYPE STATIC 
         LANGUAGE javascript 
         SOURCES bindings.i

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -48,10 +48,12 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
         get_target_property(dependencies
             ${SWIG_MODULE_${target}_REAL_NAME}
             MANUALLY_ADDED_DEPENDENCIES)
-        # add external project dependency on internal targets
-        foreach (dependency IN LISTS dependencies)
-            add_dependencies(${dependency} swig)
-        endforeach()
+        if (dependencies)
+            # add external project dependency on internal targets
+            foreach (dependency IN LISTS dependencies)
+                add_dependencies(${dependency} swig)
+            endforeach()
+        endif()
     endmacro()
 endif()
 

--- a/shared_model/packages/android/android-build.sh
+++ b/shared_model/packages/android/android-build.sh
@@ -100,9 +100,9 @@ mv "$DEPS_DIR"/lib/static/libed25519.a "$DEPS_DIR"/lib; rmdir "$DEPS_DIR"/lib/st
 
 # SWIG fixes
 sed -i.bak "s~find_package(JNI REQUIRED)~#find_package(JNI REQUIRED)~" ./iroha/shared_model/bindings/CMakeLists.txt
-sed -i.bak "s~include_directories(${JAVA_INCLUDE_PATH})~#include_directories(${JAVA_INCLUDE_PATH})~" ./iroha/shared_model/bindings/CMakeLists.txt
-sed -i.bak "s~include_directories(${JAVA_INCLUDE_PATH2})~#include_directories(${JAVA_INCLUDE_PATH2})~" ./iroha/shared_model/bindings/CMakeLists.txt
-sed -i.bak "s~# the include path to jni.h~SET(CMAKE_SWIG_FLAGS \${CMAKE_SWIG_FLAGS} -package ${PACKAGE})~" ./iroha/shared_model/bindings/CMakeLists.txt
+sed -i.bak "s~\${JAVA_INCLUDE_PATH}~#\${JAVA_INCLUDE_PATH}~" ./iroha/shared_model/bindings/CMakeLists.txt
+sed -i.bak "s~\${JAVA_INCLUDE_PATH2}~#\${JAVA_INCLUDE_PATH2}~" ./iroha/shared_model/bindings/CMakeLists.txt
+sed -i.bak "s~target_include_directories(\${SWIG_MODULE_irohajava_REAL_NAME} PUBLIC~SET(CMAKE_SWIG_FLAGS \${CMAKE_SWIG_FLAGS} -package ${PACKAGE}~" ./iroha/shared_model/bindings/CMakeLists.txt
 sed -i.bak "s~swig_link_libraries(irohajava~swig_link_libraries(irohajava \"${PWD}/protobuf/.build/lib${PROTOBUF_LIB_NAME}.a\" \"${NDK_PATH}/platforms/android-${VERSION}/${ARCH}/usr/${LIBP}/liblog.so\"~" ./iroha/shared_model/bindings/CMakeLists.txt
 
 # build iroha

--- a/shared_model/packages/android/android-build.sh
+++ b/shared_model/packages/android/android-build.sh
@@ -7,7 +7,7 @@ fi
 if [[ ( "$#" -ne 4 ) && ( "$#" -ne 5 ) ]]; then
     echo "Illegal number of parameters"
     echo "Usage: $0 <PLATFORM> <ANDROID_VERSION> <NDK_PATH> <PACKAGE> [BUILD_TYPE=Release]"
-    echo "Example: $0 arm64-v8a 26 /Users/me/Downloads/android-ndk-r16b jp.co.soramitsu.iroha.android Debug"
+    echo "Example: $0 arm64-v8a 26 $HOME/Downloads/android-ndk-r16b jp.co.soramitsu.iroha.android Debug"
     exit 1
 fi
 

--- a/shared_model/packages/android/android-build.sh
+++ b/shared_model/packages/android/android-build.sh
@@ -99,10 +99,10 @@ VERBOSE=1 cmake --build ./iroha-ed25519/build --target install -- -j"$CORES"
 mv "$DEPS_DIR"/lib/static/libed25519.a "$DEPS_DIR"/lib; rmdir "$DEPS_DIR"/lib/static/
 
 # SWIG fixes
-sed -i.bak "s~find_package(JNI REQUIRED)~#find_package(JNI REQUIRED)~" ./iroha/shared_model/bindings/CMakeLists.txt
+sed -i.bak "s~find_package(JNI REQUIRED)~SET(CMAKE_SWIG_FLAGS \${CMAKE_SWIG_FLAGS} -package ${PACKAGE})~" ./iroha/shared_model/bindings/CMakeLists.txt
 sed -i.bak "s~\${JAVA_INCLUDE_PATH}~#\${JAVA_INCLUDE_PATH}~" ./iroha/shared_model/bindings/CMakeLists.txt
 sed -i.bak "s~\${JAVA_INCLUDE_PATH2}~#\${JAVA_INCLUDE_PATH2}~" ./iroha/shared_model/bindings/CMakeLists.txt
-sed -i.bak "s~target_include_directories(\${SWIG_MODULE_irohajava_REAL_NAME} PUBLIC~SET(CMAKE_SWIG_FLAGS \${CMAKE_SWIG_FLAGS} -package ${PACKAGE}~" ./iroha/shared_model/bindings/CMakeLists.txt
+sed -i.bak "s~target_include_directories(\${SWIG_MODULE_irohajava_REAL_NAME} PUBLIC~SET(CMAKE_SWIG_FLAGS \${CMAKE_SWIG_FLAGS}~" ./iroha/shared_model/bindings/CMakeLists.txt
 sed -i.bak "s~swig_link_libraries(irohajava~swig_link_libraries(irohajava \"${PWD}/protobuf/.build/lib${PROTOBUF_LIB_NAME}.a\" \"${NDK_PATH}/platforms/android-${VERSION}/${ARCH}/usr/${LIBP}/liblog.so\"~" ./iroha/shared_model/bindings/CMakeLists.txt
 
 # build iroha


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
 - https://github.com/hyperledger/iroha/pull/1221 has broken android build script, because lines changed by `sed` were changed. These changes are fixed in the pull request
 - Changes in `UseSWIG.cmake` in CMake 3.11 have modified `swig_add_library` behaviour, so that swig generator was called before it was downloaded and built with external project. Changes from https://gitlab.kitware.com/cmake/cmake/issues/17918 are applied to CMakeLists.txt
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
 - Working android script
 - Swig build works with CMake 3.11
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
