### PR TITLE
Add GetAccountAssetTransactions handler to the CLI

### DIFF
--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -40,6 +40,7 @@ namespace iroha_cli {
       description_map_ = {
           {GET_ACC, "Get Account Information"},
           {GET_ACC_AST, "Get Account's Assets"},
+          {GET_ACC_AST_TX, "Get Account's Asset Transactions"},
           {GET_ACC_TX, "Get Account's Transactions"},
           {GET_TX, "Get Transactions by transactions' hashes"},
           {GET_ACC_SIGN, "Get Account's Signatories"},
@@ -57,6 +58,7 @@ namespace iroha_cli {
       query_params_descriptions_ = {
           {GET_ACC, {acc_id}},
           {GET_ACC_AST, {acc_id, ast_id}},
+          {GET_ACC_AST_TX, {acc_id, ast_id}},
           {GET_ACC_TX, {acc_id}},
           {GET_TX, {tx_hashes}},
           {GET_ACC_SIGN, {acc_id}},
@@ -69,6 +71,7 @@ namespace iroha_cli {
       query_handlers_ = {
           {GET_ACC, &InteractiveQueryCli::parseGetAccount},
           {GET_ACC_AST, &InteractiveQueryCli::parseGetAccountAssets},
+          {GET_ACC_AST_TX, &InteractiveQueryCli::parseGetAccountAssetTransactions},
           {GET_ACC_TX, &InteractiveQueryCli::parseGetAccountTransactions},
           {GET_TX, &InteractiveQueryCli::parseGetTransactions},
           {GET_ACC_SIGN, &InteractiveQueryCli::parseGetSignatories},
@@ -178,6 +181,14 @@ namespace iroha_cli {
       auto account_id = params[0];
       auto asset_id = params[1];
       return generator_.generateGetAccountAssets(
+          local_time_, creator_, counter_, account_id, asset_id);
+    }
+
+    std::shared_ptr<iroha::model::Query>
+    InteractiveQueryCli::parseGetAccountAssetTransactions(QueryParams params) {
+      auto account_id = params[0];
+      auto asset_id = params[1];
+      return generator_.generateGetAccountAssetTransactions(
           local_time_, creator_, counter_, account_id, asset_id);
     }
 

--- a/iroha-cli/interactive/interactive_query_cli.hpp
+++ b/iroha-cli/interactive/interactive_query_cli.hpp
@@ -79,6 +79,7 @@ namespace iroha_cli {
       // ------ Query handlers -----------
       const std::string GET_ACC = "get_acc";
       const std::string GET_ACC_AST = "get_acc_ast";
+      const std::string GET_ACC_AST_TX = "get_acc_ast_tx";
       const std::string GET_ACC_TX = "get_acc_tx";
       const std::string GET_TX = "get_tx";
       const std::string GET_ACC_SIGN = "get_acc_sign";
@@ -106,6 +107,8 @@ namespace iroha_cli {
       //  --- Specific Query parsers ---
       std::shared_ptr<iroha::model::Query> parseGetAccount(QueryParams params);
       std::shared_ptr<iroha::model::Query> parseGetAccountAssets(
+          QueryParams params);
+      std::shared_ptr<iroha::model::Query> parseGetAccountAssetTransactions(
           QueryParams params);
       std::shared_ptr<iroha::model::Query> parseGetAccountTransactions(
           QueryParams params);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Add _GetAccountAssetTransactions_ handler to `iroha-cli` and update _QueryResponseHandler_ to print more information for Transactions Responses.


### Benefits

<!-- What benefits will be realized by the code change? -->
Makes the CLI a little more complete and improves the output to make transactions a bit more traceable. 

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
None

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None
