### PR TITLE
Refactor/mv_specified_visitor

### DIFF
--- a/shared_model/builders/protobuf/block_variant_transport_builder.hpp
+++ b/shared_model/builders/protobuf/block_variant_transport_builder.hpp
@@ -8,6 +8,7 @@
 
 #include "builders/protobuf/transport_builder.hpp"
 #include "interfaces/iroha_internal/block_variant.hpp"
+#include "backend/protobuf/empty_block.hpp"
 
 namespace shared_model {
   namespace proto {

--- a/test/framework/specified_visitor.hpp
+++ b/test/framework/specified_visitor.hpp
@@ -18,15 +18,13 @@
 #ifndef IROHA_SPECIFIED_VISITOR_HPP
 #define IROHA_SPECIFIED_VISITOR_HPP
 
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include "utils/polymorphic_wrapper.hpp"
 
 namespace shared_model {
   namespace interface {
     template <typename Type>
-    class SpecifiedVisitor
-        : public boost::static_visitor<boost::optional<const Type &>> {
+    class SpecifiedVisitor : public boost::static_visitor<const Type &> {
      private:
       using Y = shared_model::detail::PolymorphicWrapper<
           std::remove_const_t<std::remove_reference_t<Type>>>;
@@ -37,7 +35,7 @@ namespace shared_model {
        * @param t polymorphic wrapper object of specified type
        * @return const reference to value stored in polymorphic wrapper
        */
-      boost::optional<const Type &> operator()(const Y &t) const {
+      const Type &operator()(const Y &t) const {
         return *t;
       }
 
@@ -46,7 +44,7 @@ namespace shared_model {
        * @param t const reference to object of specified type
        * @return const reference to value
        */
-      boost::optional<const Type &> operator()(const Type &t) const {
+      const Type &operator()(const Type &t) const {
         return t;
       }
 
@@ -57,8 +55,8 @@ namespace shared_model {
        * @return none
        */
       template <typename T>
-      boost::optional<const Type &> operator()(const T &t) const {
-        return boost::none;
+      const Type &operator()(const T &t) const {
+        throw std::runtime_error("unexpected type provided");
       }
     };
   }  // namespace interface

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -7,7 +7,7 @@
 
 #include "datetime/time.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 
 AcceptanceFixture::AcceptanceFixture()
     : kUser("user"),
@@ -23,7 +23,7 @@ AcceptanceFixture::AcceptanceFixture()
       kUserKeypair(
           shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()),
       checkStatelessInvalid([](auto &status) {
-        ASSERT_TRUE(boost::apply_visitor(
+        ASSERT_NO_THROW(boost::apply_visitor(
             shared_model::interface::SpecifiedVisitor<
                 shared_model::interface::StatelessFailedTxResponse>(),
             status.get()));

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -84,14 +84,13 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
 TEST_F(GetTransactions, HaveGetAllTx) {
   auto dummy_tx = dummyTx();
   auto check = [&dummy_tx](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get()));
-    const auto &resp = boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get());
-    ASSERT_EQ(resp.transactions().size(), 1);
-    ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+    });
   };
 
   IntegrationTestFramework(2)
@@ -112,14 +111,13 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 TEST_F(GetTransactions, HaveGetMyTx) {
   auto dummy_tx = dummyTx();
   auto check = [&dummy_tx](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get()));
-    const auto &resp = boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get());
-    ASSERT_EQ(resp.transactions().size(), 1);
-    ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+    });
   };
 
   IntegrationTestFramework(2)
@@ -169,13 +167,12 @@ TEST_F(GetTransactions, InvalidSignatures) {
  */
 TEST_F(GetTransactions, NonexistentHash) {
   auto check = [](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get()));
-    const auto &resp = boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get());
-    ASSERT_EQ(resp.transactions().size(), 0);
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 0);
+    });
   };
 
   IntegrationTestFramework(1)
@@ -194,13 +191,12 @@ TEST_F(GetTransactions, NonexistentHash) {
  */
 TEST_F(GetTransactions, OtherUserTx) {
   auto check = [](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get()));
-    const auto &resp = boost::apply_visitor(
-        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
-        status.get());
-    ASSERT_EQ(resp.transactions().size(), 0);
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 0);
+    });
   };
 
   auto tx = makeUserWithPerms();

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -8,8 +8,8 @@
 #include "builders/protobuf/queries.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "utils/query_error_response_visitor.hpp"
 #include "validators/permissions.hpp"
 
