### PR TITLE
Add missed quorum function to transaction builder

### DIFF
--- a/shared_model/bindings/model_transaction_builder.cpp
+++ b/shared_model/bindings/model_transaction_builder.cpp
@@ -20,7 +20,7 @@
 namespace shared_model {
   namespace bindings {
     ModelTransactionBuilder::ModelTransactionBuilder() {
-      *this = creatorAccountId("").createdTime(0);
+      *this = creatorAccountId("").createdTime(0).quorum(1);
     }
 
     ModelTransactionBuilder ModelTransactionBuilder::creatorAccountId(
@@ -31,6 +31,11 @@ namespace shared_model {
     ModelTransactionBuilder ModelTransactionBuilder::createdTime(
         interface::types::TimestampType created_time) {
       return ModelTransactionBuilder(builder_.createdTime(created_time));
+    }
+
+    ModelTransactionBuilder ModelTransactionBuilder::quorum(
+        interface::types::QuorumType quorum) {
+      return ModelTransactionBuilder(builder_.quorum(quorum));
     }
 
     ModelTransactionBuilder ModelTransactionBuilder::addAssetQuantity(

--- a/shared_model/bindings/model_transaction_builder.hpp
+++ b/shared_model/bindings/model_transaction_builder.hpp
@@ -55,6 +55,13 @@ namespace shared_model {
           interface::types::TimestampType created_time);
 
       /**
+       * Sets transaction quorum
+       * @param quorum to set
+       * @return builder with quorum field appended
+       */
+      ModelTransactionBuilder quorum(interface::types::QuorumType quorum);
+
+      /**
        * Adds given quantity of given asset to account
        * @param account_id - account id
        * @param asset_id - asset id

--- a/shared_model/packages/javascript/tests/txbuilder.js
+++ b/shared_model/packages/javascript/tests/txbuilder.js
@@ -9,7 +9,7 @@ const assetId = 'coin#test'
 const testAccountId = 'test@test'
 
 test('ModelTransactionBuilder tests', function (t) {
-  t.plan(135)
+  t.plan(136)
 
   let crypto = new iroha.ModelCrypto()
   let keypair = crypto.convertFromExisting(publicKey, privateKey)
@@ -29,6 +29,7 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => txBuilder.creatorAccountId('@@@').createdTime(time).build(), /Transaction should contain at least one command(.*)Wrongly formed creator_account_id, passed value: '@@@'/, 'Should throw 0 commands + Wrongly formed creator_account_id')
   t.throws(() => txBuilder.creatorAccountId(adminAccountId).createdTime(futureTime).build(), /Transaction should contain at least one command(.*)bad timestamp: sent from future/, 'Should throw exception about zero commands in transaction, Sent from future')
   t.throws(() => txBuilder.creatorAccountId(adminAccountId).createdTime(time).build(), /Transaction should contain at least one command/, 'Should throw exception about zero commands in transaction')
+  t.throws(() => txBuilder.quorum(0).build(), /(.*)Quorum should be within range \(0, 128\](.*)/, 'Should throw exception about zero quorum')
 
   // Transaction with valid creatorAccountId and createdTime
   let correctTx = txBuilder.creatorAccountId(adminAccountId).createdTime(time)

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -279,6 +279,7 @@ namespace shared_model {
         field_validator_.validateCreatorAccountId(tx_reason,
                                                   tx.creatorAccountId());
         field_validator_.validateCreatedTime(tx_reason, tx.createdTime());
+        field_validator_.validateQuorum(tx_reason, tx.quorum());
 
         if (not tx_reason.second.empty()) {
           answer.addReason(std::move(tx_reason));

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -38,7 +38,8 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
           key)
       .creatorAccountId(
           integration_framework::IntegrationTestFramework::kAdminId)
-      .createdTime(iroha::time::now());
+      .createdTime(iroha::time::now())
+      .quorum(1);
 }
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
@@ -84,7 +85,7 @@ template auto AcceptanceFixture::base<TestUnsignedQueryBuilder>(
 
 auto AcceptanceFixture::baseTx()
     -> decltype(base(TestUnsignedTransactionBuilder())) {
-  return base(TestUnsignedTransactionBuilder());
+  return base(TestUnsignedTransactionBuilder()).quorum(1);
 }
 
 auto AcceptanceFixture::baseQry()

--- a/test/module/shared_model/builders/protobuf/block_builder_test.cpp
+++ b/test/module/shared_model/builders/protobuf/block_builder_test.cpp
@@ -20,6 +20,7 @@ TEST(BlockBuilderTest, BlockWithTransactions) {
       TestTransactionBuilder()
           .createdTime(iroha::time::now())
           .creatorAccountId("admin@test")
+          .quorum(1)
           .addAssetQuantity("admin@test", "coin#test", "1.0")
           .build();
 

--- a/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
+++ b/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
@@ -56,6 +56,7 @@ class TransportBuilderTest : public ::testing::Test {
   auto getBaseTransactionBuilder() {
     return TestUnsignedTransactionBuilder()
         .createdTime(created_time)
+        .quorum(quorum)
         .setAccountQuorum(account_id, quorum);
   }
 

--- a/test/module/shared_model/validators/transaction_validator_test.cpp
+++ b/test/module/shared_model/validators/transaction_validator_test.cpp
@@ -35,6 +35,7 @@ class TransactionValidatorTest : public ValidatorsTest {
     TestTransactionBuilder builder;
     auto tx = builder.creatorAccountId(creator_account_id)
                   .createdTime(created_time)
+                  .quorum(1)
                   .build()
                   .getTransport();
     return tx;


### PR DESCRIPTION
### Description of the Change
Add missed quorum function to transaction builder

### Benefits

Quorum can be set in client code.

### Possible Drawbacks 

None
