### PR TITLE
[fix] Clang warnings

### DIFF
--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
@@ -12,12 +12,12 @@ namespace shared_model {
     TransactionsResponse::TransactionsResponse(
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
+          transactionResponse_{proto_->transactions_response()},
           transactions_{[this] {
             return std::vector<proto::Transaction>(
                 transactionResponse_.transactions().begin(),
                 transactionResponse_.transactions().end());
-          }},
-          transactionResponse_{proto_->transactions_response()} {}
+          }} {}
 
     template TransactionsResponse::TransactionsResponse(
         TransactionsResponse::TransportType &);


### PR DESCRIPTION
### Description of the Change

After [this](https://github.com/hyperledger/iroha/pull/1424) pull request Clang started [complaining](https://gist.githubusercontent.com/igor-egorov/6e109625916850b64063ac62dc3fba08/raw/de29ad4a661e01a5acab5ece97973c6e26e31128/cmake-iorhad.log) about wrong order of initialisations of fields of Proto Transaction Response, because one of them is dependent on the other, so order of initialisation was changed to eliminate the warning

### Benefits

Clang stopped complaining

### Possible Drawbacks 

None