### PR TITLE
Rework ordering service event handling

### DIFF
--- a/irohad/ordering/impl/ordering_service_impl.cpp
+++ b/irohad/ordering/impl/ordering_service_impl.cpp
@@ -33,18 +33,63 @@ namespace iroha {
         size_t delay_milliseconds,
         std::shared_ptr<network::OrderingServiceTransport> transport,
         std::shared_ptr<ametsuchi::OrderingServicePersistentState>
-            persistent_state)
+            persistent_state,
+        bool is_async)
         : wsv_(wsv),
           max_size_(max_size),
           delay_milliseconds_(delay_milliseconds),
           transport_(transport),
-          persistent_state_(persistent_state),
-          is_finished(false) {
-      updateTimer();
+          persistent_state_(persistent_state) {
       log_ = logger::log("OrderingServiceImpl");
 
       // restore state of ordering service from persistent storage
-      proposal_height = persistent_state_->loadProposalHeight().value();
+      proposal_height_ = persistent_state_->loadProposalHeight().value();
+
+      rxcpp::observable<ProposalEvent> timer =
+          rxcpp::observable<>::interval(
+              std::chrono::milliseconds(delay_milliseconds_),
+              rxcpp::observe_on_new_thread())
+              .map([](auto) { return ProposalEvent::kTimerEvent; });
+
+      if (is_async) {
+        handle_ =
+            rxcpp::observable<>::from(timer, transactions_.get_observable())
+                .merge(rxcpp::synchronize_new_thread())
+                .subscribe([this](auto &&v) {
+                  auto check_queue = [&] {
+                    switch (v) {
+                      case ProposalEvent::kTimerEvent:
+                        return not queue_.empty();
+                      case ProposalEvent::kTransactionEvent:
+                        return queue_.unsafe_size() >= max_size_;
+                      default:
+                        BOOST_ASSERT_MSG(false, "Unknown value");
+                    }
+                  };
+                  if (check_queue()) {
+                    this->generateProposal();
+                  }
+                });
+      } else {
+        handle_ =
+            rxcpp::observable<>::from(timer, transactions_.get_observable())
+                .merge()
+                .subscribe([this](auto &&v) {
+                  auto check_queue = [&] {
+                    switch (v) {
+                      case ProposalEvent::kTimerEvent:
+                        return not queue_.empty();
+                      case ProposalEvent::kTransactionEvent:
+                        return queue_.unsafe_size() >= max_size_;
+                      default:
+                        BOOST_ASSERT_MSG(false, "Unknown value");
+                    }
+                  };
+                  if (check_queue()) {
+                    this->generateProposal();
+                  }
+                });
+      }
     }
 
     void OrderingServiceImpl::onTransaction(
@@ -52,25 +97,24 @@ namespace iroha {
       queue_.push(transaction);
       log_->info("Queue size is {}", queue_.unsafe_size());
 
-      if (queue_.unsafe_size() >= max_size_) {
-        handle.unsubscribe();
-        updateTimer();
-      }
+      // on_next calls should not be concurrent
+      std::lock_guard<std::mutex> lk(m_);
+      transactions_.get_subscriber().on_next(ProposalEvent::kTransactionEvent);
     }
 
     void OrderingServiceImpl::generateProposal() {
       // TODO 05/03/2018 andrei IR-1046 Server-side shared model object
       // factories with move semantics
       iroha::protocol::Proposal proto_proposal;
-      proto_proposal.set_height(proposal_height++);
+      proto_proposal.set_height(proposal_height_++);
       proto_proposal.set_created_time(iroha::time::now());
       log_->info("Start proposal generation");
       for (std::shared_ptr<shared_model::interface::Transaction> tx;
            static_cast<size_t>(proto_proposal.transactions_size()) < max_size_
            and queue_.try_pop(tx);) {
-        *proto_proposal.add_transactions() = std::move(
-            std::static_pointer_cast<shared_model::proto::Transaction>(tx)
-                ->getTransport());
+        *proto_proposal.add_transactions() =
+            std::move(static_cast<shared_model::proto::Transaction *>(tx.get())
+                          ->getTransport());
       }
 
       auto proposal = std::make_unique<shared_model::proto::Proposal>(
@@ -78,10 +122,10 @@ namespace iroha {
 
       // Save proposal height to the persistent storage.
       // In case of restart it reloads state.
-      if (persistent_state_->saveProposalHeight(proposal_height)) {
+      if (persistent_state_->saveProposalHeight(proposal_height_)) {
         publishProposal(std::move(proposal));
       } else {
-        // TODO(@l4l) 23/03/18: publish proposal independant of psql status
+        // TODO(@l4l) 23/03/18: publish proposal independent of psql status
         // IR-1162
         log_->warn(
             "Proposal height cannot be saved. Skipping proposal publish");
@@ -103,24 +147,8 @@ namespace iroha {
       }
     }
 
-    void OrderingServiceImpl::updateTimer() {
-      std::lock_guard<std::mutex> lock(m);
-      if (is_finished) {
-        return;
-      }
-      if (not queue_.empty()) {
-        this->generateProposal();
-      }
-      timer = rxcpp::observable<>::timer(
-          std::chrono::milliseconds(delay_milliseconds_));
-      handle = timer.subscribe_on(rxcpp::observe_on_new_thread())
-                   .subscribe([this](auto) { this->updateTimer(); });
-    }
-
     OrderingServiceImpl::~OrderingServiceImpl() {
-      std::lock_guard<std::mutex> lock(m);
-      is_finished = true;
-      handle.unsubscribe();
+      handle_.unsubscribe();
     }
   }  // namespace ordering
 }  // namespace iroha

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -48,7 +48,7 @@ namespace iroha {
        * Constructor
        * @param wsv interface for fetching peers from world state view
        * @param max_size maximum size of proposal
-       * @param delay_milliseconds time
+       * @param delay_milliseconds timeout for proposal generation
        * @param transport receive transactions and publish proposals
        * @param persistent_state storage for auxiliary information
        * @param is_async whether proposals are generated in a separate thread
@@ -133,7 +133,7 @@ namespace iroha {
       /**
        * Mutex for incoming transactions
        */
-      std::mutex m_;
+      std::mutex mutex_;
 
       logger::Logger log_;
     };

--- a/irohad/ordering/impl/ordering_service_impl.hpp
+++ b/irohad/ordering/impl/ordering_service_impl.hpp
@@ -31,7 +31,6 @@ namespace iroha {
 
   namespace ametsuchi {
     class OrderingServicePersistentState;
-    class OrderingServiceTransport;
     class PeerQuery;
   }  // namespace ametsuchi
 
@@ -42,20 +41,26 @@ namespace iroha {
      * Allows receiving transactions concurrently from multiple peers by using
      * concurrent queue
      * Sends proposal by given timer interval and proposal size
-     * @param delay_milliseconds timer delay
-     * @param max_size proposal size
-     * @param persistent_state - storage for persistent state of ordering
-     * service
      */
     class OrderingServiceImpl : public network::OrderingService {
      public:
+      /**
+       * Constructor
+       * @param wsv interface for fetching peers from world state view
+       * @param max_size maximum size of proposal
+       * @param delay_milliseconds time
+       * @param transport receive transactions and publish proposals
+       * @param persistent_state storage for auxiliary information
+       * @param is_async whether proposals are generated in a separate thread
+       */
       OrderingServiceImpl(
           std::shared_ptr<ametsuchi::PeerQuery> wsv,
           size_t max_size,
           size_t delay_milliseconds,
           std::shared_ptr<network::OrderingServiceTransport> transport,
           std::shared_ptr<ametsuchi::OrderingServicePersistentState>
-              persistent_state);
+              persistent_state,
+          bool is_async = true);
 
       /**
        * Process transaction received from network
@@ -77,22 +82,16 @@ namespace iroha {
 
      private:
       /**
+       * Events for queue check strategy
+       */
+      enum class ProposalEvent { kTransactionEvent, kTimerEvent };
+
+      /**
        * Collect transactions from queue
        * Passes the generated proposal to publishProposal
        */
       void generateProposal() override;
 
-      /**
-       * Method update peers for sending proposal
-       */
-
-      /**
-       * Update the timer to be called after delay_milliseconds_
-       */
-      void updateTimer();
-
-      rxcpp::observable<long> timer;
-      rxcpp::composite_subscription handle;
       std::shared_ptr<ametsuchi::PeerQuery> wsv_;
 
       tbb::concurrent_queue<
@@ -108,10 +107,11 @@ namespace iroha {
        *  wait for specified time if queue is empty
        */
       const size_t delay_milliseconds_;
+
       std::shared_ptr<network::OrderingServiceTransport> transport_;
 
       /**
-       * Persistense storage for proposal counter.
+       * Persistent storage for proposal counter.
        * In case of relaunch, ordering server will enumerate proposals
        * consecutively.
        */
@@ -122,17 +122,18 @@ namespace iroha {
        * Proposal counter of expected proposal. Should be number of blocks in
        * the ledger + 1.
        */
-      size_t proposal_height;
+      size_t proposal_height_;
+
+      /// Observable for transaction events from the network
+      rxcpp::subjects::subject<ProposalEvent> transactions_;
+
+      /// Internal event observable handle
+      rxcpp::composite_subscription handle_;
 
       /**
-       * Mutex for proper quit handling
+       * Mutex for incoming transactions
        */
-      std::mutex m;
-
-      /**
-       * Set after destruction
-       */
-      bool is_finished;
+      std::mutex m_;
 
       logger::Logger log_;
     };

--- a/test/module/irohad/ordering/ordering_service_test.cpp
+++ b/test/module/irohad/ordering/ordering_service_test.cpp
@@ -19,6 +19,7 @@
 
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "builders/protobuf/common_objects/proto_peer_builder.hpp"
+#include "builders/protobuf/transaction.hpp"
 #include "logger/logger.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
@@ -27,7 +28,6 @@
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "ordering/impl/ordering_service_impl.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
-#include "builders/protobuf/transaction.hpp"
 
 using namespace iroha;
 using namespace iroha::ordering;
@@ -35,12 +35,12 @@ using namespace iroha::network;
 using namespace iroha::ametsuchi;
 using namespace std::chrono_literals;
 
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-using ::testing::_;
 
 static logger::Logger log_ = logger::testLog("OrderingService");
 
@@ -82,15 +82,24 @@ class OrderingServiceTest : public ::testing::Test {
   }
 
   auto getTx() {
-    return std::make_shared<shared_model::proto::Transaction>(
+    return std::make_unique<shared_model::proto::Transaction>(
         shared_model::proto::TransactionBuilder()
-        .createdTime(iroha::time::now())
-        .creatorAccountId("admin@ru")
-        .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-        .build()
-        .signAndAddSignature(
-            shared_model::crypto::DefaultCryptoAlgorithmType::
-            generateKeypair()));
+            .createdTime(iroha::time::now())
+            .creatorAccountId("admin@ru")
+            .addAssetQuantity("admin@tu", "coin#coin", "1.0")
+            .build()
+            .signAndAddSignature(
+                shared_model::crypto::DefaultCryptoAlgorithmType::
+                    generateKeypair()));
+  }
+
+  auto initOs(size_t max_proposal, size_t commit_delay) {
+    return std::make_shared<OrderingServiceImpl>(wsv,
+                                                 max_proposal,
+                                                 commit_delay,
+                                                 fake_transport,
+                                                 fake_persistent_state,
+                                                 false);
   }
 
   std::shared_ptr<MockOrderingServiceTransport> fake_transport;
@@ -113,15 +122,17 @@ TEST_F(OrderingServiceTest, SimpleTest) {
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service = initOs(max_proposal, commit_delay);
   fake_transport->subscribe(ordering_service);
 
   EXPECT_CALL(*fake_transport, publishProposalProxy(_, _)).Times(1);
 
   fake_transport->publishProposal(
       std::make_unique<shared_model::proto::Proposal>(
-          TestProposalBuilder().height(1).createdTime(iroha::time::now()).build()),
+          TestProposalBuilder()
+              .height(1)
+              .createdTime(iroha::time::now())
+              .build()),
       {});
 }
 
@@ -136,8 +147,7 @@ TEST_F(OrderingServiceTest, ValidWhenProposalSizeStrategy) {
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service = initOs(max_proposal, commit_delay);
   fake_transport->subscribe(ordering_service);
 
   // Init => proposal size 5 => 2 proposals after 10 transactions
@@ -186,8 +196,7 @@ TEST_F(OrderingServiceTest, ValidWhenTimerStrategy) {
       .Times(1)
       .WillOnce(Return(boost::optional<size_t>(2)));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service = initOs(max_proposal, commit_delay);
   fake_transport->subscribe(ordering_service);
 
   EXPECT_CALL(*fake_transport, publishProposalProxy(_, _))
@@ -224,8 +233,7 @@ TEST_F(OrderingServiceTest, BrokenPersistentState) {
       .Times(1)
       .WillRepeatedly(Return(false));
 
-  auto ordering_service = std::make_shared<OrderingServiceImpl>(
-      wsv, max_proposal, commit_delay, fake_transport, fake_persistent_state);
+  auto ordering_service = initOs(max_proposal, commit_delay);
   ordering_service->onTransaction(getTx());
 
   std::unique_lock<std::mutex> lk(m);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix issues with heap-use-after-free and `generateProposal` thread working after destructor.
 - `unsubscribe` call now blocks until a running method is completed
 - no more mutex for destructor
 - mutex is used when a transaction is received from the network, so that subject calls are not concurrent
 - queue size is verified when subscriber is called, and not when event is received
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
More stable implementation
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Code duplication in constructor caused by templates in rxcpp, which are only removed after `subscribe`. A possible solution is to pass coordination as template parameter, but this will require some type rework and renaming.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
