### PR TITLE
Fix segfault when non intialized ITF were destructed

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -229,6 +229,8 @@ namespace integration_framework {
 
   void IntegrationTestFramework::done() {
     log_->info("done");
-    iroha_instance_->instance_->storage->dropStorage();
+    if (iroha_instance_->instance_ and iroha_instance_->instance_->storage) {
+      iroha_instance_->instance_->storage->dropStorage();
+    }
   }
 }  // namespace integration_framework

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -80,3 +80,13 @@ TEST(RegressionTest, DoubleCallOfDone) {
   itf.setInitialState(kAdminKeypair).done();
   itf.done();
 }
+
+/**
+ * @given non initialized ITF instance
+ * @when done method is called inside destructor
+ * @then no exceptions are risen
+ */
+TEST(RegressionTest, DestructionOfNonInitializedItf) {
+  integration_framework::IntegrationTestFramework itf(
+      1, [](auto &itf) { itf.done(); });
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

No segfault will occur when unused ITF instance is destructed.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

The following code would not cause segfault:
```
{
  IntegrationTestFramework itf(1);
}
```

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

```
cmake -Bbuild -H.
cmake --build build --target regression_test
build/test_bin/regression_test --gtest_filter=RegressionTest.DestructionOfNonInitializedItf
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs 

The rest of ITF methods such as "sendTx" could also get the fix, but they are left without such check of null pointers as it was done inside "done" method by this fix.
**This is ok**, because "done" will be called automatically inside default ITF deleter passed to destructor and "sendTx" would not. 
Moreover, "sendTx" will generate an exception only in case of strict violation of ITF usage mechanism (calling "sendTx" without calling of "setInitialState").