### PR TITLE
Refactor/specified visitor to its namespace

### DIFF
--- a/test/framework/specified_visitor.hpp
+++ b/test/framework/specified_visitor.hpp
@@ -21,29 +21,29 @@
 #include <boost/variant.hpp>
 
 namespace framework {
-    template <typename Type>
-    class SpecifiedVisitor : public boost::static_visitor<const Type &> {
-     public:
-      /**
-       * Match template type
-       * @param t const reference to object of specified type
-       * @return const reference to value
-       */
-      const Type &operator()(const Type &t) const {
-        return t;
-      }
+  template <typename Type>
+  class SpecifiedVisitor : public boost::static_visitor<const Type &> {
+   public:
+    /**
+     * Match template type
+     * @param t const reference to object of specified type
+     * @return const reference to value
+     */
+    const Type &operator()(const Type &t) const {
+      return t;
+    }
 
-      /**
-       * Match any other type that was not matched by methods above
-       * @tparam T any type not matched by two types above
-       * @param t object of specified type
-       * @return none
-       */
-      template <typename T>
-      const Type &operator()(const T &t) const {
-        throw std::runtime_error("unexpected type provided");
-      }
-    };
+    /**
+     * Match any other type that was not matched by methods above
+     * @tparam T any type not matched by two types above
+     * @param t object of specified type
+     * @return none
+     */
+    template <typename T>
+    const Type &operator()(const T &t) const {
+      throw std::runtime_error("unexpected type provided");
+    }
+  };
 }  // namespace framework
 
 #endif  // IROHA_SPECIFIED_VISITOR_HPP

--- a/test/framework/specified_visitor.hpp
+++ b/test/framework/specified_visitor.hpp
@@ -20,8 +20,7 @@
 
 #include <boost/variant.hpp>
 
