### PR TITLE
Fix on commit

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -105,8 +105,6 @@ namespace iroha {
                                         const auto &top_hash) { return true; });
             log_->info("block inserted: {}", inserted);
             commit(std::move(storage.value));
-            notifier_.get_subscriber().on_next(
-                std::shared_ptr<shared_model::interface::Block>(clone(block)));
           },
           [&](expected::Error<std::string> &error) {
             log_->error(error.error);
@@ -258,6 +256,7 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
             stringToBytes(shared_model::converters::protobuf::modelToJson(
                 *std::static_pointer_cast<shared_model::proto::Block>(
                     block.second))));
+        notifier_.get_subscriber().on_next(block.second);
       }
 
       storage->transaction_->exec("COMMIT;");

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -650,9 +650,10 @@ TEST_F(AmetsuchiTest, TestingStorageWhenCommitBlock) {
 
   std::unique_ptr<MutableStorage> mutable_storage;
   storage->createMutableStorage().match(
-      [&mutable_storage](
-          const iroha::expected::Value<std::unique_ptr<MutableStorage>>
-              &mut_storage) { mutable_storage.swap(mut_storage.value); },
+      [&mutable_storage](iroha::expected::Value<std::unique_ptr<MutableStorage>>
+                             &mut_storage) {
+        mutable_storage = std::move(mut_storage.value);
+      },
       [](const auto &) { FAIL() << "Mutable storage cannot be created"; });
 
   mutable_storage->apply(

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -632,6 +632,46 @@ TEST_F(AmetsuchiTest, TestingStorageWhenInsertBlock) {
   ASSERT_TRUE(wrapper.validate());
 }
 
+/**
+ * @given created storage
+ * @when commit block
+ * @then committed block is emitted to observable
+ */
+TEST_F(AmetsuchiTest, TestingStorageWhenCommitBlock) {
+  auto log = logger::testLog("TestStorage");
+  ASSERT_TRUE(storage);
+
+  auto expected_block = getBlock();
+
+  // create test subscriber to check if committed block is as expected
+  auto wrapper = make_test_subscriber<CallExact>(storage->on_commit(), 1);
+  wrapper.subscribe([&expected_block](const auto &block) {
+    ASSERT_EQ(*block, expected_block);
+  });
+
+  log->info("Try commit the block");
+
+  std::unique_ptr<MutableStorage> mutable_storage;
+  storage->createMutableStorage().match(
+      [&mutable_storage](
+          iroha::expected::Value<std::unique_ptr<MutableStorage>> &_storage) {
+        mutable_storage = std::move(_storage.value);
+      },
+      [](const auto &) { FAIL() << "Mutable storage cannot be created"; });
+
+  mutable_storage->apply(
+      expected_block,
+      [](const auto &, const auto &, const auto &) { return true; });
+
+  storage->commit(std::move(mutable_storage));
+
+  log->info("Drop ledger");
+
+  storage->dropStorage();
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
 TEST_F(AmetsuchiTest, TestingStorageWhenDropAll) {
   auto logger = logger::testLog("TestStorage");
   logger->info(


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Until fix blocks were emitted only in insert_block method, which is not right, since it should emit every block when commit on storage is happening.
### Benefits

Proper behavior of ametsuchi

### Possible Drawbacks 

None
### Usage Examples or Tests

Run ametsuchi test
