### PR TITLE
Use new perms in Queries

### DIFF
--- a/irohad/execution/impl/query_execution.cpp
+++ b/irohad/execution/impl/query_execution.cpp
@@ -218,7 +218,11 @@ QueryProcessingFactory::executeGetRolePermissions(
     return buildError<shared_model::interface::NoRolesErrorResponse>();
   }
 
-  auto response = QueryResponseBuilder().rolePermissionsResponse(*perm);
+  shared_model::interface::RolePermissionSet set =
+      shared_model::interface::permissions::fromOldR(
+          std::set<std::string>{perm->begin(), perm->end()});
+
+  auto response = QueryResponseBuilder().rolePermissionsResponse(set);
   return response;
 }
 

--- a/shared_model/backend/protobuf/from_old.hpp
+++ b/shared_model/backend/protobuf/from_old.hpp
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef SHARED_MODEL_PROTOBUF_FROM_OLD
+#define SHARED_MODEL_PROTOBUF_FROM_OLD
+
 #include <map>
 #include <set>
 #include <string>
@@ -47,3 +50,5 @@ namespace shared_model {
     }  // namespace permissions
   }    // namespace interface
 }  // namespace shared_model
+
+#endif  // SHARED_MODEL_PROTOBUF_FROM_OLD

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -82,8 +82,9 @@ namespace shared_model {
           iroha::protocol::AccountAssetResponse *query_response =
               proto_query_response.mutable_account_assets_response();
 
-          for (auto &asset: assets) {
-            query_response->add_account_assets()->CopyFrom(asset.getTransport());
+          for (auto &asset : assets) {
+            query_response->add_account_assets()->CopyFrom(
+                asset.getTransport());
           }
         });
       }
