### PR TITLE
Check block in mutable storage

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -44,11 +44,16 @@ namespace iroha {
       *sql_ << "BEGIN";
     }
 
+    bool MutableStorageImpl::check(
+        const shared_model::interface::AbstractBlock &block,
+        MutableStorage::MutableStoragePredicateType<decltype(block)>
+            predicate) {
+      return predicate(block, *wsv_, top_hash_);
+    }
+
     bool MutableStorageImpl::apply(
         const shared_model::interface::Block &block,
-        std::function<bool(const shared_model::interface::Block &,
-                           WsvQuery &,
-                           const shared_model::interface::types::HashType &)>
+        MutableStoragePredicateType<const shared_model::interface::Block &>
             function) {
       auto execute_transaction = [this](auto &transaction) {
         command_executor_->setCreatorAccountId(transaction.creatorAccountId());

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -19,8 +19,8 @@
 
 #include <boost/variant/apply_visitor.hpp>
 
-#include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"
+#include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/wsv_command.hpp"
@@ -45,7 +45,7 @@ namespace iroha {
     }
 
     bool MutableStorageImpl::check(
-        const shared_model::interface::AbstractBlock &block,
+        const shared_model::interface::BlockVariant &block,
         MutableStorage::MutableStoragePredicateType<decltype(block)>
             predicate) {
       return predicate(block, *wsv_, top_hash_);

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -41,7 +41,7 @@ namespace iroha {
                          std::unique_ptr<soci::session> sql,
                          std::shared_ptr<shared_model::interface::CommonObjectsFactory>
                          factory);
-      bool check(const shared_model::interface::AbstractBlock &block,
+      bool check(const shared_model::interface::BlockVariant &block,
                  MutableStoragePredicateType<decltype(block)> function) override;
 
       bool apply(

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -41,13 +41,12 @@ namespace iroha {
                          std::unique_ptr<soci::session> sql,
                          std::shared_ptr<shared_model::interface::CommonObjectsFactory>
                          factory);
+      bool check(const shared_model::interface::AbstractBlock &block,
+                 MutableStoragePredicateType<decltype(block)> function) override;
 
       bool apply(
           const shared_model::interface::Block &block,
-          std::function<bool(const shared_model::interface::Block &,
-                             WsvQuery &,
-                             const shared_model::interface::types::HashType &)>
-              function) override;
+          MutableStoragePredicateType<decltype(block)> function) override;
 
       ~MutableStorageImpl() override;
 

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -24,7 +24,8 @@
 namespace shared_model {
   namespace interface {
     class Block;
-  }
+    class AbstractBlock;
+  }  // namespace interface
 }  // namespace shared_model
 
 namespace iroha {
@@ -38,6 +39,22 @@ namespace iroha {
      */
     class MutableStorage {
      public:
+      template <typename T>
+      using MutableStoragePredicateType =
+          std::function<bool(const T &,
+                             WsvQuery &,
+                             const shared_model::interface::types::HashType &)>;
+
+      /**
+       * Checks if block satisfies predicated
+       * @param block block to be checked
+       * @param predicate function returning true if predicate satisfied and
+       * false otherwise
+       * @return result of predicate
+       */
+      virtual bool check(const shared_model::interface::AbstractBlock &block,
+                         MutableStoragePredicateType<decltype(block)>) = 0;
+
       /**
        * Applies a block to current mutable state
        * using logic specified in function
@@ -54,10 +71,7 @@ namespace iroha {
        */
       virtual bool apply(
           const shared_model::interface::Block &block,
-          std::function<bool(const shared_model::interface::Block &,
-                             WsvQuery &,
-                             const shared_model::interface::types::HashType &)>
-              function) = 0;
+          MutableStoragePredicateType<decltype(block)> function) = 0;
 
       virtual ~MutableStorage() = default;
     };

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -24,7 +24,7 @@
 namespace shared_model {
   namespace interface {
     class Block;
-    class AbstractBlock;
+    class BlockVariant;
   }  // namespace interface
 }  // namespace shared_model
 
@@ -39,6 +39,9 @@ namespace iroha {
      */
     class MutableStorage {
      public:
+      /**
+       * Predicate type checking type T
+       */
       template <typename T>
       using MutableStoragePredicateType =
           std::function<bool(const T &,
@@ -52,7 +55,7 @@ namespace iroha {
        * false otherwise
        * @return result of predicate
        */
-      virtual bool check(const shared_model::interface::AbstractBlock &block,
+      virtual bool check(const shared_model::interface::BlockVariant &block,
                          MutableStoragePredicateType<decltype(block)>) = 0;
 
       /**

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -42,6 +42,13 @@ target_link_libraries(kv_storage_test
     ametsuchi_fixture
     )
 
+addtest(mutable_storage_test mutable_storage_test.cpp)
+target_link_libraries(mutable_storage_test
+    ametsuchi
+    libs_common
+    ametsuchi_fixture
+    )
+
 addtest(storage_init_test storage_init_test.cpp)
 target_link_libraries(storage_init_test
     ametsuchi

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -21,7 +21,6 @@
 #include <gmock/gmock.h>
 #include <boost/optional.hpp>
 #include "ametsuchi/block_query.hpp"
-#include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/key_value_storage.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/mutable_storage.hpp"
@@ -210,6 +209,13 @@ namespace iroha {
 
     class MockMutableStorage : public MutableStorage {
      public:
+      MOCK_METHOD2(
+          check,
+          bool(const shared_model::interface::AbstractBlock &,
+               std::function<
+                   bool(const shared_model::interface::AbstractBlock &,
+                        WsvQuery &,
+                        const shared_model::interface::types::HashType &)>));
       MOCK_METHOD2(
           apply,
           bool(const shared_model::interface::Block &,

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -211,9 +211,9 @@ namespace iroha {
      public:
       MOCK_METHOD2(
           check,
-          bool(const shared_model::interface::AbstractBlock &,
+          bool(const shared_model::interface::BlockVariant &,
                std::function<
-                   bool(const shared_model::interface::AbstractBlock &,
+                   bool(const shared_model::interface::BlockVariant &,
                         WsvQuery &,
                         const shared_model::interface::types::HashType &)>));
       MOCK_METHOD2(

--- a/test/module/irohad/ametsuchi/mutable_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/mutable_storage_test.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
+#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+
+using namespace iroha::ametsuchi;
+using testing::Bool;
+using testing::Values;
+using testing::WithParamInterface;
+
+class MutableStorageTest : public AmetsuchiTest,
+                           public WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    AmetsuchiTest::SetUp();
+
+    storage->createMutableStorage().match(
+        [this](iroha::expected::Value<std::unique_ptr<MutableStorage>>
+                   &mut_storage) {
+          mutable_storage_ = std::move(mut_storage.value);
+        },
+        [](const auto &) { FAIL() << "Mutable storage cannot be created"; });
+    ;
+  }
+
+  shared_model::proto::Block getBlock() {
+    auto block =
+        TestBlockBuilder()
+            .transactions(std::vector<shared_model::proto::Transaction>({}))
+            .height(1)
+            .prevHash(fake_hash)
+            .build();
+    return block;
+  }
+
+  std::string zero_string{32, '0'};
+  shared_model::crypto::Hash fake_hash{zero_string};
+  shared_model::crypto::PublicKey fake_pubkey{zero_string};
+  std::unique_ptr<MutableStorage> mutable_storage_;
+};
+
+/**
+ * @given mutable storage
+ * @when check block method takes block and predicated returning boolean value
+ * @then the same block is processed in predicate
+ * @and returned value returned by check function is the same as result of
+ * predicate
+ */
+TEST_P(MutableStorageTest, TestCheckBlock) {
+  auto expected_block = getBlock();
+  bool expected_res = GetParam();
+  ASSERT_EQ(expected_res,
+            mutable_storage_->check(
+                expected_block,
+                [&expected_block, &expected_res](
+                    const auto &block, const auto &, const auto &) {
+                  EXPECT_EQ(expected_block, block);
+                  return expected_res;
+                }));
+}
+
+INSTANTIATE_TEST_CASE_P(MutableStorageParameterizedTest,
+                        MutableStorageTest,
+                        Bool(), );

--- a/test/module/irohad/ametsuchi/mutable_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/mutable_storage_test.cpp
@@ -28,14 +28,13 @@ class MutableStorageTest : public AmetsuchiTest,
     ;
   }
 
-  shared_model::proto::Block getBlock() {
-    auto block =
+  shared_model::interface::BlockVariant getBlock() {
+    return std::make_shared<shared_model::proto::Block>(
         TestBlockBuilder()
             .transactions(std::vector<shared_model::proto::Transaction>({}))
             .height(1)
             .prevHash(fake_hash)
-            .build();
-    return block;
+            .build());
   }
 
   std::string zero_string{32, '0'};
@@ -66,4 +65,6 @@ TEST_P(MutableStorageTest, TestCheckBlock) {
 
 INSTANTIATE_TEST_CASE_P(MutableStorageParameterizedTest,
                         MutableStorageTest,
+                        // note additional comma is needed to make it compile
+                        // https://github.com/google/googletest/issues/1419
                         Bool(), );

--- a/test/module/irohad/ametsuchi/mutable_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/mutable_storage_test.cpp
@@ -25,8 +25,12 @@ class MutableStorageTest : public AmetsuchiTest,
           mutable_storage_ = std::move(mut_storage.value);
         },
         [](const auto &) { FAIL() << "Mutable storage cannot be created"; });
-    ;
   }
+
+  void TearDown() override {
+    mutable_storage_.reset();
+    AmetsuchiTest::TearDown();
+  };
 
   shared_model::interface::BlockVariant getBlock() {
     return std::make_shared<shared_model::proto::Block>(


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

In chain validator we might need to check some logic on either EmptyBlock or Block types. Current interface of mutable storage does not allow that. To overcome this issue check method has been introduced which applies predicates logic on the block without actually applying the block to the storage.

### Benefits

We can validate block on storage without applying it

### Possible Drawbacks 

Probably we don't need check method to take AbstractBlock as parameter but use EmptyBlock instead.

### Usage Examples or Tests

Mutable storage test has been introduced