### PR TITLE
Refactor TransferAsset acceptance test

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -195,6 +195,13 @@ namespace integration_framework {
     return *this;
   }
 
+  IntegrationTestFramework &IntegrationTestFramework::sendTxAwait(
+      const shared_model::proto::Transaction &tx,
+      std::function<void(const BlockType &)> check) {
+    sendTx(tx).skipProposal().checkBlock(check);
+    return *this;
+  }
+
   IntegrationTestFramework &IntegrationTestFramework::sendQuery(
       const shared_model::proto::Query &qry,
       std::function<void(const shared_model::proto::QueryResponse &)>

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -140,6 +140,17 @@ namespace integration_framework {
         const shared_model::proto::Transaction &tx);
 
     /**
+     * Send transaction to Iroha with awaiting proposal
+     * and without status validation
+     * @param tx - transaction for sending
+     * @param check - callback for checking committed block
+     * @return this
+     */
+    IntegrationTestFramework &sendTxAwait(
+        const shared_model::proto::Transaction &tx,
+        std::function<void(const BlockType &)> check);
+
+    /**
      * Check current status of transaction
      * @param hash - hash of transaction to check
      * @return TransactonResponse object

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -29,7 +29,7 @@ AcceptanceFixture::AcceptanceFixture()
             status.get()));
       }),
       initial_time(iroha::time::now()),
-      tx_counter(0) {}
+      nonce_counter(0) {}
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
     const std::string &user, const shared_model::crypto::PublicKey &key) {
@@ -94,7 +94,7 @@ auto AcceptanceFixture::baseTx()
 
 auto AcceptanceFixture::baseQry()
     -> decltype(base(TestUnsignedQueryBuilder())) {
-  return base(TestUnsignedQueryBuilder()).queryCounter(tx_counter);
+  return base(TestUnsignedQueryBuilder()).queryCounter(nonce_counter);
 }
 
 template <typename Builder>
@@ -119,5 +119,5 @@ template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
             .finish());
 
 iroha::time::time_t AcceptanceFixture::getUniqueTime() {
-  return initial_time + tx_counter++;
+  return initial_time + nonce_counter++;
 }

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -29,7 +29,7 @@ AcceptanceFixture::AcceptanceFixture()
             status.get()));
       }),
       initial_time(iroha::time::now()),
-      tx_counter(0){}
+      tx_counter(0) {}
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
     const std::string &user, const shared_model::crypto::PublicKey &key) {
@@ -94,7 +94,7 @@ auto AcceptanceFixture::baseTx()
 
 auto AcceptanceFixture::baseQry()
     -> decltype(base(TestUnsignedQueryBuilder())) {
-  return base(TestUnsignedQueryBuilder());
+  return base(TestUnsignedQueryBuilder()).queryCounter(tx_counter);
 }
 
 template <typename Builder>

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -122,7 +122,7 @@ class AcceptanceFixture : public ::testing::Test {
  private:
   iroha::time::time_t initial_time;
   /// number of created transactions, used to provide unique time
-  int tx_counter;
+  int nonce_counter;
 };
 
 #endif  // IROHA_ACCEPTANCE_FIXTURE_HPP

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -93,7 +93,7 @@ TEST_F(TransferAsset, Basic) {
  * @when execute tx with TransferAsset command
  * @then there is an empty proposal
  */
-TEST_F(TransferAsset, DISABLED_WithOnlyCanTransferPerm) {
+TEST_F(TransferAsset, WithoutCanTransfer) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser({}), check(1))
@@ -109,11 +109,13 @@ TEST_F(TransferAsset, DISABLED_WithOnlyCanTransferPerm) {
  * @when execute tx with TransferAsset command
  * @then there is an empty proposal
  */
-TEST_F(TransferAsset, DISABLED_WithOnlyCanReceivePerm) {
+TEST_F(TransferAsset, WithoutCanReceive) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser({}), check(1))
+      // TODO(@l4l) 23/06/18: remove permission with IR-1367
+      .sendTxAwait(makeSecondUser({interface::permissions::Role::kAddPeer}),
+                   check(1))
       .sendTxAwait(addAssets(), check(1))
       .sendTxAwait(makeTransfer(), check(0))
       .done();

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -19,159 +19,103 @@ using namespace shared_model;
 class TransferAsset : public AcceptanceFixture {
  public:
   /**
-   * Creates the transaction with the user creation commands
+   * Creates the transaction with the first user creation commands
    * @param perms are the permissions of the user
-   * @return built tx and a hash of its payload
+   * @return built tx
    */
-  auto makeUserWithPerms(const std::string &user,
-                         const crypto::Keypair &key,
-                         const interface::RolePermissionSet &perms,
-                         const std::string &role) {
-    return createUserWithPerms(user, key.publicKey(), role, perms)
+  auto makeFirstUser(const interface::RolePermissionSet &perms = {
+                         interface::permissions::Role::kTransfer}) {
+    auto new_perms = perms;
+    new_perms.set(interface::permissions::Role::kAddAssetQty);
+    const std::string kRole1 = "roleone";
+    return AcceptanceFixture::makeUserWithPerms(kRole1, new_perms);
+  }
+
+  /**
+   * Creates the transaction with the second user creation commands
+   * @param perms are the permissions of the user
+   * @return built tx
+   */
+  auto makeSecondUser(const interface::RolePermissionSet &perms = {
+                          interface::permissions::Role::kReceive}) {
+    return createUserWithPerms(kUser2, kUser2Keypair.publicKey(), kRole2, perms)
         .build()
         .signAndAddSignature(kAdminKeypair)
         .finish();
   }
 
-  proto::Transaction addAssets(const std::string &user,
-                               const crypto::Keypair &key) {
-    return addAssets(user, key, kAmount);
+  proto::Transaction addAssets() {
+    return addAssets(kAmount);
   }
 
-  proto::Transaction addAssets(const std::string &user,
-                               const crypto::Keypair &key,
-                               const std::string &amount) {
-    const std::string kUserId = user + "@test";
-    return proto::TransactionBuilder()
-        .creatorAccountId(kUserId)
-        .createdTime(getUniqueTime())
-        .addAssetQuantity(kUserId, kAsset, amount)
-        .quorum(1)
-        .build()
-        .signAndAddSignature(key)
-        .finish();
+  proto::Transaction addAssets(const std::string &amount) {
+    return complete(baseTx().addAssetQuantity(kUserId, kAsset, amount));
   }
 
-  /**
-   * Create valid base pre-build transaction
-   * @return pre-build tx
-   */
-  auto baseTx() {
-    return TestUnsignedTransactionBuilder()
-        .creatorAccountId(kUser1 + "@test")
-        .createdTime(getUniqueTime())
-        .quorum(1);
+  proto::Transaction makeTransfer(const std::string &amount) {
+    return complete(
+        baseTx().transferAsset(kUserId, kUser2Id, kAsset, kDesc, amount));
   }
 
-  /**
-   * Completes pre-build transaction
-   * @param builder is a pre-built tx
-   * @return built tx
-   */
-  template <typename TestTransactionBuilder>
-  auto completeTx(TestTransactionBuilder builder) {
-    return builder.build().signAndAddSignature(kUser1Keypair).finish();
+  proto::Transaction makeTransfer() {
+    return makeTransfer(kAmount);
   }
 
   const std::string kAmount = "1.0";
   const std::string kDesc = "description";
-  const std::string kUser1 = "userone";
-  const std::string kUser2 = "usertwo";
-  const std::string kRole1 = "roleone";
   const std::string kRole2 = "roletwo";
-  const std::string kUser1Id = kUser1 + "@test";
+  const std::string kUser2 = "usertwo";
   const std::string kUser2Id = kUser2 + "@test";
-  const crypto::Keypair kUser1Keypair =
-      crypto::DefaultCryptoAlgorithmType::generateKeypair();
   const crypto::Keypair kUser2Keypair =
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  const interface::RolePermissionSet kPerms{
-      interface::permissions::Role::kAddAssetQty,
-      interface::permissions::Role::kTransfer,
-      interface::permissions::Role::kReceive};
 };
 
+#define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
+
 /**
- * @given some user with all required permissions
+ * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command
  * @then there is the tx in proposal
  */
 TEST_F(TransferAsset, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(completeTx(
-          baseTx().transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, kAmount)))
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeTransfer(), check(1))
       .done();
 }
 
 /**
- * @given some user with only can_transfer permission
+ * @given pair of users
+ *        AND the first user without can_transfer permission
  * @when execute tx with TransferAsset command
  * @then there is an empty proposal
  */
-TEST_F(TransferAsset, WithOnlyCanTransferPerm) {
+TEST_F(TransferAsset, DISABLED_WithOnlyCanTransferPerm) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1,
-                                kUser1Keypair,
-                                {interface::permissions::Role::kTransfer},
-                                kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(baseTx()
-                  .transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, kAmount)
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish())
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeFirstUser({}), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeTransfer(), check(0))
       .done();
 }
 
 /**
- * @given some user with only can_receive permission
+ * @given pair of users
+ *        AND the second user without can_receive permission
  * @when execute tx with TransferAsset command
  * @then there is an empty proposal
  */
-TEST_F(TransferAsset, WithOnlyCanReceivePerm) {
+TEST_F(TransferAsset, DISABLED_WithOnlyCanReceivePerm) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1,
-                                kUser1Keypair,
-                                {interface::permissions::Role::kReceive},
-                                kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(baseTx()
-                  .transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, kAmount)
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish())
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser({}), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeTransfer(), check(0))
       .done();
 }
 
@@ -184,19 +128,11 @@ TEST_F(TransferAsset, NonexistentDest) {
   std::string nonexistent = "inexist@test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(baseTx()
-                  .transferAsset(kUser1Id, nonexistent, kAsset, kDesc, kAmount)
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish())
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(complete(baseTx().transferAsset(
+                       kUserId, nonexistent, kAsset, kDesc, kAmount)),
+                   check(0))
       .done();
 }
 
