### PR TITLE
Add test for GetAccountAssets qry

### DIFF
--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -75,3 +75,8 @@ addtest(tx_heavy_data tx_heavy_data.cpp)
 target_link_libraries(tx_heavy_data
     acceptance_fixture
     )
+
+addtest(get_account_assets_test get_account_assets_test.cpp)
+target_link_libraries(get_account_assets_test
+    acceptance_fixture
+    )

--- a/test/integration/acceptance/get_account_assets_test.cpp
+++ b/test/integration/acceptance/get_account_assets_test.cpp
@@ -1,0 +1,115 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "backend/protobuf/transaction.hpp"
+#include "builders/protobuf/queries.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "utils/query_error_response_visitor.hpp"
+
+using namespace integration_framework;
+using namespace shared_model;
+
+class GetAccountAssets : public AcceptanceFixture {
+ public:
+  /**
+   * Creates the transaction with the user creation commands
+   * @param perms are the permissions of the user
+   * @return built tx and a hash of its payload
+   */
+  auto makeUserWithPerms(const interface::RolePermissionSet &perms = {
+                             interface::permissions::Role::kGetMyAccAst}) {
+    auto new_perms = perms;
+    new_perms.set(interface::permissions::Role::kAddAssetQty);
+    new_perms.set(interface::permissions::Role::kSubtractAssetQty);
+    return AcceptanceFixture::makeUserWithPerms(kNewRole, new_perms);
+  }
+
+  /// Create command for adding assets
+  auto addAssets() {
+    return complete(
+        AcceptanceFixture::baseTx().addAssetQuantity(kUserId, kAsset, "1"));
+  }
+
+  /// Create command for removing assets
+  auto removeAssets() {
+    return complete(AcceptanceFixture::baseTx().subtractAssetQuantity(
+        kUserId, kAsset, "1"));
+  }
+
+  /**
+   * Creates valid GetAccountAssets query of current user
+   * @param hash of the tx for querying
+   * @return built query
+   */
+  auto makeQuery() {
+    return complete(baseQry().queryCounter(1).getAccountAssets(kUserId));
+  }
+
+  const std::string kNewRole = "rl";
+};
+
+/// Callback for checking that status is AccountAssetResponse
+auto checkValid = [](auto &status) {
+  ASSERT_NO_THROW(boost::apply_visitor(
+      framework::SpecifiedVisitor<interface::AccountAssetResponse>(),
+      status.get()));
+};
+
+/**
+ * @given a user with all required permissions
+ * @when GetAccountAssets is queried on the user
+ * @then there is an AccountAssetResponse
+ */
+TEST_F(GetAccountAssets, AddedAssets) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(addAssets())
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(), checkValid)
+      .done();
+}
+
+/**
+ * @given a user with all required permissions
+ * @when GetAccountAssets is queried on the user
+ * @then there is an AccountAssetResponse
+ */
+TEST_F(GetAccountAssets, RemovedAssets) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(addAssets())
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTx(removeAssets())
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(), checkValid)
+      .done();
+}
+
+/**
+ * @given a user with all required permissions
+ * @when GetAccountAssets is queried on the user
+ * @then there is an AccountAssetResponse
+ */
+TEST_F(GetAccountAssets, NonAddedAssets) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendQuery(makeQuery(), checkValid)
+      .done();
+}


### PR DESCRIPTION
### Description of the Change

There've been reported bugs about querying GetAccountAssets for zero balance. This pr introduces tests, that show the behavior is normal

### Benefits

More test for the God of Tests

### Possible Drawbacks 

None

### Usage Examples or Tests

`make get_account_assets_test && test_bin/get_account_assets_test`
