### PR TITLE
Fix RolePermissionResponse containing string

### DIFF
--- a/irohad/model/converters/impl/pb_query_response_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_response_factory.cpp
@@ -300,7 +300,7 @@ namespace iroha {
           const model::RolePermissionsResponse &response) const {
         protocol::RolePermissionsResponse res;
         for (auto perm : response.role_permissions) {
-          res.add_permissions(perm);
+          res.add_permissions(iroha::protocol::RolePermission(perm));
         }
         return res;
       }

--- a/irohad/model/queries/responses/roles_response.hpp
+++ b/irohad/model/queries/responses/roles_response.hpp
@@ -30,7 +30,7 @@ namespace iroha {
       /**
        * All role's permissions
        */
-      std::vector<std::string> role_permissions{};
+      std::vector<int> role_permissions{};
     };
 
     /**

--- a/schema/responses.proto
+++ b/schema/responses.proto
@@ -51,7 +51,7 @@ message RolesResponse {
 }
 
 message RolePermissionsResponse {
-  repeated string permissions = 1;
+  repeated RolePermission permissions = 1;
 }
 
 message ErrorResponse {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
@@ -22,7 +22,9 @@ namespace shared_model {
                 rolePermissionsResponse_.permissions(),
                 interface::RolePermissionSet{},
                 [](auto &&permissions, const auto &permission) {
-                  permissions.set(interface::permissions::fromOldR(permission));
+                  permissions.set(permissions::fromTransport(
+                      static_cast<iroha::protocol::RolePermission>(
+                          permission)));
                   return std::forward<decltype(permissions)>(permissions);
                 });
           }} {}

--- a/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_response_template.hpp
@@ -176,20 +176,9 @@ namespace shared_model {
           for (size_t i = 0; i < role_permissions.size(); ++i) {
             auto perm = static_cast<interface::permissions::Role>(i);
             if (role_permissions.test(perm)) {
-              // TODO(@l4l) 05/06/18 IR-1393
-              // replace with toTransport after fixing RolePermissionResponse
-              query_response->add_permissions(permissions::toString(perm));
+              query_response->add_permissions(permissions::toTransport(perm));
             }
           }
-
-          // TODO(@l4l) 05/06/18 IR-1393
-          // uncomment after fixing RolePermissionResponse
-          // for (size_t i = 0; i < role_permissions.size(); ++i) {
-          //   auto perm = static_cast<interface::permissions::Role>(i);
-          //   if (role_permissions[perm]) {
-          //     query_response->add_permissions(permissions::toTransport(perm));
-          //   }
-          // }
         });
       }
 


### PR DESCRIPTION
### Description of the Change

Fix RolePermissionResponse, so now it's contain proper type

### Benefits

Type consistency

### Possible Drawbacks 

None