@@ -209,23 +145,12 @@ TEST_F(TransferAsset, NonexistentAsset) {
   std::string nonexistent = "inexist#test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(
-          baseTx()
-              .transferAsset(kUser1Id, kUser2Id, nonexistent, kDesc, kAmount)
-              .build()
-              .signAndAddSignature(kUser1Keypair)
-              .finish())
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(complete(baseTx().transferAsset(
+                       kUserId, kUser2Id, nonexistent, kDesc, kAmount)),
+                   check(0))
       .done();
 }
 
@@ -238,21 +163,11 @@ TEST_F(TransferAsset, NonexistentAsset) {
 TEST_F(TransferAsset, NegativeAmount) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(baseTx()
-                  .transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, "-1.0")
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish(),
-              checkStatelessInvalid);
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTx(makeTransfer("-1.0"), checkStatelessInvalid)
+      .done();
 }
 
 /**
@@ -262,19 +177,13 @@ TEST_F(TransferAsset, NegativeAmount) {
  *       (aka skipProposal throws)
  */
 TEST_F(TransferAsset, ZeroAmount) {
-  IntegrationTestFramework(3)
+  IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(baseTx()
-                  .transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, "0.0")
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish(),
-              checkStatelessInvalid);
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTx(makeTransfer("0.0"), checkStatelessInvalid)
+      .done();
 }
 
 /**
@@ -283,15 +192,14 @@ TEST_F(TransferAsset, ZeroAmount) {
  * @then it passed to the proposal
  */
 TEST_F(TransferAsset, EmptyDesc) {
-  IntegrationTestFramework(4)
+  IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .sendTx(completeTx(
-          baseTx().transferAsset(kUser1Id, kUser2Id, kAsset, "", kAmount)))
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 4); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(complete(baseTx().transferAsset(
+                       kUserId, kUser2Id, kAsset, "", kAmount)),
+                   check(1))
       .done();
 }
 
