### PR TITLE
Add state recovery test

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <tbb/concurrent_queue.h>
+#include <boost/filesystem.hpp>
 #include "framework/integration_framework/iroha_instance.hpp"
 #include "framework/integration_framework/test_irohad.hpp"
 #include "logger/logger.hpp"
@@ -68,7 +69,10 @@ namespace integration_framework {
         size_t maximum_proposal_size,
         std::function<void(IntegrationTestFramework &)> deleter =
             [](IntegrationTestFramework &itf) { itf.done(); },
-        bool mst_support = false);
+        bool mst_support = false,
+        const std::string &block_store_path =
+        (boost::filesystem::temp_directory_path()
+            / boost::filesystem::unique_path()).string());
 
     ~IntegrationTestFramework();
 
@@ -102,6 +106,14 @@ namespace integration_framework {
     IntegrationTestFramework &setInitialState(
         const shared_model::crypto::Keypair &keypair,
         const shared_model::interface::Block &block);
+
+    /**
+     * Initialize Iroha instance using the data left in block store from
+     * previous launch of Iroha
+     * @param keypair - signing key used for initialization of previous instance
+     */
+    IntegrationTestFramework &recoverState(
+        const shared_model::crypto::Keypair &keypair);
 
     /**
      * Send transaction to Iroha and validate its status
@@ -213,6 +225,9 @@ namespace integration_framework {
     tbb::concurrent_queue<ProposalType> proposal_queue_;
     tbb::concurrent_queue<BlockType> block_queue_;
     std::shared_ptr<IrohaInstance> iroha_instance_;
+
+    void initPipeline(const shared_model::crypto::Keypair &keypair);
+    void subscribeQueuesAndRun();
 
     // config area
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -64,6 +64,7 @@ namespace integration_framework {
      * receives pointer to constructed instance of Integration Test Framework.
      * If specified, then will be called instead of default destructor's code
      * @param mst_support enables multisignature tx support
+     * @param block_store_path specifies path where blocks will be stored
      */
     explicit IntegrationTestFramework(
         size_t maximum_proposal_size,

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -22,8 +22,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/filesystem.hpp>
-
 namespace shared_model {
   namespace interface {
     class Block;
@@ -41,10 +39,7 @@ namespace integration_framework {
     /**
      * @param mst_support enables multisignature tx support
      */
-    IrohaInstance(bool mst_support, const std::string &block_store_path =
-                      (boost::filesystem::temp_directory_path()
-                       / boost::filesystem::unique_path())
-                          .string());
+    IrohaInstance(bool mst_support, const std::string &block_store_path);
 
     void makeGenesis(const shared_model::interface::Block &block);
 

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtest/gtest.h>
+#include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
@@ -44,8 +45,9 @@ TEST(RegressionTest, SequentialInitialization) {
 
   auto checkStatelessValid = [](auto &status) {
     ASSERT_TRUE(boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
-            shared_model::interface::StatelessValidTxResponse>(),
+        shared_model::interface::
+            SpecifiedVisitor<shared_model::interface::
+                                 StatelessValidTxResponse>(),
         status.get()));
   };
   auto checkProposal = [](auto &proposal) {
@@ -67,6 +69,65 @@ TEST(RegressionTest, SequentialInitialization) {
         .sendTx(tx, checkStatelessValid)
         .checkProposal(checkProposal)
         .checkBlock(checkBlock)
+        .done();
+  }
+}
+
+/**
+ * @given ITF instance
+ * @when instance is shutdown without blocks erase
+ * @then another ITF instance can restore VSW from blockstore
+ */
+TEST(RegressionTest, StateRecovery) {
+  auto userKeypair =
+      shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
+  auto tx = shared_model::proto::TransactionBuilder()
+                .createdTime(iroha::time::now())
+                .creatorAccountId("admin@test")
+                .createAccount("user", "test", userKeypair.publicKey())
+                .addAssetQuantity("admin@test", "coin#test", "133.0")
+                .transferAsset(
+                    "admin@test", "user@test", "coin#test", "descrs", "97.8")
+                .quorum(1)
+                .build()
+                .signAndAddSignature(kAdminKeypair);
+  auto hash = tx.hash();
+  auto makeQuery = [&hash](int query_counter, auto kAdminKeypair) {
+    return shared_model::proto::QueryBuilder()
+        .createdTime(iroha::time::now())
+        .creatorAccountId("admin@test")
+        .queryCounter(query_counter)
+        .getTransactions(std::vector<shared_model::crypto::Hash>{hash})
+        .build()
+        .signAndAddSignature(kAdminKeypair);
+  };
+  auto checkOne = [](auto &res) { ASSERT_EQ(res->transactions().size(), 1); };
+  auto checkQuery = [&tx](auto &status) {
+    auto resp = boost::apply_visitor(
+        shared_model::interface::
+            SpecifiedVisitor<shared_model::interface::TransactionsResponse>(),
+        status.get());
+    ASSERT_TRUE(resp);
+    ASSERT_EQ(resp.value().transactions().size(), 1);
+    ASSERT_EQ(*resp.value().transactions()[0].operator->(), tx);
+  };
+  auto path =
+      (boost::filesystem::temp_directory_path() / "iroha-state-recovery-test")
+          .string();
+  {
+    integration_framework::IntegrationTestFramework(
+        1, [](auto &) {}, false, path)
+        .setInitialState(kAdminKeypair)
+        .sendTx(tx)
+        .checkProposal(checkOne)
+        .checkBlock(checkOne)
+        .sendQuery(makeQuery(1, kAdminKeypair), checkQuery);
+  }
+  {
+    integration_framework::IntegrationTestFramework(
+        1, [](auto &itf) { itf.done(); }, false, path)
+        .recoverState(kAdminKeypair)
+        .sendQuery(makeQuery(2, kAdminKeypair), checkQuery)
         .done();
   }
 }

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -76,7 +76,7 @@ TEST(RegressionTest, SequentialInitialization) {
 /**
  * @given ITF instance
  * @when instance is shutdown without blocks erase
- * @then another ITF instance can restore VSW from blockstore
+ * @then another ITF instance can restore WSV from blockstore
  */
 TEST(RegressionTest, StateRecovery) {
   auto userKeypair =


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Add test that allows us to ensure that Iroha state still can be recovered from existing block store.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Increased coverage.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

```
cmake -H. -Bbuild
cmake --build build --target regression_test
./build/test_bin/regression_test --gtest_filter=RegressionTest.StateRecovery
```