### PR TITLE
Fix variable forward for variadic in Windows build

### DIFF
--- a/shared_model/interfaces/iroha_internal/block_variant.cpp
+++ b/shared_model/interfaces/iroha_internal/block_variant.cpp
@@ -14,7 +14,7 @@ namespace shared_model {
     decltype(auto) invoke(const BlockVariant *var, Func &&f, Args &&... args) {
       return iroha::visit_in_place(
           *var, [&](const auto &any_block) -> decltype(auto) {
-            return ((*any_block.*f)(std::forward<Args>(args)...));
+            return ((*any_block.*f)(std::forward<decltype(args)>(args)...));
           });
     }
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Windows build fails due to "`Args` are not unpacked" error, but it works with `decltype(args)`, which serves the same purpose.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Successful Windows build
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Note
Build of python bindings fails due to CI update, so there is an error displayed. The code itself builds fine.