### PR TITLE
Fix blocks query handle

### DIFF
--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -113,7 +113,6 @@ namespace iroha {
       auto qpf = QueryProcessingFactory(wsv_query, storage_->getBlockQuery());
       if (not qpf.validate(*qry)) {
         auto response = buildBlocksQueryError("Stateful invalid");
-        blocksQuerySubject_.get_subscriber().on_next(response);
         return rxcpp::observable<>::just(
             std::shared_ptr<shared_model::interface::BlockQueryResponse>(
                 response));


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

BlocksQueryHandle method emitted block error response to the blocks observable, which lead to getting stateful invalid responses by users who subscribed on committed blocks.
### Benefits

No one will get block error response but the caller who sent bad request

### Possible Drawbacks 

None

### Usage Examples or Tests 
New blocks query test