-namespace shared_model {
-  namespace interface {
+namespace framework {
     template <typename Type>
     class SpecifiedVisitor : public boost::static_visitor<const Type &> {
      public:
@@ -45,7 +44,6 @@ namespace shared_model {
         throw std::runtime_error("unexpected type provided");
       }
     };
-  }  // namespace interface
-}  // namespace shared_model
+}  // namespace framework
 
 #endif  // IROHA_SPECIFIED_VISITOR_HPP

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -24,7 +24,7 @@ AcceptanceFixture::AcceptanceFixture()
           shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()),
       checkStatelessInvalid([](auto &status) {
         ASSERT_NO_THROW(boost::apply_visitor(
-            shared_model::interface::SpecifiedVisitor<
+            framework::SpecifiedVisitor<
                 shared_model::interface::StatelessFailedTxResponse>(),
             status.get()));
       }) {}

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -86,7 +86,7 @@ TEST_F(GetTransactions, HaveGetAllTx) {
   auto check = [&dummy_tx](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          framework::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
       ASSERT_EQ(resp.transactions().front(), dummy_tx);
@@ -113,7 +113,7 @@ TEST_F(GetTransactions, HaveGetMyTx) {
   auto check = [&dummy_tx](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          framework::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
       ASSERT_EQ(resp.transactions().front(), dummy_tx);
@@ -170,7 +170,7 @@ TEST_F(GetTransactions, NonexistentHash) {
   auto check = [](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          framework::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 0);
     });
@@ -194,7 +194,7 @@ TEST_F(GetTransactions, OtherUserTx) {
   auto check = [](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          framework::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 0);
     });

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -57,7 +57,7 @@ TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
   auto check = [&dummy_tx](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          interface::SpecifiedVisitor<interface::TransactionsResponse>(),
+          framework::SpecifiedVisitor<interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);
       ASSERT_EQ(resp.transactions().front(), dummy_tx);

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -15,7 +15,7 @@ class AcceptanceTest : public AcceptanceFixture {
   const std::function<void(const shared_model::proto::TransactionResponse &)>
       checkStatelessValid = [](auto &status) {
         ASSERT_NO_THROW(boost::apply_visitor(
-            shared_model::interface::SpecifiedVisitor<
+            framework::SpecifiedVisitor<
                 shared_model::interface::StatelessValidTxResponse>(),
             status.get()));
       };

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -124,7 +124,7 @@ TEST_F(HeavyTransactionTest, DISABLED_QueryLargeData) {
   auto query_checker = [&](auto &status) {
     ASSERT_NO_THROW({
       auto &&response = boost::apply_visitor(
-          interface::SpecifiedVisitor<const interface::AccountResponse &>(),
+          framework::SpecifiedVisitor<const interface::AccountResponse &>(),
           status.get());
 
       boost::property_tree::ptree root;

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -81,7 +81,7 @@ TEST(PipelineIntegrationTest, SendTx) {
 
   auto checkStatelessValid = [](auto &status) {
     ASSERT_NO_THROW(boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::StatelessValidTxResponse>(),
         status.get()));
   };

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -58,7 +58,7 @@ template <class T>
 std::shared_ptr<T> getConcreteCommand(
     const std::unique_ptr<shared_model::interface::Command> &command) {
   return clone(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<T>(), command->get()));
+      framework::SpecifiedVisitor<T>(), command->get()));
 }
 
 class CommandValidateExecuteTest : public ::testing::Test {

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -103,7 +103,7 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
   auto wrapper = make_test_subscriber<CallExact>(qpi.queryNotifier(), 1);
   wrapper.subscribe([](auto response) {
     ASSERT_NO_THROW(
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get()));
   });

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -70,7 +70,7 @@ class TransactionProcessorTest : public ::testing::Test {
       auto tx_status = status_map.find(tx.hash());
       ASSERT_NE(tx_status, status_map.end());
       ASSERT_NO_THROW(boost::apply_visitor(
-          shared_model::interface::SpecifiedVisitor<Status>(),
+          framework::SpecifiedVisitor<Status>(),
           tx_status->second->get()));
     }
   }
@@ -376,7 +376,7 @@ TEST_F(TransactionProcessorTest, MultisigExpired) {
   auto wrapper = make_test_subscriber<CallExact>(tp->transactionNotifier(), 1);
   wrapper.subscribe([](auto response) {
     ASSERT_NO_THROW(
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::MstExpiredResponse>(),
                              response->get()));
   });

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -233,7 +233,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   ASSERT_NO_THROW({
     const auto &account_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              resp.get());
 
@@ -278,7 +278,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
 
   ASSERT_NO_THROW({
     const auto &detail_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              resp.get());
 
@@ -388,7 +388,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   auto resp = shared_model::proto::QueryResponse(response);
   ASSERT_NO_THROW({
     const auto &asset_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         resp.get());
 
@@ -482,7 +482,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
   auto shared_response = shared_model::proto::QueryResponse(response);
   ASSERT_NO_THROW({
     auto resp_pubkey = *boost::apply_visitor(
-                            shared_model::interface::SpecifiedVisitor<
+                            framework::SpecifiedVisitor<
                                 shared_model::interface::SignatoriesResponse>(),
                             shared_response.get())
                             .keys()
@@ -547,7 +547,7 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   auto resp = shared_model::proto::QueryResponse(response);
   ASSERT_NO_THROW({
     const auto &tx_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         resp.get());
 

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -150,7 +150,7 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get());
     ASSERT_EQ(cast_resp.account().accountId(), admin_id);
@@ -180,7 +180,7 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
@@ -210,7 +210,7 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
@@ -245,7 +245,7 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
@@ -369,7 +369,7 @@ TEST_F(GetAccountAssetsTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         response->get());
 
@@ -414,7 +414,7 @@ TEST_F(GetAccountAssetsTest, AllAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         response->get());
 
@@ -459,7 +459,7 @@ TEST_F(GetAccountAssetsTest, DomainAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         response->get());
 
@@ -501,7 +501,7 @@ TEST_F(GetAccountAssetsTest, GrantAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         response->get());
 
@@ -628,7 +628,7 @@ TEST_F(GetSignatoriesTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::SignatoriesResponse>(),
         response->get());
 
@@ -658,7 +658,7 @@ TEST_F(GetSignatoriesTest, AllAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::SignatoriesResponse>(),
         response->get());
 
@@ -688,7 +688,7 @@ TEST_F(GetSignatoriesTest, DomainAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::SignatoriesResponse>(),
         response->get());
 
@@ -723,7 +723,7 @@ TEST_F(GetSignatoriesTest, GrantAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::SignatoriesResponse>(),
         response->get());
 
@@ -826,7 +826,7 @@ TEST_F(GetAccountTransactionsTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -861,7 +861,7 @@ TEST_F(GetAccountTransactionsTest, AllAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -896,7 +896,7 @@ TEST_F(GetAccountTransactionsTest, DomainAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -935,7 +935,7 @@ TEST_F(GetAccountTransactionsTest, GrantAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -999,7 +999,7 @@ TEST_F(GetAccountTransactionsTest, NoAccountExist) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+      boost::apply_visitor(framework::SpecifiedVisitor<
                                shared_model::interface::TransactionsResponse>(),
                            response->get()));
 }
@@ -1041,7 +1041,7 @@ TEST_F(GetAccountAssetsTransactionsTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -1076,7 +1076,7 @@ TEST_F(GetAccountAssetsTransactionsTest, AllAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -1111,7 +1111,7 @@ TEST_F(GetAccountAssetsTransactionsTest, DomainAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -1150,7 +1150,7 @@ TEST_F(GetAccountAssetsTransactionsTest, GrantAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         response->get());
 
@@ -1214,7 +1214,7 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAccountExist) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+      boost::apply_visitor(framework::SpecifiedVisitor<
                                shared_model::interface::TransactionsResponse>(),
                            response->get()));
 }
@@ -1242,7 +1242,7 @@ TEST_F(GetAccountAssetsTransactionsTest, NoAssetExist) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW(
-      boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+      boost::apply_visitor(framework::SpecifiedVisitor<
                                shared_model::interface::TransactionsResponse>(),
                            response->get()));
 }
@@ -1283,7 +1283,7 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AssetResponse>(),
                              response->get());
 
@@ -1369,7 +1369,7 @@ TEST_F(GetRolesTest, ValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::RolesResponse>(),
                              response->get());
 
@@ -1455,7 +1455,7 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
     const auto &cast_resp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::RolePermissionsResponse>(),
         response->get());
 

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -72,7 +72,7 @@ TEST(QueryResponse, ErrorResponseLoad) {
         ASSERT_NO_THROW({
           ASSERT_EQ(i,
                     boost::apply_visitor(
-                        shared_model::interface::SpecifiedVisitor<
+                        framework::SpecifiedVisitor<
                             shared_model::interface::ErrorQueryResponse>(),
                         shared_response.get())
                         .get()

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -57,7 +57,7 @@ TEST(QueryResponseBuilderTest, AccountAssetResponse) {
 
   ASSERT_NO_THROW({
     const auto &tmp = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountAssetResponse>(),
         query_response.get());
     const auto &asset_response = tmp.accountAsset();
@@ -78,7 +78,7 @@ TEST(QueryResponseBuilderTest, AccountDetailResponse) {
 
   ASSERT_NO_THROW({
     const auto &account_detail_response = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::AccountDetailResponse>(),
         query_response.get());
 
@@ -107,7 +107,7 @@ TEST(QueryResponseBuilderTest, AccountResponse) {
 
   ASSERT_NO_THROW({
     const auto &account_response =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AccountResponse>(),
                              query_response.get());
 
@@ -156,7 +156,7 @@ TEST(QueryResponseBuilderTest, SignatoriesResponse) {
 
   ASSERT_NO_THROW({
     const auto &signatories_response = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::SignatoriesResponse>(),
         query_response.get());
 
@@ -183,7 +183,7 @@ TEST(QueryResponseBuilderTest, TransactionsResponse) {
 
   ASSERT_NO_THROW({
     const auto &transactions_response = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::TransactionsResponse>(),
         query_response.get());
 
@@ -204,7 +204,7 @@ TEST(QueryResponseBuilderTest, AssetResponse) {
 
   ASSERT_NO_THROW({
     const auto &asset_response =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::AssetResponse>(),
                              query_response.get());
 
@@ -225,7 +225,7 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
 
   ASSERT_NO_THROW({
     const auto &roles_response =
-        boost::apply_visitor(shared_model::interface::SpecifiedVisitor<
+        boost::apply_visitor(framework::SpecifiedVisitor<
                                  shared_model::interface::RolesResponse>(),
                              query_response.get());
 
@@ -243,7 +243,7 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
 
   ASSERT_NO_THROW({
     const auto &role_permissions_response = boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::RolePermissionsResponse>(),
         query_response.get());
 

--- a/test/module/shared_model/builders/protobuf/transaction_responses/proto_transaction_response_builder.cpp
+++ b/test/module/shared_model/builders/protobuf/transaction_responses/proto_transaction_response_builder.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(ProtoTransactionStatusBuilderTest, TestStatusType) {
                       .build();
 
   ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<StatusType>(),
+      framework::SpecifiedVisitor<StatusType>(),
       response.get()));
 
   auto proto_status = response.getTransport();

--- a/test/module/shared_model/builders/transaction_responses/transaction_response_builder_test.cpp
+++ b/test/module/shared_model/builders/transaction_responses/transaction_response_builder_test.cpp
@@ -73,7 +73,7 @@ TYPED_TEST(TransactionResponseBuilderTest, StatusType) {
 
   // check if type in response is as expected
   ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<StatusType>(),
+      framework::SpecifiedVisitor<StatusType>(),
       response->get()));
 
   ASSERT_EQ(response->transactionHash(), expected_hash);
@@ -98,6 +98,6 @@ TEST(ProtoTransactionStatusBuilderTest, SeveralObjectsFromOneBuilder) {
   ASSERT_EQ(response1->transactionHash(), expected_hash);
 
   ASSERT_NO_THROW(boost::apply_visitor(
-      shared_model::interface::SpecifiedVisitor<NotReceivedStatusType>(),
+      framework::SpecifiedVisitor<NotReceivedStatusType>(),
       response1->get()));
 }

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -46,7 +46,7 @@ TEST(RegressionTest, SequentialInitialization) {
 
   auto checkStatelessValid = [](auto &status) {
     ASSERT_NO_THROW(boost::apply_visitor(
-        shared_model::interface::SpecifiedVisitor<
+        framework::SpecifiedVisitor<
             shared_model::interface::StatelessValidTxResponse>(),
         status.get()));
   };
@@ -109,7 +109,7 @@ TEST(RegressionTest, StateRecovery) {
   auto checkQuery = [&tx](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
-          shared_model::interface::SpecifiedVisitor<
+          framework::SpecifiedVisitor<
               shared_model::interface::TransactionsResponse>(),
           status.get());
       ASSERT_EQ(resp.transactions().size(), 1);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

After last refactor (moving the Specified Visitor to tests) it still remained in shared_model::interface namespace. Now, it is fixed, and visitor lies in test framework namespace.

### Benefits

Namespaces are now consistent.

### Possible Drawbacks 

None