### PR TITLE
Use new perms in Ametsuchi

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_command.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.hpp
@@ -20,9 +20,6 @@
 
 #include "ametsuchi/wsv_command.hpp"
 
-#include <set>
-#include <string>
-
 #include "ametsuchi/impl/postgres_wsv_common.hpp"
 
 namespace iroha {
@@ -43,8 +40,8 @@ namespace iroha {
 
       WsvCommandResult insertRolePermissions(
           const shared_model::interface::types::RoleIdType &role_id,
-          const std::set<shared_model::interface::types::PermissionNameType>
-              &permissions) override;
+          const shared_model::interface::RolePermissionSet &permissions)
+          override;
 
       WsvCommandResult insertAccount(
           const shared_model::interface::Account &account) override;
@@ -80,15 +77,13 @@ namespace iroha {
           const shared_model::interface::types::AccountIdType
               &permittee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) override;
+          shared_model::interface::permissions::Grantable permission) override;
 
       WsvCommandResult deleteAccountGrantablePermission(
           const shared_model::interface::types::AccountIdType
               &permittee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) override;
+          shared_model::interface::permissions::Grantable permission) override;
 
      private:
       pqxx::nontransaction &transaction_;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -35,8 +35,7 @@ namespace iroha {
       getAccountRoles(const shared_model::interface::types::AccountIdType
                           &account_id) override;
 
-      boost::optional<
-          std::vector<shared_model::interface::types::PermissionNameType>>
+      boost::optional<shared_model::interface::RolePermissionSet>
       getRolePermissions(
           const shared_model::interface::types::RoleIdType &role_name) override;
 
@@ -51,9 +50,10 @@ namespace iroha {
                          &account_id) override;
       boost::optional<std::shared_ptr<shared_model::interface::Asset>> getAsset(
           const shared_model::interface::types::AssetIdType &asset_id) override;
-      boost::optional<std::vector<std::shared_ptr<shared_model::interface::AccountAsset>>>
-      getAccountAssets(
-          const shared_model::interface::types::AccountIdType &account_id) override;
+      boost::optional<
+          std::vector<std::shared_ptr<shared_model::interface::AccountAsset>>>
+      getAccountAssets(const shared_model::interface::types::AccountIdType
+                           &account_id) override;
       boost::optional<std::shared_ptr<shared_model::interface::AccountAsset>>
       getAccountAsset(
           const shared_model::interface::types::AccountIdType &account_id,
@@ -70,8 +70,7 @@ namespace iroha {
           const shared_model::interface::types::AccountIdType
               &permitee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) override;
+          shared_model::interface::permissions::Grantable permission) override;
 
      private:
       std::unique_ptr<pqxx::lazyconnection> connection_ptr_;

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -22,6 +22,7 @@
 #include "ametsuchi/impl/postgres_block_query.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/impl/temporary_wsv_impl.hpp"
+#include "backend/protobuf/permissions.hpp"
 #include "converters/protobuf/json_proto_converter.hpp"
 #include "postgres_ordering_service_persistent_state.hpp"
 
@@ -144,9 +145,9 @@ namespace iroha {
       auto drop = R"(
 DROP TABLE IF EXISTS account_has_signatory;
 DROP TABLE IF EXISTS account_has_asset;
-DROP TABLE IF EXISTS role_has_permissions;
+DROP TABLE IF EXISTS role_has_permissions CASCADE;
 DROP TABLE IF EXISTS account_has_roles;
-DROP TABLE IF EXISTS account_has_grantable_permissions;
+DROP TABLE IF EXISTS account_has_grantable_permissions CASCADE;
 DROP TABLE IF EXISTS account;
 DROP TABLE IF EXISTS asset;
 DROP TABLE IF EXISTS domain;
@@ -299,6 +300,116 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
     rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
     StorageImpl::on_commit() {
       return notifier_.get_observable();
+    }
+
+    template <typename Perm>
+    static const std::string createPermissionTypes(
+        const std::string &type_name) {
+      std::string s =
+          "DO $$\nBEGIN\nIF NOT EXISTS (SELECT 1 FROM pg_type "
+          "WHERE typname='" + type_name + "')"
+          " THEN CREATE TYPE " + type_name + " AS ENUM (";
+      const auto count = static_cast<size_t>(Perm::COUNT);
+      for (size_t i = 0; i < count; ++i) {
+        s += "'"
+            + shared_model::proto::permissions::toString(static_cast<Perm>(i))
+            + "'";
+        if (i != count - 1) {
+          s += ',';
+        }
+      }
+      return s + ");\nEND IF;\nEND $$;";
+    }
+
+    const std::string &StorageImpl::init_ =
+        createPermissionTypes<shared_model::interface::permissions::Role>(
+            "role_perm")
+        + createPermissionTypes<
+              shared_model::interface::permissions::Grantable>("grantable_perm")
+        + R"(
+CREATE TABLE IF NOT EXISTS role (
+    role_id character varying(32),
+    PRIMARY KEY (role_id)
+);
+CREATE TABLE IF NOT EXISTS domain (
+    domain_id character varying(255),
+    default_role character varying(32) NOT NULL REFERENCES role(role_id),
+    PRIMARY KEY (domain_id)
+);
+CREATE TABLE IF NOT EXISTS signatory (
+    public_key bytea NOT NULL,
+    PRIMARY KEY (public_key)
+);
+CREATE TABLE IF NOT EXISTS account (
+    account_id character varying(288),
+    domain_id character varying(255) NOT NULL REFERENCES domain,
+    quorum int NOT NULL,
+    data JSONB,
+    PRIMARY KEY (account_id)
+);
+CREATE TABLE IF NOT EXISTS account_has_signatory (
+    account_id character varying(288) NOT NULL REFERENCES account,
+    public_key bytea NOT NULL REFERENCES signatory,
+    PRIMARY KEY (account_id, public_key)
+);
+CREATE TABLE IF NOT EXISTS peer (
+    public_key bytea NOT NULL,
+    address character varying(261) NOT NULL UNIQUE,
+    PRIMARY KEY (public_key)
+);
+CREATE TABLE IF NOT EXISTS asset (
+    asset_id character varying(288),
+    domain_id character varying(255) NOT NULL REFERENCES domain,
+    precision int NOT NULL,
+    data json,
+    PRIMARY KEY (asset_id)
+);
+CREATE TABLE IF NOT EXISTS account_has_asset (
+    account_id character varying(288) NOT NULL REFERENCES account,
+    asset_id character varying(288) NOT NULL REFERENCES asset,
+    amount decimal NOT NULL,
+    PRIMARY KEY (account_id, asset_id)
+);
+CREATE TABLE IF NOT EXISTS role_has_permissions (
+    role_id character varying(32) NOT NULL REFERENCES role,
+    permission role_perm,
+    PRIMARY KEY (role_id, permission)
+);
+CREATE TABLE IF NOT EXISTS account_has_roles (
+    account_id character varying(288) NOT NULL REFERENCES account,
+    role_id character varying(32) NOT NULL REFERENCES role,
+    PRIMARY KEY (account_id, role_id)
+);
+CREATE TABLE IF NOT EXISTS account_has_grantable_permissions (
+    permittee_account_id character varying(288) NOT NULL REFERENCES account,
+    account_id character varying(288) NOT NULL REFERENCES account,
+    permission grantable_perm,
+    PRIMARY KEY (permittee_account_id, account_id, permission)
+);
+CREATE TABLE IF NOT EXISTS height_by_hash (
+    hash bytea,
+    height text
+);
+CREATE TABLE IF NOT EXISTS height_by_account_set (
+    account_id text,
+    height text
+);
+CREATE TABLE IF NOT EXISTS index_by_creator_height (
+    id serial,
+    creator_id text,
+    height text,
+    index text
+);
+CREATE TABLE IF NOT EXISTS index_by_id_height_asset (
+    id text,
+    height text,
+    asset_id text,
+    index text
+);
+)";
+
+    const std::string &StorageImpl::initQuery() {
+      return init_;
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -110,87 +110,10 @@ namespace iroha {
           notifier_;
 
      protected:
-      const std::string init_ = R"(
-CREATE TABLE IF NOT EXISTS role (
-    role_id character varying(32),
-    PRIMARY KEY (role_id)
-);
-CREATE TABLE IF NOT EXISTS domain (
-    domain_id character varying(255),
-    default_role character varying(32) NOT NULL REFERENCES role(role_id),
-    PRIMARY KEY (domain_id)
-);
-CREATE TABLE IF NOT EXISTS signatory (
-    public_key bytea NOT NULL,
-    PRIMARY KEY (public_key)
-);
-CREATE TABLE IF NOT EXISTS account (
-    account_id character varying(288),
-    domain_id character varying(255) NOT NULL REFERENCES domain,
-    quorum int NOT NULL,
-    data JSONB,
-    PRIMARY KEY (account_id)
-);
-CREATE TABLE IF NOT EXISTS account_has_signatory (
-    account_id character varying(288) NOT NULL REFERENCES account,
-    public_key bytea NOT NULL REFERENCES signatory,
-    PRIMARY KEY (account_id, public_key)
-);
-CREATE TABLE IF NOT EXISTS peer (
-    public_key bytea NOT NULL,
-    address character varying(261) NOT NULL UNIQUE,
-    PRIMARY KEY (public_key)
-);
-CREATE TABLE IF NOT EXISTS asset (
-    asset_id character varying(288),
-    domain_id character varying(255) NOT NULL REFERENCES domain,
-    precision int NOT NULL,
-    data json,
-    PRIMARY KEY (asset_id)
-);
-CREATE TABLE IF NOT EXISTS account_has_asset (
-    account_id character varying(288) NOT NULL REFERENCES account,
-    asset_id character varying(288) NOT NULL REFERENCES asset,
-    amount decimal NOT NULL,
-    PRIMARY KEY (account_id, asset_id)
-);
-CREATE TABLE IF NOT EXISTS role_has_permissions (
-    role_id character varying(32) NOT NULL REFERENCES role,
-    permission_id character varying(45),
-    PRIMARY KEY (role_id, permission_id)
-);
-CREATE TABLE IF NOT EXISTS account_has_roles (
-    account_id character varying(288) NOT NULL REFERENCES account,
-    role_id character varying(32) NOT NULL REFERENCES role,
-    PRIMARY KEY (account_id, role_id)
-);
-CREATE TABLE IF NOT EXISTS account_has_grantable_permissions (
-    permittee_account_id character varying(288) NOT NULL REFERENCES account,
-    account_id character varying(288) NOT NULL REFERENCES account,
-    permission_id character varying(45),
-    PRIMARY KEY (permittee_account_id, account_id, permission_id)
-);
-CREATE TABLE IF NOT EXISTS height_by_hash (
-    hash bytea,
-    height text
-);
-CREATE TABLE IF NOT EXISTS height_by_account_set (
-    account_id text,
-    height text
-);
-CREATE TABLE IF NOT EXISTS index_by_creator_height (
-    id serial,
-    creator_id text,
-    height text,
-    index text
-);
-CREATE TABLE IF NOT EXISTS index_by_id_height_asset (
-    id text,
-    height text,
-    asset_id text,
-    index text
-);
-)";
+      static const std::string &initQuery();
+
+     private:
+      static const std::string &init_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/wsv_command.hpp
+++ b/irohad/ametsuchi/wsv_command.hpp
@@ -24,6 +24,7 @@
 #include "common/result.hpp"
 #include "common/types.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permissions.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -96,37 +97,34 @@ namespace iroha {
        */
       virtual WsvCommandResult insertRolePermissions(
           const shared_model::interface::types::RoleIdType &role_id,
-          const std::set<shared_model::interface::types::PermissionNameType>
-              &permissions) = 0;
+          const shared_model::interface::RolePermissionSet &permissions) = 0;
 
       /**
        * Insert grantable permission
        * @param permittee_account_id to who give the grant permission
        * @param account_id on which account
-       * @param permission_id what permission
+       * @param permission what permission
        * @return WsvCommandResult, which will contain error in case of failure
        */
       virtual WsvCommandResult insertAccountGrantablePermission(
           const shared_model::interface::types::AccountIdType
               &permittee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) = 0;
+          shared_model::interface::permissions::Grantable permission) = 0;
 
       /**
        * Delete grantable permission
        * @param permittee_account_id to who the grant permission was previously
        * granted
        * @param account_id on which account
-       * @param permission_id what permission
+       * @param permission what permission
        * @return WsvCommandResult, which will contain error in case of failure
        */
       virtual WsvCommandResult deleteAccountGrantablePermission(
           const shared_model::interface::types::AccountIdType
               &permittee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) = 0;
