### PR TITLE
Remove clearSignatures method

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -131,7 +131,6 @@ namespace iroha {
       }
 
       void YacGateImpl::copySignatures(const CommitMessage &commit) {
-        current_block_.second->clearSignatures();
         for (const auto &vote : commit.votes) {
           auto sig = vote.hash.block_signature;
           current_block_.second->addSignature(sig->signedData(),

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -91,11 +91,6 @@ namespace shared_model {
         return true;
       }
 
-      bool clearSignatures() override {
-        signatures_->clear();
-        return (signatures_->size() == 0);
-      }
-
       interface::types::TimestampType createdTime() const override {
         return payload_.created_time();
       }

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -135,11 +135,6 @@ namespace shared_model {
         return true;
       }
 
-      bool clearSignatures() override {
-        signatures_->clear();
-        return (signatures_->size() == 0);
-      }
-
       interface::types::TimestampType createdTime() const override {
         return proto_->payload().created_time();
       }

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -83,11 +83,6 @@ namespace shared_model {
         return true;
       }
 
-      bool clearSignatures() override {
-        signatures_->clear();
-        return (signatures_->size() == 0);
-      }
-
       interface::types::TimestampType createdTime() const override {
         return payload_.created_time();
       }

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -71,12 +71,6 @@ namespace shared_model {
                                 const crypto::PublicKey &public_key) = 0;
 
       /**
-       * Clear object's signatures
-       * @return true, if signatures were cleared
-       */
-      virtual bool clearSignatures() = 0;
-
-      /**
        * @return time of creation
        */
       virtual types::TimestampType createdTime() const = 0;


### PR DESCRIPTION
### Description of the Change
The shared model had the method that clean signatures inside an object. This method is not suitable for the philosophy of sh_m objects - this method does object invalid in terms of stateless validation. 


### Benefits
Remove method that breaks stateless validation for sh_m objects.

### Possible Drawbacks 
We have to check the stability of bindings by ourself. CI cannot handle it now.
