### PR TITLE
Remove polymorphic wrapper from query response

### DIFF
--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -67,8 +67,8 @@ namespace shared_model {
       QueryResponse(QueryResponse &&o) noexcept
           : QueryResponse(std::move(o.proto_)) {}
 
-      QueryResponseVariantType get() const override {
-        return *variant_;
+      const QueryResponseVariantType &get() const override {
+        return *ivariant_;
       }
 
       const interface::types::HashType &queryHash() const override {
@@ -89,6 +89,10 @@ namespace shared_model {
             template load<ProtoQueryResponseVariantType>(
                 std::forward<decltype(ar)>(ar), which);
       }};
+
+      const Lazy<QueryResponseVariantType> ivariant_{
+          detail::makeLazyInitializer(
+              [this] { return QueryResponseVariantType(*variant_); })};
 
       const Lazy<interface::types::HashType> hash_{[this] {
         return interface::types::HashType(

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -36,41 +36,24 @@
 #include "utils/lazy_initializer.hpp"
 #include "utils/variant_deserializer.hpp"
 
-template <typename... T, typename Archive>
-auto loadQueryResponse(Archive &&ar) {
-  int which =
-      ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
-  return shared_model::detail::variant_impl<T...>::template load<
-      shared_model::interface::QueryResponse::QueryResponseVariantType>(
-      std::forward<Archive>(ar), which);
-}
-
 namespace shared_model {
   namespace proto {
     class QueryResponse final
         : public CopyableProto<interface::QueryResponse,
                                iroha::protocol::QueryResponse,
                                QueryResponse> {
-     private:
-      template <typename... Value>
-      using w = boost::variant<detail::PolymorphicWrapper<Value>...>;
-
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      using LazyVariantType = Lazy<QueryResponseVariantType>;
-
      public:
       /// type of proto variant
-      using ProtoQueryResponseVariantType = w<AccountAssetResponse,
-                                              AccountDetailResponse,
-                                              AccountResponse,
-                                              ErrorQueryResponse,
-                                              SignatoriesResponse,
-                                              TransactionsResponse,
-                                              AssetResponse,
-                                              RolesResponse,
-                                              RolePermissionsResponse>;
+      using ProtoQueryResponseVariantType =
+          boost::variant<AccountAssetResponse,
+                         AccountDetailResponse,
+                         AccountResponse,
+                         ErrorQueryResponse,
+                         SignatoriesResponse,
+                         TransactionsResponse,
+                         AssetResponse,
+                         RolesResponse,
+                         RolePermissionsResponse>;
 
       /// list of types in variant
       using ProtoQueryResponseListType = ProtoQueryResponseVariantType::types;
@@ -84,7 +67,7 @@ namespace shared_model {
       QueryResponse(QueryResponse &&o) noexcept
           : QueryResponse(std::move(o.proto_)) {}
 
-      const QueryResponseVariantType &get() const override {
+      QueryResponseVariantType get() const override {
         return *variant_;
       }
 
@@ -93,8 +76,18 @@ namespace shared_model {
       }
 
      private:
+      template <typename T>
+      using Lazy = detail::LazyInitializer<T>;
+
+      using LazyVariantType = Lazy<ProtoQueryResponseVariantType>;
+
       const LazyVariantType variant_{[this] {
-        return loadQueryResponse<ProtoQueryResponseListType>(*proto_);
+        auto &&ar = *proto_;
+        int which =
+            ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
+        return shared_model::detail::variant_impl<ProtoQueryResponseListType>::
+            template load<ProtoQueryResponseVariantType>(
+                std::forward<decltype(ar)>(ar), which);
       }};
 
       const Lazy<interface::types::HashType> hash_{[this] {

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -62,7 +62,7 @@ namespace shared_model {
       /**
        * @return reference to const variant with concrete qr
        */
-      virtual QueryResponseVariantType get() const = 0;
+      virtual const QueryResponseVariantType &get() const = 0;
 
       /**
        * @return hash of corresponding query

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -40,9 +40,9 @@ namespace shared_model {
      */
     class QueryResponse : public ModelPrimitive<QueryResponse> {
      private:
-      /// Shortcut type for polymorphic wrapper
+      /// Shortcut type for const reference
       template <typename... Value>
-      using w = boost::variant<detail::PolymorphicWrapper<Value>...>;
+      using w = boost::variant<const Value &...>;
 
      public:
       /// Type of container with all concrete query response
@@ -62,7 +62,7 @@ namespace shared_model {
       /**
        * @return reference to const variant with concrete qr
        */
-      virtual const QueryResponseVariantType &get() const = 0;
+      virtual QueryResponseVariantType get() const = 0;
 
       /**
        * @return hash of corresponding query

--- a/shared_model/utils/query_error_response_visitor.hpp
+++ b/shared_model/utils/query_error_response_visitor.hpp
@@ -20,7 +20,6 @@
 
 #include <boost/variant.hpp>
 #include "interfaces/query_responses/error_query_response.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -28,9 +27,8 @@ namespace shared_model {
     class QueryErrorResponseChecker : public boost::static_visitor<bool> {
      public:
       bool operator()(
-          const shared_model::detail::PolymorphicWrapper<
-              shared_model::interface::ErrorQueryResponse> &status) const {
-        return iroha::visit_in_place(status->get(),
+          const shared_model::interface::ErrorQueryResponse &status) const {
+        return iroha::visit_in_place(status.get(),
                                      [](const Error &) { return true; },
                                      [](const auto &) { return false; });
       }

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -21,6 +21,7 @@
 #include "cryptography/keypair.hpp"
 #include "execution/query_execution.hpp"
 #include "framework/test_subscriber.hpp"
+#include "interfaces/utils/specified_visitor.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
@@ -100,8 +101,10 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
 
   auto wrapper = make_test_subscriber<CallExact>(qpi.queryNotifier(), 1);
   wrapper.subscribe([](auto response) {
-    ASSERT_NO_THROW(boost::get<const shared_model::interface::AccountResponse>(
-        response->get()));
+    ASSERT_TRUE(
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             response->get()));
   });
   qpi.queryHandle(
       std::make_shared<shared_model::proto::Query>(query.getTransport()));

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -100,9 +100,8 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
 
   auto wrapper = make_test_subscriber<CallExact>(qpi.queryNotifier(), 1);
   wrapper.subscribe([](auto response) {
-    ASSERT_NO_THROW(
-        boost::get<shared_model::detail::PolymorphicWrapper<
-            shared_model::interface::AccountResponse>>(response->get()));
+    ASSERT_NO_THROW(boost::get<const shared_model::interface::AccountResponse>(
+        response->get()));
   });
   qpi.queryHandle(
       std::make_shared<shared_model::proto::Query>(query.getTransport()));

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -223,11 +223,11 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  auto account_resp = boost::get<shared_model::detail::PolymorphicWrapper<
-      shared_model::interface::AccountResponse>>(resp.get());
+  auto &account_resp =
+      boost::get<const shared_model::interface::AccountResponse>(resp.get());
 
-  ASSERT_EQ(account_resp->account().accountId(), accountB->accountId());
-  ASSERT_EQ(account_resp->roles().size(), 1);
+  ASSERT_EQ(account_resp.account().accountId(), accountB->accountId());
+  ASSERT_EQ(account_resp.roles().size(), 1);
   ASSERT_EQ(model_query.hash(), resp.queryHash());
 }
 
@@ -263,11 +263,11 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  auto detail_resp = boost::get<shared_model::detail::PolymorphicWrapper<
-      shared_model::interface::AccountResponse>>(resp.get());
+  auto &detail_resp =
+      boost::get<const shared_model::interface::AccountResponse>(resp.get());
 
-  ASSERT_EQ(detail_resp->account().accountId(), account->accountId());
-  ASSERT_EQ(detail_resp->account().domainId(), account->domainId());
+  ASSERT_EQ(detail_resp.account().accountId(), account->accountId());
+  ASSERT_EQ(detail_resp.account().domainId(), account->domainId());
   ASSERT_EQ(model_query.hash(), resp.queryHash());
 }
 
@@ -367,13 +367,14 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   ASSERT_FALSE(response.has_error_response());
 
   auto resp = shared_model::proto::QueryResponse(response);
-  auto asset_resp = boost::get<shared_model::detail::PolymorphicWrapper<
-      shared_model::interface::AccountAssetResponse>>(resp.get());
+  auto &asset_resp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          resp.get());
 
   // Check if the fields in account asset response are correct
-  ASSERT_EQ(asset_resp->accountAsset().assetId(), account_asset->assetId());
-  ASSERT_EQ(asset_resp->accountAsset().accountId(), account_asset->accountId());
-  ASSERT_EQ(asset_resp->accountAsset().balance(), account_asset->balance());
+  ASSERT_EQ(asset_resp.accountAsset().assetId(), account_asset->assetId());
+  ASSERT_EQ(asset_resp.accountAsset().accountId(), account_asset->accountId());
+  ASSERT_EQ(asset_resp.accountAsset().balance(), account_asset->balance());
   ASSERT_EQ(model_query.hash(), resp.queryHash());
 }
 
@@ -454,10 +455,11 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   auto stat = torii_utils::QuerySyncClient(Ip, Port).Find(
       model_query.getTransport(), response);
   auto shared_response = shared_model::proto::QueryResponse(response);
-  auto resp_pubkey = *boost::get<shared_model::detail::PolymorphicWrapper<
-      shared_model::interface::SignatoriesResponse>>(shared_response.get())
-                          ->keys()
-                          .begin();
+  auto resp_pubkey =
+      *boost::get<const shared_model::interface::SignatoriesResponse>(
+          shared_response.get())
+          .keys()
+          .begin();
 
   ASSERT_TRUE(stat.ok());
   /// Should not return Error Response because tx is stateless and stateful
@@ -514,10 +516,11 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
   auto resp = shared_model::proto::QueryResponse(response);
-  auto tx_resp = boost::get<shared_model::detail::PolymorphicWrapper<
-      shared_model::interface::TransactionsResponse>>(resp.get());
+  auto &tx_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          resp.get());
 
-  const auto &txs = tx_resp->transactions();
+  const auto &txs = tx_resp.transactions();
   for (auto i = 0ul; i < txs.size(); i++) {
     ASSERT_EQ(txs.at(i)->creatorAccountId(), account.accountId());
   }

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -27,6 +27,7 @@
 #include "builders/protobuf/common_objects/proto_asset_builder.hpp"
 #include "execution/query_execution.hpp"
 #include "framework/test_subscriber.hpp"
+#include "interfaces/utils/specified_visitor.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "utils/query_error_response_visitor.hpp"
 #include "validators/permissions.hpp"
@@ -147,8 +148,10 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
       .WillOnce(Return(role_permissions));
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
-  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
-      response->get());
+  auto &cast_resp =
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AccountResponse>(),
+                            response->get());
   ASSERT_EQ(cast_resp.account().accountId(), admin_id);
 }
 
@@ -173,8 +176,10 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
-      response->get());
+  auto &cast_resp =
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AccountResponse>(),
+                            response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -199,8 +204,10 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
-      response->get());
+  auto &cast_resp =
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AccountResponse>(),
+                            response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -230,8 +237,10 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
-      response->get());
+  auto &cast_resp =
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AccountResponse>(),
+                            response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -350,9 +359,10 @@ TEST_F(GetAccountAssetsTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountAsset(admin_id, asset_id))
       .WillOnce(Return(accountAsset));
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::AccountAssetResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountAssetResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), admin_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -392,9 +402,10 @@ TEST_F(GetAccountAssetsTest, AllAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::AccountAssetResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountAssetResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -434,9 +445,10 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::AccountAssetResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountAssetResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -473,9 +485,10 @@ TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::AccountAssetResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountAssetResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -598,8 +611,9 @@ TEST_F(GetSignatoriesTest, MyAccountValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::SignatoriesResponse>(
-          response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::SignatoriesResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -625,8 +639,9 @@ TEST_F(GetSignatoriesTest, AllAccountValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::SignatoriesResponse>(
-          response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::SignatoriesResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -652,8 +667,9 @@ TEST_F(GetSignatoriesTest, DomainAccountValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::SignatoriesResponse>(
-          response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::SignatoriesResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -684,8 +700,9 @@ TEST_F(GetSignatoriesTest, GrantAccountValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::SignatoriesResponse>(
-          response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::SignatoriesResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -783,9 +800,10 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -815,9 +833,10 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -847,9 +866,10 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -883,9 +903,10 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -945,9 +966,10 @@ TEST_F(GetAccountTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get()));
+  ASSERT_NO_THROW(*boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get()));
 }
 
 /// --------- Get Account Assets Transactions-------------
@@ -985,9 +1007,10 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1017,9 +1040,10 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1049,9 +1073,10 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1085,9 +1110,10 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1147,9 +1173,10 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get()));
+  ASSERT_NO_THROW(*boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get()));
 }
 
 /**
@@ -1174,9 +1201,10 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAssetExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          response->get()));
+  ASSERT_NO_THROW(*boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      response->get()));
 }
 
 /// --------- Get Asset Info -------------
@@ -1214,7 +1242,9 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::AssetResponse>(response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AssetResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
 }
@@ -1296,7 +1326,9 @@ TEST_F(GetRolesTest, ValidCase) {
 
   auto response = validateAndExecute(query);
   auto &cast_resp =
-      boost::get<const shared_model::interface::RolesResponse>(response->get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::RolesResponse>(),
+                            response->get());
 
   ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
@@ -1377,9 +1409,10 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      boost::get<const shared_model::interface::RolePermissionsResponse>(
-          response->get());
+  auto &cast_resp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::RolePermissionsResponse>(),
+      response->get());
 
   ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
   for (size_t i = 0; i < perms.size(); ++i) {

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -44,10 +44,6 @@ using namespace shared_model::permissions;
 
 using wTransaction = std::shared_ptr<shared_model::interface::Transaction>;
 
-// TODO: 28/03/2018 x3medima17 remove poly wrapper, IR-1011
-template <class T>
-using w = shared_model::detail::PolymorphicWrapper<T>;
-
 class QueryValidateExecuteTest : public ::testing::Test {
  public:
   QueryValidateExecuteTest() = default;
@@ -151,9 +147,9 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
       .WillOnce(Return(role_permissions));
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::AccountResponse>>(response->get());
-  ASSERT_EQ(cast_resp->account().accountId(), admin_id);
+  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
+      response->get());
+  ASSERT_EQ(cast_resp.account().accountId(), admin_id);
 }
 
 /**
@@ -177,9 +173,9 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::AccountResponse>>(response->get());
-  ASSERT_EQ(cast_resp->account().accountId(), account_id);
+  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
+      response->get());
+  ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
 /**
@@ -203,9 +199,9 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::AccountResponse>>(response->get());
-  ASSERT_EQ(cast_resp->account().accountId(), account_id);
+  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
+      response->get());
+  ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
 /**
@@ -234,9 +230,9 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::AccountResponse>>(response->get());
-  ASSERT_EQ(cast_resp->account().accountId(), account_id);
+  auto &cast_resp = boost::get<const shared_model::interface::AccountResponse>(
+      response->get());
+  ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
 /**
@@ -354,11 +350,12 @@ TEST_F(GetAccountAssetsTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountAsset(admin_id, asset_id))
       .WillOnce(Return(accountAsset));
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::AccountAssetResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->accountAsset().accountId(), admin_id);
-  ASSERT_EQ(cast_resp->accountAsset().assetId(), asset_id);
+  ASSERT_EQ(cast_resp.accountAsset().accountId(), admin_id);
+  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
 }
 
 /**
@@ -395,11 +392,12 @@ TEST_F(GetAccountAssetsTest, AllAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::AccountAssetResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp->accountAsset().assetId(), asset_id);
+  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
 }
 
 /**
@@ -436,11 +434,12 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::AccountAssetResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp->accountAsset().assetId(), asset_id);
+  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
 }
 
 /**
@@ -474,11 +473,12 @@ TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::AccountAssetResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp->accountAsset().assetId(), asset_id);
+  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
 }
 
 /**
@@ -597,10 +597,11 @@ TEST_F(GetSignatoriesTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(admin_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::SignatoriesResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::SignatoriesResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->keys().size(), 1);
+  ASSERT_EQ(cast_resp.keys().size(), 1);
 }
 
 /**
@@ -623,10 +624,11 @@ TEST_F(GetSignatoriesTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::SignatoriesResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::SignatoriesResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->keys().size(), 1);
+  ASSERT_EQ(cast_resp.keys().size(), 1);
 }
 
 /**
@@ -649,10 +651,11 @@ TEST_F(GetSignatoriesTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::SignatoriesResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::SignatoriesResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->keys().size(), 1);
+  ASSERT_EQ(cast_resp.keys().size(), 1);
 }
 
 /**
@@ -680,10 +683,11 @@ TEST_F(GetSignatoriesTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::SignatoriesResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::SignatoriesResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->keys().size(), 1);
+  ASSERT_EQ(cast_resp.keys().size(), 1);
 }
 
 /**
@@ -779,11 +783,12 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(admin_id, tx->creatorAccountId());
   }
 }
@@ -810,11 +815,12 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -841,11 +847,12 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -876,11 +883,12 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -937,8 +945,9 @@ TEST_F(GetAccountTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  ASSERT_NO_THROW(
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get()));
 }
 
 /// --------- Get Account Assets Transactions-------------
@@ -976,11 +985,12 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(admin_id, tx->creatorAccountId());
   }
 }
@@ -1007,11 +1017,12 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -1038,11 +1049,12 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -1073,11 +1085,12 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get());
 
-  ASSERT_EQ(cast_resp->transactions().size(), N);
-  for (const auto &tx : cast_resp->transactions()) {
+  ASSERT_EQ(cast_resp.transactions().size(), N);
+  for (const auto &tx : cast_resp.transactions()) {
     EXPECT_EQ(account_id, tx->creatorAccountId());
   }
 }
@@ -1134,8 +1147,9 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  ASSERT_NO_THROW(
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get()));
 }
 
 /**
@@ -1160,8 +1174,9 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAssetExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  auto cast_resp = boost::get<w<shared_model::interface::TransactionsResponse>>(
-      response->get());
+  ASSERT_NO_THROW(
+      boost::get<const shared_model::interface::TransactionsResponse>(
+          response->get()));
 }
 
 /// --------- Get Asset Info -------------
@@ -1198,10 +1213,10 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAsset(asset_id)).WillOnce(Return(asset));
 
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::AssetResponse>>(response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::AssetResponse>(response->get());
 
-  ASSERT_EQ(cast_resp->asset().assetId(), asset_id);
+  ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
 }
 
 /**
@@ -1280,13 +1295,13 @@ TEST_F(GetRolesTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRoles()).WillOnce(Return(roles));
 
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::RolesResponse>>(response->get());
+  auto &cast_resp =
+      boost::get<const shared_model::interface::RolesResponse>(response->get());
 
-  ASSERT_EQ(cast_resp->roles().size(), roles.size());
+  ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
   for (size_t i = 0; i < roles.size(); ++i) {
-    ASSERT_EQ(cast_resp->roles().at(i), roles.at(i));
+    ASSERT_EQ(cast_resp.roles().at(i), roles.at(i));
   }
 }
 
@@ -1362,13 +1377,13 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
 
   auto response = validateAndExecute(query);
-  auto cast_resp =
-      boost::get<w<shared_model::interface::RolePermissionsResponse>>(
+  auto &cast_resp =
+      boost::get<const shared_model::interface::RolePermissionsResponse>(
           response->get());
 
-  ASSERT_EQ(cast_resp->rolePermissions().size(), perms.size());
+  ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
   for (size_t i = 0; i < perms.size(); ++i) {
-    ASSERT_EQ(cast_resp->rolePermissions().at(i), perms.at(i));
+    ASSERT_EQ(cast_resp.rolePermissions().at(i), perms.at(i));
   }
 }
 

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -21,6 +21,7 @@
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/irange.hpp>
 #include "cryptography/hash.hpp"
+#include "interfaces/utils/specified_visitor.hpp"
 
 /**
  * @given protobuf's QueryResponse with different responses and some hash
@@ -69,9 +70,11 @@ TEST(QueryResponse, ErrorResponseLoad) {
             error_resp, resp_reason, resp_reason_enum->value(i)->number());
         auto shared_response = shared_model::proto::QueryResponse(response);
         ASSERT_EQ(i,
-                  boost::get<const shared_model::interface::ErrorQueryResponse>(
+                  boost::apply_visitor(
+                      shared_model::interface::SpecifiedVisitor<
+                          shared_model::interface::ErrorQueryResponse>(),
                       shared_response.get())
-                      .get()
+                      ->get()
                       .which());
         ASSERT_EQ(shared_response.queryHash(),
                   shared_model::crypto::Hash(hash));

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -69,10 +69,9 @@ TEST(QueryResponse, ErrorResponseLoad) {
             error_resp, resp_reason, resp_reason_enum->value(i)->number());
         auto shared_response = shared_model::proto::QueryResponse(response);
         ASSERT_EQ(i,
-                  boost::get<shared_model::detail::PolymorphicWrapper<
-                      shared_model::interface::ErrorQueryResponse>>(
+                  boost::get<const shared_model::interface::ErrorQueryResponse>(
                       shared_response.get())
-                      ->get()
+                      .get()
                       .which());
         ASSERT_EQ(shared_response.queryHash(),
                   shared_model::crypto::Hash(hash));

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -47,9 +47,6 @@ const shared_model::interface::types::DetailType account_detail =
 const auto query_hash = shared_model::interface::types::HashType("hashhash");
 decltype(iroha::time::now()) created_time = iroha::time::now();
 
-template <class T>
-using w = shared_model::detail::PolymorphicWrapper<T>;
-
 TEST(QueryResponseBuilderTest, AccountAssetResponse) {
   shared_model::proto::TemplateQueryResponseBuilder<> builder;
   shared_model::proto::QueryResponse query_response =
@@ -57,9 +54,10 @@ TEST(QueryResponseBuilderTest, AccountAssetResponse) {
           .accountAssetResponse(asset_id, account_id, proto_amount)
           .build();
 
-  const auto tmp = boost::get<w<shared_model::interface::AccountAssetResponse>>(
-      query_response.get());
-  const auto &asset_response = tmp->accountAsset();
+  const auto &tmp =
+      boost::get<const shared_model::interface::AccountAssetResponse>(
+          query_response.get());
+  const auto &asset_response = tmp.accountAsset();
 
   ASSERT_EQ(asset_response.assetId(), asset_id);
   ASSERT_EQ(asset_response.accountId(), account_id);
@@ -74,11 +72,11 @@ TEST(QueryResponseBuilderTest, AccountDetailResponse) {
           .accountDetailResponse(account_detail)
           .build();
 
-  const auto account_detail_response =
-      boost::get<w<shared_model::interface::AccountDetailResponse>>(
+  const auto &account_detail_response =
+      boost::get<const shared_model::interface::AccountDetailResponse>(
           query_response.get());
 
-  ASSERT_EQ(account_detail_response->detail(), account_detail);
+  ASSERT_EQ(account_detail_response.detail(), account_detail);
   ASSERT_EQ(query_response.queryHash(), query_hash);
 }
 
@@ -100,12 +98,12 @@ TEST(QueryResponseBuilderTest, AccountResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).accountResponse(account, roles).build();
 
-  const auto account_response =
-      boost::get<w<shared_model::interface::AccountResponse>>(
+  const auto &account_response =
+      boost::get<const shared_model::interface::AccountResponse>(
           query_response.get());
 
-  ASSERT_EQ(account_response->account(), account);
-  ASSERT_EQ(account_response->roles(), roles);
+  ASSERT_EQ(account_response.account(), account);
+  ASSERT_EQ(account_response.roles(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);
 }
 
@@ -146,11 +144,11 @@ TEST(QueryResponseBuilderTest, SignatoriesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).signatoriesResponse(keys).build();
 
-  const auto signatories_response =
-      boost::get<w<shared_model::interface::SignatoriesResponse>>(
+  const auto &signatories_response =
+      boost::get<const shared_model::interface::SignatoriesResponse>(
           query_response.get());
 
-  const auto &resp_keys = signatories_response->keys();
+  const auto &resp_keys = signatories_response.keys();
   ASSERT_EQ(keys.size(), resp_keys.size());
 
   for (auto i = 0u; i < keys.size(); i++) {
@@ -170,11 +168,11 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).transactionsResponse({transaction}).build();
 
-  const auto transactions_response =
-      boost::get<w<shared_model::interface::TransactionsResponse>>(
+  const auto &transactions_response =
+      boost::get<const shared_model::interface::TransactionsResponse>(
           query_response.get());
 
-  const auto &txs = transactions_response->transactions();
+  const auto &txs = transactions_response.transactions();
 
   ASSERT_EQ(txs.size(), 1);
   ASSERT_EQ(*txs.back(), transaction);
@@ -188,11 +186,11 @@ TEST(QueryResponseBuilderTest, AssetResponse) {
           .assetResponse(asset_id, domain_id, valid_precision)
           .build();
 
-  const auto asset_response =
-      boost::get<w<shared_model::interface::AssetResponse>>(
+  const auto &asset_response =
+      boost::get<const shared_model::interface::AssetResponse>(
           query_response.get());
 
-  const auto &asset = asset_response->asset();
+  const auto &asset = asset_response.asset();
   ASSERT_EQ(asset.assetId(), asset_id);
   ASSERT_EQ(asset.domainId(), domain_id);
   ASSERT_EQ(asset.precision(), valid_precision);
@@ -206,11 +204,11 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolesResponse(roles).build();
 
-  const auto roles_response =
-      boost::get<w<shared_model::interface::RolesResponse>>(
+  const auto &roles_response =
+      boost::get<const shared_model::interface::RolesResponse>(
           query_response.get());
 
-  ASSERT_EQ(roles_response->roles(), roles);
+  ASSERT_EQ(roles_response.roles(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);
 }
 
@@ -221,10 +219,10 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
 
-  const auto role_permissions_response =
-      boost::get<w<shared_model::interface::RolePermissionsResponse>>(
+  const auto &role_permissions_response =
+      boost::get<const shared_model::interface::RolePermissionsResponse>(
           query_response.get());
 
-  ASSERT_EQ(role_permissions_response->rolePermissions(), roles);
+  ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);
 }

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -24,6 +24,7 @@
 #include "builders/protobuf/common_objects/proto_amount_builder.hpp"
 #include "cryptography/keypair.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/utils/specified_visitor.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
@@ -54,9 +55,10 @@ TEST(QueryResponseBuilderTest, AccountAssetResponse) {
           .accountAssetResponse(asset_id, account_id, proto_amount)
           .build();
 
-  const auto &tmp =
-      boost::get<const shared_model::interface::AccountAssetResponse>(
-          query_response.get());
+  const auto &tmp = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountAssetResponse>(),
+      query_response.get());
   const auto &asset_response = tmp.accountAsset();
 
   ASSERT_EQ(asset_response.assetId(), asset_id);
@@ -72,9 +74,10 @@ TEST(QueryResponseBuilderTest, AccountDetailResponse) {
           .accountDetailResponse(account_detail)
           .build();
 
-  const auto &account_detail_response =
-      boost::get<const shared_model::interface::AccountDetailResponse>(
-          query_response.get());
+  const auto &account_detail_response = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountDetailResponse>(),
+      query_response.get());
 
   ASSERT_EQ(account_detail_response.detail(), account_detail);
   ASSERT_EQ(query_response.queryHash(), query_hash);
@@ -99,8 +102,9 @@ TEST(QueryResponseBuilderTest, AccountResponse) {
       builder.queryHash(query_hash).accountResponse(account, roles).build();
 
   const auto &account_response =
-      boost::get<const shared_model::interface::AccountResponse>(
-          query_response.get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AccountResponse>(),
+                            query_response.get());
 
   ASSERT_EQ(account_response.account(), account);
   ASSERT_EQ(account_response.roles(), roles);
@@ -145,8 +149,9 @@ TEST(QueryResponseBuilderTest, SignatoriesResponse) {
       builder.queryHash(query_hash).signatoriesResponse(keys).build();
 
   const auto &signatories_response =
-      boost::get<const shared_model::interface::SignatoriesResponse>(
-          query_response.get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::SignatoriesResponse>(),
+                            query_response.get());
 
   const auto &resp_keys = signatories_response.keys();
   ASSERT_EQ(keys.size(), resp_keys.size());
@@ -168,9 +173,10 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).transactionsResponse({transaction}).build();
 
-  const auto &transactions_response =
-      boost::get<const shared_model::interface::TransactionsResponse>(
-          query_response.get());
+  const auto &transactions_response = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::TransactionsResponse>(),
+      query_response.get());
 
   const auto &txs = transactions_response.transactions();
 
@@ -187,8 +193,9 @@ TEST(QueryResponseBuilderTest, AssetResponse) {
           .build();
 
   const auto &asset_response =
-      boost::get<const shared_model::interface::AssetResponse>(
-          query_response.get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::AssetResponse>(),
+                            query_response.get());
 
   const auto &asset = asset_response.asset();
   ASSERT_EQ(asset.assetId(), asset_id);
@@ -205,8 +212,9 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
       builder.queryHash(query_hash).rolesResponse(roles).build();
 
   const auto &roles_response =
-      boost::get<const shared_model::interface::RolesResponse>(
-          query_response.get());
+      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                shared_model::interface::RolesResponse>(),
+                            query_response.get());
 
   ASSERT_EQ(roles_response.roles(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);
@@ -219,9 +227,10 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
 
-  const auto &role_permissions_response =
-      boost::get<const shared_model::interface::RolePermissionsResponse>(
-          query_response.get());
+  const auto &role_permissions_response = *boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::RolePermissionsResponse>(),
+      query_response.get());
 
   ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Continuing #1366 
Replace `boost::get` with `SpecifiedVisitor` because `boost::get` is also used for `boost::optional`, and it cannot be applied to interface.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Even less polymorphic wrapper!
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
