### PR TITLE
Fix libed25519 linked dynamically

### DIFF
--- a/.jenkinsci/bindings.groovy
+++ b/.jenkinsci/bindings.groovy
@@ -5,6 +5,8 @@ def doJavaBindings(buildType=Release) {
   def commit = env.GIT_COMMIT
   def artifactsPath = sprintf('%1$s/java-bindings-%2$s-%3$s-%4$s.zip', 
     [currentPath, buildType, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)])
+  // do not use preinstalled libed25519
+  sh "rm -rf /usr/local/include/ed25519*; unlink /usr/local/lib/libed25519.so; rm -f /usr/local/lib/libed25519.so.1.2.2"
   sh """
     cmake \
       -H. \


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Java bindings on Jenkins CI are generated with dynamically linked `libed25519.so`. End users do not necessarily have this library installed on the system. This makes Java bindings without `libed25519.so` not usable. This PR fixes this issue by removing ed25519 files from the system prior configuring the build with CMake.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Generation of working Java bindings on CI without the need to have ed25519 installed on the system
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests
Freshly generated Java bindings to test with:
https://artifact.soramitsu.co.jp/iroha/bindings/java/java-bindings-Release-20180523-928b22.zip