@@ -166,13 +167,17 @@ namespace shared_model {
       }
 
       auto rolePermissionsResponse(
-          const std::vector<interface::types::PermissionNameType>
-              &role_permissions) const {
+          const interface::RolePermissionSet &role_permissions) const {
         return queryResponseField([&](auto &proto_query_response) {
           iroha::protocol::RolePermissionsResponse *query_response =
               proto_query_response.mutable_role_permissions_response();
-          for (const auto &perm : role_permissions) {
-            query_response->add_permissions(perm);
+          for (size_t i = 0; i < role_permissions.size(); ++i) {
+            auto perm = static_cast<interface::permissions::Role>(i);
+            if (role_permissions[perm]) {
+              // TODO(@l4l) 05/06/18 IR-1393
+              // replace with toTransport after fixing RolePermissionResponse
+              query_response->add_permissions(permissions::toString(perm));
+            }
           }
         });
       }

--- a/shared_model/interfaces/query_responses/role_permissions.hpp
+++ b/shared_model/interfaces/query_responses/role_permissions.hpp
@@ -20,6 +20,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permissions.hpp"
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -30,25 +31,16 @@ namespace shared_model {
     class RolePermissionsResponse
         : public ModelPrimitive<RolePermissionsResponse> {
      public:
-      /// type of role permissions collection
-      using PermissionNameCollectionType =
-          std::vector<types::PermissionNameType>;
-
       /**
        * @return role permissions
        */
-      virtual const PermissionNameCollectionType &rolePermissions() const = 0;
+      virtual const RolePermissionSet &rolePermissions() const = 0;
 
       /**
        * Stringify the data.
        * @return string representation of data.
        */
-      std::string toString() const override {
-        return detail::PrettyStringBuilder()
-            .init("RolePermissionsResponse")
-            .appendAll(rolePermissions(), [](auto perm) { return perm; })
-            .finalize();
-      }
+      std::string toString() const override = 0;
 
       /**
        * Implementation of operator ==

--- a/test/module/irohad/validation/query_execution.cpp
+++ b/test/module/irohad/validation/query_execution.cpp
@@ -149,10 +149,9 @@ TEST_F(GetAccountTest, MyAccountValidCase) {
   EXPECT_CALL(*wsv_query, getAccount(admin_id)).WillOnce(Return(creator));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), admin_id);
   });
 }
@@ -179,10 +178,9 @@ TEST_F(GetAccountTest, AllAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -209,10 +207,9 @@ TEST_F(GetAccountTest, DomainAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -244,10 +241,9 @@ TEST_F(GetAccountTest, GrantAccountValidCase) {
       .WillOnce(Return(admin_roles));
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AccountResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AccountResponse>(),
+        response->get());
     ASSERT_EQ(cast_resp.account().accountId(), account_id);
   });
 }
@@ -1290,10 +1286,9 @@ TEST_F(GetAssetInfoTest, MyAccountValidCase) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::AssetResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::AssetResponse>(),
+        response->get());
 
     ASSERT_EQ(cast_resp.asset().assetId(), asset_id);
   });
@@ -1376,10 +1371,9 @@ TEST_F(GetRolesTest, ValidCase) {
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
-    const auto &cast_resp =
-        boost::apply_visitor(framework::SpecifiedVisitor<
-                                 shared_model::interface::RolesResponse>(),
-                             response->get());
+    const auto &cast_resp = boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::RolesResponse>(),
+        response->get());
 
     ASSERT_EQ(cast_resp.roles().size(), roles.size());
 
@@ -1437,10 +1431,11 @@ class GetRolePermissionsTest : public QueryValidateExecuteTest {
   void SetUp() override {
     QueryValidateExecuteTest::SetUp();
     role_permissions = {can_get_roles};
-    perms = {can_get_my_account, can_get_my_signatories};
+    perms = {shared_model::interface::permissions::Role::kGetMyAccount,
+             shared_model::interface::permissions::Role::kGetMySignatories};
   }
   std::string role_id = "user";
-  std::vector<std::string> perms;
+  shared_model::interface::RolePermissionSet perms;
 };
 
 /**
@@ -1458,7 +1453,8 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
       .WillOnce(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getRolePermissions(admin_role))
       .WillOnce(Return(role_permissions));
-  EXPECT_CALL(*wsv_query, getRolePermissions(role_id)).WillOnce(Return(perms));
+  EXPECT_CALL(*wsv_query, getRolePermissions(role_id))
+      .WillOnce(Return(shared_model::proto::permissions::toString(perms)));
 
   auto response = validateAndExecute(query);
   ASSERT_NO_THROW({
@@ -1469,7 +1465,7 @@ TEST_F(GetRolePermissionsTest, ValidCase) {
 
     ASSERT_EQ(cast_resp.rolePermissions().size(), perms.size());
     for (size_t i = 0; i < perms.size(); ++i) {
-      ASSERT_EQ(cast_resp.rolePermissions().at(i), perms.at(i));
+      ASSERT_EQ(cast_resp.rolePermissions(), perms);
     }
   });
 }

--- a/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
+++ b/test/module/shared_model/builders/common_objects/query_response_builder_test.cpp
@@ -239,11 +239,16 @@ TEST(QueryResponseBuilderTest, RolesResponse) {
 }
 
 TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
-  const std::vector<std::string> roles = {"role1", "role2", "role3"};
+  shared_model::interface::RolePermissionSet permissions(
+      {shared_model::interface::permissions::Role::kAppendRole,
+       shared_model::interface::permissions::Role::kAddAssetQty,
+       shared_model::interface::permissions::Role::kAddPeer});
 
   shared_model::proto::TemplateQueryResponseBuilder<> builder;
   shared_model::proto::QueryResponse query_response =
-      builder.queryHash(query_hash).rolePermissionsResponse(roles).build();
+      builder.queryHash(query_hash)
+          .rolePermissionsResponse(permissions)
+          .build();
 
   ASSERT_NO_THROW({
     const auto &role_permissions_response = boost::apply_visitor(
@@ -251,7 +256,7 @@ TEST(QueryResponseBuilderTest, RolePermissionsResponse) {
             shared_model::interface::RolePermissionsResponse>(),
         query_response.get());
 
-    ASSERT_EQ(role_permissions_response.rolePermissions(), roles);
+    ASSERT_EQ(role_permissions_response.rolePermissions(), permissions);
     ASSERT_EQ(query_response.queryHash(), query_hash);
   });
 }


### PR DESCRIPTION
### Description of the Change

RolePermissionsResponse uses shared model permission

### Benefits

One more step toward legacy model removal

### Possible Drawbacks 

None