### PR TITLE
Use hex-encoded query hashes instead of binary hashes

### DIFF
--- a/irohad/model/converters/impl/pb_query_response_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_response_factory.cpp
@@ -84,7 +84,7 @@ namespace iroha {
         }
 
         if (response) {
-          response->set_query_hash(query_response->query_hash.to_string());
+          response->set_query_hash(query_response->query_hash.to_hexstring());
         }
         return response;
       }

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -73,7 +73,7 @@ namespace torii {
             [&hash, &response](
                 const iroha::expected::Error<std::string> &error) {
               response.set_query_hash(
-                  shared_model::crypto::toBinaryString(hash));
+                  hash.hex());
               response.mutable_error_response()->set_reason(
                   iroha::protocol::ErrorResponse::STATELESS_INVALID);
             });

--- a/schema/responses.proto
+++ b/schema/responses.proto
@@ -89,5 +89,5 @@ message QueryResponse {
     RolesResponse roles_response = 8;
     RolePermissionsResponse role_permissions_response = 9;
   }
-  bytes query_hash = 10;
+  string query_hash = 10;
 }

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -39,10 +39,9 @@ template <typename... T, typename Archive>
 auto loadQueryResponse(Archive &&ar) {
   int which =
       ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
-  return shared_model::detail::variant_impl<T...>::
-      template load<shared_model::interface::QueryResponse::
-                        QueryResponseVariantType>(std::forward<Archive>(ar),
-                                                  which);
+  return shared_model::detail::variant_impl<T...>::template load<
+      shared_model::interface::QueryResponse::QueryResponseVariantType>(
+      std::forward<Archive>(ar), which);
 }
 
 namespace shared_model {
@@ -97,8 +96,10 @@ namespace shared_model {
         return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
       }};
 
-      const Lazy<interface::types::HashType> hash_{
-          [this] { return interface::types::HashType(proto_->query_hash()); }};
+      const Lazy<interface::types::HashType> hash_{[this] {
+        return interface::types::HashType(
+            iroha::hexstringToBytestring(proto_->query_hash()).get());
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -205,7 +205,7 @@ namespace shared_model {
       auto queryHash(const interface::types::HashType &query_hash) const {
         return transform<QueryHash>([&](auto &proto_query_response) {
           proto_query_response.set_query_hash(
-              crypto::toBinaryString(query_hash));
+              query_hash.hex());
         });
       }
 

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -30,7 +30,7 @@
 TEST(QueryResponse, QueryResponseLoad) {
   iroha::protocol::QueryResponse response;
   const std::string hash = "123";
-  response.set_query_hash(hash);
+  response.set_query_hash(iroha::bytestringToHexstring(hash));
   auto refl = response.GetReflection();
   auto desc = response.GetDescriptor();
   auto resp_status = desc->FindOneofByName("response");
@@ -54,7 +54,7 @@ TEST(QueryResponse, QueryResponseLoad) {
 TEST(QueryResponse, ErrorResponseLoad) {
   iroha::protocol::QueryResponse response;
   const std::string hash = "123";
-  response.set_query_hash(hash);
+  response.set_query_hash(iroha::bytestringToHexstring(hash));
   auto error_resp = response.mutable_error_response();
   auto refl = error_resp->GetReflection();
   auto desc = error_resp->GetDescriptor();


### PR DESCRIPTION
Signed-off-by: Moonraker <ssolonets@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This pr change QueryResponse.query_hash to be a hex-encoded string instead of byte array.

### Benefits

Since this data is returned inside a json object is should have a hex representation - similar to transaction hashes. Binary strings can be a problem to deal with in some client languages. 

### Possible Drawbacks 
--

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
