### PR TITLE
YAC Rx timer dependency

### DIFF
--- a/irohad/consensus/yac/impl/timer_impl.cpp
+++ b/irohad/consensus/yac/impl/timer_impl.cpp
@@ -21,17 +21,17 @@
 namespace iroha {
   namespace consensus {
     namespace yac {
-      void TimerImpl::invokeAfterDelay(uint64_t millis,
-                                       std::function<void()> handler) {
+      TimerImpl::TimerImpl(rxcpp::observable<Rep> invoke_delay)
+          : invoke_delay_(invoke_delay) {}
+
+      void TimerImpl::invokeAfterDelay(std::function<void()> handler) {
         deny();
-        handler_ = std::move(handler);
-        timer = rxcpp::observable<>::timer(std::chrono::milliseconds(millis));
-        handle = timer.subscribe_on(rxcpp::observe_on_new_thread())
-                     .subscribe([this](auto) { handler_(); });
+        handle_ = invoke_delay_.subscribe(
+            [handler{std::move(handler)}](auto) { handler(); });
       }
 
       void TimerImpl::deny() {
-        handle.unsubscribe();
+        handle_.unsubscribe();
       }
 
       TimerImpl::~TimerImpl() {

--- a/irohad/consensus/yac/impl/timer_impl.cpp
+++ b/irohad/consensus/yac/impl/timer_impl.cpp
@@ -21,12 +21,13 @@
 namespace iroha {
   namespace consensus {
     namespace yac {
-      TimerImpl::TimerImpl(rxcpp::observable<Rep> invoke_delay)
-          : invoke_delay_(invoke_delay) {}
+      TimerImpl::TimerImpl(
+          std::function<rxcpp::observable<TimeoutType>()> invoke_delay)
+          : invoke_delay_(std::move(invoke_delay)) {}
 
       void TimerImpl::invokeAfterDelay(std::function<void()> handler) {
         deny();
-        handle_ = invoke_delay_.subscribe(
+        handle_ = invoke_delay_().subscribe(
             [handler{std::move(handler)}](auto) { handler(); });
       }
 

--- a/irohad/consensus/yac/impl/timer_impl.hpp
+++ b/irohad/consensus/yac/impl/timer_impl.hpp
@@ -27,13 +27,14 @@ namespace iroha {
       class TimerImpl : public Timer {
        public:
         /// Delay observable type
-        using Rep = long;
+        using TimeoutType = long;
 
         /**
          * Constructor
          * @param invoke_delay cold observable which specifies invoke strategy
          */
-        TimerImpl(rxcpp::observable<Rep> invoke_delay);
+        explicit TimerImpl(
+            std::function<rxcpp::observable<TimeoutType>()> invoke_delay);
         TimerImpl(const TimerImpl &) = delete;
         TimerImpl &operator=(const TimerImpl &) = delete;
 
@@ -43,7 +44,7 @@ namespace iroha {
         ~TimerImpl() override;
 
        private:
-        rxcpp::observable<Rep> invoke_delay_;
+        std::function<rxcpp::observable<TimeoutType>()> invoke_delay_;
         rxcpp::composite_subscription handle_;
       };
     }  // namespace yac

--- a/irohad/consensus/yac/impl/timer_impl.hpp
+++ b/irohad/consensus/yac/impl/timer_impl.hpp
@@ -26,21 +26,25 @@ namespace iroha {
     namespace yac {
       class TimerImpl : public Timer {
        public:
-        TimerImpl() = default;
+        /// Delay observable type
+        using Rep = long;
+
+        /**
+         * Constructor
+         * @param invoke_delay cold observable which specifies invoke strategy
+         */
+        TimerImpl(rxcpp::observable<Rep> invoke_delay);
         TimerImpl(const TimerImpl &) = delete;
         TimerImpl &operator=(const TimerImpl &) = delete;
 
-        void invokeAfterDelay(uint64_t millis,
-                              std::function<void()> handler) override;
+        void invokeAfterDelay(std::function<void()> handler) override;
         void deny() override;
 
         ~TimerImpl() override;
 
        private:
-        std::function<void()> handler_;
-
-        rxcpp::observable<long> timer;
-        rxcpp::composite_subscription handle;
+        rxcpp::observable<Rep> invoke_delay_;
+        rxcpp::composite_subscription handle_;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -54,24 +54,21 @@ namespace iroha {
           std::shared_ptr<YacNetwork> network,
           std::shared_ptr<YacCryptoProvider> crypto,
           std::shared_ptr<Timer> timer,
-          ClusterOrdering order,
-          uint64_t delay) {
+          ClusterOrdering order) {
         return std::make_shared<Yac>(
-            vote_storage, network, crypto, timer, order, delay);
+            vote_storage, network, crypto, timer, order);
       }
 
       Yac::Yac(YacVoteStorage vote_storage,
                std::shared_ptr<YacNetwork> network,
                std::shared_ptr<YacCryptoProvider> crypto,
                std::shared_ptr<Timer> timer,
-               ClusterOrdering order,
-               uint64_t delay)
+               ClusterOrdering order)
           : vote_storage_(std::move(vote_storage)),
             network_(std::move(network)),
             crypto_(std::move(crypto)),
             timer_(std::move(timer)),
-            cluster_order_(order),
-            delay_(delay) {
+            cluster_order_(order){
         log_ = logger::log("YAC");
       }
 
@@ -137,8 +134,7 @@ namespace iroha {
         network_->send_vote(cluster_order_.currentLeader(), vote);
         cluster_order_.switchToNext();
         if (cluster_order_.hasNext()) {
-          timer_->invokeAfterDelay(delay_,
-                                   [this, vote] { this->votingStep(vote); });
+          timer_->invokeAfterDelay([this, vote] { this->votingStep(vote); });
         }
       }
 

--- a/irohad/consensus/yac/timer.hpp
+++ b/irohad/consensus/yac/timer.hpp
@@ -30,12 +30,10 @@ namespace iroha {
       class Timer {
        public:
         /**
-         * Invoke handler after delay
-         * @param millis - number of milliseconds before invoking
+         * Invoke handler with class-specific strategy
          * @param handler - function, that will be invoked
          */
-        virtual void invokeAfterDelay(uint64_t millis,
-                                      std::function<void()> handler) = 0;
+        virtual void invokeAfterDelay(std::function<void()> handler) = 0;
 
         /**
          * Stop timer

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -48,15 +48,13 @@ namespace iroha {
             std::shared_ptr<YacNetwork> network,
             std::shared_ptr<YacCryptoProvider> crypto,
             std::shared_ptr<Timer> timer,
-            ClusterOrdering order,
-            uint64_t delay);
+            ClusterOrdering order);
 
         Yac(YacVoteStorage vote_storage,
             std::shared_ptr<YacNetwork> network,
             std::shared_ptr<YacCryptoProvider> crypto,
             std::shared_ptr<Timer> timer,
-            ClusterOrdering order,
-            uint64_t delay);
+            ClusterOrdering order);
 
         // ------|Hash gate|------
 
@@ -132,9 +130,6 @@ namespace iroha {
 
         // ------|One round|------
         ClusterOrdering cluster_order_;
-
-        // ------|Constants|------
-        const uint64_t delay_;
 
         // ------|Logger|------
         logger::Logger log_;

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -46,8 +46,15 @@ namespace iroha {
       }
 
       auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
-        return std::make_shared<TimerImpl>(rxcpp::observable<>::timer(
-            delay_milliseconds, rxcpp::observe_on_new_thread()));
+        return std::make_shared<TimerImpl>([delay_milliseconds] {
+          // static factory with a single thread
+          static rxcpp::observe_on_one_worker worker(
+              rxcpp::observe_on_new_thread()
+                  .create_coordinator()
+                  .get_scheduler());
+          return rxcpp::observable<>::timer(
+              std::chrono::milliseconds(delay_milliseconds), worker);
+        });
       }
 
       auto YacInit::createHashProvider() {

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -45,8 +45,9 @@ namespace iroha {
         return crypto;
       }
 
-      auto YacInit::createTimer() {
-        return std::make_shared<TimerImpl>();
+      auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
+        return std::make_shared<TimerImpl>(rxcpp::observable<>::timer(
+            delay_milliseconds, rxcpp::observe_on_new_thread()));
       }
 
       auto YacInit::createHashProvider() {
@@ -60,9 +61,8 @@ namespace iroha {
         return Yac::create(YacVoteStorage(),
                            createNetwork(),
                            createCryptoProvider(keypair),
-                           createTimer(),
-                           initial_order,
-                           delay_milliseconds.count());
+                           createTimer(delay_milliseconds),
+                           initial_order);
       }
 
       std::shared_ptr<YacGate> YacInit::initConsensusGate(

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -48,12 +48,30 @@ namespace iroha {
       auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
         return std::make_shared<TimerImpl>([delay_milliseconds] {
           // static factory with a single thread
-          static rxcpp::observe_on_one_worker worker(
+          //
+          // observe_on_new_thread -- coordination which creates new thread with
+          // observe_on strategy -- all subsequent operations will be performed
+          // on this thread.
+          //
+          // scheduler owns a timeline that is exposed by the now() method.
+          // scheduler is also a factory for workers in that timeline.
+          //
+          // coordination is a factory for coordinators and has a scheduler.
+          //
+          // coordinator has a worker, and is a factory for coordinated
+          // observables, subscribers and schedulable functions.
+          //
+          // A new thread scheduler is created
+          // by calling .create_coordinator().get_scheduler()
+          //
+          // static allows to reuse the same thread in subsequent calls to this
+          // lambda
+          static rxcpp::observe_on_one_worker coordination(
               rxcpp::observe_on_new_thread()
                   .create_coordinator()
                   .get_scheduler());
           return rxcpp::observable<>::timer(
-              std::chrono::milliseconds(delay_milliseconds), worker);
+              std::chrono::milliseconds(delay_milliseconds), coordination);
         });
       }
 

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -48,7 +48,7 @@ namespace iroha {
 
         auto createCryptoProvider(const shared_model::crypto::Keypair &keypair);
 
-        auto createTimer();
+        auto createTimer(std::chrono::milliseconds delay_milliseconds);
 
         auto createHashProvider();
 

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -78,8 +78,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
     auto order = ClusterOrdering::create(default_peers);
     ASSERT_TRUE(order);
 
-    yac = Yac::create(
-        YacVoteStorage(), network, crypto, timer, order.value());
+    yac = Yac::create(YacVoteStorage(), network, crypto, timer, order.value());
     network->subscribe(yac);
 
     grpc::ServerBuilder builder;
@@ -128,8 +127,10 @@ TEST_F(ConsensusSunnyDayTest, SunnyDayTest) {
   std::condition_variable cv;
   std::mutex m;
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
-  wrapper.subscribe(
-      [&cv](auto hash) { std::cout << "^_^ COMMITTED!!!" << std::endl; cv.notify_one(); });
+  wrapper.subscribe([&cv](auto hash) {
+    std::cout << "^_^ COMMITTED!!!" << std::endl;
+    cv.notify_one();
+  });
 
   EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
       .Times(1)

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -75,10 +75,11 @@ class ConsensusSunnyDayTest : public ::testing::Test {
     crypto = std::make_shared<FixedCryptoProvider>(std::to_string(my_num));
     timer = std::make_shared<TimerImpl>([this] {
       // static factory with a single thread
-      static rxcpp::observe_on_one_worker worker(
+      // see YacInit::createTimer in consensus_init.cpp
+      static rxcpp::observe_on_one_worker coordination(
           rxcpp::observe_on_new_thread().create_coordinator().get_scheduler());
       return rxcpp::observable<>::timer(std::chrono::milliseconds(delay),
-                                        worker);
+                                        coordination);
     });
     auto order = ClusterOrdering::create(default_peers);
     ASSERT_TRUE(order);

--- a/test/module/irohad/consensus/yac/timer_test.cpp
+++ b/test/module/irohad/consensus/yac/timer_test.cpp
@@ -24,41 +24,44 @@ using namespace iroha::consensus::yac;
 class TimerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    timer = std::make_shared<TimerImpl>();
+    timer = std::make_shared<TimerImpl>(invoke_delay.get_observable());
   }
 
   void TearDown() override {
     timer.reset();
   }
 
+  void invokeTimer() {
+    invoke_delay.get_subscriber().on_next(0);
+  }
+
  public:
+  rxcpp::subjects::subject<TimerImpl::Rep> invoke_delay;
   std::shared_ptr<Timer> timer;
 };
 
 TEST_F(TimerTest, NothingInvokedWhenDenied) {
   int status = 0;
 
-  timer->invokeAfterDelay(50, [&status]() { status = 1; });
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  timer->invokeAfterDelay([&status] { status = 1; });
   timer->deny();
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  invokeTimer();
   ASSERT_EQ(status, 0);
 }
 
 TEST_F(TimerTest, FirstInvokedWhenOneSubmitted) {
   int status = 0;
 
-  timer->invokeAfterDelay(10, [&status]() { status = 1; });
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  timer->invokeAfterDelay([&status] { status = 1; });
+  invokeTimer();
   ASSERT_EQ(status, 1);
 }
 
 TEST_F(TimerTest, SecondInvokedWhenTwoSubmitted) {
   int status = 0;
 
-  timer->invokeAfterDelay(10, [&status]() { status = 1; });
-  std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  timer->invokeAfterDelay(10, [&status]() { status = 2; });
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  timer->invokeAfterDelay([&status] { status = 1; });
+  timer->invokeAfterDelay([&status] { status = 2; });
+  invokeTimer();
   ASSERT_EQ(status, 2);
 }

--- a/test/module/irohad/consensus/yac/timer_test.cpp
+++ b/test/module/irohad/consensus/yac/timer_test.cpp
@@ -24,7 +24,8 @@ using namespace iroha::consensus::yac;
 class TimerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    timer = std::make_shared<TimerImpl>(invoke_delay.get_observable());
+    timer = std::make_shared<TimerImpl>(
+        [this] { return invoke_delay.get_observable(); });
   }
 
   void TearDown() override {
@@ -36,7 +37,7 @@ class TimerTest : public ::testing::Test {
   }
 
  public:
-  rxcpp::subjects::subject<TimerImpl::Rep> invoke_delay;
+  rxcpp::subjects::subject<TimerImpl::TimeoutType> invoke_delay;
   std::shared_ptr<Timer> timer;
 };
 

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -100,8 +100,7 @@ namespace iroha {
 
       class MockTimer : public Timer {
        public:
-        void invokeAfterDelay(uint64_t millis,
-                              std::function<void()> handler) override {
+        void invokeAfterDelay(std::function<void()> handler) override {
           handler();
         }
 
@@ -243,7 +242,6 @@ namespace iroha {
         std::shared_ptr<MockYacNetwork> network;
         std::shared_ptr<MockYacCryptoProvider> crypto;
         std::shared_ptr<MockTimer> timer;
-        uint64_t delay = 100500;
         std::shared_ptr<Yac> yac;
 
         // ------|Round|------
@@ -267,8 +265,7 @@ namespace iroha {
                             network,
                             crypto,
                             timer,
-                            ordering.value(),
-                            delay);
+                            ordering.value());
           network->subscribe(yac);
         };
 

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -261,17 +261,17 @@ namespace iroha {
           timer = std::make_shared<MockTimer>();
           auto ordering = ClusterOrdering::create(default_peers);
           ASSERT_TRUE(ordering);
-          yac = Yac::create(YacVoteStorage(),
-                            network,
-                            crypto,
-                            timer,
-                            ordering.value());
-          network->subscribe(yac);
-        };
+          initYac(ordering.value());
+        }
 
         void TearDown() override {
           network->release();
-        };
+        }
+
+        void initYac(ClusterOrdering ordering) {
+          yac = Yac::create(YacVoteStorage(), network, crypto, timer, ordering);
+          network->subscribe(yac);
+        }
       };
     }  // namespace yac
   }    // namespace consensus

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -41,8 +41,7 @@ TEST_F(YacTest, InvalidCaseWhenNotReceiveSupermajority) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(my_peers.size());
@@ -80,8 +79,7 @@ TEST_F(YacTest, InvalidCaseWhenDoesNotVerify) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
 
@@ -120,8 +118,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _))

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -41,12 +41,8 @@ TEST_F(YacTest, InvalidCaseWhenNotReceiveSupermajority) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(my_peers.size());
@@ -84,12 +80,8 @@ TEST_F(YacTest, InvalidCaseWhenDoesNotVerify) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
 
@@ -128,12 +120,8 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _))

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -49,8 +49,6 @@ TEST_F(YacTest, YacWhenInit) {
 
   MockTimer timer_;
 
-  auto fake_delay_ = 100500;
-
   auto order = ClusterOrdering::create(default_peers);
   ASSERT_TRUE(order);
 
@@ -58,8 +56,7 @@ TEST_F(YacTest, YacWhenInit) {
                           std::make_shared<MockYacNetwork>(network_),
                           std::make_shared<MockYacCryptoProvider>(crypto_),
                           std::make_shared<MockTimer>(timer_),
-                          *order,
-                          fake_delay_);
+                          *order);
 
   network_.subscribe(yac_);
 }

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -38,13 +38,6 @@ using namespace framework::test_subscriber;
 using namespace std;
 
 /**
- * Test provide use case for init yac object
- */
-TEST_F(YacTest, YacWhenInit) {
-  // covered by setup
-}
-
-/**
  * Test provide scenario when yac vote for hash
  */
 TEST_F(YacTest, YacWhenVoting) {

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -30,8 +30,8 @@
 using ::testing::_;
 using ::testing::An;
 using ::testing::AtLeast;
-using ::testing::Return;
 using ::testing::Invoke;
+using ::testing::Return;
 
 using namespace iroha::consensus::yac;
 using namespace framework::test_subscriber;
@@ -41,24 +41,7 @@ using namespace std;
  * Test provide use case for init yac object
  */
 TEST_F(YacTest, YacWhenInit) {
-  cout << "----------|Just init object|----------" << endl;
-
-  MockYacNetwork network_;
-
-  MockYacCryptoProvider crypto_;
-
-  MockTimer timer_;
-
-  auto order = ClusterOrdering::create(default_peers);
-  ASSERT_TRUE(order);
-
-  auto yac_ = Yac::create(YacVoteStorage(),
-                          std::make_shared<MockYacNetwork>(network_),
-                          std::make_shared<MockYacCryptoProvider>(crypto_),
-                          std::make_shared<MockTimer>(timer_),
-                          *order);
-
-  network_.subscribe(yac_);
+  // covered by setup
 }
 
 /**
@@ -178,14 +161,14 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveCommitMessage) {
  * @then commit is sent to the network before notifying subscribers
  */
 TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyVote) {
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).Times(default_peers.size())
+  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
+      .Times(default_peers.size())
       .WillRepeatedly(Return(true));
   std::vector<CommitMessage> messages;
   EXPECT_CALL(*network, send_commit(_, _))
       .Times(default_peers.size())
-      .WillRepeatedly(Invoke([&](const auto &, const auto &msg) {
-        messages.push_back(msg);
-      }));
+      .WillRepeatedly(Invoke(
+          [&](const auto &, const auto &msg) { messages.push_back(msg); }));
 
   yac->on_commit().subscribe([&](auto msg) {
     // verify that commits are already sent to the network
@@ -212,9 +195,8 @@ TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyReject) {
   std::vector<CommitMessage> messages;
   EXPECT_CALL(*network, send_commit(_, _))
       .Times(default_peers.size())
-      .WillRepeatedly(Invoke([&](const auto &, const auto &msg) {
-        messages.push_back(msg);
-      }));
+      .WillRepeatedly(Invoke(
+          [&](const auto &, const auto &msg) { messages.push_back(msg); }));
 
   yac->on_commit().subscribe([&](auto msg) {
     // verify that commits are already sent to the network

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -41,12 +41,8 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -76,12 +72,8 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -118,13 +110,10 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
   EXPECT_CALL(*timer, deny()).Times(2);
 
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -166,12 +155,8 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -214,12 +199,8 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -41,8 +41,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -72,8 +71,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -112,8 +110,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
 
   EXPECT_CALL(*timer, deny()).Times(2);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
   auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
@@ -155,8 +152,7 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -199,8 +195,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -73,8 +73,7 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value());
+  initYac(my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -73,12 +73,8 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  // delay preference
-  uint64_t wait_seconds = 10;
-  delay = wait_seconds * 1000;
-
   yac = Yac::create(
-      YacVoteStorage(), network, crypto, timer, my_order.value(), delay);
+      YacVoteStorage(), network, crypto, timer, my_order.value());
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Add external rx observable to yac timer, so that it is possible to write it in a testable way -- events are fired at expected time points.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Timer testability without real time assumptions
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Not as flexible as before -- it's not possible to reuse the same timer with different delays. But since changes are local -- only consensus is involved -- it's fine to change interface later when something more flexible will be required.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->