+          shared_model::interface::permissions::Grantable permission) = 0;
 
       /**
        *git

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -28,6 +28,7 @@
 #include "interfaces/common_objects/asset.hpp"
 #include "interfaces/common_objects/domain.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "interfaces/permissions.hpp"
 #include "interfaces/queries/query.hpp"
 #include "interfaces/query_responses/query_response.hpp"
 #include "interfaces/transaction.hpp"
@@ -46,15 +47,14 @@ namespace iroha {
        * Check if permitee has permission on account
        * @param permitee_account_id
        * @param account_id
-       * @param permission_id
+       * @param permission
        * @return true if has permission, false otherwise
        */
       virtual bool hasAccountGrantablePermission(
           const shared_model::interface::types::AccountIdType
               &permitee_account_id,
           const shared_model::interface::types::AccountIdType &account_id,
-          const shared_model::interface::types::PermissionNameType
-              &permission_id) = 0;
+          shared_model::interface::permissions::Grantable permission) = 0;
 
       /**
        * Get iroha domain
@@ -79,8 +79,7 @@ namespace iroha {
        * @param role_name
        * @return
        */
-      virtual boost::optional<
-          std::vector<shared_model::interface::types::PermissionNameType>>
+      virtual boost::optional<shared_model::interface::RolePermissionSet>
       getRolePermissions(
           const shared_model::interface::types::RoleIdType &role_name) = 0;
 
