### PR TITLE
Move vote collection validation to transport

### DIFF
--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -86,10 +86,6 @@ namespace iroha {
 
       boost::optional<Answer> YacVoteStorage::insert_votes(
           std::vector<VoteMessage> &votes, uint64_t peers_in_round) {
-        if (not sameProposals(votes)) {
-          return boost::none;
-        }
-
         auto storage = findProposalStorage(votes.at(0), peers_in_round);
         return storage->insert(votes);
       }


### PR DESCRIPTION

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
An attempt to move validation logic from consensus core to transport to perform stateless validation
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Clearer responsibility separation
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Transport contains validation logic in addition to gRPC specific methods -- some middle validation layer should be separated from transport
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->