### PR TITLE
Use new permissions in builders/bindings

### DIFF
--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -760,7 +760,7 @@ namespace iroha {
     auto set = command.rolePermissions();
     for (size_t i = 0; i < set.size(); ++i) {
       auto perm = static_cast<shared_model::interface::permissions::Role>(i);
-      if (set[perm]
+      if (set.test(perm)
           && not checkAccountRolePermission(
                  creator_account_id, queries, perm)) {
         return false;

--- a/irohad/execution/impl/query_execution.cpp
+++ b/irohad/execution/impl/query_execution.cpp
@@ -78,12 +78,12 @@ bool hasQueryPermission(const std::string &creator,
                // 2. Creator want to query his account, must have role
                // permission
                (creator == target_account
-                and perms_set.value()[indiv_permission_id])
+                and perms_set.value().test(indiv_permission_id))
                or  // 3. Creator has global permission to get any account
-               perms_set.value()[all_permission_id]
+               perms_set.value().test(all_permission_id)
                or  // 4. Creator has domain permission
                (getDomainFromName(creator) == getDomainFromName(target_account)
-                and perms_set.value()[domain_permission_id])));
+                and perms_set.value().test(domain_permission_id))));
 }
 bool QueryProcessingFactory::validate(
     const shared_model::interface::BlocksQuery &query) {

--- a/irohad/execution/impl/query_execution.cpp
+++ b/irohad/execution/impl/query_execution.cpp
@@ -218,7 +218,11 @@ QueryProcessingFactory::executeGetRolePermissions(
     return buildError<shared_model::interface::NoRolesErrorResponse>();
   }
 
-  auto response = QueryResponseBuilder().rolePermissionsResponse(*perm);
+  shared_model::interface::RolePermissionSet set =
+      shared_model::interface::permissions::fromOldR(
+          std::set<std::string>{perm->begin(), perm->end()});
+
+  auto response = QueryResponseBuilder().rolePermissionsResponse(set);
   return response;
 }
 

--- a/shared_model/backend/protobuf/from_old.hpp
+++ b/shared_model/backend/protobuf/from_old.hpp
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef SHARED_MODEL_PROTOBUF_FROM_OLD
+#define SHARED_MODEL_PROTOBUF_FROM_OLD
+
 #include <map>
 #include <set>
 #include <string>
@@ -47,3 +50,5 @@ namespace shared_model {
     }  // namespace permissions
   }    // namespace interface
 }  // namespace shared_model
+
+#endif  // SHARED_MODEL_PROTOBUF_FROM_OLD

