### PR TITLE
* Fix operator== for signatures type in old-fashion model and sh_m

### DIFF
--- a/irohad/model/impl/model_operators.cpp
+++ b/irohad/model/impl/model_operators.cpp
@@ -201,7 +201,7 @@ namespace iroha {
 
     /* Signature */
     bool Signature::operator==(const Signature &rhs) const {
-      return rhs.pubkey == pubkey && rhs.signature == signature;
+      return rhs.pubkey == pubkey;
     }
 
     /* Transaction */

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -77,7 +77,7 @@ namespace shared_model {
         if (std::find_if(signatures_->begin(),
                      signatures_->end(),
                      [&public_key](auto signature) {
-                       return signature->publicKey() == public_key;
+                       return signature.publicKey() == public_key;
                      }) != signatures_->end()) {
           return false;
         }

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -75,10 +75,11 @@ namespace shared_model {
                         const crypto::PublicKey &public_key) override {
         // if already has such signature
         if (std::find_if(signatures_->begin(),
-                     signatures_->end(),
-                     [&public_key](auto signature) {
-                       return signature.publicKey() == public_key;
-                     }) != signatures_->end()) {
+                         signatures_->end(),
+                         [&public_key](const auto &signature) {
+                           return signature.publicKey() == public_key;
+                         })
+            != signatures_->end()) {
           return false;
         }
 
@@ -126,7 +127,7 @@ namespace shared_model {
       }};
 
       const Lazy<SignatureSetType<proto::Signature>> signatures_{[this] {
-          SignatureSetType<proto::Signature> sigs;
+        SignatureSetType<proto::Signature> sigs;
         for (const auto &sig : proto_->signatures()) {
           sigs.emplace(sig);
         }

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -75,11 +75,10 @@ namespace shared_model {
                         const crypto::PublicKey &public_key) override {
         // if already has such signature
         if (std::find_if(signatures_->begin(),
-                         signatures_->end(),
-                         [&public_key](const auto &signature) {
-                           return signature.publicKey() == public_key;
-                         })
-            != signatures_->end()) {
+                     signatures_->end(),
+                     [&public_key](auto signature) {
+                       return signature->publicKey() == public_key;
+                     }) != signatures_->end()) {
           return false;
         }
 

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -66,8 +66,8 @@ namespace shared_model {
         // if already has such signature
         if (std::find_if(signatures_->begin(),
                          signatures_->end(),
-                         [&public_key](const auto& signature) {
-                           return signature.publicKey() == public_key;
+                         [&public_key](auto signature) {
+                           return signature->publicKey() == public_key;
                          })
             != signatures_->end()) {
           return false;

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -66,7 +66,7 @@ namespace shared_model {
         // if already has such signature
         if (std::find_if(signatures_->begin(),
                          signatures_->end(),
-                         [&public_key](auto signature) {
+                         [&public_key](const auto &signature) {
                            return signature.publicKey() == public_key;
                          })
             != signatures_->end()) {

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -67,7 +67,7 @@ namespace shared_model {
         if (std::find_if(signatures_->begin(),
                          signatures_->end(),
                          [&public_key](auto signature) {
-                           return signature->publicKey() == public_key;
+                           return signature.publicKey() == public_key;
                          })
             != signatures_->end()) {
           return false;

--- a/shared_model/interfaces/common_objects/signature.hpp
+++ b/shared_model/interfaces/common_objects/signature.hpp
@@ -58,8 +58,7 @@ namespace shared_model {
       virtual const SignedType &signedData() const = 0;
 
       bool operator==(const Signature &rhs) const override {
-        return publicKey() == rhs.publicKey()
-            and signedData() == rhs.signedData();
+        return publicKey() == rhs.publicKey();
       }
 
 #ifndef DISABLE_BACKWARD

--- a/test/module/irohad/model/operators/model_operators_test.cpp
+++ b/test/module/irohad/model/operators/model_operators_test.cpp
@@ -313,7 +313,15 @@ TEST(ModelOperatorTest, SignatureTest) {
 
   ASSERT_EQ(sig1, sig2);
   sig1.signature[0] = 0x23;
-  ASSERT_NE(sig1, sig2);
+
+  // equals because public keys are same
+  ASSERT_EQ(sig1, sig2);
+
+  auto sig3 = createSignature();
+  sig3.pubkey[0] = 0x23;
+
+  // not equals because public keys are different
+  ASSERT_NE(sig1, sig3);
 }
 
 // -----|Transaction|-----

--- a/test/module/shared_model/cryptography/CMakeLists.txt
+++ b/test/module/shared_model/cryptography/CMakeLists.txt
@@ -10,3 +10,8 @@ target_link_libraries(crypto_usage_test
         schema
         iroha_amount
         )
+
+addtest(security_signatures_test security_signatures_test.cpp)
+target_link_libraries(security_signatures_test
+        shared_model_proto_builders
+        )

--- a/test/module/shared_model/cryptography/security_signatures_test.cpp
+++ b/test/module/shared_model/cryptography/security_signatures_test.cpp
@@ -32,9 +32,9 @@ TEST(SecuritySignature, SignatureOperatorEqual) {
 }
 
 /**
- * @given Transaction with marked signature
+ * @given Transaction with given signature
  * @when  Invoke ::addSignature with same public key but different signed
- * @then  Expect that second signature doesn't added
+ * @then  Expect that second signature wasn't added
  */
 TEST(SecuritySignature, TransactionAddsignature) {
   auto tx = TestTransactionBuilder().build();
@@ -45,9 +45,9 @@ TEST(SecuritySignature, TransactionAddsignature) {
 }
 
 /**
- * @given Block with marked signature
+ * @given Block with given signature
  * @when  Invoke ::addSignature with same public key but different signed
- * @then  Expect that second signature doesn't added
+ * @then  Expect that second signature wasn't added
  */
 TEST(SecuritySignature, BlockAddSignature) {
   auto block = TestBlockBuilder().build();

--- a/test/module/shared_model/cryptography/security_signatures_test.cpp
+++ b/test/module/shared_model/cryptography/security_signatures_test.cpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_signature_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+
+/**
+ * @given Two signatures with same pub key but different signed
+ * @when  Invoke operator==
+ * @then  Expect true
+ */
+TEST(SecuritySignature, SignatureOperatorEqual) {
+  auto first_signature =
+      TestSignatureBuilder()
+          .publicKey(shared_model::crypto::PublicKey("one"))
+          .signedData(shared_model::crypto::Signed("signed_one"))
+          .build();
+
+  auto second_signature =
+      TestSignatureBuilder()
+          .publicKey(shared_model::crypto::PublicKey("one"))
+          .signedData(shared_model::crypto::Signed("signed_two"))
+          .build();
+
+  ASSERT_TRUE(first_signature == second_signature);
+}
+
+/**
+ * @given Transaction with marked signature
+ * @when  Invoke ::addSignature with same public key but different signed
+ * @then  Expect true
+ */
+TEST(SecuritySignature, TransactionAddsignature) {
+  auto tx = TestTransactionBuilder().build();
+  ASSERT_TRUE(tx.addSignature(shared_model::crypto::Signed("sign_one"),
+                              shared_model::crypto::PublicKey("key_one")));
+  ASSERT_FALSE(tx.addSignature(shared_model::crypto::Signed("sign_two"),
+                               shared_model::crypto::PublicKey("key_one")));
+}
+
+/**
+ * @given Block with marked signature
+ * @when  Invoke ::addSignature with same public key but different signed
+ * @then  Expect true
+ */
+TEST(SecuritySignature, BlockAddSignature) {
+  auto block = TestBlockBuilder().build();
+  ASSERT_TRUE(block.addSignature(shared_model::crypto::Signed("sign_one"),
+                                 shared_model::crypto::PublicKey("key_one")));
+  ASSERT_FALSE(block.addSignature(shared_model::crypto::Signed("sign_two"),
+                                  shared_model::crypto::PublicKey("key_one")));
+}

--- a/test/module/shared_model/cryptography/security_signatures_test.cpp
+++ b/test/module/shared_model/cryptography/security_signatures_test.cpp
@@ -34,7 +34,7 @@ TEST(SecuritySignature, SignatureOperatorEqual) {
 /**
  * @given Transaction with marked signature
  * @when  Invoke ::addSignature with same public key but different signed
- * @then  Expect true
+ * @then  Expect that second signature doesn't added
  */
 TEST(SecuritySignature, TransactionAddsignature) {
   auto tx = TestTransactionBuilder().build();
@@ -47,7 +47,7 @@ TEST(SecuritySignature, TransactionAddsignature) {
 /**
  * @given Block with marked signature
  * @when  Invoke ::addSignature with same public key but different signed
- * @then  Expect true
+ * @then  Expect that second signature doesn't added
  */
 TEST(SecuritySignature, BlockAddSignature) {
   auto block = TestBlockBuilder().build();


### PR DESCRIPTION
### Description of the Change
* Fix sh_m and old-fashion model signature operator==
* Fix ::addSignature for sh_m tx and block

### Benefits
Close potential security issues for Iroha's stateless validation.

### Usage Examples or Tests *[optional]*
Tests are provided.