### PR TITLE
Fix issues with GetTransaction validation

### DIFF
--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -54,6 +54,8 @@ namespace shared_model {
         crypto::DefaultCryptoAlgorithmType::kPublicKeyLength;
     const size_t FieldValidator::signature_size =
         crypto::DefaultCryptoAlgorithmType::kSignatureLength;
+    const size_t FieldValidator::hash_size =
+        crypto::DefaultCryptoAlgorithmType::kHashLength;
     /// limit for the set account detail size in bytes
     const size_t FieldValidator::value_size = 4 * 1024 * 1024;
     const size_t FieldValidator::description_size = 64;
@@ -375,6 +377,14 @@ namespace shared_model {
             (boost::format("Height should be > 0, passed value: %d") % height)
                 .str();
         reason.second.push_back(message);
+      }
+    }
+
+    void FieldValidator::validateHash(ReasonsGroupType &reason,
+                                      const crypto::Hash &hash) const {
+      if (hash.size() != hash_size) {
+        reason.second.push_back(
+            (boost::format("Hash has invalid size: %d") % hash.size()).str());
       }
     }
   }  // namespace validation

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -154,6 +154,9 @@ namespace shared_model {
       void validateHeight(ReasonsGroupType &reason,
                           const interface::types::HeightType &height) const;
 
+      void validateHash(ReasonsGroupType &reason,
+                        const crypto::Hash &hash) const;
+
      private:
       const static std::string account_name_pattern_;
       const static std::string asset_name_pattern_;
@@ -187,6 +190,7 @@ namespace shared_model {
       // size of key
       static const size_t public_key_size;
       static const size_t signature_size;
+      static const size_t hash_size;
       static const size_t value_size;
       static const size_t description_size;
     };

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -80,6 +80,11 @@ namespace shared_model {
         ReasonsGroupType reason;
         reason.first = "GetTransactions";
 
+        const auto &hashes = qry.transactionHashes();
+        if (hashes.size() == 0) {
+          reason.second.push_back("tx_hashes cannot be empty");
+        }
+
         return reason;
       }
 

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -85,6 +85,10 @@ namespace shared_model {
           reason.second.push_back("tx_hashes cannot be empty");
         }
 
+        for (const auto &h : hashes) {
+          validator_.validateHash(reason, h);
+        }
+
         return reason;
       }
 

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -477,8 +477,6 @@ public class QueryTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
-    // TODO igor-egorov, 08.05.2018, IR-1325
-    @Disabled
     @Test
     void getTransactionsWithInvalidHashSizes() {
         String hashes[] = {
@@ -496,8 +494,6 @@ public class QueryTest {
         }
     }
 
-    // TODO igor-egorov, 08.05.2018, IR-1325
-    @Disabled
     @Test
     void getTransactionsWithOneValidAndOneInvalidHash1() {
         Hash valid = new Hash("12345678901234567890123456789012");
@@ -510,8 +506,6 @@ public class QueryTest {
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
-    // TODO igor-egorov, 08.05.2018, IR-1325
-    @Disabled
     @Test
     void getTransactionsWithOneValidAndOneInvalidHash2() {
         Hash valid = new Hash("12345678901234567890123456789012");

--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -471,8 +471,6 @@ public class QueryTest {
 
     // The following four tests are disabled because there is a need to
     // clarify desired behavior.
-    // TODO igor-egorov, 08.05.2018, IR-1322
-    @Disabled
     @Test
     void getTransactionsWithEmptyVector() {
         ModelQueryBuilder builder = base().getTransactions(new HashVector());

--- a/test/module/shared_model/bindings/query-test.py
+++ b/test/module/shared_model/bindings/query-test.py
@@ -330,8 +330,6 @@ class BuilderTest(unittest.TestCase):
     query = self.builder.getTransactions(hv).build()
     self.assertTrue(self.check_proto_query(self.proto(query)))
 
-  # TODO igor-egorov, 11.05.2018, IR-1322
-  @unittest.skip("IR-1322")
   def test_get_transactions_with_empty_vector(self):
     with self.assertRaises(ValueError):
       self.base().getTransactions(iroha.HashVector()).build()

--- a/test/module/shared_model/bindings/query-test.py
+++ b/test/module/shared_model/bindings/query-test.py
@@ -334,8 +334,6 @@ class BuilderTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       self.base().getTransactions(iroha.HashVector()).build()
 
-  # TODO igor-egorov, 11.05.2018, IR-1325
-  @unittest.skip("IR-1325")
   def test_get_transactions_with_invalid_hash_sizes(self):
     hashes = [
       "",
@@ -349,8 +347,6 @@ class BuilderTest(unittest.TestCase):
       with self.assertRaises(ValueError):
         self.base().getTransactions(hv).build()
 
-  # TODO igor-egorov, 11.05.2018, IR-1325
-  @unittest.skip("IR-1325")
   def test_get_transactions_with_one_valid_and_one_invalid_hash_1(self):
     hv = iroha.HashVector()
     hv.append(iroha.Hash("1" * 32))
@@ -359,8 +355,6 @@ class BuilderTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       self.base().getTransactions(hv).build()
 
-  # TODO igor-egorov, 11.05.2018, IR-1325
-  @unittest.skip("IR-1325")
   def test_get_transactions_with_one_valid_and_one_invalid_hash_2(self):
     hv = iroha.HashVector()
     hv.append(iroha.Hash("1"))


### PR DESCRIPTION
### Description of the Change

GetTransaction qry is know validated for:
- tx_hash must be non-empty
- tx_hash elements must be valid hash (in terms of size)

### Tests

Presented for bindings:
`ctest -R '(python|java)'`