--- a/shared_model/backend/protobuf/impl/permissions.cpp
+++ b/shared_model/backend/protobuf/impl/permissions.cpp
@@ -9,10 +9,6 @@ namespace shared_model {
   namespace proto {
     namespace permissions {
 
-      bool isValid(iroha::protocol::RolePermission perm) noexcept {
-        return iroha::protocol::RolePermission_IsValid(perm);
-      }
-
       interface::permissions::Role fromTransport(
           iroha::protocol::RolePermission perm) noexcept {
         return static_cast<interface::permissions::Role>(perm);
@@ -25,10 +21,6 @@ namespace shared_model {
 
       std::string toString(interface::permissions::Role r) {
         return iroha::protocol::RolePermission_Name(toTransport(r));
-      }
-
-      bool isValid(iroha::protocol::GrantablePermission perm) noexcept {
-        return iroha::protocol::GrantablePermission_IsValid(perm);
       }
 
       interface::permissions::Grantable fromTransport(

--- a/shared_model/backend/protobuf/impl/permissions.cpp
+++ b/shared_model/backend/protobuf/impl/permissions.cpp
@@ -42,7 +42,7 @@ namespace shared_model {
         std::vector<std::string> v;
         for (size_t i = 0; i < set.size(); ++i) {
           auto perm = static_cast<interface::permissions::Role>(i);
-          if (set[perm]) {
+          if (set.test(perm)) {
             v.push_back(toString(perm));
           }
         }
@@ -55,7 +55,7 @@ namespace shared_model {
         std::vector<std::string> v;
         for (size_t i = 0; i < set.size(); ++i) {
           auto perm = static_cast<interface::permissions::Grantable>(i);
-          if (set[perm]) {
+          if (set.test(perm)) {
             v.push_back(toString(perm));
           }
         }

--- a/shared_model/backend/protobuf/permissions.hpp
+++ b/shared_model/backend/protobuf/permissions.hpp
@@ -17,13 +17,6 @@
 namespace shared_model {
   namespace proto {
     namespace permissions {
-
-      /**
-       * @param perm protocol object for checking
-       * @return true if valid, false otherwise
-       */
-      bool isValid(iroha::protocol::RolePermission perm) noexcept;
-
       /**
        * Perform deserialization without checks
        * @param perm protocol object for conversion
@@ -44,12 +37,6 @@ namespace shared_model {
        * @return its string representation
        */
       std::string toString(interface::permissions::Role r);
-
-      /**
-       * @param perm protocol object for checking
-       * @return true if valid, false otherwise
-       */
-      bool isValid(iroha::protocol::GrantablePermission perm) noexcept;
 
       /**
        * Perform deserialization without checks

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -35,6 +35,7 @@ namespace std {
   %template(StringVector) vector<string>;
   %ignore vector<shared_model::crypto::Hash>::vector(size_type);
   %template(HashVector) vector<shared_model::crypto::Hash>;
+  %template(IntVector) vector<int>;
 };
 
 %exception {
@@ -42,6 +43,8 @@ namespace std {
     $action
   } catch (const std::invalid_argument &e) {
     SWIG_exception(SWIG_ValueError, e.what());
+  } catch (const std::out_of_range &e) {
+    SWIG_exception(SWIG_OverflowError, e.what());
   }
 }
 
@@ -50,6 +53,19 @@ namespace std {
 %rename(b_equal) shared_model::crypto::Blob::operator==;
 %rename(kp_equal) shared_model::crypto::Keypair::operator==;
 %rename(hash_invoke) shared_model::crypto::Hash::Hasher::operator();
+
+%ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Role>);
+%ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Grantable>);
+
+%extend shared_model::interface::PermissionSet {
+  PermissionSet(const std::vector<int> &perms) {
+    shared_model::interface::PermissionSet<Perm> *set = new shared_model::interface::PermissionSet<Perm>;
+    for (auto p: perms) {
+      set->set(static_cast<Perm>(p));
+    }
+    return set;
+  }
+}
 
 %{
 #include "bindings/model_transaction_builder.hpp"
@@ -62,11 +78,13 @@ namespace std {
 %include "cryptography/blob.hpp"
 %include "interfaces/common_objects/types.hpp"
 %include "interfaces/base/signable.hpp"
+%include "interfaces/permissions.hpp"
 %include "cryptography/public_key.hpp"
 %include "cryptography/private_key.hpp"
 %include "cryptography/hash.hpp"
 %include "cryptography/keypair.hpp"
 %include "cryptography/signed.hpp"
+%include "backend/protobuf/permissions.hpp"
 %include "backend/protobuf/transaction.hpp"
 %include "backend/protobuf/queries/proto_query.hpp"
 
@@ -80,3 +98,6 @@ namespace std {
 %template (UnsignedQuery) shared_model::proto::UnsignedWrapper<shared_model::proto::Query>;
 %template (ModelProtoTransaction) shared_model::bindings::ModelProto<shared_model::proto::UnsignedWrapper<shared_model::proto::Transaction>>;
 %template (ModelProtoQuery) shared_model::bindings::ModelProto<shared_model::proto::UnsignedWrapper<shared_model::proto::Query>>;
+%template (RolePermissionSet) shared_model::interface::PermissionSet<shared_model::interface::permissions::Role>;
+%template (GrantablePermissionSet) shared_model::interface::PermissionSet<shared_model::interface::permissions::Grantable>;
+

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -19,7 +19,7 @@
 
 #define DEPRECATED
 #define FINAL
-#pragma SWIG nowarn=325, 401, 509, 516
+#pragma SWIG nowarn=325, 401, 509, 516, 320
 
 %include "std_string.i"
 %include "stdint.i"
@@ -56,6 +56,10 @@ namespace std {
 
 %ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Role>);
 %ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Grantable>);
+%rename(bset_and) shared_model::interface::PermissionSet::operator&=;
+%rename(bset_or) shared_model::interface::PermissionSet::operator|=;
+%rename(bset_xor) shared_model::interface::PermissionSet::operator^=;
+%ignore shared_model::interface::PermissionSet::operator[];
 
 %extend shared_model::interface::PermissionSet {
   PermissionSet(const std::vector<int> &perms) {

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -61,6 +61,11 @@ namespace std {
 %rename(bset_xor) shared_model::interface::PermissionSet::operator^=;
 %ignore shared_model::interface::PermissionSet::operator[];
 
+#if defined(SWIGJAVA) || defined(SWIGJAVASCRIPT)
+%rename(equal) shared_model::interface::PermissionSet::operator==;
+%rename(not_equal) shared_model::interface::PermissionSet::operator!=;
+#endif
+
 %extend shared_model::interface::PermissionSet {
   PermissionSet(const std::vector<int> &perms) {
     shared_model::interface::PermissionSet<Perm> *set = new shared_model::interface::PermissionSet<Perm>;

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -19,7 +19,7 @@
 
 #define DEPRECATED
 #define FINAL
-#pragma SWIG nowarn=325, 401, 509, 516, 320
+#pragma SWIG nowarn=325, 401, 509, 516
 
 %include "std_string.i"
 %include "stdint.i"

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -59,7 +59,6 @@ namespace std {
 %rename(bset_and) shared_model::interface::PermissionSet::operator&=;
 %rename(bset_or) shared_model::interface::PermissionSet::operator|=;
 %rename(bset_xor) shared_model::interface::PermissionSet::operator^=;
-%ignore shared_model::interface::PermissionSet::operator[];
 
 #if defined(SWIGJAVA) || defined(SWIGJAVASCRIPT)
 %rename(equal) shared_model::interface::PermissionSet::operator==;

--- a/shared_model/bindings/model_transaction_builder.cpp
+++ b/shared_model/bindings/model_transaction_builder.cpp
@@ -98,7 +98,7 @@ namespace shared_model {
 
     ModelTransactionBuilder ModelTransactionBuilder::createRole(
         const interface::types::RoleIdType &role_name,
-        const std::vector<interface::types::PermissionNameType> &permissions) {
+        const interface::RolePermissionSet &permissions) {
       return ModelTransactionBuilder(
           builder_.createRole(role_name, permissions));
     }
@@ -112,14 +112,14 @@ namespace shared_model {
 
     ModelTransactionBuilder ModelTransactionBuilder::grantPermission(
         const interface::types::AccountIdType &account_id,
-        const interface::types::PermissionNameType &permission) {
+        interface::permissions::Grantable permission) {
       return ModelTransactionBuilder(
           builder_.grantPermission(account_id, permission));
     }
 
     ModelTransactionBuilder ModelTransactionBuilder::revokePermission(
         const interface::types::AccountIdType &account_id,
-        const interface::types::PermissionNameType &permission) {
+        interface::permissions::Grantable permission) {
       return ModelTransactionBuilder(
           builder_.revokePermission(account_id, permission));
     }

--- a/shared_model/bindings/model_transaction_builder.hpp
+++ b/shared_model/bindings/model_transaction_builder.hpp
@@ -155,7 +155,7 @@ namespace shared_model {
        */
       ModelTransactionBuilder createRole(
           const interface::types::RoleIdType &role_name,
-          const std::vector<interface::types::PermissionNameType> &permissions);
+          const interface::RolePermissionSet &permissions);
 
       /**
        * Detaches role
@@ -175,7 +175,7 @@ namespace shared_model {
        */
       ModelTransactionBuilder grantPermission(
           const interface::types::AccountIdType &account_id,
-          const interface::types::PermissionNameType &permission);
+          interface::permissions::Grantable permission);
 
       /**
        * Revokes permission
@@ -185,7 +185,7 @@ namespace shared_model {
        */
       ModelTransactionBuilder revokePermission(
           const interface::types::AccountIdType &account_id,
-          const interface::types::PermissionNameType &permission);
+          interface::permissions::Grantable permission);
 
       /**
        * Sets account detail

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -6,10 +6,12 @@
 #ifndef IROHA_PROTO_QUERY_RESPONSE_BUILDER_TEMPLATE_HPP
 #define IROHA_PROTO_QUERY_RESPONSE_BUILDER_TEMPLATE_HPP
 
+#include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/helpers.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permissions.hpp"
 #include "responses.pb.h"
 
 namespace shared_model {
@@ -174,13 +176,21 @@ namespace shared_model {
           for (const auto &perm : role_permissions) {
             query_response->add_permissions(perm);
           }
+
+          // TODO(@l4l) 05/06/18 IR-1393
+          // uncomment after fixing RolePermissionResponse
+          // for (size_t i = 0; i < role_permissions.size(); ++i) {
+          //   auto perm = static_cast<interface::permissions::Role>(i);
+          //   if (role_permissions[perm]) {
+          //     query_response->add_permissions(permissions::toTransport(perm));
+          //   }
+          // }
         });
       }
 
       auto queryHash(const interface::types::HashType &query_hash) const {
         return transform<QueryHash>([&](auto &proto_query_response) {
-          proto_query_response.set_query_hash(
-              query_hash.hex());
+          proto_query_response.set_query_hash(query_hash.hex());
         });
       }
 

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -84,8 +84,9 @@ namespace shared_model {
           iroha::protocol::AccountAssetResponse *query_response =
               proto_query_response.mutable_account_assets_response();
 
-          for (auto &asset: assets) {
-            query_response->add_account_assets()->CopyFrom(asset.getTransport());
+          for (auto &asset : assets) {
+            query_response->add_account_assets()->CopyFrom(
+                asset.getTransport());
           }
         });
       }
@@ -168,13 +169,17 @@ namespace shared_model {
       }
 
       auto rolePermissionsResponse(
-          const std::vector<interface::types::PermissionNameType>
-              &role_permissions) const {
+          const interface::RolePermissionSet &role_permissions) const {
         return queryResponseField([&](auto &proto_query_response) {
           iroha::protocol::RolePermissionsResponse *query_response =
               proto_query_response.mutable_role_permissions_response();
-          for (const auto &perm : role_permissions) {
-            query_response->add_permissions(perm);
+          for (size_t i = 0; i < role_permissions.size(); ++i) {
+            auto perm = static_cast<interface::permissions::Role>(i);
+            if (role_permissions[perm]) {
+              // TODO(@l4l) 05/06/18 IR-1393
+              // replace with toTransport after fixing RolePermissionResponse
+              query_response->add_permissions(permissions::toString(perm));
+            }
           }
 
           // TODO(@l4l) 05/06/18 IR-1393

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -175,7 +175,7 @@ namespace shared_model {
               proto_query_response.mutable_role_permissions_response();
           for (size_t i = 0; i < role_permissions.size(); ++i) {
             auto perm = static_cast<interface::permissions::Role>(i);
-            if (role_permissions[perm]) {
+            if (role_permissions.test(perm)) {
               // TODO(@l4l) 05/06/18 IR-1393
               // replace with toTransport after fixing RolePermissionResponse
               query_response->add_permissions(permissions::toString(perm));

--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -209,7 +209,7 @@ namespace shared_model {
           command->set_role_name(role_name);
           for (size_t i = 0; i < permissions.size(); ++i) {
             auto perm = static_cast<interface::permissions::Role>(i);
-            if (permissions[perm]) {
+            if (permissions.test(perm)) {
               command->add_permissions(permissions::toTransport(perm));
             }
           }

--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -27,9 +27,11 @@
 #include "primitive.pb.h"
 
 #include "amount/amount.hpp"
+#include "backend/protobuf/permissions.hpp"
 #include "builders/protobuf/helpers.hpp"
 #include "builders/protobuf/unsigned_proto.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permissions.hpp"
 #include "validators/default_validator.hpp"
 
 namespace shared_model {
@@ -200,31 +202,18 @@ namespace shared_model {
         });
       }
 
-      template <typename Collection>
       auto createRole(const interface::types::RoleIdType &role_name,
-                      const Collection &permissions) const {
+                      const interface::RolePermissionSet &permissions) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_create_role();
           command->set_role_name(role_name);
-          boost::for_each(permissions, [&command](const auto &perm) {
-            iroha::protocol::RolePermission p;
-            iroha::protocol::RolePermission_Parse(perm, &p);
-            command->add_permissions(p);
-          });
+          for (size_t i = 0; i < permissions.size(); ++i) {
+            auto perm = static_cast<interface::permissions::Role>(i);
+            if (permissions[perm]) {
+              command->add_permissions(permissions::toTransport(perm));
+            }
+          }
         });
-      }
-
-      auto createRole(
-          const interface::types::RoleIdType &role_name,
-          std::initializer_list<interface::types::PermissionNameType>
-              permissions) const {
-        return createRole(role_name, permissions);
-      }
-
-      template <typename... Permission>
-      auto createRole(const interface::types::RoleIdType &role_name,
-                      const Permission &... permissions) const {
-        return createRole(role_name, {permissions...});
       }
 
       auto detachRole(const interface::types::AccountIdType &account_id,
@@ -236,27 +225,22 @@ namespace shared_model {
         });
       }
 
-      auto grantPermission(
-          const interface::types::AccountIdType &account_id,
-          const interface::types::PermissionNameType &permission) const {
+      auto grantPermission(const interface::types::AccountIdType &account_id,
+                           interface::permissions::Grantable permission) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_grant_permission();
           command->set_account_id(account_id);
-          iroha::protocol::GrantablePermission p;
-          iroha::protocol::GrantablePermission_Parse(permission, &p);
-          command->set_permission(p);
+          command->set_permission(permissions::toTransport(permission));
         });
       }
 
       auto revokePermission(
           const interface::types::AccountIdType &account_id,
-          const interface::types::PermissionNameType &permission) const {
+          interface::permissions::Grantable permission) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_revoke_permission();
           command->set_account_id(account_id);
-          iroha::protocol::GrantablePermission p;
-          iroha::protocol::GrantablePermission_Parse(permission, &p);
-          command->set_permission(p);
+          command->set_permission(permissions::toTransport(permission));
         });
       }
 

--- a/shared_model/interfaces/impl/permissions.cpp
+++ b/shared_model/interfaces/impl/permissions.cpp
@@ -26,21 +26,43 @@ namespace shared_model {
         }
         return Role::COUNT;
       }
+
+      bool isValid(Role perm) noexcept {
+        auto p = static_cast<size_t>(perm);
+        return p < static_cast<size_t>(Role::COUNT);
+      }
+
+      bool isValid(Grantable perm) noexcept {
+        auto p = static_cast<size_t>(perm);
+        return p < static_cast<size_t>(Grantable::COUNT);
+      }
     }  // namespace permissions
   }    // namespace interface
 }  // namespace shared_model
 
 template <typename Perm>
-PermissionSet<Perm>::PermissionSet(std::initializer_list<Perm> list) {
-  append(list);
+constexpr auto bit(Perm p) {
+  return static_cast<size_t>(p);
 }
 
 template <typename Perm>
-PermissionSet<Perm> &PermissionSet<Perm>::append(
-    std::initializer_list<Perm> list) {
+PermissionSet<Perm>::PermissionSet() : Parent() {}
+
+template <typename Perm>
+PermissionSet<Perm>::PermissionSet(std::initializer_list<Perm> list) {
   for (auto l : list) {
     set(l);
   }
+}
+
+template <typename Perm>
+size_t PermissionSet<Perm>::size() const {
+  return Parent::size();
+}
+
+template <typename Perm>
+PermissionSet<Perm> &PermissionSet<Perm>::reset() {
+  Parent::reset();
   return *this;
 }
 
@@ -64,6 +86,11 @@ bool PermissionSet<Perm>::operator[](Perm p) const {
 template <typename Perm>
 bool PermissionSet<Perm>::test(Perm p) const {
   return PermissionSet<Perm>::Parent::test(bit(p));
+}
+
+template <typename Perm>
+bool PermissionSet<Perm>::none() const {
+  return Parent::none();
 }
 
 template <typename Perm>

--- a/shared_model/interfaces/impl/permissions.cpp
+++ b/shared_model/interfaces/impl/permissions.cpp
@@ -79,11 +79,6 @@ PermissionSet<Perm> &PermissionSet<Perm>::unset(Perm p) {
 }
 
 template <typename Perm>
-bool PermissionSet<Perm>::operator[](Perm p) const {
-  return Parent::operator[](bit(p));
-}
-
-template <typename Perm>
 bool PermissionSet<Perm>::test(Perm p) const {
   return PermissionSet<Perm>::Parent::test(bit(p));
 }

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -8,6 +8,7 @@
 
 #include <bitset>
 #include <initializer_list>
+#include <vector>
 
 namespace shared_model {
   namespace interface {
@@ -71,6 +72,18 @@ namespace shared_model {
       };
 
       Role permissionFor(Grantable);
+
+      /**
+       * @param perm protocol object for checking
+       * @return true if valid, false otherwise
+       */
+      bool isValid(interface::permissions::Role perm) noexcept;
+
+      /**
+       * @param perm protocol object for checking
+       * @return true if valid, false otherwise
+       */
+      bool isValid(interface::permissions::Grantable perm) noexcept;
     }  // namespace permissions
 
     template <typename Perm>
@@ -80,18 +93,17 @@ namespace shared_model {
       using Parent = std::bitset<static_cast<size_t>(Perm::COUNT)>;
 
      public:
-      using Parent::Parent;
-      using Parent::reset;
-      using Parent::size;
-      explicit PermissionSet(std::initializer_list<Perm> list);
+      PermissionSet();
+      PermissionSet(std::initializer_list<Perm> list);
 
-      PermissionSet &append(std::initializer_list<Perm> list);
-
+      size_t size() const;
+      PermissionSet &reset();
       PermissionSet &set(Perm p);
       PermissionSet &unset(Perm p);
 
       bool operator[](Perm p) const;
       bool test(Perm p) const;
+      bool none() const;
 
       bool isSubsetOf(const PermissionSet<Perm> &r) const;
 
@@ -100,11 +112,6 @@ namespace shared_model {
       PermissionSet<Perm> &operator&=(const PermissionSet<Perm> &r);
       PermissionSet<Perm> &operator|=(const PermissionSet<Perm> &r);
       PermissionSet<Perm> &operator^=(const PermissionSet<Perm> &r);
-
-     private:
-      constexpr auto bit(Perm p) const {
-        return static_cast<size_t>(p);
-      }
     };
 
     extern template class PermissionSet<permissions::Role>;

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -114,9 +114,6 @@ namespace shared_model {
       PermissionSet<Perm> &operator^=(const PermissionSet<Perm> &r);
     };
 
-    extern template class PermissionSet<permissions::Role>;
-    extern template class PermissionSet<permissions::Grantable>;
-
     using RolePermissionSet = PermissionSet<permissions::Role>;
     using GrantablePermissionSet = PermissionSet<permissions::Grantable>;
   }  // namespace interface

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -101,7 +101,6 @@ namespace shared_model {
       PermissionSet &set(Perm p);
       PermissionSet &unset(Perm p);
 
-      bool operator[](Perm p) const;
       bool test(Perm p) const;
       bool none() const;
 

--- a/shared_model/interfaces/query_responses/role_permissions.hpp
+++ b/shared_model/interfaces/query_responses/role_permissions.hpp
@@ -20,6 +20,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permissions.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -30,25 +31,16 @@ namespace shared_model {
     class RolePermissionsResponse
         : public ModelPrimitive<RolePermissionsResponse> {
      public:
-      /// type of role permissions collection
-      using PermissionNameCollectionType =
-          std::vector<types::PermissionNameType>;
-
       /**
        * @return role permissions
        */
-      virtual const PermissionNameCollectionType &rolePermissions() const = 0;
+      virtual const RolePermissionSet &rolePermissions() const = 0;
 
       /**
        * Stringify the data.
        * @return string representation of data.
        */
-      std::string toString() const override {
-        return detail::PrettyStringBuilder()
-            .init("RolePermissionsResponse")
-            .appendAll(rolePermissions(), [](auto perm) { return perm; })
-            .finalize();
-      }
+      std::string toString() const override = 0;
 
       /**
        * Implementation of operator ==

--- a/shared_model/packages/javascript/tests/txbuilder.js
+++ b/shared_model/packages/javascript/tests/txbuilder.js
@@ -9,7 +9,7 @@ const assetId = 'coin#test'
 const testAccountId = 'test@test'
 
 test('ModelTransactionBuilder tests', function (t) {
-  t.plan(136)
+  t.plan(133)
 
   let crypto = new iroha.ModelCrypto()
   let keypair = crypto.convertFromExisting(publicKey, privateKey)
@@ -123,19 +123,16 @@ test('ModelTransactionBuilder tests', function (t) {
   t.throws(() => correctTx.createRole(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.createRole(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
 
-  let sv = new iroha.StringVector()
-  sv.add('can_add_peer')
-  sv.add('can_read_assets')
-  let emptySv = new iroha.StringVector()
-  let invalidPermissionSv = new iroha.StringVector()
-  invalidPermissionSv.add('wrong_permission')
+  let emptyPerm = new iroha.RolePermissionSet()
+  let validPermissions = new iroha.RolePermissionSet()
+  validPermissions.set(iroha.Role_kAddPeer)
+  validPermissions.set(iroha.Role_kAddAssetQty)
 
-  t.throws(() => correctTx.createRole('new_user_role', emptySv).build(), /Permission set should contain at least one permission/, 'Should throw Permission set should contain at least one permission')
-  t.throws(() => correctTx.createRole('new_user_role', invalidPermissionSv).build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
-  t.throws(() => correctTx.createRole('', sv).build(), /Wrongly formed role_id, passed value: ''/, 'Should throw Wrongly formed role_id')
-  t.throws(() => correctTx.createRole('@@@', sv).build(), /Wrongly formed role_id, passed value: '@@@'/, 'Should throw Wrongly formed role_id')
-  t.throws(() => correctTx.createRole('new_user_role', '').build(), /argument 3 of type 'std::vector< shared_model::interface::types::PermissionNameType >/, 'Should throw ...argument 3 of type...')
-  t.doesNotThrow(() => correctTx.createRole('new_user_role', sv).build(), null, 'Should not throw any exceptions')
+  t.throws(() => correctTx.createRole('new_user_role', emptyPerm).build(), /Permission set should contain at least one permission/, 'Should throw Permission set should contain at least one permission')
+  t.throws(() => correctTx.createRole('', validPermissions).build(), /Wrongly formed role_id, passed value: ''/, 'Should throw Wrongly formed role_id')
+  t.throws(() => correctTx.createRole('@@@', validPermissions).build(), /Wrongly formed role_id, passed value: '@@@'/, 'Should throw Wrongly formed role_id')
+  t.throws(() => correctTx.createRole('new_user_role', '').build(), /argument 3 of type 'shared_model::interface::RolePermissionSet/, 'Should throw ...argument 3 of type...')
+  t.doesNotThrow(() => correctTx.createRole('new_user_role', validPermissions).build(), null, 'Should not throw any exceptions')
 
   // detachRole() tests
   t.comment('Testing detachRole()')
@@ -151,21 +148,19 @@ test('ModelTransactionBuilder tests', function (t) {
   t.comment('Testing grantPermission()')
   t.throws(() => correctTx.grantPermission(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.grantPermission(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
-  t.throws(() => correctTx.grantPermission('', 'can_read_assets').build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.grantPermission('@@@', 'can_read_assets').build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.grantPermission(adminAccountId, '').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
-  t.throws(() => correctTx.grantPermission(adminAccountId, '@@@').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
-  t.doesNotThrow(() => correctTx.grantPermission(adminAccountId, 'can_read_assets').build(), null, 'Should not throw any exceptions')
+  t.throws(() => correctTx.grantPermission('', iroha.Grantable_kSetMyQuorum).build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
+  t.throws(() => correctTx.grantPermission('@@@', iroha.Grantable_kSetMyQuorum).build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
+  t.throws(() => correctTx.grantPermission(adminAccountId, '').build(), /argument 3 of type 'shared_model::interface::permissions::Grantable/, 'Should throw ...argument 3 of type...')
+  t.doesNotThrow(() => correctTx.grantPermission(adminAccountId, iroha.Grantable_kSetMyQuorum).build(), null, 'Should not throw any exceptions')
 
   // revokePermission() tests
   t.comment('Testing revokePermission()')
   t.throws(() => correctTx.revokePermission(), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
   t.throws(() => correctTx.revokePermission(''), /Error: Illegal number of arguments/, 'Should throw Illegal number of arguments')
-  t.throws(() => correctTx.revokePermission('', 'can_read_assets').build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.revokePermission('@@@', 'can_read_assets').build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
-  t.throws(() => correctTx.revokePermission(adminAccountId, '').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
-  t.throws(() => correctTx.revokePermission(adminAccountId, '@@@').build(), /Provided permission does not exist/, 'Should throw Provided permission does not exist')
-  t.doesNotThrow(() => correctTx.revokePermission(adminAccountId, 'can_read_assets').build(), null, 'Should not throw any exceptions')
+  t.throws(() => correctTx.revokePermission('', iroha.Grantable_kSetMyQuorum).build(), /Wrongly formed account_id, passed value: ''/, 'Should throw Wrongly formed account_id')
+  t.throws(() => correctTx.revokePermission('@@@', iroha.Grantable_kSetMyQuorum).build(), /Wrongly formed account_id, passed value: '@@@'/, 'Should throw Wrongly formed account_id')
+  t.throws(() => correctTx.revokePermission(adminAccountId, '').build(), /argument 3 of type 'shared_model::interface::permissions::Grantable/, 'Should throw ...argument 3 of type...')
+  t.doesNotThrow(() => correctTx.revokePermission(adminAccountId, iroha.Grantable_kSetMyQuorum).build(), null, 'Should not throw any exceptions')
 
   // setAccountDetail() tests
   t.comment('Testing setAccountDetail()')

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -25,7 +25,6 @@
 
 #include "cryptography/crypto_provider/crypto_verifier.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
-#include "permissions.hpp"
 #include "validators/field_validator.hpp"
 
 // TODO: 15.02.18 nickaleks Change structure to compositional IR-978
@@ -231,28 +230,37 @@ namespace shared_model {
       }
     }
 
-    void FieldValidator::validatePermission(
+    void FieldValidator::validateRolePermission(
         ReasonsGroupType &reason,
-        const interface::types::PermissionNameType &permission_name) const {
-      if (shared_model::permissions::all_perm_group.find(permission_name)
-          == shared_model::permissions::all_perm_group.end()) {
-        reason.second.push_back("Provided permission does not exist");
+        const interface::permissions::Role &permission) const {
+      if (not isValid(permission)) {
+        reason.second.push_back("Provided role permission does not exist");
       }
     }
 
-    void FieldValidator::validatePermissions(
+    void FieldValidator::validateGrantablePermission(
         ReasonsGroupType &reason,
-        const interface::types::PermissionSetType &permissions) const {
-      if (permissions.empty()) {
+        const interface::permissions::Grantable &permission) const {
+      if (not isValid(permission)) {
+        reason.second.push_back("Provided grantable permission does not exist");
+      }
+    }
+
+    void FieldValidator::validateRolePermissions(
+        ReasonsGroupType &reason,
+        const interface::RolePermissionSet &permissions) const {
+      if (permissions.none()) {
         reason.second.push_back(
             "Permission set should contain at least one permission");
       }
-      if (not std::includes(shared_model::permissions::role_perm_group.begin(),
-                            shared_model::permissions::role_perm_group.end(),
-                            permissions.begin(),
-                            permissions.end())) {
+    }
+
+    void FieldValidator::validateGrantablePermissions(
+        ReasonsGroupType &reason,
+        const interface::GrantablePermissionSet &permissions) const {
+      if (permissions.none()) {
         reason.second.push_back(
-            "Provided permissions are not subset of the allowed permissions");
+            "Permission set should contain at least one permission");
       }
     }
 

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -23,6 +23,7 @@
 #include "datetime/time.hpp"
 #include "interfaces/base/signable.hpp"
 #include "interfaces/commands/command.hpp"
+#include "interfaces/permissions.hpp"
 #include "interfaces/transaction.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
 #include "validators/answer.hpp"
@@ -107,13 +108,21 @@ namespace shared_model {
           ReasonsGroupType &reason,
           const interface::types::PrecisionType &precision) const;
 
-      void validatePermission(
+      void validateRolePermission(
           ReasonsGroupType &reason,
-          const interface::types::PermissionNameType &permission_name) const;
+          const interface::permissions::Role &permission) const;
 
-      void validatePermissions(
+      void validateGrantablePermission(
           ReasonsGroupType &reason,
-          const interface::types::PermissionSetType &permissions) const;
+          const interface::permissions::Grantable &permission) const;
+
+      void validateRolePermissions(
+          ReasonsGroupType &reason,
+          const interface::RolePermissionSet &permissions) const;
+
+      void validateGrantablePermissions(
+          ReasonsGroupType &reason,
+          const interface::GrantablePermissionSet &permissions) const;
 
       void validateQuorum(ReasonsGroupType &reason,
                           const interface::types::QuorumType &quorum) const;

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -117,9 +117,8 @@ namespace shared_model {
         ReasonsGroupType reason;
         addInvalidCommand(reason, "CreateRole");
 
-        auto tmp = proto::permissions::toString(cr.rolePermissions());
         validator_.validateRoleId(reason, cr.roleName());
-        validator_.validatePermissions(reason, {tmp.begin(), tmp.end()});
+        validator_.validateRolePermissions(reason, cr.rolePermissions());
 
         return reason;
       }
@@ -139,8 +138,7 @@ namespace shared_model {
         addInvalidCommand(reason, "GrantPermission");
 
         validator_.validateAccountId(reason, gp.accountId());
-        validator_.validatePermission(
-            reason, proto::permissions::toString(gp.permissionName()));
+        validator_.validateGrantablePermission(reason, gp.permissionName());
 
         return reason;
       }
@@ -159,8 +157,7 @@ namespace shared_model {
         addInvalidCommand(reason, "RevokePermission");
 
         validator_.validateAccountId(reason, rp.accountId());
-        validator_.validatePermission(
-            reason, proto::permissions::toString(rp.permissionName()));
+        validator_.validateGrantablePermission(reason, rp.permissionName());
 
         return reason;
       }

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -33,9 +33,7 @@
 #include "datetime/time.hpp"
 #include "framework/integration_framework/iroha_instance.hpp"
 #include "framework/integration_framework/test_irohad.hpp"
-// TODO (@l4l) IR-874 create more comfort way for permission-dependent proto
-// building
-#include "validators/permissions.hpp"
+#include "interfaces/permissions.hpp"
 
 using namespace shared_model::crypto;
 using namespace std::literals::string_literals;
@@ -72,17 +70,17 @@ namespace integration_framework {
 
   shared_model::proto::Block IntegrationTestFramework::defaultBlock(
       const shared_model::crypto::Keypair &key) {
+    shared_model::interface::RolePermissionSet all_perms{};
+    for (size_t i = 0; i < all_perms.size(); ++i) {
+      auto perm = static_cast<shared_model::interface::permissions::Role>(i);
+      all_perms.set(perm);
+    }
     auto genesis_tx =
         shared_model::proto::TransactionBuilder()
             .creatorAccountId(kAdminId)
             .createdTime(iroha::time::now())
             .addPeer("0.0.0.0:50541", key.publicKey())
-            .createRole(kDefaultRole,
-                        // TODO (@l4l) IR-874 create more comfort way for
-                        // permission-dependent proto building
-                        std::vector<std::string>{
-                            shared_model::permissions::role_perm_group.begin(),
-                            shared_model::permissions::role_perm_group.end()})
+            .createRole(kDefaultRole, all_perms)
             .createDomain(kDefaultDomain, kDefaultRole)
             .createAccount(kAdminName, kDefaultDomain, key.publicKey())
             .createAsset(kAssetName, kDefaultDomain, 1)

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -46,7 +46,7 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
     const std::string &user,
     const shared_model::crypto::PublicKey &key,
     const std::string &role_id,
-    std::vector<std::string> perms) {
+    const shared_model::interface::RolePermissionSet &perms) {
   const auto user_id = user + "@"
       + integration_framework::IntegrationTestFramework::kDefaultDomain;
   return createUser(user, key)
@@ -57,7 +57,8 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
 }
 
 shared_model::proto::Transaction AcceptanceFixture::makeUserWithPerms(
-    const std::string &role_name, const std::vector<std::string> &perms) {
+    const std::string &role_name,
+    const shared_model::interface::RolePermissionSet &perms) {
   return createUserWithPerms(kUser, kUserKeypair.publicKey(), role_name, perms)
       .build()
       .signAndAddSignature(kAdminKeypair)
@@ -65,7 +66,7 @@ shared_model::proto::Transaction AcceptanceFixture::makeUserWithPerms(
 }
 
 shared_model::proto::Transaction AcceptanceFixture::makeUserWithPerms(
-    const std::vector<std::string> &perms) {
+    const shared_model::interface::RolePermissionSet &perms) {
   return makeUserWithPerms(kRole, perms);
 }
 

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include "cryptography/keypair.hpp"
+#include "interfaces/permissions.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 
@@ -49,7 +50,7 @@ class AcceptanceFixture : public ::testing::Test {
       const std::string &user,
       const shared_model::crypto::PublicKey &key,
       const std::string &role_id,
-      std::vector<std::string> perms);
+      const shared_model::interface::RolePermissionSet &perms);
 
   /**
    * Creates the transaction with the user creation commands
@@ -58,7 +59,8 @@ class AcceptanceFixture : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   shared_model::proto::Transaction makeUserWithPerms(
-      const std::string &role_name, const std::vector<std::string> &perms);
+      const std::string &role_name,
+      const shared_model::interface::RolePermissionSet &perms);
 
   /**
    * Creates the transaction with the user creation commands
@@ -66,7 +68,7 @@ class AcceptanceFixture : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   shared_model::proto::Transaction makeUserWithPerms(
-      const std::vector<std::string> &perms);
+      const shared_model::interface::RolePermissionSet &perms);
 
   /**
    * Add default user creator account id and current created time to builder

--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -6,15 +6,14 @@
 #include <gtest/gtest.h>
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
 
 class AddAssetQuantity : public AcceptanceFixture {
  public:
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_add_asset_qty}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kAddAssetQty}) {
     return AcceptanceFixture::makeUserWithPerms(perms);
   }
 
@@ -47,7 +46,7 @@ TEST_F(AddAssetQuantity, Basic) {
 TEST_F(AddAssetQuantity, NoPermissions) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kGetMyTxs}))
       .skipProposal()
       .skipBlock()
       .sendTx(complete(baseTx().addAssetQuantity(kUserId, kAsset, kAmount)))
@@ -197,9 +196,7 @@ TEST_F(AddAssetQuantity, OtherDomain) {
               .creatorAccountId(
                   integration_framework::IntegrationTestFramework::kAdminId)
               .createdTime(iroha::time::now())
-              .createRole(kNewRole,
-                          std::vector<std::string>{
-                              shared_model::permissions::can_get_my_txs})
+              .createRole(kNewRole, {interface::permissions::Role::kGetMyTxs})
               .createDomain(kNewDomain, kNewRole)
               .createAccount(
                   kNewUser,

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -6,15 +6,14 @@
 #include <gtest/gtest.h>
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
 
 class CreateAccount : public AcceptanceFixture {
  public:
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_create_account}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kCreateAccount}) {
     return AcceptanceFixture::makeUserWithPerms(perms);
   }
 
@@ -50,7 +49,7 @@ TEST_F(CreateAccount, Basic) {
 TEST_F(CreateAccount, NoPermissions) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kGetMyTxs}))
       .skipProposal()
       .skipBlock()
       .sendTx(complete(baseTx().createAccount(

--- a/test/integration/acceptance/create_domain_test.cpp
+++ b/test/integration/acceptance/create_domain_test.cpp
@@ -6,15 +6,14 @@
 #include <gtest/gtest.h>
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
 
 class CreateDomain : public AcceptanceFixture {
  public:
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_create_domain}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kCreateDomain}) {
     return AcceptanceFixture::makeUserWithPerms(perms);
   }
 
@@ -47,7 +46,7 @@ TEST_F(CreateDomain, Basic) {
 TEST_F(CreateDomain, NoPermissions) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_my_txs}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kGetMyTxs}))
       .skipProposal()
       .skipBlock()
       .sendTx(complete(baseTx().createDomain(kNewDomain, kRole)))

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -11,7 +11,6 @@
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "utils/query_error_response_visitor.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -23,10 +22,10 @@ class GetTransactions : public AcceptanceFixture {
    * @param perms are the permissions of the user
    * @return built tx and a hash of its payload
    */
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_get_my_txs}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kGetMyTxs}) {
     auto new_perms = perms;
-    new_perms.push_back(shared_model::permissions::can_set_quorum);
+    new_perms.set(interface::permissions::Role::kSetQuorum);
     return AcceptanceFixture::makeUserWithPerms(kNewRole, new_perms);
   }
 
@@ -68,7 +67,7 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
   auto dummy_tx = dummyTx();
   IntegrationTestFramework(2)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_read_assets}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kReadAssets}))
       .sendTx(dummy_tx)
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); })
@@ -95,7 +94,7 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 
   IntegrationTestFramework(2)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_get_all_txs}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kGetAllTxs}))
       .sendTx(dummy_tx)
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); })

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -6,7 +6,6 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -18,10 +17,10 @@ class QueryAcceptanceTest : public AcceptanceFixture {
    * @param perms are the permissions of the user
    * @return built tx and a hash of its payload
    */
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_get_my_txs}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kGetMyTxs}) {
     auto new_perms = perms;
-    new_perms.push_back(shared_model::permissions::can_set_quorum);
+    new_perms.set(interface::permissions::Role::kSetQuorum);
     return AcceptanceFixture::makeUserWithPerms(kNewRole, new_perms);
   }
 

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -9,7 +9,6 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -21,9 +20,9 @@ class SubtractAssetQuantity : public AcceptanceFixture {
    * @param perms are the permissions of the user
    * @return built tx and a hash of its payload
    */
-  auto makeUserWithPerms(const std::vector<std::string> &perms = {
-                             shared_model::permissions::can_subtract_asset_qty,
-                             shared_model::permissions::can_add_asset_qty}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kSubtractAssetQty,
+                             interface::permissions::Role::kAddAssetQty}) {
     return AcceptanceFixture::makeUserWithPerms(perms);
   }
 
