### PR TITLE
Fix build of python_tests target

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -74,7 +74,7 @@ function(compile_proto_to_cpp PROTO)
       OUTPUT ${IROHA_SCHEMA_DIR}/${GEN_PB_HEADER} ${IROHA_SCHEMA_DIR}/${GEN_PB}
       COMMAND ${GEN_COMMAND}
       ARGS -I${GEN_ARGS} -I. --cpp_out=${IROHA_SCHEMA_DIR} ${PROTO}
-      DEPENDS protoc ${PROTO}
+      DEPENDS protoc ${IROHA_SCHEMA_DIR}/${PROTO}
       WORKING_DIRECTORY ${IROHA_SCHEMA_DIR}
       )
 endfunction()
@@ -88,7 +88,7 @@ function(compile_proto_to_grpc_cpp PROTO)
       OUTPUT ${IROHA_SCHEMA_DIR}/${GEN_GRPC_PB_HEADER} ${IROHA_SCHEMA_DIR}/${GEN_GRPC_PB}
       COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${protobuf_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH} "${protoc_EXECUTABLE}"
       ARGS -I${protobuf_INCLUDE_DIR} -I. --grpc_out=${IROHA_SCHEMA_DIR} --plugin=protoc-gen-grpc="${grpc_CPP_PLUGIN}" ${PROTO}
-      DEPENDS grpc_cpp_plugin ${PROTO}
+      DEPENDS grpc_cpp_plugin ${IROHA_SCHEMA_DIR}/${PROTO}
       WORKING_DIRECTORY ${IROHA_SCHEMA_DIR}
       )
 endfunction()
@@ -107,7 +107,7 @@ function(compile_proto_to_python PROTO)
       OUTPUT ${SWIG_BUILD_DIR}/${PY_PB}
       COMMAND ${GEN_COMMAND}
       ARGS -I${GEN_ARGS} -I. --python_out=${SWIG_BUILD_DIR} ${PROTO}
-      DEPENDS protoc ${PROTO}
+      DEPENDS protoc ${IROHA_SCHEMA_DIR}/${PROTO}
       WORKING_DIRECTORY ${IROHA_SCHEMA_DIR}
       )
 endfunction()


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Build of python_tests target was broken by commit https://github.com/hyperledger/iroha/commit/df23d337ca82e39451b78fbe7eaf6cb1b216caec. This pr fixes that.

Special thanks to @lebdron 🎉🎉

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Now we able to build `python_tests`

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None (?)

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 

```
cmake -H. -Bbuild -DSWIG_PYTHON=ON
cmake --build build --target irohapy
cmake --build build --target python_tests
cd build
ctest -R python . # it is expected that python_query_test fails (getaccountassets, will be fixed later) 
```