### PR TITLE
Add crypto related sizes consts

### DIFF
--- a/shared_model/bindings/model_crypto.cpp
+++ b/shared_model/bindings/model_crypto.cpp
@@ -17,7 +17,7 @@
 
 #include "bindings/model_crypto.hpp"
 #include "common/byteutils.hpp"
-#include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "generator/generator.hpp"
 
 namespace shared_model {
@@ -28,8 +28,8 @@ namespace shared_model {
 
     crypto::Keypair ModelCrypto::fromPrivateKey(
         const std::string &private_key) {
-      // TODO 07/06/18 Akvinikym: remove magic number (64) IR-977
-      if (private_key.size() != 64) {
+      if (private_key.size()
+          != crypto::DefaultCryptoAlgorithmType::kPrivateKeyLength) {
         throw std::invalid_argument("input string has incorrect length "
                                     + std::to_string(private_key.length()));
       }

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
@@ -48,10 +48,16 @@ namespace shared_model {
     }
 
     Keypair CryptoProviderEd25519Sha3::generateKeypair(const Seed &seed) {
-      auto keypair =
-          iroha::create_keypair(iroha::blob_t<32>::from_string(toBinaryString(seed)));
+      auto keypair = iroha::create_keypair(
+          iroha::blob_t<32>::from_string(toBinaryString(seed)));
       return Keypair(PublicKey(keypair.pubkey.to_string()),
                      PrivateKey(keypair.privkey.to_string()));
     }
+
+    const size_t CryptoProviderEd25519Sha3::kHashLength = 256 / 8;
+    const size_t CryptoProviderEd25519Sha3::kPublicKeyLength = 256 / 8;
+    const size_t CryptoProviderEd25519Sha3::kPrivateKeyLength = 512 / 8;
+    const size_t CryptoProviderEd25519Sha3::kSignatureLength = 512 / 8;
+    const size_t CryptoProviderEd25519Sha3::kSeedLength = 256 / 8;
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
@@ -72,6 +72,12 @@ namespace shared_model {
        * @return generated keypair
        */
       static Keypair generateKeypair(const Seed &seed);
+
+      static const size_t kHashLength;
+      static const size_t kPublicKeyLength;
+      static const size_t kPrivateKeyLength;
+      static const size_t kSignatureLength;
+      static const size_t kSeedLength;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -20,9 +20,7 @@
 #include <boost/algorithm/string_regex.hpp>
 #include <boost/format.hpp>
 #include <limits>
-
-#include "interfaces/queries/query_payload_meta.hpp"
-
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/crypto_provider/crypto_verifier.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
 #include "validators/field_validator.hpp"
@@ -52,7 +50,10 @@ namespace shared_model {
         R"([A-Za-z0-9_]{1,64})";
     const std::string FieldValidator::role_id_pattern_ = R"#([a-z_0-9]{1,32})#";
 
-    const size_t FieldValidator::public_key_size = 32;
+    const size_t FieldValidator::public_key_size =
+        crypto::DefaultCryptoAlgorithmType::kPublicKeyLength;
+    const size_t FieldValidator::signature_size =
+        crypto::DefaultCryptoAlgorithmType::kSignatureLength;
     /// limit for the set account detail size in bytes
     const size_t FieldValidator::value_size = 4 * 1024 * 1024;
     const size_t FieldValidator::description_size = 64;
@@ -328,15 +329,13 @@ namespace shared_model {
         const auto &pkey = signature.publicKey();
         bool is_valid = true;
 
-        if (sign.blob().size() != 64) {
-          // TODO (@l4l) 03/02/18: IR-977 replace signature size with a const
+        if (sign.blob().size() != signature_size) {
           reason.second.push_back(
               (boost::format("Invalid signature: %s") % sign.hex()).str());
           is_valid = false;
         }
 
-        if (pkey.blob().size() != 32) {
-          // TODO (@l4l) 03/02/18: IR-977 replace public key size with a const
+        if (pkey.blob().size() != public_key_size) {
           reason.second.push_back(
               (boost::format("Invalid pubkey: %s") % pkey.hex()).str());
           is_valid = false;

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -24,8 +24,8 @@
 #include "interfaces/base/signable.hpp"
 #include "interfaces/commands/command.hpp"
 #include "interfaces/permissions.hpp"
-#include "interfaces/transaction.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
+#include "interfaces/transaction.hpp"
 #include "validators/answer.hpp"
 
 namespace shared_model {
@@ -143,8 +143,9 @@ namespace shared_model {
           const interface::types::SignatureRangeType &signatures,
           const crypto::Blob &source) const;
 
-      void validateQueryPayloadMeta(ReasonsGroupType &reason,
-                              const interface::QueryPayloadMeta &meta) const;
+      void validateQueryPayloadMeta(
+          ReasonsGroupType &reason,
+          const interface::QueryPayloadMeta &meta) const;
 
       void validateDescription(
           ReasonsGroupType &reason,
@@ -185,6 +186,7 @@ namespace shared_model {
 
       // size of key
       static const size_t public_key_size;
+      static const size_t signature_size;
       static const size_t value_size;
       static const size_t description_size;
     };

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -186,7 +186,9 @@ TEST_F(GetTransactions, NonexistentHash) {
       .sendTx(makeUserWithPerms())
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .sendQuery(makeQuery(crypto::Hash(std::string(32, '0'))), check)
+      .sendQuery(makeQuery(crypto::Hash(std::string(
+                     crypto::DefaultCryptoAlgorithmType::kHashLength, '0'))),
+                 check)
       .done();
 }
 

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -228,8 +228,11 @@ TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
           .build();
   auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
       shared_model::crypto::Blob(tx.payload()), kAdminKeypair);
-  tx.addSignature(signedBlob,
-                  shared_model::crypto::PublicKey(std::string(32, 'a')));
+  tx.addSignature(
+      signedBlob,
+      shared_model::crypto::PublicKey(std::string(
+          shared_model::crypto::DefaultCryptoAlgorithmType::kPublicKeyLength,
+          'a')));
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(tx, checkStatelessInvalid)

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -40,13 +40,8 @@ auto mk_local_peer(uint64_t num) {
 class FixedCryptoProvider : public MockYacCryptoProvider {
  public:
   explicit FixedCryptoProvider(const std::string &public_key) {
-    // TODO 15.04.2018 x3medima17 IR-1189: move to separate class
-    auto size =
-        shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()
-            .publicKey()
-            .size();
-    // TODO 16.04.2018 x3medima17 IR-977: add sizes
-    std::string key(size, 0);
+    std::string key(
+        shared_model::crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, 0);
     std::copy(public_key.begin(), public_key.end(), key.begin());
     pubkey = clone(shared_model::crypto::PublicKey(key));
   }

--- a/test/integration/transport/ordering_gate_service_test.cpp
+++ b/test/integration/transport/ordering_gate_service_test.cpp
@@ -101,11 +101,14 @@ class OrderingGateServiceTest : public ::testing::Test {
     ASSERT_TRUE(gate_server);
 
     // setup peer
-    peer = clone(shared_model::proto::PeerBuilder()
-                     .address(kAddress + ":" + std::to_string(gate_port))
-                     .pubkey(shared_model::interface::types::PubkeyType(
-                         std::string(32, '0')))
-                     .build());
+    peer = clone(
+        shared_model::proto::PeerBuilder()
+            .address(kAddress + ":" + std::to_string(gate_port))
+            .pubkey(shared_model::interface::types::PubkeyType(
+                std::string(shared_model::crypto::DefaultCryptoAlgorithmType::
+                                kPublicKeyLength,
+                            '0')))
+            .build());
   }
 
   void TearDown() override {

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -182,7 +182,8 @@ TEST_F(BlockQueryTest, GetTransactionsExistingTxHashes) {
  */
 TEST_F(BlockQueryTest, GetTransactionsIncludesNonExistingTxHashes) {
   shared_model::crypto::Hash invalid_tx_hash_1(zero_string),
-      invalid_tx_hash_2(std::string(32, '9'));
+      invalid_tx_hash_2(std::string(
+          shared_model::crypto::DefaultCryptoAlgorithmType::kHashLength, '9'));
   auto wrapper = make_test_subscriber<CallExact>(
       blocks->getTransactions({invalid_tx_hash_1, invalid_tx_hash_2}), 2);
   wrapper.subscribe(

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -182,9 +182,13 @@ class CommandValidateExecuteTest : public ::testing::Test {
   const std::string kMasterRole = "master";
   const std::vector<std::string> admin_roles = {kAdminRole};
   const shared_model::interface::types::PubkeyType kPubKey1 =
-      shared_model::interface::types::PubkeyType(std::string(32, '1'));
+      shared_model::interface::types::PubkeyType(std::string(
+          shared_model::crypto::DefaultCryptoAlgorithmType::kPublicKeyLength,
+          '1'));
   const shared_model::interface::types::PubkeyType kPubKey2 =
-      shared_model::interface::types::PubkeyType(std::string(32, '2'));
+      shared_model::interface::types::PubkeyType(std::string(
+          shared_model::crypto::DefaultCryptoAlgorithmType::kPublicKeyLength,
+          '2'));
 
   std::vector<std::string> role_permissions;
   std::shared_ptr<shared_model::interface::Account> creator, account;
@@ -1354,8 +1358,7 @@ TEST_F(TransferAssetTest, ValidWhenCreatorHasPermission) {
   EXPECT_CALL(*wsv_query, getAccountAsset(transfer_asset->destAccountId(), _))
       .WillOnce(Return(boost::none));
 
-  EXPECT_CALL(*wsv_query,
-              getAccountAsset(transfer_asset->srcAccountId(), _))
+  EXPECT_CALL(*wsv_query, getAccountAsset(transfer_asset->srcAccountId(), _))
       .Times(2)
       .WillRepeatedly(Return(src_wallet));
   EXPECT_CALL(*wsv_query, getAsset(transfer_asset->assetId()))

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -88,7 +88,9 @@ class BlockLoaderTest : public testing::Test {
                shared_model::validation::DefaultBlockValidator,
                shared_model::proto::Block>()
         .height(1)
-        .prevHash(Hash(std::string(32, '0')))
+        .prevHash(Hash(std::string(
+            shared_model::crypto::DefaultCryptoAlgorithmType::kHashLength,
+            '0')))
         .createdTime(iroha::time::now());
   }
 

--- a/test/module/shared_model/builders/protobuf/block_builder_test.cpp
+++ b/test/module/shared_model/builders/protobuf/block_builder_test.cpp
@@ -27,7 +27,9 @@ TEST(BlockBuilderTest, BlockWithTransactions) {
   ASSERT_NO_THROW(
       BlockBuilder()
           .createdTime(iroha::time::now())
-          .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
+          .prevHash(shared_model::crypto::Hash(std::string(
+              shared_model::crypto::DefaultCryptoAlgorithmType::kHashLength,
+              '0')))
           .height(1)
           .transactions(std::vector<decltype(tx)>{tx})
           .build());
@@ -44,7 +46,9 @@ TEST(BlockBuilderTest, DISABLED_BlockWithNoTransactions) {
   ASSERT_ANY_THROW(
       BlockBuilder()
           .createdTime(iroha::time::now())
-          .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
+          .prevHash(shared_model::crypto::Hash(std::string(
+              shared_model::crypto::DefaultCryptoAlgorithmType::kHashLength,
+              '0')))
           .height(1)
           .transactions(std::vector<shared_model::proto::Transaction>())
           .build());

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -357,44 +357,44 @@ class FieldValidatorTest : public ValidatorsTest {
   std::vector<FieldTestCase> peer_test_cases{
       // clang-format off
       // ip addresses
-      makeValidPeerAddressTestCase("zeros_ip","0.0.0.0:0", std::string(32, '0')),
-      makeValidPeerAddressTestCase("max_ip", "255.255.255.255:65535", std::string(32, '0')),
-      makeValidPeerAddressTestCase("common_ip","192.168.0.1:8080", std::string(32, '0')),
+      makeValidPeerAddressTestCase("zeros_ip","0.0.0.0:0", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("max_ip", "255.255.255.255:65535", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("common_ip","192.168.0.1:8080", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
 
-      makeInvalidPeerAddressTestCase("invalid_peer_address", "182.13.35.1:3040xx", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("invalid symbol in ip", "-0.0.0.0:0", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("too big number in ip", "256.256.256.255:65535", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("too big port", "192.168.0.1:65536", std::string(32, '0')),
+      makeInvalidPeerAddressTestCase("invalid_peer_address", "182.13.35.1:3040xx", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("invalid symbol in ip", "-0.0.0.0:0", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("too big number in ip", "256.256.256.255:65535", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("too big port", "192.168.0.1:65536", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
 
       // hostname
-      makeValidPeerAddressTestCase("valid hostname with port", "abc.efg:0", std::string(32, '0')),
-      makeValidPeerAddressTestCase("valid hostname with max port", "abc.efg.hij:65535", std::string(32, '0')),
-      makeValidPeerAddressTestCase("hostname with hyphen", "a-hyphen.ru-i:8080", std::string(32, '0')),
-      makeValidPeerAddressTestCase("common hostname with port", "altplus.com.jp:80", std::string(32, '0')),
-      makeValidPeerAddressTestCase("max label length in hostname with port", "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad:8080", std::string(32, '0')),
+      makeValidPeerAddressTestCase("valid hostname with port", "abc.efg:0", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("valid hostname with max port", "abc.efg.hij:65535", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("hostname with hyphen", "a-hyphen.ru-i:8080", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("common hostname with port", "altplus.com.jp:80", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeValidPeerAddressTestCase("max label length in hostname with port", "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad:8080", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
       makeValidPeerAddressTestCase("max domain name length in hostname with port",
                                    "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
                                    "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
                                    "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
-                                   "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad:256", std::string(32, '0')),
+                                   "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad:256", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
 
 
-      makeInvalidPeerAddressTestCase("hostname starting with nonletter", "9.start.with.non.letter:0", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname starting with dash", "-startWithDash:65535", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname starting with at", "@.is.not.allowed:8080", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname with space", "no space is allowed:80", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname with too big port", "too.big.port:65536", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname with not allowed character", "some\u2063host:123", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname ending with hyphen", "endWith-:909", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("hostname with too large label", "aLabelMustNotExceeds63charactersALabelMustNotExceeds63characters:9090", std::string(32, '0')),
+      makeInvalidPeerAddressTestCase("hostname starting with nonletter", "9.start.with.non.letter:0", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname starting with dash", "-startWithDash:65535", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname starting with at", "@.is.not.allowed:8080", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname with space", "no space is allowed:80", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname with too big port", "too.big.port:65536", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname with not allowed character", "some\u2063host:123", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname ending with hyphen", "endWith-:909", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("hostname with too large label", "aLabelMustNotExceeds63charactersALabelMustNotExceeds63characters:9090", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
       makeInvalidPeerAddressTestCase("hostname with more than 256 character domain",
       "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
       "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
       "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPad."
-      "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPadP:256", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("empty address", "", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("empty domain", ":6565", std::string(32, '0')),
-      makeInvalidPeerAddressTestCase("empty domain two : symbols", "::6565:", std::string(32, '0')),
+      "maxLabelLengthIs63paddingPaddingPaddingPaddingPaddingPaddingPadP:256", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("empty address", "", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("empty domain", ":6565", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
+      makeInvalidPeerAddressTestCase("empty domain two : symbols", "::6565:", std::string(crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, '0')),
 
       // invalid pubkey
       makeInvalidPeerPubkeyTestCase("invalid_peer_pubkey_length",


### PR DESCRIPTION
### Description of the Change

Remove magic consts from code related to crypto sizes and introduce such constants in crypto provider

### Benefits

No magics

### Possible Drawbacks 

None
