### PR TITLE
Prepare YAC for BFT OS and gossip vote propagation

### DIFF
--- a/irohad/consensus/yac/cluster_order.hpp
+++ b/irohad/consensus/yac/cluster_order.hpp
@@ -18,9 +18,11 @@
 #ifndef IROHA_CLUSTER_ORDER_HPP
 #define IROHA_CLUSTER_ORDER_HPP
 
-#include <boost/optional.hpp>
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include <boost/optional.hpp>
+#include "consensus/yac/yac_types.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -65,7 +67,7 @@ namespace iroha {
         std::vector<std::shared_ptr<shared_model::interface::Peer>> getPeers()
             const;
 
-        size_t getNumberOfPeers() const;
+        PeersNumberType getNumberOfPeers() const;
 
         virtual ~ClusterOrdering() = default;
 
@@ -77,7 +79,7 @@ namespace iroha {
             std::vector<std::shared_ptr<shared_model::interface::Peer>> order);
 
         std::vector<std::shared_ptr<shared_model::interface::Peer>> order_;
-        uint32_t index_ = 0;
+        PeersNumberType index_ = 0;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.cpp
@@ -33,8 +33,8 @@ namespace iroha {
             and peersSubset(signatures, peers);
       }
 
-      bool SupermajorityCheckerImpl::checkSize(uint64_t current,
-                                               uint64_t all) const {
+      bool SupermajorityCheckerImpl::checkSize(PeersNumberType current,
+                                               PeersNumberType all) const {
         if (current > all) {
           return false;
         }
@@ -55,9 +55,9 @@ namespace iroha {
                       }));
       }
 
