### PR TITLE
Fix block query race condition

### DIFF
--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -32,6 +32,17 @@ namespace iroha {
           log_(logger::log("PostgresBlockIndex")),
           execute_{makeExecuteOptional(transaction_, log_)} {}
 
+    PostgresBlockQuery::PostgresBlockQuery(
+        std::unique_ptr<pqxx::lazyconnection> connection,
+        std::unique_ptr<pqxx::nontransaction> transaction,
+        FlatFile &file_store)
+        : connection_ptr_(std::move(connection)),
+          transaction_ptr_(std::move(transaction)),
+          block_store_(file_store),
+          transaction_(*transaction_ptr_),
+          log_(logger::log("PostgresBlockIndex")),
+          execute_{makeExecuteOptional(transaction_, log_)} {}
+
     rxcpp::observable<BlockQuery::wBlock> PostgresBlockQuery::getBlocks(
         shared_model::interface::types::HeightType height, uint32_t count) {
       shared_model::interface::types::HeightType last_id =

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -19,6 +19,7 @@
 #define IROHA_POSTGRES_FLAT_BLOCK_QUERY_HPP
 
 #include <boost/optional.hpp>
+#include <pqxx/connection>
 #include <pqxx/nontransaction>
 
 #include "ametsuchi/block_query.hpp"
@@ -37,6 +38,9 @@ namespace iroha {
     class PostgresBlockQuery : public BlockQuery {
      public:
       PostgresBlockQuery(pqxx::nontransaction &transaction_,
+                         FlatFile &file_store);
+      PostgresBlockQuery(std::unique_ptr<pqxx::lazyconnection> connection,
+                         std::unique_ptr<pqxx::nontransaction> transaction,
                          FlatFile &file_store);
 
       rxcpp::observable<wTransaction> getAccountTransactions(
@@ -92,6 +96,9 @@ namespace iroha {
        */
       std::function<void(pqxx::result &result)> callback(
           const rxcpp::subscriber<wTransaction> &s, uint64_t block_id);
+
+      std::unique_ptr<pqxx::lazyconnection> connection_ptr_;
+      std::unique_ptr<pqxx::nontransaction> transaction_ptr_;
 
       FlatFile &block_store_;
       pqxx::nontransaction &transaction_;

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -33,7 +33,7 @@ namespace iroha {
     class FlatFile;
 
     struct ConnectionContext {
-      ConnectionContext(std::unique_ptr<FlatFile> block_store);
+      explicit ConnectionContext(std::unique_ptr<FlatFile> block_store);
 
       std::unique_ptr<FlatFile> block_store;
     };

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -33,13 +33,9 @@ namespace iroha {
     class FlatFile;
 
     struct ConnectionContext {
-      ConnectionContext(std::unique_ptr<FlatFile> block_store,
-                        std::unique_ptr<pqxx::lazyconnection> pg_lazy,
-                        std::unique_ptr<pqxx::nontransaction> pg_nontx);
+      ConnectionContext(std::unique_ptr<FlatFile> block_store);
 
       std::unique_ptr<FlatFile> block_store;
-      std::unique_ptr<pqxx::lazyconnection> pg_lazy;
-      std::unique_ptr<pqxx::nontransaction> pg_nontx;
     };
 
     class StorageImpl : public Storage {
@@ -49,7 +45,7 @@ namespace iroha {
           const std::string &options_str_without_dbname);
 
       static expected::Result<ConnectionContext, std::string> initConnections(
-          std::string block_store_dir, std::string postgres_options);
+          std::string block_store_dir);
 
      public:
       static expected::Result<std::shared_ptr<StorageImpl>, std::string> create(
@@ -89,14 +85,10 @@ namespace iroha {
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       on_commit() override;
 
-      ~StorageImpl() override;
-
      protected:
       StorageImpl(std::string block_store_dir,
                   PostgresOptions postgres_options,
-                  std::unique_ptr<FlatFile> block_store,
-                  std::unique_ptr<pqxx::lazyconnection> wsv_connection,
-                  std::unique_ptr<pqxx::nontransaction> wsv_transaction);
+                  std::unique_ptr<FlatFile> block_store);
 
       /**
        * Folder with raw blocks
@@ -108,17 +100,6 @@ namespace iroha {
 
      private:
       std::unique_ptr<FlatFile> block_store_;
-
-      /**
-       * Pg connection with direct transaction management
-       */
-      std::unique_ptr<pqxx::lazyconnection> wsv_connection_;
-
-      std::unique_ptr<pqxx::nontransaction> wsv_transaction_;
-
-      std::shared_ptr<WsvQuery> wsv_;
-
-      std::shared_ptr<BlockQuery> blocks_;
 
       // Allows multiple readers and a single writer
       std::shared_timed_mutex rw_lock_;

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -268,7 +268,7 @@ void Irohad::initTransactionCommandService() {
       std::make_shared<TransactionProcessorImpl>(pcs, mst_processor);
 
   command_service = std::make_shared<::torii::CommandService>(
-      tx_processor, storage->getBlockQuery(), proposal_delay_);
+      tx_processor, storage, proposal_delay_);
 
   log_->info("[Init] => command service");
 }

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "ametsuchi/block_query.hpp"
+#include "ametsuchi/storage.hpp"
 #include "cache/cache.hpp"
 #include "cryptography/hash.hpp"
 #include "endpoint.grpc.pb.h"
@@ -45,7 +45,7 @@ namespace torii {
      */
     CommandService(
         std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
-        std::shared_ptr<iroha::ametsuchi::BlockQuery> block_query,
+        std::shared_ptr<iroha::ametsuchi::Storage> storage,
         std::chrono::milliseconds proposal_delay);
 
     /**
@@ -138,7 +138,7 @@ namespace torii {
                                           shared_model::crypto::Hash::Hasher>;
 
     std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor_;
-    std::shared_ptr<iroha::ametsuchi::BlockQuery> block_query_;
+    std::shared_ptr<iroha::ametsuchi::Storage> storage_;
     std::chrono::milliseconds proposal_delay_;
     std::chrono::milliseconds start_tx_processing_duration_;
     std::shared_ptr<CacheType> cache_;

--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include "torii/command_service.hpp"
+
 #include <thread>
 
 #include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
@@ -27,7 +29,6 @@
 #include "common/types.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "endpoint.pb.h"
-#include "torii/command_service.hpp"
 #include "validators/default_validator.hpp"
 
 using namespace std::chrono_literals;
@@ -36,10 +37,10 @@ namespace torii {
 
   CommandService::CommandService(
       std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor,
-      std::shared_ptr<iroha::ametsuchi::BlockQuery> block_query,
+      std::shared_ptr<iroha::ametsuchi::Storage> storage,
       std::chrono::milliseconds proposal_delay)
       : tx_processor_(tx_processor),
-        block_query_(block_query),
+        storage_(storage),
         proposal_delay_(proposal_delay),
         start_tx_processing_duration_(1s),
         cache_(std::make_shared<CacheType>()),
@@ -124,7 +125,7 @@ namespace torii {
       response.CopyFrom(*resp);
     } else {
       response.set_tx_hash(request.tx_hash());
-      if (block_query_->hasTxWithHash(
+      if (storage_->getBlockQuery()->hasTxWithHash(
               shared_model::crypto::Hash(request.tx_hash()))) {
         response.set_tx_status(iroha::protocol::TxStatus::COMMITTED);
       } else {

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -67,6 +67,7 @@ namespace iroha {
       auto qry_resp =
           std::static_pointer_cast<shared_model::proto::QueryResponse>(
               qpf_response);
+      std::lock_guard<std::mutex> lock(notifier_mutex_);
       subject_.get_subscriber().on_next(
           std::make_shared<shared_model::proto::QueryResponse>(
               qry_resp->getTransport()));

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -58,6 +58,7 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::QueryResponse>>
           subject_;
       std::shared_ptr<ametsuchi::Storage> storage_;
+      std::mutex notifier_mutex_;
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -51,6 +51,11 @@ target_link_libraries(invalid_fields_test
     acceptance_fixture
     )
 
+addtest(query_test query_test.cpp)
+target_link_libraries(query_test
+    acceptance_fixture
+    )
+
 addtest(subtract_asset_qty_test subtract_asset_qty_test.cpp)
 target_link_libraries(subtract_asset_qty_test
     acceptance_fixture

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "validators/permissions.hpp"
+
+using namespace integration_framework;
+using namespace shared_model;
+
+class QueryAcceptanceTest : public AcceptanceFixture {
+ public:
+  /**
+   * Creates the transaction with the user creation commands
+   * @param perms are the permissions of the user
+   * @return built tx and a hash of its payload
+   */
+  auto makeUserWithPerms(const std::vector<std::string> &perms = {
+                             shared_model::permissions::can_get_my_txs}) {
+    auto new_perms = perms;
+    new_perms.push_back(shared_model::permissions::can_set_quorum);
+    return AcceptanceFixture::makeUserWithPerms(kNewRole, new_perms);
+  }
+
+  /**
+   * Valid transaction that user can execute.
+   * @return built tx and a hash of its payload
+   * Note: It should affect the ledger minimally
+   */
+  auto dummyTx() {
+    return complete(AcceptanceFixture::baseTx().setAccountQuorum(kUserId, 1));
+  }
+
+  /**
+   * Creates valid GetTransactions query of current user
+   * @param hash of the tx for querying
+   * @return built query
+   */
+  auto makeQuery(const crypto::Hash &hash) {
+    return complete(baseQry().queryCounter(1).getTransactions(
+        std::vector<crypto::Hash>{hash}));
+  }
+
+  const std::string kNewRole = "rl";
+};
+
+/**
+ * @given some user with only can_get_my_txs permission
+ * @when query GetTransactions of existing transaction of the user in parallel
+ * @then receive TransactionsResponse with the transaction hash
+ */
+TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
+  auto dummy_tx = dummyTx();
+  auto check = [&dummy_tx](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &resp = boost::apply_visitor(
+          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+    });
+  };
+
+  IntegrationTestFramework itf(2);
+  itf.setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .sendTx(dummy_tx)
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); });
+
+  const auto num_queries = 5;
+
+  auto send_query = [&] {
+    for (int i = 0; i < num_queries; ++i) {
+      itf.sendQuery(makeQuery(dummy_tx.hash()), check);
+    }
+  };
+
+  const auto num_threads = 5;
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back(send_query);
+  }
+
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  itf.done();
+}

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -99,7 +99,7 @@ class ClientServerTest : public testing::Test {
     //----------- Server run ----------------
     runner
         ->append(std::make_unique<torii::CommandService>(
-            tx_processor, block_query, proposal_delay))
+            tx_processor, storage, proposal_delay))
         .append(std::make_unique<torii::QueryService>(qpi))
         .run()
         .match(

--- a/test/module/irohad/ametsuchi/storage_init_test.cpp
+++ b/test/module/irohad/ametsuchi/storage_init_test.cpp
@@ -71,7 +71,8 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
  * @then Database is not created and error case is executed
  */
 TEST_F(StorageInitTest, CreateStorageWithInvalidPgOpt) {
-  std::string pg_opt = "host=localhost port=5432 users=nonexistinguser";
+  std::string pg_opt =
+      "host=localhost port=5432 users=nonexistinguser dbname=test";
   StorageImpl::create(block_store_path, pg_opt)
       .match(
           [](const Value<std::shared_ptr<StorageImpl>> &) {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -83,6 +83,7 @@ class ToriiServiceTest : public testing::Test {
     mst = std::make_shared<iroha::MockMstProcessor>();
     wsv_query = std::make_shared<MockWsvQuery>();
     block_query = std::make_shared<MockBlockQuery>();
+    storage = std::make_shared<MockStorage>();
 
     EXPECT_CALL(*mst, onPreparedTransactionsImpl())
         .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
@@ -94,11 +95,12 @@ class ToriiServiceTest : public testing::Test {
 
     EXPECT_CALL(*block_query, getTxByHashSync(_))
         .WillRepeatedly(Return(boost::none));
+    EXPECT_CALL(*storage, getBlockQuery()).WillRepeatedly(Return(block_query));
 
     //----------- Server run ----------------
     runner
         ->append(std::make_unique<torii::CommandService>(
-            tx_processor, block_query, proposal_delay))
+            tx_processor, storage, proposal_delay))
         .run()
         .match(
             [this](iroha::expected::Value<int> port) {
@@ -115,6 +117,7 @@ class ToriiServiceTest : public testing::Test {
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;
+  std::shared_ptr<MockStorage> storage;
 
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Proposal>>
       prop_notifier_;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Same connection was reused from different gRPC threads causing errors.
 - Return block query with unique connection

 - Use mutex when writing to query notifier

 - Remove unused connections from storage

 - Use unique connection for each status query
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Stable block query in terms of postgres connections.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
A new connection is created on each query 🙈 
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 
https://github.com/hyperledger/iroha/blob/1443c2611ccc2eb3e14e93e10e8d3cdf2da2fdf2/test/integration/acceptance/query_test.cpp#L74-L91
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
