### PR TITLE
Feature/java tests

### DIFF
--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.math.BigInteger;
 
@@ -27,6 +28,71 @@ public class BuilderTest {
     private Keypair keys;
     private ModelTransactionBuilder builder;
 
+
+    /* Stateless validation rules are listed
+     * here https://github.com/hyperledger/iroha/pull/1148
+     */
+
+    // Symbols of type 1 (format [a-z_0-9]{1,32}) are used
+    // as account_name, asset_name and role_id.
+    private final String[] validNameSymbols1 = {
+        "a",
+        "asset",
+        "234234",
+        "_",
+        "_123",
+        "123_23",
+        "234asset_",
+        "__",
+        "12345678901234567890123456789012"
+    };
+    private final String[] invalidNameSymbols1 = {
+        "",
+        "A",
+        "assetV",
+        "asSet",
+        "asset%",
+        "^123",
+        "verylongassetname_thenameislonger",
+        "verylongassetname_thenameislongerthanitshouldbe",
+        "assset-01"
+    };
+
+    // Symbols of type 2 (format [A-Za-z0-9_]{1,64})
+    // are used as key identifier for setAccountDetail command
+    private final String[] validNameSymbols2 = {
+        "a",
+        "A",
+        "1",
+        "_",
+        "Key",
+        "Key0_",
+        "verylongAndValidKeyName___1110100010___veryveryveryverylongvalid"
+    };
+    private final String[] invalidNameSymbols2 = {
+        "",
+        "Key&",
+        "key-30",
+        "verylongAndValidKeyName___1110100010___veryveryveryverylongvalid1",
+        "@@@"
+    };
+
+    private final String[] invalidHosts = {
+        "257.257.257.257",
+        "host#host",
+        "asd@asd",
+        "ab..cd",
+        "",
+        "   "
+    };
+
+    private final String[] invalidKeysBytes = {
+        "",
+        "a",
+        "1111111111111111111111111111111",
+        "111111111111111111111111111111111"
+    };
+
     ModelTransactionBuilder base() {
         return new ModelTransactionBuilder()
                 .createdTime(BigInteger.valueOf(System.currentTimeMillis()))
@@ -35,56 +101,6 @@ public class BuilderTest {
 
     void setAddPeer() {
         builder.addPeer("123.123.123.123", keys.publicKey());
-    }
-
-    @BeforeEach
-    void setUp() {
-        keys = new ModelCrypto().generateKeypair();
-        builder = base();
-    }
-
-    @Test
-    void emptyTx() {
-        ModelTransactionBuilder builder = new ModelTransactionBuilder();
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    @Test
-    void outdatedAddPeer() {
-        setAddPeer();
-        for (BigInteger i : new BigInteger[]{BigInteger.valueOf(0),
-                BigInteger.valueOf(System.currentTimeMillis() - 100_000_000),
-                BigInteger.valueOf(System.currentTimeMillis() + 1000)}) {
-            builder.createdTime(i);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
-    }
-
-    @Test
-    void addPeerWithInvalidCreator() {
-        setAddPeer();
-        for (String i : new String[]{"", "invalid", "@invalid", "invalid@"}) {
-            builder.creatorAccountId(i);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
-    }
-
-    @Test
-    void addPeerWithInvalidKeySize() {
-        setAddPeer();
-        for (String i : new String[]{"", "a", "1111111111111111111111111111111", "111111111111111111111111111111111"}) {
-            ModelTransactionBuilder builder = base().addPeer("123.123.123.123", new PublicKey(i));
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
-    }
-
-    @Test
-    void addPeerWithInvalidHost() {
-        setAddPeer();
-        for (String i : new String[]{"257.257.257.257", "host#host", "asd@asd", "ab..cd"}) {
-            ModelTransactionBuilder builder = base().addPeer(i, keys.publicKey());
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
     }
 
     Blob proto(UnsignedTx tx) {
@@ -114,6 +130,20 @@ public class BuilderTest {
         return true;
     }
 
+    @BeforeEach
+    void setUp() {
+        keys = new ModelCrypto().generateKeypair();
+        builder = base();
+    }
+
+    @Test
+    void emptyTx() {
+        ModelTransactionBuilder builder = new ModelTransactionBuilder();
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== AddPeer Tests ====================== */
+
     @Test
     void addPeer() {
         UnsignedTx tx = builder.addPeer("123.123.123.123:123", keys.publicKey()).build();
@@ -121,10 +151,103 @@ public class BuilderTest {
     }
 
     @Test
-    void addSignatory() {
-        UnsignedTx tx = builder.addSignatory("admin@test", keys.publicKey()).build();
-        assertTrue(checkProtoTx(proto(tx)));
+    void outdatedAddPeer() {
+        setAddPeer();
+        for (BigInteger i: new BigInteger[]{BigInteger.valueOf(0),
+                BigInteger.valueOf(System.currentTimeMillis() - 100_000_000),
+                BigInteger.valueOf(System.currentTimeMillis() + 1000)}) {
+            builder.createdTime(i);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
     }
+
+    @Test
+    void addPeerWithInvalidCreator() {
+        setAddPeer();
+        for (String account: invalidNameSymbols1) {
+            builder.creatorAccountId(account + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addPeerWithEmptyCreator() {
+        setAddPeer();
+        builder.creatorAccountId("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void addPeerWithInvalidCreatorDomain() {
+        setAddPeer();
+        for (String host: invalidHosts) {
+            builder.creatorAccountId("admin@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addPeerWithInvalidKeySize() {
+        setAddPeer();
+        for (String key: invalidKeysBytes) {
+            ModelTransactionBuilder builder = base().addPeer("123.123.123.123", new PublicKey(key));
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addPeerWithInvalidHost() {
+        setAddPeer();
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().addPeer(host, keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== AddSignatory Tests ====================== */
+
+    @Test
+    void addSignatory() {
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            UnsignedTx tx = builder.addSignatory("admin@test", keys.publicKey()).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void addSignatoryInvalidAccountName() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@domain";
+            ModelTransactionBuilder builder = base().addSignatory(accountId, keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addSignatoryEmptyAccountId() {
+        ModelTransactionBuilder builder = base().addSignatory("", keys.publicKey());
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void addSignatoryInvalidDomain() {
+        for (String host: invalidHosts) {
+            String accountId = "user@" + host;
+            ModelTransactionBuilder builder = base().addSignatory(accountId, keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addSignatoryInvalidKey() {
+        for (String invalidKeyBytes: invalidKeysBytes) {
+            ModelTransactionBuilder builder = base().addSignatory("admin@test", new PublicKey(invalidKeyBytes));
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== AddAssetQuantity Tests ====================== */
 
     @Test
     void addAssetQuantity() {
@@ -133,38 +256,726 @@ public class BuilderTest {
     }
 
     @Test
-    void removeSignatory() {
-        UnsignedTx tx = builder.removeSignatory("admin@test", keys.publicKey()).build();
-        assertTrue(checkProtoTx(proto(tx)));
+    void addAssetQuantityValidAccountsAndAssets() {
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            for (String assetName: validNameSymbols1) {
+                String assetId = assetName + "#test";
+                UnsignedTx tx = builder.addAssetQuantity(accountId, assetId, "100").build();
+                assertTrue(checkProtoTx(proto(tx)));
+            }
+        }
     }
+
+    @Test
+    void addAssetZeroQuantity() {
+        ModelTransactionBuilder builder = base().addAssetQuantity("admin@test", "asset#domain", "0");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void addAssetQuantityInvalidAccountName() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().addAssetQuantity(accountId, "asset#domain", "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addAssetQuantityEmptyAccount() {
+        ModelTransactionBuilder builder = base().addAssetQuantity("", "asset#test", "10");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void addAssetQuantityInvalidAssetName() {
+        for (String assetName: invalidNameSymbols1) {
+            String assetId = assetName + "#test";
+            ModelTransactionBuilder builder = base().addAssetQuantity("account@test", assetId, "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void addAssetQuantityEmptyAsset() {
+        ModelTransactionBuilder builder = base().addAssetQuantity("account@test", "", "10");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void addAssetQuantityInvalidAmount() {
+        for (String amount: new String[]{"", "-12", "-13.45", "chars", "chars10"}) {
+            ModelTransactionBuilder builder = base().addAssetQuantity("account@test", "asset#test", amount);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== RemoveSignatory Tests ====================== */
+
+    @Test
+    void removeSignatory() {
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            UnsignedTx tx = builder.removeSignatory(accountId, keys.publicKey()).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void removeSignatoryEmptyAccount() {
+        ModelTransactionBuilder builder = base().removeSignatory("", keys.publicKey());
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void removeSignatoryInvalidAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().removeSignatory(accountId, keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void removeSignatoryInvalidKey() {
+        for (String invalidKeyBytes: invalidKeysBytes) {
+            ModelTransactionBuilder builder = base().removeSignatory("admin@test", new PublicKey(invalidKeyBytes));
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== CreateAccount Tests ====================== */
 
     @Test
     void createAccount() {
-        UnsignedTx tx = builder.createAccount("admin", "domain", keys.publicKey()).build();
-        assertTrue(checkProtoTx(proto(tx)));
+        for (String accountName: validNameSymbols1) {
+            UnsignedTx tx = builder.createAccount(accountName, "domain", keys.publicKey()).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
     }
+
+    @Test
+    void createAccountInvalidAccountName() {
+        for (String accountName: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().createAccount(accountName, "domain", keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void createAccountInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().createAccount("admin", host, keys.publicKey());
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void createAccountInvalidKey() {
+        for (String invalidKeyBytes: invalidKeysBytes) {
+            ModelTransactionBuilder builder = base().createAccount("admin", "test", new PublicKey(invalidKeyBytes));
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== CreateDomain Tests ====================== */
 
     @Test
     void createDomain() {
-        UnsignedTx tx = builder.createDomain("domain", "role").build();
-        assertTrue(checkProtoTx(proto(tx)));
+        for (String role: validNameSymbols1) {
+            UnsignedTx tx = builder.createDomain("domain", role).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
     }
+
+    @Test
+    void createDomainInvalidHost() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().createDomain(host, "role");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void createDomainInvalidRole() {
+        for (String role: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().createDomain("domain", role);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== SetAccountQuorum Tests ====================== */
+
 
     @Test
     void setAccountQuorum() {
-        UnsignedTx tx = builder.setAccountQuorum("admin@test", 123).build();
-        assertTrue(checkProtoTx(proto(tx)));
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            UnsignedTx tx = builder.setAccountQuorum("admin@test", 128).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
     }
+
+    @Test
+    void setAccountQuorumInvalidAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().setAccountQuorum(accountId, 123);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void setAccountQuorumInvalidDomain() {
+        for (String host: invalidHosts) {
+            String accountId = "admin@" + host;
+            ModelTransactionBuilder builder = base().setAccountQuorum(accountId, 123);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void setAccountQuorumInvalidQuantity() {
+        for (int quorumSize: new int[]{0, 129, -100}) {
+            ModelTransactionBuilder builder = base().setAccountQuorum("admin@test", quorumSize);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== TransferAsset Tests ====================== */
 
     @Test
     void transferAsset() {
-        UnsignedTx tx = builder.transferAsset("from@test", "to@test", "asset#test", "description", "123.456").build();
-        assertTrue(checkProtoTx(proto(tx)));
+        for (int i = 0; i < validNameSymbols1.length; i++) {
+            String from = validNameSymbols1[i] + "@test";
+            String to = validNameSymbols1[(i + 1) % validNameSymbols1.length] + "@test";
+            String asset = validNameSymbols1[(i + 2) % validNameSymbols1.length] + "#test";
+            UnsignedTx tx = builder.transferAsset(from, to, asset, "description", "123.456").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
     }
 
     @Test
+    void transferAssetWithValidName() {
+        for (String assetName: validNameSymbols1) {
+            String assetId = assetName + "#test";
+            UnsignedTx tx = builder.transferAsset("from@test", "to@test", assetId, "description", "100").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void transferAssetWithInvalidName() {
+        for (String assetName: invalidNameSymbols1) {
+            String assetId = assetName + "#test";
+            ModelTransactionBuilder builder = base().transferAsset("from@test", "to@test", assetId, "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithInvalidFromAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().transferAsset(accountId, "to@test", "asset#test", "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithInvalidToAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().transferAsset("from@test", accountId, "asset#test", "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithEmptyFromAccount() {
+        ModelTransactionBuilder builder = base().transferAsset("", "to@test", "asset#test", "description", "100");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void transferAssetWithEmptyToAccount() {
+        ModelTransactionBuilder builder = base().transferAsset("from@test", "", "asset#test", "description", "100");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void transferAssetWithInvalidFromHost() {
+        for (String host: invalidHosts) {
+            String accountId = "from@" + host;
+            ModelTransactionBuilder builder = base().transferAsset(accountId, "to@test", "asset#test", "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithInvalidToHost() {
+        for (String host: invalidHosts) {
+            String accountId = "to@" + host;
+            ModelTransactionBuilder builder = base().transferAsset("from@test", accountId, "asset#test", "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithInvalidAssetDomain() {
+        for (String host: invalidHosts) {
+            String assetId = "asset#" + host;
+            ModelTransactionBuilder builder = base().transferAsset("from@test", "to@test", assetId, "description", "100");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void transferAssetWithEmptyAssetName() {
+        ModelTransactionBuilder builder = base().transferAsset("from@test", "to@test", "", "description", "100");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void transferAssetDescriptionBoundaryValues() {
+        for (String description1: new String[]{"", "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234"}) {
+            UnsignedTx tx = builder.transferAsset("from@test", "to@test", "asset#test", description1, "100").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+
+        String description2 = "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde12345";
+        ModelTransactionBuilder builder = base().transferAsset("from@test", "to@test", "asset#test", description2, "100");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void transferAssetMaximumAmount() {
+        BigInteger base = new BigInteger("2");
+        BigInteger one = new BigInteger("1");
+        BigInteger maxUint256 = base.pow(256).subtract(one);
+        BigInteger oversizedInt = maxUint256.add(one);
+
+        String maxAmount1 = maxUint256.toString();
+        String maxAmount2 = maxAmount1.substring(0, 10) + "." + maxAmount1.substring(10, maxAmount1.length());
+
+        for (String amount: new String[]{maxAmount1, maxAmount2}) {
+            UnsignedTx tx = builder.transferAsset("from@test", "to@test", "asset#test", "description", amount).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+
+        ModelTransactionBuilder mtb = base().transferAsset("from@test", "to@test", "asset#test", "description", oversizedInt.toString());
+        assertThrows(IllegalArgumentException.class, mtb::build);
+    }
+
+
+    /* ====================== SetAccountDetail Tests ====================== */
+
+    @Test
     void setAccountDetail() {
-        UnsignedTx tx = builder.setAccountDetail("admin@test", "fyodor", "kek").build();
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            UnsignedTx tx = builder.setAccountDetail(accountId, "fyodor", "kek").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void setAccountDetailInvalidAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().setAccountDetail(accountId, "fyodor", "true");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void setAccountDetailEmptyAccount() {
+        ModelTransactionBuilder builder = base().setAccountDetail("", "fyodor", "true");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void setAccountDetailInvalidAccountDomain() {
+        for (String host: invalidHosts) {
+            String accountId = "admin@" + host;
+            ModelTransactionBuilder builder = base().setAccountDetail(accountId, "fyodor", "true");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void setAccountDetailValidKey() {
+        for (String key: validNameSymbols2) {
+            UnsignedTx tx = builder.setAccountDetail("admin@test", key, "true").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void setAccountDetailInvalidKey() {
+        for (String key: invalidNameSymbols2) {
+            ModelTransactionBuilder builder = base().setAccountDetail("admin@test", key, "true");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void setAccountDetailValidValue() {
+        int length = 4 * 1024 * 1024;
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append("a");
+        }
+
+        for (String value: new String[]{"", sb.toString()}) {
+            UnsignedTx tx = builder.setAccountDetail("admin@test", "fyodor", value).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void setAccountDetailWithOversizedValue() {
+        int length = 4 * 1024 * 1024 + 1;
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append("a");
+        }
+
+        ModelTransactionBuilder builder = base().setAccountDetail("admin@test", "fyodor", sb.toString());
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== AppendRole Tests ====================== */
+
+    @Test
+    void appendRole() {
+        for (String account: validNameSymbols1) {
+            String accountId = account + "@test";
+            UnsignedTx tx = builder.appendRole(accountId, account).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void appendRoleInvalidAccount() {
+        for (String account: invalidNameSymbols1) {
+            String accountId = account + "@test";
+            ModelTransactionBuilder builder = base().appendRole(accountId, "user");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void appendRoleInvalidDomain() {
+        for (String host: invalidHosts) {
+            String accountId = "admin@" + host;
+            ModelTransactionBuilder builder = base().appendRole(accountId, "user");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void appendRoleWithInvalidName() {
+        for (String role: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().appendRole("admin@test", role);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+
+    /* ====================== CreateAsset Tests ====================== */
+
+    @Test
+    void createAsset() {
+        for (String assetName: validNameSymbols1) {
+            UnsignedTx tx = builder.createAsset(assetName, "test", (short) 6).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void createAssetWithInvalidName() {
+        for (String asset: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().createAsset(asset, "test", (short) 6);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void createAssetWithInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().createAsset("asset", host, (short) 6);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void createAssetWithZeroPrecision() {
+        UnsignedTx tx = builder.createAsset("asset", "test", (short) 0).build();
         assertTrue(checkProtoTx(proto(tx)));
+    }
+
+    /* ====================== CreateRole Tests ====================== */
+
+    @Test
+    void createRole() {
+        StringVector permissions = new StringVector();
+        permissions.add("can_receive");
+        permissions.add("can_get_roles");
+        assertTrue(permissions.size() == 2);
+
+        for (String role: validNameSymbols1) {
+            UnsignedTx tx = builder.createRole(role, permissions).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void createRoleWithInvalidName() {
+        StringVector permissions = new StringVector();
+        permissions.add("can_receive");
+        permissions.add("can_get_roles");
+        assertTrue(permissions.size() == 2);
+
+        for (String role: invalidNameSymbols1) {
+            ModelTransactionBuilder mtb = base().createRole(role, permissions);
+            assertThrows(IllegalArgumentException.class, mtb::build);
+        }
+    }
+
+    @Test
+    void createRoleEmptyPermissions() {
+        StringVector permissions = new StringVector();
+
+        ModelTransactionBuilder builder = new ModelTransactionBuilder();
+        builder.createRole("new_role", permissions);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void createRoleWrongPermissions() {
+        StringVector permissions = new StringVector();
+        permissions.add("wrong_permission");
+        permissions.add("can_receive");
+
+        ModelTransactionBuilder builder = base().createRole("new_role", permissions);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+
+    /* Test differs from the previous by the order of permissions' mames in vector.
+     * Test is disabled because there is no exception thrown when it should be.
+     */
+    /* Disabled till IR-1267 will be fixed. */
+    @Disabled
+    @Test
+    void createRoleWrongPermissions2() {
+        StringVector permissions = new StringVector();
+        permissions.add("can_receive");
+        permissions.add("wrong_permission");
+
+        ModelTransactionBuilder builder = base().createRole("new_role", permissions);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== DetachRole Tests ====================== */
+
+    @Test
+    void detachRole() {
+        for (String name: validNameSymbols1) {
+            String accountId = name + "@test";
+            UnsignedTx tx = builder.detachRole(accountId, name).build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void detachRoleInvalidAccountName() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().detachRole(accountId, "role");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void detachRoleInvalidDomain() {
+        for (String host: invalidHosts) {
+            String accountId = "admin@" + host;
+            ModelTransactionBuilder builder = base().detachRole(accountId, "role");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void detachRoleWithEmptyAccount() {
+        ModelTransactionBuilder builder = base().detachRole("", "role");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void detachRoleWithInvalidName() {
+        for (String role: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().detachRole("admin@test", role);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== GrantPermission Tests ====================== */
+
+    @Test
+    void grantPermission() {
+        for (String accountName: validNameSymbols1) {
+            String accountId = accountName + "@test";
+            UnsignedTx tx = builder.grantPermission(accountId, "can_set_my_quorum").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void grantPermissionInvalidAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            String accountId = accountName + "@test";
+            ModelTransactionBuilder builder = base().grantPermission(accountId, "can_set_my_quorum");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void grantPermissionEmptyAccount() {
+        ModelTransactionBuilder builder = base().grantPermission("", "can_set_my_quorum");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void grantPermissionWithInvalidName() {
+        String permissions[] = {
+            "",
+            "random",
+            "can_read_assets" // non-grantable permission
+        };
+
+        for (String permission: permissions) {
+            ModelTransactionBuilder builder = base().grantPermission("admin@test", permission);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== RevokePermission Tests ====================== */
+
+    @Test
+    void revokePermission() {
+        for (String accountName: validNameSymbols1) {
+            UnsignedTx tx = builder.revokePermission(accountName + "@test", "can_set_my_quorum").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void revokePermissionInvalidAccount() {
+        for (String accountName: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().revokePermission(accountName + "@test", "can_set_my_quorum");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void revokePermissionInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().revokePermission("admin@" + host, "can_set_my_quorum");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void revokePermissionEmptyAccount() {
+        ModelTransactionBuilder builder = base().revokePermission("", "can_set_my_quorum");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void revokePermissionWithInvalidName() {
+        String permissions[] = {
+            "",
+            "random",
+            "can_read_assets" // non-grantable permission
+        };
+
+        for (String permission: permissions) {
+            ModelTransactionBuilder builder = base().revokePermission("admin@test", permission);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== SubtractAssetQuantity Tests ====================== */
+
+    @Test
+    void subtractAssetQuantity() {
+        for (String name: validNameSymbols1) {
+            UnsignedTx tx = builder.subtractAssetQuantity(name + "@test", name + "#test", "10.22").build();
+            assertTrue(checkProtoTx(proto(tx)));
+        }
+    }
+
+    @Test
+    void subtractAssetQuantityInvalidAccount() {
+        for (String account: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity(account + "@test", "coin#test", "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void subtractAssetQuantityInvalidAccountDomain() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@" + host, "coin#test", "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void subtractAssetQuantityInvalidAsset() {
+        for (String asset: invalidNameSymbols1) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", asset + "#test", "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void subtractAssetQuantityInvalidAssetDomain() {
+        for (String host: invalidHosts) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", "coin#" + host, "10");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void subtractAssetQuantityEmptyAccount() {
+        ModelTransactionBuilder builder = base().subtractAssetQuantity("", "coin#test", "10");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void subtractAssetQuantityEmptyAsset() {
+        ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", "", "10");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void subtractAssetQuantityInvalidAmount() {
+        String invalidAmounts[] = {
+            "",
+            "0",
+            "chars",
+            "-10",
+            "10chars",
+            "10.10.10"
+        };
+
+        for (String amount: invalidAmounts) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", "coin#test", amount);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
     }
 }

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -82,7 +82,7 @@ public class BuilderTest {
         "@@@"
     };
 
-    private final String[] validHosts = {
+    private final String[] validDomains = {
         "test",
         "u9EEA432F",
         "a-hyphen",
@@ -94,7 +94,7 @@ public class BuilderTest {
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad"
     };
 
-    private final String[] invalidHosts = {
+    private final String[] invalidDomains = {
         "",
         " ",
         "   ",
@@ -110,7 +110,7 @@ public class BuilderTest {
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPadP",
         "257.257.257.257",
-        "host#host",
+        "domain#domain",
         "asd@asd",
         "ab..cd"
     };
@@ -175,8 +175,8 @@ public class BuilderTest {
 
     @Test
     void addPeer() {
-        for (String host: validHosts) {
-            UnsignedTx tx = builder.addPeer(host + ":123", keys.publicKey()).build();
+        for (String domain: validDomains) {
+            UnsignedTx tx = builder.addPeer(domain + ":123", keys.publicKey()).build();
             assertTrue(checkProtoTx(proto(tx)));
         }
     }
@@ -211,8 +211,8 @@ public class BuilderTest {
     @Test
     void addPeerWithInvalidCreatorDomain() {
         setAddPeer();
-        for (String host: invalidHosts) {
-            builder.creatorAccountId("admin@" + host);
+        for (String domain: invalidDomains) {
+            builder.creatorAccountId("admin@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -227,10 +227,10 @@ public class BuilderTest {
     }
 
     @Test
-    void addPeerWithInvalidHost() {
+    void addPeerWithInvalidDomain() {
         setAddPeer();
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().addPeer(host, keys.publicKey());
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().addPeer(domain, keys.publicKey());
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -240,8 +240,8 @@ public class BuilderTest {
     @Test
     void addSignatory() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 UnsignedTx tx = builder.addSignatory(accountId, keys.publicKey()).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -265,8 +265,8 @@ public class BuilderTest {
 
     @Test
     void addSignatoryInvalidDomain() {
-        for (String host: invalidHosts) {
-            String accountId = "user@" + host;
+        for (String domain: invalidDomains) {
+            String accountId = "user@" + domain;
             ModelTransactionBuilder builder = base().addSignatory(accountId, keys.publicKey());
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -290,9 +290,9 @@ public class BuilderTest {
 
     @Test
     void addAssetQuantityValidAccountsAndAssets() {
-        for (String host: validHosts) {
+        for (String domain: validDomains) {
             for (String name: validNameSymbols1) {
-                UnsignedTx tx = builder.addAssetQuantity(name + "@" + host, name + "#" + host, "100").build();
+                UnsignedTx tx = builder.addAssetQuantity(name + "@" + domain, name + "#" + domain, "100").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -300,16 +300,16 @@ public class BuilderTest {
 
     @Test
     void addAssetQuantityInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().addAssetQuantity("admin@" + host, "asset#test", "10");
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().addAssetQuantity("admin@" + domain, "asset#test", "10");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
 
     @Test
     void addAssetQuantityInvalidAssetDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().addAssetQuantity("admin@test", "asset#" + host, "10");
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().addAssetQuantity("admin@test", "asset#" + domain, "10");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -363,8 +363,8 @@ public class BuilderTest {
     @Test
     void removeSignatory() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 UnsignedTx tx = builder.removeSignatory(accountId, keys.publicKey()).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -388,8 +388,8 @@ public class BuilderTest {
 
     @Test
     void removeSignatoryInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().removeSignatory("admin@" + host, keys.publicKey());
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().removeSignatory("admin@" + domain, keys.publicKey());
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -407,8 +407,8 @@ public class BuilderTest {
     @Test
     void createAccount() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedTx tx = builder.createAccount(accountName, host, keys.publicKey()).build();
+            for (String domain: validDomains) {
+                UnsignedTx tx = builder.createAccount(accountName, domain, keys.publicKey()).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -424,8 +424,8 @@ public class BuilderTest {
 
     @Test
     void createAccountInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().createAccount("admin", host, keys.publicKey());
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().createAccount("admin", domain, keys.publicKey());
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -443,17 +443,17 @@ public class BuilderTest {
     @Test
     void createDomain() {
         for (String role: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedTx tx = builder.createDomain(host, role).build();
+            for (String domain: validDomains) {
+                UnsignedTx tx = builder.createDomain(domain, role).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
     }
 
     @Test
-    void createDomainInvalidHost() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().createDomain(host, "role");
+    void createDomainInvalidDomain() {
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().createDomain(domain, "role");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -472,8 +472,8 @@ public class BuilderTest {
     @Test
     void setAccountQuorum() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 UnsignedTx tx = builder.setAccountQuorum(accountId, 128).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -491,8 +491,8 @@ public class BuilderTest {
 
     @Test
     void setAccountQuorumInvalidDomain() {
-        for (String host: invalidHosts) {
-            String accountId = "admin@" + host;
+        for (String domain: invalidDomains) {
+            String accountId = "admin@" + domain;
             ModelTransactionBuilder builder = base().setAccountQuorum(accountId, 123);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -516,11 +516,11 @@ public class BuilderTest {
 
     @Test
     void transferAsset() {
-        for (String host: validHosts) {
+        for (String domain: validDomains) {
             for (int i = 0; i < validNameSymbols1.length; i++) {
-                String from = validNameSymbols1[i] + "@" + host;
-                String to = validNameSymbols1[(i + 1) % validNameSymbols1.length] + "@" + host;
-                String asset = validNameSymbols1[(i + 2) % validNameSymbols1.length] + "#" + host;
+                String from = validNameSymbols1[i] + "@" + domain;
+                String to = validNameSymbols1[(i + 1) % validNameSymbols1.length] + "@" + domain;
+                String asset = validNameSymbols1[(i + 2) % validNameSymbols1.length] + "#" + domain;
                 UnsignedTx tx = builder.transferAsset(from, to, asset, "description", "123.456").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -576,18 +576,18 @@ public class BuilderTest {
     }
 
     @Test
-    void transferAssetWithInvalidFromHost() {
-        for (String host: invalidHosts) {
-            String accountId = "from@" + host;
+    void transferAssetWithInvalidFromDomain() {
+        for (String domain: invalidDomains) {
+            String accountId = "from@" + domain;
             ModelTransactionBuilder builder = base().transferAsset(accountId, "to@test", "asset#test", "description", "100");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
 
     @Test
-    void transferAssetWithInvalidToHost() {
-        for (String host: invalidHosts) {
-            String accountId = "to@" + host;
+    void transferAssetWithInvalidToDomain() {
+        for (String domain: invalidDomains) {
+            String accountId = "to@" + domain;
             ModelTransactionBuilder builder = base().transferAsset("from@test", accountId, "asset#test", "description", "100");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -595,8 +595,8 @@ public class BuilderTest {
 
     @Test
     void transferAssetWithInvalidAssetDomain() {
-        for (String host: invalidHosts) {
-            String assetId = "asset#" + host;
+        for (String domain: invalidDomains) {
+            String assetId = "asset#" + domain;
             ModelTransactionBuilder builder = base().transferAsset("from@test", "to@test", assetId, "description", "100");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -645,8 +645,8 @@ public class BuilderTest {
     @Test
     void setAccountDetail() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 UnsignedTx tx = builder.setAccountDetail(accountId, "fyodor", "kek").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -670,8 +670,8 @@ public class BuilderTest {
 
     @Test
     void setAccountDetailInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            String accountId = "admin@" + host;
+        for (String domain: invalidDomains) {
+            String accountId = "admin@" + domain;
             ModelTransactionBuilder builder = base().setAccountDetail(accountId, "fyodor", "true");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -724,8 +724,8 @@ public class BuilderTest {
     @Test
     void appendRole() {
         for (String account: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = account + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = account + "@" + domain;
                 UnsignedTx tx = builder.appendRole(accountId, account).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -743,8 +743,8 @@ public class BuilderTest {
 
     @Test
     void appendRoleInvalidDomain() {
-        for (String host: invalidHosts) {
-            String accountId = "admin@" + host;
+        for (String domain: invalidDomains) {
+            String accountId = "admin@" + domain;
             ModelTransactionBuilder builder = base().appendRole(accountId, "user");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -764,8 +764,8 @@ public class BuilderTest {
     @Test
     void createAsset() {
         for (String assetName: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedTx tx = builder.createAsset(assetName, host, (short) 6).build();
+            for (String domain: validDomains) {
+                UnsignedTx tx = builder.createAsset(assetName, domain, (short) 6).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -781,8 +781,8 @@ public class BuilderTest {
 
     @Test
     void createAssetWithInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().createAsset("asset", host, (short) 6);
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().createAsset("asset", domain, (short) 6);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -866,8 +866,8 @@ public class BuilderTest {
     @Test
     void detachRole() {
         for (String name: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = name + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = name + "@" + domain;
                 UnsignedTx tx = builder.detachRole(accountId, name).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -885,8 +885,8 @@ public class BuilderTest {
 
     @Test
     void detachRoleInvalidDomain() {
-        for (String host: invalidHosts) {
-            String accountId = "admin@" + host;
+        for (String domain: invalidDomains) {
+            String accountId = "admin@" + domain;
             ModelTransactionBuilder builder = base().detachRole(accountId, "role");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
@@ -911,8 +911,8 @@ public class BuilderTest {
     @Test
     void grantPermission() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 UnsignedTx tx = builder.grantPermission(accountId, "can_set_my_quorum").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
@@ -922,8 +922,8 @@ public class BuilderTest {
     @Test
     void grantPermissionInvalidAccount() {
         for (String accountName: invalidNameSymbols1) {
-            for (String host: validHosts) {
-                String accountId = accountName + "@" + host;
+            for (String domain: validDomains) {
+                String accountId = accountName + "@" + domain;
                 ModelTransactionBuilder builder = base().grantPermission(accountId, "can_set_my_quorum");
                 assertThrows(IllegalArgumentException.class, builder::build);
             }
@@ -955,8 +955,8 @@ public class BuilderTest {
     @Test
     void revokePermission() {
         for (String accountName: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedTx tx = builder.revokePermission(accountName + "@" + host, "can_set_my_quorum").build();
+            for (String domain: validDomains) {
+                UnsignedTx tx = builder.revokePermission(accountName + "@" + domain, "can_set_my_quorum").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -972,8 +972,8 @@ public class BuilderTest {
 
     @Test
     void revokePermissionInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().revokePermission("admin@" + host, "can_set_my_quorum");
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().revokePermission("admin@" + domain, "can_set_my_quorum");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -1003,8 +1003,8 @@ public class BuilderTest {
     @Test
     void subtractAssetQuantity() {
         for (String name: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedTx tx = builder.subtractAssetQuantity(name + "@" + host, name + "#" + host, "10.22").build();
+            for (String domain: validDomains) {
+                UnsignedTx tx = builder.subtractAssetQuantity(name + "@" + domain, name + "#" + domain, "10.22").build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -1020,8 +1020,8 @@ public class BuilderTest {
 
     @Test
     void subtractAssetQuantityInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@" + host, "coin#test", "10");
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@" + domain, "coin#test", "10");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -1036,8 +1036,8 @@ public class BuilderTest {
 
     @Test
     void subtractAssetQuantityInvalidAssetDomain() {
-        for (String host: invalidHosts) {
-            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", "coin#" + host, "10");
+        for (String domain: invalidDomains) {
+            ModelTransactionBuilder builder = base().subtractAssetQuantity("admin@test", "coin#" + domain, "10");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -830,6 +830,11 @@ public class BuilderTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
+    /* Disabled till IR-1267 will be fixed. */
+    /* Please run this test on mac host after enabling,
+       because the test was passing on Linux host and failing on macOs.
+    */
+    @Disabled
     @Test
     void createRoleWrongPermissions() {
         StringVector permissions = new StringVector();

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -936,6 +936,10 @@ public class BuilderTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
+    // TODO igor-egorov, 14.05.2018 IR-1267
+    // Please test using clang on macOS before enabling
+    // This test does not fail on Linux with GCC 5.4.0
+    @Disabled
     @Test
     void grantPermissionWithInvalidName() {
         String permissions[] = {
@@ -984,6 +988,10 @@ public class BuilderTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
+    // TODO igor-egorov, 14.05.2018 IR-1267
+    // Please test using clang on macOS before enabling
+    // This test does not fail on Linux with GCC 5.4.0
+    @Disabled
     @Test
     void revokePermissionWithInvalidName() {
         String permissions[] = {

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -1,3 +1,8 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.math.BigInteger;
 
@@ -27,46 +28,70 @@ public class QueryTest {
     private Keypair keys;
     private ModelQueryBuilder builder;
 
+    // Symbols of type 1 (format [a-z_0-9]{1,32}) are used
+    // as account_name, asset_name and role_id.
+    private final String[] validNameSymbols1 = {
+        "a",
+        "asset",
+        "234234",
+        "_",
+        "_123",
+        "123_23",
+        "234asset_",
+        "__",
+        "12345678901234567890123456789012"
+    };
+    private final String[] invalidNameSymbols1 = {
+        "",
+        "A",
+        "assetV",
+        "asSet",
+        "asset%",
+        "^123",
+        "verylongassetname_thenameislonger",
+        "verylongassetname_thenameislongerthanitshouldbe",
+        "assset-01"
+    };
+
+    // Symbols of type 2 (format [A-Za-z0-9_]{1,64})
+    // are used as key identifier for setAccountDetail command
+    private final String[] validNameSymbols2 = {
+        "a",
+        "A",
+        "1",
+        "_",
+        "Key",
+        "Key0_",
+        "verylongAndValidKeyName___1110100010___veryveryveryverylongvalid"
+    };
+    private final String[] invalidNameSymbols2 = {
+        "",
+        "Key&",
+        "key-30",
+        "verylongAndValidKeyName___1110100010___veryveryveryverylongvalid1",
+        "@@@"
+    };
+
+    private final String[] invalidHosts = {
+        "257.257.257.257",
+        "host#host",
+        "asd@asd",
+        "ab..cd",
+        "",
+        "   "
+    };
+
+    private final String[] invalidKeysBytes = {
+        "",
+        "a",
+        "1111111111111111111111111111111",
+        "111111111111111111111111111111111"
+    };
+
     ModelQueryBuilder base() {
         return new ModelQueryBuilder().queryCounter(BigInteger.valueOf(123))
                 .createdTime(BigInteger.valueOf(System.currentTimeMillis()))
                 .creatorAccountId("admin@test");
-    }
-
-    void setGetAccount() {
-        builder.getAccount("user@test");
-    }
-
-    @BeforeEach
-    void setUp() {
-        keys = new ModelCrypto().generateKeypair();
-        builder = base();
-    }
-
-    @Test
-    void emptyQuery() {
-        ModelQueryBuilder builder = new ModelQueryBuilder();
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    @Test
-    void outdatedAddPeer() {
-        setGetAccount();
-        for (BigInteger i : new BigInteger[]{BigInteger.valueOf(0),
-                BigInteger.valueOf(System.currentTimeMillis() - 100_000_000),
-                BigInteger.valueOf(System.currentTimeMillis() + 1000)}) {
-            builder.createdTime(i);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
-    }
-
-    @Test
-    void getAccountWithInvalidCreator() {
-        setGetAccount();
-        for (String i : new String[]{"", "invalid", "@invalid", "invalid@"}) {
-            builder.creatorAccountId(i);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
     }
 
     Blob proto(UnsignedQuery query) {
@@ -96,35 +121,258 @@ public class QueryTest {
         return true;
     }
 
+    void setGetAccount() {
+        builder.getAccount("user@test");
+    }
+
+    @BeforeEach
+    void setUp() {
+        keys = new ModelCrypto().generateKeypair();
+        builder = base();
+    }
+
+    @Test
+    void emptyQuery() {
+        ModelQueryBuilder builder = new ModelQueryBuilder();
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetAccount Tests ====================== */
+
+
+    @Test
+    void outdatedGetAccount() {
+        setGetAccount();
+        for (BigInteger i : new BigInteger[]{BigInteger.valueOf(0),
+                BigInteger.valueOf(System.currentTimeMillis() - 100_000_000),
+                BigInteger.valueOf(System.currentTimeMillis() + 1000)}) {
+            builder.createdTime(i);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountWithInvalidCreator() {
+        setGetAccount();
+        for (String accountName: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().creatorAccountId(accountName + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountWithInvalidCreatorDomain() {
+        setGetAccount();
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().creatorAccountId("user@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountWithEmptyCreator() {
+        setGetAccount();
+        builder.creatorAccountId("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
     @Test
     void getAccount() {
-        UnsignedQuery query = builder.getAccount("user@test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String accountName: validNameSymbols1) {
+            UnsignedQuery query = builder.getAccount(accountName + "@test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
     }
+
+    @Test
+    void getAccountWithInvalidName() {
+        for (String accountName: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccount(accountName + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountWithInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccount("admin@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== GetSignatories Tests ====================== */
 
     @Test
     void getSignatories() {
-        UnsignedQuery query = builder.getSignatories("user@test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String account: validNameSymbols1) {
+            UnsignedQuery query = builder.getSignatories(account + "@test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
     }
+
+    @Test
+    void getSignatoriesInvalidAccount() {
+        for (String account: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getSignatories(account + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getSignatoriesEmptyAccount() {
+        builder.getSignatories("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void getSignatoriesInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getSignatories("user@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    /* ====================== GetAccountTransactions Tests ====================== */
 
     @Test
     void getAccountTransactions() {
-        UnsignedQuery query = builder.getAccountTransactions("user@test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String account: validNameSymbols1) {
+            UnsignedQuery query = builder.getAccountTransactions(account + "@test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
     }
+
+    @Test
+    void getAccountTransactionsInvalidName() {
+        for (String account: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountTransactions(account + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountTransactionsInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountTransactions("user@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountTransactionsEmptyAccount() {
+        ModelQueryBuilder builder = base().getAccountTransactions("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetAccountAssetTransactions Tests ====================== */
 
     @Test
     void getAccountAssetTransactions() {
-        UnsignedQuery query = builder.getAccountAssetTransactions("user@test", "coin#test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String name: validNameSymbols1) {
+            UnsignedQuery query = builder.getAccountAssetTransactions(name + "@test", name + "#test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
     }
 
     @Test
-    void getAccountAssets() {
-        UnsignedQuery query = builder.getAccountAssets("user@test", "coin#test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+    void getAccountAssetTransactionsInvalidAccountName() {
+        for (String account: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions(account + "@test", "coin#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
     }
+
+    @Test
+    void getAccountAssetTransactionsInvalidAccountDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@" + host, "coin#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetTransactionsEmptyAccount() {
+        ModelQueryBuilder builder = base().getAccountAssetTransactions("", "coin#test");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void getAccountAssetTransactionsInvalidAssetName() {
+        for (String asset: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@test", asset + "#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetTransactionsInvalidAssetDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@test", "coin#" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetTransactionsEmptyAsset() {
+        ModelQueryBuilder builder = base().getAccountAssetTransactions("user@test", "");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetAccountAssets Tests ====================== */
+
+    @Test
+    void getAccountAssets() {
+        for (String name: validNameSymbols1) {
+            UnsignedQuery query = builder.getAccountAssets(name + "@test", name + "#test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
+    }
+
+    @Test
+    void getAccountAssetsWithInvalidAccountName() {
+        for (String account: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountAssets(account + "@test", "coin#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetsWithInvalidAccountDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountAssets("user@" + host, "coin#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetsWithEmptyAccount() {
+        ModelQueryBuilder builder = base().getAccountAssets("", "coin#test");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void getAccountAssetsWithInvalidAssetName() {
+        for (String asset: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountAssets("user@test", asset + "#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetsWithInvalidAssetDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountAssets("user@test", "coin#" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountAssetsWithEmptyAsset() {
+        ModelQueryBuilder builder = base().getAccountAssets("user@test", "");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetRoles Tests ====================== */
 
     @Test
     void getRoles() {
@@ -132,17 +380,63 @@ public class QueryTest {
         assertTrue(checkProtoQuery(proto(query)));
     }
 
+    /* ====================== GetAssetInfo Tests ====================== */
+
     @Test
     void getAssetInfo() {
-        UnsignedQuery query = builder.getAssetInfo("coin#test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String asset: validNameSymbols1) {
+            UnsignedQuery query = builder.getAssetInfo(asset + "#test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
     }
 
     @Test
-    void getRolePermissions() {
-        UnsignedQuery query = builder.getRolePermissions("user").build();
-        assertTrue(checkProtoQuery(proto(query)));
+    void getAssetInfoWithInvalidName() {
+        for (String asset: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAssetInfo(asset + "#test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
     }
+
+    @Test
+    void getAssetInfoWithInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAssetInfo("coin#" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAssetInfoWithEmptyName() {
+        ModelQueryBuilder builder = base().getAssetInfo("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetRolePermissions Tests ====================== */
+
+    @Test
+    void getRolePermissions() {
+        for (String role: validNameSymbols1) {
+            UnsignedQuery query = builder.getRolePermissions(role).build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
+    }
+
+    @Test
+    void getRolePermissionsWithInvalidName() {
+        for (String role: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getRolePermissions(role);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getRolePermissionsWithEmptyName() {
+        ModelQueryBuilder builder = base().getRolePermissions("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetTransactions Tests ====================== */
 
     @Test
     void getTransactions() {
@@ -156,9 +450,88 @@ public class QueryTest {
         assertTrue(checkProtoQuery(proto(query)));
     }
 
+    // The following four tests are disabled because there is a need to
+    // clarify desired behavior.
+    @Disabled
+    @Test
+    void getTransactionsWithEmptyVector() {
+        ModelQueryBuilder builder = base().getTransactions(new HashVector());
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Disabled
+    @Test
+    void getTransactionsWithInvalidHashSizes() {
+        String hashes[] = {
+            "",
+            "1",
+            "1234567890123456789012345678901",
+            "123456789012345678901234567890123"
+        };
+
+        for (String hash: hashes) {
+            HashVector hv = new HashVector();
+            hv.add(new Hash(hash));
+            ModelQueryBuilder builder = base().getTransactions(hv);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Disabled
+    @Test
+    void getTransactionsWithOneValidAndOneInvalidHash1() {
+        Hash valid = new Hash("12345678901234567890123456789012");
+        Hash invalid = new Hash("1");
+
+        HashVector hv = new HashVector();
+        hv.add(valid);
+        hv.add(invalid);
+        ModelQueryBuilder builder = base().getTransactions(hv);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Disabled
+    @Test
+    void getTransactionsWithOneValidAndOneInvalidHash2() {
+        Hash valid = new Hash("12345678901234567890123456789012");
+        Hash invalid = new Hash("1");
+
+        HashVector hv = new HashVector();
+        hv.add(invalid);
+        hv.add(valid);
+        ModelQueryBuilder builder = base().getTransactions(hv);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    /* ====================== GetAccountDetail Tests ====================== */
+
     @Test
     void getAccountDetail() {
-        UnsignedQuery query = builder.getAccountDetail("user@test").build();
-        assertTrue(checkProtoQuery(proto(query)));
+        for (String account: validNameSymbols1) {
+            UnsignedQuery query = builder.getAccountDetail(account + "@test").build();
+            assertTrue(checkProtoQuery(proto(query)));
+        }
+    }
+
+    @Test
+    void getAccountDetailWithInvalidName() {
+        for (String account: invalidNameSymbols1) {
+            ModelQueryBuilder builder = base().getAccountDetail(account + "@test");
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountDetailWithInvalidDomain() {
+        for (String host: invalidHosts) {
+            ModelQueryBuilder builder = base().getAccountDetail("user@" + host);
+            assertThrows(IllegalArgumentException.class, builder::build);
+        }
+    }
+
+    @Test
+    void getAccountDetailWithEmptyName() {
+        ModelQueryBuilder builder = base().getAccountDetail("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 }

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -77,13 +77,37 @@ public class QueryTest {
         "@@@"
     };
 
+    private final String[] validHosts = {
+        "test",
+        "u9EEA432F",
+        "a-hyphen",
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad",
+        "endWith0",
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad"
+    };
+
     private final String[] invalidHosts = {
+        "",
+        " ",
+        "   ",
+        "9start.with.digit",
+        "-startWithDash",
+        "@.is.not.allowed",
+        "no space is allowed",
+        "endWith-",
+        "label.endedWith-.is.not.allowed",
+        "aLabelMustNotExceeds63charactersALabelMustNotExceeds63characters",
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
+        "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPadP",
         "257.257.257.257",
         "host#host",
         "asd@asd",
-        "ab..cd",
-        "",
-        "   "
+        "ab..cd"
     };
 
     private final String[] invalidKeysBytes = {
@@ -160,8 +184,10 @@ public class QueryTest {
     void getAccountWithInvalidCreator() {
         setGetAccount();
         for (String accountName: invalidNameSymbols1) {
-            ModelQueryBuilder builder = base().creatorAccountId(accountName + "@test");
-            assertThrows(IllegalArgumentException.class, builder::build);
+            for (String host: validHosts) {
+                ModelQueryBuilder builder = base().creatorAccountId(accountName + "@" + host);
+                assertThrows(IllegalArgumentException.class, builder::build);
+            }
         }
     }
 
@@ -210,8 +236,10 @@ public class QueryTest {
     @Test
     void getSignatories() {
         for (String account: validNameSymbols1) {
-            UnsignedQuery query = builder.getSignatories(account + "@test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getSignatories(account + "@" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 
@@ -242,8 +270,10 @@ public class QueryTest {
     @Test
     void getAccountTransactions() {
         for (String account: validNameSymbols1) {
-            UnsignedQuery query = builder.getAccountTransactions(account + "@test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getAccountTransactions(account + "@" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 
@@ -274,8 +304,10 @@ public class QueryTest {
     @Test
     void getAccountAssetTransactions() {
         for (String name: validNameSymbols1) {
-            UnsignedQuery query = builder.getAccountAssetTransactions(name + "@test", name + "#test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getAccountAssetTransactions(name + "@" + host, name + "#" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 
@@ -328,8 +360,10 @@ public class QueryTest {
     @Test
     void getAccountAssets() {
         for (String name: validNameSymbols1) {
-            UnsignedQuery query = builder.getAccountAssets(name + "@test", name + "#test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getAccountAssets(name + "@" + host, name + "#" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 
@@ -390,8 +424,10 @@ public class QueryTest {
     @Test
     void getAssetInfo() {
         for (String asset: validNameSymbols1) {
-            UnsignedQuery query = builder.getAssetInfo(asset + "#test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getAssetInfo(asset + "#" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 
@@ -517,8 +553,10 @@ public class QueryTest {
     @Test
     void getAccountDetail() {
         for (String account: validNameSymbols1) {
-            UnsignedQuery query = builder.getAccountDetail(account + "@test").build();
-            assertTrue(checkProtoQuery(proto(query)));
+            for (String host: validHosts) {
+                UnsignedQuery query = builder.getAccountDetail(account + "@" + host).build();
+                assertTrue(checkProtoQuery(proto(query)));
+            }
         }
     }
 

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -77,7 +77,7 @@ public class QueryTest {
         "@@@"
     };
 
-    private final String[] validHosts = {
+    private final String[] validDomains = {
         "test",
         "u9EEA432F",
         "a-hyphen",
@@ -89,7 +89,7 @@ public class QueryTest {
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad"
     };
 
-    private final String[] invalidHosts = {
+    private final String[] invalidDomains = {
         "",
         " ",
         "   ",
@@ -105,7 +105,7 @@ public class QueryTest {
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad." +
         "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPadP",
         "257.257.257.257",
-        "host#host",
+        "domain#domain",
         "asd@asd",
         "ab..cd"
     };
@@ -184,8 +184,8 @@ public class QueryTest {
     void getAccountWithInvalidCreator() {
         setGetAccount();
         for (String accountName: invalidNameSymbols1) {
-            for (String host: validHosts) {
-                ModelQueryBuilder builder = base().creatorAccountId(accountName + "@" + host);
+            for (String domain: validDomains) {
+                ModelQueryBuilder builder = base().creatorAccountId(accountName + "@" + domain);
                 assertThrows(IllegalArgumentException.class, builder::build);
             }
         }
@@ -194,8 +194,8 @@ public class QueryTest {
     @Test
     void getAccountWithInvalidCreatorDomain() {
         setGetAccount();
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().creatorAccountId("user@" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().creatorAccountId("user@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -225,8 +225,8 @@ public class QueryTest {
 
     @Test
     void getAccountWithInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccount("admin@" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccount("admin@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -236,8 +236,8 @@ public class QueryTest {
     @Test
     void getSignatories() {
         for (String account: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getSignatories(account + "@" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getSignatories(account + "@" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -259,8 +259,8 @@ public class QueryTest {
 
     @Test
     void getSignatoriesInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getSignatories("user@" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getSignatories("user@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -270,8 +270,8 @@ public class QueryTest {
     @Test
     void getAccountTransactions() {
         for (String account: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getAccountTransactions(account + "@" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getAccountTransactions(account + "@" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -287,8 +287,8 @@ public class QueryTest {
 
     @Test
     void getAccountTransactionsInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountTransactions("user@" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountTransactions("user@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -304,8 +304,8 @@ public class QueryTest {
     @Test
     void getAccountAssetTransactions() {
         for (String name: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getAccountAssetTransactions(name + "@" + host, name + "#" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getAccountAssetTransactions(name + "@" + domain, name + "#" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -321,8 +321,8 @@ public class QueryTest {
 
     @Test
     void getAccountAssetTransactionsInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@" + host, "coin#test");
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@" + domain, "coin#test");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -343,8 +343,8 @@ public class QueryTest {
 
     @Test
     void getAccountAssetTransactionsInvalidAssetDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@test", "coin#" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountAssetTransactions("user@test", "coin#" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -360,8 +360,8 @@ public class QueryTest {
     @Test
     void getAccountAssets() {
         for (String name: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getAccountAssets(name + "@" + host, name + "#" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getAccountAssets(name + "@" + domain, name + "#" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -377,8 +377,8 @@ public class QueryTest {
 
     @Test
     void getAccountAssetsWithInvalidAccountDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountAssets("user@" + host, "coin#test");
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountAssets("user@" + domain, "coin#test");
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -399,8 +399,8 @@ public class QueryTest {
 
     @Test
     void getAccountAssetsWithInvalidAssetDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountAssets("user@test", "coin#" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountAssets("user@test", "coin#" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -424,8 +424,8 @@ public class QueryTest {
     @Test
     void getAssetInfo() {
         for (String asset: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getAssetInfo(asset + "#" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getAssetInfo(asset + "#" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -441,8 +441,8 @@ public class QueryTest {
 
     @Test
     void getAssetInfoWithInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAssetInfo("coin#" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAssetInfo("coin#" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -553,8 +553,8 @@ public class QueryTest {
     @Test
     void getAccountDetail() {
         for (String account: validNameSymbols1) {
-            for (String host: validHosts) {
-                UnsignedQuery query = builder.getAccountDetail(account + "@" + host).build();
+            for (String domain: validDomains) {
+                UnsignedQuery query = builder.getAccountDetail(account + "@" + domain).build();
                 assertTrue(checkProtoQuery(proto(query)));
             }
         }
@@ -570,8 +570,8 @@ public class QueryTest {
 
     @Test
     void getAccountDetailWithInvalidDomain() {
-        for (String host: invalidHosts) {
-            ModelQueryBuilder builder = base().getAccountDetail("user@" + host);
+        for (String domain: invalidDomains) {
+            ModelQueryBuilder builder = base().getAccountDetail("user@" + domain);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -1,3 +1,8 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -457,6 +457,7 @@ public class QueryTest {
 
     // The following four tests are disabled because there is a need to
     // clarify desired behavior.
+    // TODO igor-egorov, 08.05.2018, IR-1322
     @Disabled
     @Test
     void getTransactionsWithEmptyVector() {
@@ -464,6 +465,7 @@ public class QueryTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
+    // TODO igor-egorov, 08.05.2018, IR-1325
     @Disabled
     @Test
     void getTransactionsWithInvalidHashSizes() {
@@ -482,6 +484,7 @@ public class QueryTest {
         }
     }
 
+    // TODO igor-egorov, 08.05.2018, IR-1325
     @Disabled
     @Test
     void getTransactionsWithOneValidAndOneInvalidHash1() {
@@ -495,6 +498,7 @@ public class QueryTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
+    // TODO igor-egorov, 08.05.2018, IR-1325
     @Disabled
     @Test
     void getTransactionsWithOneValidAndOneInvalidHash2() {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Add new tests for Iroha Java bindings. 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

New test set cover building of Iroha's queries and commands. Each parameter of either command or query is tested separately from other parameters for boundary values (in a moment only one method's parameter takes invalid value - the rest are provided with valid values).

The total number of tests for commands is 96, queries - 47.

| Iroha Command | Tests |
| --- | --- |
| | emptyTx |
| **AddPeer** | addPeer<br/> outdatedAddPeer<br/> addPeerWithInvalidCreator<br/> addPeerWithEmptyCreator<br/> addPeerWithInvalidCreatorDomain<br/> addPeerWithInvalidKeySize<br/> addPeerWithInvalidHost |
| **AddSignatory** | addSignatory<br/> addSignatoryInvalidAccountName<br/> addSignatoryEmptyAccountId<br/> addSignatoryInvalidDomain<br/> addSignatoryInvalidKey |
| **AddAssetQuantity** | addAssetQuantity<br/> addAssetQuantityValidAccountsAndAssets<br/> addAssetQuantityInvalidAccountDomain<br/> addAssetQuantityInvalidAssetDomain<br/> addAssetZeroQuantity<br/> addAssetQuantityInvalidAccountName<br/> addAssetQuantityEmptyAccount<br/> addAssetQuantityInvalidAssetName<br/> addAssetQuantityEmptyAsset<br/> addAssetQuantityInvalidAmount |
| **RemoveSignatory** | removeSignatory<br/> removeSignatoryEmptyAccount<br/> removeSignatoryInvalidAccount<br/> removeSignatoryInvalidAccountDomain<br/> removeSignatoryInvalidKey |
| **CreateAccount** | createAccount<br/> createAccountInvalidAccountName<br/> createAccountInvalidDomain<br/> createAccountInvalidKey |
| **CreateDomain** | createDomain<br/> createDomainInvalidHost<br/> createDomainInvalidRole |
| **SetAccountQuorum** | setAccountQuorum<br/> setAccountQuorumInvalidAccount<br/> setAccountQuorumInvalidDomain<br/> setAccountQuorumEmptyAccount<br/> setAccountQuorumInvalidQuantity |
| **TransferAsset** | transferAsset<br/> transferAssetWithValidName<br/> transferAssetWithInvalidName<br/> transferAssetWithInvalidFromAccount<br/> transferAssetWithInvalidToAccount<br/> transferAssetWithEmptyFromAccount<br/> transferAssetWithEmptyToAccount<br/> transferAssetWithInvalidFromHost<br/> transferAssetWithInvalidToHost<br/> transferAssetWithInvalidAssetDomain<br/> transferAssetWithEmptyAssetName<br/> transferAssetDescriptionBoundaryValues<br/> transferAssetMaximumAmount |
| **SetAccountDetail** | setAccountDetail<br/> setAccountDetailInvalidAccount<br/> setAccountDetailEmptyAccount<br/> setAccountDetailInvalidAccountDomain<br/> setAccountDetailValidKey<br/> setAccountDetailInvalidKey<br/> setAccountDetailValidValue<br/> setAccountDetailWithOversizedValue |
| **AppendRole** | appendRole<br/> appendRoleInvalidAccount<br/> appendRoleInvalidDomain<br/> appendRoleWithInvalidName |
| **CreateAsset** | createAsset<br/> createAssetWithInvalidName<br/> createAssetWithInvalidDomain<br/> createAssetWithZeroPrecision |
| **CreateRole** | createRole<br/> createRoleWithInvalidName<br/> createRoleEmptyPermissions<br/> createRoleWrongPermissions<br/> createRoleWrongPermissions2 |
| **DetachRole** | detachRole<br/> detachRoleInvalidAccountName<br/> detachRoleInvalidDomain<br/> detachRoleWithEmptyAccount<br/> detachRoleWithInvalidName |
| **GrantPermission** | grantPermission<br/> grantPermissionInvalidAccount<br/> grantPermissionEmptyAccount<br/> grantPermissionWithInvalidName |
| **RevokePermission** | revokePermission<br/> revokePermissionInvalidAccount<br/> revokePermissionInvalidDomain<br/> revokePermissionEmptyAccount<br/> revokePermissionWithInvalidName |
| **SubtractAssetQuantity** | subtractAssetQuantity<br/> subtractAssetQuantityInvalidAccount<br/> subtractAssetQuantityInvalidAccountDomain<br/> subtractAssetQuantityInvalidAsset<br/> subtractAssetQuantityInvalidAssetDomain<br/> subtractAssetQuantityEmptyAccount<br/> subtractAssetQuantityEmptyAsset<br/> subtractAssetQuantityInvalidAmount |


| Iroha Query | Tests |
| --- | --- |
| | emptyQuery |
| **GetAccount** | outdatedGetAccount<br/> getAccountWithInvalidCreator<br/> getAccountWithInvalidCreatorDomain<br/> getAccountWithEmptyCreator<br/> getAccount<br/> getAccountWithInvalidName<br/> getAccountWithInvalidDomain |
| **GetSignatories** | getSignatories<br/> getSignatoriesInvalidAccount<br/> getSignatoriesEmptyAccount<br/> getSignatoriesInvalidDomain |
| **GetAccountTransactions** | getAccountTransactions<br/> getAccountTransactionsInvalidName<br/> getAccountTransactionsInvalidDomain<br/> getAccountTransactionsEmptyAccount |
| **GetAccountAssetTransactions** | getAccountAssetTransactions<br/> getAccountAssetTransactionsInvalidAccountName<br/> getAccountAssetTransactionsInvalidAccountDomain<br/> getAccountAssetTransactionsEmptyAccount<br/> getAccountAssetTransactionsInvalidAssetName<br/> getAccountAssetTransactionsInvalidAssetDomain<br/> getAccountAssetTransactionsEmptyAsset |
| **GetAccountAssets** | getAccountAssets<br/> getAccountAssetsWithInvalidAccountName<br/> getAccountAssetsWithInvalidAccountDomain<br/> getAccountAssetsWithEmptyAccount<br/> getAccountAssetsWithInvalidAssetName<br/> getAccountAssetsWithInvalidAssetDomain<br/> getAccountAssetsWithEmptyAsset |
| **GetRoles** | getRoles |
| **GetAssetInfo** | getAssetInfo<br/> getAssetInfoWithInvalidName<br/> getAssetInfoWithInvalidDomain<br/> getAssetInfoWithEmptyName |
| **GetRolePermissions** | getRolePermissions<br/> getRolePermissionsWithInvalidName<br/> getRolePermissionsWithEmptyName |
| **GetTransactions** | getTransactions<br/> getTransactionsWithEmptyVector<br/> getTransactionsWithInvalidHashSizes<br/> getTransactionsWithOneValidAndOneInvalidHash1<br/> getTransactionsWithOneValidAndOneInvalidHash2 |
| **GetAccountDetail** | getAccountDetail<br/> getAccountDetailWithInvalidName<br/> getAccountDetailWithInvalidDomain<br/> getAccountDetailWithEmptyName |



<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Summary tests' compilation and execution time is about 110 seconds.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

```cmake -H. -Bbuild -DSWIG_JAVA=ON```
```cmake --build build --target irohajava -- -j4```
```cd build```
```ctest -R java --output-on-failure```