@@ -96,8 +95,7 @@ namespace iroha {
        * @param account_id
        * @return
        */
-      virtual boost::optional<
-          std::shared_ptr<shared_model::interface::Account>>
+      virtual boost::optional<std::shared_ptr<shared_model::interface::Account>>
       getAccount(
           const shared_model::interface::types::AccountIdType &account_id) = 0;
 
@@ -132,8 +130,8 @@ namespace iroha {
        * @param account_id
        * @return
        */
-      virtual boost::optional<std::vector<
-          std::shared_ptr<shared_model::interface::AccountAsset>>>
+      virtual boost::optional<
+          std::vector<std::shared_ptr<shared_model::interface::AccountAsset>>>
       getAccountAssets(
           const shared_model::interface::types::AccountIdType &account_id) = 0;
       /**

--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -253,9 +253,8 @@ namespace iroha {
       const shared_model::interface::CreateRole &command) {
     std::string command_name = "CreateRole";
     auto result = commands->insertRole(command.roleName()) | [&] {
-      auto tmp = toString(command.rolePermissions());
       return commands->insertRolePermissions(command.roleName(),
-                                             {tmp.begin(), tmp.end()});
+                                             command.rolePermissions());
     };
     return makeExecutionResult(result, command_name);
   }
@@ -269,11 +268,10 @@ namespace iroha {
 
   ExecutionResult CommandExecutor::operator()(
       const shared_model::interface::GrantPermission &command) {
-    return makeExecutionResult(commands->insertAccountGrantablePermission(
-                                   command.accountId(),
-                                   creator_account_id,
-                                   toString(command.permissionName())),
-                               "GrantPermission");
+    return makeExecutionResult(
+        commands->insertAccountGrantablePermission(
+            command.accountId(), creator_account_id, command.permissionName()),
+        "GrantPermission");
   }
 
   ExecutionResult CommandExecutor::operator()(
@@ -289,11 +287,10 @@ namespace iroha {
 
   ExecutionResult CommandExecutor::operator()(
       const shared_model::interface::RevokePermission &command) {
-    return makeExecutionResult(commands->deleteAccountGrantablePermission(
-                                   command.accountId(),
-                                   creator_account_id,
-                                   toString(command.permissionName())),
-                               "RevokePermission");
+    return makeExecutionResult(
+        commands->deleteAccountGrantablePermission(
+            command.accountId(), creator_account_id, command.permissionName()),
+        "RevokePermission");
   }
 
   ExecutionResult CommandExecutor::operator()(
@@ -531,10 +528,9 @@ namespace iroha {
                  creator_account_id, queries, Role::kAddSignatory))
         or
         // Case 2. Creator has granted permission for it
-        (queries.hasAccountGrantablePermission(
-            creator_account_id,
-            command.accountId(),
-            toString(Role::kAddMySignatory)));
+        (queries.hasAccountGrantablePermission(creator_account_id,
+                                               command.accountId(),
+                                               Grantable::kAddMySignatory));
   }
 
   bool CommandValidator::hasPermissions(
@@ -610,7 +606,7 @@ namespace iroha {
         or (queries.hasAccountGrantablePermission(
                creator_account_id,
                command.accountId(),
-               toString(Role::kRemoveMySignatory)));
+               Grantable::kRemoveMySignatory));
   }
 
   bool CommandValidator::hasPermissions(
@@ -618,9 +614,7 @@ namespace iroha {
       ametsuchi::WsvQuery &queries,
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return queries.hasAccountGrantablePermission(
-        command.accountId(),
-        creator_account_id,
-        toString(command.permissionName()));
+        command.accountId(), creator_account_id, command.permissionName());
   }
 
   bool CommandValidator::hasPermissions(
@@ -631,10 +625,9 @@ namespace iroha {
         // Case 1. Creator set details for his account
         creator_account_id == command.accountId() or
         // Case 2. Creator has grantable permission to set account key/value
-        queries.hasAccountGrantablePermission(
-            creator_account_id,
-            command.accountId(),
-            toString(Role::kSetMyAccountDetail));
+        queries.hasAccountGrantablePermission(creator_account_id,
+                                              command.accountId(),
+                                              Grantable::kSetMyAccountDetail);
   }
 
   bool CommandValidator::hasPermissions(
@@ -647,10 +640,9 @@ namespace iroha {
          and checkAccountRolePermission(
                  creator_account_id, queries, Role::kSetQuorum))
         // 2. Creator has granted permission on it
-        or (queries.hasAccountGrantablePermission(
-               creator_account_id,
-               command.accountId(),
-               toString(Role::kSetMyQuorum)));
+        or (queries.hasAccountGrantablePermission(creator_account_id,
+                                                  command.accountId(),
+                                                  Grantable::kSetMyQuorum));
   }
 
   bool CommandValidator::hasPermissions(
@@ -672,7 +664,7 @@ namespace iroha {
                 and queries.hasAccountGrantablePermission(
                         creator_account_id,
                         command.srcAccountId(),
-                        toString(Role::kTransferMyAssets)))
+                        Grantable::kTransferMyAssets))
                or
                // 2. Creator transfer from their account
                (creator_account_id == command.srcAccountId()
@@ -715,21 +707,15 @@ namespace iroha {
       return false;
     }
 
-    std::set<std::string> account_permissions;
+    shared_model::interface::RolePermissionSet account_permissions;
     for (const auto &role : *account_roles) {
       auto permissions = queries.getRolePermissions(role);
       if (not permissions)
         continue;
-      for (const auto &permission : *permissions)
-        account_permissions.insert(permission);
+      account_permissions |= *permissions;
     }
 
-    return std::none_of((*role_permissions).begin(),
-                        (*role_permissions).end(),
-                        [&account_permissions](const auto &perm) {
-                          return account_permissions.find(perm)
-                              == account_permissions.end();
-                        });
+    return role_permissions->isSubsetOf(account_permissions);
   }
 
   bool CommandValidator::isValid(

--- a/shared_model/interfaces/impl/permissions.cpp
+++ b/shared_model/interfaces/impl/permissions.cpp
@@ -23,8 +23,26 @@ namespace shared_model {
             return Role::kSetMyAccountDetail;
           case Grantable::kTransferMyAssets:
             return Role::kTransferMyAssets;
+          default:;
         }
         return Role::COUNT;
+      }
+
+      Grantable permissionOf(Role g) {
+        switch (g) {
+          case Role::kAddMySignatory:
+            return Grantable::kAddMySignatory;
+          case Role::kRemoveMySignatory:
+            return Grantable::kRemoveMySignatory;
+          case Role::kSetMyQuorum:
+            return Grantable::kSetMyQuorum;
+          case Role::kSetMyAccountDetail:
+            return Grantable::kSetMyAccountDetail;
+          case Role::kTransferMyAssets:
+            return Grantable::kTransferMyAssets;
+          default:;
+        }
+        return Grantable::COUNT;
       }
     }  // namespace permissions
   }    // namespace interface
@@ -87,17 +105,29 @@ PermissionSet<Perm> &PermissionSet<Perm>::operator&=(
   Parent::operator&=(r);
   return *this;
 }
+
 template <typename Perm>
 PermissionSet<Perm> &PermissionSet<Perm>::operator|=(
     const PermissionSet<Perm> &r) {
   Parent::operator|=(r);
   return *this;
 }
+
 template <typename Perm>
 PermissionSet<Perm> &PermissionSet<Perm>::operator^=(
     const PermissionSet<Perm> &r) {
   Parent::operator^=(r);
   return *this;
+}
+
+template <typename Perm>
+void PermissionSet<Perm>::iterate(std::function<void(Perm)> f) const {
+  for (size_t i = 0; i < size(); ++i) {
+    auto perm = static_cast<Perm>(i);
+    if (operator[](perm)) {
+      f(perm);
+    }
+  }
 }
 
 template class shared_model::interface::PermissionSet<permissions::Role>;

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -7,6 +7,7 @@
 #define IROHA_SHARED_MODEL_PERMISSIONS_HPP
 
 #include <bitset>
+#include <functional>
 #include <initializer_list>
 
 namespace shared_model {
@@ -71,6 +72,7 @@ namespace shared_model {
       };
 
       Role permissionFor(Grantable);
+      Grantable permissionOf(Role);
     }  // namespace permissions
 
     template <typename Perm>
@@ -100,6 +102,8 @@ namespace shared_model {
       PermissionSet<Perm> &operator&=(const PermissionSet<Perm> &r);
       PermissionSet<Perm> &operator|=(const PermissionSet<Perm> &r);
       PermissionSet<Perm> &operator^=(const PermissionSet<Perm> &r);
+
+      void iterate(std::function<void(Perm)> f) const;
 
      private:
       constexpr auto bit(Perm p) const {

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -36,7 +36,6 @@
 #include "model/converters/json_query_factory.hpp"
 #include "model/converters/json_transaction_factory.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
-#include "validators/permissions.hpp"
 
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
@@ -50,7 +49,6 @@ using namespace iroha::ametsuchi;
 using namespace iroha::network;
 using namespace iroha::validation;
 using namespace shared_model::proto;
-using namespace shared_model::permissions;
 
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds proposal_delay = 10s;
@@ -240,9 +238,13 @@ TEST_F(ClientServerTest, SendQueryWhenValid) {
   EXPECT_CALL(*wsv_query, getSignatories("admin@test"))
       .WillRepeatedly(Return(signatories));
 
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  "admin@test", "test@test", can_get_my_acc_detail))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          "admin@test",
+          "test@test",
+          shared_model::interface::permissions::permissionOf(
+              shared_model::interface::permissions::Role::kGetMyAccDetail)))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccountDetail("test@test"))
@@ -270,9 +272,13 @@ TEST_F(ClientServerTest, SendQueryWhenStatefulInvalid) {
   EXPECT_CALL(*wsv_query, getSignatories("admin@test"))
       .WillRepeatedly(Return(signatories));
 
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  "admin@test", "test@test", can_get_my_acc_detail))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          "admin@test",
+          "test@test",
+          shared_model::interface::permissions::permissionOf(
+              shared_model::interface::permissions::Role::kGetMyAccDetail)))
       .WillOnce(Return(false));
 
   EXPECT_CALL(*wsv_query, getAccountRoles("admin@test"))

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -41,7 +41,7 @@ namespace iroha {
       MOCK_METHOD1(getAccountDetail,
                    boost::optional<std::string>(const std::string &account_id));
       MOCK_METHOD1(getRolePermissions,
-                   boost::optional<std::vector<std::string>>(
+                   boost::optional<shared_model::interface::RolePermissionSet>(
                        const std::string &role_name));
       MOCK_METHOD0(getRoles, boost::optional<std::vector<std::string>>());
       MOCK_METHOD1(
@@ -73,10 +73,11 @@ namespace iroha {
           getDomain,
           boost::optional<std::shared_ptr<shared_model::interface::Domain>>(
               const std::string &domain_id));
-      MOCK_METHOD3(hasAccountGrantablePermission,
-                   bool(const std::string &permitee_account_id,
-                        const std::string &account_id,
-                        const std::string &permission_id));
+      MOCK_METHOD3(
+          hasAccountGrantablePermission,
+          bool(const std::string &permitee_account_id,
+               const std::string &account_id,
+               shared_model::interface::permissions::Grantable permission));
     };
 
     class MockWsvCommand : public WsvCommand {
@@ -88,19 +89,25 @@ namespace iroha {
       MOCK_METHOD2(deleteAccountRole,
                    WsvCommandResult(const std::string &account_id,
                                     const std::string &role_name));
-      MOCK_METHOD2(insertRolePermissions,
-                   WsvCommandResult(const std::string &role_id,
-                                    const std::set<std::string> &permissions));
+      MOCK_METHOD2(
+          insertRolePermissions,
+          WsvCommandResult(
+              const std::string &role_id,
+              const shared_model::interface::RolePermissionSet &permissions));
 
-      MOCK_METHOD3(insertAccountGrantablePermission,
-                   WsvCommandResult(const std::string &permittee_account_id,
-                                    const std::string &account_id,
-                                    const std::string &permission_id));
+      MOCK_METHOD3(
+          insertAccountGrantablePermission,
+          WsvCommandResult(
+              const std::string &permittee_account_id,
+              const std::string &account_id,
+              shared_model::interface::permissions::Grantable permission));
 
-      MOCK_METHOD3(deleteAccountGrantablePermission,
-                   WsvCommandResult(const std::string &permittee_account_id,
-                                    const std::string &account_id,
-                                    const std::string &permission_id));
+      MOCK_METHOD3(
+          deleteAccountGrantablePermission,
+          WsvCommandResult(
+              const std::string &permittee_account_id,
+              const std::string &account_id,
+              shared_model::interface::permissions::Grantable permission));
       MOCK_METHOD1(insertAccount,
                    WsvCommandResult(const shared_model::interface::Account &));
       MOCK_METHOD1(updateAccount,

--- a/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
@@ -40,6 +40,10 @@ namespace iroha {
                             .quorum(1)
                             .jsonData(R"({"id@domain": {"key": "value"}})")
                             .build());
+        role_permissions.set(
+            shared_model::interface::permissions::Role::kAddMySignatory);
+        grantable_permission =
+            shared_model::interface::permissions::Grantable::kAddMySignatory;
       }
 
       void SetUp() override {
@@ -59,7 +63,9 @@ namespace iroha {
         wsv_transaction->exec(init_);
       }
 
-      std::string role = "role", permission = "permission";
+      std::string role = "role";
+      shared_model::interface::RolePermissionSet role_permissions;
+      shared_model::interface::permissions::Grantable grantable_permission;
       std::unique_ptr<shared_model::interface::Account> account;
       std::unique_ptr<shared_model::interface::Domain> domain;
 
@@ -111,12 +117,11 @@ namespace iroha {
      * @then RolePermissions are inserted
      */
     TEST_F(RolePermissionsTest, InsertRolePermissionsWhenRoleExists) {
-      ASSERT_TRUE(val(command->insertRolePermissions(role, {permission})));
+      ASSERT_TRUE(val(command->insertRolePermissions(role, role_permissions)));
 
       auto permissions = query->getRolePermissions(role);
       ASSERT_TRUE(permissions);
-      ASSERT_EQ(1, permissions->size());
-      ASSERT_EQ(permission, permissions->front());
+      ASSERT_EQ(role_permissions, permissions);
     }
 
     /**
@@ -126,11 +131,12 @@ namespace iroha {
      */
     TEST_F(RolePermissionsTest, InsertRolePermissionsWhenNoRole) {
       auto new_role = role + " ";
-      ASSERT_TRUE(err(command->insertRolePermissions(new_role, {permission})));
+      ASSERT_TRUE(
+          err(command->insertRolePermissions(new_role, role_permissions)));
 
       auto permissions = query->getRolePermissions(new_role);
       ASSERT_TRUE(permissions);
-      ASSERT_EQ(0, permissions->size());
+      ASSERT_NE(*permissions &= role_permissions, role_permissions);
     }
 
     class AccountTest : public WsvQueryCommandTest {
@@ -351,10 +357,14 @@ namespace iroha {
     TEST_F(AccountGrantablePermissionTest,
            InsertAccountGrantablePermissionWhenAccountsExist) {
       ASSERT_TRUE(val(command->insertAccountGrantablePermission(
-          permittee_account->accountId(), account->accountId(), permission)));
+          permittee_account->accountId(),
+          account->accountId(),
+          grantable_permission)));
 
-      ASSERT_TRUE(query->hasAccountGrantablePermission(
-          permittee_account->accountId(), account->accountId(), permission));
+      ASSERT_TRUE(
+          query->hasAccountGrantablePermission(permittee_account->accountId(),
+                                               account->accountId(),
+                                               grantable_permission));
     }
 
     /**
@@ -366,20 +376,20 @@ namespace iroha {
            InsertAccountGrantablePermissionWhenNoPermitteeAccount) {
       auto permittee_account_id = permittee_account->accountId() + " ";
       ASSERT_TRUE(err(command->insertAccountGrantablePermission(
-          permittee_account_id, account->accountId(), permission)));
+          permittee_account_id, account->accountId(), grantable_permission)));
 
       ASSERT_FALSE(query->hasAccountGrantablePermission(
-          permittee_account_id, account->accountId(), permission));
+          permittee_account_id, account->accountId(), grantable_permission));
     }
 
     TEST_F(AccountGrantablePermissionTest,
            InsertAccountGrantablePermissionWhenNoAccount) {
       auto account_id = account->accountId() + " ";
       ASSERT_TRUE(err(command->insertAccountGrantablePermission(
-          permittee_account->accountId(), account_id, permission)));
+          permittee_account->accountId(), account_id, grantable_permission)));
 
       ASSERT_FALSE(query->hasAccountGrantablePermission(
-          permittee_account->accountId(), account_id, permission));
+          permittee_account->accountId(), account_id, grantable_permission));
     }
 
     /**
@@ -390,10 +400,14 @@ namespace iroha {
     TEST_F(AccountGrantablePermissionTest,
            DeleteAccountGrantablePermissionWhenAccountsPermissionExist) {
       ASSERT_TRUE(val(command->deleteAccountGrantablePermission(
-          permittee_account->accountId(), account->accountId(), permission)));
+          permittee_account->accountId(),
+          account->accountId(),
+          grantable_permission)));
 
-      ASSERT_FALSE(query->hasAccountGrantablePermission(
-          permittee_account->accountId(), account->accountId(), permission));
+      ASSERT_FALSE(
+          query->hasAccountGrantablePermission(permittee_account->accountId(),
+                                               account->accountId(),
+                                               grantable_permission));
     }
 
     class DeletePeerTest : public WsvQueryCommandTest {

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -5,6 +5,7 @@
 
 #include <limits>
 
+#include "backend/protobuf/from_old.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "builders/default_builders.hpp"
 #include "execution/command_executor.hpp"
@@ -46,8 +47,8 @@ std::unique_ptr<shared_model::interface::Command> buildCommand(
 template <class T>
 std::shared_ptr<T> getConcreteCommand(
     const std::unique_ptr<shared_model::interface::Command> &command) {
-  return clone(boost::apply_visitor(
-      framework::SpecifiedVisitor<T>(), command->get()));
+  return clone(
+      boost::apply_visitor(framework::SpecifiedVisitor<T>(), command->get()));
 }
 
 class CommandValidateExecuteTest : public ::testing::Test {
@@ -186,7 +187,7 @@ class CommandValidateExecuteTest : public ::testing::Test {
   const shared_model::interface::types::PubkeyType kPubKey2 =
       shared_model::interface::types::PubkeyType(std::string(32, '2'));
 
-  std::vector<std::string> role_permissions;
+  shared_model::interface::RolePermissionSet role_permissions;
   std::shared_ptr<shared_model::interface::Account> creator, account;
   std::shared_ptr<shared_model::interface::Amount> balance;
   std::shared_ptr<shared_model::interface::Asset> asset;
@@ -206,7 +207,7 @@ class AddAssetQuantityTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kAddAssetQty)};
+    role_permissions.set(Role::kAddAssetQty);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().addAssetQuantity(
@@ -368,7 +369,7 @@ class SubtractAssetQuantityTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kSubtractAssetQty)};
+    role_permissions.set(Role::kSubtractAssetQty);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().subtractAssetQuantity(
@@ -523,7 +524,7 @@ class AddSignatoryTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kAddSignatory)};
+    role_permissions.set(Role::kAddSignatory);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -541,10 +542,10 @@ class AddSignatoryTest : public CommandValidateExecuteTest {
  * @then executor finishes successfully
  */
 TEST_F(AddSignatoryTest, ValidWhenCreatorHasPermissions) {
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(kAdminId,
-                                            add_signatory->accountId(),
-                                            toString(Role::kAddMySignatory)))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          kAdminId, add_signatory->accountId(), Grantable::kAddMySignatory))
       .WillOnce(Return(true));
   EXPECT_CALL(*wsv_command, insertSignatory(add_signatory->pubkey()))
       .WillOnce(Return(WsvCommandResult()));
