### PR TITLE
[Feature] Change paths to use Shared Model in NPM

### DIFF
--- a/shared_model/packages/javascript/binding.gyp
+++ b/shared_model/packages/javascript/binding.gyp
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'iroha_home_dir': '../../../'
+    'iroha_lib_dir': '../../'
   },
   'targets': [
     {
@@ -11,18 +11,17 @@
           'action_name': 'configure',
           'message': 'Generate CMake build configuration for shared_model...',
           'inputs': [
-            '<(iroha_home_dir)/shared_model/bindings/CMakeLists.txt'
+            '<(iroha_lib_dir)/bindings/CMakeLists.txt'
           ],
           'outputs': [
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/Makefile',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/Makefile',
           ],
           'action': [
             'cmake', 
-            '-H<(iroha_home_dir)', 
+            '-H<(iroha_lib_dir)', 
             '-B<(SHARED_INTERMEDIATE_DIR)', 
             '-DSWIG_NODE=ON', 
             '-DENABLE_LIBS_PACKAGING=OFF',
-            '-DSHARED_MODEL_DISABLE_COMPATIBILITY=ON', 
             '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
             '-DCMAKE_BUILD_TYPE=Release'
           ],
@@ -31,12 +30,12 @@
           'action_name': 'build',
           'message': 'Build shared_model libraries by CMake...',
           'inputs': [
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/Makefile',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/Makefile',
           ],
           'outputs': [
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/bindingsJAVASCRIPT_wrap.cxx',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/libirohanode.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/libbindings.a'
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/bindingsJAVASCRIPT_wrap.cxx',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/libirohanode.a',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/libbindings.a'
           ],
           'action': [
             'cmake', 
@@ -53,20 +52,17 @@
       'copies': [
         {
           'files': [
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/libirohanode.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/libbindings.a',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/libirohanode.a',
+            '<(SHARED_INTERMEDIATE_DIR)/bindings/libbindings.a',
             '<(SHARED_INTERMEDIATE_DIR)/schema/libschema.a',
-            '<(SHARED_INTERMEDIATE_DIR)/libs/generator/libgenerator.a',
-            '<(SHARED_INTERMEDIATE_DIR)/libs/amount/libiroha_amount.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/validators/libshared_model_stateless_validation.a',
-            # Cryptography libs
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/cryptography/ed25519_sha3_impl/libshared_model_cryptography.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/cryptography/ed25519_sha3_impl/internal/libhash.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/cryptography/ed25519_sha3_impl/internal/libed25519_crypto.a',
-            '<(SHARED_INTERMEDIATE_DIR)/shared_model/cryptography/model_impl/libshared_model_cryptography_model.a',
+            '<(SHARED_INTERMEDIATE_DIR)/validators/libshared_model_stateless_validation.a',
+            '<(SHARED_INTERMEDIATE_DIR)/cryptography/ed25519_sha3_impl/libshared_model_cryptography.a',
+            '<(SHARED_INTERMEDIATE_DIR)/cryptography/ed25519_sha3_impl/internal/libhash.a',
+            '<(SHARED_INTERMEDIATE_DIR)/cryptography/ed25519_sha3_impl/internal/libed25519_crypto.a',
+            '<(SHARED_INTERMEDIATE_DIR)/cryptography/model_impl/libshared_model_cryptography_model.a',
 
             # Third-party libraries
-            '<(iroha_home_dir)/external/src/hyperledger_ed25519-build/libed25519.a'
+            '<(iroha_lib_dir)/external/src/hyperledger_ed25519-build/libed25519.a'
           ],
           'destination': '<(PRODUCT_DIR)'
         }
@@ -76,12 +72,14 @@
       'target_name': '<(module_name)',
       'dependencies': [ 'shared_model' ],
       'include_dirs': [
-        '<(iroha_home_dir)/shared_model',
-        '<(iroha_home_dir)/libs',
-        '<(iroha_home_dir)/schema'
+        '<(iroha_lib_dir)',
+        # TODO: Remove these include directories when Shared Model 
+        # will be completely separated from Iroha
+        '<(iroha_lib_dir)/../schema',
+        '<(iroha_lib_dir)/../libs'
       ],
       'sources': [
-        '<(SHARED_INTERMEDIATE_DIR)/shared_model/bindings/bindingsJAVASCRIPT_wrap.cxx'
+        '<(SHARED_INTERMEDIATE_DIR)/bindings/bindingsJAVASCRIPT_wrap.cxx'
       ],
       'cflags_cc': ['-std=c++14', '-fexceptions', '-DDISABLE_BACKWARD'],
       'cflags_cc!': ['-fno-rtti'],
@@ -91,8 +89,6 @@
 
         '-lirohanode', # Library contains SWIG runtime
         '-lbindings',
-        '-lgenerator',
-        '-liroha_amount',
         '-lschema',
         '-lshared_model_stateless_validation',
         # Cryptography libs

--- a/shared_model/packages/javascript/binding.gyp
+++ b/shared_model/packages/javascript/binding.gyp
@@ -54,6 +54,8 @@
           'files': [
             '<(SHARED_INTERMEDIATE_DIR)/bindings/libirohanode.a',
             '<(SHARED_INTERMEDIATE_DIR)/bindings/libbindings.a',
+            '<(SHARED_INTERMEDIATE_DIR)/generator/libgenerator.a',
+            '<(SHARED_INTERMEDIATE_DIR)/amount/libiroha_amount.a',
             '<(SHARED_INTERMEDIATE_DIR)/schema/libschema.a',
             '<(SHARED_INTERMEDIATE_DIR)/validators/libshared_model_stateless_validation.a',
             '<(SHARED_INTERMEDIATE_DIR)/cryptography/ed25519_sha3_impl/libshared_model_cryptography.a',
@@ -89,6 +91,8 @@
 
         '-lirohanode', # Library contains SWIG runtime
         '-lbindings',
+        '-lgenerator',
+        '-liroha_amount',
         '-lschema',
         '-lshared_model_stateless_validation',
         # Cryptography libs


### PR DESCRIPTION
Signed-off-by: Arseniy Fokin <stinger112@gmail.com>

### Description of the Change
Use only Shared Model own build system instead of Iroha's one.
Paths to Iroha home have been changed to Shared Model home.