### PR TITLE
include package name declarations in generated java bindings

### DIFF
--- a/example/java/TransactionExample.java
+++ b/example/java/TransactionExample.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.lang.Thread;
 
+import jp.co.soramitsu.iroha.*;
+
 class TransactionExample {
     static {
         try {

--- a/example/java/prepare.sh
+++ b/example/java/prepare.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname $(dirname "${CURDIR}"))"
-cmake -H$IROHA_HOME -Bbuild -DSWIG_JAVA=ON -DSWIG_JAVA_PKG="jp.co.soramitsu.iroha" -DSWIG_JAVA_OUTDIR="jp.co.soramitsu.iroha";
+cmake -H$IROHA_HOME -Bbuild -DSWIG_JAVA=ON -DSWIG_JAVA_PKG="jp.co.soramitsu.iroha";
 cmake --build build/ --target irohajava -- -j"$(getconf _NPROCESSORS_ONLN)"

--- a/example/java/prepare.sh
+++ b/example/java/prepare.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 CURDIR="$(cd "$(dirname "$0")"; pwd)"
 IROHA_HOME="$(dirname $(dirname "${CURDIR}"))"
-cmake -H$IROHA_HOME -Bbuild -DSWIG_JAVA=ON;
+cmake -H$IROHA_HOME -Bbuild -DSWIG_JAVA=ON -DSWIG_JAVA_PKG="jp.co.soramitsu.iroha" -DSWIG_JAVA_OUTDIR="jp.co.soramitsu.iroha";
 cmake --build build/ --target irohajava -- -j"$(getconf _NPROCESSORS_ONLN)"

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -33,7 +33,7 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
     find_package(swig REQUIRED)
     include(${SWIG_USE_FILE})
 
-    if (SWIG_JAVA)
+    if (SWIG_JAVA AND SWIG_JAVA_PKG)
         set(CMAKE_SWIG_FLAGS -package ${SWIG_JAVA_PKG})
         string(REPLACE "." "/" CMAKE_SWIG_OUTDIR  ${SWIG_JAVA_PKG})   
     else()

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -33,7 +33,13 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
     find_package(swig REQUIRED)
     include(${SWIG_USE_FILE})
 
-    set(CMAKE_SWIG_FLAGS "")
+    if (SWIG_JAVA)
+        set(CMAKE_SWIG_FLAGS -package ${SWIG_JAVA_PKG})
+        set(CMAKE_SWIG_OUTDIR ${SWIG_JAVA_OUTDIR})     
+    else()
+        set(CMAKE_SWIG_FLAGS "")
+    endif()
+    
     set_source_files_properties(bindings.i PROPERTIES CPLUSPLUS ON)
     set_property(GLOBAL PROPERTY SWIG_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/shared_model/bindings/CMakeLists.txt
+++ b/shared_model/bindings/CMakeLists.txt
@@ -35,7 +35,7 @@ if (SWIG_PYTHON OR SWIG_JAVA OR SWIG_CSHARP OR SWIG_NODE)
 
     if (SWIG_JAVA)
         set(CMAKE_SWIG_FLAGS -package ${SWIG_JAVA_PKG})
-        set(CMAKE_SWIG_OUTDIR ${SWIG_JAVA_OUTDIR})     
+        string(REPLACE "." "/" CMAKE_SWIG_OUTDIR  ${SWIG_JAVA_PKG})   
     else()
         set(CMAKE_SWIG_FLAGS "")
     endif()


### PR DESCRIPTION
Include package name declarations inside generated java bindings 

Classes inside the generated lib can now be imported from the package. 

Don't foresee any drawbacks
