### PR TITLE
Remove release build withRegistry wrapper

### DIFF
--- a/.jenkinsci/release-build.groovy
+++ b/.jenkinsci/release-build.groovy
@@ -56,47 +56,45 @@ def doReleaseBuild() {
   sh "mv /tmp/${GIT_COMMIT}-${BUILD_NUMBER}/iroha.deb /tmp/${env.GIT_COMMIT}"
   sh "chmod +x /tmp/${env.GIT_COMMIT}/entrypoint.sh"
   iCRelease = docker.build("${DOCKER_REGISTRY_BASENAME}:${GIT_COMMIT}-${BUILD_NUMBER}-release", "--no-cache -f /tmp/${env.GIT_COMMIT}/Dockerfile /tmp/${env.GIT_COMMIT}")
-  docker.withRegistry('https://registry.hub.docker.com', 'docker-hub-credentials') {
-    if (env.GIT_LOCAL_BRANCH == 'develop') {
-      iCRelease.push("${platform}-develop")
-      if (manifest.manifestSupportEnabled()) {
-        manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:develop", 
-          ["${DOCKER_REGISTRY_BASENAME}:x86_64-develop", 
-           "${DOCKER_REGISTRY_BASENAME}:armv7l-develop", 
-           "${DOCKER_REGISTRY_BASENAME}:aarch64-develop"])
-        manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:develop",
-          [
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:x86_64-develop",
-             arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:armv7l-develop",
-             arch: 'arm', os: 'linux', osfeatures: [], variant: 'v7'],
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:aarch64-develop",
-             arch: 'arm64', os: 'linux', osfeatures: [], variant: '']
-          ])
-        withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
-          manifest.manifestPush("${DOCKER_REGISTRY_BASENAME}:develop", login, password)
-        }      
+  if (env.GIT_LOCAL_BRANCH == 'develop') {
+    iCRelease.push("${platform}-develop")
+    if (manifest.manifestSupportEnabled()) {
+      manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:develop",
+        ["${DOCKER_REGISTRY_BASENAME}:x86_64-develop",
+         "${DOCKER_REGISTRY_BASENAME}:armv7l-develop",
+         "${DOCKER_REGISTRY_BASENAME}:aarch64-develop"])
+      manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:develop",
+        [
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:x86_64-develop",
+           arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:armv7l-develop",
+           arch: 'arm', os: 'linux', osfeatures: [], variant: 'v7'],
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:aarch64-develop",
+           arch: 'arm64', os: 'linux', osfeatures: [], variant: '']
+        ])
+      withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
+        manifest.manifestPush("${DOCKER_REGISTRY_BASENAME}:develop", login, password)
       }
     }
-    else if (env.GIT_LOCAL_BRANCH == 'master') {
-      iCRelease.push("${platform}-latest")
-      if (manifest.manifestSupportEnabled()) {
-        manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:latest",
-          ["${DOCKER_REGISTRY_BASENAME}:x86_64-latest",
-           "${DOCKER_REGISTRY_BASENAME}:armv7l-latest",
-           "${DOCKER_REGISTRY_BASENAME}:aarch64-latest"])
-        manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:latest",
-          [
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:x86_64-latest",
-             arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:armv7l-latest",
-             arch: 'arm', os: 'linux', osfeatures: [], variant: 'v7'],
-            [manifest: "${DOCKER_REGISTRY_BASENAME}:aarch64-latest",
-             arch: 'arm64', os: 'linux', osfeatures: [], variant: '']
-          ])
-        withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
-          manifest.manifestPush("${DOCKER_REGISTRY_BASENAME}:latest", login, password)
-        }      
+  }
+  else if (env.GIT_LOCAL_BRANCH == 'master') {
+    iCRelease.push("${platform}-latest")
+    if (manifest.manifestSupportEnabled()) {
+      manifest.manifestCreate("${DOCKER_REGISTRY_BASENAME}:latest",
+        ["${DOCKER_REGISTRY_BASENAME}:x86_64-latest",
+         "${DOCKER_REGISTRY_BASENAME}:armv7l-latest",
+         "${DOCKER_REGISTRY_BASENAME}:aarch64-latest"])
+      manifest.manifestAnnotate("${DOCKER_REGISTRY_BASENAME}:latest",
+        [
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:x86_64-latest",
+           arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:armv7l-latest",
+           arch: 'arm', os: 'linux', osfeatures: [], variant: 'v7'],
+          [manifest: "${DOCKER_REGISTRY_BASENAME}:aarch64-latest",
+           arch: 'arm64', os: 'linux', osfeatures: [], variant: '']
+        ])
+      withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
+        manifest.manifestPush("${DOCKER_REGISTRY_BASENAME}:latest", login, password)
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
`withRegistry` wrapper used in `release-build.groovy` file prevented from executing experimental Docker commands. Namely, `docker manifest` that is used to manage manifest files on Docker hub. My suggestion is that this wrapper somehow fiddles with the system environment and shoves its own `config.json` without experimental features enabled.
This wrapper was redundant anyway as we use `withCredentials` to passthrough login and password for Docker hub.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Develop and Master branch on Jenkins CI will not be failing every time
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