@@ -587,10 +588,10 @@ TEST_F(AddSignatoryTest, ValidWhenSameAccount) {
  * @then executor will be failed
  */
 TEST_F(AddSignatoryTest, InvalidWhenNoPermissions) {
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(kAdminId,
-                                            add_signatory->accountId(),
-                                            toString(Role::kAddMySignatory)))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          kAdminId, add_signatory->accountId(), Grantable::kAddMySignatory))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -608,10 +609,10 @@ TEST_F(AddSignatoryTest, InvalidWhenNoAccount) {
   add_signatory =
       getConcreteCommand<shared_model::interface::AddSignatory>(command);
 
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(kAdminId,
-                                            add_signatory->accountId(),
-                                            toString(Role::kAddMySignatory)))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          kAdminId, add_signatory->accountId(), Grantable::kAddMySignatory))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -629,10 +630,10 @@ TEST_F(AddSignatoryTest, InvalidWhenSameKey) {
   add_signatory =
       getConcreteCommand<shared_model::interface::AddSignatory>(command);
 
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(kAdminId,
-                                            add_signatory->accountId(),
-                                            toString(Role::kAddMySignatory)))
+  EXPECT_CALL(
+      *wsv_query,
+      hasAccountGrantablePermission(
+          kAdminId, add_signatory->accountId(), Grantable::kAddMySignatory))
       .WillOnce(Return(true));
   EXPECT_CALL(*wsv_command, insertSignatory(add_signatory->pubkey()))
       .WillOnce(Return(makeEmptyError()));
