### PR TITLE
Fix bugs related to SetAccountDetail

### DIFF
--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -629,7 +629,10 @@ namespace iroha {
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     return
         // Case 1. Creator set details for his account
-        creator_account_id == command.accountId() or
+        creator_account_id == command.accountId()
+        or checkAccountRolePermission(
+               creator_account_id, queries, Role::kSetDetail)
+        or
         // Case 2. Creator has grantable permission to set account key/value
         queries.hasAccountGrantablePermission(
             creator_account_id,

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -75,3 +75,7 @@ addtest(tx_heavy_data tx_heavy_data.cpp)
 target_link_libraries(tx_heavy_data
     acceptance_fixture
     )
+
+addtest(set_account_detail_test set_account_detail_test.cpp)
+target_link_libraries(set_account_detail_test
+    acceptance_fixture)

--- a/test/integration/acceptance/set_account_detail_test.cpp
+++ b/test/integration/acceptance/set_account_detail_test.cpp
@@ -1,0 +1,156 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "builders/protobuf/block.hpp"
+#include "builders/protobuf/transaction.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "validators/permissions.hpp"
+
+using namespace integration_framework;
+using namespace shared_model;
+
+class SetAccountDetail : public AcceptanceFixture {
+ public:
+  auto makeUserWithPerms(const std::vector<std::string> &perms = {
+                             permissions::can_add_peer}) {
+    return AcceptanceFixture::makeUserWithPerms(perms);
+  }
+
+  auto baseTx(const interface::types::AccountIdType &account_id,
+              const interface::types::AccountDetailKeyType &key,
+              const interface::types::AccountDetailValueType &value) {
+    return AcceptanceFixture::baseTx().setAccountDetail(account_id, key, value);
+  }
+
+  auto baseTx(const interface::types::AccountIdType &account_id) {
+    return baseTx(account_id, kKey, kValue);
+  }
+
+  auto makeSecondUser(const std::vector<std::string> &perms = {
+                          permissions::can_add_peer}) {
+    static const std::string kRole2 = "roletwo";
+    return AcceptanceFixture::createUserWithPerms(
+               kUser2, kUser2Keypair.publicKey(), kRole2, perms)
+        .build()
+        .signAndAddSignature(kAdminKeypair)
+        .finish();
+  }
+
+  const interface::types::AccountDetailKeyType kKey = "key";
+  const interface::types::AccountDetailValueType kValue = "value";
+  const std::string kUser2 = "user2";
+  const std::string kUser2Id =
+      kUser2 + "@" + IntegrationTestFramework::kDefaultDomain;
+  const crypto::Keypair kUser2Keypair =
+      crypto::DefaultCryptoAlgorithmType::generateKeypair();
+};
+
+/**
+ * @given a user without can_set_detail permission
+ * @when execute tx with SetAccountDetail command aimed to the user
+ * @then there is the tx in proposal
+ */
+TEST_F(SetAccountDetail, Self) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(complete(baseTx(kUserId)))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
+ * @given a pair of users and first one without permissions
+ * @when the first one tries to use SetAccountDetail on the second
+ * @then there is the tx in proposal
+ */
+TEST_F(SetAccountDetail, WithoutNoPerm) {
+  auto second_user_tx = makeSecondUser();
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(second_user_tx)
+      .skipProposal()
+      .checkBlock([](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1)
+            << "Cannot create second user account";
+      })
+      .sendTx(complete(baseTx(kUser2Id)))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .done();
+}
+
+/**
+ * @given a pair of users and first one with can_set_detail perm
+ * @when the first one tries to use SetAccountDetail on the second
+ * @then there is the tx in proposal
+ */
+TEST_F(SetAccountDetail, WithPerm) {
+  auto second_user_tx = makeSecondUser();
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms({permissions::can_set_detail}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(second_user_tx)
+      .skipProposal()
+      .checkBlock([](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1)
+            << "Cannot create second user account";
+      })
+      .sendTx(complete(baseTx(kUser2Id)))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
+ * @given a pair of users
+ *        AND second has been granted can_set_my_detail from the first
+ * @when the first one tries to use SetAccountDetail on the second
+ * @then there is no tx in proposal
+ */
+TEST_F(SetAccountDetail, DISABLED_WithGrantablePerm) {
+  auto second_user_tx = makeSecondUser();
+  auto set_detail_cmd = baseTx(kUserId)
+                            .creatorAccountId(kUser2Id)
+                            .build()
+                            .signAndAddSignature(kUser2Keypair)
+                            .finish();
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {permissions::can_grant + permissions::can_set_my_account_detail}))
+      .skipProposal()
+      .skipBlock()
+      .sendTx(second_user_tx)
+      .skipProposal()
+      .checkBlock([](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1)
+            << "Cannot create second user account";
+      })
+      .sendTx(complete(AcceptanceFixture::baseTx().grantPermission(
+          kUser2Id, shared_model::permissions::can_set_my_account_detail)))
+      .skipProposal()
+      .checkBlock([](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1) << "Cannot grant permission";
+      })
+      .sendTx(set_detail_cmd)
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -2128,7 +2128,7 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
     // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
     command = buildCommand(
         TestTransactionBuilder().setAccountDetail(kAdminId, kKey, kValue));