@@ -89,7 +88,7 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
 TEST_F(SubtractAssetQuantity, NoPermissions) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms({shared_model::permissions::can_add_asset_qty}))
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kAddAssetQty}))
       .skipProposal()
       .skipBlock()
       .sendTx(replenish())

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -11,7 +11,6 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "utils/query_error_response_visitor.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -25,7 +24,7 @@ class TransferAsset : public AcceptanceFixture {
    */
   auto makeUserWithPerms(const std::string &user,
                          const crypto::Keypair &key,
-                         const std::vector<std::string> &perms,
+                         const interface::RolePermissionSet &perms,
                          const std::string &role) {
     return createUserWithPerms(user, key.publicKey(), role, perms)
         .build()
@@ -85,10 +84,10 @@ class TransferAsset : public AcceptanceFixture {
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
   const crypto::Keypair kUser2Keypair =
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  const std::vector<std::string> kPerms{
-      shared_model::permissions::can_add_asset_qty,
-      shared_model::permissions::can_transfer,
-      shared_model::permissions::can_receive};
+  const interface::RolePermissionSet kPerms{
+      interface::permissions::Role::kAddAssetQty,
+      interface::permissions::Role::kTransfer,
+      interface::permissions::Role::kReceive};
 };
 
 /**
@@ -119,7 +118,7 @@ TEST_F(TransferAsset, WithOnlyCanTransferPerm) {
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms(kUser1,
                                 kUser1Keypair,
-                                {shared_model::permissions::can_transfer},
+                                {interface::permissions::Role::kTransfer},
                                 kRole1))
       .skipProposal()
       .skipBlock()
@@ -149,7 +148,7 @@ TEST_F(TransferAsset, WithOnlyCanReceivePerm) {
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms(kUser1,
                                 kUser1Keypair,
-                                {shared_model::permissions::can_receive},
+                                {interface::permissions::Role::kReceive},
                                 kRole1))
       .skipProposal()
       .skipBlock()
@@ -411,9 +410,7 @@ TEST_F(TransferAsset, InterDomain) {
               .creatorAccountId(
                   integration_framework::IntegrationTestFramework::kAdminId)
               .createdTime(iroha::time::now())
-              .createRole(kNewRole,
-                          std::vector<std::string>{
-                              shared_model::permissions::can_receive})
+              .createRole(kNewRole, {interface::permissions::Role::kReceive})
               .createDomain(kNewDomain, kNewRole)
               .createAccount(
                   kUser2,

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -10,7 +10,6 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -22,10 +21,8 @@ class HeavyTransactionTest : public AcceptanceFixture {
    * @param perms are the permissions of the user
    * @return built tx and a hash of its payload
    */
-  auto makeUserWithPerms(
-      const std::vector<std::string> &perms = {
-          shared_model::permissions::role_perm_group.begin(),
-          shared_model::permissions::role_perm_group.end()}) {
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kSetDetail}) {
     return AcceptanceFixture::makeUserWithPerms(perms);
   }
 

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -19,7 +19,6 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
-#include "validators/permissions.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;
@@ -43,13 +42,12 @@ class MstPipelineTest : public AcceptanceFixture {
    * @return built tx and a hash of its payload
    */
   auto makeMstUser(size_t sigs = kSignatories) {
-    auto tx =
-        createUserWithPerms(kUser,
-                            kUserKeypair.publicKey(),
-                            kNewRole,
-                            std::vector<std::string>{
-                                shared_model::permissions::can_add_asset_qty})
-            .setAccountQuorum(kUserId, sigs + 1);
+    auto tx = createUserWithPerms(
+                  kUser,
+                  kUserKeypair.publicKey(),
+                  kNewRole,
+                  {shared_model::interface::permissions::Role::kAddAssetQty})
+                  .setAccountQuorum(kUserId, sigs + 1);
 
     for (size_t i = 0; i < sigs; ++i) {
       signatories.emplace_back(

--- a/test/module/irohad/ametsuchi/kv_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/kv_storage_test.cpp
@@ -22,10 +22,10 @@
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/impl/storage_impl.hpp"
 #include "ametsuchi/mutable_storage.hpp"
+#include "interfaces/permissions.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
-#include "validators/permissions.hpp"
 
 using namespace iroha::ametsuchi;
 
@@ -57,19 +57,16 @@ class KVTest : public AmetsuchiTest {
             .creatorAccountId("userone@ru")
             .createRole(
                 "user",
-                std::vector<shared_model::interface::types::PermissionNameType>{
-                    shared_model::permissions::can_add_peer,
-                    shared_model::permissions::can_create_asset,
-                    shared_model::permissions::can_get_my_account})
+                {shared_model::interface::permissions::Role::kAddPeer,
+                 shared_model::interface::permissions::Role::kCreateAsset,
+                 shared_model::interface::permissions::Role::kGetMyAccount})
             .createDomain("ru", "user")
-            .createAccount(
-                account_name1,
-                domain_id,
-                shared_model::crypto::PublicKey(empty_key))
-            .createAccount(
-                account_name2,
-                domain_id,
-                shared_model::crypto::PublicKey(empty_key))
+            .createAccount(account_name1,
+                           domain_id,
+                           shared_model::crypto::PublicKey(empty_key))
+            .createAccount(account_name2,
+                           domain_id,
+                           shared_model::crypto::PublicKey(empty_key))
             .setAccountDetail(account_name2 + "@" + domain_id, "age", "24")
             .build();
     auto block1 =

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -46,8 +46,8 @@ std::unique_ptr<shared_model::interface::Command> buildCommand(
 template <class T>
 std::shared_ptr<T> getConcreteCommand(
     const std::unique_ptr<shared_model::interface::Command> &command) {
-  return clone(boost::apply_visitor(
-      framework::SpecifiedVisitor<T>(), command->get()));
+  return clone(
+      boost::apply_visitor(framework::SpecifiedVisitor<T>(), command->get()));
 }
 
 class CommandValidateExecuteTest : public ::testing::Test {
@@ -1735,7 +1735,7 @@ class CreateRoleTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    std::set<std::string> perm = {toString(Role::kCreateRole)};
+    shared_model::interface::RolePermissionSet perm = {Role::kCreateRole};
     role_permissions = {toString(Role::kCreateRole)};
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
@@ -1789,8 +1789,8 @@ TEST_F(CreateRoleTest, InvalidCaseWhenNoPermissions) {
  */
 TEST_F(CreateRoleTest, InvalidCaseWhenRoleSuperset) {
   // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
-  std::set<std::string> master_perms = {toString(Role::kAddPeer),
-                                        toString(Role::kAppendRole)};
+  shared_model::interface::RolePermissionSet master_perms = {Role::kAddPeer,
+                                                             Role::kAppendRole};
   command = buildCommand(
       TestTransactionBuilder().createRole(kMasterRole, master_perms));
 
@@ -1998,8 +1998,8 @@ class GrantPermissionTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    expected_permission = toString(Grantable::kAddMySignatory);
-    role_permissions = {"can_grant_" + expected_permission};
+    expected_permission = Grantable::kAddMySignatory;
+    role_permissions = {"can_grant_" + toString(expected_permission)};
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().grantPermission(
@@ -2008,7 +2008,7 @@ class GrantPermissionTest : public CommandValidateExecuteTest {
         getConcreteCommand<shared_model::interface::GrantPermission>(command);
   }
   std::shared_ptr<shared_model::interface::GrantPermission> grant_permission;
-  std::string expected_permission;
+  Grantable expected_permission;
 };
 
 /**
@@ -2024,7 +2024,7 @@ TEST_F(GrantPermissionTest, ValidCase) {
   EXPECT_CALL(*wsv_command,
               insertAccountGrantablePermission(grant_permission->accountId(),
                                                creator->accountId(),
-                                               expected_permission))
+                                               toString(expected_permission)))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -2051,7 +2051,7 @@ TEST_F(GrantPermissionTest, InvalidCaseWhenInsertGrantablePermissionFails) {
   EXPECT_CALL(*wsv_command,
               insertAccountGrantablePermission(grant_permission->accountId(),
                                                creator->accountId(),
-                                               expected_permission))
+                                               toString(expected_permission)))
       .WillOnce(Return(makeEmptyError()));
   ASSERT_TRUE(err(execute(command)));
 }
@@ -2061,7 +2061,7 @@ class RevokePermissionTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    expected_permission = toString(Grantable::kAddMySignatory);
+    expected_permission = Grantable::kAddMySignatory;
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().revokePermission(
@@ -2071,7 +2071,7 @@ class RevokePermissionTest : public CommandValidateExecuteTest {
   }
 
   std::shared_ptr<shared_model::interface::RevokePermission> revoke_permission;
-  std::string expected_permission;
+  Grantable expected_permission;
 };
 
 /**
@@ -2080,15 +2080,15 @@ class RevokePermissionTest : public CommandValidateExecuteTest {
  * @then execute succeses
  */
 TEST_F(RevokePermissionTest, ValidCase) {
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          revoke_permission->accountId(), kAdminId, expected_permission))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(revoke_permission->accountId(),
+                                            kAdminId,
+                                            toString(expected_permission)))
       .WillOnce(Return(true));
   EXPECT_CALL(*wsv_command,
               deleteAccountGrantablePermission(revoke_permission->accountId(),
                                                creator->accountId(),
-                                               expected_permission))
+                                               toString(expected_permission)))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -2099,10 +2099,10 @@ TEST_F(RevokePermissionTest, ValidCase) {
  * @then execute failed
  */
 TEST_F(RevokePermissionTest, InvalidCaseNoPermissions) {
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          revoke_permission->accountId(), kAdminId, expected_permission))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(revoke_permission->accountId(),
+                                            kAdminId,
+                                            toString(expected_permission)))
       .WillOnce(Return(false));
   ASSERT_TRUE(err(validateAndExecute(command)));
 }
@@ -2116,7 +2116,7 @@ TEST_F(RevokePermissionTest, InvalidCaseDeleteAccountPermissionvFails) {
   EXPECT_CALL(*wsv_command,
               deleteAccountGrantablePermission(revoke_permission->accountId(),
                                                creator->accountId(),
-                                               expected_permission))
+                                               toString(expected_permission)))
       .WillOnce(Return(makeEmptyError()));
   ASSERT_TRUE(err(execute(command)));
 }

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -149,10 +149,9 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), admin_id);
   });
 }
