### PR TITLE
fix iroha dockerimage tag

### DIFF
--- a/deploy/ansible/roles/iroha-cluster-deploy-node/defaults/main.yml
+++ b/deploy/ansible/roles/iroha-cluster-deploy-node/defaults/main.yml
@@ -8,6 +8,6 @@
   containerConfPath: /opt/iroha_data  # path to folder with config files inside docker container
 
   irohaDockerImage: hyperledger/iroha # docker image name
-  irohaDockerImageTag: master  # docker image tag
+  irohaDockerImageTag: latest  # docker image tag
   dbDockerImage: postgres
   dbDockerImageTag: 9.5

--- a/deploy/ansible/roles/iroha-cluster-deploy-node/defaults/main.yml
+++ b/deploy/ansible/roles/iroha-cluster-deploy-node/defaults/main.yml
@@ -8,6 +8,6 @@
   containerConfPath: /opt/iroha_data  # path to folder with config files inside docker container
 
   irohaDockerImage: hyperledger/iroha # docker image name
-  irohaDockerImageTag: develop  # docker image tag
+  irohaDockerImageTag: master  # docker image tag
   dbDockerImage: postgres
   dbDockerImageTag: 9.5

--- a/deploy/ansible/roles/iroha-standalone-deploy-node/defaults/main.yml
+++ b/deploy/ansible/roles/iroha-standalone-deploy-node/defaults/main.yml
@@ -8,6 +8,6 @@
   containerConfPath: /opt/iroha_data
 
   irohaDockerImage: hyperledger/iroha # docker image name
-  irohaDockerImageTag: develop  # docker image tag
+  irohaDockerImageTag: master  # docker image tag
   dbDockerImage: postgres
   dbDockerImageTag: 9.5

--- a/deploy/ansible/roles/iroha-standalone-deploy-node/defaults/main.yml
+++ b/deploy/ansible/roles/iroha-standalone-deploy-node/defaults/main.yml
@@ -8,6 +8,6 @@
   containerConfPath: /opt/iroha_data
 
   irohaDockerImage: hyperledger/iroha # docker image name
-  irohaDockerImageTag: master  # docker image tag
+  irohaDockerImageTag: latest  # docker image tag
   dbDockerImage: postgres
   dbDockerImageTag: 9.5


### PR DESCRIPTION
Signed-off-by: tyvision <antykushin@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

As docker container naming on dockerhub has been fixed, we need to update ansible playbooks for iroha deployment.
Variable `irohaDockerImageTag` is changed from `develop` to `master`

### Benefits

It fixes iroha deployment in docker using ansible

### Possible Drawbacks 

### Usage Examples or Tests *[optional]*

### Alternate Designs *[optional]*
