### PR TITLE
Remove polymorphic wrapper from transaction and transaction collection

### DIFF
--- a/iroha-cli/impl/query_response_handler.cpp
+++ b/iroha-cli/impl/query_response_handler.cpp
@@ -175,16 +175,16 @@ namespace iroha_cli {
       const iroha::protocol::QueryResponse &response) {
     auto resp = shared_model::proto::TransactionsResponse(response);
     auto txs = resp.transactions();
-    std::for_each(txs.begin(), txs.end(), [this](auto tx) {
+    std::for_each(txs.begin(), txs.end(), [this](auto &tx) {
       log_->info("[Transaction]");
-      log_->info(prefix.at(kHash), tx->hash().hex());
-      log_->info(prefix.at(kCreatorId), tx->creatorAccountId());
-      log_->info(prefix.at(kCreatedTime), tx->createdTime());
-      log_->info(prefix.at(kCommands), tx->commands().size());
+      log_->info(prefix.at(kHash), tx.hash().hex());
+      log_->info(prefix.at(kCreatorId), tx.creatorAccountId());
+      log_->info(prefix.at(kCreatedTime), tx.createdTime());
+      log_->info(prefix.at(kCommands), tx.commands().size());
 
-      auto cmds = tx->commands();
-      std::for_each(cmds.begin(), cmds.end(), [this](auto cmd) {
-        log_->info(prefix.at(kDefault), cmd->toString());
+      auto cmds = tx.commands();
+      std::for_each(cmds.begin(), cmds.end(), [this](auto &cmd) {
+        log_->info(prefix.at(kDefault), cmd.toString());
       });
     });
   }

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -54,9 +54,8 @@ namespace iroha {
             function) {
       auto execute_transaction = [this](auto &transaction) {
         command_executor_->setCreatorAccountId(transaction->creatorAccountId());
-        auto execute_command = [this](auto command) {
-          auto result =
-              boost::apply_visitor(*command_executor_, command->get());
+        auto execute_command = [this](auto &command) {
+          auto result = boost::apply_visitor(*command_executor_, command.get());
           return result.match([](expected::Value<void> &v) { return true; },
                               [&](expected::Error<ExecutionError> &e) {
                                 log_->error(e.error.toString());

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -53,7 +53,7 @@ namespace iroha {
                            const shared_model::interface::types::HashType &)>
             function) {
       auto execute_transaction = [this](auto &transaction) {
-        command_executor_->setCreatorAccountId(transaction->creatorAccountId());
+        command_executor_->setCreatorAccountId(transaction.creatorAccountId());
         auto execute_command = [this](auto &command) {
           auto result = boost::apply_visitor(*command_executor_, command.get());
           return result.match([](expected::Value<void> &v) { return true; },
@@ -62,8 +62,8 @@ namespace iroha {
                                 return false;
                               });
         };
-        return std::all_of(transaction->commands().begin(),
-                           transaction->commands().end(),
+        return std::all_of(transaction.commands().begin(),
+                           transaction.commands().end(),
                            execute_command);
       };
 

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -59,7 +59,7 @@ namespace iroha {
           true,
           [&](auto &status, const auto &cmd) {
             return visit_in_place(
-                cmd->get(),
+                cmd.get(),
                 [&](const shared_model::interface::TransferAsset &command) {
                   status &=
                       this->indexAccountIdHeight(command.srcAccountId(), height)

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -94,8 +94,8 @@ namespace iroha {
       boost::for_each(
           block.transactions() | boost::adaptors::indexed(0),
           [&](const auto &tx) {
-            const auto &creator_id = tx.value()->creatorAccountId();
-            const auto &hash = tx.value()->hash().blob();
+            const auto &creator_id = tx.value().creatorAccountId();
+            const auto &hash = tx.value().hash().blob();
             const auto &index = std::to_string(tx.index());
 
             // tx hash -> block where hash is stored
@@ -117,7 +117,7 @@ namespace iroha {
                 + ");");
 
             this->indexAccountAssets(
-                creator_id, height, index, tx.value()->commands());
+                creator_id, height, index, tx.value().commands());
           });
     }
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -17,7 +17,6 @@
 
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/indexed.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/numeric.hpp>
 #include <unordered_set>

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -139,7 +139,7 @@ namespace iroha {
             }),
             [&](const auto &x) {
               subscriber.on_next(PostgresBlockQuery::wTransaction(
-                  clone(*block->transactions().at(x))));
+                  clone(block->transactions()[x])));
             });
       };
     }
@@ -225,10 +225,10 @@ namespace iroha {
       auto it =
           std::find_if(block->transactions().begin(),
                        block->transactions().end(),
-                       [&hash](const auto &tx) { return tx->hash() == hash; });
+                       [&hash](const auto &tx) { return tx.hash() == hash; });
       if (it != block->transactions().end()) {
         result = boost::optional<PostgresBlockQuery::wTransaction>(
-            PostgresBlockQuery::wTransaction(clone(**it)));
+            PostgresBlockQuery::wTransaction(clone(*it)));
       }
       return result;
     }

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -45,12 +45,12 @@ namespace iroha {
       const auto &tx_creator = tx.creatorAccountId();
       command_executor_->setCreatorAccountId(tx_creator);
       command_validator_->setCreatorAccountId(tx_creator);
-      auto execute_command = [this, &tx_creator](auto command) {
+      auto execute_command = [this, &tx_creator](auto &command) {
         auto account = wsv_->getAccount(tx_creator).value();
-        if (not boost::apply_visitor(*command_validator_, command->get())) {
+        if (not boost::apply_visitor(*command_validator_, command.get())) {
           return false;
         }
-        auto result = boost::apply_visitor(*command_executor_, command->get());
+        auto result = boost::apply_visitor(*command_executor_, command.get());
         return result.match([](expected::Value<void> &v) { return true; },
                             [this](expected::Error<ExecutionError> &e) {
                               log_->error(e.error.toString());

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -103,11 +103,9 @@ namespace iroha {
       // TODO: Alexey Chernyshov IR-1011 2018-03-08 rework BlockBuilder logic,
       // so that this cast will not be needed
       auto proto_txs =
-          proposal.transactions()
-          | boost::adaptors::transformed([](const auto &polymorphic_tx) {
-              return static_cast<const shared_model::proto::Transaction &>(
-                  *polymorphic_tx);
-            });
+          proposal.transactions() | boost::adaptors::transformed([](auto &tx) {
+            return static_cast<const shared_model::proto::Transaction &>(tx);
+          });
       auto block = std::make_shared<shared_model::proto::Block>(
           shared_model::proto::UnsignedBlockBuilder()
               .height(proposal.height())

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -35,7 +35,7 @@ namespace iroha {
       // insert all txs from proposal to proposal set
       pcs_->on_proposal().subscribe([this](auto model_proposal) {
         for (const auto &tx : model_proposal->transactions()) {
-          auto hash = tx->hash();
+          auto hash = tx.hash();
           proposal_set_.insert(hash);
           log_->info("on proposal stateless success: {}", hash.hex());
           // different on_next() calls (this one and below) can happen in
@@ -55,7 +55,7 @@ namespace iroha {
             // on next..
             [this](auto model_block) {
               for (const auto &tx : model_block->transactions()) {
-                auto hash = tx->hash();
+                auto hash = tx.hash();
                 if (this->proposal_set_.find(hash) != proposal_set_.end()) {
                   proposal_set_.erase(hash);
                   candidate_set_.insert(hash);

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -119,8 +119,12 @@ namespace shared_model {
       }};
 
       const Lazy<SignatureSetType<proto::Signature>> signatures_{[this] {
-        return SignatureSetType<proto::Signature>(proto_->signatures().begin(),
-                                                  proto_->signatures().end());
+        auto signatures = proto_->signatures()
+            | boost::adaptors::transformed([](const auto &x) {
+                            return proto::Signature(x);
+                          });
+        return SignatureSetType<proto::Signature>(signatures.begin(),
+                                                  signatures.end());
       }};
 
       const Lazy<interface::types::BlobType> payload_blob_{

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -20,7 +20,6 @@
 
 #include "interfaces/iroha_internal/block.hpp"
 
-#include <boost/range/numeric.hpp>
 #include "backend/protobuf/common_objects/signature.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "backend/protobuf/util.hpp"
@@ -35,9 +34,6 @@ namespace shared_model {
     class Block final : public CopyableProto<interface::Block,
                                              iroha::protocol::Block,
                                              Block> {
-      template <class T>
-      using w = detail::PolymorphicWrapper<T>;
-
      public:
       template <class BlockType>
       explicit Block(BlockType &&block)
@@ -47,7 +43,7 @@ namespace shared_model {
 
       Block(Block &&o) noexcept : Block(std::move(o.proto_)) {}
 
-      const interface::types::TransactionsCollectionType &transactions()
+      interface::types::TransactionsCollectionType transactions()
           const override {
         return *transactions_;
       }
@@ -110,13 +106,9 @@ namespace shared_model {
 
       const iroha::protocol::Block::Payload &payload_{proto_->payload()};
 
-      const Lazy<std::vector<w<interface::Transaction>>> transactions_{[this] {
-        std::vector<w<interface::Transaction>> txs;
-        for (const auto &tx : payload_.transactions()) {
-          auto tmp = detail::makePolymorphic<proto::Transaction>(tx);
-          txs.emplace_back(tmp);
-        }
-        return txs;
+      const Lazy<std::vector<proto::Transaction>> transactions_{[this] {
+        return std::vector<proto::Transaction>(payload_.transactions().begin(),
+                                               payload_.transactions().end());
       }};
 
       const Lazy<interface::types::BlobType> blob_{
@@ -127,11 +119,8 @@ namespace shared_model {
       }};
 
       const Lazy<SignatureSetType<proto::Signature>> signatures_{[this] {
-        SignatureSetType<proto::Signature> sigs;
-        for (const auto &sig : proto_->signatures()) {
-          sigs.emplace(sig);
-        }
-        return sigs;
+        return SignatureSetType<proto::Signature>(proto_->signatures().begin(),
+                                                  proto_->signatures().end());
       }};
 
       const Lazy<interface::types::BlobType> payload_blob_{

--- a/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
@@ -20,6 +20,8 @@
 
 #include "interfaces/queries/get_transactions.hpp"
 
+#include <boost/range/numeric.hpp>
+
 #include "queries.pb.h"
 #include "utils/lazy_initializer.hpp"
 #include "utils/reference_holder.hpp"

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -18,7 +18,6 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_QUERY_HPP
 #define IROHA_SHARED_MODEL_PROTO_QUERY_HPP
 
-#include <boost/range/numeric.hpp>
 #include "backend/protobuf/common_objects/signature.hpp"
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/query.hpp"

--- a/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
@@ -55,16 +55,11 @@ namespace shared_model {
       const iroha::protocol::TransactionsResponse &transactionResponse_{
           proto_->transactions_response()};
 
-      const Lazy<interface::types::TransactionsCollectionType> transactions_{
-          [this] {
-            return boost::accumulate(
-                transactionResponse_.transactions(),
-                interface::types::TransactionsCollectionType{},
-                [](auto &&txs, const auto &tx) {
-                  txs.emplace_back(new Transaction(tx));
-                  return std::move(txs);
-                });
-          }};
+      const Lazy<std::vector<proto::Transaction>> transactions_{[this] {
+        return std::vector<proto::Transaction>(
+            transactionResponse_.transactions().begin(),
+            transactionResponse_.transactions().end());
+      }};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -20,6 +20,8 @@
 
 #include "interfaces/transaction.hpp"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 #include "backend/protobuf/commands/proto_command.hpp"
 #include "backend/protobuf/common_objects/signature.hpp"
 #include "block.pb.h"
@@ -107,8 +109,12 @@ namespace shared_model {
           [this] { return makeBlob(payload_); }};
 
       const Lazy<SignatureSetType<proto::Signature>> signatures_{[this] {
-        return SignatureSetType<proto::Signature>(proto_->signatures().begin(),
-                                                  proto_->signatures().end());
+        auto signatures = proto_->signatures()
+            | boost::adaptors::transformed([](const auto &x) {
+                            return proto::Signature(x);
+                          });
+        return SignatureSetType<proto::Signature>(signatures.begin(),
+                                                  signatures.end());
       }};
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -20,7 +20,6 @@
 
 #include "interfaces/transaction.hpp"
 
-#include <boost/range/numeric.hpp>
 #include "backend/protobuf/commands/proto_command.hpp"
 #include "backend/protobuf/common_objects/signature.hpp"
 #include "block.pb.h"

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -45,7 +45,7 @@ namespace shared_model {
         return payload_.creator_account_id();
       }
 
-      const Transaction::CommandsType &commands() const override {
+      Transaction::CommandsType commands() const override {
         return *commands_;
       }
 
@@ -96,13 +96,9 @@ namespace shared_model {
 
       const iroha::protocol::Transaction::Payload &payload_{proto_->payload()};
 
-      const Lazy<CommandsType> commands_{[this] {
-        return boost::accumulate(payload_.commands(),
-                                 CommandsType{},
-                                 [](auto &&acc, const auto &cmd) {
-                                   acc.emplace_back(new Command(cmd));
-                                   return std::forward<decltype(acc)>(acc);
-                                 });
+      const Lazy<std::vector<proto::Command>> commands_{[this] {
+        return std::vector<proto::Command>(payload_.commands().begin(),
+                                           payload_.commands().end());
       }};
 
       const Lazy<interface::types::BlobType> blob_{
@@ -112,12 +108,8 @@ namespace shared_model {
           [this] { return makeBlob(payload_); }};
 
       const Lazy<SignatureSetType<proto::Signature>> signatures_{[this] {
-        return boost::accumulate(proto_->signatures(),
-                                 SignatureSetType<proto::Signature>{},
-                                 [](auto &&acc, const auto &sig) {
-                                   acc.emplace(sig);
-                                   return std::forward<decltype(acc)>(acc);
-                                 });
+        return SignatureSetType<proto::Signature>(proto_->signatures().begin(),
+                                                  proto_->signatures().end());
       }};
     };
   }  // namespace proto

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -88,10 +88,11 @@ namespace shared_model {
       using AccountDetailValueType = std::string;
       /// Type of a number of transactions in block
       using TransactionsNumberType = uint16_t;
-      /// Type of a single Transaction
-      using TransactionType = detail::PolymorphicWrapper<Transaction>;
       /// Type of transactions' collection
-      using TransactionsCollectionType = std::vector<TransactionType>;
+      using TransactionsCollectionType =
+          boost::any_range<Transaction,
+                           boost::random_access_traversal_tag,
+                           const Transaction &>;
       /// Type of the transfer message
       using DescriptionType = std::string;
     }  // namespace types

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -35,7 +35,7 @@ namespace shared_model {
       /**
        * @return collection of transactions
        */
-      virtual const types::TransactionsCollectionType &transactions() const = 0;
+      virtual types::TransactionsCollectionType transactions() const = 0;
 
       std::string toString() const override {
         return detail::PrettyStringBuilder()
@@ -46,7 +46,7 @@ namespace shared_model {
             .append("txsNumber", std::to_string(txsNumber()))
             .append("createdtime", std::to_string(createdTime()))
             .append("transactions")
-            .appendAll(transactions(), [](auto &tx) { return tx->toString(); })
+            .appendAll(transactions(), [](auto &tx) { return tx.toString(); })
             .append("signatures")
             .appendAll(signatures(), [](auto &sig) { return sig.toString(); })
             .finalize();

--- a/shared_model/interfaces/iroha_internal/proposal.hpp
+++ b/shared_model/interfaces/iroha_internal/proposal.hpp
@@ -18,27 +18,19 @@
 #ifndef IROHA_SHARED_MODEL_PROPOSAL_HPP
 #define IROHA_SHARED_MODEL_PROPOSAL_HPP
 
-#include <boost/range/numeric.hpp>
-#include <vector>
-
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/transaction.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 
 namespace shared_model {
   namespace interface {
 
     class Proposal : public ModelPrimitive<Proposal> {
      public:
-      template <class T>
-      using w = detail::PolymorphicWrapper<T>;
-      using TransactionContainer = std::vector<w<interface::Transaction>>;
-
       /**
        * @return transactions
        */
-      virtual const std::vector<w<Transaction>> &transactions() const = 0;
+      virtual types::TransactionsCollectionType transactions() const = 0;
 
       /**
        * @return the height
@@ -62,7 +54,7 @@ namespace shared_model {
             .append("transactions")
             .appendAll(
                 transactions(),
-                [](auto &transaction) { return transaction->toString(); })
+                [](auto &transaction) { return transaction.toString(); })
             .finalize();
       }
     };

--- a/shared_model/interfaces/query_responses/transactions_response.hpp
+++ b/shared_model/interfaces/query_responses/transactions_response.hpp
@@ -41,7 +41,7 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("TransactionsResponse")
-            .appendAll(transactions(), [](auto &tx) { return tx->toString(); })
+            .appendAll(transactions(), [](auto &tx) { return tx.toString(); })
             .finalize();
       }
 

--- a/shared_model/interfaces/transaction.hpp
+++ b/shared_model/interfaces/transaction.hpp
@@ -18,12 +18,9 @@
 #ifndef IROHA_SHARED_MODEL_TRANSACTION_HPP
 #define IROHA_SHARED_MODEL_TRANSACTION_HPP
 
-#include <vector>
-
 #include "interfaces/base/signable.hpp"
 #include "interfaces/commands/command.hpp"
 #include "interfaces/common_objects/types.hpp"
-#include "utils/polymorphic_wrapper.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -48,16 +45,15 @@ namespace shared_model {
        */
       virtual QuorumType quorum() const = 0;
 
-      /// Type of command
-      using CommandType = detail::PolymorphicWrapper<Command>;
-
       /// Type of ordered collection of commands
-      using CommandsType = std::vector<CommandType>;
+      using CommandsType = boost::any_range<Command,
+                                            boost::random_access_traversal_tag,
+                                            const Command &>;
 
       /**
        * @return attached commands
        */
-      virtual const CommandsType &commands() const = 0;
+      virtual CommandsType commands() const = 0;
 
       std::string toString() const override {
         return detail::PrettyStringBuilder()
@@ -68,7 +64,7 @@ namespace shared_model {
             .append("quorum", std::to_string(quorum()))
             .append("commands")
             .appendAll(commands(),
-                       [](auto &command) { return command->toString(); })
+                       [](auto &command) { return command.toString(); })
             .append("signatures")
             .appendAll(signatures(), [](auto &sig) { return sig.toString(); })
             .finalize();

--- a/shared_model/validators/container_validator.hpp
+++ b/shared_model/validators/container_validator.hpp
@@ -17,6 +17,7 @@
 
 #ifndef IROHA_CONTAINER_VALIDATOR_HPP
 #define IROHA_CONTAINER_VALIDATOR_HPP
+
 #include <boost/format.hpp>
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -29,7 +30,7 @@ namespace shared_model {
   namespace validation {
 
     /**
-     * Class that validates blocks and proposal common fieds
+     * Class that validates blocks and proposal common fields
      */
     template <typename Iface,
               typename FieldValidator,
@@ -50,7 +51,7 @@ namespace shared_model {
           const interface::types::TransactionsCollectionType &transactions)
           const {
         for (const auto &tx : transactions) {
-          validateTransaction(reason, *tx);
+          validateTransaction(reason, tx);
         }
       }
 

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -264,8 +264,7 @@ namespace shared_model {
         }
 
         for (const auto &command : tx.commands()) {
-          auto reason =
-              boost::apply_visitor(command_validator_, command->get());
+          auto reason = boost::apply_visitor(command_validator_, command.get());
           if (not reason.second.empty()) {
             answer.addReason(std::move(reason));
           }

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -89,7 +89,7 @@ TEST_F(GetTransactions, HaveGetAllTx) {
           interface::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
-      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+      ASSERT_EQ(resp.transactions().front(), dummy_tx);
     });
   };
 
@@ -116,7 +116,7 @@ TEST_F(GetTransactions, HaveGetMyTx) {
           interface::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
-      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+      ASSERT_EQ(resp.transactions().front(), dummy_tx);
     });
   };
 

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -60,7 +60,7 @@ TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
           interface::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
-      ASSERT_EQ(*resp.transactions()[0].operator->(), dummy_tx);
+      ASSERT_EQ(resp.transactions().front(), dummy_tx);
     });
   };
 

--- a/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_transfer_test.cpp
@@ -132,7 +132,7 @@ namespace iroha {
      */
     TEST_F(BlockQueryTransferTest, SenderAssetName) {
       auto block = makeBlockWithCreator(creator1, creator2, asset, creator1);
-      tx_hashes.push_back(block.transactions().back()->hash());
+      tx_hashes.push_back(block.transactions().back().hash());
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
@@ -150,7 +150,7 @@ namespace iroha {
      */
     TEST_F(BlockQueryTransferTest, ReceiverAssetName) {
       auto block = makeBlockWithCreator(creator1, creator2, asset, creator1);
-      tx_hashes.push_back(block.transactions().back()->hash());
+      tx_hashes.push_back(block.transactions().back().hash());
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
@@ -168,7 +168,7 @@ namespace iroha {
      */
     TEST_F(BlockQueryTransferTest, GrantedTransfer) {
       auto block = makeBlockWithCreator(creator1, creator2, asset, creator3);
-      tx_hashes.push_back(block.transactions().back()->hash());
+      tx_hashes.push_back(block.transactions().back().hash());
       insert(block);
 
       auto wrapper = make_test_subscriber<CallExact>(
@@ -187,12 +187,12 @@ namespace iroha {
     TEST_F(BlockQueryTransferTest, TwoBlocks) {
       auto block = makeBlock(creator1, creator2, asset);
 
-      tx_hashes.push_back(block.transactions().back()->hash());
+      tx_hashes.push_back(block.transactions().back().hash());
       insert(block);
 
       auto block2 = makeBlock(creator1, creator2, asset, 2, block.hash());
 
-      tx_hashes.push_back(block.transactions().back()->hash());
+      tx_hashes.push_back(block.transactions().back().hash());
       insert(block2);
 
       auto wrapper = make_test_subscriber<CallExact>(

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -45,7 +45,7 @@ using namespace shared_model::permissions;
  */
 std::unique_ptr<shared_model::interface::Command> buildCommand(
     const TestTransactionBuilder &builder) {
-  return clone(*(builder.build().commands().front()));
+  return clone(builder.build().commands().front());
 }
 
 /**

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -542,8 +542,8 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
         resp.get());
 
     const auto &txs = tx_resp.transactions();
-    for (auto i = 0ul; i < txs.size(); i++) {
-      ASSERT_EQ(txs.at(i)->creatorAccountId(), account.accountId());
+    for (const auto &tx : txs) {
+      ASSERT_EQ(tx.creatorAccountId(), account.accountId());
     }
     ASSERT_EQ(model_query.hash(), resp.queryHash());
   });

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -832,7 +832,7 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(admin_id, tx->creatorAccountId());
+      EXPECT_EQ(admin_id, tx.creatorAccountId());
     }
   });
 }
@@ -867,7 +867,7 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }
@@ -902,7 +902,7 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }
@@ -941,7 +941,7 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }
@@ -1047,7 +1047,7 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(admin_id, tx->creatorAccountId());
+      EXPECT_EQ(admin_id, tx.creatorAccountId());
     }
   });
 }
@@ -1082,7 +1082,7 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }
@@ -1117,7 +1117,7 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }
@@ -1156,7 +1156,7 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
 
     ASSERT_EQ(cast_resp.transactions().size(), N);
     for (const auto &tx : cast_resp.transactions()) {
-      EXPECT_EQ(account_id, tx->creatorAccountId());
+      EXPECT_EQ(account_id, tx.creatorAccountId());
     }
   });
 }

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -190,7 +190,7 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
     const auto &txs = transactions_response.transactions();
 
     ASSERT_EQ(txs.size(), 1);
-    ASSERT_EQ(*txs.back(), transaction);
+    ASSERT_EQ(txs.back(), transaction);
     ASSERT_EQ(query_response.queryHash(), query_hash);
   });
 }

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -110,7 +110,7 @@ TEST(RegressionTest, StateRecovery) {
               shared_model::interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
-      ASSERT_EQ(*resp.transactions()[0].operator->(), tx);
+      ASSERT_EQ(resp.transactions().front(), tx);
     });
   };
   auto path =


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Continuing #1397 
Replaced intermediate transaction collection in stateful validator with `boost::filtered`
Hopefully only one more PR required to remove polymorphic wrapper from the project
GCC 5.4 required a workaround for set initialization because it used `insert` instead of `emplace` in iterator constructor
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Even less polymorphic wrapper
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
