### PR TITLE
Remove move semantics from ModelProto template

### DIFF
--- a/example/python/tx-example.py
+++ b/example/python/tx-example.py
@@ -221,7 +221,7 @@ def get_account_asset():
     query = query_builder.creatorAccountId(creator) \
         .createdTime(current_time) \
         .queryCounter(query_counter) \
-        .getAccountAssets("userone@domain", "coin#domain") \
+        .getAccountAssets("userone@domain") \
         .build()
 
     query_response = send_query(query, key_pair)

--- a/shared_model/bindings/model_proto.hpp
+++ b/shared_model/bindings/model_proto.hpp
@@ -31,7 +31,7 @@ namespace shared_model {
     template <typename UnsignedWrapper>
     class ModelProto {
      public:
-      ModelProto(UnsignedWrapper &&us) : us_(std::move(us)) {}
+      ModelProto(UnsignedWrapper &us) : us_(us) {}
       /**
        * Signs and adds a signature for a proto object
        * @param keypair - keypair to sign
@@ -40,7 +40,7 @@ namespace shared_model {
       ModelProto<UnsignedWrapper> signAndAddSignature(
           const crypto::Keypair &keypair) {
         UnsignedWrapper wrapper = us_.signAndAddSignature(keypair);
-        return ModelProto<UnsignedWrapper>(std::move(wrapper));
+        return ModelProto<UnsignedWrapper>(wrapper);
       }
 
       /**


### PR DESCRIPTION
### Description of the Change
This pr removes move semantics from ModelProto.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Swig doesn't support move semantics so it can't be used in client interfaces. This leads to segfault in tx_example.py.

### How to check
1. Build and run irohad
2. Run example/python/prepare.sh
3. Run python2 tx-example.py

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


