### PR TITLE
Iroha client returning success with transaction been written to postgres

### DIFF
--- a/iroha-cli/grpc_response_handler.hpp
+++ b/iroha-cli/grpc_response_handler.hpp
@@ -33,7 +33,7 @@ namespace iroha_cli {
      * Handle iroha GRPC TxResponse
      * @param response
      */
-    void handle(CliClient::Response<CliClient::TxStatus> response);
+    bool handle(CliClient::Response<CliClient::TxStatus> response);
     /**
      * Handle Iroha GRPC QueryResponse
      * @param response

--- a/iroha-cli/impl/grpc_response_handler.cpp
+++ b/iroha-cli/impl/grpc_response_handler.cpp
@@ -41,12 +41,15 @@ namespace iroha_cli {
     handler_map_[DATA_LOSS] = "DATA_LOSS";
   }
 
-  void GrpcResponseHandler::handle(
+  bool GrpcResponseHandler::handle(
       CliClient::Response<CliClient::TxStatus> response) {
     if (response.status.ok()) {
       tx_handler_.handle(response.answer);
+        return true ;
     } else {
       handleGrpcErrors(response.status.error_code());
+        std::cout << "Error has occured. Not able to complete transaction" << std::endl ;
+        return false ;
     }
   }
 

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -482,10 +482,12 @@ namespace iroha_cli {
 
       GrpcResponseHandler response_handler;
 
-      response_handler.handle(
-          CliClient(address.value().first, address.value().second).sendTx(tx));
+      if(response_handler.handle(
+          CliClient(address.value().first, address.value().second).sendTx(tx)))
 
-      printTxHash(tx);
+          printTxHash(tx);
+
+
       printEnd();
       // Stop parsing
       return false;


### PR DESCRIPTION
Signed-off-by: Ashwin Balasubramanian <balathinnappan@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Added return type bool to GRPC handler. On success returns true, false otherwise. If true the transaction is complete issue #724 .
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Error codes not handled properly. User will find it difficult to find why the transaction has been cancelled.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
Can be tested by execution of a transaction on iroha-cli.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
Need to handle the error more elaborately.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
