### PR TITLE
Fix query_test RC

### DIFF
--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -82,6 +82,7 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::Query> qry) {
       if (not checkSignatories(*qry)) {
         auto response = buildStatefulError(qry->hash());
+        std::lock_guard<std::mutex> lock(notifier_mutex_);
         subject_.get_subscriber().on_next(response);
         return;
       }

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -63,12 +63,14 @@ TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
     });
   };
 
-  IntegrationTestFramework itf(2);
+  IntegrationTestFramework itf(1);
   itf.setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendTx(dummy_tx)
       .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); });
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
 
   const auto num_queries = 5;
   const auto hash = dummy_tx.hash();

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -53,7 +53,7 @@ class QueryAcceptanceTest : public AcceptanceFixture {
  */
 TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
   auto dummy_tx = dummyTx();
-  auto check = [&dummy_tx](auto &status) {
+  auto check = [dummy_tx = dummy_tx](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp = boost::apply_visitor(
           framework::SpecifiedVisitor<interface::TransactionsResponse>(),
@@ -71,10 +71,11 @@ TEST_F(QueryAcceptanceTest, ParallelBlockQuery) {
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 2); });
 
   const auto num_queries = 5;
+  const auto hash = dummy_tx.hash();
 
   auto send_query = [&] {
     for (int i = 0; i < num_queries; ++i) {
-      itf.sendQuery(makeQuery(dummy_tx.hash()), check);
+      itf.sendQuery(makeQuery(hash), check);
     }
   };
 


### PR DESCRIPTION
### Description of the Change

Fix query_test nasty bug.

- query_processor_impl doesn't have proper mutex lock for its observable
- using `dummy_tx` by ref occasionally causes heap overflow, so capture by value
- (optional) hash can be retrieved once

### Benefits

Make CI Green Again

### Possible Drawbacks 

Quite slower due to copying (~100ms for me, so not really a big problem)

### Usage Examples or Tests

`make query_test && test_bin/query_test`
