### PR TITLE
Add prefix with type of test for Ctest names

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -27,8 +27,15 @@ function(addtest test_name SOURCES)
   add_executable(${test_name} ${SOURCES})
   target_link_libraries(${test_name} gtest gmock)
   target_include_directories(${test_name} PUBLIC ${PROJECT_SOURCE_DIR}/test)
+
+  # fetch directory after test in source dir call
+  # for example:
+  # "/Users/user/iroha/test/integration/acceptance"
+  # match to "integration"
+  string(REGEX REPLACE ".*test\\/([a-zA-Z]+).*" "\\1" output ${CMAKE_CURRENT_SOURCE_DIR})
+
   add_test(
-      NAME ${test_name}
+      NAME "${output}_${test_name}"
       COMMAND $<TARGET_FILE:${test_name}> ${test_xml_output}
   )
   strictmode(${test_name})


### PR DESCRIPTION
### Description of the Change

Add the type of tests for Ctest names. Type of test is fetching from the source path of the test.
Currently available the following prefixes:
* "module_" for unit tests
* "regression_" for finding regressions
* "integration_" for integration tests
* and "system_" for system tests, respectively.

### Benefits
Possible to build only required tests for different cases in CI

### Possible Drawbacks 
Name of tests is not a same with the name of a target.
