### PR TITLE
Feat/run node tests

### DIFF
--- a/shared_model/packages/javascript/package.json
+++ b/shared_model/packages/javascript/package.json
@@ -44,14 +44,14 @@
   "dependencies": {
     "google-protobuf": "^3.5.0",
     "grpc": "^1.9.1",
-    "node-pre-gyp": "^0.6.39",
-    "tap-dot": "^1.0.5"
+    "node-pre-gyp": "^0.6.39"
   },
   "devDependencies": {
     "grpc-tools": "^1.6.6",
     "node-gyp": "^3.6.2",
     "node-pre-gyp-github": "^1.3.1",
-    "tape": "^4.9.0"
+    "tape": "^4.9.0",
+    "tap-dot": "^1.0.5"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/shared_model/packages/javascript/package.json
+++ b/shared_model/packages/javascript/package.json
@@ -7,7 +7,7 @@
     "prepare": "sh scripts/generate-protobuf.sh",
     "prepublishOnly": "npm ls",
     "install": "node-pre-gyp install --fallback-to-build",
-    "test": "tape tests/**/*.js | tap-spec",
+    "test": "tape tests/**/*.js | tap-dot",
     "build": "node-pre-gyp build",
     "rebuild": "node-pre-gyp rebuild"
   },
@@ -44,13 +44,13 @@
   "dependencies": {
     "google-protobuf": "^3.5.0",
     "grpc": "^1.9.1",
-    "node-pre-gyp": "^0.6.39"
+    "node-pre-gyp": "^0.6.39",
+    "tap-dot": "^1.0.5"
   },
   "devDependencies": {
     "grpc-tools": "^1.6.6",
     "node-gyp": "^3.6.2",
     "node-pre-gyp-github": "^1.3.1",
-    "tap-spec": "^4.1.1",
     "tape": "^4.9.0"
   },
   "bundledDependencies": [

--- a/shared_model/packages/javascript/package.json
+++ b/shared_model/packages/javascript/package.json
@@ -50,8 +50,8 @@
     "grpc-tools": "^1.6.6",
     "node-gyp": "^3.6.2",
     "node-pre-gyp-github": "^1.3.1",
-    "tape": "^4.9.0",
-    "tap-dot": "^1.0.5"
+    "tap-dot": "^1.0.5",
+    "tape": "^4.9.0"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/shared_model/packages/javascript/tests/txbuilder.js
+++ b/shared_model/packages/javascript/tests/txbuilder.js
@@ -36,7 +36,7 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => correctTx.addAssetQuantity(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.addAssetQuantity(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.addAssetQuantity('', ''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
-  t.throws(() => correctTx.addAssetQuantity('', '', '').build(), /AddAssetQuantity: \[\[Wrongly formed account_id, passed value: '' Wrongly formed asset_id, passed value: '' Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw wrongly formed account_id, asset_id, Amount must be greater than 0')
+  t.throws(() => correctTx.addAssetQuantity('', '', '').build(), /AddAssetQuantity: \[\[Wrongly formed account_id, passed value: ''(.*)Wrongly formed asset_id, passed value: ''(.*)Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw wrongly formed account_id, asset_id, Amount must be greater than 0')
   t.throws(() => correctTx.addAssetQuantity(adminAccountId, assetId, '0').build(), /AddAssetQuantity: \[\[Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw Amount must be greater than 0')
   t.throws(() => correctTx.addAssetQuantity('', assetId, '1000').build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
   t.throws(() => correctTx.addAssetQuantity('@@@', assetId, '1000').build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
@@ -120,9 +120,10 @@ test('ModelTransactionBuilder tests', function (t) {
   t.comment('Testing createRole()')
   t.throws(() => correctTx.createRole(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.createRole(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
+  // TODO: Test for incorrect permissions/empty permissions, check /shared_model/validators/field_validator.cpp
   let sv = new iroha.StringVector()
-  sv.add('permission1')
-  sv.add('permission2')
+  sv.add('can_add_peer')
+  sv.add('can_read_assets')
   t.throws(() => correctTx.createRole('', sv).build(), /Wrongly formed role_id, passed value: ''/, 'Should throw Wrongly formed role_id')
   t.throws(() => correctTx.createRole('@@@', sv).build(), /Wrongly formed role_id, passed value: '@@@'/, 'Should throw Wrongly formed role_id')
   t.throws(() => correctTx.createRole('ruser', '').build(), /argument 3 of type 'std::vector< shared_model::interface::types::PermissionNameType >/, 'Should throw ...argument 3 of type...')
@@ -145,8 +146,8 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => correctTx.grantPermission(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.grantPermission('', 'can_read_assets').build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
   t.throws(() => correctTx.grantPermission('@@@', 'can_read_assets').build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.grantPermission(adminAccountId, '').build(), /Wrongly formed permission, passed value: ''/, 'Should throw Wrongly formed permission')
-  t.throws(() => correctTx.grantPermission(adminAccountId, '@@@').build(), /Wrongly formed permission, passed value: '@@@'/, 'Should throw Wrongly formed permission')
+  t.throws(() => correctTx.grantPermission(adminAccountId, '').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
+  t.throws(() => correctTx.grantPermission(adminAccountId, '@@@').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
   t.doesNotThrow(() => correctTx.grantPermission(adminAccountId, 'can_read_assets').build(), null, 'Should not throw any exceptions')
 
   // revokePermission() tests
@@ -155,8 +156,8 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => correctTx.revokePermission(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.revokePermission('', 'can_read_assets').build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
   t.throws(() => correctTx.revokePermission('@@@', 'can_read_assets').build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.revokePermission(adminAccountId, '').build(), /Wrongly formed permission, passed value: ''/, 'Should throw Wrongly formed permission')
-  t.throws(() => correctTx.revokePermission(adminAccountId, '@@@').build(), /Wrongly formed permission, passed value: '@@@'/, 'Should throw Wrongly formed permission')
+  t.throws(() => correctTx.revokePermission(adminAccountId, '').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
+  t.throws(() => correctTx.revokePermission(adminAccountId, '@@@').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
   t.doesNotThrow(() => correctTx.revokePermission(adminAccountId, 'can_read_assets').build(), null, 'Should not throw any exceptions')
 
   // setAccountDetail() tests
@@ -184,7 +185,7 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => correctTx.subtractAssetQuantity(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.subtractAssetQuantity(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.subtractAssetQuantity('', ''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
-  t.throws(() => correctTx.subtractAssetQuantity('', '', '').build(), /SubtractAssetQuantity: \[\[Wrongly formed account_id, passed value: '' Wrongly formed asset_id, passed value: '' Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw wrongly formed account_id, asset_id, Amount must be greater than 0')
+  t.throws(() => correctTx.subtractAssetQuantity('', '', '').build(), /SubtractAssetQuantity: \[\[Wrongly formed account_id, passed value: ''(.*)Wrongly formed asset_id, passed value: ''(.*)Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw wrongly formed account_id, asset_id, Amount must be greater than 0')
   t.throws(() => correctTx.subtractAssetQuantity(adminAccountId, assetId, '0').build(), /SubtractAssetQuantity: \[\[Amount must be greater than 0, passed value: 0 \]\]/, 'Should throw Amount must be greater than 0')
   // TODO: MAYBE Throw an exception on real amount
   // t.throws(() => correctTx.subtractAssetQuantity(adminAccountId, assetId, '0.123').build(), /SubtractAssetQuantity: \[\[Amount must be integer, passed value: 0.123 \]\]/, 'Should throw Amount must be integer')

--- a/test/module/shared_model/bindings/CMakeLists.txt
+++ b/test/module/shared_model/bindings/CMakeLists.txt
@@ -68,3 +68,10 @@ if (SWIG_JAVA)
   set_tests_properties(java_builders_test
     PROPERTIES DEPENDS builders)
 endif()
+
+if (SWIG_NODE)
+  find_package (nodejs REQUIRED)
+  add_test(NAME javascript_tests
+    COMMAND npm run test
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/shared_model/packages/javascript)
+endif()


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Added ability for ctest to run Node.js tests ([IR-1188](https://soramitsu.atlassian.net/browse/IR-1188)) Fixed some incorrect tests ([IR-1266](https://soramitsu.atlassian.net/browse/IR-1266)).

Bonus: improved tests run's output by changing output package :)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Now we can integrate Node.js tests into CI and test Node.js package
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
First, you need to build our Node.js package.
```
cd shared_model/packages/javascript
npm install --build-from-source=iroha-lib
```

After it go as usual:
```
cmake -DSWIG_NODE=ON ..
ctest -R javascript_tests
```
Note that 4 tests (`x Should throw Provided permission does not exist`) _should_ fail because of bug in `shared_model`
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
