### PR TITLE
Cleanup SDK interface

### DIFF
--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -86,7 +86,7 @@ namespace shared_model {
         return payload_.created_time();
       }
 
-      Transaction::QuorumType quorum() const override {
+      interface::types::QuorumType quorum() const override {
         return payload_.quorum();
       }
 

--- a/shared_model/bindings/bindings.i
+++ b/shared_model/bindings/bindings.i
@@ -28,6 +28,7 @@
 
 %{
 #include "cryptography/hash.hpp"
+#include "interfaces/common_objects/signature.hpp"
 %}
 
 namespace std {
@@ -36,6 +37,7 @@ namespace std {
   %ignore vector<shared_model::crypto::Hash>::vector(size_type);
   %template(HashVector) vector<shared_model::crypto::Hash>;
   %template(IntVector) vector<int>;
+  %template(SignatureVector) vector<const shared_model::interface::Signature*>;
 };
 
 %exception {
@@ -48,11 +50,53 @@ namespace std {
   }
 }
 
+%ignore shared_model::proto::Query::get;
+%ignore shared_model::proto::Transaction::commands;
+%ignore shared_model::proto::Query::signatures;
+%ignore shared_model::proto::BlocksQuery::signatures;
+%ignore shared_model::proto::Transaction::signatures;
+%ignore toTransport;
+%ignore fromTransport;
+
+%extend shared_model::proto::Query {
+  std::vector<const shared_model::interface::Signature*> signs() {
+    std::vector<const shared_model::interface::Signature*> sigs;
+
+    for (const auto &s : $self->signatures()) {
+      sigs.push_back(&s);
+    }
+    return sigs;
+  }
+}
+
+%extend shared_model::proto::BlocksQuery {
+  std::vector<const shared_model::interface::Signature*> signs() {
+    std::vector<const shared_model::interface::Signature*> sigs;
+
+    for (const auto &s : $self->signatures()) {
+      sigs.push_back(&s);
+    }
+    return sigs;
+  }
+}
+
+%extend shared_model::proto::Transaction {
+  std::vector<const shared_model::interface::Signature*> signs() {
+    std::vector<const shared_model::interface::Signature*> sigs;
+
+    for (const auto &s : $self->signatures()) {
+      sigs.push_back(&s);
+    }
+    return sigs;
+  }
+}
+
 %rename(ModelTransaction) iroha::protocol::Transaction;
 %rename(_interface) interface;
 %rename(b_equal) shared_model::crypto::Blob::operator==;
 %rename(kp_equal) shared_model::crypto::Keypair::operator==;
 %rename(hash_invoke) shared_model::crypto::Hash::Hasher::operator();
+%rename(Signature) shared_model::interface::Signature;
 
 %ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Role>);
 %ignore shared_model::interface::PermissionSet::PermissionSet(std::initializer_list<shared_model::interface::permissions::Grantable>);
@@ -61,8 +105,8 @@ namespace std {
 %rename(bset_xor) shared_model::interface::PermissionSet::operator^=;
 
 #if defined(SWIGJAVA) || defined(SWIGJAVASCRIPT)
-%rename(equal) shared_model::interface::PermissionSet::operator==;
-%rename(not_equal) shared_model::interface::PermissionSet::operator!=;
+%rename(equal) operator==;
+%rename(not_equal) operator!=;
 #endif
 
 %extend shared_model::interface::PermissionSet {
@@ -86,6 +130,7 @@ namespace std {
 
 %include "cryptography/blob.hpp"
 %include "interfaces/common_objects/types.hpp"
+%include "interfaces/common_objects/signature.hpp"
 %include "interfaces/base/signable.hpp"
 %include "interfaces/permissions.hpp"
 %include "cryptography/public_key.hpp"

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -63,7 +63,7 @@ namespace shared_model {
       /// Permission set
       using PermissionSetType = std::set<PermissionNameType>;
       /// Type of Quorum used in transaction and set quorum
-      using QuorumType = uint32_t;
+      using QuorumType = uint8_t;
       /// Type of signature range, which returns when signatures are invoked
       using SignatureRangeType = boost::any_range<const interface::Signature &,
                                                   boost::forward_traversal_tag>;

--- a/shared_model/interfaces/transaction.hpp
+++ b/shared_model/interfaces/transaction.hpp
@@ -37,13 +37,10 @@ namespace shared_model {
        */
       virtual const types::AccountIdType &creatorAccountId() const = 0;
 
-      /// Type of quorum
-      using QuorumType = uint8_t;
-
       /**
        * @return quorum of transaction
        */
-      virtual QuorumType quorum() const = 0;
+      virtual types::QuorumType quorum() const = 0;
 
       /// Type of ordered collection of commands
       using CommandsType = boost::any_range<Command,


### PR DESCRIPTION
### Description of the Change

So far bindings was quite messy and a lot of useless functions/types was shared. This pr aimed at cleaning sdk interface, particularly:

- Reusing existent type instead of `proto::Transaction::QuorumType`
- Ignoring functions in backend, that returns `boost::variant`
- Create wrappers for `proto::*::signatures()` (because `boost::any_range` cannot be used)

### Benefits

Lesser useless stuff in bindings

### Possible Drawbacks 

Code duplication in _bindings.i_ :( Feel free to propose a better solution
