### PR TITLE
[Fix] Add wrapped exception to ModelCrypto::fromPrivateKey

### DIFF
--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -28,6 +28,9 @@ namespace shared_model {
 
     crypto::Keypair ModelCrypto::fromPrivateKey(
         const std::string &private_key) {
+      if (private_key.length() != 32)  {
+        throw iroha::BadFormatException("blob_t: input string has incorrect length " + std::to_string(private_key.length()));
+      }
       auto byte_string = iroha::hexstringToBytestring(private_key);
       if (not byte_string) {
         throw std::runtime_error("invalid seed");

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -37,7 +37,7 @@ namespace shared_model {
 
       /**
        * Creates keypair (ed25519) from provided private key
-       * @param private_key - ed25519 hex-encoded private key
+       * @param private_key - ed25519 hex-encoded private key with 32 length
        * @return created keypair
        */
       crypto::Keypair fromPrivateKey(const std::string &private_key);

--- a/shared_model/packages/javascript/tests/crypto.js
+++ b/shared_model/packages/javascript/tests/crypto.js
@@ -1,13 +1,15 @@
-var test = require('tape')
-var iroha = require('../index')
+const test = require('tape')
+const iroha = require('../index')
 
 const publicKey = '407e57f50ca48969b08ba948171bb2435e035d82cec417e18e4a38f5fb113f83'
 const privateKey = '1d7e0a32ee0affeb4d22acd73c2c6fb6bd58e266c8c2ce4fa0ffe3dd6a253ffb'
 const randomKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const incorrectInputLength = 'aaaaaaaaaaaaaaaa'
+const incorrectInputShorter = 'a'
+const incorrectInputLonger = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 test('ModelCrypto tests', function (t) {
-  t.plan(8)
+  t.plan(9)
 
   let crypto = new iroha.ModelCrypto()
 
@@ -22,7 +24,8 @@ test('ModelCrypto tests', function (t) {
   t.equal(newKeypair.publicKey().hex().length, publicKey.length, 'Size of generated public key should be the same as size of predefined public key')
   t.equal(newKeypair.privateKey().hex().length, privateKey.length, 'Size of generated private key should be the same as size of predefined private key')
 
-  t.throws(() => crypto.fromPrivateKey(incorrectInputLength), /input string has incorrect length/, 'Should throw "input string has incorrect length"')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputShorter), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys shorter then 32')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputLonger), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys longer then 32')
   t.equal(crypto.fromPrivateKey(privateKey).publicKey().hex(), publicKey)
 
   t.end()


### PR DESCRIPTION
[IR-1223](https://soramitsu.atlassian.net/browse/IR-1223)

### Description of the Change

This PR restricts the length of  ModelCrypto::fromPrivateKey function to 32 and throws wrapped exception to SWIG.

### Benefits

An exception can be caught by client's code.