@@ -302,17 +210,15 @@ TEST_F(TransferAsset, EmptyDesc) {
  *       (aka skipProposal throws)
  */
 TEST_F(TransferAsset, LongDesc) {
-  std::string long_desc(100000, 'a');
-  auto invalid_tx = completeTx(
-      baseTx().transferAsset(kUser1Id, kUser2Id, kAsset, long_desc, kAmount));
-  IntegrationTestFramework(3)
+  IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(invalid_tx, checkStatelessInvalid)
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTx(
+          complete(baseTx().transferAsset(
+              kUserId, kUser2Id, kAsset, std::string(100000, 'a'), kAmount)),
+          checkStatelessInvalid)
       .done();
 }
 
@@ -324,20 +230,10 @@ TEST_F(TransferAsset, LongDesc) {
 TEST_F(TransferAsset, MoreThanHas) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair, "50.0"))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(completeTx(
-          baseTx().transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, "100.0")))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets("50.0"), check(1))
+      .sendTxAwait(makeTransfer("100.0"), check(0))
       .done();
 }
 
@@ -355,32 +251,15 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
       "2495.0";  // 2**252 - 1
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair, uint256_halfmax))
-      .skipProposal()
-      .skipBlock()
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(addAssets(uint256_halfmax), check(1))
       // Send first half of the maximum
