### PR TITLE
Replace builders with test builders, make unique txs by number

### DIFF
--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <boost/range/join.hpp>
@@ -103,14 +91,7 @@ class TransactionProcessorTest : public ::testing::Test {
 TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
   std::vector<shared_model::proto::Transaction> txs;
   for (size_t i = 0; i < proposal_size; i++) {
-    auto &&tx = shared_model::proto::TransactionBuilder()
-                    .createdTime(iroha::time::now())
-                    .creatorAccountId("admin@ru")
-                    .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-                    .build()
-                    .signAndAddSignature(
-                        shared_model::crypto::DefaultCryptoAlgorithmType::
-                            generateKeypair());
+    auto &&tx = TestTransactionBuilder().createdTime(i).build();
     txs.push_back(tx);
     status_map[tx.hash()] =
         status_builder.notReceived().txHash(tx.hash()).build();
@@ -131,11 +112,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
 
   // create proposal and notify about it
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
-      shared_model::proto::ProposalBuilder()
-          .height(2)
-          .createdTime(iroha::time::now())
-          .transactions(txs)
-          .build());
+      TestProposalBuilder().transactions(txs).build());
 
   prop_notifier.get_subscriber().on_next(proposal);
   prop_notifier.get_subscriber().on_completed();
@@ -156,14 +133,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
 TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
   std::vector<shared_model::proto::Transaction> txs;
   for (size_t i = 0; i < proposal_size; i++) {
-    auto &&tx = shared_model::proto::TransactionBuilder()
-                    .createdTime(iroha::time::now())
-                    .creatorAccountId("admin@ru")
-                    .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-                    .build()
-                    .signAndAddSignature(
-                        shared_model::crypto::DefaultCryptoAlgorithmType::
-                            generateKeypair());
+    auto &&tx = TestTransactionBuilder().createdTime(i).build();
     txs.push_back(tx);
     status_map[tx.hash()] =
         status_builder.notReceived().txHash(tx.hash()).build();
@@ -186,21 +156,12 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
 
   // 1. Create proposal and notify transaction processor about it
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
-      shared_model::proto::ProposalBuilder()
-          .height(2)
-          .createdTime(iroha::time::now())
-          .transactions(txs)
-          .build());
+      TestProposalBuilder().transactions(txs).build());
 
   prop_notifier.get_subscriber().on_next(proposal);
   prop_notifier.get_subscriber().on_completed();
 
-  auto block = TestBlockBuilder()
-                   .height(1)
-                   .createdTime(iroha::time::now())
-                   .transactions(txs)
-                   .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
-                   .build();
+  auto block = TestBlockBuilder().transactions(txs).build();
 
   // 2. Create block and notify transaction processor about it
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
@@ -230,14 +191,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
 TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
   std::vector<shared_model::proto::Transaction> txs;
   for (size_t i = 0; i < proposal_size; i++) {
-    auto &&tx = shared_model::proto::TransactionBuilder()
-                    .createdTime(iroha::time::now())
-                    .creatorAccountId("admin@ru")
-                    .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-                    .build()
-                    .signAndAddSignature(
-                        shared_model::crypto::DefaultCryptoAlgorithmType::
-                            generateKeypair());
+    auto &&tx = TestTransactionBuilder().createdTime(i).build();
     txs.push_back(tx);
     status_map[tx.hash()] =
         status_builder.notReceived().txHash(tx.hash()).build();
@@ -261,21 +215,12 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
 
   // 1. Create proposal and notify transaction processor about it
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
-      shared_model::proto::ProposalBuilder()
-          .height(2)
-          .createdTime(iroha::time::now())
-          .transactions(txs)
-          .build());
+      TestProposalBuilder().transactions(txs).build());
 
   prop_notifier.get_subscriber().on_next(proposal);
   prop_notifier.get_subscriber().on_completed();
 
-  auto block = TestBlockBuilder()
-                   .height(1)
-                   .createdTime(iroha::time::now())
-                   .transactions(txs)
-                   .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
-                   .build();
+  auto block = TestBlockBuilder().transactions(txs).build();
 
   // 2. Create block and notify transaction processor about it
   Commit single_commit = rxcpp::observable<>::just(
@@ -300,14 +245,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
 TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
   std::vector<shared_model::proto::Transaction> block_txs;
   for (size_t i = 0; i < block_size; i++) {
-    auto &&tx = shared_model::proto::TransactionBuilder()
-                    .createdTime(iroha::time::now())
-                    .creatorAccountId("admin@ru")
-                    .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-                    .build()
-                    .signAndAddSignature(
-                        shared_model::crypto::DefaultCryptoAlgorithmType::
-                            generateKeypair());
+    auto &&tx = TestTransactionBuilder().createdTime(i).build();
     block_txs.push_back(tx);
     status_map[tx.hash()] =
         status_builder.notReceived().txHash(tx.hash()).build();
@@ -317,14 +255,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
       invalid_txs;  // transactions will be stateful invalid if appeared
                     // in proposal but didn't appear in block
   for (size_t i = block_size; i < proposal_size; i++) {
-    auto &&tx = shared_model::proto::TransactionBuilder()
-                    .createdTime(iroha::time::now())
-                    .creatorAccountId("admin@ru")
-                    .addAssetQuantity("admin@tu", "coin#coin", "1.0")
-                    .build()
-                    .signAndAddSignature(
-                        shared_model::crypto::DefaultCryptoAlgorithmType::
-                            generateKeypair());
+    auto &&tx = TestTransactionBuilder().createdTime(i).build();
     invalid_txs.push_back(tx);
     status_map[tx.hash()] =
         status_builder.notReceived().txHash(tx.hash()).build();
@@ -346,21 +277,14 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
   });
 
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
-      shared_model::proto::ProposalBuilder()
-          .height(2)
-          .createdTime(iroha::time::now())
+      TestProposalBuilder()
           .transactions(boost::join(block_txs, invalid_txs))
           .build());
 
   prop_notifier.get_subscriber().on_next(proposal);
   prop_notifier.get_subscriber().on_completed();
 
-  auto block = TestBlockBuilder()
-                   .height(1)
-                   .createdTime(iroha::time::now())
-                   .transactions(block_txs)
-                   .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
-                   .build();
+  auto block = TestBlockBuilder().transactions(block_txs).build();
 
   Commit single_commit = rxcpp::observable<>::just(
       std::shared_ptr<shared_model::interface::Block>(clone(block)));


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix instabilities in tx processor test due to `iroha::time::now()` calls returning same time between iterations.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Deterministic tx processor test.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->