### PR TITLE
Extract signaturesSubset function

### DIFF
--- a/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
@@ -18,6 +18,7 @@
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/signature.hpp"
+#include "validation/utils.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -44,19 +45,11 @@ namespace iroha {
           const shared_model::interface::types::SignatureRangeType &signatures,
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &peers) const {
-        return std::all_of(
-            signatures.begin(),
-            signatures.end(),
-            [&peers](const auto &signature) {
-              return std::find_if(
-                         peers.begin(),
-                         peers.end(),
-                         [&signature](const std::shared_ptr<
-                                      shared_model::interface::Peer> &peer) {
-                           return signature.publicKey() == peer->pubkey();
-                         })
-                  != peers.end();
-            });
+        std::vector<shared_model::crypto::PublicKey> keys;
+        for (const auto &p : peers) {
+          keys.push_back(p->pubkey());
+        }
+        return validation::signaturesSubset(signatures, keys);
       }
 
       bool SupermajorityCheckerImpl::hasReject(uint64_t frequent,

--- a/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
+#include <boost/range/adaptors.hpp>
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "validation/utils.hpp"
@@ -45,11 +46,13 @@ namespace iroha {
           const shared_model::interface::types::SignatureRangeType &signatures,
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &peers) const {
-        std::vector<shared_model::crypto::PublicKey> keys;
-        for (const auto &p : peers) {
-          keys.push_back(p->pubkey());
-        }
-        return validation::signaturesSubset(signatures, keys);
+        return validation::signaturesSubset(
+            signatures,
+            peers
+                | boost::adaptors::transformed(
+                      [](const auto &p) -> decltype(auto) {
+                        return p->pubkey();
+                      }));
       }
 
       bool SupermajorityCheckerImpl::hasReject(uint64_t frequent,

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "torii/processor/query_processor_impl.hpp"
+#include "boost/range/size.hpp"
+#include "validation/utils.hpp"
 
 namespace iroha {
   namespace torii {
@@ -40,17 +42,15 @@ namespace iroha {
 
     bool QueryProcessorImpl::checkSignatories(
         const shared_model::interface::Query &qry) {
-      const auto &sig = *qry.signatures().begin();
-
       const auto &wsv_query = storage_->getWsvQuery();
-      auto qpf = QueryProcessingFactory(wsv_query, storage_->getBlockQuery());
+
       auto signatories = wsv_query->getSignatories(qry.creatorAccountId());
-      if (not signatories) {
-        return false;
-      }
-      return std::find(
-                 signatories->begin(), signatories->end(), sig.publicKey())
-          != signatories->end();
+      const auto &sig = qry.signatures();
+
+      return boost::range_detail::range_calculate_size(sig) == 1
+          && signatories | [&sig](const auto &signatories) {
+               return validation::signaturesSubset(sig, signatories);
+             };
     }
 
     void QueryProcessorImpl::queryHandle(

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -47,7 +47,7 @@ namespace iroha {
       auto signatories = wsv_query->getSignatories(qry.creatorAccountId());
       const auto &sig = qry.signatures();
 
-      return boost::range_detail::range_calculate_size(sig) == 1
+      return boost::size(sig) == 1
           && signatories | [&sig](const auto &signatories) {
                return validation::signaturesSubset(sig, signatories);
              };

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -48,9 +48,9 @@ namespace iroha {
       const auto &sig = qry.signatures();
 
       return boost::size(sig) == 1
-          && signatories | [&sig](const auto &signatories) {
-               return validation::signaturesSubset(sig, signatories);
-             };
+          and signatories | [&sig](const auto &signatories) {
+                return validation::signaturesSubset(sig, signatories);
+              };
     }
 
     void QueryProcessorImpl::queryHandle(

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -18,8 +18,8 @@
 #include "validation/impl/stateful_validator_impl.hpp"
 
 #include <boost/range/adaptor/transformed.hpp>
-
 #include "builders/protobuf/proposal.hpp"
+#include "validation/utils.hpp"
 
 namespace iroha {
   namespace validation {
@@ -34,7 +34,7 @@ namespace iroha {
         ametsuchi::TemporaryWsv &temporaryWsv) {
       log_->info("transactions in proposal: {}",
                  proposal.transactions().size());
-      auto checking_transaction = [this](const auto &tx, auto &queries) {
+      auto checking_transaction = [](const auto &tx, auto &queries) {
         return bool(queries.getAccount(tx.creatorAccountId()) |
                     [&](const auto &account) {
                       // Check if tx creator has account and has quorum to
@@ -47,8 +47,7 @@ namespace iroha {
                     [&](const auto &signatories) {
                       // Check if signatures in transaction are account
                       // signatory
-                      return this->signaturesSubset(tx.signatures(),
-                                                    signatories)
+                      return signaturesSubset(tx.signatures(), signatories)
                           ? boost::make_optional(signatories)
                           : boost::none;
                     });
@@ -91,23 +90,5 @@ namespace iroha {
       return std::make_shared<decltype(validated_proposal)>(
           validated_proposal.getTransport());
     }
-
-    bool StatefulValidatorImpl::signaturesSubset(
-        const shared_model::interface::types::SignatureRangeType &signatures,
-        const std::vector<shared_model::crypto::PublicKey> &public_keys) {
-      // TODO 09/10/17 Lebedev: simplify the subset verification IR-510
-      // #goodfirstissue
-      std::unordered_set<std::string> txPubkeys;
-      for (auto &sign : signatures) {
-        txPubkeys.insert(sign.publicKey().toString());
-      }
-      return std::all_of(public_keys.begin(),
-                         public_keys.end(),
-                         [&txPubkeys](const auto &public_key) {
-                           return txPubkeys.find(public_key.toString())
-                               != txPubkeys.end();
-                         });
-    }
-
   }  // namespace validation
 }  // namespace iroha

--- a/irohad/validation/impl/stateful_validator_impl.hpp
+++ b/irohad/validation/impl/stateful_validator_impl.hpp
@@ -44,18 +44,6 @@ namespace iroha {
           const shared_model::interface::Proposal &proposal,
           ametsuchi::TemporaryWsv &temporaryWsv) override;
 
-     private:
-      /**
-       * Checks if public keys of signatures are present in vector of pubkeys
-       * @param signatures - collection of signatures
-       * @param public_keys - collection of public keys
-       * @return true, if all public keys of signatures are present in vector of
-       * pubkeys
-       */
-      bool signaturesSubset(
-          const shared_model::interface::types::SignatureRangeType &signatures,
-          const std::vector<shared_model::crypto::PublicKey> &public_keys);
-
       logger::Logger log_;
     };
   }  // namespace validation

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string>
+#include <vector>
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace iroha {
+  namespace validation {
+    /**
+     * Checks if signatures' public keys are present in vector of pubkeys
+     * @param signatures - collection of signatures
+     * @param public_keys - collection of public keys
+     * @return true, if all public keys of signatures are present in vector of
+     * pubkeys
+     */
+    inline bool signaturesSubset(
+        const shared_model::interface::types::SignatureRangeType &signatures,
+        const std::vector<shared_model::crypto::PublicKey> &public_keys) {
+      return std::all_of(
+          signatures.begin(),
+          signatures.end(),
+          [&public_keys](const auto &signature) {
+            return std::find_if(public_keys.begin(),
+                                public_keys.end(),
+                                [&signature](const auto &public_key) {
+                                  return signature.publicKey() == public_key;
+                                })
+                != public_keys.end();
+          });
+    }
+
+  }  // namespace validation
+}  // namespace iroha

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <boost/range/any_range.hpp>
 #include <string>
 #include <vector>
 #include "cryptography/public_key.hpp"
@@ -19,7 +20,8 @@ namespace iroha {
      */
     inline bool signaturesSubset(
         const shared_model::interface::types::SignatureRangeType &signatures,
-        const boost::any_range<shared_model::crypto::PublicKey, boost::forward_traversal_tag> &public_keys) {
+        const boost::any_range<shared_model::crypto::PublicKey,
+                               boost::forward_traversal_tag> &public_keys) {
       return std::all_of(
           signatures.begin(),
           signatures.end(),

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -19,7 +19,7 @@ namespace iroha {
      */
     inline bool signaturesSubset(
         const shared_model::interface::types::SignatureRangeType &signatures,
-        const std::vector<shared_model::crypto::PublicKey> &public_keys) {
+        const boost::any_range<shared_model::crypto::PublicKey, boost::forward_traversal_tag> &public_keys) {
       return std::all_of(
           signatures.begin(),
           signatures.end(),

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(chain_validation_test
     chain_validator
     shared_model_stateless_validation
     )
+
+addtest(stateful_validator_test stateful_validator_test.cpp)
+target_link_libraries(stateful_validator_test
+  shared_model_default_builders
+  )

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "builders/protobuf/common_objects/proto_signature_builder.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "validation/utils.hpp"
+
+using namespace iroha::validation;
+using namespace shared_model::crypto;
+
+class SignaturesSubset : public testing::Test {
+ public:
+  auto makeSignature(PublicKey key, std::string sign) {
+    return shared_model::proto::SignatureBuilder()
+        .publicKey(key)
+        .signedData(Signed(sign))
+        .build();
+  }
+};
+
+/**
+ * @given three different keys and three signatures with the same keys
+ * @when signaturesSubset is executed
+ * @then returned true
+ */
+TEST_F(SignaturesSubset, Equal) {
+  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b"), PublicKey("c")};
+  std::vector<shared_model::proto::Signature> signatures;
+  for (const auto &k : keys) {
+    signatures.push_back(makeSignature(k, ""));
+  }
+  ASSERT_TRUE(signaturesSubset(signatures, keys));
+}
+
+/**
+ * @given two different keys and two signatures with the same keys plus
+ * additional one
+ * @when signaturesSubset is executed
+ * @then returned false
+ */
+TEST_F(SignaturesSubset, Lesser) {
+  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b")};
+  std::vector<shared_model::proto::Signature> signatures;
+  for (const auto &k : keys) {
+    signatures.push_back(makeSignature(k, ""));
+  }
+  signatures.push_back(makeSignature(PublicKey("c"), ""));
+  ASSERT_FALSE(signaturesSubset(signatures, keys));
+}
+
+/**
+ * @given three different keys and two signatures with the first pair of keys
+ * @when signaturesSubset is executed
+ * @then returned true
+ */
+TEST_F(SignaturesSubset, StrictSubset) {
+  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b")};
+  std::vector<shared_model::proto::Signature> signatures;
+  for (const auto &k : keys) {
+    signatures.push_back(makeSignature(k, ""));
+  }
+  keys.push_back(PublicKey("c"));
+  ASSERT_TRUE(signaturesSubset(signatures, keys));
+}
+
+/**
+ * @given two same keys and two signatures with different keys
+ * @when signaturesSubset is executed
+ * @then returned false
+ */
+TEST_F(SignaturesSubset, PublickeyUniqueness) {
+  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("a")};
+  std::vector<shared_model::proto::Signature> signatures;
+  signatures.push_back(makeSignature(PublicKey("a"), ""));
+  signatures.push_back(makeSignature(PublicKey("c"), ""));
+  ASSERT_FALSE(signaturesSubset(signatures, keys));
+}


### PR DESCRIPTION
### Description of the Change

Decrease redundancy in public key check in signature range.

### Benefits

Less self-repeating code

### Possible Drawbacks 

There's additional alloc+copy in SupermajorityCheckerImpl, that probably might be optimized