@@ -84,12 +84,14 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
 TEST_F(GetTransactions, HaveGetAllTx) {
   auto dummy_tx = dummyTx();
   auto check = [&dummy_tx](auto &status) {
-    auto resp = boost::apply_visitor(
+    ASSERT_NO_THROW(boost::apply_visitor(
+        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+        status.get()));
+    const auto &resp = boost::apply_visitor(
         interface::SpecifiedVisitor<interface::TransactionsResponse>(),
         status.get());
-    ASSERT_TRUE(resp);
-    ASSERT_EQ(resp.value().transactions().size(), 1);
-    ASSERT_EQ(*resp.value().transactions()[0].operator->(), dummy_tx);
+    ASSERT_EQ(resp.transactions().size(), 1);
+    ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
   };
 
   IntegrationTestFramework(2)
@@ -110,12 +112,14 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 TEST_F(GetTransactions, HaveGetMyTx) {
   auto dummy_tx = dummyTx();
   auto check = [&dummy_tx](auto &status) {
-    auto resp = boost::apply_visitor(
+    ASSERT_NO_THROW(boost::apply_visitor(
+        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+        status.get()));
+    const auto &resp = boost::apply_visitor(
         interface::SpecifiedVisitor<interface::TransactionsResponse>(),
         status.get());
-    ASSERT_TRUE(resp);
-    ASSERT_EQ(resp.value().transactions().size(), 1);
-    ASSERT_EQ(*resp.value().transactions()[0].operator->(), dummy_tx);
+    ASSERT_EQ(resp.transactions().size(), 1);
+    ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
   };
 
   IntegrationTestFramework(2)
@@ -165,11 +169,13 @@ TEST_F(GetTransactions, InvalidSignatures) {
  */
 TEST_F(GetTransactions, NonexistentHash) {
   auto check = [](auto &status) {
-    auto resp = boost::apply_visitor(
+    ASSERT_NO_THROW(boost::apply_visitor(
+        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+        status.get()));
+    const auto &resp = boost::apply_visitor(
         interface::SpecifiedVisitor<interface::TransactionsResponse>(),
         status.get());
-    ASSERT_TRUE(resp);
-    ASSERT_EQ(resp.value().transactions().size(), 0);
+    ASSERT_EQ(resp.transactions().size(), 0);
   };
 
   IntegrationTestFramework(1)
@@ -188,11 +194,13 @@ TEST_F(GetTransactions, NonexistentHash) {
  */
 TEST_F(GetTransactions, OtherUserTx) {
   auto check = [](auto &status) {
-    auto resp = boost::apply_visitor(
+    ASSERT_NO_THROW(boost::apply_visitor(
+        interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+        status.get()));
+    const auto &resp = boost::apply_visitor(
         interface::SpecifiedVisitor<interface::TransactionsResponse>(),
         status.get());
-    ASSERT_TRUE(resp);
-    ASSERT_EQ(resp.value().transactions().size(), 0);
+    ASSERT_EQ(resp.transactions().size(), 0);
   };
 
   auto tx = makeUserWithPerms();

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -4,8 +4,8 @@
  */
 
 #include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 
 class AcceptanceTest : public AcceptanceFixture {
  public:
@@ -14,7 +14,7 @@ class AcceptanceTest : public AcceptanceFixture {
 
   const std::function<void(const shared_model::proto::TransactionResponse &)>
       checkStatelessValid = [](auto &status) {
-        ASSERT_TRUE(boost::apply_visitor(
+        ASSERT_NO_THROW(boost::apply_visitor(
             shared_model::interface::SpecifiedVisitor<
                 shared_model::interface::StatelessValidTxResponse>(),
             status.get()));

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -8,8 +8,8 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "validators/permissions.hpp"
 
 using namespace integration_framework;
@@ -122,7 +122,10 @@ TEST_F(HeavyTransactionTest, DISABLED_QueryLargeData) {
   auto name_generator = [](auto val) { return "foo_" + std::to_string(val); };
 
   auto query_checker = [&](auto &status) {
-    auto &&response = *boost::apply_visitor(
+    ASSERT_NO_THROW(boost::apply_visitor(
+        interface::SpecifiedVisitor<const interface::AccountResponse &>(),
+        status.get()));
+    auto &&response = boost::apply_visitor(
         interface::SpecifiedVisitor<const interface::AccountResponse &>(),
         status.get());
 

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -122,22 +122,21 @@ TEST_F(HeavyTransactionTest, DISABLED_QueryLargeData) {
   auto name_generator = [](auto val) { return "foo_" + std::to_string(val); };
 
   auto query_checker = [&](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        interface::SpecifiedVisitor<const interface::AccountResponse &>(),
-        status.get()));
-    auto &&response = boost::apply_visitor(
-        interface::SpecifiedVisitor<const interface::AccountResponse &>(),
-        status.get());
+    ASSERT_NO_THROW({
+      auto &&response = boost::apply_visitor(
+          interface::SpecifiedVisitor<const interface::AccountResponse &>(),
+          status.get());
 
-    boost::property_tree::ptree root;
-    boost::property_tree::read_json(response.account().jsonData(), root);
-    auto user = root.get_child(kUserId);
+      boost::property_tree::ptree root;
+      boost::property_tree::read_json(response.account().jsonData(), root);
+      auto user = root.get_child(kUserId);
 
-    ASSERT_EQ(number_of_times, user.size());
+      ASSERT_EQ(number_of_times, user.size());
 
-    for (auto i = 0u; i < number_of_times; ++i) {
-      ASSERT_EQ(data, user.get<std::string>(name_generator(i)));
-    }
+      for (auto i = 0u; i < number_of_times; ++i) {
+        ASSERT_EQ(data, user.get<std::string>(name_generator(i)));
+      }
+    });
   };
 
   IntegrationTestFramework itf(1);

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -22,7 +22,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "datetime/time.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 constexpr auto kUser = "user@test";

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -20,8 +20,8 @@
 #include "builders/default_builders.hpp"
 #include "execution/command_executor.hpp"
 #include "framework/result_fixture.hpp"
+#include "framework/specified_visitor.hpp"
 #include "interfaces/commands/command.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "validators/permissions.hpp"
@@ -57,10 +57,8 @@ std::unique_ptr<shared_model::interface::Command> buildCommand(
 template <class T>
 std::shared_ptr<T> getConcreteCommand(
     const std::unique_ptr<shared_model::interface::Command> &command) {
-  return clone(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<T>(),
-                           command->get())
-          .value());
+  return clone(boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<T>(), command->get()));
 }
 
 class CommandValidateExecuteTest : public ::testing::Test {

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -21,7 +21,7 @@
 #include "cryptography/keypair.hpp"
 #include "execution/query_execution.hpp"
 #include "framework/test_subscriber.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
@@ -101,7 +101,7 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
 
   auto wrapper = make_test_subscriber<CallExact>(qpi.queryNotifier(), 1);
   wrapper.subscribe([](auto response) {
-    ASSERT_TRUE(
+    ASSERT_NO_THROW(
         boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get()));

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -7,8 +7,8 @@
 #include "builders/protobuf/common_objects/proto_signature_builder.hpp"
 #include "builders/protobuf/proposal.hpp"
 #include "builders/protobuf/transaction.hpp"
+#include "framework/specified_visitor.hpp"
 #include "framework/test_subscriber.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
@@ -364,7 +364,7 @@ TEST_F(TransactionProcessorTest, MultisigExpired) {
 
   auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
   wrapper.subscribe([](auto response) {
-    ASSERT_TRUE(
+    ASSERT_NO_THROW(
         boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
                                  shared_model::interface::MstExpiredResponse>(),
                              response->get()));

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -227,18 +227,16 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           resp.get()));
-  const auto &account_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           resp.get());
+  ASSERT_NO_THROW({
+    const auto &account_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             resp.get());
 
-  ASSERT_EQ(account_resp.account().accountId(), accountB->accountId());
-  ASSERT_EQ(account_resp.roles().size(), 1);
-  ASSERT_EQ(model_query.hash(), resp.queryHash());
+    ASSERT_EQ(account_resp.account().accountId(), accountB->accountId());
+    ASSERT_EQ(account_resp.roles().size(), 1);
+    ASSERT_EQ(model_query.hash(), resp.queryHash());
+  });
 }
 
 TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
@@ -273,18 +271,16 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           resp.get()));
-  const auto &detail_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           resp.get());
+  ASSERT_NO_THROW({
+    const auto &detail_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             resp.get());
 
-  ASSERT_EQ(detail_resp.account().accountId(), account->accountId());
-  ASSERT_EQ(detail_resp.account().domainId(), account->domainId());
-  ASSERT_EQ(model_query.hash(), resp.queryHash());
+    ASSERT_EQ(detail_resp.account().accountId(), account->accountId());
+    ASSERT_EQ(detail_resp.account().domainId(), account->domainId());
+    ASSERT_EQ(model_query.hash(), resp.queryHash());
+  });
 }
 
 /**
@@ -383,20 +379,19 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   ASSERT_FALSE(response.has_error_response());
 
   auto resp = shared_model::proto::QueryResponse(response);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           resp.get()));
-  const auto &asset_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           resp.get());
+  ASSERT_NO_THROW({
+    const auto &asset_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        resp.get());
 
-  // Check if the fields in account asset response are correct
-  ASSERT_EQ(asset_resp.accountAsset().assetId(), account_asset->assetId());
-  ASSERT_EQ(asset_resp.accountAsset().accountId(), account_asset->accountId());
-  ASSERT_EQ(asset_resp.accountAsset().balance(), account_asset->balance());
-  ASSERT_EQ(model_query.hash(), resp.queryHash());
+    // Check if the fields in account asset response are correct
+    ASSERT_EQ(asset_resp.accountAsset().assetId(), account_asset->assetId());
+    ASSERT_EQ(asset_resp.accountAsset().accountId(),
+              account_asset->accountId());
+    ASSERT_EQ(asset_resp.accountAsset().balance(), account_asset->balance());
+    ASSERT_EQ(model_query.hash(), resp.queryHash());
+  });
 }
 
 /**
@@ -476,24 +471,22 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
   auto shared_response = shared_model::proto::QueryResponse(response);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           shared_response.get()));
-  auto resp_pubkey =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+  ASSERT_NO_THROW({
+    auto resp_pubkey = *boost::apply_visitor(
+                            shared_model::interface::SpecifiedVisitor<
                                 shared_model::interface::SignatoriesResponse>(),
                             shared_response.get())
-           .keys()
-           .begin();
+                            .keys()
+                            .begin();
 
-  ASSERT_TRUE(stat.ok());
-  /// Should not return Error Response because tx is stateless and stateful
-  /// valid
-  ASSERT_FALSE(response.has_error_response());
-  // check if fields in response are valid
-  ASSERT_EQ(*resp_pubkey, signatories.back());
-  ASSERT_EQ(model_query.hash(), shared_response.queryHash());
+    ASSERT_TRUE(stat.ok());
+    /// Should not return Error Response because tx is stateless and stateful
+    /// valid
+    ASSERT_FALSE(response.has_error_response());
+    // check if fields in response are valid
+    ASSERT_EQ(*resp_pubkey, signatories.back());
+    ASSERT_EQ(model_query.hash(), shared_response.queryHash());
+  });
 }
 
 /**
@@ -542,20 +535,18 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
   auto resp = shared_model::proto::QueryResponse(response);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           resp.get()));
-  const auto &tx_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           resp.get());
+  ASSERT_NO_THROW({
+    const auto &tx_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        resp.get());
 
-  const auto &txs = tx_resp.transactions();
-  for (auto i = 0ul; i < txs.size(); i++) {
-    ASSERT_EQ(txs.at(i)->creatorAccountId(), account.accountId());
-  }
-  ASSERT_EQ(model_query.hash(), resp.queryHash());
+    const auto &txs = tx_resp.transactions();
+    for (auto i = 0ul; i < txs.size(); i++) {
+      ASSERT_EQ(txs.at(i)->creatorAccountId(), account.accountId());
+    }
+    ASSERT_EQ(model_query.hash(), resp.queryHash());
+  });
 }
 
 TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -27,7 +27,7 @@ limitations under the License.
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 #include "main/server_runner.hpp"
 #include "torii/processor/query_processor_impl.hpp"
 #include "torii/query_client.hpp"
@@ -227,10 +227,14 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  auto &account_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            resp.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           resp.get()));
+  const auto &account_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           resp.get());
 
   ASSERT_EQ(account_resp.account().accountId(), accountB->accountId());
   ASSERT_EQ(account_resp.roles().size(), 1);
@@ -269,10 +273,14 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  auto &detail_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            resp.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           resp.get()));
+  const auto &detail_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           resp.get());
 
   ASSERT_EQ(detail_resp.account().accountId(), account->accountId());
   ASSERT_EQ(detail_resp.account().domainId(), account->domainId());
@@ -375,10 +383,14 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   ASSERT_FALSE(response.has_error_response());
 
   auto resp = shared_model::proto::QueryResponse(response);
-  auto &asset_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      resp.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           resp.get()));
+  const auto &asset_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           resp.get());
 
   // Check if the fields in account asset response are correct
   ASSERT_EQ(asset_resp.accountAsset().assetId(), account_asset->assetId());
@@ -464,11 +476,15 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
   auto shared_response = shared_model::proto::QueryResponse(response);
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           shared_response.get()));
   auto resp_pubkey =
       *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
                                 shared_model::interface::SignatoriesResponse>(),
                             shared_response.get())
-           ->keys()
+           .keys()
            .begin();
 
   ASSERT_TRUE(stat.ok());
@@ -526,10 +542,14 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
   auto resp = shared_model::proto::QueryResponse(response);
-  auto &tx_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      resp.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           resp.get()));
+  const auto &tx_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           resp.get());
 
   const auto &txs = tx_resp.transactions();
   for (auto i = 0ul; i < txs.size(); i++) {

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -148,15 +148,13 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
       .WillOnce(Return(role_permissions));
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get());
-  ASSERT_EQ(cast_resp.account().accountId(), admin_id);
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             response->get());
+    ASSERT_EQ(cast_resp.account().accountId(), admin_id);
+  });
 }
 
 /**
@@ -180,15 +178,13 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get());
-  ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             response->get());
+    ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  });
 }
 
 /**
@@ -212,15 +208,13 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get());
-  ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             response->get());
+    ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  });
 }
 
 /**
@@ -249,15 +243,13 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           response->get());
-  ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             response->get());
+    ASSERT_EQ(cast_resp.account().accountId(), account_id);
+  });
 }
 
 /**
@@ -375,17 +367,15 @@ TEST_F(GetAccountAssetsTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountAsset(admin_id, asset_id))
       .WillOnce(Return(accountAsset));
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.accountAsset().accountId(), admin_id);
-  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+    ASSERT_EQ(cast_resp.accountAsset().accountId(), admin_id);
+    ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+  });
 }
 
 /**
@@ -422,17 +412,15 @@ TEST_F(GetAccountAssetsTest, AllAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+    ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+    ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+  });
 }
 
 /**
@@ -469,17 +457,15 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get()));
-  auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+    ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+    ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+  });
 }
 
 /**
@@ -513,17 +499,15 @@ TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
-  ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+    ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
+    ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
+  });
 }
 
 /**
@@ -642,16 +626,14 @@ TEST_F(GetSignatoriesTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(admin_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::SignatoriesResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.keys().size(), 1);
+    ASSERT_EQ(cast_resp.keys().size(), 1);
+  });
 }
 
 /**
@@ -674,16 +656,14 @@ TEST_F(GetSignatoriesTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::SignatoriesResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.keys().size(), 1);
+    ASSERT_EQ(cast_resp.keys().size(), 1);
+  });
 }
 
 /**
@@ -706,16 +686,14 @@ TEST_F(GetSignatoriesTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::SignatoriesResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.keys().size(), 1);
+    ASSERT_EQ(cast_resp.keys().size(), 1);
+  });
 }
 
 /**
@@ -743,16 +721,14 @@ TEST_F(GetSignatoriesTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::SignatoriesResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.keys().size(), 1);
+    ASSERT_EQ(cast_resp.keys().size(), 1);
+  });
 }
 
 /**
@@ -848,19 +824,17 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(admin_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(admin_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -885,19 +859,17 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -922,19 +894,17 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -963,19 +933,17 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -1071,19 +1039,17 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(admin_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(admin_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -1108,19 +1074,17 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -1145,19 +1109,17 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -1186,19 +1148,17 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.transactions().size(), N);
-  for (const auto &tx : cast_resp.transactions()) {
-    EXPECT_EQ(account_id, tx->creatorAccountId());
-  }
+    ASSERT_EQ(cast_resp.transactions().size(), N);
+    for (const auto &tx : cast_resp.transactions()) {
+      EXPECT_EQ(account_id, tx->creatorAccountId());
+    }
+  });
 }
 
 /**
@@ -1321,16 +1281,14 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAsset(asset_id)).WillOnce(Return(asset));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AssetResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AssetResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AssetResponse>(),
+                             response->get());
 
-  ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
+    ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
+  });
 }
 
 /**
@@ -1409,20 +1367,18 @@ TEST_F(GetRolesTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRoles()).WillOnce(Return(roles));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::RolesResponse>(),
-                           response->get()));
-  const auto &cast_resp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::RolesResponse>(),
-                           response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::RolesResponse>(),
+                             response->get());
 
-  ASSERT_EQ(cast_resp.roles().size(), roles.size());
+    ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
-  for (size_t i = 0; i < roles.size(); ++i) {
-    ASSERT_EQ(cast_resp.roles().at(i), roles.at(i));
-  }
+    for (size_t i = 0; i < roles.size(); ++i) {
+      ASSERT_EQ(cast_resp.roles().at(i), roles.at(i));
+    }
+  });
 }
 
 /**
@@ -1497,19 +1453,17 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::RolePermissionsResponse>(),
-      response->get()));
-  const auto &cast_resp = boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::RolePermissionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW({
+    const auto &cast_resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::RolePermissionsResponse>(),
+        response->get());
 
-  ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
-  for (size_t i = 0; i < perms.size(); ++i) {
-    ASSERT_EQ(cast_resp.rolePermissions().at(i), perms.at(i));
-  }
+    ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
+    for (size_t i = 0; i < perms.size(); ++i) {
+      ASSERT_EQ(cast_resp.rolePermissions().at(i), perms.at(i));
+    }
+  });
 }
 
 /**

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -26,8 +26,8 @@
 #include "builders/protobuf/common_objects/proto_amount_builder.hpp"
 #include "builders/protobuf/common_objects/proto_asset_builder.hpp"
 #include "execution/query_execution.hpp"
+#include "framework/specified_visitor.hpp"
 #include "framework/test_subscriber.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "utils/query_error_response_visitor.hpp"
 #include "validators/permissions.hpp"
@@ -148,10 +148,14 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
       .WillOnce(Return(role_permissions));
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get());
   ASSERT_EQ(cast_resp.account().accountId(), admin_id);
 }
 
@@ -176,10 +180,14 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -204,10 +212,14 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -237,10 +249,14 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(account_id))
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           response->get());
   ASSERT_EQ(cast_resp.account().accountId(), account_id);
 }
 
@@ -359,10 +375,14 @@ TEST_F(GetAccountAssetsTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccountAsset(admin_id, asset_id))
       .WillOnce(Return(accountAsset));
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), admin_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -402,10 +422,14 @@ TEST_F(GetAccountAssetsTest, AllAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -445,10 +469,14 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get()));
+  auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -485,10 +513,14 @@ TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
       .WillOnce(Return(accountAsset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.accountAsset().accountId(), account_id);
   ASSERT_EQ(cast_resp.accountAsset().assetId(), asset_id);
@@ -610,10 +642,14 @@ TEST_F(GetSignatoriesTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(admin_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::SignatoriesResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -638,10 +674,14 @@ TEST_F(GetSignatoriesTest, AllAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::SignatoriesResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -666,10 +706,14 @@ TEST_F(GetSignatoriesTest, DomainAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::SignatoriesResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -699,10 +743,14 @@ TEST_F(GetSignatoriesTest, GrantAccountValidCase) {
   EXPECT_CALL(*wsv_query, getSignatories(account_id)).WillOnce(Return(signs));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::SignatoriesResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.keys().size(), 1);
 }
@@ -800,10 +848,14 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -833,10 +885,14 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -866,10 +922,14 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -903,10 +963,14 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -966,10 +1030,10 @@ TEST_F(GetAccountTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(*boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get()));
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
 }
 
 /// --------- Get Account Assets Transactions-------------
@@ -1007,10 +1071,14 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1040,10 +1108,14 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1073,10 +1145,14 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1110,10 +1186,14 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
       .WillOnce(Return(txs_observable));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.transactions().size(), N);
   for (const auto &tx : cast_resp.transactions()) {
@@ -1173,10 +1253,10 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAccountExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(*boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get()));
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
 }
 
 /**
@@ -1201,10 +1281,10 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAssetExist) {
       .WillOnce(Return(rxcpp::observable<>::empty<wTransaction>()));
 
   auto response = validateAndExecute(query);
-  ASSERT_NO_THROW(*boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      response->get()));
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           response->get()));
 }
 
 /// --------- Get Asset Info -------------
@@ -1241,10 +1321,14 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAsset(asset_id)).WillOnce(Return(asset));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AssetResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AssetResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AssetResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
 }
@@ -1325,10 +1409,14 @@ TEST_F(GetRolesTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRoles()).WillOnce(Return(roles));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::RolesResponse>(),
-                            response->get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::RolesResponse>(),
+                           response->get()));
+  const auto &cast_resp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::RolesResponse>(),
+                           response->get());
 
   ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
@@ -1409,7 +1497,11 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
 
   auto response = validateAndExecute(query);
-  auto &cast_resp = *boost::apply_visitor(
+  ASSERT_NO_THROW(boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::RolePermissionsResponse>(),
+      response->get()));
+  const auto &cast_resp = boost::apply_visitor(
       shared_model::interface::SpecifiedVisitor<
           shared_model::interface::RolePermissionsResponse>(),
       response->get());

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -21,7 +21,7 @@
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/irange.hpp>
 #include "cryptography/hash.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 
 /**
  * @given protobuf's QueryResponse with different responses and some hash
@@ -69,12 +69,16 @@ TEST(QueryResponse, ErrorResponseLoad) {
         refl->SetEnumValue(
             error_resp, resp_reason, resp_reason_enum->value(i)->number());
         auto shared_response = shared_model::proto::QueryResponse(response);
+        ASSERT_NO_THROW(boost::apply_visitor(
+            shared_model::interface::SpecifiedVisitor<
+                shared_model::interface::ErrorQueryResponse>(),
+            shared_response.get()));
         ASSERT_EQ(i,
                   boost::apply_visitor(
                       shared_model::interface::SpecifiedVisitor<
                           shared_model::interface::ErrorQueryResponse>(),
                       shared_response.get())
-                      ->get()
+                      .get()
                       .which());
         ASSERT_EQ(shared_response.queryHash(),
                   shared_model::crypto::Hash(hash));

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -69,18 +69,16 @@ TEST(QueryResponse, ErrorResponseLoad) {
         refl->SetEnumValue(
             error_resp, resp_reason, resp_reason_enum->value(i)->number());
         auto shared_response = shared_model::proto::QueryResponse(response);
-        ASSERT_NO_THROW(boost::apply_visitor(
-            shared_model::interface::SpecifiedVisitor<
-                shared_model::interface::ErrorQueryResponse>(),
-            shared_response.get()));
-        ASSERT_EQ(i,
-                  boost::apply_visitor(
-                      shared_model::interface::SpecifiedVisitor<
-                          shared_model::interface::ErrorQueryResponse>(),
-                      shared_response.get())
-                      .get()
-                      .which());
-        ASSERT_EQ(shared_response.queryHash(),
-                  shared_model::crypto::Hash(hash));
+        ASSERT_NO_THROW({
+          ASSERT_EQ(i,
+                    boost::apply_visitor(
+                        shared_model::interface::SpecifiedVisitor<
+                            shared_model::interface::ErrorQueryResponse>(),
+                        shared_response.get())
+                        .get()
+                        .which());
+          ASSERT_EQ(shared_response.queryHash(),
+                    shared_model::crypto::Hash(hash));
+        });
       });
 }

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -23,8 +23,8 @@
 #include "builders/protobuf/common_objects/proto_account_builder.hpp"
 #include "builders/protobuf/common_objects/proto_amount_builder.hpp"
 #include "cryptography/keypair.hpp"
+#include "framework/specified_visitor.hpp"
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
@@ -55,10 +55,14 @@ TEST(QueryResponseBuilderTest, AccountAssetResponse) {
           .accountAssetResponse(asset_id, account_id, proto_amount)
           .build();
 
-  const auto &tmp = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountAssetResponse>(),
-      query_response.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           query_response.get()));
+  const auto &tmp =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountAssetResponse>(),
+                           query_response.get());
   const auto &asset_response = tmp.accountAsset();
 
   ASSERT_EQ(asset_response.assetId(), asset_id);
@@ -74,7 +78,11 @@ TEST(QueryResponseBuilderTest, AccountDetailResponse) {
           .accountDetailResponse(account_detail)
           .build();
 
-  const auto &account_detail_response = *boost::apply_visitor(
+  ASSERT_NO_THROW(boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::AccountDetailResponse>(),
+      query_response.get()));
+  const auto &account_detail_response = boost::apply_visitor(
       shared_model::interface::SpecifiedVisitor<
           shared_model::interface::AccountDetailResponse>(),
       query_response.get());
@@ -101,10 +109,14 @@ TEST(QueryResponseBuilderTest, AccountResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).accountResponse(account, roles).build();
 
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           query_response.get()));
   const auto &account_response =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AccountResponse>(),
-                            query_response.get());
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AccountResponse>(),
+                           query_response.get());
 
   ASSERT_EQ(account_response.account(), account);
   ASSERT_EQ(account_response.roles(), roles);
@@ -148,10 +160,14 @@ TEST(QueryResponseBuilderTest, SignatoriesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).signatoriesResponse(keys).build();
 
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           query_response.get()));
   const auto &signatories_response =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::SignatoriesResponse>(),
-                            query_response.get());
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::SignatoriesResponse>(),
+                           query_response.get());
 
   const auto &resp_keys = signatories_response.keys();
   ASSERT_EQ(keys.size(), resp_keys.size());
@@ -173,10 +189,14 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).transactionsResponse({transaction}).build();
 
-  const auto &transactions_response = *boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::TransactionsResponse>(),
-      query_response.get());
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           query_response.get()));
+  const auto &transactions_response =
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::TransactionsResponse>(),
+                           query_response.get());
 
   const auto &txs = transactions_response.transactions();
 
@@ -192,10 +212,14 @@ TEST(QueryResponseBuilderTest, AssetResponse) {
           .assetResponse(asset_id, domain_id, valid_precision)
           .build();
 
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AssetResponse>(),
+                           query_response.get()));
   const auto &asset_response =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::AssetResponse>(),
-                            query_response.get());
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::AssetResponse>(),
+                           query_response.get());
 
   const auto &asset = asset_response.asset();
   ASSERT_EQ(asset.assetId(), asset_id);
@@ -211,10 +235,14 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolesResponse(roles).build();
 
+  ASSERT_NO_THROW(
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::RolesResponse>(),
+                           query_response.get()));
   const auto &roles_response =
-      *boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                                shared_model::interface::RolesResponse>(),
-                            query_response.get());
+      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                               shared_model::interface::RolesResponse>(),
+                           query_response.get());
 
   ASSERT_EQ(roles_response.roles(), roles);
   ASSERT_EQ(query_response.queryHash(), query_hash);
@@ -227,7 +255,11 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
 
-  const auto &role_permissions_response = *boost::apply_visitor(
+  ASSERT_NO_THROW(boost::apply_visitor(
+      shared_model::interface::SpecifiedVisitor<
+          shared_model::interface::RolePermissionsResponse>(),
+      query_response.get()));
+  const auto &role_permissions_response = boost::apply_visitor(
       shared_model::interface::SpecifiedVisitor<
           shared_model::interface::RolePermissionsResponse>(),
       query_response.get());

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -55,20 +55,18 @@ TEST(QueryResponseBuilderTest, AccountAssetResponse) {
           .accountAssetResponse(asset_id, account_id, proto_amount)
           .build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           query_response.get()));
-  const auto &tmp =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountAssetResponse>(),
-                           query_response.get());
-  const auto &asset_response = tmp.accountAsset();
+  ASSERT_NO_THROW({
+    const auto &tmp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountAssetResponse>(),
+        query_response.get());
+    const auto &asset_response = tmp.accountAsset();
 
-  ASSERT_EQ(asset_response.assetId(), asset_id);
-  ASSERT_EQ(asset_response.accountId(), account_id);
-  ASSERT_EQ(asset_response.balance(), proto_amount);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(asset_response.assetId(), asset_id);
+    ASSERT_EQ(asset_response.accountId(), account_id);
+    ASSERT_EQ(asset_response.balance(), proto_amount);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, AccountDetailResponse) {
@@ -78,17 +76,15 @@ TEST(QueryResponseBuilderTest, AccountDetailResponse) {
           .accountDetailResponse(account_detail)
           .build();
 
-  ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountDetailResponse>(),
-      query_response.get()));
-  const auto &account_detail_response = boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::AccountDetailResponse>(),
-      query_response.get());
+  ASSERT_NO_THROW({
+    const auto &account_detail_response = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::AccountDetailResponse>(),
+        query_response.get());
 
-  ASSERT_EQ(account_detail_response.detail(), account_detail);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(account_detail_response.detail(), account_detail);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, AccountResponse) {
@@ -109,18 +105,16 @@ TEST(QueryResponseBuilderTest, AccountResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).accountResponse(account, roles).build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           query_response.get()));
-  const auto &account_response =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AccountResponse>(),
-                           query_response.get());
+  ASSERT_NO_THROW({
+    const auto &account_response =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AccountResponse>(),
+                             query_response.get());
 
-  ASSERT_EQ(account_response.account(), account);
-  ASSERT_EQ(account_response.roles(), roles);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(account_response.account(), account);
+    ASSERT_EQ(account_response.roles(), roles);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 template <typename T>
@@ -160,22 +154,20 @@ TEST(QueryResponseBuilderTest, SignatoriesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).signatoriesResponse(keys).build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           query_response.get()));
-  const auto &signatories_response =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::SignatoriesResponse>(),
-                           query_response.get());
+  ASSERT_NO_THROW({
+    const auto &signatories_response = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::SignatoriesResponse>(),
+        query_response.get());
 
-  const auto &resp_keys = signatories_response.keys();
-  ASSERT_EQ(keys.size(), resp_keys.size());
+    const auto &resp_keys = signatories_response.keys();
+    ASSERT_EQ(keys.size(), resp_keys.size());
 
-  for (auto i = 0u; i < keys.size(); i++) {
-    ASSERT_EQ(keys.at(i).blob(), resp_keys.at(i)->blob());
-  }
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    for (auto i = 0u; i < keys.size(); i++) {
+      ASSERT_EQ(keys.at(i).blob(), resp_keys.at(i)->blob());
+    }
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, TransactionsResponse) {
@@ -189,20 +181,18 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).transactionsResponse({transaction}).build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           query_response.get()));
-  const auto &transactions_response =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::TransactionsResponse>(),
-                           query_response.get());
+  ASSERT_NO_THROW({
+    const auto &transactions_response = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        query_response.get());
 
-  const auto &txs = transactions_response.transactions();
+    const auto &txs = transactions_response.transactions();
 
-  ASSERT_EQ(txs.size(), 1);
-  ASSERT_EQ(*txs.back(), transaction);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(txs.size(), 1);
+    ASSERT_EQ(*txs.back(), transaction);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, AssetResponse) {
@@ -212,20 +202,18 @@ TEST(QueryResponseBuilderTest, AssetResponse) {
           .assetResponse(asset_id, domain_id, valid_precision)
           .build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AssetResponse>(),
-                           query_response.get()));
-  const auto &asset_response =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::AssetResponse>(),
-                           query_response.get());
+  ASSERT_NO_THROW({
+    const auto &asset_response =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::AssetResponse>(),
+                             query_response.get());
 
-  const auto &asset = asset_response.asset();
-  ASSERT_EQ(asset.assetId(), asset_id);
-  ASSERT_EQ(asset.domainId(), domain_id);
-  ASSERT_EQ(asset.precision(), valid_precision);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    const auto &asset = asset_response.asset();
+    ASSERT_EQ(asset.assetId(), asset_id);
+    ASSERT_EQ(asset.domainId(), domain_id);
+    ASSERT_EQ(asset.precision(), valid_precision);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, RolesResponse) {
@@ -235,17 +223,15 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolesResponse(roles).build();
 
-  ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::RolesResponse>(),
-                           query_response.get()));
-  const auto &roles_response =
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
-                               shared_model::interface::RolesResponse>(),
-                           query_response.get());
+  ASSERT_NO_THROW({
+    const auto &roles_response =
+        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+                                 shared_model::interface::RolesResponse>(),
+                             query_response.get());
 
-  ASSERT_EQ(roles_response.roles(), roles);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(roles_response.roles(), roles);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }
 
 TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
@@ -255,15 +241,13 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
   shared_model::proto::QueryResponse query_response =
       builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
 
-  ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::RolePermissionsResponse>(),
-      query_response.get()));
-  const auto &role_permissions_response = boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<
-          shared_model::interface::RolePermissionsResponse>(),
-      query_response.get());
+  ASSERT_NO_THROW({
+    const auto &role_permissions_response = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::RolePermissionsResponse>(),
+        query_response.get());
 
-  ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
-  ASSERT_EQ(query_response.queryHash(), query_hash);
+    ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
+    ASSERT_EQ(query_response.queryHash(), query_hash);
+  });
 }

--- a/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
+++ b/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
@@ -19,12 +19,12 @@
 
 #include "block.pb.h"
 #include "builders/protobuf/block.hpp"
+#include "builders/protobuf/block_variant_transport_builder.hpp"
 #include "builders/protobuf/empty_block.hpp"
 #include "builders/protobuf/proposal.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "builders/protobuf/transport_builder.hpp"
-#include "builders/protobuf/block_variant_transport_builder.hpp"
 #include "common/types.hpp"
 #include "framework/result_fixture.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -102,16 +102,14 @@ TEST(RegressionTest, StateRecovery) {
   };
   auto checkOne = [](auto &res) { ASSERT_EQ(res->transactions().size(), 1); };
   auto checkQuery = [&tx](auto &status) {
-    ASSERT_NO_THROW(boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
-            shared_model::interface::TransactionsResponse>(),
-        status.get()));
-    const auto &resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
-            shared_model::interface::TransactionsResponse>(),
-        status.get());
-    ASSERT_EQ(resp.transactions().size(), 1);
-    ASSERT_EQ(*resp.transactions()[0].operator->(), tx);
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          shared_model::interface::SpecifiedVisitor<
+              shared_model::interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(*resp.transactions()[0].operator->(), tx);
+    });
   };
   auto path =
       (boost::filesystem::temp_directory_path() / "iroha-state-recovery-test")

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -20,7 +20,7 @@
 #include "builders/protobuf/transaction.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "interfaces/utils/specified_visitor.hpp"
+#include "framework/specified_visitor.hpp"
 
 constexpr auto kUser = "user@test";
 constexpr auto kAsset = "asset#domain";
@@ -44,10 +44,9 @@ TEST(RegressionTest, SequentialInitialization) {
                         generateKeypair());
 
   auto checkStatelessValid = [](auto &status) {
-    ASSERT_TRUE(boost::apply_visitor(
-        shared_model::interface::
-            SpecifiedVisitor<shared_model::interface::
-                                 StatelessValidTxResponse>(),
+    ASSERT_NO_THROW(boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::StatelessValidTxResponse>(),
         status.get()));
   };
   auto checkProposal = [](auto &proposal) {
@@ -103,13 +102,16 @@ TEST(RegressionTest, StateRecovery) {
   };
   auto checkOne = [](auto &res) { ASSERT_EQ(res->transactions().size(), 1); };
   auto checkQuery = [&tx](auto &status) {
-    auto resp = boost::apply_visitor(
-        shared_model::interface::
-            SpecifiedVisitor<shared_model::interface::TransactionsResponse>(),
+    ASSERT_NO_THROW(boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
+        status.get()));
+    const auto &resp = boost::apply_visitor(
+        shared_model::interface::SpecifiedVisitor<
+            shared_model::interface::TransactionsResponse>(),
         status.get());
-    ASSERT_TRUE(resp);
-    ASSERT_EQ(resp.value().transactions().size(), 1);
-    ASSERT_EQ(*resp.value().transactions()[0].operator->(), tx);
+    ASSERT_EQ(resp.transactions().size(), 1);
+    ASSERT_EQ(*resp.transactions()[0].operator->(), tx);
   };
   auto path =
       (boost::filesystem::temp_directory_path() / "iroha-state-recovery-test")


### PR DESCRIPTION
Move specified_visitor to test framework

Signed-off-by: Akvinikym <anarant12@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Class specified_visitor was previously located in shared_model, which is inappropriate, as it is used only in tests, so it was moved to test framework.
Also, it used to return an optional value, which is now changed to exception throwing in case we meet unexpected class. 

### Benefits

- code becomes more logically structured
- no additional overhead during tests to get values from optionals

### Possible Drawbacks 

None