@@ -179,10 +178,9 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -209,10 +207,9 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -244,10 +241,9 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -1290,10 +1286,9 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AssetResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AssetResponse>(),
+        response->get());
 
     ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
   });
@@ -1376,10 +1371,9 @@ TEST_F(GetRolesTest, ValidCase) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::RolesResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::RolesResponse>(),
+        response->get());
 
     ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
@@ -1437,10 +1431,11 @@ class GetRolePermissionsTest : public QueryValidateExecuteTest {
   void SetUp() override {
     QueryValidateExecuteTest::SetUp();
     role_permissions = {can_get_roles};
-    perms = {can_get_my_account, can_get_my_signatories};
+    perms = {shared_model::interface::permissions::Role::kGetMyAccount,
+             shared_model::interface::permissions::Role::kGetMySignatories};
   }
   std::string role_id = "user";
-  std::vector<std::string> perms;
+  shared_model::interface::RolePermissionSet perms;
 };
 
 /**
@@ -1458,7 +1453,8 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
       .WillOnce(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getRolePermissions(admin_role))
       .WillOnce(Return(role_permissions));
-  EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
+  EXPECT_CALL(*wsv_query, getRolePermissions(role_id))
+      .WillOnce(Return(shared_model::proto::permissions::toString(perms)));
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
@@ -1469,7 +1465,7 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
 
     ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
     for (size_t i = 0; i < perms.size(); ++i) {
-      ASSERT_EQ(cast_resp.rolePermissions().at(i), perms.at(i));
+      ASSERT_EQ(cast_resp.rolePermissions(), perms);
     }
   });
 }

--- a/test/module/shared_model/backend_proto/permissions_test.cpp
+++ b/test/module/shared_model/backend_proto/permissions_test.cpp
@@ -68,8 +68,7 @@ TYPED_TEST_CASE(ProtoPermission, PermTypes);
  */
 TYPED_TEST(ProtoPermission, IsValid) {
   boost::for_each(boost::irange(0, TypeParam::size()), [&](auto i) {
-    this->perm = getRole<decltype(this->perm)>(i);
-    ASSERT_TRUE(isValid(this->perm));
+    ASSERT_TRUE(isValid(getRole<typename TypeParam::Model>(i)));
   });
 }
 
