### PR TITLE
Update block variant

### DIFF
--- a/libs/common/visitor.hpp
+++ b/libs/common/visitor.hpp
@@ -87,7 +87,7 @@ namespace iroha {
    * @param lambdas
    */
   template <typename TVariant, typename... TVisitors>
-  constexpr auto visit_in_place(TVariant &&variant, TVisitors &&... visitors) {
+  constexpr decltype(auto) visit_in_place(TVariant &&variant, TVisitors &&... visitors) {
     auto visitor = make_visitor(visitors...);
     return boost::apply_visitor(visitor, std::forward<TVariant>(variant));
   }

--- a/shared_model/builders/protobuf/block_variant_transport_builder.hpp
+++ b/shared_model/builders/protobuf/block_variant_transport_builder.hpp
@@ -6,6 +6,7 @@
 #ifndef IROHA_BLOCK_VARIANT_TRANSPORT_BUILDER_HPP
 #define IROHA_BLOCK_VARIANT_TRANSPORT_BUILDER_HPP
 
+#include "backend/protobuf/block.hpp"
 #include "backend/protobuf/empty_block.hpp"
 #include "builders/protobuf/transport_builder.hpp"
 #include "interfaces/iroha_internal/block_variant.hpp"

--- a/shared_model/builders/protobuf/block_variant_transport_builder.hpp
+++ b/shared_model/builders/protobuf/block_variant_transport_builder.hpp
@@ -9,7 +9,6 @@
 #include "backend/protobuf/empty_block.hpp"
 #include "builders/protobuf/transport_builder.hpp"
 #include "interfaces/iroha_internal/block_variant.hpp"
-#include "backend/protobuf/empty_block.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -19,7 +18,7 @@ namespace shared_model {
      * @tparam SV Stateless validator type
      */
     template <typename SV>
-    class TransportBuilder<interface::BlockVariantType, SV> {
+    class TransportBuilder<interface::BlockVariant, SV> {
      private:
       /**
        * Create container type (i.e. Block or EmptyBlock)
@@ -29,7 +28,7 @@ namespace shared_model {
        * type
        */
       template <typename T>
-      iroha::expected::Result<interface::BlockVariantType, std::string>
+      iroha::expected::Result<interface::BlockVariant, std::string>
       createContainer(const iroha::protocol::Block &transport) {
         auto result = std::make_shared<T>(transport);
         auto answer = stateless_validator_.validate(*result);
@@ -40,7 +39,7 @@ namespace shared_model {
       }
 
      public:
-      TransportBuilder<interface::BlockVariantType, SV>(
+      TransportBuilder<interface::BlockVariant, SV>(
           SV stateless_validator = SV())
           : stateless_validator_(stateless_validator) {}
 
@@ -49,7 +48,7 @@ namespace shared_model {
        * @param transport -- protobuf object from which BlockVariant is built
        * @return Result containing either BlockVariantType or message string
        */
-      iroha::expected::Result<interface::BlockVariantType, std::string> build(
+      iroha::expected::Result<interface::BlockVariant, std::string> build(
           iroha::protocol::Block transport) {
         if (transport.payload().transactions().size() == 0) {
           return createContainer<shared_model::proto::EmptyBlock>(transport);

--- a/shared_model/interfaces/CMakeLists.txt
+++ b/shared_model/interfaces/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(shared_model_interfaces
     commands/impl/set_quorum.cpp
     commands/impl/subtract_asset_quantity.cpp
     commands/impl/transfer_asset.cpp
+    iroha_internal/block_variant.cpp
     )
 
 target_link_libraries(shared_model_interfaces

--- a/shared_model/interfaces/iroha_internal/block_variant.cpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.cpp
@@ -9,7 +9,7 @@ namespace shared_model {
   namespace interface {
 
     template <typename Func, typename... Args>
-    static auto invoke(const BlockVariant *var, Func &&f, Args &&... args) {
+    decltype(auto) invoke(const BlockVariant *var, Func &&f, Args &&... args) {
       return iroha::visit_in_place(
           *var, [&](const auto &any_block) -> decltype(auto) {
             return ((*any_block.*f)(std::forward<Args>(args)...));
@@ -21,15 +21,15 @@ namespace shared_model {
     }
 
     const interface::types::HashType &BlockVariant::prevHash() const {
-      return std::move(invoke(this, &AbstractBlock::prevHash));
+      return invoke(this, &AbstractBlock::prevHash);
     }
 
     const interface::types::BlobType &BlockVariant::blob() const {
-      return std::move(invoke(this, &AbstractBlock::blob));
+      return invoke(this, &AbstractBlock::blob);
     }
 
     interface::types::SignatureRangeType BlockVariant::signatures() const {
-      return std::move(invoke(this, &AbstractBlock::signatures));
+      return invoke(this, &AbstractBlock::signatures);
     }
 
     bool BlockVariant::addSignature(const crypto::Signed &signed_blob,
@@ -39,11 +39,11 @@ namespace shared_model {
     }
 
     interface::types::TimestampType BlockVariant::createdTime() const {
-      return std::move(invoke(this, &AbstractBlock::createdTime));
+      return invoke(this, &AbstractBlock::createdTime);
     }
 
     const interface::types::BlobType &BlockVariant::payload() const {
-      return std::move(invoke(this, &AbstractBlock::payload));
+      return invoke(this, &AbstractBlock::payload);
     }
 
     bool BlockVariant::operator==(const BlockVariant &rhs) const {

--- a/shared_model/interfaces/iroha_internal/block_variant.cpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "interfaces/iroha_internal/block_variant.hpp"
+
+namespace shared_model {
+  namespace interface {
+
+    template <typename Func>
+    auto invoke(const BlockVariant *var, Func f) {
+      return iroha::visit_in_place(
+          *var, [&f](const auto any_block) { return (*any_block.*f)(); });
+    }
+
+    interface::types::HeightType BlockVariant::height() const {
+      return invoke(this, &AbstractBlock::height);
+    }
+
+    const interface::types::HashType &BlockVariant::prevHash() const {
+      return std::move(invoke(this, &AbstractBlock::prevHash));
+    }
+
+    const interface::types::BlobType &BlockVariant::blob() const {
+      return std::move(invoke(this, &AbstractBlock::blob));
+    }
+
+    interface::types::SignatureRangeType BlockVariant::signatures() const {
+      return std::move(invoke(this, &AbstractBlock::signatures));
+    }
+
+    bool BlockVariant::addSignature(const crypto::Signed &signed_blob,
+                                    const crypto::PublicKey &public_key) {
+      return iroha::visit_in_place(
+          *this, [&signed_blob, &public_key](const auto &any_block) {
+            return any_block->addSignature(signed_blob, public_key);
+          });
+    }
+
+    interface::types::TimestampType BlockVariant::createdTime() const {
+      return std::move(iroha::visit_in_place(*this, [](const auto &any_block) {
+        return any_block->createdTime();
+      }));
+    }
+
+    const interface::types::BlobType &BlockVariant::payload() const {
+      return std::move(invoke(this, &AbstractBlock::payload));
+    }
+
+    bool BlockVariant::operator==(const BlockVariant &rhs) const {
+      return AbstractBlock::operator==(rhs);
+    }
+
+    BlockVariant *BlockVariant::clone() const {
+      return new BlockVariant(*this);
+    }
+
+  }  // namespace interface
+}  // namespace shared_model

--- a/shared_model/interfaces/iroha_internal/block_variant.cpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/iroha_internal/block_variant.hpp"
 
+#include "common/visitor.hpp"
+
 namespace shared_model {
   namespace interface {
 

--- a/shared_model/interfaces/iroha_internal/block_variant.hpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.hpp
@@ -6,6 +6,7 @@
 #ifndef IROHA_BLOCK_VARIANT_HPP
 #define IROHA_BLOCK_VARIANT_HPP
 
+#include "common/visitor.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/empty_block.hpp"
 
@@ -23,53 +24,28 @@ namespace shared_model {
                          std::shared_ptr<shared_model::interface::EmptyBlock>>;
 
      public:
+      using AbstractBlock::hash;
       using VariantType::VariantType;
 
-      interface::types::HeightType height() const override {
-        return iroha::visit_in_place(
-            *this, [](const auto &any_block) { return any_block->height(); });
-      }
+      interface::types::HeightType height() const override;
 
-      const interface::types::HashType &prevHash() const override {
-        return std::move(iroha::visit_in_place(
-            *this,
-            [](const auto &any_block) { return any_block->prevHash(); }));
-      }
+      const interface::types::HashType &prevHash() const override;
 
-      const interface::types::BlobType &blob() const override {
-        return std::move(iroha::visit_in_place(
-            *this, [](const auto &any_block) { return any_block->blob(); }));
-      }
+      const interface::types::BlobType &blob() const override;
 
-      interface::types::SignatureRangeType signatures() const override {
-        return std::move(iroha::visit_in_place(
-            *this,
-            [](const auto &any_block) { return any_block->signatures(); }));
-      }
+      interface::types::SignatureRangeType signatures() const override;
 
       bool addSignature(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key) override {
-        return std::move(iroha::visit_in_place(
-            *this, [&signed_blob, &public_key](const auto &any_block) {
-              return any_block->addSignature(signed_blob, public_key);
-            }));
-      }
+                        const crypto::PublicKey &public_key) override;
 
-      interface::types::TimestampType createdTime() const override {
-        return std::move(iroha::visit_in_place(
-            *this,
-            [](const auto &any_block) { return any_block->createdTime(); }));
-      }
+      interface::types::TimestampType createdTime() const override;
 
-      const interface::types::BlobType &payload() const override {
-        return std::move(iroha::visit_in_place(
-            *this, [](const auto &any_block) { return any_block->payload(); }));
-      }
+      const interface::types::BlobType &payload() const override;
+
+      bool operator==(const BlockVariant &rhs) const;
 
      protected:
-      BlockVariant *clone() const override {
-        return new BlockVariant(*this);
-      }
+      BlockVariant *clone() const override;
     };
 
   }  // namespace interface

--- a/shared_model/interfaces/iroha_internal/block_variant.hpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.hpp
@@ -12,10 +12,66 @@
 namespace shared_model {
   namespace interface {
 
-    /// Block variant with either block or empty block
-    using BlockVariantType =
-        boost::variant<std::shared_ptr<shared_model::interface::Block>,
-                       std::shared_ptr<shared_model::interface::EmptyBlock>>;
+    class BlockVariant
+        : public boost::variant<
+              std::shared_ptr<shared_model::interface::Block>,
+              std::shared_ptr<shared_model::interface::EmptyBlock>>,
+          protected AbstractBlock {
+     private:
+      using VariantType =
+          boost::variant<std::shared_ptr<shared_model::interface::Block>,
+                         std::shared_ptr<shared_model::interface::EmptyBlock>>;
+
+     public:
+      using VariantType::VariantType;
+
+      interface::types::HeightType height() const override {
+        return iroha::visit_in_place(
+            *this, [](const auto &any_block) { return any_block->height(); });
+      }
+
+      const interface::types::HashType &prevHash() const override {
+        return std::move(iroha::visit_in_place(
+            *this,
+            [](const auto &any_block) { return any_block->prevHash(); }));
+      }
+
+      const interface::types::BlobType &blob() const override {
+        return std::move(iroha::visit_in_place(
+            *this, [](const auto &any_block) { return any_block->blob(); }));
+      }
+
+      interface::types::SignatureRangeType signatures() const override {
+        return std::move(iroha::visit_in_place(
+            *this,
+            [](const auto &any_block) { return any_block->signatures(); }));
+      }
+
+      bool addSignature(const crypto::Signed &signed_blob,
+                        const crypto::PublicKey &public_key) override {
+        return std::move(iroha::visit_in_place(
+            *this, [&signed_blob, &public_key](const auto &any_block) {
+              return any_block->addSignature(signed_blob, public_key);
+            }));
+      }
+
+      interface::types::TimestampType createdTime() const override {
+        return std::move(iroha::visit_in_place(
+            *this,
+            [](const auto &any_block) { return any_block->createdTime(); }));
+      }
+
+      const interface::types::BlobType &payload() const override {
+        return std::move(iroha::visit_in_place(
+            *this, [](const auto &any_block) { return any_block->payload(); }));
+      }
+
+     protected:
+      BlockVariant *clone() const override {
+        return new BlockVariant(*this);
+      }
+    };
+
   }  // namespace interface
 }  // namespace shared_model
 

--- a/shared_model/interfaces/iroha_internal/block_variant.hpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.hpp
@@ -6,7 +6,6 @@
 #ifndef IROHA_BLOCK_VARIANT_HPP
 #define IROHA_BLOCK_VARIANT_HPP
 
-#include "common/visitor.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/empty_block.hpp"
 

--- a/shared_model/validators/any_block_validator.hpp
+++ b/shared_model/validators/any_block_validator.hpp
@@ -31,7 +31,7 @@ namespace shared_model {
         return empty_block_validator_.validate(empty_block);
       }
 
-      Answer validate(const interface::BlockVariantType &block_variant) const {
+      Answer validate(const interface::BlockVariant &block_variant) const {
         return iroha::visit_in_place(
             block_variant, [this](auto block) { return validate(*block); });
       }

--- a/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
+++ b/test/module/shared_model/builders/protobuf/transport_builder_test.cpp
@@ -353,17 +353,17 @@ TEST_F(TransportBuilderTest, EmptyBlockCreationTest) {
 
 /**
  * @given Valid block protobuf object with no transactions
- * @when TransportBuilder tries to build BlockVariantType object
+ * @when TransportBuilder tries to build BlockVariant object
  * @then built object contains EmptyBlock shared model object
  * AND it is equal to the original object
  */
 TEST_F(TransportBuilderTest, BlockVariantWithValidEmptyBlock) {
   auto emptyBlock = createEmptyBlock();
-  interface::BlockVariantType orig_model =
+  interface::BlockVariant orig_model =
       std::make_shared<decltype(emptyBlock)>(emptyBlock.getTransport());
 
   auto val = framework::expected::val(
-      TransportBuilder<interface::BlockVariantType,
+      TransportBuilder<interface::BlockVariant,
                        validation::DefaultAnyBlockValidator>()
           .build(emptyBlock.getTransport()));
   ASSERT_TRUE(val);
@@ -380,14 +380,14 @@ TEST_F(TransportBuilderTest, BlockVariantWithValidEmptyBlock) {
 
 /**
  * @given Invalid block protobuf object with no transactions
- * @when TransportBuilder tries to build BlockVariantType object
+ * @when TransportBuilder tries to build BlockVariant object
  * @then build fails
  */
 TEST_F(TransportBuilderTest, BlockVariantWithInvalidEmptyBlock) {
   auto emptyBlock = createInvalidEmptyBlock();
 
   auto error = framework::expected::err(
-      TransportBuilder<interface::BlockVariantType,
+      TransportBuilder<interface::BlockVariant,
                        validation::DefaultAnyBlockValidator>()
           .build(emptyBlock.getTransport()));
   ASSERT_TRUE(error);
@@ -395,13 +395,13 @@ TEST_F(TransportBuilderTest, BlockVariantWithInvalidEmptyBlock) {
 
 /**
  * @given Valid block protobuf object with non empty set of transactions
- * @when TransportBuilder tries to build BlockVariantType object
+ * @when TransportBuilder tries to build BlockVariant object
  * @then built object contains Block shared model object
  * AND it is equal to the original object
  */
 TEST_F(TransportBuilderTest, BlockVariantWithValidBlock) {
   auto block = createBlock();
-  interface::BlockVariantType orig_model =
+  interface::BlockVariant orig_model =
       std::make_shared<decltype(block)>(block.getTransport());
   auto val = framework::expected::val(
       TransportBuilder<decltype(orig_model),
@@ -422,14 +422,14 @@ TEST_F(TransportBuilderTest, BlockVariantWithValidBlock) {
 
 /**
  * @given Invalid block protobuf object with non-empty transactions set
- * @when TransportBuilder tries to build BlockVariantType object
+ * @when TransportBuilder tries to build BlockVariant object
  * @then build fails
  */
 TEST_F(TransportBuilderTest, BlockVariantWithInvalidBlock) {
   auto block = createInvalidBlock();
 
   auto error = framework::expected::err(
-      TransportBuilder<interface::BlockVariantType,
+      TransportBuilder<interface::BlockVariant,
                        validation::DefaultAnyBlockValidator>()
           .build(block.getTransport()));
   ASSERT_TRUE(error);


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Before BlockVariant was implemented via `using BlockVariantType=boost::variant<Block, EmptyBlock>`. This is not convenient in irohad because it forces to use visitors every time when it is needed to access BlockVariant's fields

Now it is a class which gives more convenient access to the fields in stored type

### Benefits

More convenient field access for BlockVariant

### Possible Drawbacks 

Multiple inheritance from boost::variant (to allow instantiation with either Block or EmptyBlock) and AbstractBlock (to guarantee AbstractBlocks interface)