-      .sendTx(completeTx(baseTx().transferAsset(
-          kUser1Id, kUser2Id, kAsset, kDesc, uint256_halfmax)))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTxAwait(makeTransfer(uint256_halfmax), check(1))
       // Restore self balance
-      .sendTx(addAssets(kUser1, kUser1Keypair, uint256_halfmax))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTxAwait(addAssets(uint256_halfmax), check(1))
       // Send second half of the maximum
-      .sendTx(completeTx(baseTx().transferAsset(
-          kUser1Id, kUser2Id, kAsset, kDesc, uint256_halfmax)))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(makeTransfer(uint256_halfmax), check(0))
       .done();
 }
 
@@ -392,14 +271,12 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
  *       (aka skipProposal throws)
  */
 TEST_F(TransferAsset, SourceIsDest) {
-  IntegrationTestFramework(2)
+  IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .sendTx(addAssets(kUser1, kUser1Keypair))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(completeTx(baseTx().transferAsset(
-                  kUser1Id, kUser1Id, kAsset, kDesc, kAmount)),
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(addAssets(), check(1))
+      .sendTx(complete(baseTx().transferAsset(
+                  kUserId, kUserId, kAsset, kDesc, kAmount)),
               checkStatelessInvalid);
 }
 
@@ -410,40 +287,32 @@ TEST_F(TransferAsset, SourceIsDest) {
  * @then the tx is commited
  */
 TEST_F(TransferAsset, InterDomain) {
-  const auto kNewRole = "newrl";
-  const auto kNewDomain = "newdom";
-  const auto kUser2Id = kUser2 + "@" + kNewDomain;
+  const std::string kNewDomain = "newdom";
+  const std::string kUser2Id = kUser2 + "@" + kNewDomain;
+  const std::string kNewAssetId =
+      IntegrationTestFramework::kAssetName + "#" + kNewDomain;
+
+  auto make_second_user =
+      baseTx()
+          .creatorAccountId(IntegrationTestFramework::kAdminId)
+          .createRole(kRole2, {interface::permissions::Role::kReceive})
+          .createDomain(kNewDomain, kRole2)
+          .createAccount(kUser2, kNewDomain, kUser2Keypair.publicKey())
+          .createAsset(IntegrationTestFramework::kAssetName, kNewDomain, 1)
+          .build()
+          .signAndAddSignature(kAdminKeypair)
+          .finish();
+  auto add_assets =
+      complete(baseTx().addAssetQuantity(kUserId, kNewAssetId, kAmount));
+  auto make_transfer = complete(
+      baseTx().transferAsset(kUserId, kUser2Id, kNewAssetId, kDesc, kAmount));
+
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(
-          shared_model::proto::TransactionBuilder()
-              .creatorAccountId(
-                  integration_framework::IntegrationTestFramework::kAdminId)
-              .createdTime(getUniqueTime())
-              .createRole(kNewRole, {interface::permissions::Role::kReceive})
-              .createDomain(kNewDomain, kNewRole)
-              .createAccount(
-                  kUser2,
-                  kNewDomain,
-                  crypto::DefaultCryptoAlgorithmType::generateKeypair()
-                      .publicKey())
-              .createAsset(IntegrationTestFramework::kAssetName, kNewDomain, 1)
-              .quorum(1)
-              .build()
-              .signAndAddSignature(kAdminKeypair)
-              .finish())
-      .skipProposal()
-      .skipBlock()
-      .sendTx(addAssets(kUser1, kUser1Keypair, kAmount))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(completeTx(
-          baseTx().transferAsset(kUser1Id, kUser2Id, kAsset, kDesc, kAmount)))
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(make_second_user, check(1))
+      .sendTxAwait(add_assets, check(1))
+      .sendTxAwait(make_transfer, check(1))
       .done();
 }
 
@@ -457,14 +326,28 @@ TEST_F(TransferAsset, BigPrecision) {
   const std::string kNewAsset = IntegrationTestFramework::kAssetName + "a";
   const std::string kNewAssetId =
       kNewAsset + "#" + IntegrationTestFramework::kDefaultDomain;
-  const auto precision = 5;
+  const auto kPrecision = 5;
   const std::string kInitial = "500";
   const std::string kForTransfer = "1";
   const std::string kLeft = "499";
 
+  auto create_asset =
+      baseTx()
+          .creatorAccountId(
+              integration_framework::IntegrationTestFramework::kAdminId)
+          .createAsset(
+              kNewAsset, IntegrationTestFramework::kDefaultDomain, kPrecision)
+          .build()
+          .signAndAddSignature(kAdminKeypair)
+          .finish();
+  auto add_assets =
+      complete(baseTx().addAssetQuantity(kUserId, kNewAssetId, kInitial));
+  auto make_transfer = complete(baseTx().transferAsset(
+      kUserId, kUser2Id, kNewAssetId, kDesc, kForTransfer));
+
   auto check_balance = [](std::string account_id, std::string val) {
     return [a = std::move(account_id),
-            v = val + "." + std::string(precision, '0')](auto &resp) {
+            v = val + "." + std::string(kPrecision, '0')](auto &resp) {
       auto &acc_ast = boost::apply_visitor(
           framework::SpecifiedVisitor<interface::AccountAssetResponse>(),
           resp.get());
@@ -475,12 +358,11 @@ TEST_F(TransferAsset, BigPrecision) {
       }
     };
   };
+
   auto make_query = [this](std::string account_id) {
-    return proto::QueryBuilder()
+    return baseQry()
         .creatorAccountId(IntegrationTestFramework::kAdminId)
-        .createdTime(getUniqueTime())
         .getAccountAssets(account_id)
-        .queryCounter(1)
         .build()
         .signAndAddSignature(kAdminKeypair)
         .finish();
@@ -488,50 +370,12 @@ TEST_F(TransferAsset, BigPrecision) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms(kUser1, kUser1Keypair, kPerms, kRole1))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(makeUserWithPerms(kUser2, kUser2Keypair, kPerms, kRole2))
-      .skipProposal()
-      .skipBlock()
-      .sendTx(proto::TransactionBuilder()
-                  .creatorAccountId(
-                      integration_framework::IntegrationTestFramework::kAdminId)
-                  .createdTime(getUniqueTime())
-                  .quorum(1)
-                  .createAsset(kNewAsset,
-                               IntegrationTestFramework::kDefaultDomain,
-                               precision)
-                  .build()
-                  .signAndAddSignature(kAdminKeypair)
-                  .finish())
-      .skipProposal()
-      .checkBlock([](auto &block) {
-        ASSERT_EQ(block->transactions().size(), 1) << "Cannot create asset";
-      })
-      .sendTx(proto::TransactionBuilder()
-                  .creatorAccountId(kUser1Id)
-                  .createdTime(getUniqueTime())
-                  .quorum(1)
-                  .addAssetQuantity(kUser1Id, kNewAssetId, kInitial)
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish())
-      .checkBlock([](auto &block) {
-        ASSERT_EQ(block->transactions().size(), 1) << "Cannot add assets";
-      })
-      .sendTx(proto::TransactionBuilder()
-                  .creatorAccountId(kUser1Id)
-                  .createdTime(getUniqueTime())
-                  .quorum(1)
-                  .transferAsset(
-                      kUser1Id, kUser2Id, kNewAssetId, kDesc, kForTransfer)
-                  .build()
-                  .signAndAddSignature(kUser1Keypair)
-                  .finish())
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .sendQuery(make_query(kUser1Id), check_balance(kUser1Id, kLeft))
+      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeSecondUser(), check(1))
+      .sendTxAwait(create_asset, check(1))
+      .sendTxAwait(add_assets, check(1))
+      .sendTxAwait(make_transfer, check(1))
+      .sendQuery(make_query(kUserId), check_balance(kUserId, kLeft))
       .sendQuery(make_query(kUser2Id), check_balance(kUser2Id, kForTransfer))
       .done();
 }


### PR DESCRIPTION
### Description of the Change

- Add IntegrationTestFramework::sendTxAwait
- Reuse AcceptanceFixture primitive in TA test
- Move out primitive methods in fixture
- Fix WithOnlyCanTransferPerm/WithOnlyCanReceivePerm tests

Also, [I've tried](http://termbin.com/ega0) to remove `Role::kAddAssetQty` from the first user but it seems to have some bug. Feel free to review/comment it as well

### Benefits

Lesser simpler code -> lesser bugs

### Possible Drawbacks 

None?

### Usage Examples or Tests

`make transfer_asset_test && test_bin/transfer_asset_test`
