### PR TITLE
Use С++11 syntax for constexpr function

### DIFF
--- a/libs/common/visitor.hpp
+++ b/libs/common/visitor.hpp
@@ -88,8 +88,7 @@ namespace iroha {
    */
   template <typename TVariant, typename... TVisitors>
   constexpr decltype(auto) visit_in_place(TVariant &&variant, TVisitors &&... visitors) {
-    auto visitor = make_visitor(visitors...);
-    return boost::apply_visitor(visitor, std::forward<TVariant>(variant));
+    return boost::apply_visitor(make_visitor(visitors...), std::forward<TVariant>(variant));
   }
 }  // namespace iroha
 


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Fix constexpr function in visitor.hpp: C++14 syntax for that aspect is unsupported by NDK compiler.

### Benefits

<!-- What benefits will be realized by the code change? -->
Working android bindings.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
It remains unclear what's the problem exactly - problems with C++14 support by NDK (unlikely) or just a problem with constexpr functions.