-      bool SupermajorityCheckerImpl::hasReject(uint64_t frequent,
-                                               uint64_t voted,
-                                               uint64_t all) const {
+      bool SupermajorityCheckerImpl::hasReject(PeersNumberType frequent,
+                                               PeersNumberType voted,
+                                               PeersNumberType all) const {
         auto not_voted = all - voted;
         return not checkSize(frequent + not_voted, all);
       }

--- a/irohad/consensus/yac/impl/supermajority_checker_impl.hpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_impl.hpp
@@ -40,7 +40,8 @@ namespace iroha {
             const std::vector<std::shared_ptr<shared_model::interface::Peer>>
                 &peers) const override;
 
-        virtual bool checkSize(uint64_t current, uint64_t all) const override;
+        virtual bool checkSize(PeersNumberType current,
+                               PeersNumberType all) const override;
 
         virtual bool peersSubset(
             const shared_model::interface::types::SignatureRangeType
@@ -48,9 +49,9 @@ namespace iroha {
             const std::vector<std::shared_ptr<shared_model::interface::Peer>>
                 &peers) const override;
 
-        virtual bool hasReject(uint64_t frequent,
-                               uint64_t voted,
-                               uint64_t all) const override;
+        virtual bool hasReject(PeersNumberType frequent,
+                               PeersNumberType voted,
+                               PeersNumberType all) const override;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -187,7 +187,7 @@ namespace iroha {
               break;
             case ProposalState::kSentProcessed:
               if (state.size() == 1) {
-                findPeer(state.at(0)) | [&](const auto &from) {
+                this->findPeer(state.at(0)) | [&](const auto &from) {
                   log_->info("Propagate state {} directly to {}",
                              state.at(0).hash.proposal_hash,
                              from->address());

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -108,7 +108,7 @@ namespace iroha {
                    vote.hash.proposal_hash,
                    vote.hash.block_hash);
 
-        network_->send_vote(cluster_order_.currentLeader(), vote);
+        network_->sendState(cluster_order_.currentLeader(), {vote});
         cluster_order_.switchToNext();
         if (cluster_order_.hasNext()) {
           timer_->invokeAfterDelay([this, vote] { this->votingStep(vote); });
@@ -220,7 +220,7 @@ namespace iroha {
 
       void Yac::propagateCommitDirectly(const shared_model::interface::Peer &to,
                                         const CommitMessage &msg) {
-        network_->send_commit(to, msg);
+        network_->sendState(to, msg.votes);
       }
 
       void Yac::propagateReject(const RejectMessage &msg) {
@@ -231,7 +231,7 @@ namespace iroha {
 
       void Yac::propagateRejectDirectly(const shared_model::interface::Peer &to,
                                         const RejectMessage &msg) {
-        network_->send_reject(std::move(to), std::move(msg));
+        network_->sendState(std::move(to), std::move(msg.votes));
       }
 
     }  // namespace yac

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -46,11 +46,6 @@ namespace iroha {
         return result;
       }
 
-      template <typename T>
-      static std::string cryptoError(const std::initializer_list<T> &votes) {
-        return cryptoError<std::initializer_list<T>>(votes);
-      }
-
       std::shared_ptr<Yac> Yac::create(
           YacVoteStorage vote_storage,
           std::shared_ptr<YacNetwork> network,
@@ -92,30 +87,12 @@ namespace iroha {
 
       // ------|Network notifications|------
 
-      void Yac::on_vote(VoteMessage vote) {
+      void Yac::onState(std::vector<VoteMessage> state) {
         std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify({vote})) {
-          applyState({vote});
+        if (crypto_->verify(state)) {
+          applyState(state);
         } else {
-          log_->warn(cryptoError({vote}));
-        }
-      }
-
-      void Yac::on_commit(CommitMessage commit) {
-        std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify(commit.votes)) {
-          applyState(commit.votes);
-        } else {
-          log_->warn(cryptoError(commit.votes));
-        }
-      }
-
-      void Yac::on_reject(RejectMessage reject) {
-        std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify(reject.votes)) {
-          applyState(reject.votes);
-        } else {
-          log_->warn(cryptoError(reject.votes));
+          log_->warn(cryptoError(state));
         }
       }
 

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -86,7 +86,7 @@ namespace iroha {
         votingStep(vote);
       }
 
-      rxcpp::observable<CommitMessage> Yac::on_commit() {
+      rxcpp::observable<Answer> Yac::onOutcome() {
         return notifier_.get_observable();
       }
 

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -169,8 +169,8 @@ namespace iroha {
           auto proposal_hash = getProposalHash(commit.votes).value();
           auto already_processed =
               vote_storage_.getProcessingState(proposal_hash);
-          if (not already_processed) {
-            vote_storage_.markAsProcessedState(proposal_hash);
+          if (already_processed != ProposalState::kSentNotProcessed) {
+            vote_storage_.nextProcessingState(proposal_hash);
             visit_in_place(answer,
                            [&](const CommitMessage &commit) {
                              notifier_.get_subscriber().on_next(commit);
@@ -195,8 +195,8 @@ namespace iroha {
           auto already_processed =
               vote_storage_.getProcessingState(proposal_hash);
 
-          if (not already_processed) {
-            vote_storage_.markAsProcessedState(proposal_hash);
+          if (already_processed != ProposalState::kSentNotProcessed) {
+            vote_storage_.nextProcessingState(proposal_hash);
             visit_in_place(answer,
                            [&](const RejectMessage &reject) {
                              log_->warn(kRejectMsg);
@@ -233,8 +233,8 @@ namespace iroha {
           auto already_processed =
               vote_storage_.getProcessingState(proposal_hash);
 
-          if (not already_processed) {
-            vote_storage_.markAsProcessedState(proposal_hash);
+          if (already_processed != ProposalState::kSentNotProcessed) {
+            vote_storage_.nextProcessingState(proposal_hash);
             visit_in_place(answer,
                            [&](const CommitMessage &commit) {
                              // propagate for all

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -94,7 +94,7 @@ namespace iroha {
 
       void Yac::on_vote(VoteMessage vote) {
         std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify(vote)) {
+        if (crypto_->verify({vote})) {
           applyState({vote});
         } else {
           log_->warn(cryptoError({vote}));
@@ -103,7 +103,7 @@ namespace iroha {
 
       void Yac::on_commit(CommitMessage commit) {
         std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify(commit)) {
+        if (crypto_->verify(commit.votes)) {
           applyState(commit.votes);
         } else {
           log_->warn(cryptoError(commit.votes));
@@ -112,7 +112,7 @@ namespace iroha {
 
       void Yac::on_reject(RejectMessage reject) {
         std::lock_guard<std::mutex> guard(mutex_);
-        if (crypto_->verify(reject)) {
+        if (crypto_->verify(reject.votes)) {
           applyState(reject.votes);
         } else {
           log_->warn(cryptoError(reject.votes));

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -163,8 +163,8 @@ namespace iroha {
       void Yac::applyCommit(
           boost::optional<std::shared_ptr<shared_model::interface::Peer>> from,
           const CommitMessage &commit) {
-        auto answer =
-            vote_storage_.store(commit, cluster_order_.getNumberOfPeers());
+        auto answer = vote_storage_.store(commit.votes,
+                                          cluster_order_.getNumberOfPeers());
         answer | [&](const auto &answer) {
           auto proposal_hash = getProposalHash(commit.votes).value();
           auto already_processed =
@@ -188,8 +188,8 @@ namespace iroha {
       void Yac::applyReject(
           boost::optional<std::shared_ptr<shared_model::interface::Peer>> from,
           const RejectMessage &reject) {
-        auto answer =
-            vote_storage_.store(reject, cluster_order_.getNumberOfPeers());
+        auto answer = vote_storage_.store(reject.votes,
+                                          cluster_order_.getNumberOfPeers());
         answer | [&](const auto &answer) {
           auto proposal_hash = getProposalHash(reject.votes).value();
           auto already_processed =
@@ -226,7 +226,7 @@ namespace iroha {
         }
 
         auto answer =
-            vote_storage_.store(vote, cluster_order_.getNumberOfPeers());
+            vote_storage_.store({vote}, cluster_order_.getNumberOfPeers());
 
         answer | [&](const auto &answer) {
           auto &proposal_hash = vote.hash.proposal_hash;

--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
@@ -27,27 +27,18 @@ namespace iroha {
           const shared_model::crypto::Keypair &keypair)
           : keypair_(keypair) {}
 
-      bool CryptoProviderImpl::verify(CommitMessage msg) {
+      bool CryptoProviderImpl::verify(std::vector<VoteMessage> msg) {
         return std::all_of(
-            std::begin(msg.votes),
-            std::end(msg.votes),
-            [this](const auto &vote) { return this->verify(vote); });
-      }
+            std::begin(msg), std::end(msg), [](const auto &vote) {
+              auto serialized =
+                  PbConverters::serializeVote(vote).hash().SerializeAsString();
+              auto blob = shared_model::crypto::Blob(serialized);
 
-      bool CryptoProviderImpl::verify(RejectMessage msg) {
-        return std::all_of(
-            std::begin(msg.votes),
-            std::end(msg.votes),
-            [this](const auto &vote) { return this->verify(vote); });
-      }
-
-      bool CryptoProviderImpl::verify(VoteMessage msg) {
-        auto serialized =
-            PbConverters::serializeVote(msg).hash().SerializeAsString();
-        auto blob = shared_model::crypto::Blob(serialized);
-
-        return shared_model::crypto::CryptoVerifier<>::verify(
-            msg.signature->signedData(), blob, msg.signature->publicKey());
+              return shared_model::crypto::CryptoVerifier<>::verify(
+                  vote.signature->signedData(),
+                  blob,
+                  vote.signature->publicKey());
+            });
       }
 
       VoteMessage CryptoProviderImpl::getVote(YacHash hash) {

--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.hpp
@@ -29,11 +29,7 @@ namespace iroha {
         explicit CryptoProviderImpl(
             const shared_model::crypto::Keypair &keypair);
 
-        bool verify(CommitMessage msg) override;
-
-        bool verify(RejectMessage msg) override;
-
-        bool verify(VoteMessage msg) override;
+        bool verify(std::vector<VoteMessage> msg) override;
 
         VoteMessage getVote(YacHash hash) override;
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -68,7 +68,7 @@ namespace iroha {
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       YacGateImpl::on_commit() {
         return hash_gate_->onOutcome().flat_map([this](auto message) {
-          // TODO IR-497 Work on reject case
+          // TODO 10.06.2018 andrei: IR-497 Work on reject case
           auto commit_message = boost::get<CommitMessage>(message);
           // map commit to block if it is present or loaded from other peer
           return rxcpp::observable<>::create<

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -67,7 +67,9 @@ namespace iroha {
 
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       YacGateImpl::on_commit() {
-        return hash_gate_->on_commit().flat_map([this](auto commit_message) {
+        return hash_gate_->onOutcome().flat_map([this](auto message) {
+          // TODO IR-497 Work on reject case
+          auto commit_message = boost::get<CommitMessage>(message);
           // map commit to block if it is present or loaded from other peer
           return rxcpp::observable<>::create<
               std::shared_ptr<shared_model::interface::Block>>(

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -26,7 +26,7 @@ namespace iroha {
 
       YacBlockStorage::YacBlockStorage(
           YacHash hash,
-          uint64_t peers_in_round,
+          PeersNumberType peers_in_round,
           std::shared_ptr<SupermajorityChecker> supermajority_checker)
           : hash_(std::move(hash)),
             peers_in_round_(peers_in_round),

--- a/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
@@ -40,18 +40,17 @@ namespace iroha {
           return iter;
         }
         // insert and return new
-        return block_storages_.emplace(
-            block_storages_.end(),
-            YacHash(proposal_hash, block_hash),
-            peers_in_round_,
-            supermajority_checker_);
+        return block_storages_.emplace(block_storages_.end(),
+                                       YacHash(proposal_hash, block_hash),
+                                       peers_in_round_,
+                                       supermajority_checker_);
       }
 
       // --------| public api |--------
 
       YacProposalStorage::YacProposalStorage(
           ProposalHash hash,
-          uint64_t peers_in_round,
+          PeersNumberType peers_in_round,
           std::shared_ptr<SupermajorityChecker> supermajority_checker)
           : current_state_(boost::none),
             hash_(std::move(hash)),

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -37,7 +37,7 @@ namespace iroha {
       }
 
       auto YacVoteStorage::findProposalStorage(const VoteMessage &msg,
-                                               uint64_t peers_in_round) {
+                                               PeersNumberType peers_in_round) {
         auto val = getProposalStorage(msg.hash.proposal_hash);
         if (val != proposal_storages_.end()) {
           return val;
@@ -52,7 +52,7 @@ namespace iroha {
       // --------| public api |--------
 
       boost::optional<Answer> YacVoteStorage::store(
-          std::vector<VoteMessage> state, uint64_t peers_in_round) {
+          std::vector<VoteMessage> state, PeersNumberType peers_in_round) {
         auto storage = findProposalStorage(state.at(0), peers_in_round);
         return storage->insert(state);
       }

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -52,17 +52,17 @@ namespace iroha {
       // --------| public api |--------
 
       boost::optional<Answer> YacVoteStorage::store(VoteMessage vote,
-                                                     uint64_t peers_in_round) {
+                                                    uint64_t peers_in_round) {
         return findProposalStorage(vote, peers_in_round)->insert(vote);
       }
 
       boost::optional<Answer> YacVoteStorage::store(CommitMessage commit,
-                                                     uint64_t peers_in_round) {
+                                                    uint64_t peers_in_round) {
         return insert_votes(commit.votes, peers_in_round);
       }
 
       boost::optional<Answer> YacVoteStorage::store(RejectMessage reject,
-                                                     uint64_t peers_in_round) {
+                                                    uint64_t peers_in_round) {
         return insert_votes(reject.votes, peers_in_round);
       }
 
@@ -74,12 +74,23 @@ namespace iroha {
         return bool(iter->getState());
       }
 
-      bool YacVoteStorage::getProcessingState(const ProposalHash &hash) {
-        return processing_state_.count(hash) != 0;
+      ProposalState YacVoteStorage::getProcessingState(
+          const ProposalHash &hash) {
+        return processing_state_[hash];
       }
 
-      void YacVoteStorage::markAsProcessedState(const ProposalHash &hash) {
-        processing_state_.insert(hash);
+      void YacVoteStorage::nextProcessingState(const ProposalHash &hash) {
+        auto &val = processing_state_[hash];
+        switch (val) {
+          case ProposalState::kNotSentNotProcessed:
+            val = ProposalState::kSentNotProcessed;
+            break;
+          case ProposalState::kSentNotProcessed:
+            val = ProposalState::kSentProcessed;
+            break;
+          case ProposalState::kSentProcessed:
+            break;
+        }
       }
 
       // --------| private api |--------

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -51,19 +51,10 @@ namespace iroha {
 
       // --------| public api |--------
 
-      boost::optional<Answer> YacVoteStorage::store(VoteMessage vote,
-                                                    uint64_t peers_in_round) {
-        return findProposalStorage(vote, peers_in_round)->insert(vote);
-      }
-
-      boost::optional<Answer> YacVoteStorage::store(CommitMessage commit,
-                                                    uint64_t peers_in_round) {
-        return insert_votes(commit.votes, peers_in_round);
-      }
-
-      boost::optional<Answer> YacVoteStorage::store(RejectMessage reject,
-                                                    uint64_t peers_in_round) {
-        return insert_votes(reject.votes, peers_in_round);
+      boost::optional<Answer> YacVoteStorage::store(
+          std::vector<VoteMessage> state, uint64_t peers_in_round) {
+        auto storage = findProposalStorage(state.at(0), peers_in_round);
+        return storage->insert(state);
       }
 
       bool YacVoteStorage::isHashCommitted(ProposalHash hash) {
@@ -91,14 +82,6 @@ namespace iroha {
           case ProposalState::kSentProcessed:
             break;
         }
-      }
-
-      // --------| private api |--------
-
-      boost::optional<Answer> YacVoteStorage::insert_votes(
-          std::vector<VoteMessage> &votes, uint64_t peers_in_round) {
-        auto storage = findProposalStorage(votes.at(0), peers_in_round);
-        return storage->insert(votes);
       }
 
     }  // namespace yac

--- a/irohad/consensus/yac/storage/yac_block_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_block_storage.hpp
@@ -55,7 +55,7 @@ namespace iroha {
          * Try to insert vote to storage
          * @param msg - vote for insertion
          * @return actual state of storage,
-         * nullopt when storage doesn't has supermajority
+         * boost::none when storage doesn't have supermajority
          */
         boost::optional<Answer> insert(VoteMessage msg);
 
@@ -63,7 +63,7 @@ namespace iroha {
          * Insert vector of votes to current storage
          * @param votes - bunch of votes for insertion
          * @return state of storage after insertion last vote,
-         * nullopt when storage doesn't has supermajority
+         * boost::none when storage doesn't have supermajority
          */
         boost::optional<Answer> insert(std::vector<VoteMessage> votes);
 

--- a/irohad/consensus/yac/storage/yac_block_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_block_storage.hpp
@@ -19,13 +19,14 @@
 #define IROHA_YAC_BLOCK_VOTE_STORAGE_HPP
 
 #include <memory>
-#include <boost/optional.hpp>
 #include <vector>
 
+#include <boost/optional.hpp>
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
 #include "consensus/yac/messages.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
+#include "consensus/yac/yac_types.hpp"
 #include "logger/logger.hpp"
 
 namespace iroha {
@@ -46,7 +47,7 @@ namespace iroha {
        public:
         YacBlockStorage(
             YacHash hash,
-            uint64_t peers_in_round,
+            PeersNumberType peers_in_round,
             std::shared_ptr<SupermajorityChecker> supermajority_checker =
                 std::make_shared<SupermajorityCheckerImpl>());
 
@@ -120,7 +121,7 @@ namespace iroha {
         /**
          * Number of peers in current round
          */
-        uint64_t peers_in_round_;
+        PeersNumberType peers_in_round_;
 
         /**
          * Provide functions to check supermajority

--- a/irohad/consensus/yac/storage/yac_common.hpp
+++ b/irohad/consensus/yac/storage/yac_common.hpp
@@ -53,7 +53,9 @@ namespace iroha {
        * @return hash, if collection elements have same hash, otherwise nullopt
        */
       boost::optional<YacHash> getHash(const std::vector<VoteMessage> &votes);
+
     }  // namespace yac
   }    // namespace consensus
 }  // namespace iroha
+
 #endif  // IROHA_YAC_COMMON_HPP

--- a/irohad/consensus/yac/storage/yac_common.hpp
+++ b/irohad/consensus/yac/storage/yac_common.hpp
@@ -42,7 +42,8 @@ namespace iroha {
       /**
        * Provide hash common for whole collection
        * @param votes - collection with votes
-       * @return hash, if collection has same proposal hash, otherwise nullopt
+       * @return hash, if collection has same proposal hash,
+       * otherwise boost::none
        */
       boost::optional<ProposalHash> getProposalHash(
           const std::vector<VoteMessage> &votes);
@@ -50,7 +51,8 @@ namespace iroha {
       /**
        * Get common hash from collection
        * @param votes - collection with votes
-       * @return hash, if collection elements have same hash, otherwise nullopt
+       * @return hash, if collection elements have same hash,
+       * otherwise boost::none
        */
       boost::optional<YacHash> getHash(const std::vector<VoteMessage> &votes);
 

--- a/irohad/consensus/yac/storage/yac_proposal_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_proposal_storage.hpp
@@ -65,7 +65,7 @@ namespace iroha {
          * Try to insert vote to storage
          * @param vote - object for insertion
          * @return result, that contains actual state of storage.
-         * Nullopt if not inserted, possible reasons - duplication,
+         * boost::none if not inserted, possible reasons - duplication,
          * wrong proposal hash.
          */
         boost::optional<Answer> insert(VoteMessage vote);

--- a/irohad/consensus/yac/storage/yac_proposal_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_proposal_storage.hpp
@@ -19,13 +19,14 @@
 #define IROHA_YAC_PROPOSAL_STORAGE_HPP
 
 #include <memory>
-#include <boost/optional.hpp>
 #include <vector>
 
+#include <boost/optional.hpp>
 #include "consensus/yac/impl/supermajority_checker_impl.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "consensus/yac/storage/yac_block_storage.hpp"
 #include "consensus/yac/storage/yac_common.hpp"
+#include "consensus/yac/yac_types.hpp"
 #include "logger/logger.hpp"
 
 namespace iroha {
@@ -56,7 +57,7 @@ namespace iroha {
 
         YacProposalStorage(
             ProposalHash hash,
-            uint64_t peers_in_round,
+            PeersNumberType peers_in_round,
             std::shared_ptr<SupermajorityChecker> supermajority_checker =
                 std::make_shared<SupermajorityCheckerImpl>());
 
@@ -138,7 +139,7 @@ namespace iroha {
         /**
          * Provide number of peers participated in current round
          */
-        uint64_t peers_in_round_;
+        PeersNumberType peers_in_round_;
 
         /**
          * Provide functions to check supermajority

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -18,8 +18,8 @@
 #ifndef IROHA_YAC_VOTE_STORAGE_HPP
 #define IROHA_YAC_VOTE_STORAGE_HPP
 
-#include <memory>
 #include <boost/optional.hpp>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -67,33 +67,13 @@ namespace iroha {
         // --------| public api |--------
 
         /**
-         * Insert vote in storage
-         * @param msg - current vote message
+         * Insert votes in storage
+         * @param state - current message with votes
          * @param peers_in_round - number of peers participated in round
-         * @return structure with result of inserting. Nullopt if mgs not valid.
+         * @return structure with result of inserting. Nullopt if msg not valid.
          */
-        boost::optional<Answer> store(VoteMessage msg,
-                                       uint64_t peers_in_round);
-
-        /**
-         * Insert commit in storage
-         * @param commit - message with votes
-         * @param peers_in_round - number of peers in current consensus round
-         * @return structure with result of inserting.
-         * Nullopt if commit not valid.
-         */
-        boost::optional<Answer> store(CommitMessage commit,
-                                       uint64_t peers_in_round);
-
-        /**
-         * Insert reject message in storage
-         * @param reject - message with votes
-         * @param peers_in_round - number of peers in current consensus round
-         * @return structure with result of inserting.
-         * Nullopt if reject not valid.
-         */
-        boost::optional<Answer> store(RejectMessage reject,
-                                       uint64_t peers_in_round);
+        boost::optional<Answer> store(std::vector<VoteMessage> state,
+                                      uint64_t peers_in_round);
 
         /**
          * Provide status about closing round with parameters hash
@@ -119,17 +99,6 @@ namespace iroha {
         void nextProcessingState(const ProposalHash &hash);
 
        private:
-        // --------| private api |--------
-
-        /**
-         * Insert votes in storage
-         * @param votes - collection for insertion
-         * @param peers_in_round - number of peers in current round
-         * @return answer after insertion collection
-         */
-        boost::optional<Answer> insert_votes(std::vector<VoteMessage> &votes,
-                                              uint64_t peers_in_round);
-
         // --------| fields |--------
 
         /**

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -32,6 +32,27 @@ namespace iroha {
     namespace yac {
       class YacProposalStorage;
 
+      /**
+       * Proposal outcome states for multicast propagation strategy
+       *
+       * kNotSentNotProcessed - outcome was not propagated in the network
+       * AND it was not passed to pipeline. Initial state after receiving an
+       * outcome from storage. Outcome with votes is propagated to the network
+       * in this state.
+       *
+       * kSentNotProcessed - outcome was propagated in the network
+       * AND it was not passed to pipeline. State can be set in two cases:
+       * 1. Outcome is received from the network. Some node has already achieved
+       * an outcome and has propagated it to the network, so the first state is
+       * skipped.
+       * 2. Outcome was propagated to the network
+       * Outcome is passed to pipeline in this state.
+       *
+       * kSentProcessed - outcome was propagated in the network
+       * AND it was passed to pipeline. Set after passing proposal to pipeline.
+       * This state is final. Receiving a network message in this state results
+       * in direct propagation of outcome to message sender.
+       */
       enum class ProposalState {
         kNotSentNotProcessed,
         kSentNotProcessed,
@@ -70,7 +91,8 @@ namespace iroha {
          * Insert votes in storage
          * @param state - current message with votes
          * @param peers_in_round - number of peers participated in round
-         * @return structure with result of inserting. Nullopt if msg not valid.
+         * @return structure with result of inserting.
+         * boost::none if msg not valid.
          */
         boost::optional<Answer> store(std::vector<VoteMessage> state,
                                       uint64_t peers_in_round);
@@ -94,6 +116,7 @@ namespace iroha {
          * kNotSentNotProcessed -> kSentNotProcessed
          * kSentNotProcessed -> kSentProcessed
          * kSentProcessed -> kSentProcessed
+         * @see ProposalState description for transition cases
          * @param hash - target tag
          */
         void nextProcessingState(const ProposalHash &hash);

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -18,14 +18,15 @@
 #ifndef IROHA_YAC_VOTE_STORAGE_HPP
 #define IROHA_YAC_VOTE_STORAGE_HPP
 
-#include <boost/optional.hpp>
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
+#include <boost/optional.hpp>
 #include "consensus/yac/messages.hpp"  // because messages passed by value
 #include "consensus/yac/storage/storage_result.hpp"  // for Answer
 #include "consensus/yac/storage/yac_common.hpp"      // for ProposalHash
+#include "consensus/yac/yac_types.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -82,7 +83,7 @@ namespace iroha {
          * @return - iter for required proposal storage
          */
         auto findProposalStorage(const VoteMessage &msg,
-                                 uint64_t peers_in_round);
+                                 PeersNumberType peers_in_round);
 
        public:
         // --------| public api |--------
@@ -95,7 +96,7 @@ namespace iroha {
          * boost::none if msg not valid.
          */
         boost::optional<Answer> store(std::vector<VoteMessage> state,
-                                      uint64_t peers_in_round);
+                                      PeersNumberType peers_in_round);
 
         /**
          * Provide status about closing round with parameters hash
@@ -139,4 +140,5 @@ namespace iroha {
     }  // namespace yac
   }    // namespace consensus
 }  // namespace iroha
+
 #endif  // IROHA_YAC_VOTE_STORAGE_HPP

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -20,7 +20,7 @@
 
 #include <memory>
 #include <boost/optional.hpp>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 #include "consensus/yac/messages.hpp"  // because messages passed by value
@@ -31,6 +31,12 @@ namespace iroha {
   namespace consensus {
     namespace yac {
       class YacProposalStorage;
+
+      enum class ProposalState {
+        kNotSentNotProcessed,
+        kSentNotProcessed,
+        kSentProcessed
+      };
 
       /**
        * Class provide storage for votes and useful methods for it.
@@ -92,7 +98,7 @@ namespace iroha {
         /**
          * Provide status about closing round with parameters hash
          * @param hash - target hash of round
-         * @return true, if rould closed
+         * @return true, if round closed
          */
         bool isHashCommitted(ProposalHash hash);
 
@@ -101,13 +107,16 @@ namespace iroha {
          * @param hash - target tag
          * @return value attached to parameter's hash. Default is false.
          */
-        bool getProcessingState(const ProposalHash &hash);
+        ProposalState getProcessingState(const ProposalHash &hash);
 
         /**
-         * Mark hash as processed.
+         * Mark hash with following transition:
+         * kNotSentNotProcessed -> kSentNotProcessed
+         * kSentNotProcessed -> kSentProcessed
+         * kSentProcessed -> kSentProcessed
          * @param hash - target tag
          */
-        void markAsProcessedState(const ProposalHash &hash);
+        void nextProcessingState(const ProposalHash &hash);
 
        private:
         // --------| private api |--------
@@ -132,7 +141,7 @@ namespace iroha {
          * Processing set provide user flags about processing some hashes.
          * If hash exists <=> processed
          */
-        std::unordered_set<ProposalHash> processing_state_;
+        std::unordered_map<ProposalHash, ProposalState> processing_state_;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -36,6 +36,11 @@ namespace iroha {
       /**
        * Proposal outcome states for multicast propagation strategy
        *
+       * Outcome is either CommitMessage, which guarantees that supermajority of
+       * votes for the proposal-block hashes is collected, or RejectMessage,
+       * which states that supermajority of votes for a block hash cannot be
+       * achieved
+       *
        * kNotSentNotProcessed - outcome was not propagated in the network
        * AND it was not passed to pipeline. Initial state after receiving an
        * outcome from storage. Outcome with votes is propagated to the network

--- a/irohad/consensus/yac/supermajority_checker.hpp
+++ b/irohad/consensus/yac/supermajority_checker.hpp
@@ -19,6 +19,8 @@
 #define IROHA_CONSENSUS_SUPERMAJORITY_CHECKER_HPP
 
 #include <vector>
+
+#include "consensus/yac/yac_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -57,7 +59,8 @@ namespace iroha {
          * @param all number of peers
          * @return true if supermajority is possible or false otherwise
          */
-        virtual bool checkSize(uint64_t current, uint64_t all) const = 0;
+        virtual bool checkSize(PeersNumberType current,
+                               PeersNumberType all) const = 0;
 
         /**
          * Checks if signatures is a subset of signatures of peers
@@ -80,9 +83,9 @@ namespace iroha {
          * @param all - number of peers in round
          * @return true, if reject
          */
-        virtual bool hasReject(uint64_t frequent,
-                               uint64_t voted,
-                               uint64_t all) const = 0;
+        virtual bool hasReject(PeersNumberType frequent,
+                               PeersNumberType voted,
+                               PeersNumberType all) const = 0;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -21,11 +21,11 @@
 #include <memory>
 
 #include "consensus/yac/messages.hpp"
+#include "consensus/yac/storage/yac_common.hpp"
 #include "consensus/yac/transport/yac_pb_converters.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "logger/logger.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
-#include "consensus/yac/storage/yac_common.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -113,7 +113,7 @@ namespace iroha {
         log_->info(
             "Receive vote {} from {}", vote.hash.block_hash, context->peer());
 
-        handler_.lock()->on_vote(vote);
+        handler_.lock()->onState({vote});
         return grpc::Status::OK;
       }
 
@@ -135,7 +135,7 @@ namespace iroha {
                    commit.votes.size(),
                    context->peer());
 
-        handler_.lock()->on_commit(commit);
+        handler_.lock()->onState(commit.votes);
         return grpc::Status::OK;
       }
 
@@ -157,7 +157,7 @@ namespace iroha {
                    reject.votes.size(),
                    context->peer());
 
-        handler_.lock()->on_reject(reject);
+        handler_.lock()->onState(reject.votes);
         return grpc::Status::OK;
       }
 

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -18,6 +18,7 @@
 #ifndef IROHA_NETWORK_IMPL_HPP
 #define IROHA_NETWORK_IMPL_HPP
 
+#include <consensus/yac/messages.hpp>
 #include <memory>
 #include <unordered_map>
 
@@ -53,33 +54,13 @@ namespace iroha {
                        VoteMessage vote) override;
 
         /**
-         * Receive vote from another peer;
+         * Receive votes from another peer;
          * Naming is confusing, because this is rpc call that
          * perform on another machine;
          */
-        grpc::Status SendVote(
+        grpc::Status SendState(
             ::grpc::ServerContext *context,
-            const ::iroha::consensus::yac::proto::Vote *request,
-            ::google::protobuf::Empty *response) override;
-
-        /**
-         * Receive commit from another peer;
-         * Naming is confusing, because this is rpc call that
-         * perform on another machine;
-         */
-        grpc::Status SendCommit(
-            ::grpc::ServerContext *context,
-            const ::iroha::consensus::yac::proto::Commit *request,
-            ::google::protobuf::Empty *response) override;
-
-        /**
-         * Receive reject from another peer;
-         * Naming is confusing, because this is rpc call that
-         * perform on another machine;
-         */
-        grpc::Status SendReject(
-            ::grpc::ServerContext *context,
-            const ::iroha::consensus::yac::proto::Reject *request,
+            const ::iroha::consensus::yac::proto::State *request,
             ::google::protobuf::Empty *response) override;
 
        private:

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -44,14 +44,12 @@ namespace iroha {
                           network::AsyncGrpcClient<google::protobuf::Empty> {
        public:
         NetworkImpl();
+
         void subscribe(
             std::shared_ptr<YacNetworkNotifications> handler) override;
-        void send_commit(const shared_model::interface::Peer &to,
-                         const CommitMessage &commit) override;
-        void send_reject(const shared_model::interface::Peer &to,
-                         RejectMessage reject) override;
-        void send_vote(const shared_model::interface::Peer &to,
-                       VoteMessage vote) override;
+
+        void sendState(const shared_model::interface::Peer &to,
+                       const std::vector<VoteMessage> &state) override;
 
         /**
          * Receive votes from another peer;

--- a/irohad/consensus/yac/transport/yac_network_interface.hpp
+++ b/irohad/consensus/yac/transport/yac_network_interface.hpp
@@ -30,8 +30,6 @@ namespace iroha {
   namespace consensus {
     namespace yac {
 
-      struct CommitMessage;
-      struct RejectMessage;
       struct VoteMessage;
 
       class YacNetworkNotifications {
@@ -51,28 +49,12 @@ namespace iroha {
             std::shared_ptr<YacNetworkNotifications> handler) = 0;
 
         /**
-         * Directly share commit message
+         * Directly share collection of votes
          * @param to - peer recipient
-         * @param commit - message for sending
+         * @param state - message for sending
          */
-        virtual void send_commit(const shared_model::interface::Peer &to,
-                                 const CommitMessage &commit) = 0;
-
-        /**
-         * Directly share reject message
-         * @param to - peer recipient
-         * @param reject - message for sending
-         */
-        virtual void send_reject(const shared_model::interface::Peer &to,
-                                 RejectMessage reject) = 0;
-
-        /**
-         * Directly share vote message
-         * @param to - peer recipient
-         * @param vote - message for sending
-         */
-        virtual void send_vote(const shared_model::interface::Peer &to,
-                               VoteMessage vote) = 0;
+        virtual void sendState(const shared_model::interface::Peer &to,
+                               const std::vector<VoteMessage> &state) = 0;
 
         /**
          * Virtual destructor required for inheritance

--- a/irohad/consensus/yac/transport/yac_network_interface.hpp
+++ b/irohad/consensus/yac/transport/yac_network_interface.hpp
@@ -37,22 +37,10 @@ namespace iroha {
       class YacNetworkNotifications {
        public:
         /**
-         * Callback on receiving commit message
-         * @param commit - provided message
+         * Callback on receiving collection of votes
+         * @param state - provided message
          */
-        virtual void on_commit(CommitMessage commit) = 0;
-
-        /**
-         * Callback on receiving reject message
-         * @param reject - provided message
-         */
-        virtual void on_reject(RejectMessage reject) = 0;
-
-        /**
-         * Callback on receiving vote message
-         * @param vote - provided message
-         */
-        virtual void on_vote(VoteMessage vote) = 0;
+        virtual void onState(std::vector<VoteMessage> state) = 0;
 
         virtual ~YacNetworkNotifications() = default;
       };

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -92,12 +92,9 @@ namespace iroha {
         void applyState(const std::vector<VoteMessage> &state);
 
         // ------|Propagation|------
-        void propagateCommit(const CommitMessage &msg);
-        void propagateCommitDirectly(const shared_model::interface::Peer &to,
-                                     const CommitMessage &msg);
-        void propagateReject(const RejectMessage &msg);
-        void propagateRejectDirectly(const shared_model::interface::Peer &to,
-                                     const RejectMessage &msg);
+        void propagateState(const std::vector<VoteMessage> &msg);
+        void propagateStateDirectly(const shared_model::interface::Peer &to,
+                                    const std::vector<VoteMessage> &msg);
 
         // ------|Fields|------
         YacVoteStorage vote_storage_;

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -93,24 +93,7 @@ namespace iroha {
         findPeer(const VoteMessage &vote);
 
         // ------|Apply data|------
-
-        /**
-         * Methods take optional peer as argument since peer which sent the
-         * message could be missing from the ledger. This is the case when the
-         * top block in ledger does not correspond to consensus round number
-         */
-
-        void applyCommit(
-            boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-                from,
-            const CommitMessage &commit);
-        void applyReject(
-            boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-                from,
-            const RejectMessage &reject);
-        void applyVote(boost::optional<
-                           std::shared_ptr<shared_model::interface::Peer>> from,
-                       const VoteMessage &vote);
+        void applyState(const std::vector<VoteMessage> &state);
 
         // ------|Propagation|------
         void propagateCommit(const CommitMessage &msg);

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -58,17 +58,17 @@ namespace iroha {
 
         // ------|Hash gate|------
 
-        virtual void vote(YacHash hash, ClusterOrdering order);
+        void vote(YacHash hash, ClusterOrdering order) override;
 
-        virtual rxcpp::observable<CommitMessage> on_commit();
+        rxcpp::observable<Answer> onOutcome() override;
 
         // ------|Network notifications|------
 
-        virtual void on_commit(CommitMessage commit);
+        void on_commit(CommitMessage commit) override;
 
-        virtual void on_reject(RejectMessage reject);
+        void on_reject(RejectMessage reject) override;
 
-        virtual void on_vote(VoteMessage vote);
+        void on_vote(VoteMessage vote) override;
 
        private:
         // ------|Private interface|------
@@ -125,7 +125,7 @@ namespace iroha {
         std::shared_ptr<YacNetwork> network_;
         std::shared_ptr<YacCryptoProvider> crypto_;
         std::shared_ptr<Timer> timer_;
-        rxcpp::subjects::subject<CommitMessage> notifier_;
+        rxcpp::subjects::subject<Answer> notifier_;
         std::mutex mutex_;
 
         // ------|One round|------

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -83,7 +83,7 @@ namespace iroha {
         /**
          * Find corresponding peer in the ledger from vote message
          * @param vote message containing peer information
-         * @return peer if it is present in the ledger, nullopt otherwise
+         * @return peer if it is present in the ledger, boost::none otherwise
          */
         boost::optional<std::shared_ptr<shared_model::interface::Peer>>
         findPeer(const VoteMessage &vote);

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -64,11 +64,7 @@ namespace iroha {
 
         // ------|Network notifications|------
 
-        void on_commit(CommitMessage commit) override;
-
-        void on_reject(RejectMessage reject) override;
-
-        void on_vote(VoteMessage vote) override;
+        void onState(std::vector<VoteMessage> state) override;
 
        private:
         // ------|Private interface|------

--- a/irohad/consensus/yac/yac_crypto_provider.hpp
+++ b/irohad/consensus/yac/yac_crypto_provider.hpp
@@ -18,14 +18,12 @@
 #ifndef IROHA_YAC_CRYPTO_PROVIDER_HPP
 #define IROHA_YAC_CRYPTO_PROVIDER_HPP
 
-#include "consensus/yac/yac_hash_provider.hpp" // for YacHash (passed by copy)
+#include "consensus/yac/yac_hash_provider.hpp"  // for YacHash (passed by copy)
 
 namespace iroha {
   namespace consensus {
     namespace yac {
 
-      struct CommitMessage;
-      struct RejectMessage;
       struct VoteMessage;
 
       class YacCryptoProvider {
@@ -35,21 +33,7 @@ namespace iroha {
          * @param msg - for verification
          * @return true if signature correct
          */
-        virtual bool verify(CommitMessage msg) = 0;
-
-        /**
-         * Verify signatory of message
-         * @param msg - for verification
-         * @return true if signature correct
-         */
-        virtual bool verify(RejectMessage msg) = 0;
-
-        /**
-         * Verify signatory of message
-         * @param msg - for verification
-         * @return true if signature correct
-         */
-        virtual bool verify(VoteMessage msg) = 0;
+        virtual bool verify(std::vector<VoteMessage> msg) = 0;
 
         /**
          * Generate vote for provided hash;

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -43,7 +43,7 @@ namespace iroha {
         virtual void vote(YacHash hash, ClusterOrdering order) = 0;
 
         /**
-         * Observable with consensus outcomes in network
+         * Observable with consensus outcomes - commits and rejects - in network
          * @return observable for subscription
          */
         virtual rxcpp::observable<Answer> onOutcome() = 0;

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -18,8 +18,9 @@
 #ifndef IROHA_YAC_GATE_HPP
 #define IROHA_YAC_GATE_HPP
 
-#include "network/consensus_gate.hpp"
 #include <rxcpp/rx-observable.hpp>
+#include "consensus/yac/storage/storage_result.hpp"
+#include "network/consensus_gate.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -27,7 +28,6 @@ namespace iroha {
 
       class YacHash;
       class ClusterOrdering;
-      struct CommitMessage;
 
       class YacGate : public network::ConsensusGate {};
 
@@ -43,10 +43,10 @@ namespace iroha {
         virtual void vote(YacHash hash, ClusterOrdering order) = 0;
 
         /**
-         * Observable with committed hashes in network
+         * Observable with consensus outcomes in network
          * @return observable for subscription
          */
-        virtual rxcpp::observable<CommitMessage> on_commit() = 0;
+        virtual rxcpp::observable<Answer> onOutcome() = 0;
 
         virtual ~HashGate() = default;
       };

--- a/irohad/consensus/yac/yac_types.hpp
+++ b/irohad/consensus/yac/yac_types.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_YAC_TYPES_HPP
+#define IROHA_YAC_TYPES_HPP
+
+#include <cstddef>
+
+namespace iroha {
+  namespace consensus {
+    namespace yac {
+
+      /// Type for number of peers in round.
+      using PeersNumberType = size_t;
+
+    }  // namespace yac
+  }    // namespace consensus
+}  // namespace iroha
+
+#endif  // IROHA_YAC_TYPES_HPP

--- a/schema/yac.proto
+++ b/schema/yac.proto
@@ -19,16 +19,10 @@ message Vote {
   Signature signature = 2;
 }
 
-message Commit {
-  repeated Vote votes = 1;
-}
-
-message Reject {
+message State {
   repeated Vote votes = 1;
 }
 
 service Yac {
-  rpc SendVote (Vote) returns (google.protobuf.Empty);
-  rpc SendCommit (Commit) returns (google.protobuf.Empty);
-  rpc SendReject (Reject) returns (google.protobuf.Empty);
+  rpc SendState (State) returns (google.protobuf.Empty);
 }

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -25,6 +25,7 @@
 #include "module/irohad/consensus/yac/yac_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_signature_builder.hpp"
 
+using ::testing::_;
 using ::testing::An;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
@@ -143,10 +144,7 @@ TEST_F(ConsensusSunnyDayTest, SunnyDayTest) {
     cv.notify_one();
   });
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   // Wait for other peers to start
   std::this_thread::sleep_for(std::chrono::milliseconds(delay_before));

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -132,7 +132,7 @@ std::vector<std::shared_ptr<shared_model::interface::Peer>>
 
 TEST_F(ConsensusSunnyDayTest, SunnyDayTest) {
   std::condition_variable cv;
-  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
   wrapper.subscribe(
       [](auto hash) { std::cout << "^_^ COMMITTED!!!" << std::endl; });
 

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -84,7 +84,7 @@ namespace iroha {
             .WillRepeatedly(
                 InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));
 
-        network->send_vote(*peer, message);
+        network->sendState(*peer, {message});
 
         // wait for response reader thread
         std::unique_lock<std::mutex> lock(mtx);

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -79,7 +79,7 @@ namespace iroha {
        * @then vote handled
        */
       TEST_F(YacNetworkTest, MessageHandledWhenMessageSent) {
-        EXPECT_CALL(*notifications, on_vote(message))
+        EXPECT_CALL(*notifications, onState(std::vector<VoteMessage>{message}))
             .Times(1)
             .WillRepeatedly(
                 InvokeWithoutArgs(&cv, &std::condition_variable::notify_one));

--- a/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
@@ -18,8 +18,8 @@
 #include <gtest/gtest.h>
 #include <boost/optional.hpp>
 
-#include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "consensus/yac/storage/yac_block_storage.hpp"
+#include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "consensus/yac/storage/yac_vote_storage.hpp"
 #include "logger/logger.hpp"
 #include "module/irohad/consensus/yac/yac_mocks.hpp"
@@ -31,7 +31,7 @@ static logger::Logger log_ = logger::testLog("YacBlockStorage");
 class YacBlockStorageTest : public ::testing::Test {
  public:
   YacHash hash;
-  uint64_t number_of_peers;
+  PeersNumberType number_of_peers;
   YacBlockStorage storage = YacBlockStorage(YacHash("proposal", "commit"), 4);
   std::vector<VoteMessage> valid_votes;
 

--- a/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
@@ -51,7 +51,7 @@ namespace iroha {
 
         auto vote = crypto_provider->getVote(hash);
 
-        ASSERT_TRUE(crypto_provider->verify(vote));
+        ASSERT_TRUE(crypto_provider->verify({vote}));
       }
 
       TEST_F(YacCryptoProviderTest, InvalidWhenMessageChanged) {
@@ -67,7 +67,7 @@ namespace iroha {
 
         vote.hash.block_hash = "hash changed";
 
-        ASSERT_FALSE(crypto_provider->verify(vote));
+        ASSERT_FALSE(crypto_provider->verify({vote}));
       }
 
     }  // namespace yac

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -64,7 +64,7 @@ class YacGateTest : public ::testing::Test {
     message.hash = expected_hash;
     message.signature = clone(signature);
     commit_message = CommitMessage({message});
-    expected_commit = rxcpp::observable<>::just(commit_message);
+    expected_commit = rxcpp::observable<>::just(Answer(commit_message));
 
     hash_gate = make_unique<MockHashGate>();
     peer_orderer = make_unique<MockYacPeerOrderer>();
@@ -86,7 +86,7 @@ class YacGateTest : public ::testing::Test {
   std::shared_ptr<shared_model::interface::Block> expected_block;
   VoteMessage message;
   CommitMessage commit_message;
-  rxcpp::observable<CommitMessage> expected_commit;
+  rxcpp::observable<Answer> expected_commit;
 
   unique_ptr<MockHashGate> hash_gate;
   unique_ptr<MockYacPeerOrderer> peer_orderer;
@@ -109,7 +109,7 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(expected_hash, _)).Times(1);
 
-  EXPECT_CALL(*hash_gate, on_commit()).WillOnce(Return(expected_commit));
+  EXPECT_CALL(*hash_gate, onOutcome()).WillOnce(Return(expected_commit));
 
   // generate order of peers
   EXPECT_CALL(*peer_orderer, getOrdering(_))
@@ -139,7 +139,7 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(_, _)).Times(0);
 
-  EXPECT_CALL(*hash_gate, on_commit()).Times(0);
+  EXPECT_CALL(*hash_gate, onOutcome()).Times(0);
 
   // generate order of peers
   EXPECT_CALL(*peer_orderer, getOrdering(_)).WillOnce(Return(boost::none));
@@ -176,10 +176,10 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommit) {
   message.hash = expected_hash;
 
   commit_message = CommitMessage({message});
-  expected_commit = rxcpp::observable<>::just(commit_message);
+  expected_commit = rxcpp::observable<>::just(Answer(commit_message));
 
   // yac consensus
-  EXPECT_CALL(*hash_gate, on_commit()).WillOnce(Return(expected_commit));
+  EXPECT_CALL(*hash_gate, onOutcome()).WillOnce(Return(expected_commit));
 
   // convert yac hash to model hash
   EXPECT_CALL(*hash_provider, toModelHash(expected_hash))
@@ -229,10 +229,10 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommitFailFirst) {
   message.hash = expected_hash;
 
   commit_message = CommitMessage({message});
-  expected_commit = rxcpp::observable<>::just(commit_message);
+  expected_commit = rxcpp::observable<>::just(Answer(commit_message));
 
   // yac consensus
-  EXPECT_CALL(*hash_gate, on_commit()).WillOnce(Return(expected_commit));
+  EXPECT_CALL(*hash_gate, onOutcome()).WillOnce(Return(expected_commit));
 
   // convert yac hash to model hash
   EXPECT_CALL(*hash_provider, toModelHash(expected_hash))

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -218,7 +218,7 @@ namespace iroha {
                      &signatures,
                  const std::vector<
                      std::shared_ptr<shared_model::interface::Peer>> &peers));
-        MOCK_CONST_METHOD2(checkSize, bool(uint64_t current, uint64_t all));
+        MOCK_CONST_METHOD2(checkSize, bool(PeersNumberType, PeersNumberType));
         MOCK_CONST_METHOD2(
             peersSubset,
             bool(const shared_model::interface::types::SignatureRangeType
@@ -226,7 +226,7 @@ namespace iroha {
                  const std::vector<
                      std::shared_ptr<shared_model::interface::Peer>> &peers));
         MOCK_CONST_METHOD3(
-            hasReject, bool(uint64_t frequent, uint64_t voted, uint64_t all));
+            hasReject, bool(PeersNumberType, PeersNumberType, PeersNumberType));
       };
 
       class YacTest : public ::testing::Test {

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -78,9 +78,7 @@ namespace iroha {
 
       class MockYacCryptoProvider : public YacCryptoProvider {
        public:
-        MOCK_METHOD1(verify, bool(CommitMessage));
-        MOCK_METHOD1(verify, bool(RejectMessage));
-        MOCK_METHOD1(verify, bool(VoteMessage));
+        MOCK_METHOD1(verify, bool(std::vector<VoteMessage>));
 
         VoteMessage getVote(YacHash hash) override {
           VoteMessage vote;

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -161,7 +161,7 @@ namespace iroha {
        public:
         MOCK_METHOD2(vote, void(YacHash, ClusterOrdering));
 
-        MOCK_METHOD0(on_commit, rxcpp::observable<CommitMessage>());
+        MOCK_METHOD0(onOutcome, rxcpp::observable<Answer>());
 
         MockHashGate() = default;
 

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -124,14 +124,9 @@ namespace iroha {
           notification.reset();
         }
 
-        MOCK_METHOD2(send_commit,
+        MOCK_METHOD2(sendState,
                      void(const shared_model::interface::Peer &,
-                          const CommitMessage &));
-        MOCK_METHOD2(send_reject,
-                     void(const shared_model::interface::Peer &,
-                          RejectMessage));
-        MOCK_METHOD2(send_vote,
-                     void(const shared_model::interface::Peer &, VoteMessage));
+                          const std::vector<VoteMessage> &));
 
         MockYacNetwork() = default;
 

--- a/test/module/irohad/consensus/yac/yac_mocks.hpp
+++ b/test/module/irohad/consensus/yac/yac_mocks.hpp
@@ -212,9 +212,7 @@ namespace iroha {
 
       class MockYacNetworkNotifications : public YacNetworkNotifications {
        public:
-        MOCK_METHOD1(on_commit, void(CommitMessage));
-        MOCK_METHOD1(on_reject, void(RejectMessage));
-        MOCK_METHOD1(on_vote, void(VoteMessage));
+        MOCK_METHOD1(onState, void(std::vector<VoteMessage>));
       };
 
       class MockSupermajorityChecker : public SupermajorityChecker {

--- a/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
@@ -29,7 +29,7 @@ static logger::Logger log_ = logger::testLog("YacProposalStorage");
 class YacProposalStorageTest : public ::testing::Test {
  public:
   YacHash hash;
-  uint64_t number_of_peers;
+  PeersNumberType number_of_peers;
   YacProposalStorage storage = YacProposalStorage("proposal", 4);
   std::vector<VoteMessage> valid_votes;
 

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -49,9 +49,7 @@ TEST_F(YacTest, InvalidCaseWhenNotReceiveSupermajority) {
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   YacHash hash1("proposal_hash", "block_hash");
   YacHash hash2("proposal_hash", "block_hash2");
@@ -85,10 +83,7 @@ TEST_F(YacTest, InvalidCaseWhenDoesNotVerify) {
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>()))
-      .WillRepeatedly(Return(false));
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(false));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(false));
 
   YacHash hash1("proposal_hash", "block_hash");
   YacHash hash2("proposal_hash", "block_hash2");
@@ -129,9 +124,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
 
   EXPECT_CALL(*timer, deny()).Times(1);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).WillOnce(Return(true));
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   YacHash hash1("proposal_hash", "block_hash");
   YacHash hash2("proposal_hash", "block_hash2");

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -43,9 +43,7 @@ TEST_F(YacTest, InvalidCaseWhenNotReceiveSupermajority) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(my_peers.size());
-  EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
+  EXPECT_CALL(*network, sendState(_, _)).Times(2 * my_peers.size());
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
@@ -79,7 +77,7 @@ TEST_F(YacTest, InvalidCaseWhenDoesNotVerify) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
+  EXPECT_CALL(*network, sendState(_, _)).Times(0);
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
@@ -115,12 +113,10 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _))
+  EXPECT_CALL(*network, sendState(_, _))
       .Times(my_peers.size() + 1);  // $(peers.size()) sendings done during
                                     // multicast + 1 for single peer, who votes
                                     // after reject happened
-  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
 
   EXPECT_CALL(*timer, deny()).Times(1);
 

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -56,10 +56,10 @@ TEST_F(YacTest, InvalidCaseWhenNotReceiveSupermajority) {
   yac->vote(hash1, my_order.value());
 
   for (auto i = 0; i < 2; ++i) {
-    yac->on_vote(create_vote(hash1, std::to_string(i)));
+    yac->onState({create_vote(hash1, std::to_string(i))});
   };
   for (auto i = 2; i < 4; ++i) {
-    yac->on_vote(create_vote(hash2, std::to_string(i)));
+    yac->onState({create_vote(hash2, std::to_string(i))});
   };
 }
 
@@ -89,10 +89,10 @@ TEST_F(YacTest, InvalidCaseWhenDoesNotVerify) {
   YacHash hash2("proposal_hash", "block_hash2");
 
   for (auto i = 0; i < 2; ++i) {
-    yac->on_vote(create_vote(hash1, std::to_string(i)));
+    yac->onState({create_vote(hash1, std::to_string(i))});
   };
   for (auto i = 2; i < 4; ++i) {
-    yac->on_vote(create_vote(hash2, std::to_string(i)));
+    yac->onState({create_vote(hash2, std::to_string(i))});
   };
 }
 
@@ -142,11 +142,11 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
   };
 
   for (const auto &vote : votes) {
-    yac->on_vote(vote);
+    yac->onState({vote});
   }
 
-  yac->on_reject(RejectMessage(votes));
+  yac->onState(votes);
   auto peer = my_order->getPeers().back();
   auto pubkey = shared_model::crypto::toBinaryString(peer->pubkey());
-  yac->on_vote(create_vote(hash1, pubkey));
+  yac->onState({create_vote(hash1, pubkey)});
 }

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -69,11 +69,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveOneVote) {
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
   EXPECT_CALL(*network, send_vote(_, _)).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
 
   YacHash received_hash("my_proposal", "my_block");
   auto peer = default_peers.at(0);
@@ -100,9 +96,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveSupermajorityOfVotes) {
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
   EXPECT_CALL(*network, send_vote(_, _)).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
+  EXPECT_CALL(*crypto, verify(_))
       .Times(default_peers.size())
       .WillRepeatedly(Return(true));
 
@@ -134,9 +128,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveCommitMessage) {
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
   EXPECT_CALL(*network, send_vote(_, _)).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).WillOnce(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).Times(0);
+  EXPECT_CALL(*crypto, verify(_)).WillOnce(Return(true));
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
@@ -156,7 +148,7 @@ TEST_F(YacTest, YacWhenColdStartAndAchieveCommitMessage) {
  * @then commit is sent to the network before notifying subscribers
  */
 TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyVote) {
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
+  EXPECT_CALL(*crypto, verify(_))
       .Times(default_peers.size())
       .WillRepeatedly(Return(true));
   std::vector<CommitMessage> messages;
@@ -186,9 +178,7 @@ TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyVote) {
  * @then commit is sent to the network before notifying subscribers
  */
 TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyReject) {
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).WillOnce(Return(true));
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).WillOnce(Return(true));
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
   std::vector<CommitMessage> messages;
   EXPECT_CALL(*network, send_commit(_, _))

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -49,9 +49,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   YacHash my_hash("proposal_hash", "block_hash");
   yac->vote(my_hash, my_order.value());
@@ -85,10 +83,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .WillRepeatedly(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   yac->vote(my_hash, my_order.value());
 
@@ -131,10 +126,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
   EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .WillRepeatedly(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
   yac->vote(my_hash, my_order.value());
 
@@ -170,13 +162,7 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).Times(2).WillRepeatedly(Return(true));
 
   YacHash my_hash("proposal_hash", "block_hash");
 
@@ -214,11 +200,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).Times(0);
+  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
 
   YacHash my_hash("proposal_hash", "block_hash");
 

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -43,9 +43,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
+  EXPECT_CALL(*network, sendState(_, _)).Times(2 * my_peers.size());
 
   EXPECT_CALL(*timer, deny()).Times(0);
 
@@ -77,9 +75,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
     ASSERT_EQ(my_hash, boost::get<CommitMessage>(val).votes.at(0).hash);
   });
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
+  EXPECT_CALL(*network, sendState(_, _)).Times(my_peers.size());
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
@@ -122,9 +118,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
     ASSERT_EQ(my_hash, boost::get<CommitMessage>(val).votes.at(0).hash);
   });
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
+  EXPECT_CALL(*network, sendState(_, _)).Times(my_peers.size());
 
   EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
@@ -156,9 +150,7 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(my_peers.size());
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(my_peers.size());
+  EXPECT_CALL(*network, sendState(_, _)).Times(2 * my_peers.size());
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
@@ -194,9 +186,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
+  EXPECT_CALL(*network, sendState(_, _)).Times(0);
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -101,6 +101,14 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   ASSERT_TRUE(wrapper.validate());
 }
 
+/**
+ * @given initialized YAC with empty state
+ * @when vote for hash
+ * AND receive commit for voted hash
+ * AND receive second commit for voted hash
+ * @then commit is emitted once
+ * AND timer is denied once
+ */
 TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   auto my_peers = decltype(default_peers)(
       {default_peers.begin(), default_peers.begin() + 4});
@@ -109,7 +117,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   auto my_order = ClusterOrdering::create(my_peers);
   ASSERT_TRUE(my_order);
 
-  EXPECT_CALL(*timer, deny()).Times(2);
+  EXPECT_CALL(*timer, deny()).Times(1);
 
   initYac(my_order.value());
 

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -74,9 +74,10 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   initYac(my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
-  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
-  wrapper.subscribe(
-      [my_hash](auto val) { ASSERT_EQ(my_hash, val.votes.at(0).hash); });
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
+  wrapper.subscribe([my_hash](auto val) {
+    ASSERT_EQ(my_hash, boost::get<CommitMessage>(val).votes.at(0).hash);
+  });
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -113,9 +114,10 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   initYac(my_order.value());
 
   YacHash my_hash("proposal_hash", "block_hash");
-  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
-  wrapper.subscribe(
-      [my_hash](auto val) { ASSERT_EQ(my_hash, val.votes.at(0).hash); });
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
+  wrapper.subscribe([my_hash](auto val) {
+    ASSERT_EQ(my_hash, boost::get<CommitMessage>(val).votes.at(0).hash);
+  });
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
@@ -170,9 +172,10 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
 
   YacHash my_hash("proposal_hash", "block_hash");
 
-  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 1);
-  wrapper.subscribe(
-      [my_hash](auto val) { ASSERT_EQ(my_hash, val.votes.at(0).hash); });
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
+  wrapper.subscribe([my_hash](auto val) {
+    ASSERT_EQ(my_hash, boost::get<CommitMessage>(val).votes.at(0).hash);
+  });
 
   yac->vote(my_hash, my_order.value());
 

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -57,7 +57,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
   for (auto i = 0; i < 3; ++i) {
     auto peer = my_peers.at(i);
     auto pubkey = shared_model::crypto::toBinaryString(peer->pubkey());
-    yac->on_vote(create_vote(my_hash, pubkey));
+    yac->onState({create_vote(my_hash, pubkey)});
   };
 }
 
@@ -92,7 +92,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommit) {
   for (auto i = 0; i < 4; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(CommitMessage(votes));
+  yac->onState(votes);
   ASSERT_TRUE(wrapper.validate());
 }
 
@@ -136,13 +136,13 @@ TEST_F(YacTest, ValidCaseWhenReceiveCommitTwice) {
   for (auto i = 0; i < 3; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(CommitMessage(votes));
+  yac->onState(votes);
 
   // second commit
   for (auto i = 1; i < 4; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(CommitMessage(votes));
+  yac->onState(votes);
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -175,11 +175,11 @@ TEST_F(YacTest, ValidCaseWhenSoloConsensus) {
 
   auto vote_message = create_vote(my_hash, std::to_string(0));
 
-  yac->on_vote(vote_message);
+  yac->onState({vote_message});
 
   auto commit_message = CommitMessage({vote_message});
 
-  yac->on_commit(commit_message);
+  yac->onState(commit_message.votes);
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -209,7 +209,7 @@ TEST_F(YacTest, ValidCaseWhenVoteAfterCommit) {
   for (auto i = 0; i < 3; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(CommitMessage(votes));
+  yac->onState(votes);
 
   yac->vote(my_hash, my_order.value());
 }

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -50,7 +50,7 @@ TEST_F(YacTest, UnknownVoteBeforeCommit) {
   vote.signature = createSig(unknown);
 
   // assume that our peer receive message
-  network->notification->on_vote(vote);
+  network->notification->onState({vote});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -86,11 +86,11 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
   for (auto i = 0; i < 3; ++i) {
     votes.push_back(create_vote(my_hash, std::to_string(i)));
   };
-  yac->on_commit(CommitMessage(votes));
+  yac->onState(votes);
 
   VoteMessage vote;
   vote.hash = my_hash;
   std::string unknown = "unknown";
   vote.signature = createSig(unknown);
-  yac->on_vote(vote);
+  yac->onState({vote});
 }

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -42,11 +42,7 @@ TEST_F(YacTest, UnknownVoteBeforeCommit) {
   EXPECT_CALL(*network, send_reject(_, _)).Times(0);
   EXPECT_CALL(*network, send_vote(_, _)).Times(0);
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>()))
-      .Times(1)
-      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
 
   VoteMessage vote;
   vote.hash = YacHash("my_proposal", "my_block");
@@ -81,9 +77,7 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
-  EXPECT_CALL(*crypto, verify(An<CommitMessage>())).WillOnce(Return(true));
-  EXPECT_CALL(*crypto, verify(An<RejectMessage>())).Times(0);
-  EXPECT_CALL(*crypto, verify(An<VoteMessage>())).WillOnce(Return(true));
+  EXPECT_CALL(*crypto, verify(_)).Times(2).WillRepeatedly(Return(true));
 
   YacHash my_hash("proposal_hash", "block_hash");
 

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -35,7 +35,7 @@ using namespace std;
  */
 TEST_F(YacTest, UnknownVoteBeforeCommit) {
   // verify that commit not emitted
-  auto wrapper = make_test_subscriber<CallExact>(yac->on_commit(), 0);
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 0);
   wrapper.subscribe();
 
   EXPECT_CALL(*network, send_commit(_, _)).Times(0);

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -38,9 +38,7 @@ TEST_F(YacTest, UnknownVoteBeforeCommit) {
   auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 0);
   wrapper.subscribe();
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
+  EXPECT_CALL(*network, sendState(_, _)).Times(0);
 
   EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
 
@@ -71,9 +69,7 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
 
   initYac(my_order.value());
 
-  EXPECT_CALL(*network, send_commit(_, _)).Times(0);
-  EXPECT_CALL(*network, send_reject(_, _)).Times(0);
-  EXPECT_CALL(*network, send_vote(_, _)).Times(0);
+  EXPECT_CALL(*network, sendState(_, _)).Times(0);
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Change YAC transport and interfaces:
 - Transport Commit and Reject messages replaced with State message
 - Single endpoint used to send state
 - Single methods to process state instead of 3 methods for vote, commit, and reject in YAC related classes
 - YAC interface returns outcome -- commit or reject, so it can be appropriately handled by consensus users
 - Commit/reject is passed to YAC subscribers only after receiving an appropriate message instead of a single vote [IR-1401](https://soramitsu.atlassian.net/browse/IR-1401)
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
 - Unified network interface which can be used by multiple propagation strategies like multicast or gossip
 - Simplified logic in transport, storage, crypto verifier, message handlers
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
 - More complex logic in YAC message handler -- probably it is possible to move it to separate class
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Note to reviewers
Since the pull request affects ~22~34 files, it may be difficult to review as a single change/pull request.
Each commit in this branch passes the tests, so it can be safely separated into multiple pull requests by request of reviewers.
Also you can consider reviewing separate commits, as they localize the changes to different entities, such as network notifications, crypto provider, storage, and YAC itself.