@@ -645,7 +646,7 @@ class CreateAccountTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kCreateAccount)};
+    role_permissions.set(Role::kCreateAccount);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -722,7 +723,7 @@ class CreateAssetTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kCreateAsset)};
+    role_permissions.set(Role::kCreateAsset);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -780,7 +781,7 @@ class CreateDomainTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kCreateDomain)};
+    role_permissions.set(Role::kCreateDomain);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command =
@@ -843,7 +844,7 @@ class RemoveSignatoryTest : public CommandValidateExecuteTest {
 
     many_pubkeys = {creator_key, account_key};
 
-    role_permissions = {toString(Role::kRemoveSignatory)};
+    role_permissions.set(Role::kRemoveSignatory);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -867,7 +868,7 @@ TEST_F(RemoveSignatoryTest, ValidWhenMultipleKeys) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(remove_signatory->accountId()))
@@ -894,7 +895,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenSingleKey) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(remove_signatory->accountId()))
@@ -923,7 +924,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoPermissions) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -947,7 +948,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoKey) {
       *wsv_query,
       hasAccountGrantablePermission(kAdminId,
                                     wrong_key_remove_signatory->accountId(),
-                                    toString(Role::kRemoveMySignatory)))
+                                    Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(wrong_key_remove_signatory->accountId()))
@@ -969,7 +970,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoAccount) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(remove_signatory->accountId()))
@@ -991,7 +992,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoSignatories) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(remove_signatory->accountId()))
@@ -1013,7 +1014,7 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoAccountAndSignatories) {
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(kAdminId,
                                             remove_signatory->accountId(),
-                                            toString(Role::kRemoveMySignatory)))
+                                            Grantable::kRemoveMySignatory))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccount(remove_signatory->accountId()))
@@ -1039,12 +1040,12 @@ TEST_F(RemoveSignatoryTest, InvalidWhenNoPermissionToRemoveFromSelf) {
       getConcreteCommand<shared_model::interface::RemoveSignatory>(command);
 
   EXPECT_CALL(*wsv_query, getRolePermissions(kAdminRole))
-      .WillOnce(Return(std::vector<std::string>{}));
+      .WillOnce(Return(shared_model::interface::RolePermissionSet{}));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator->accountId()))
       .WillOnce(Return(std::vector<std::string>{kAdminRole}));
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  kAdminId, kAdminId, toString(Role::kRemoveMySignatory)))
+                  kAdminId, kAdminId, Grantable::kRemoveMySignatory))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -1070,7 +1071,7 @@ class SetQuorumTest : public CommandValidateExecuteTest {
     CommandValidateExecuteTest::SetUp();
 
     account_pubkeys = {kPubKey1, kPubKey2};
-    role_permissions = {toString(Role::kSetQuorum)};
+    role_permissions.set(Role::kSetQuorum);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command =
@@ -1098,10 +1099,9 @@ class SetQuorumTest : public CommandValidateExecuteTest {
  * @then execute successes
  */
 TEST_F(SetQuorumTest, ValidWhenCreatorHasPermissions) {
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          kAdminId, set_quorum->accountId(), toString(Role::kSetMyQuorum)))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  kAdminId, set_quorum->accountId(), Grantable::kSetMyQuorum))
       .WillOnce(Return(true));
   EXPECT_CALL(*wsv_query, getAccount(set_quorum->accountId()))
       .WillOnce(Return(account));
