### PR TITLE
Automate Docker manifest uploading

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -2,6 +2,7 @@
 
 def doDebugBuild(coverageEnabled=false) {
   def dPullOrBuild = load ".jenkinsci/docker-pull-or-build.groovy"
+  def manifest = load ".jenkinsci/docker-manifest.groovy"
   def parallelism = params.PARALLELISM
   def platform = sh(script: 'uname -m', returnStdout: true).trim()
   // params are always null unless job is started
@@ -19,7 +20,25 @@ def doDebugBuild(coverageEnabled=false) {
                                            "${env.GIT_RAW_BASE_URL}/${env.GIT_COMMIT}/docker/develop/Dockerfile",
                                            "${env.GIT_RAW_BASE_URL}/${env.GIT_PREVIOUS_COMMIT}/docker/develop/Dockerfile",
                                            "${env.GIT_RAW_BASE_URL}/develop/docker/develop/Dockerfile",
-                                           ['PARALLELISM': parallelism])  
+                                           ['PARALLELISM': parallelism])
+  if (GIT_LOCAL_BRANCH == 'develop' && manifest.manifestSupportEnabled()) {
+    manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:develop-build", 
+      ["${DOCKER_REGISTRY_BASENAME}:x86_64-develop-build", 
+       "${DOCKER_REGISTRY_BASENAME}:armv7l-develop-build", 
+       "${DOCKER_REGISTRY_BASENAME}:aarch64-develop-build"])
+    manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:develop-build",
+      [
+        [manifest: "${DOCKER_REGISTRY_BASENAME}:x86_64-develop-build",
+         arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
+        [manifest: "${DOCKER_REGISTRY_BASENAME}:armv7l-develop-build",
+         arch: 'arm', os: 'linux', osfeatures: [], variant: 'v7'],
+        [manifest: "${DOCKER_REGISTRY_BASENAME}:aarch64-develop-build",
+         arch: 'arm64', os: 'linux', osfeatures: [], variant: '']
+      ])
+    withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
+      manifest.manifestPush("${DOCKER_REGISTRY_BASENAME}:develop-build", login, password)
+    }
+  }
   docker.image('postgres:9.5').withRun(""
     + " -e POSTGRES_USER=${env.IROHA_POSTGRES_USER}"
     + " -e POSTGRES_PASSWORD=${env.IROHA_POSTGRES_PASSWORD}"
@@ -74,7 +93,7 @@ def doDebugBuild(coverageEnabled=false) {
           sh """
             sonar-scanner \
               -Dsonar.github.disableInlineComments \
-              -Dsonar.github.repository='hyperledger/iroha' \
+              -Dsonar.github.repository='${DOCKER_REGISTRY_BASENAME}' \
               -Dsonar.analysis.mode=preview \
               -Dsonar.login=${SONAR_TOKEN} \
               -Dsonar.projectVersion=${BUILD_TAG} \

--- a/.jenkinsci/docker-manifest.groovy
+++ b/.jenkinsci/docker-manifest.groovy
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+def manifestSupportEnabled() {
+	def dockerVersion = sh(script: "docker -v", returnStdout: true).trim()
+	def experimentalEnabled = sh(script: "grep -i experimental ~/.docker/config.json", returnStatus: true)
+	return experimentalEnabled == 0 && dockerVersion ==~ /^Docker version 18.*$/
+
+}
+
+def manifestCreate(manifestListName, manifests) {
+	sh "docker manifest create ${manifestListName} ${manifests.join(' ')}"
+}
+
+def manifestAnnotate(manifestListName, manifestsWithFeatures) {
+	manifestsWithFeatures.each {
+		sh """
+			docker manifest annotate ${manifestListName} ${it['manifest']} --arch "${it['arch']}" \
+			--os "${it['os']}" --os-features "${it['osfeatures'].join(',')}" --variant "${it['variant']}"
+		"""
+	}
+}
+
+def manifestPush(manifestListName, dockerRegistryLogin, dockerRegistryPassword) {
+	sh "docker login -u '${dockerRegistryLogin}' -p '${dockerRegistryPassword}'"
+	sh "docker manifest push --purge ${manifestListName}"
+}
+
+return this

--- a/.jenkinsci/docker-pull-or-build.groovy
+++ b/.jenkinsci/docker-pull-or-build.groovy
@@ -29,24 +29,24 @@ def dockerPullOrUpdate(imageName, currentDockerfileURL, previousDockerfileURL, r
     // Worst case scenario. We cannot count on the local cache
     // because Dockerfile may contain apt-get entries that would try to update
     // from invalid (stale) addresses
-    iC = docker.build("hyperledger/iroha:${commit}-${BUILD_NUMBER}", "${buildOptions} --no-cache -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")
+    iC = docker.build("${DOCKER_REGISTRY_BASENAME}:${commit}-${BUILD_NUMBER}", "${buildOptions} --no-cache -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")
   }
   else {
     // first commit in this branch or Dockerfile modified
     if (remoteFilesDiffer(currentDockerfileURL, referenceDockerfileURL)) {
       // if we're lucky to build on the same agent, image will be built using cache
-      iC = docker.build("hyperledger/iroha:${commit}-${BUILD_NUMBER}", "$buildOptions -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")
+      iC = docker.build("${DOCKER_REGISTRY_BASENAME}:${commit}-${BUILD_NUMBER}", "$buildOptions -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")
     }
     else {
       // try pulling image from Dockerhub, probably image is already there
-      def testExitCode = sh(script: "docker pull hyperledger/iroha:${imageName}", returnStatus: true)
+      def testExitCode = sh(script: "docker pull ${DOCKER_REGISTRY_BASENAME}:${imageName}", returnStatus: true)
       if (testExitCode != 0) {
         // image does not (yet) exist on Dockerhub. Build it
-        iC = docker.build("hyperledger/iroha:${commit}-${BUILD_NUMBER}", "$buildOptions --no-cache -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")   
+        iC = docker.build("${DOCKER_REGISTRY_BASENAME}:${commit}-${BUILD_NUMBER}", "$buildOptions --no-cache -f /tmp/${env.GIT_COMMIT}/f1 /tmp/${env.GIT_COMMIT}")   
       }
       else {
         // no difference found compared to both previous and reference Dockerfile
-        iC = docker.image("hyperledger/iroha:${imageName}")
+        iC = docker.image("${DOCKER_REGISTRY_BASENAME}:${imageName}")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
     SORABOT_TOKEN = credentials('SORABOT_TOKEN')
     SONAR_TOKEN = credentials('SONAR_TOKEN')
     GIT_RAW_BASE_URL = "https://raw.githubusercontent.com/hyperledger/iroha"
+    DOCKER_REGISTRY_BASENAME = "hyperledger/iroha"
 
     IROHA_NETWORK = "iroha-0${CHANGE_ID}-${GIT_COMMIT}-${BUILD_NUMBER}"
     IROHA_POSTGRES_HOST = "pg-0${CHANGE_ID}-${GIT_COMMIT}-${BUILD_NUMBER}"


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Introduce automatic updates of Docker manifest file with each push to Docker registry. Previously it was uploaded manually once (`docker/manifest.yaml`) using `manifest-tool` Go-written program. It was considered sufficient and assumed that each successive update of an image under some tag would update its parent reference. Turned out we must reupload manifest file with each push of the tag. Instead of using `manifest-tool` this PR exploits a new feature introduced in Docker 18. It allows to manipulate manifest file using Docker CLI itself.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Always up-to-date Docker manifest file
### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Slightly slower Jenkins CI builds (~3-4s degradation per build)