### PR TITLE
add on_commit observable to storage

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -126,6 +126,8 @@ namespace iroha {
                                         const auto &top_hash) { return true; });
             log_->info("block inserted: {}", inserted);
             commit(std::move(storage.value));
+            notifier_.get_subscriber().on_next(
+                std::shared_ptr<shared_model::interface::Block>(clone(block)));
           },
           [&](expected::Error<std::string> &error) {
             log_->error(error.error);
@@ -282,6 +284,10 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
 
     std::shared_ptr<BlockQuery> StorageImpl::getBlockQuery() const {
       return blocks_;
+    }
+    rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+    StorageImpl::on_commit() {
+      return notifier_.get_observable();
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -20,8 +20,8 @@
 
 #include "ametsuchi/storage.hpp"
 
-#include <cmath>
 #include <boost/optional.hpp>
+#include <cmath>
 #include <pqxx/pqxx>
 #include <shared_mutex>
 #include "logger/logger.hpp"
@@ -61,7 +61,8 @@ namespace iroha {
        * @param blocks - block for insertion
        * @return true if all blocks are inserted
        */
-      virtual bool insertBlock(const shared_model::interface::Block &block) override;
+      virtual bool insertBlock(
+          const shared_model::interface::Block &block) override;
 
       /**
        * Insert blocks without validation
@@ -69,7 +70,8 @@ namespace iroha {
        * @return true if inserted
        */
       virtual bool insertBlocks(
-          const std::vector<std::shared_ptr<shared_model::interface::Block>> &blocks) override;
+          const std::vector<std::shared_ptr<shared_model::interface::Block>>
+              &blocks) override;
 
       virtual void dropStorage() override;
 
@@ -78,6 +80,9 @@ namespace iroha {
       std::shared_ptr<WsvQuery> getWsvQuery() const override;
 
       std::shared_ptr<BlockQuery> getBlockQuery() const override;
+
+      rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+      on_commit() override;
 
       ~StorageImpl() override;
 
@@ -114,6 +119,9 @@ namespace iroha {
       std::shared_timed_mutex rw_lock_;
 
       logger::Logger log_;
+
+      rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
+          notifier_;
 
      protected:
       const std::string init_ = R"(

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_AMETSUCHI_H
 #define IROHA_AMETSUCHI_H
 
+#include <rxcpp/rx-observable.hpp>
 #include <vector>
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/temporary_factory.hpp"
@@ -27,7 +28,7 @@ namespace shared_model {
   namespace interface {
     class Block;
   }
-}
+}  // namespace shared_model
 
 namespace iroha {
 
@@ -58,7 +59,16 @@ namespace iroha {
        * @param blocks - collection of blocks for insertion
        * @return true if inserted
        */
-      virtual bool insertBlocks(const std::vector<std::shared_ptr<shared_model::interface::Block>> &blocks) = 0;
+      virtual bool insertBlocks(
+          const std::vector<std::shared_ptr<shared_model::interface::Block>>
+              &blocks) = 0;
+
+      /**
+       * method called when block is written to the storage
+       * @return observable with the Block committed
+       */
+      virtual rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+      on_commit() = 0;
 
       /**
        * Remove all information from ledger

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -232,6 +232,9 @@ namespace iroha {
                    bool(const std::vector<
                         std::shared_ptr<shared_model::interface::Block>> &));
       MOCK_METHOD0(dropStorage, void(void));
+      MOCK_METHOD0(
+          on_commit,
+          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>());
 
       void commit(std::unique_ptr<MutableStorage> storage) override {
         doCommit(storage.get());

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -621,6 +621,8 @@ TEST_F(AmetsuchiTest, TestingStorageWhenInsertBlock) {
       "=> insert block "
       "=> assert that inserted");
   ASSERT_TRUE(storage);
+  auto wrapper = make_test_subscriber<CallExact>(storage->on_commit(), 1);
+  wrapper.subscribe();
   auto wsv = storage->getWsvQuery();
   ASSERT_EQ(0, wsv->getPeers().value().size());
 
@@ -636,6 +638,8 @@ TEST_F(AmetsuchiTest, TestingStorageWhenInsertBlock) {
   log->info("Drop ledger");
 
   storage->dropStorage();
+
+  ASSERT_TRUE(wrapper.validate());
 }
 
 TEST_F(AmetsuchiTest, TestingStorageWhenDropAll) {


### PR DESCRIPTION
Signed-off-by: Moonraker <ssolonets@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

adds on_commit observable to storage

### Benefits

needed for blockQuery in the future

### Possible Drawbacks 

--

<!-- Explain what other alternates were considered and why the proposed version was selected -->