@@ -1138,10 +1138,9 @@ TEST_F(SetQuorumTest, ValidWhenSameAccount) {
  * @then execute fails
  */
 TEST_F(SetQuorumTest, InvalidWhenNoPermissions) {
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          kAdminId, set_quorum->accountId(), toString(Role::kSetMyQuorum)))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  kAdminId, set_quorum->accountId(), Grantable::kSetMyQuorum))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -1157,10 +1156,9 @@ TEST_F(SetQuorumTest, InvalidWhenNoAccount) {
       buildCommand(TestTransactionBuilder().setAccountQuorum(kNoAcountId, 2));
   set_quorum = getConcreteCommand<shared_model::interface::SetQuorum>(command);
 
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          kAdminId, set_quorum->accountId(), toString(Role::kSetMyQuorum)))
+  EXPECT_CALL(*wsv_query,
+              hasAccountGrantablePermission(
+                  kAdminId, set_quorum->accountId(), Grantable::kSetMyQuorum))
       .WillOnce(Return(false));
 
   ASSERT_TRUE(err(validateAndExecute(command)));
@@ -1241,7 +1239,8 @@ class TransferAssetTest : public CommandValidateExecuteTest {
                            .balance(*balance)
                            .build());
 
-    role_permissions = {toString(Role::kTransfer), toString(Role::kReceive)};
+    role_permissions.set(Role::kTransfer);
+    role_permissions.set(Role::kReceive);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().transferAsset(
@@ -1343,7 +1342,7 @@ TEST_F(TransferAssetTest, ValidWhenCreatorHasPermission) {
 
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  kAdminId, kAccountId, toString(Role::kTransferMyAssets)))
+                  kAdminId, kAccountId, Grantable::kTransferMyAssets))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*wsv_query, getAccountRoles(transfer_asset->destAccountId()))
@@ -1354,8 +1353,7 @@ TEST_F(TransferAssetTest, ValidWhenCreatorHasPermission) {
   EXPECT_CALL(*wsv_query, getAccountAsset(transfer_asset->destAccountId(), _))
       .WillOnce(Return(boost::none));
 
-  EXPECT_CALL(*wsv_query,
-              getAccountAsset(transfer_asset->srcAccountId(), _))
+  EXPECT_CALL(*wsv_query, getAccountAsset(transfer_asset->srcAccountId(), _))
       .Times(2)
       .WillRepeatedly(Return(src_wallet));
   EXPECT_CALL(*wsv_query, getAsset(transfer_asset->assetId()))
@@ -1671,7 +1669,7 @@ TEST_F(TransferAssetTest, InvalidWhenCreatorHasNoPermission) {
 
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  kAdminId, kAccountId, toString(Role::kTransferMyAssets)))
+                  kAdminId, kAccountId, Grantable::kTransferMyAssets))
       .WillOnce(Return(false));
   ASSERT_TRUE(err(validateAndExecute(command)));
 }
