### PR TITLE
Add missing libraries to iOS build

### DIFF
--- a/shared_model/packages/ios/ios-build.sh
+++ b/shared_model/packages/ios/ios-build.sh
@@ -118,6 +118,8 @@ cp "$DEPS_DIR"/lib/lib${PROTOBUF_LIB_NAME}.a \
  ./iroha/shared_model/build/cryptography/model_impl/libshared_model_cryptography_model.a \
  ./iroha/shared_model/build/validators/libshared_model_stateless_validation.a \
  ./iroha/shared_model/build/schema/libschema.a \
+ ./iroha/shared_model/build/interfaces/libshared_model_interfaces.a \
+ ./iroha/shared_model/build/backend/protobuf/libshared_model_proto_backend.a \
  lib
 cp -R "$DEPS_DIR"/include/* include
 (cd ./iroha/shared_model; find . -name '*.hpp' | cpio -pdm ../../include)


### PR DESCRIPTION
### Description of the Change

Add missing libraries in ios-build.sh script in order to make it work with new library structure of shared model

### Benefits

Now all missing libraries for building iOS project copying into libs folder

### Possible Drawbacks 

None
