### PR TITLE
Cache CLI input values

### DIFF
--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -38,25 +38,22 @@ namespace iroha_cli {
           // commonParamsMap
           {SAVE_CODE, makeParamsDescription({"Path to save json file"})},
           {SEND_CODE,
-           {std::make_shared<ParamData>(
-                ParamData({"Peer address", default_ip})),
-            std::make_shared<ParamData>(
-                ParamData({"Peer port", std::to_string(default_port)}))}}
+           {ParamData({"Peer address", default_ip}),
+            ParamData({"Peer port", std::to_string(default_port)})}}
           // commonParamsMap
       };
     }
 
     ParamsDescription makeParamsDescription(
         const std::vector<std::string> &params) {
-      return std::accumulate(
-          params.begin(),
-          params.end(),
-          ParamsDescription{},
-          [](auto &&acc, auto &el) {
-            acc.push_back(std::make_shared<ParamData>(ParamData({el, {}})));
-            return std::forward<decltype(acc)>(acc);
-            ;
-          });
+      return std::accumulate(params.begin(),
+                             params.end(),
+                             ParamsDescription{},
+                             [](auto &&acc, auto &el) {
+                               acc.push_back(ParamData({el, {}}));
+                               return std::forward<decltype(acc)>(acc);
+                               ;
+                             });
     }
 
     void handleEmptyCommand() {
@@ -81,7 +78,7 @@ namespace iroha_cli {
       std::cout << "Run " << command
                 << " with following parameters: " << std::endl;
       std::for_each(parameters.begin(), parameters.end(), [](auto el) {
-        std::cout << "  " << el->message << std::endl;
+        std::cout << "  " << el.message << std::endl;
       });
     }
 
@@ -130,9 +127,8 @@ namespace iroha_cli {
     }
 
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap params_map) {
-      auto params_description =
-          findInHandlerMap(command_name, std::move(params_map));
+        std::string line, std::string command_name, ParamsMap &params_map) {
+      auto params_description = findInHandlerMap(command_name, params_map);
       if (not params_description) {
         // Report no params where found for this command
         std::cout << "Command params not found" << std::endl;
@@ -145,16 +141,16 @@ namespace iroha_cli {
         std::vector<std::string> params;
         std::for_each(params_description.value().begin(),
                       params_description.value().end(),
-                      [&params](auto param) {
-                        auto val = promptString(*param);
+                      [&params](auto &param) {
+                        auto val = promptString(param);
                         if (val) {
                           if (not val.value().empty()) {
                             // Update input cache
-                            param->cache = val.value();
+                            param.cache = val.value();
                             params.push_back(val.value());
-                          } else if (not param->cache.empty()) {
+                          } else if (not param.cache.empty()) {
                             // Input cache is not empty, use cached value
-                            params.push_back(param->cache);
+                            params.push_back(param.cache);
                           }
                         }
                       });

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -53,7 +53,6 @@ namespace iroha_cli {
                              [](auto &&acc, auto &el) {
                                acc.push_back(ParamData({el, {}}));
                                return std::forward<decltype(acc)>(acc);
-                               ;
                              });
     }
 

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <utility>
 #include <numeric>
+#include <utility>
 
 #include "interactive/interactive_common_cli.hpp"
 #include "parser/parser.hpp"
@@ -37,25 +37,26 @@ namespace iroha_cli {
       return {
           // commonParamsMap
           {SAVE_CODE, makeParamsDescription({"Path to save json file"})},
-          {SEND_CODE, {
-              std::make_shared<ParamData>(ParamData({"Peer address", default_ip})),
-              std::make_shared<ParamData>(ParamData({"Peer port", std::to_string(default_port)}))
-            }
-          }
+          {SEND_CODE,
+           {std::make_shared<ParamData>(
+                ParamData({"Peer address", default_ip})),
+            std::make_shared<ParamData>(
+                ParamData({"Peer port", std::to_string(default_port)}))}}
           // commonParamsMap
       };
     }
 
-    ParamsDescription makeParamsDescription(const std::vector<std::string> &params) {
-        return std::accumulate(
-            params.begin(),
-            params.end(),
-            ParamsDescription{},
-            [](auto &&acc, auto &el) {
-                acc.push_back(std::make_shared<ParamData>(ParamData({el, {}})));
-                return std::forward<decltype(acc)>(acc);;
-            }
-        );
+    ParamsDescription makeParamsDescription(
+        const std::vector<std::string> &params) {
+      return std::accumulate(
+          params.begin(),
+          params.end(),
+          ParamsDescription{},
+          [](auto &&acc, auto &el) {
+            acc.push_back(std::make_shared<ParamData>(ParamData({el, {}})));
+            return std::forward<decltype(acc)>(acc);
+            ;
+          });
     }
 
     void handleEmptyCommand() {
@@ -72,8 +73,7 @@ namespace iroha_cli {
 
     bool isBackOption(std::string line) {
       auto command = parser::parseFirstCommand(std::move(line));
-      return command
-          and (*command == "0" or *command == BACK_CODE);
+      return command and (*command == "0" or *command == BACK_CODE);
     }
 
     void printCommandParameters(std::string &command,
@@ -103,11 +103,11 @@ namespace iroha_cli {
     }
 
     boost::optional<std::string> promptString(const ParamData &param) {
-        std::string message = param.message;
-        if (not param.cache.empty()) {
-            message += " (" + param.cache + ")";
-        }
-        return promptString(message);
+      std::string message = param.message;
+      if (not param.cache.empty()) {
+        message += " (" + param.cache + ")";
+      }
+      return promptString(message);
     }
 
     void printEnd() {
@@ -148,14 +148,14 @@ namespace iroha_cli {
                       [&params](auto param) {
                         auto val = promptString(*param);
                         if (val) {
-                            if (not val.value().empty()) {
-                                // Update input cache
-                                param->cache = val.value();
-                                params.push_back(val.value());
-                            } else if (not param->cache.empty()) {
-                                // Input cache is not empty, use cached value
-                                params.push_back(param->cache);
-                            }
+                          if (not val.value().empty()) {
+                            // Update input cache
+                            param->cache = val.value();
+                            params.push_back(val.value());
+                          } else if (not param->cache.empty()) {
+                            // Input cache is not empty, use cached value
+                            params.push_back(param->cache);
+                          }
                         }
                       });
         if (params.size() != params_description.value().size()) {

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -35,13 +35,23 @@ namespace iroha_cli {
                                  int default_port) {
       return {
           // commonParamsMap
-          {SAVE_CODE, {"Path to save json file"}},
-          {SEND_CODE,
-           {"Peer address (" + default_ip + ")",
-            "Peer port (" + std::to_string(default_port) + ")"}}
+          {SAVE_CODE, {std::make_pair("Path to save json file", "")}},
+          {SEND_CODE, {
+			  std::make_pair("Peer address", default_ip),
+			  std::make_pair("Peer port", std::to_string(default_port))
+			}
+		  }
           // commonParamsMap
       };
     }
+
+	ParamsData makeParamsData(std::vector<std::string> params) {
+		ParamsData data;
+		std::for_each(params.begin(), params.end(), [&data](auto el) {
+			data.push_back(std::make_pair(el, ""));
+		});
+		return data;
+	}
 
     void handleEmptyCommand() {
       std::cout << "Put not empty command" << std::endl;
@@ -62,11 +72,11 @@ namespace iroha_cli {
     }
 
     void printCommandParameters(std::string &command,
-                                std::vector<std::string> parameters) {
+                                ParamsData parameters) {
       std::cout << "Run " << command
                 << " with following parameters: " << std::endl;
       std::for_each(parameters.begin(), parameters.end(), [](auto el) {
-        std::cout << "  " << el << std::endl;
+        std::cout << "  " << std::get<0>(el) << std::endl;
       });
     }
 
@@ -86,6 +96,14 @@ namespace iroha_cli {
       }
       return line;
     }
+
+	boost::optional<std::string> promptString(std::pair<std::string, std::string> params) {
+		std::string message = std::get<0>(params);
+		if (not std::get<1>(params).empty()) {
+			message += " (" + std::get<1>(params) + ")";
+		}
+		return promptString(message);
+	}
 
     void printEnd() {
       std::cout << "--------------------" << std::endl;
@@ -107,10 +125,10 @@ namespace iroha_cli {
     }
 
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap params_map) {
-      auto params_description =
-          findInHandlerMap(command_name, std::move(params_map));
-      if (not params_description) {
+        std::string line, std::string command_name, ParamsMap &params_map) {
+      auto params_data =
+          findInHandlerMap(command_name, params_map);
+      if (not params_data) {
         // Report no params where found for this command
         std::cout << "Command params not found" << std::endl;
         // Stop parsing, something is not implemented
@@ -120,22 +138,27 @@ namespace iroha_cli {
       if (words.size() == 1) {
         // Start interactive mode
         std::vector<std::string> params;
-        std::for_each(params_description.value().begin(),
-                      params_description.value().end(),
+        std::for_each(params_data.value().begin(),
+                      params_data.value().end(),
                       [&params](auto param) {
                         auto val = promptString(param);
-                        if (val and not val.value().empty()) {
-                          params.push_back(val.value());
-                        }
+						if (val) {
+							if (not val.value().empty()) {
+								std::get<1>(param) = val.value();
+								params.push_back(val.value());
+							} else if (not std::get<1>(param).empty()) {
+								params.push_back(std::get<1>(param));
+							}
+						}
                       });
-        if (params.size() != params_description.value().size()) {
+        if (params.size() != params_data.value().size()) {
           // Wrong params passed
           return boost::none;
         }
         return params;
-      } else if (words.size() != params_description.value().size() + 1) {
+      } else if (words.size() != params_data.value().size() + 1) {
         // Not enough parameters passed
-        printCommandParameters(command_name, params_description.value());
+        printCommandParameters(command_name, params_data.value());
         return boost::none;
       } else {
         // Remove command name, return parameters

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -17,6 +17,7 @@
 #include <numeric>
 #include <utility>
 
+#include "common/types.hpp"
 #include "interactive/interactive_common_cli.hpp"
 #include "parser/parser.hpp"
 
@@ -142,17 +143,17 @@ namespace iroha_cli {
         std::for_each(params_description.value().begin(),
                       params_description.value().end(),
                       [&params](auto &param) {
-                        auto val = promptString(param);
-                        if (val) {
-                          if (not val.value().empty()) {
+                        using namespace iroha;
+                        promptString(param) | [&](auto &val) {
+                          if (not val.empty()) {
                             // Update input cache
-                            param.cache = val.value();
-                            params.push_back(val.value());
+                            param.cache = val;
+                            params.push_back(val);
                           } else if (not param.cache.empty()) {
                             // Input cache is not empty, use cached value
                             params.push_back(param.cache);
                           }
-                        }
+                        };
                       });
         if (params.size() != params_description.value().size()) {
           // Wrong params passed

--- a/iroha-cli/interactive/impl/interactive_common_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_common_cli.cpp
@@ -35,10 +35,10 @@ namespace iroha_cli {
                                  int default_port) {
       return {
           // commonParamsMap
-          {SAVE_CODE, {std::make_pair("Path to save json file", "")}},
+          {SAVE_CODE, makeParamsData({"Path to save json file"})},
           {SEND_CODE, {
-			  std::make_pair("Peer address", default_ip),
-			  std::make_pair("Peer port", std::to_string(default_port))
+			  std::make_shared<param_t>(std::make_pair("Peer address", default_ip)),
+			  std::make_shared<param_t>(std::make_pair("Peer port", std::to_string(default_port)))
 			}
 		  }
           // commonParamsMap
@@ -48,7 +48,7 @@ namespace iroha_cli {
 	ParamsData makeParamsData(std::vector<std::string> params) {
 		ParamsData data;
 		std::for_each(params.begin(), params.end(), [&data](auto el) {
-			data.push_back(std::make_pair(el, ""));
+			data.push_back(std::make_shared<param_t>(std::make_pair(el, "")));
 		});
 		return data;
 	}
@@ -76,7 +76,7 @@ namespace iroha_cli {
       std::cout << "Run " << command
                 << " with following parameters: " << std::endl;
       std::for_each(parameters.begin(), parameters.end(), [](auto el) {
-        std::cout << "  " << std::get<0>(el) << std::endl;
+        std::cout << "  " << std::get<0>(*el) << std::endl;
       });
     }
 
@@ -125,7 +125,7 @@ namespace iroha_cli {
     }
 
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap &params_map) {
+        std::string line, std::string command_name, ParamsMap params_map) {
       auto params_data =
           findInHandlerMap(command_name, params_map);
       if (not params_data) {
@@ -141,13 +141,13 @@ namespace iroha_cli {
         std::for_each(params_data.value().begin(),
                       params_data.value().end(),
                       [&params](auto param) {
-                        auto val = promptString(param);
+                        auto val = promptString(*param);
 						if (val) {
 							if (not val.value().empty()) {
-								std::get<1>(param) = val.value();
+								std::get<1>(*param) = val.value();
 								params.push_back(val.value());
-							} else if (not std::get<1>(param).empty()) {
-								params.push_back(std::get<1>(param));
+							} else if (not std::get<1>(*param).empty()) {
+								params.push_back(std::get<1>(*param));
 							}
 						}
                       });

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -58,17 +58,17 @@ namespace iroha_cli {
       const auto role_id = "Requested role name";
       const auto tx_hashes = "Requested tx hashes";
 
-      query_params_descriptions_ = {
-          {GET_ACC, {acc_id}},
-          {GET_ACC_AST, {acc_id, ast_id}},
-          {GET_ACC_AST_TX, {acc_id, ast_id}},
-          {GET_ACC_TX, {acc_id}},
-          {GET_TX, {tx_hashes}},
-          {GET_ACC_SIGN, {acc_id}},
-          {GET_ROLES, {}},
-          {GET_AST_INFO, {ast_id}},
-          {GET_ROLE_PERM, {role_id}}
-          // query_params_descriptions_
+      query_params_data_ = {
+          {GET_ACC, makeParamsData({acc_id})},
+          {GET_ACC_AST, makeParamsData({acc_id, ast_id})},
+          {GET_ACC_AST_TX, makeParamsData({acc_id, ast_id})},
+          {GET_ACC_TX, makeParamsData({acc_id})},
+          {GET_TX, makeParamsData({tx_hashes})},
+          {GET_ACC_SIGN, makeParamsData({acc_id})},
+          {GET_ROLES, makeParamsData({})},
+          {GET_AST_INFO, makeParamsData({ast_id})},
+          {GET_ROLE_PERM, makeParamsData({role_id})}
+          // query_params_data_
       };
 
       query_handlers_ = {
@@ -85,7 +85,7 @@ namespace iroha_cli {
       };
 
       menu_points_ = formMenu(
-          query_handlers_, query_params_descriptions_, description_map_);
+          query_handlers_, query_params_data_, description_map_);
       // Add "go back" option
       addBackOption(menu_points_);
     }
@@ -93,11 +93,11 @@ namespace iroha_cli {
     void InteractiveQueryCli::create_result_menu() {
       result_handlers_ = {{SAVE_CODE, &InteractiveQueryCli::parseSaveFile},
                           {SEND_CODE, &InteractiveQueryCli::parseSendToIroha}};
-      result_params_descriptions_ =
+      result_params_data_ =
           getCommonParamsMap(default_peer_ip_, default_port_);
 
       result_points_ = formMenu(result_handlers_,
-                                result_params_descriptions_,
+                                result_params_data_,
                                 getCommonDescriptionMap());
       addBackOption(result_points_);
     }
@@ -159,7 +159,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<std::shared_ptr<iroha::model::Query>>(
-          this, line, query_handlers_, query_params_descriptions_);
+          this, line, query_handlers_, query_params_data_);
       if (not res) {
         // Continue parsing
         return true;
@@ -260,7 +260,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_descriptions_);
+          this, line, result_handlers_, result_params_data_);
 
       return res.get_value_or(true);
     }

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -58,17 +58,17 @@ namespace iroha_cli {
       const auto role_id = "Requested role name";
       const auto tx_hashes = "Requested tx hashes";
 
-      query_params_data_ = {
-          {GET_ACC, makeParamsData({acc_id})},
-          {GET_ACC_AST, makeParamsData({acc_id, ast_id})},
-          {GET_ACC_AST_TX, makeParamsData({acc_id, ast_id})},
-          {GET_ACC_TX, makeParamsData({acc_id})},
-          {GET_TX, makeParamsData({tx_hashes})},
-          {GET_ACC_SIGN, makeParamsData({acc_id})},
-          {GET_ROLES, makeParamsData({})},
-          {GET_AST_INFO, makeParamsData({ast_id})},
-          {GET_ROLE_PERM, makeParamsData({role_id})}
-          // query_params_data_
+      query_params_map_ = {
+          {GET_ACC, makeParamsDescription({acc_id})},
+          {GET_ACC_AST, makeParamsDescription({acc_id, ast_id})},
+          {GET_ACC_AST_TX, makeParamsDescription({acc_id, ast_id})},
+          {GET_ACC_TX, makeParamsDescription({acc_id})},
+          {GET_TX, makeParamsDescription({tx_hashes})},
+          {GET_ACC_SIGN, makeParamsDescription({acc_id})},
+          {GET_ROLES, makeParamsDescription({})},
+          {GET_AST_INFO, makeParamsDescription({ast_id})},
+          {GET_ROLE_PERM, makeParamsDescription({role_id})}
+          // query_params_map_
       };
 
       query_handlers_ = {
@@ -85,7 +85,7 @@ namespace iroha_cli {
       };
 
       menu_points_ = formMenu(
-          query_handlers_, query_params_data_, description_map_);
+          query_handlers_, query_params_map_, description_map_);
       // Add "go back" option
       addBackOption(menu_points_);
     }
@@ -93,11 +93,11 @@ namespace iroha_cli {
     void InteractiveQueryCli::create_result_menu() {
       result_handlers_ = {{SAVE_CODE, &InteractiveQueryCli::parseSaveFile},
                           {SEND_CODE, &InteractiveQueryCli::parseSendToIroha}};
-      result_params_data_ =
+      result_params_map_ =
           getCommonParamsMap(default_peer_ip_, default_port_);
 
       result_points_ = formMenu(result_handlers_,
-                                result_params_data_,
+                                result_params_map_,
                                 getCommonDescriptionMap());
       addBackOption(result_points_);
     }
@@ -159,7 +159,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<std::shared_ptr<iroha::model::Query>>(
-          this, line, query_handlers_, query_params_data_);
+          this, line, query_handlers_, query_params_map_);
       if (not res) {
         // Continue parsing
         return true;
@@ -260,7 +260,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_data_);
+          this, line, result_handlers_, result_params_map_);
 
       return res.get_value_or(true);
     }

--- a/iroha-cli/interactive/impl/interactive_query_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_query_cli.cpp
@@ -74,7 +74,8 @@ namespace iroha_cli {
       query_handlers_ = {
           {GET_ACC, &InteractiveQueryCli::parseGetAccount},
           {GET_ACC_AST, &InteractiveQueryCli::parseGetAccountAssets},
-          {GET_ACC_AST_TX, &InteractiveQueryCli::parseGetAccountAssetTransactions},
+          {GET_ACC_AST_TX,
+           &InteractiveQueryCli::parseGetAccountAssetTransactions},
           {GET_ACC_TX, &InteractiveQueryCli::parseGetAccountTransactions},
           {GET_TX, &InteractiveQueryCli::parseGetTransactions},
           {GET_ACC_SIGN, &InteractiveQueryCli::parseGetSignatories},
@@ -84,8 +85,8 @@ namespace iroha_cli {
           // query_handlers_
       };
 
-      menu_points_ = formMenu(
-          query_handlers_, query_params_map_, description_map_);
+      menu_points_ =
+          formMenu(query_handlers_, query_params_map_, description_map_);
       // Add "go back" option
       addBackOption(menu_points_);
     }
@@ -93,12 +94,10 @@ namespace iroha_cli {
     void InteractiveQueryCli::create_result_menu() {
       result_handlers_ = {{SAVE_CODE, &InteractiveQueryCli::parseSaveFile},
                           {SEND_CODE, &InteractiveQueryCli::parseSendToIroha}};
-      result_params_map_ =
-          getCommonParamsMap(default_peer_ip_, default_port_);
+      result_params_map_ = getCommonParamsMap(default_peer_ip_, default_port_);
 
-      result_points_ = formMenu(result_handlers_,
-                                result_params_map_,
-                                getCommonDescriptionMap());
+      result_points_ = formMenu(
+          result_handlers_, result_params_map_, getCommonDescriptionMap());
       addBackOption(result_points_);
     }
 
@@ -259,8 +258,8 @@ namespace iroha_cli {
         return true;
       }
 
-      auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_map_);
+      auto res =
+          handleParse<bool>(this, line, result_handlers_, result_params_map_);
 
       return res.get_value_or(true);
     }

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -50,7 +50,8 @@ namespace iroha_cli {
       descriptionMap_ = {{GET_TX_INFO, "Get status of transaction"}};
       const auto tx_id = "Requested tx hash";
 
-      requestParamsDescriptions_ = {{GET_TX_INFO, makeParamsDescription({tx_id})}};
+      requestParamsDescriptions_ = {
+          {GET_TX_INFO, makeParamsDescription({tx_id})}};
       actionHandlers_ = {{GET_TX_INFO, &InteractiveStatusCli::parseGetHash}};
 
       menuPoints_ = formMenu(
@@ -76,7 +77,7 @@ namespace iroha_cli {
       printMenu("Choose action: ", menuPoints_);
       while (isParsing) {
         auto line = promptString("> ");
-        if (not line){
+        if (not line) {
           // line has terminating symbol
           isParsing = false;
           break;

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -50,7 +50,7 @@ namespace iroha_cli {
       descriptionMap_ = {{GET_TX_INFO, "Get status of transaction"}};
       const auto tx_id = "Requested tx hash";
 
-      requestParamsDescriptions_ = {{GET_TX_INFO, {tx_id}}};
+      requestParamsDescriptions_ = {{GET_TX_INFO, makeParamsData({tx_id})}};
       actionHandlers_ = {{GET_TX_INFO, &InteractiveStatusCli::parseGetHash}};
 
       menuPoints_ = formMenu(

--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -50,7 +50,7 @@ namespace iroha_cli {
       descriptionMap_ = {{GET_TX_INFO, "Get status of transaction"}};
       const auto tx_id = "Requested tx hash";
 
-      requestParamsDescriptions_ = {{GET_TX_INFO, makeParamsData({tx_id})}};
+      requestParamsDescriptions_ = {{GET_TX_INFO, makeParamsDescription({tx_id})}};
       actionHandlers_ = {{GET_TX_INFO, &InteractiveStatusCli::parseGetHash}};
 
       menuPoints_ = formMenu(

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -87,31 +87,34 @@ namespace iroha_cli {
       const auto can_roles = "Can create/append roles";
 
       command_params_map_ = {
-          {ADD_ASSET_QTY, makeParamsDescription({acc_id, ast_id, amount_a, amount_b})},
+          {ADD_ASSET_QTY,
+           makeParamsDescription({acc_id, ast_id, amount_a, amount_b})},
           {ADD_PEER, makeParamsDescription({peer_id, pub_key})},
           {ADD_SIGN, makeParamsDescription({acc_id, pub_key})},
           {CREATE_ACC, makeParamsDescription({acc_name, dom_id, pub_key})},
-          {CREATE_DOMAIN, makeParamsDescription({dom_id, std::string("Default ") + role})},
-          {CREATE_ASSET, makeParamsDescription({ast_name, dom_id, ast_precision})},
+          {CREATE_DOMAIN,
+           makeParamsDescription({dom_id, std::string("Default ") + role})},
+          {CREATE_ASSET,
+           makeParamsDescription({ast_name, dom_id, ast_precision})},
           {REMOVE_SIGN, makeParamsDescription({acc_id, pub_key})},
           {SET_QUO, makeParamsDescription({acc_id, quorum})},
           {SUB_ASSET_QTY, makeParamsDescription({})},
           {TRAN_ASSET,
-            makeParamsDescription({std::string("Src") + acc_id,
-            std::string("Dest") + acc_id,
-            ast_id,
-            amount_a,
-            amount_b})},
+           makeParamsDescription({std::string("Src") + acc_id,
+                                  std::string("Dest") + acc_id,
+                                  ast_id,
+                                  amount_a,
+                                  amount_b})},
           {CREATE_ROLE,
-            makeParamsDescription({role,
-            can_read_self,
-            can_edit_self,
-            can_read_all,
-            can_transfer_receive,
-            can_asset_creator,
-            can_create_domain,
-            can_roles,
-            can_create_account})},
+           makeParamsDescription({role,
+                                  can_read_self,
+                                  can_edit_self,
+                                  can_read_all,
+                                  can_transfer_receive,
+                                  can_asset_creator,
+                                  can_create_domain,
+                                  can_roles,
+                                  can_create_account})},
           {APPEND_ROLE, makeParamsDescription({acc_id, role})},
           {DETACH_ROLE, makeParamsDescription({acc_id, role})},
           {GRANT_PERM, makeParamsDescription({acc_id, perm})},
@@ -141,9 +144,8 @@ namespace iroha_cli {
           // Command parsers
       };
 
-      commands_menu_ = formMenu(command_handlers_,
-                                command_params_map_,
-                                commands_description_map_);
+      commands_menu_ = formMenu(
+          command_handlers_, command_params_map_, commands_description_map_);
       // Add "go back" option
       addBackOption(commands_menu_);
     }
@@ -159,8 +161,7 @@ namespace iroha_cli {
       result_desciption.insert(
           {BACK_CODE, "Go back and start a new transaction"});
 
-      result_params_map =
-          getCommonParamsMap(default_peer_ip_, default_port_);
+      result_params_map = getCommonParamsMap(default_peer_ip_, default_port_);
 
       result_params_map.insert({ADD_CMD, {}});
       result_params_map.insert({BACK_CODE, {}});
@@ -173,8 +174,8 @@ namespace iroha_cli {
           // Parsers for result
       };
 
-      result_menu_ = formMenu(
-          result_handlers_, result_params_map, result_desciption);
+      result_menu_ =
+          formMenu(result_handlers_, result_params_map, result_desciption);
     }
 
     InteractiveTransactionCli::InteractiveTransactionCli(
@@ -457,8 +458,8 @@ namespace iroha_cli {
 
     bool InteractiveTransactionCli::parseResult(std::string line) {
       // Find in result handler map
-      auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_map);
+      auto res =
+          handleParse<bool>(this, line, result_handlers_, result_params_map);
       return res.get_value_or(true);
     }
 

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -86,24 +86,24 @@ namespace iroha_cli {
       const auto can_asset_creator = "Can create/add new assets";
       const auto can_roles = "Can create/append roles";
 
-      command_params_data_ = {
-          {ADD_ASSET_QTY, makeParamsData({acc_id, ast_id, amount_a, amount_b})},
-          {ADD_PEER, makeParamsData({peer_id, pub_key})},
-          {ADD_SIGN, makeParamsData({acc_id, pub_key})},
-          {CREATE_ACC, makeParamsData({acc_name, dom_id, pub_key})},
-          {CREATE_DOMAIN, makeParamsData({dom_id, std::string("Default ") + role})},
-          {CREATE_ASSET, makeParamsData({ast_name, dom_id, ast_precision})},
-          {REMOVE_SIGN, makeParamsData({acc_id, pub_key})},
-          {SET_QUO, makeParamsData({acc_id, quorum})},
-          {SUB_ASSET_QTY, makeParamsData({})},
+      command_params_map_ = {
+          {ADD_ASSET_QTY, makeParamsDescription({acc_id, ast_id, amount_a, amount_b})},
+          {ADD_PEER, makeParamsDescription({peer_id, pub_key})},
+          {ADD_SIGN, makeParamsDescription({acc_id, pub_key})},
+          {CREATE_ACC, makeParamsDescription({acc_name, dom_id, pub_key})},
+          {CREATE_DOMAIN, makeParamsDescription({dom_id, std::string("Default ") + role})},
+          {CREATE_ASSET, makeParamsDescription({ast_name, dom_id, ast_precision})},
+          {REMOVE_SIGN, makeParamsDescription({acc_id, pub_key})},
+          {SET_QUO, makeParamsDescription({acc_id, quorum})},
+          {SUB_ASSET_QTY, makeParamsDescription({})},
           {TRAN_ASSET,
-           makeParamsData({std::string("Src") + acc_id,
+            makeParamsDescription({std::string("Src") + acc_id,
             std::string("Dest") + acc_id,
             ast_id,
             amount_a,
             amount_b})},
           {CREATE_ROLE,
-           makeParamsData({role,
+            makeParamsDescription({role,
             can_read_self,
             can_edit_self,
             can_read_all,
@@ -112,11 +112,11 @@ namespace iroha_cli {
             can_create_domain,
             can_roles,
             can_create_account})},
-          {APPEND_ROLE, makeParamsData({acc_id, role})},
-          {DETACH_ROLE, makeParamsData({acc_id, role})},
-          {GRANT_PERM, makeParamsData({acc_id, perm})},
-          {REVOKE_PERM, makeParamsData({acc_id, perm})},
-          {SET_ACC_KV, makeParamsData({acc_id, "key", "value"})}
+          {APPEND_ROLE, makeParamsDescription({acc_id, role})},
+          {DETACH_ROLE, makeParamsDescription({acc_id, role})},
+          {GRANT_PERM, makeParamsDescription({acc_id, perm})},
+          {REVOKE_PERM, makeParamsDescription({acc_id, perm})},
+          {SET_ACC_KV, makeParamsDescription({acc_id, "key", "value"})}
           // command parameters descriptions
       };
 
@@ -142,7 +142,7 @@ namespace iroha_cli {
       };
 
       commands_menu_ = formMenu(command_handlers_,
-                                command_params_data_,
+                                command_params_map_,
                                 commands_description_map_);
       // Add "go back" option
       addBackOption(commands_menu_);
@@ -159,11 +159,11 @@ namespace iroha_cli {
       result_desciption.insert(
           {BACK_CODE, "Go back and start a new transaction"});
 
-      result_params_data =
+      result_params_map =
           getCommonParamsMap(default_peer_ip_, default_port_);
 
-      result_params_data.insert({ADD_CMD, {}});
-      result_params_data.insert({BACK_CODE, {}});
+      result_params_map.insert({ADD_CMD, {}});
+      result_params_map.insert({BACK_CODE, {}});
 
       result_handlers_ = {
           {SAVE_CODE, &InteractiveTransactionCli::parseSaveFile},
@@ -174,7 +174,7 @@ namespace iroha_cli {
       };
 
       result_menu_ = formMenu(
-          result_handlers_, result_params_data, result_desciption);
+          result_handlers_, result_params_map, result_desciption);
     }
 
     InteractiveTransactionCli::InteractiveTransactionCli(
@@ -227,7 +227,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<std::shared_ptr<iroha::model::Command>>(
-          this, line, command_handlers_, command_params_data_);
+          this, line, command_handlers_, command_params_map_);
 
       if (not res) {
         // Continue parsing
@@ -458,7 +458,7 @@ namespace iroha_cli {
     bool InteractiveTransactionCli::parseResult(std::string line) {
       // Find in result handler map
       auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_data);
+          this, line, result_handlers_, result_params_map);
       return res.get_value_or(true);
     }
 

--- a/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_transaction_cli.cpp
@@ -86,24 +86,24 @@ namespace iroha_cli {
       const auto can_asset_creator = "Can create/add new assets";
       const auto can_roles = "Can create/append roles";
 
-      command_params_descriptions_ = {
-          {ADD_ASSET_QTY, {acc_id, ast_id, amount_a, amount_b}},
-          {ADD_PEER, {peer_id, pub_key}},
-          {ADD_SIGN, {acc_id, pub_key}},
-          {CREATE_ACC, {acc_name, dom_id, pub_key}},
-          {CREATE_DOMAIN, {dom_id, std::string("Default ") + role}},
-          {CREATE_ASSET, {ast_name, dom_id, ast_precision}},
-          {REMOVE_SIGN, {acc_id, pub_key}},
-          {SET_QUO, {acc_id, quorum}},
-          {SUB_ASSET_QTY, {}},
+      command_params_data_ = {
+          {ADD_ASSET_QTY, makeParamsData({acc_id, ast_id, amount_a, amount_b})},
+          {ADD_PEER, makeParamsData({peer_id, pub_key})},
+          {ADD_SIGN, makeParamsData({acc_id, pub_key})},
+          {CREATE_ACC, makeParamsData({acc_name, dom_id, pub_key})},
+          {CREATE_DOMAIN, makeParamsData({dom_id, std::string("Default ") + role})},
+          {CREATE_ASSET, makeParamsData({ast_name, dom_id, ast_precision})},
+          {REMOVE_SIGN, makeParamsData({acc_id, pub_key})},
+          {SET_QUO, makeParamsData({acc_id, quorum})},
+          {SUB_ASSET_QTY, makeParamsData({})},
           {TRAN_ASSET,
-           {std::string("Src") + acc_id,
+           makeParamsData({std::string("Src") + acc_id,
             std::string("Dest") + acc_id,
             ast_id,
             amount_a,
-            amount_b}},
+            amount_b})},
           {CREATE_ROLE,
-           {role,
+           makeParamsData({role,
             can_read_self,
             can_edit_self,
             can_read_all,
@@ -111,12 +111,12 @@ namespace iroha_cli {
             can_asset_creator,
             can_create_domain,
             can_roles,
-            can_create_account}},
-          {APPEND_ROLE, {acc_id, role}},
-          {DETACH_ROLE, {acc_id, role}},
-          {GRANT_PERM, {acc_id, perm}},
-          {REVOKE_PERM, {acc_id, perm}},
-          {SET_ACC_KV, {acc_id, "key", "value"}}
+            can_create_account})},
+          {APPEND_ROLE, makeParamsData({acc_id, role})},
+          {DETACH_ROLE, makeParamsData({acc_id, role})},
+          {GRANT_PERM, makeParamsData({acc_id, perm})},
+          {REVOKE_PERM, makeParamsData({acc_id, perm})},
+          {SET_ACC_KV, makeParamsData({acc_id, "key", "value"})}
           // command parameters descriptions
       };
 
@@ -142,7 +142,7 @@ namespace iroha_cli {
       };
 
       commands_menu_ = formMenu(command_handlers_,
-                                command_params_descriptions_,
+                                command_params_data_,
                                 commands_description_map_);
       // Add "go back" option
       addBackOption(commands_menu_);
@@ -159,11 +159,11 @@ namespace iroha_cli {
       result_desciption.insert(
           {BACK_CODE, "Go back and start a new transaction"});
 
-      result_params_descriptions =
+      result_params_data =
           getCommonParamsMap(default_peer_ip_, default_port_);
 
-      result_params_descriptions.insert({ADD_CMD, {}});
-      result_params_descriptions.insert({BACK_CODE, {}});
+      result_params_data.insert({ADD_CMD, {}});
+      result_params_data.insert({BACK_CODE, {}});
 
       result_handlers_ = {
           {SAVE_CODE, &InteractiveTransactionCli::parseSaveFile},
@@ -174,7 +174,7 @@ namespace iroha_cli {
       };
 
       result_menu_ = formMenu(
-          result_handlers_, result_params_descriptions, result_desciption);
+          result_handlers_, result_params_data, result_desciption);
     }
 
     InteractiveTransactionCli::InteractiveTransactionCli(
@@ -227,7 +227,7 @@ namespace iroha_cli {
       }
 
       auto res = handleParse<std::shared_ptr<iroha::model::Command>>(
-          this, line, command_handlers_, command_params_descriptions_);
+          this, line, command_handlers_, command_params_data_);
 
       if (not res) {
         // Continue parsing
@@ -458,7 +458,7 @@ namespace iroha_cli {
     bool InteractiveTransactionCli::parseResult(std::string line) {
       // Find in result handler map
       auto res = handleParse<bool>(
-          this, line, result_handlers_, result_params_descriptions);
+          this, line, result_handlers_, result_params_data);
       return res.get_value_or(true);
     }
 

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -19,12 +19,12 @@
 #define IROHA_CLI_INTERACTIVE_COMMON_CLI_HPP
 
 #include <algorithm>
-#include <iostream>
 #include <boost/optional.hpp>
+#include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <memory>
 
 namespace parser {
   boost::optional<std::string> parseFirstCommand(std::string line);
@@ -47,11 +47,10 @@ namespace iroha_cli {
       RESULT
     };
 
-
     // Parameter prompt and default/cache
     struct ParamData {
-        std::string message;
-        std::string cache;
+      std::string message;
+      std::string cache;
     };
 
     // Description of parameters
@@ -81,7 +80,8 @@ namespace iroha_cli {
     ParamsMap getCommonParamsMap(const std::string &default_ip,
                                  int default_port);
 
-    ParamsDescription makeParamsDescription(const std::vector<std::string> &params);
+    ParamsDescription makeParamsDescription(
+        const std::vector<std::string> &params);
 
     /**
      * Handle error with empty command
@@ -189,7 +189,7 @@ namespace iroha_cli {
      */
     template <typename K, typename V>
     boost::optional<V> findInHandlerMap(K command_name,
-                                         std::unordered_map<K, V> params_map) {
+                                        std::unordered_map<K, V> params_map) {
       auto it = params_map.find(command_name);
       if (it == params_map.end()) {
         // Command not found, report error

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -47,9 +47,19 @@ namespace iroha_cli {
       RESULT
     };
 
-    // Parameter prompt and default/cache
+    /**
+     * Data structure for parameter data
+     *
+     */
     struct ParamData {
+      /**
+       * Message to display when prompting for user input
+       */
       std::string message;
+
+      /**
+       * Cached user input for the parameter or the default value
+       */
       std::string cache;
     };
 
@@ -75,11 +85,19 @@ namespace iroha_cli {
 
     /**
      * Return mapping of Command_name to parameters descriptions
-     * @return Map with parameters of common commands
+     * @param default_ip - default hostname or IP to be used when connecting to
+     * irohad
+     * @param default_port - default port to be used when connecting to irohad
+     * @return ParamsMap with parameters of common commands
      */
     ParamsMap getCommonParamsMap(const std::string &default_ip,
                                  int default_port);
 
+    /**
+     * Creates parameters descriptions with empty default/cache values
+     * @param params - parameters as a vector of prompt messages
+     * @return ParamsDescription with parameter data
+     */
     ParamsDescription makeParamsDescription(
         const std::vector<std::string> &params);
 

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -54,7 +54,7 @@ namespace iroha_cli {
     };
 
     // Description of parameters
-    using ParamsDescription = std::vector<std::shared_ptr<ParamData>>;
+    using ParamsDescription = std::vector<ParamData>;
     // map for command - command description relationship
     using DescriptionMap = std::unordered_map<std::string, std::string>;
     // Points in a menu
@@ -153,7 +153,7 @@ namespace iroha_cli {
      * @return vector with needed parameters
      */
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap params_map);
+        std::string line, std::string command_name, ParamsMap &params_map);
 
     /**
      * Add menu point to vector menu
@@ -188,8 +188,8 @@ namespace iroha_cli {
      * @return nullopt if key not found, value if found
      */
     template <typename K, typename V>
-    boost::optional<V> findInHandlerMap(K command_name,
-                                        std::unordered_map<K, V> params_map) {
+    boost::optional<V &> findInHandlerMap(
+        K command_name, std::unordered_map<K, V> &params_map) {
       auto it = params_map.find(command_name);
       if (it == params_map.end()) {
         // Command not found, report error
@@ -228,7 +228,7 @@ namespace iroha_cli {
         C class_pointer,
         std::string &line,
         std::unordered_map<std::string, V> &parsers_map,
-        ParamsMap params_map) {
+        ParamsMap &params_map) {
       auto raw_command = parser::parseFirstCommand(line);
       if (not raw_command) {
         handleEmptyCommand();

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -47,17 +47,16 @@ namespace iroha_cli {
     };
 
 
-	using param_t = std::pair<std::string, std::string>;
-	using ParamsData = std::vector<std::shared_ptr<param_t>>;
-
+    // Parameter prompt and default/cache value pair
+    using ParamData = std::pair<std::string, std::string>;
     // Description of parameters
-    using ParamsDescription = std::vector<std::string>;
+    using ParamsDescription = std::vector<std::shared_ptr<ParamData>>;
     // map for command - command description relationship
     using DescriptionMap = std::unordered_map<std::string, std::string>;
     // Points in a menu
     using MenuPoints = std::vector<std::string>;
     // map for command - ParamsDescription relationship
-    using ParamsMap = std::unordered_map<std::string, ParamsData>;
+    using ParamsMap = std::unordered_map<std::string, ParamsDescription>;
 
     // ------ Common commands short name ---------
     const std::string SAVE_CODE = "save";
@@ -77,7 +76,7 @@ namespace iroha_cli {
     ParamsMap getCommonParamsMap(const std::string &default_ip,
                                  int default_port);
 
-	ParamsData makeParamsData(std::vector<std::string> params);
+    ParamsDescription makeParamsDescription(std::vector<std::string> params);
 
     /**
      * Handle error with empty command
@@ -114,7 +113,7 @@ namespace iroha_cli {
      * @param parameters needed to run the command
      */
     void printCommandParameters(std::string &command,
-                                ParamsData parameters);
+                                ParamsDescription parameters);
 
     /**
      * Pretty Print of menu
@@ -131,11 +130,11 @@ namespace iroha_cli {
     boost::optional<std::string> promptString(const std::string &message);
 
     /**
-     * Get string input from user
-     * @param message Message to ask user
+     * Construct a prompt and get a string input from user
+     * @param param Parameter to collect the input for
      * @return nullopt if termintaing symbol, else user's input
      */
-    boost::optional<std::string> promptString(std::pair<std::string, std::string> params);
+    boost::optional<std::string> promptString(ParamData param);
 
     /**
      * Parse parameters in interactive and shortcuted mode.

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 namespace parser {
   boost::optional<std::string> parseFirstCommand(std::string line);

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -49,7 +49,6 @@ namespace iroha_cli {
 
     /**
      * Data structure for parameter data
-     *
      */
     struct ParamData {
       /**

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -47,7 +47,8 @@ namespace iroha_cli {
     };
 
 
-	using ParamsData = std::vector<std::pair<std::string, std::string>>;
+	using param_t = std::pair<std::string, std::string>;
+	using ParamsData = std::vector<std::shared_ptr<param_t>>;
 
     // Description of parameters
     using ParamsDescription = std::vector<std::string>;
@@ -148,7 +149,7 @@ namespace iroha_cli {
      * @return vector with needed parameters
      */
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap &params_map);
+        std::string line, std::string command_name, ParamsMap params_map);
 
     /**
      * Add menu point to vector menu
@@ -184,7 +185,7 @@ namespace iroha_cli {
      */
     template <typename K, typename V>
     boost::optional<V> findInHandlerMap(K command_name,
-                                         std::unordered_map<K, V> &params_map) {
+                                         std::unordered_map<K, V> params_map) {
       auto it = params_map.find(command_name);
       if (it == params_map.end()) {
         // Command not found, report error
@@ -223,7 +224,7 @@ namespace iroha_cli {
         C class_pointer,
         std::string &line,
         std::unordered_map<std::string, V> &parsers_map,
-        ParamsMap &params_map) {
+        ParamsMap params_map) {
       auto raw_command = parser::parseFirstCommand(line);
       if (not raw_command) {
         handleEmptyCommand();

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -48,8 +48,12 @@ namespace iroha_cli {
     };
 
 
-    // Parameter prompt and default/cache value pair
-    using ParamData = std::pair<std::string, std::string>;
+    // Parameter prompt and default/cache
+    struct ParamData {
+        std::string message;
+        std::string cache;
+    };
+
     // Description of parameters
     using ParamsDescription = std::vector<std::shared_ptr<ParamData>>;
     // map for command - command description relationship
@@ -77,7 +81,7 @@ namespace iroha_cli {
     ParamsMap getCommonParamsMap(const std::string &default_ip,
                                  int default_port);
 
-    ParamsDescription makeParamsDescription(std::vector<std::string> params);
+    ParamsDescription makeParamsDescription(const std::vector<std::string> &params);
 
     /**
      * Handle error with empty command
@@ -114,7 +118,7 @@ namespace iroha_cli {
      * @param parameters needed to run the command
      */
     void printCommandParameters(std::string &command,
-                                ParamsDescription parameters);
+                                const ParamsDescription &parameters);
 
     /**
      * Pretty Print of menu
@@ -135,7 +139,7 @@ namespace iroha_cli {
      * @param param Parameter to collect the input for
      * @return nullopt if termintaing symbol, else user's input
      */
-    boost::optional<std::string> promptString(ParamData param);
+    boost::optional<std::string> promptString(const ParamData &param);
 
     /**
      * Parse parameters in interactive and shortcuted mode.

--- a/iroha-cli/interactive/interactive_common_cli.hpp
+++ b/iroha-cli/interactive/interactive_common_cli.hpp
@@ -46,6 +46,9 @@ namespace iroha_cli {
       RESULT
     };
 
+
+	using ParamsData = std::vector<std::pair<std::string, std::string>>;
+
     // Description of parameters
     using ParamsDescription = std::vector<std::string>;
     // map for command - command description relationship
@@ -53,7 +56,7 @@ namespace iroha_cli {
     // Points in a menu
     using MenuPoints = std::vector<std::string>;
     // map for command - ParamsDescription relationship
-    using ParamsMap = std::unordered_map<std::string, ParamsDescription>;
+    using ParamsMap = std::unordered_map<std::string, ParamsData>;
 
     // ------ Common commands short name ---------
     const std::string SAVE_CODE = "save";
@@ -72,6 +75,8 @@ namespace iroha_cli {
      */
     ParamsMap getCommonParamsMap(const std::string &default_ip,
                                  int default_port);
+
+	ParamsData makeParamsData(std::vector<std::string> params);
 
     /**
      * Handle error with empty command
@@ -108,7 +113,7 @@ namespace iroha_cli {
      * @param parameters needed to run the command
      */
     void printCommandParameters(std::string &command,
-                                std::vector<std::string> parameters);
+                                ParamsData parameters);
 
     /**
      * Pretty Print of menu
@@ -125,6 +130,13 @@ namespace iroha_cli {
     boost::optional<std::string> promptString(const std::string &message);
 
     /**
+     * Get string input from user
+     * @param message Message to ask user
+     * @return nullopt if termintaing symbol, else user's input
+     */
+    boost::optional<std::string> promptString(std::pair<std::string, std::string> params);
+
+    /**
      * Parse parameters in interactive and shortcuted mode.
      * Function run interactive mode if in line only the command name is passed.
      * Function will parse all needed parameters from line if the line with
@@ -136,7 +148,7 @@ namespace iroha_cli {
      * @return vector with needed parameters
      */
     boost::optional<std::vector<std::string>> parseParams(
-        std::string line, std::string command_name, ParamsMap params_map);
+        std::string line, std::string command_name, ParamsMap &params_map);
 
     /**
      * Add menu point to vector menu
@@ -172,7 +184,7 @@ namespace iroha_cli {
      */
     template <typename K, typename V>
     boost::optional<V> findInHandlerMap(K command_name,
-                                         std::unordered_map<K, V> params_map) {
+                                         std::unordered_map<K, V> &params_map) {
       auto it = params_map.find(command_name);
       if (it == params_map.end()) {
         // Command not found, report error
@@ -211,7 +223,7 @@ namespace iroha_cli {
         C class_pointer,
         std::string &line,
         std::unordered_map<std::string, V> &parsers_map,
-        ParamsMap params_map) {
+        ParamsMap &params_map) {
       auto raw_command = parser::parseFirstCommand(line);
       if (not raw_command) {
         handleEmptyCommand();

--- a/iroha-cli/interactive/interactive_query_cli.hpp
+++ b/iroha-cli/interactive/interactive_query_cli.hpp
@@ -95,7 +95,7 @@ namespace iroha_cli {
       DescriptionMap description_map_;
 
       // Parameters descriptions of queries
-      ParamsMap query_params_descriptions_;
+      ParamsMap query_params_data_;
 
       /**
        * Parse line for query
@@ -127,7 +127,7 @@ namespace iroha_cli {
       std::unordered_map<QueryName, ResultHandler> result_handlers_;
 
       // Parameters descriptions of result commands
-      ParamsMap result_params_descriptions_;
+      ParamsMap result_params_data_;
 
       /**
        * Parse line for result

--- a/iroha-cli/interactive/interactive_query_cli.hpp
+++ b/iroha-cli/interactive/interactive_query_cli.hpp
@@ -95,7 +95,7 @@ namespace iroha_cli {
       DescriptionMap description_map_;
 
       // Parameters descriptions of queries
-      ParamsMap query_params_data_;
+      ParamsMap query_params_map_;
 
       /**
        * Parse line for query
@@ -127,7 +127,7 @@ namespace iroha_cli {
       std::unordered_map<QueryName, ResultHandler> result_handlers_;
 
       // Parameters descriptions of result commands
-      ParamsMap result_params_data_;
+      ParamsMap result_params_map_;
 
       /**
        * Parse line for result

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -99,7 +99,7 @@ namespace iroha_cli {
       std::unordered_map<std::string, CommandHandler> command_handlers_;
 
       // Descriptions for commands parameters
-      ParamsMap command_params_data_;
+      ParamsMap command_params_map_;
 
       // Descriptions for commands
       DescriptionMap commands_description_map_;
@@ -151,7 +151,7 @@ namespace iroha_cli {
       std::unordered_map<std::string, ResultHandler> result_handlers_;
 
       // Description for result command
-      ParamsMap result_params_data;
+      ParamsMap result_params_map;
 
       /**
        * Parse line for result

--- a/iroha-cli/interactive/interactive_transaction_cli.hpp
+++ b/iroha-cli/interactive/interactive_transaction_cli.hpp
@@ -99,7 +99,7 @@ namespace iroha_cli {
       std::unordered_map<std::string, CommandHandler> command_handlers_;
 
       // Descriptions for commands parameters
-      ParamsMap command_params_descriptions_;
+      ParamsMap command_params_data_;
 
       // Descriptions for commands
       DescriptionMap commands_description_map_;
@@ -151,7 +151,7 @@ namespace iroha_cli {
       std::unordered_map<std::string, ResultHandler> result_handlers_;
 
       // Description for result command
-      ParamsMap result_params_descriptions;
+      ParamsMap result_params_data;
 
       /**
        * Parse line for result


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Cache CLI input values to make it more convenient (#827).

There are two use cases. 

1. Make is possible to use default values provided during creation of a `iroha_cli::interactive::ParamsMap` - If a default value is provided (e.g. default host/port), that will be used when the user input is empty.
2. Cache any user inputs - When an input is captured for a parameter, that value is cached and displayed on the input prompt for that parameter. If the user input is empty, cache value will be used.

### Benefits

Get rid of annoying repeated host/port entries when attempting to send requests to Iroha (among other inputs) and make the CLI less frustrating to use.

### Possible Drawbacks 

There's no option to remove a cached value other than replacing it with a new value. However, the CLI doesn't allow empty inputs so this shouldn't be a problem.

### Usage Examples or Tests

#### Scenario 1 - Using default values

There's no user input for `Peer port (50051)`, default is used (prompt displays the default values).
```
$ ../build/bin/iroha-cli -account_name admin@test
Welcome to Iroha-Cli. 
Choose what to do:
1. New transaction (tx)
2. New query (qry)
3. New transaction status request (st)
> : 2
Choose query: 
1. Get Account Information (get_acc)
2. Get Account's Asset Transactions (get_acc_ast_tx)
3. Get Account's Signatories (get_acc_sign)
4. Get Account's Assets (get_acc_ast)
5. Get all current roles in the system (get_roles)
6. Get information about asset (get_ast_info)
7. Get Account's Transactions (get_acc_tx)
8. Get Transactions by transactions' hashes (get_tx)
9. Get all permissions related to role (get_role_perm)
0. Back (b)
> : 7
Requested account Id: admin@test
Query is formed. Choose what to do:
1. Send to Iroha peer (send)
2. Save as json file (save)
0. Back (b)
> : 1
Peer address (0.0.0.0): localhost
Peer port (50051):
[2018-06-22 22:42:44.265421000][th:5963568][info] QueryResponseHandler [Transaction]
[2018-06-22 22:42:44.265988000][th:5963568][info] QueryResponseHandler -Hash- ed98fb922acad35d9262d56115daba6b092722f60523a9e3e03e642cc2364fd3
[2018-06-22 22:42:44.266060000][th:5963568][info] QueryResponseHandler -Creator Id- admin@test
[2018-06-22 22:42:44.266081000][th:5963568][info] QueryResponseHandler -Created Time- 1529697208667
[2018-06-22 22:42:44.266162000][th:5963568][info] QueryResponseHandler -Commands- 3
[2018-06-22 22:42:44.267579000][th:5963568][info] QueryResponseHandler  CreateAsset: [asset_name=coolcoin, domain_id=test, precision=2, ] 
[2018-06-22 22:42:44.267692000][th:5963568][info] QueryResponseHandler  AddAssetQuantity: [account_id=admin@test, asset_id=coolcoin#test, amount=Amount: [intValue=50050, precision=2, ], ] 
[2018-06-22 22:42:44.267753000][th:5963568][info] QueryResponseHandler  TransferAsset: [src_account_id=admin@test, dest_account_id=test@test, asset_id=coolcoin#test, description=, amount=Amount: [intValue=10050, precision=2, ], ] 
--------------------
```

#### Scenario 2 - Using cached values

There aren't any user inputs for `Requested account Id (admin@test)`, `Peer address (localhost)` and `Peer port (50051) `, cached valued are used. Note the prompt displays the cached values. 

```
Choose what to do:
1. New transaction (tx)
2. New query (qry)
3. New transaction status request (st)
> : 2
Choose query: 
1. Get Account Information (get_acc)
2. Get Account's Asset Transactions (get_acc_ast_tx)
3. Get Account's Signatories (get_acc_sign)
4. Get Account's Assets (get_acc_ast)
5. Get all current roles in the system (get_roles)
6. Get information about asset (get_ast_info)
7. Get Account's Transactions (get_acc_tx)
8. Get Transactions by transactions' hashes (get_tx)
9. Get all permissions related to role (get_role_perm)
0. Back (b)
> : 7
Requested account Id (admin@test): 
Query is formed. Choose what to do:
1. Send to Iroha peer (send)
2. Save as json file (save)
0. Back (b)
> : 1
Peer address (localhost): 
Peer port (50051): 
[2018-06-22 22:42:51.678041000][th:5963568][info] QueryResponseHandler [Transaction]
[2018-06-22 22:42:51.678202000][th:5963568][info] QueryResponseHandler -Hash- ed98fb922acad35d9262d56115daba6b092722f60523a9e3e03e642cc2364fd3
[2018-06-22 22:42:51.678225000][th:5963568][info] QueryResponseHandler -Creator Id- admin@test
[2018-06-22 22:42:51.678237000][th:5963568][info] QueryResponseHandler -Created Time- 1529697208667
[2018-06-22 22:42:51.678266000][th:5963568][info] QueryResponseHandler -Commands- 3
[2018-06-22 22:42:51.678312000][th:5963568][info] QueryResponseHandler  CreateAsset: [asset_name=coolcoin, domain_id=test, precision=2, ] 
[2018-06-22 22:42:51.678363000][th:5963568][info] QueryResponseHandler  AddAssetQuantity: [account_id=admin@test, asset_id=coolcoin#test, amount=Amount: [intValue=50050, precision=2, ], ] 
[2018-06-22 22:42:51.678408000][th:5963568][info] QueryResponseHandler  TransferAsset: [src_account_id=admin@test, dest_account_id=test@test, asset_id=coolcoin#test, description=, amount=Amount: [intValue=10050, precision=2, ], ] 
--------------------
Choose what to do:
1. New transaction (tx)
2. New query (qry)
3. New transaction status request (st)
> : 
```