@@ -1681,7 +1679,7 @@ class AddPeerTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kAddPeer)};
+    role_permissions.set(Role::kAddPeer);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -1736,7 +1734,7 @@ class CreateRoleTest : public CommandValidateExecuteTest {
     CommandValidateExecuteTest::SetUp();
 
     std::set<std::string> perm = {toString(Role::kCreateRole)};
-    role_permissions = {toString(Role::kCreateRole)};
+    role_permissions.set(Role::kCreateRole);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command =
@@ -1759,12 +1757,9 @@ TEST_F(CreateRoleTest, ValidCase) {
       .WillRepeatedly(Return(role_permissions));
   EXPECT_CALL(*wsv_command, insertRole(create_role->roleName()))
       .WillOnce(Return(WsvCommandResult()));
-  auto tmp = shared_model::proto::permissions::toString(
-      create_role->rolePermissions());
-  shared_model::interface::types::PermissionSetType permission_set = {
-      tmp.begin(), tmp.end()};
   EXPECT_CALL(*wsv_command,
-              insertRolePermissions(create_role->roleName(), permission_set))
+              insertRolePermissions(create_role->roleName(),
+                                    create_role->rolePermissions()))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -1817,7 +1812,7 @@ class AppendRoleTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kAppendRole)};
+    role_permissions.set(Role::kAppendRole);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -1939,7 +1934,7 @@ class DetachRoleTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    role_permissions = {toString(Role::kDetachRole)};
+    role_permissions.set(Role::kDetachRole);
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
@@ -1998,17 +1993,17 @@ class GrantPermissionTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    expected_permission = toString(Grantable::kAddMySignatory);
-    role_permissions = {"can_grant_" + expected_permission};
+    role_permissions.set(permissionFor(expected_permission));
 