@@ -128,7 +127,7 @@ TYPED_TEST(ProtoPermission, SizesMatch) {
 TEST(ProtoPermission, PermissionSet) {
   using Role = shared_model::interface::permissions::Role;
   using PermSet = shared_model::interface::PermissionSet<Role>;
-  PermSet set{Role::kAppendRole, Role::kAddAssetQty, Role::kAddPeer};
+  PermSet set({Role::kAppendRole, Role::kAddAssetQty, Role::kAddPeer});
   ASSERT_TRUE(set[Role::kAppendRole]);
   ASSERT_TRUE(set[Role::kAddAssetQty]);
   ASSERT_TRUE(set[Role::kAddPeer]);
@@ -142,27 +141,27 @@ TEST(ProtoPermission, PermissionSet) {
 TEST(ProtoPermission, PermissionSubset) {
   using Role = shared_model::interface::permissions::Role;
   using PermSet = shared_model::interface::PermissionSet<Role>;
-  PermSet big{Role::kAppendRole,
-              Role::kCreateRole,
-              Role::kDetachRole,
-              Role::kAddAssetQty,
-              Role::kSubtractAssetQty,
-              Role::kAddPeer,
-              Role::kAddSignatory,
-              Role::kRemoveSignatory,
-              Role::kSetQuorum,
-              Role::kCreateAccount,
-              Role::kSetDetail,
-              Role::kCreateAsset,
-              Role::kTransfer,
-              Role::kReceive};
-  PermSet sub{Role::kAppendRole,
-              Role::kCreateRole,
-              Role::kDetachRole,
-              Role::kSubtractAssetQty,
-              Role::kAddSignatory,
-              Role::kSetDetail,
-              Role::kCreateAsset};
+  PermSet big({Role::kAppendRole,
+               Role::kCreateRole,
+               Role::kDetachRole,
+               Role::kAddAssetQty,
+               Role::kSubtractAssetQty,
+               Role::kAddPeer,
+               Role::kAddSignatory,
+               Role::kRemoveSignatory,
+               Role::kSetQuorum,
+               Role::kCreateAccount,
+               Role::kSetDetail,
+               Role::kCreateAsset,
+               Role::kTransfer,
+               Role::kReceive});
+  PermSet sub({Role::kAppendRole,
+               Role::kCreateRole,
+               Role::kDetachRole,
+               Role::kSubtractAssetQty,
+               Role::kAddSignatory,
+               Role::kSetDetail,
+               Role::kCreateAsset});
   auto nonsub = sub;
   ASSERT_FALSE(big.test(Role::kGetDomainAccounts));
   nonsub.set(Role::kGetDomainAccounts);

--- a/test/module/shared_model/backend_proto/permissions_test.cpp
+++ b/test/module/shared_model/backend_proto/permissions_test.cpp
@@ -128,14 +128,14 @@ TEST(ProtoPermission, PermissionSet) {
   using Role = shared_model::interface::permissions::Role;
   using PermSet = shared_model::interface::PermissionSet<Role>;
   PermSet set({Role::kAppendRole, Role::kAddAssetQty, Role::kAddPeer});
-  ASSERT_TRUE(set[Role::kAppendRole]);
-  ASSERT_TRUE(set[Role::kAddAssetQty]);
-  ASSERT_TRUE(set[Role::kAddPeer]);
-  ASSERT_FALSE(set[Role::kTransfer]);
+  ASSERT_TRUE(set.test(Role::kAppendRole));
+  ASSERT_TRUE(set.test(Role::kAddAssetQty));
+  ASSERT_TRUE(set.test(Role::kAddPeer));
+  ASSERT_FALSE(set.test(Role::kTransfer));
   set.set(Role::kTransfer);
-  ASSERT_TRUE(set[Role::kTransfer]);
+  ASSERT_TRUE(set.test(Role::kTransfer));
   set.unset(Role::kAddAssetQty);
-  ASSERT_FALSE(set[Role::kAddAssetQty]);
+  ASSERT_FALSE(set.test(Role::kAddAssetQty));
 }
 
 TEST(ProtoPermission, PermissionSubset) {

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -797,11 +797,9 @@ public class BuilderTest {
 
     @Test
     void createRole() {
-        StringVector permissions = new StringVector();
-        permissions.add("can_receive");
-        permissions.add("can_get_roles");
-        assertTrue(permissions.size() == 2);
-
+        RolePermissionSet permissions = new RolePermissionSet();
+        permissions.set(Role.kReceive);
+        permissions.set(Role.kGetRoles);
         for (String role: validNameSymbols1) {
             UnsignedTx tx = builder.createRole(role, permissions).build();
             assertTrue(checkProtoTx(proto(tx)));
@@ -810,11 +808,9 @@ public class BuilderTest {
 
     @Test
     void createRoleWithInvalidName() {
-        StringVector permissions = new StringVector();
-        permissions.add("can_receive");
-        permissions.add("can_get_roles");
-        assertTrue(permissions.size() == 2);
-
+        RolePermissionSet permissions = new RolePermissionSet();
+        permissions.set(Role.kReceive);
+        permissions.set(Role.kGetRoles);
         for (String role: invalidNameSymbols1) {
             ModelTransactionBuilder mtb = base().createRole(role, permissions);
             assertThrows(IllegalArgumentException.class, mtb::build);
@@ -823,41 +819,10 @@ public class BuilderTest {
 
     @Test
     void createRoleEmptyPermissions() {
-        StringVector permissions = new StringVector();
+        RolePermissionSet permissions = new RolePermissionSet();
 
         ModelTransactionBuilder builder = new ModelTransactionBuilder();
         builder.createRole("new_role", permissions);
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    /* Disabled till IR-1267 will be fixed. */
-    /* Please run this test on mac host after enabling,
-       because the test was passing on Linux host and failing on macOs.
-    */
-    @Disabled
-    @Test
-    void createRoleWrongPermissions() {
-        StringVector permissions = new StringVector();
-        permissions.add("wrong_permission");
-        permissions.add("can_receive");
-
-        ModelTransactionBuilder builder = base().createRole("new_role", permissions);
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-
-    /* Test differs from the previous by the order of permissions' mames in vector.
-     * Test is disabled because there is no exception thrown when it should be.
-     */
-    /* Disabled till IR-1267 will be fixed. */
-    @Disabled
-    @Test
-    void createRoleWrongPermissions2() {
-        StringVector permissions = new StringVector();
-        permissions.add("can_receive");
-        permissions.add("wrong_permission");
-
-        ModelTransactionBuilder builder = base().createRole("new_role", permissions);
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
@@ -913,7 +878,7 @@ public class BuilderTest {
         for (String accountName: validNameSymbols1) {
             for (String domain: validDomains) {
                 String accountId = accountName + "@" + domain;
-                UnsignedTx tx = builder.grantPermission(accountId, "can_set_my_quorum").build();
+                UnsignedTx tx = builder.grantPermission(accountId, Grantable.kSetMyQuorum).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -924,7 +889,7 @@ public class BuilderTest {
         for (String accountName: invalidNameSymbols1) {
             for (String domain: validDomains) {
                 String accountId = accountName + "@" + domain;
-                ModelTransactionBuilder builder = base().grantPermission(accountId, "can_set_my_quorum");
+                ModelTransactionBuilder builder = base().grantPermission(accountId, Grantable.kSetMyQuorum);
                 assertThrows(IllegalArgumentException.class, builder::build);
             }
         }
@@ -932,26 +897,8 @@ public class BuilderTest {
 
     @Test
     void grantPermissionEmptyAccount() {
-        ModelTransactionBuilder builder = base().grantPermission("", "can_set_my_quorum");
+        ModelTransactionBuilder builder = base().grantPermission("", Grantable.kSetMyQuorum);
         assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    // TODO igor-egorov, 14.05.2018 IR-1267
-    // Please test using clang on macOS before enabling
-    // This test does not fail on Linux with GCC 5.4.0
-    @Disabled
-    @Test
-    void grantPermissionWithInvalidName() {
-        String permissions[] = {
-            "",
-            "random",
-            "can_read_assets" // non-grantable permission
-        };
-
-        for (String permission: permissions) {
-            ModelTransactionBuilder builder = base().grantPermission("admin@test", permission);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
     }
 
     /* ====================== RevokePermission Tests ====================== */
@@ -960,7 +907,7 @@ public class BuilderTest {
     void revokePermission() {
         for (String accountName: validNameSymbols1) {
             for (String domain: validDomains) {
-                UnsignedTx tx = builder.revokePermission(accountName + "@" + domain, "can_set_my_quorum").build();
+                UnsignedTx tx = builder.revokePermission(accountName + "@" + domain, Grantable.kSetMyQuorum).build();
                 assertTrue(checkProtoTx(proto(tx)));
             }
         }
@@ -969,7 +916,7 @@ public class BuilderTest {
     @Test
     void revokePermissionInvalidAccount() {
         for (String accountName: invalidNameSymbols1) {
-            ModelTransactionBuilder builder = base().revokePermission(accountName + "@test", "can_set_my_quorum");
+            ModelTransactionBuilder builder = base().revokePermission(accountName + "@test", Grantable.kSetMyQuorum);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
@@ -977,33 +924,15 @@ public class BuilderTest {
     @Test
     void revokePermissionInvalidDomain() {
         for (String domain: invalidDomains) {
-            ModelTransactionBuilder builder = base().revokePermission("admin@" + domain, "can_set_my_quorum");
+            ModelTransactionBuilder builder = base().revokePermission("admin@" + domain, Grantable.kSetMyQuorum);
             assertThrows(IllegalArgumentException.class, builder::build);
         }
     }
 
     @Test
     void revokePermissionEmptyAccount() {
-        ModelTransactionBuilder builder = base().revokePermission("", "can_set_my_quorum");
+        ModelTransactionBuilder builder = base().revokePermission("", Grantable.kSetMyQuorum);
         assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    // TODO igor-egorov, 14.05.2018 IR-1267
-    // Please test using clang on macOS before enabling
-    // This test does not fail on Linux with GCC 5.4.0
-    @Disabled
-    @Test
-    void revokePermissionWithInvalidName() {
-        String permissions[] = {
-            "",
-            "random",
-            "can_read_assets" // non-grantable permission
-        };
-
-        for (String permission: permissions) {
-            ModelTransactionBuilder builder = base().revokePermission("admin@test", permission);
-            assertThrows(IllegalArgumentException.class, builder::build);
-        }
     }
 
     /* ====================== SubtractAssetQuantity Tests ====================== */

--- a/test/module/shared_model/bindings/builder-test.py
+++ b/test/module/shared_model/bindings/builder-test.py
@@ -522,50 +522,18 @@ class BuilderTest(unittest.TestCase):
   # ====================== CreateRole Tests ======================
 
   def test_create_role(self):
-    permissions = iroha.StringVector()
-    permissions.append("can_receive")
-    permissions.append("can_get_roles")
-    self.assertTrue(permissions.size() == 2)
-
     for name in VALID_NAMES_1:
-      tx = self.builder.createRole(name, permissions).build()
+      tx = self.builder.createRole(name, iroha.RolePermissionSet([iroha.Role_kReceive, iroha.Role_kGetRoles])).build()
       self.assertTrue(self.check_proto_tx(self.proto(tx)))
 
   def test_create_role_with_invalid_name(self):
-    permissions = iroha.StringVector()
-    permissions.append("can_receive")
-    permissions.append("can_get_roles")
-
     for name in INVALID_NAMES_1:
       with self.assertRaises(ValueError):
-        self.base().createRole(name, permissions).build()
+        self.base().createRole(name, iroha.RolePermissionSet([iroha.Role_kReceive, iroha.Role_kGetRoles])).build()
 
   def test_create_role_with_empty_permissions(self):
-    permissions = iroha.StringVector()
-    self.assertTrue(permissions.size() == 0)
-
     with self.assertRaises(ValueError):
-      self.base().createRole("user", permissions).build()
-
-  # TODO igor-egorov, 11.05.2018, IR-1267
-  @unittest.skip("Disabled till IR-1267 will be fixed")
-  def test_create_role_wrong_permissions(self):
-    permissions = iroha.StringVector()
-    permissions.append("wrong_permission")
-    permissions.append("can_receive")
-
-    with self.assertRaises(ValueError):
-      self.base().createRole("user", permissions).build()
-
-  # TODO igor-egorov, 11.05.2018, IR-1267
-  @unittest.skip("Disabled till IR-1267 will be fixed")
-  def test_create_role_wrong_permissions_2(self):
-    permissions = iroha.StringVector()
-    permissions.append("can_receive")
-    permissions.append("wrong_permission")
-
-    with self.assertRaises(ValueError):
-      self.base().createRole("user", permissions).build()
+      self.base().createRole("user", iroha.RolePermissionSet([])).build()
 
   # ====================== DetachRole Tests ======================
 
@@ -599,70 +567,44 @@ class BuilderTest(unittest.TestCase):
   def test_grant_permission(self):
     for domain in VALID_DOMAINS:
       for name in VALID_NAMES_1:
-        tx = self.builder.grantPermission("{}@{}".format(name, domain), "can_set_my_quorum").build()
+        tx = self.builder.grantPermission("{}@{}".format(name, domain), iroha.Grantable_kSetMyQuorum).build()
         self.assertTrue(self.check_proto_tx(self.proto(tx)))
 
   def test_grant_permission_empty_account(self):
     with self.assertRaises(ValueError):
-      self.base().grantPermission("", "can_set_my_quorum").build()
+      self.base().grantPermission("", iroha.Grantable_kSetMyQuorum).build()
 
   def test_grant_permission_invalid_account(self):
     for name in INVALID_NAMES_1:
       with self.assertRaises(ValueError):
-        self.base().grantPermission("{}@test".format(name), "can_set_my_quorum").build()
+        self.base().grantPermission("{}@test".format(name), iroha.Grantable_kSetMyQuorum).build()
 
   def test_grant_permission_invalid_account_domain(self):
     for domain in INVALID_DOMAINS:
       with self.assertRaises(ValueError):
-        self.base().grantPermission("admin@{}".format(domain), "can_set_my_quorum").build()
-
-  # TODO @bakhtin, 30.05.2018, IR-1267
-  @unittest.skip("Disabled till IR-1267 will be fixed")
-  def test_grant_permission_with_invalid_name(self):
-    permissions = [
-      "",
-      "random",
-      "can_read_assets"  # non-grantable permission
-    ]
-
-    for perm in permissions:
-      with self.assertRaises(ValueError):
-        self.base().grantPermission("admin@test", perm).build()
+        self.base().grantPermission("admin@{}".format(domain), iroha.Grantable_kSetMyQuorum).build()
 
   # ====================== RevokePermission Tests ======================
 
   def test_revoke_permission(self):
     for domain in VALID_DOMAINS:
       for name in VALID_NAMES_1:
-        tx = self.builder.revokePermission("{}@{}".format(name, domain), "can_set_my_quorum").build()
+        tx = self.builder.revokePermission("{}@{}".format(name, domain), iroha.Grantable_kSetMyQuorum).build()
         self.assertTrue(self.check_proto_tx(self.proto(tx)))
 
   def test_revoke_permission_invalid_account(self):
     for name in INVALID_NAMES_1:
       with self.assertRaises(ValueError):
-        self.base().revokePermission("{}@test".format(name), "can_set_my_quorum").build()
+        self.base().revokePermission("{}@test".format(name), iroha.Grantable_kSetMyQuorum).build()
 
   def test_revoke_permission_invalid_account_domain(self):
     for domain in INVALID_DOMAINS:
       with self.assertRaises(ValueError):
-        self.base().revokePermission("admin@{}".format(domain), "can_set_my_quorum").build()
+        self.base().revokePermission("admin@{}".format(domain), iroha.Grantable_kSetMyQuorum).build()
 
   def test_revoke_permission_empty_account(self):
     with self.assertRaises(ValueError):
-      self.base().revokePermission("", "can_set_my_quorum").build()
-
-  # TODO @bakhtin, 30.05.2018, IR-1267
-  @unittest.skip("Disabled till IR-1267 will be fixed")
-  def test_revoke_permission_with_invalid_name(self):
-    permissions = [
-      "",
-      "random",
-      "can_read_assets"  # non-grantable permission
-    ]
-
-    for perm in permissions:
-      with self.assertRaises(ValueError):
-        self.base().revokePermission("admin@test", perm).build()
+      self.base().revokePermission("", iroha.Grantable_kSetMyQuorum).build()
 
   # ====================== SubtractAssetQuantity Tests ======================
 

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -239,11 +239,16 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
 }
 
 TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
-  const std::vector<std::string> roles = {"role1", "role2", "role3"};
+  shared_model::interface::RolePermissionSet permissions(
+      {shared_model::interface::permissions::Role::kAppendRole,
+       shared_model::interface::permissions::Role::kAddAssetQty,
+       shared_model::interface::permissions::Role::kAddPeer});
 
   shared_model::proto::TemplateQueryResponseBuilder<> builder;
   shared_model::proto::QueryResponse query_response =
-      builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
+      builder.queryHash(query_hash)
+          .rolePermissionsResponse(permissions)
+          .build();
 
   ASSERT_NO_THROW({
     const auto &role_permissions_response = boost::apply_visitor(
@@ -251,7 +256,7 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
             shared_model::interface::RolePermissionsResponse>(),
         query_response.get());
 
-    ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
+    ASSERT_EQ(role_permissions_response.rolePermissions(), permissions);
     ASSERT_EQ(query_response.queryHash(), query_hash);
   });
 }

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -24,6 +24,7 @@
 #include <boost/range/irange.hpp>
 
 #include "datetime/time.hpp"
+#include "interfaces/permissions.hpp"
 #include "primitive.pb.h"
 #include "queries.pb.h"
 
@@ -61,7 +62,9 @@ class ValidatorsTest : public ::testing::Test {
     field_setters["asset_name"] = setString(asset_name);
     field_setters["precision"] = setUInt32(precision);
     field_setters["permissions"] = addEnum(role_permission);
-    field_setters["permission"] = setEnum(grantable_permission);
+    field_setters["grantable_permissions"] = addEnum(grantable_permission);
+    field_setters["permission"] = setEnum(role_permission);
+    field_setters["grantable_permission"] = setEnum(grantable_permission);
     field_setters["key"] = setString(detail_key);
     field_setters["detail"] = setString(detail_key);
     field_setters["value"] = setString("");
@@ -165,7 +168,8 @@ class ValidatorsTest : public ::testing::Test {
   std::string description;
   std::string public_key;
   std::string hash;
-  std::string permission;
+  shared_model::interface::permissions::Role model_role_permission;
+  shared_model::interface::permissions::Grantable model_grantable_permission;
   iroha::protocol::RolePermission role_permission;
   iroha::protocol::GrantablePermission grantable_permission;
   uint8_t quorum;


### PR DESCRIPTION
### Description of the Change

Builders migrated to use new permissions
Fixed permission/permission set interface a bit
FieldValidator now has 4 validation methods a pair for permission enums and a pair for their sets. Tests added only for used ones (two aren't used actually)
RolePermissionsResponse uses shared model permission

### Benefits

One more step toward legacy model removal

### Possible Drawbacks 

None