-    set_aacount_detail =
+    set_account_detail =
         getConcreteCommand<shared_model::interface::SetAccountDetail>(command);
 
     role_permissions = {toString(Role::kSetDetail)};
@@ -2138,7 +2138,7 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
   const std::string kValue = "val";
   const std::string kNeededPermission = toString(Role::kSetMyAccountDetail);
 
-  std::shared_ptr<shared_model::interface::SetAccountDetail> set_aacount_detail;
+  std::shared_ptr<shared_model::interface::SetAccountDetail> set_account_detail;
 };
 
 /**
@@ -2148,10 +2148,10 @@ class SetAccountDetailTest : public CommandValidateExecuteTest {
  */
 TEST_F(SetAccountDetailTest, ValidWhenSetOwnAccount) {
   EXPECT_CALL(*wsv_command,
-              setAccountKV(set_aacount_detail->accountId(),
+              setAccountKV(set_account_detail->accountId(),
                            creator->accountId(),
-                           set_aacount_detail->key(),
-                           set_aacount_detail->value()))
+                           set_account_detail->key(),
+                           set_account_detail->value()))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -2165,14 +2165,14 @@ TEST_F(SetAccountDetailTest, InvalidWhenOtherCreator) {
   // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
   command = buildCommand(
       TestTransactionBuilder().setAccountDetail(kAccountId, kKey, kValue));
-  set_aacount_detail =
+  set_account_detail =
       getConcreteCommand<shared_model::interface::SetAccountDetail>(command);
 
   EXPECT_CALL(*wsv_query, getAccountRoles(kAdminId))
       .WillOnce(Return(std::vector<std::string>{}));
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  kAdminId, set_aacount_detail->accountId(), kNeededPermission))
+                  kAdminId, set_account_detail->accountId(), kNeededPermission))
       .WillOnce(Return(false));
   ASSERT_TRUE(err(validateAndExecute(command)));
 }
@@ -2186,7 +2186,7 @@ TEST_F(SetAccountDetailTest, ValidWhenHasRolePermission) {
   // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
   command = buildCommand(
       TestTransactionBuilder().setAccountDetail(kAccountId, kKey, kValue));
-  set_aacount_detail =
+  set_account_detail =
       getConcreteCommand<shared_model::interface::SetAccountDetail>(command);
 
   EXPECT_CALL(*wsv_query, getAccountRoles(kAdminId))
@@ -2195,10 +2195,10 @@ TEST_F(SetAccountDetailTest, ValidWhenHasRolePermission) {
       .WillOnce(Return(role_permissions));
 
   EXPECT_CALL(*wsv_command,
-              setAccountKV(set_aacount_detail->accountId(),
+              setAccountKV(set_account_detail->accountId(),
                            creator->accountId(),
-                           set_aacount_detail->key(),
-                           set_aacount_detail->value()))
+                           set_account_detail->key(),
+                           set_account_detail->value()))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -2212,20 +2212,20 @@ TEST_F(SetAccountDetailTest, ValidWhenHasGrantblePermission) {
   // TODO 2018-04-20 Alexey Chernyshov - IR-1276 - rework with CommandBuilder
   command = buildCommand(
       TestTransactionBuilder().setAccountDetail(kAccountId, kKey, kValue));
-  set_aacount_detail =
+  set_account_detail =
       getConcreteCommand<shared_model::interface::SetAccountDetail>(command);
 
   EXPECT_CALL(*wsv_query, getAccountRoles(kAdminId))
       .WillOnce(Return(std::vector<std::string>{}));
   EXPECT_CALL(*wsv_query,
               hasAccountGrantablePermission(
-                  kAdminId, set_aacount_detail->accountId(), kNeededPermission))
+                  kAdminId, set_account_detail->accountId(), kNeededPermission))
       .WillOnce(Return(true));
   EXPECT_CALL(*wsv_command,
-              setAccountKV(set_aacount_detail->accountId(),
+              setAccountKV(set_account_detail->accountId(),
                            creator->accountId(),
-                           set_aacount_detail->key(),
-                           set_aacount_detail->value()))
+                           set_account_detail->key(),
+                           set_account_detail->value()))
       .WillOnce(Return(WsvCommandResult()));
   ASSERT_TRUE(val(validateAndExecute(command)));
 }
@@ -2237,10 +2237,10 @@ TEST_F(SetAccountDetailTest, ValidWhenHasGrantblePermission) {
  */
 TEST_F(SetAccountDetailTest, InvalidWhenSetAccountKVFails) {
   EXPECT_CALL(*wsv_command,
-              setAccountKV(set_aacount_detail->accountId(),
+              setAccountKV(set_account_detail->accountId(),
                            creator->accountId(),
-                           set_aacount_detail->key(),
-                           set_aacount_detail->value()))
+                           set_account_detail->key(),
+                           set_account_detail->value()))
       .WillOnce(Return(makeEmptyError()));
   ASSERT_TRUE(err(execute(command)));
 }


### PR DESCRIPTION
### Description of the Change

Makes a required fixes so that following tests accepted:
- SetAccountDetail on itself can be set w/o any perm

### Benefits

Less bugs, more coverage

### Possible Drawbacks 

None