-    // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
+    // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with
+    // CommandBuilder
     command = buildCommand(TestTransactionBuilder().grantPermission(
-        kAccountId, expected_permission));
+        kAccountId, toString(expected_permission)));
     grant_permission =
         getConcreteCommand<shared_model::interface::GrantPermission>(command);
   }
   std::shared_ptr<shared_model::interface::GrantPermission> grant_permission;
-  std::string expected_permission;
+  const Grantable expected_permission = Grantable::kAddMySignatory;
 };
 
 /**
@@ -2061,17 +2056,17 @@ class RevokePermissionTest : public CommandValidateExecuteTest {
   void SetUp() override {
     CommandValidateExecuteTest::SetUp();
 
-    expected_permission = toString(Grantable::kAddMySignatory);
+    expected_permission = Grantable::kAddMySignatory;
 
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(TestTransactionBuilder().revokePermission(
-        kAccountId, expected_permission));
+        kAccountId, toString(expected_permission)));
     revoke_permission =
         getConcreteCommand<shared_model::interface::RevokePermission>(command);
   }
 
   std::shared_ptr<shared_model::interface::RevokePermission> revoke_permission;
-  std::string expected_permission;
+  Grantable expected_permission;
 };
 
 /**
@@ -2132,12 +2127,12 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
     set_aacount_detail =
         getConcreteCommand<shared_model::interface::SetAccountDetail>(command);
 
-    role_permissions = {toString(Role::kSetQuorum)};
+    role_permissions.set(Role::kSetQuorum);
   }
 
   const std::string kKey = "key";
   const std::string kValue = "val";
-  const std::string kNeededPermission = toString(Role::kSetMyAccountDetail);
+  const Grantable kNeededPermission = Grantable::kSetMyAccountDetail;
 
   std::shared_ptr<shared_model::interface::SetAccountDetail> set_aacount_detail;
 };


### PR DESCRIPTION
### Description of the Change

Ametsuchi uses new model. WSV scheme is now unisng new enum types. 

### Benefits

One more step toward legacy model removal

### Possible Drawbacks 

Additional string allocation at postgres

### Alternate Designs

IMO postgres should use bitstring (for enums) and know nothing about enum strcture (thus less pain with migrations)