### PR TITLE
Fix peer query race condition

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -126,10 +126,8 @@ bool Irohad::restoreWsv() {
 /**
  * Initializing peer query interface
  */
-void Irohad::initPeerQuery() {
-  wsv = std::make_shared<ametsuchi::PeerQueryWsv>(storage->getWsvQuery());
-
-  log_->info("[Init] => peer query");
+std::unique_ptr<iroha::ametsuchi::PeerQuery> Irohad::initPeerQuery() {
+  return std::make_unique<ametsuchi::PeerQueryWsv>(storage->getWsvQuery());
 }
 
 /**
@@ -157,7 +155,7 @@ void Irohad::initValidators() {
  * Initializing ordering gate
  */
 void Irohad::initOrderingGate() {
-  ordering_gate = ordering_init.initOrderingGate(wsv,
+  ordering_gate = ordering_init.initOrderingGate(initPeerQuery(),
                                                  max_proposal_size_,
                                                  proposal_delay_,
                                                  ordering_service_storage_,
@@ -183,7 +181,8 @@ void Irohad::initSimulator() {
  * Initializing block loader
  */
 void Irohad::initBlockLoader() {
-  block_loader = loader_init.initBlockLoader(wsv, storage->getBlockQuery());
+  block_loader =
+      loader_init.initBlockLoader(initPeerQuery(), storage->getBlockQuery());
 
   log_->info("[Init] => block loader");
 }
@@ -192,8 +191,12 @@ void Irohad::initBlockLoader() {
  * Initializing consensus gate
  */
 void Irohad::initConsensusGate() {
-  consensus_gate = yac_init.initConsensusGate(
-      wsv, simulator, block_loader, keypair, vote_delay_, load_delay_);
+  consensus_gate = yac_init.initConsensusGate(initPeerQuery(),
+                                              simulator,
+                                              block_loader,
+                                              keypair,
+                                              vote_delay_,
+                                              load_delay_);
 
   log_->info("[Init] => consensus gate");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -112,7 +112,7 @@ class Irohad {
 
   virtual void initStorage();
 
-  virtual void initPeerQuery();
+  virtual std::unique_ptr<iroha::ametsuchi::PeerQuery> initPeerQuery();
 
   virtual void initCryptoProvider();
 
@@ -157,9 +157,6 @@ class Irohad {
   // validators
   std::shared_ptr<iroha::validation::StatefulValidator> stateful_validator;
   std::shared_ptr<iroha::validation::ChainValidator> chain_validator;
-
-  // peer query
-  std::shared_ptr<iroha::ametsuchi::PeerQuery> wsv;
 
   // WSV restorer
   std::shared_ptr<iroha::ametsuchi::WsvRestorer> wsv_restorer_;


### PR DESCRIPTION

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Block loader, consensus, and ordering service can access peer query concurrently, which may lead to race condition if same connection is reused, because postgres connection does not handle concurrent accesses. Separate connection are used in these components now.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Less race conditions, more stable tests
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
At least two new connections to database. Probably a more elegant way can be found later with a connection pool for example.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
