### PR TITLE
[Bug] Segmentation Fault on Negative Precision for CLI

### DIFF
--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -226,7 +226,7 @@ namespace iroha_cli {
       auto res = handleParse<std::shared_ptr<iroha::model::Command>>(
           this, line, command_handlers_, command_params_descriptions_);
 
-      if (not res) {
+      if (not *res) {
         // Continue parsing
         return true;
       }
@@ -333,7 +333,7 @@ namespace iroha_cli {
           parser::parseValue<boost::multiprecision::uint256_t>(params[2]);
       auto precision = parser::parseValue<uint32_t>(params[3]);
       if (not val_int or not precision) {
-        std::cout << "Wrong format for amount" << std::endl;
+        std::cout << "Wrong format for amount or precision should be greater than 0" << std::endl;
         return nullptr;
       }
       if (precision.value() > 255) {

--- a/irohad/execution/CMakeLists.txt
+++ b/irohad/execution/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(common_execution
         )
 target_link_libraries(common_execution
         rxcpp
+        boost
         )
 
 add_library(command_execution

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -2,12 +2,17 @@ add_library(libs_common
     files.cpp
     )
 
+add_library(common INTERFACE)
+
+target_include_directories(common INTERFACE
+        ${PROJECT_SOURCE_DIR}/libs/common
+        )
+
 target_link_libraries(libs_common
     logger
+    boost
     )
-target_link_libraries(libs_common boost)
-add_library(common INTERFACE)
-target_include_directories(common INTERFACE
-    ${PROJECT_SOURCE_DIR}/libs/common
-    )
+target_link_libraries(common INTERFACE
+        boost
+        )
 

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(libs_common
 target_link_libraries(libs_common
     logger
     )
-
+target_link_libraries(libs_common boost)
 add_library(common INTERFACE)
 target_include_directories(common INTERFACE
     ${PROJECT_SOURCE_DIR}/libs/common

--- a/libs/parser/CMakeLists.txt
+++ b/libs/parser/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_library(parser STATIC parser.cpp)
-target_link_libraries(parser boost)
+target_link_libraries(parser 
+    boost
+    )

--- a/libs/parser/CMakeLists.txt
+++ b/libs/parser/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(parser STATIC parser.cpp)
+target_link_libraries(parser boost)

--- a/test/module/irohad/common/CMakeLists.txt
+++ b/test/module/irohad/common/CMakeLists.txt
@@ -1,8 +1,8 @@
 AddTest(blob_converter_test blob_converter_test.cpp)
+
 target_link_libraries(blob_converter_test
-    common
-        boost
-    )
+        common
+        )
 
 AddTest(raw_block_loader_test raw_block_loader_test.cpp)
 target_link_libraries(raw_block_loader_test

--- a/test/module/irohad/common/CMakeLists.txt
+++ b/test/module/irohad/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 AddTest(blob_converter_test blob_converter_test.cpp)
 target_link_libraries(blob_converter_test
     common
+        boost
     )
 
 AddTest(raw_block_loader_test raw_block_loader_test.cpp)

--- a/test/module/libs/converter/CMakeLists.txt
+++ b/test/module/libs/converter/CMakeLists.txt
@@ -1,1 +1,3 @@
 addtest(string_converter_test string_converter_test.cpp)
+
+target_link_libraries(string_converter_test boost)

--- a/test/module/libs/converter/CMakeLists.txt
+++ b/test/module/libs/converter/CMakeLists.txt
@@ -1,3 +1,5 @@
 addtest(string_converter_test string_converter_test.cpp)
 
-target_link_libraries(string_converter_test boost)
+target_link_libraries(string_converter_test
+        common
+        )


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Changes made for the issue #1259. 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Segmentation fault on entering wrong values in CLI does not occur

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

1. Open up a new terminal and login to the test domain using the CLI.
2. "Create a new transaction"
3. "Add Asset Quantity"
4. Choose an Account ID, Asset ID, and Amount. (See picture above for example values.)
5. Enter a negative precision amount.
6. Enter peer address and port.


<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
None

<!-- Explain what other alternates were considered and why the proposed version was selected -->
