### PR TITLE
Fix docker network teardown procedure

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -9,7 +9,7 @@ def doDebugBuild(coverageEnabled=false) {
   def previousCommit = pCommit.previousCommitOrCurrent()
   // params are always null unless job is started
   // this is the case for the FIRST build only.
-  // So just set this to same value as default. 
+  // So just set this to same value as default.
   // This is a known bug. See https://issues.jenkins-ci.org/browse/JENKINS-41929
   if (!parallelism) {
     parallelism = 4
@@ -25,9 +25,9 @@ def doDebugBuild(coverageEnabled=false) {
                                            ['PARALLELISM': parallelism])
 
   if (GIT_LOCAL_BRANCH == 'develop' && manifest.manifestSupportEnabled()) {
-    manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:develop-build", 
-      ["${DOCKER_REGISTRY_BASENAME}:x86_64-develop-build", 
-       "${DOCKER_REGISTRY_BASENAME}:armv7l-develop-build", 
+    manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:develop-build",
+      ["${DOCKER_REGISTRY_BASENAME}:x86_64-develop-build",
+       "${DOCKER_REGISTRY_BASENAME}:armv7l-develop-build",
        "${DOCKER_REGISTRY_BASENAME}:aarch64-develop-build"])
     manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:develop-build",
       [
@@ -70,7 +70,7 @@ def doDebugBuild(coverageEnabled=false) {
         ccache --show-stats
         ccache --zero-stats
         ccache --max-size=5G
-      """  
+      """
       sh """
         cmake \
           -DTESTING=ON \

--- a/.jenkinsci/docker-cleanup.groovy
+++ b/.jenkinsci/docker-cleanup.groovy
@@ -3,7 +3,6 @@
 def doDockerCleanup() {
 
     sh """
-      docker rm -f $IROHA_POSTGRES_HOST || true
       # Check whether the image is the last-standing man
       # i.e., no other tags exist for this image
       docker rmi \$(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}\\t{{.ID}}' | grep \$(docker images --no-trunc --format '{{.ID}}' ${iC.id}) | head -n -1 | cut -f 1) || true

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -10,10 +10,8 @@ def linuxPostStep() {
       }
     }
     finally {
-      if (env.BUILD_TYPE == 'Debug') {
-        def cleanup = load ".jenkinsci/docker-cleanup.groovy"
-        cleanup.doDockerCleanup()
-      }
+      def cleanup = load ".jenkinsci/docker-cleanup.groovy"
+      cleanup.doDockerCleanup()
       cleanWs()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 // Overall pipeline looks like the following
-//         
+//
 //   |--Linux-----|----Debug
-//   |            |----Release 
+//   |            |----Release
 //   |    OR
-//   |           
+//   |
 //-- |--Linux ARM-|----Debug
 //   |            |----Release
 //   |    OR
@@ -101,7 +101,7 @@ pipeline {
         stage('ARMv7') {
           when {
             beforeAgent true
-            expression { return params.ARMv7 } 
+            expression { return params.ARMv7 }
           }
           agent { label 'armv7' }
           steps {
@@ -110,7 +110,7 @@ pipeline {
               coverage = load ".jenkinsci/selected-branches-coverage.groovy"
               if (!params.Linux && !params.ARMv8 && !params.MacOS && (coverage.selectedBranchesCoverage(['develop', 'master']))) {
                 debugBuild.doDebugBuild(true)
-              }              
+              }
               else {
                 debugBuild.doDebugBuild()
               }
@@ -132,7 +132,7 @@ pipeline {
         stage('ARMv8') {
           when {
             beforeAgent true
-            expression { return params.ARMv8 } 
+            expression { return params.ARMv8 }
           }
           agent { label 'armv8' }
           steps {
@@ -245,7 +245,7 @@ pipeline {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]
-                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))                        
+                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
                     }
                   }
                   finally {
@@ -264,7 +264,7 @@ pipeline {
     }
     stage('Build Release') {
       when {
-        expression { params.BUILD_TYPE == 'Release' }      
+        expression { params.BUILD_TYPE == 'Release' }
       }
       parallel {
         stage('Linux') {
@@ -307,7 +307,7 @@ pipeline {
                 post.linuxPostStep()
               }
             }
-          }           
+          }
         }
         stage('ARMv8') {
           when {
@@ -328,7 +328,7 @@ pipeline {
                 post.linuxPostStep()
               }
             }
-          }          
+          }
         }
         stage('MacOS') {
           when {
@@ -436,7 +436,7 @@ pipeline {
             iC.inside("-v /tmp/${env.GIT_COMMIT}/entrypoint.sh:/entrypoint.sh:ro -v /tmp/${env.GIT_COMMIT}/bindings-artifact:/tmp/bindings-artifact") {
               bindings.doAndroidBindings(params.ABABIVersion)
             }
-          }          
+          }
         }
       }
       post {


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Make sure Docker containers and network teardown procedure is run after every CI build. Previously, conditional statement prevented from running the procedure correctly. It checked for `Debug` build flag, although this flag was substituted by `Release` flag in some cases (e.g., when `Debug` build followed by `Release`).
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Prevent Docker subsystem on Jenkins build agents from inter-container networks count overflow (Max 31 network is allowed).
### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->