### PR TITLE
Fix/wrap exception for ModelCrypto::fromPrivateKey(priv_key)

### DIFF
--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -28,7 +28,8 @@ namespace shared_model {
 
     crypto::Keypair ModelCrypto::fromPrivateKey(
         const std::string &private_key) {
-      if (private_key.length() != 64) {
+      // TODO 07/06/18 Akvinikym: remove magic number (64) IR-977
+      if (private_key.size() != 64) {
         throw std::invalid_argument("input string has incorrect length "
                                     + std::to_string(private_key.length()));
       }

--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -28,9 +28,13 @@ namespace shared_model {
 
     crypto::Keypair ModelCrypto::fromPrivateKey(
         const std::string &private_key) {
+      if (private_key.length() != 64) {
+        throw std::invalid_argument("input string has incorrect length "
+                                    + std::to_string(private_key.length()));
+      }
       auto byte_string = iroha::hexstringToBytestring(private_key);
       if (not byte_string) {
-        throw std::runtime_error("invalid seed");
+        throw std::invalid_argument("invalid seed");
       }
       return crypto::CryptoProviderEd25519Sha3::generateKeypair(
           crypto::Seed(*byte_string));

--- a/shared_model/bindings/model_crypto.hpp
+++ b/shared_model/bindings/model_crypto.hpp
@@ -37,7 +37,7 @@ namespace shared_model {
 
       /**
        * Creates keypair (ed25519) from provided private key
-       * @param private_key - ed25519 hex-encoded private key
+       * @param private_key - ed25519 hex-encoded private key with length 64
        * @return created keypair
        */
       crypto::Keypair fromPrivateKey(const std::string &private_key);

--- a/shared_model/packages/javascript/tests/crypto.js
+++ b/shared_model/packages/javascript/tests/crypto.js
@@ -6,7 +6,7 @@ const privateKey = '1d7e0a32ee0affeb4d22acd73c2c6fb6bd58e266c8c2ce4fa0ffe3dd6a25
 const randomKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const incorrectInputLength = 'aaaaaaaaaaaaaaaa'
 const incorrectInputShorter = 'a'
-const incorrectInputLonger = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const incorrectInputLonger = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 test('ModelCrypto tests', function (t) {
   t.plan(9)
@@ -24,8 +24,8 @@ test('ModelCrypto tests', function (t) {
   t.equal(newKeypair.publicKey().hex().length, publicKey.length, 'Size of generated public key should be the same as size of predefined public key')
   t.equal(newKeypair.privateKey().hex().length, privateKey.length, 'Size of generated private key should be the same as size of predefined private key')
 
-  t.throws(() => crypto.fromPrivateKey(incorrectInputShorter), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys shorter then 32')
-  t.throws(() => crypto.fromPrivateKey(incorrectInputLonger), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys longer then 32')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputShorter), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys shorter then 64')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputLonger), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys longer then 64')
   t.equal(crypto.fromPrivateKey(privateKey).publicKey().hex(), publicKey)
 
   t.end()

--- a/shared_model/packages/javascript/tests/crypto.js
+++ b/shared_model/packages/javascript/tests/crypto.js
@@ -5,9 +5,11 @@ const publicKey = '407e57f50ca48969b08ba948171bb2435e035d82cec417e18e4a38f5fb113
 const privateKey = '1d7e0a32ee0affeb4d22acd73c2c6fb6bd58e266c8c2ce4fa0ffe3dd6a253ffb'
 const randomKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const incorrectInputLength = 'aaaaaaaaaaaaaaaa'
+const incorrectInputShorter = 'a'
+const incorrectInputLonger = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 test('ModelCrypto tests', function (t) {
-  t.plan(8)
+  t.plan(9)
 
   let crypto = new iroha.ModelCrypto()
 
@@ -22,7 +24,8 @@ test('ModelCrypto tests', function (t) {
   t.equal(newKeypair.publicKey().hex().length, publicKey.length, 'Size of generated public key should be the same as size of predefined public key')
   t.equal(newKeypair.privateKey().hex().length, privateKey.length, 'Size of generated private key should be the same as size of predefined private key')
 
-  t.throws(() => crypto.fromPrivateKey(incorrectInputLength), /input string has incorrect length/, 'Should throw "input string has incorrect length"')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputShorter), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys shorter then 32')
+  t.throws(() => crypto.fromPrivateKey(incorrectInputLonger), /input string has incorrect length/, 'Should throw "input string has incorrect length" for keys longer then 32')
   t.equal(crypto.fromPrivateKey(privateKey).publicKey().hex(), publicKey)
 
   t.end()

--- a/test/module/shared_model/bindings/model_crypto_test.cpp
+++ b/test/module/shared_model/bindings/model_crypto_test.cpp
@@ -37,11 +37,11 @@ TEST(ModelCryptoTest, GenerateKeypair) {
  */
 TEST(ModelCryptoTest, GenerateKeypairInvalidSeed) {
   ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
-      std::string(64, 'g'));, std::runtime_error);
+      std::string(64, 'g'));, std::invalid_argument);
   ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
-      std::string(63, 'a'));, std::runtime_error);
+      std::string(63, 'a'));, std::invalid_argument);
   ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
-      std::string(65, 'a'));, std::runtime_error);
+      std::string(65, 'a'));, std::invalid_argument);
   ASSERT_THROW(shared_model::bindings::ModelCrypto().fromPrivateKey(
       std::string(32, 'a'));, std::invalid_argument);
 }


### PR DESCRIPTION
Signed-off-by: Akvinikym <anarant12@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

[IR-1223](https://soramitsu.atlassian.net/browse/IR-1223)

### Description of the Change

Previously, there was no possibility for client code to catch exceptions thrown by ModelCrypto::fromPrivateKey method, so type of exception was changed to std::invalid_argument.
Also, a check for equality between private_key argument's length and 64 was added with related exception throw in case of failure.
Lastly, a couple of new tests were written to test new functionality. 
Overall, this is remake of [old pull request](https://github.com/hyperledger/iroha/pull/1254), which was not fixed and merged.

### Benefits

The exception can now be caught by client's code

### Possible Drawbacks 

None