### PR TITLE
Fix build issues related to changes in "amount utils"

### DIFF
--- a/shared_model/utils/CMakeLists.txt
+++ b/shared_model/utils/CMakeLists.txt
@@ -2,3 +2,7 @@
 add_library(shared_model_amount_utils
     amount_utils.cpp
     )
+
+target_link_libraries(shared_model_amount_utils
+    shared_model_proto_backend
+    )

--- a/shared_model/utils/amount_utils.cpp
+++ b/shared_model/utils/amount_utils.cpp
@@ -16,7 +16,11 @@
  */
 
 #include "utils/amount_utils.hpp"
+
 #include <boost/format.hpp>
+
+#include "builders/default_builders.hpp"
+#include "builders/protobuf/common_objects/proto_amount_builder.hpp"
 
 namespace shared_model {
   namespace detail {

--- a/shared_model/utils/amount_utils.hpp
+++ b/shared_model/utils/amount_utils.hpp
@@ -20,11 +20,12 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-#include "builders/default_builders.hpp"
-#include "builders/protobuf/common_objects/proto_amount_builder.hpp"
 #include "common/result.hpp"
 
 namespace shared_model {
+  namespace interface {
+    class Amount;
+  }  // namespace interface
   namespace detail {
     boost::multiprecision::uint256_t increaseValuePrecision(
         boost::multiprecision::uint256_t value, int degree);

--- a/shared_model/utils/amount_utils.hpp
+++ b/shared_model/utils/amount_utils.hpp
@@ -26,6 +26,7 @@ namespace shared_model {
   namespace interface {
     class Amount;
   }  // namespace interface
+
   namespace detail {
     boost::multiprecision::uint256_t increaseValuePrecision(
         boost::multiprecision::uint256_t value, int degree);

--- a/test/module/shared_model/amount_utils_test.cpp
+++ b/test/module/shared_model/amount_utils_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include "builders/default_builders.hpp"
 #include "utils/amount_utils.hpp"
 
 using namespace shared_model::detail;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

It was unable to build Iroha on some systems. The fix arranges dependencies as it should be.

Thanks to @lebdron for the fix!

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Iroha can be built on systems without google protobuf header files installed.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

`cmake -H. -Bbuild`
`cmake --build build`