### PR TITLE
Remove hasAccountGrantablePermissions in qry exec

### DIFF
--- a/irohad/execution/impl/query_execution.cpp
+++ b/irohad/execution/impl/query_execution.cpp
@@ -59,32 +59,28 @@ shared_model::proto::TemplateQueryResponseBuilder<1> statefulFailed() {
   return buildError<shared_model::interface::StatefulFailedErrorResponse>();
 }
 
-bool hasQueryPermission(const std::string &creator,
-                        const std::string &target_account,
-                        WsvQuery &wsv_query,
-                        Role indiv_permission_id,
-                        Role all_permission_id,
-                        Role domain_permission_id) {
+static bool hasQueryPermission(const std::string &creator,
+                               const std::string &target_account,
+                               WsvQuery &wsv_query,
+                               Role indiv_permission_id,
+                               Role all_permission_id,
+                               Role domain_permission_id) {
   auto perms_set = iroha::getAccountPermissions(creator, wsv_query);
-  auto grantable = permissionOf(indiv_permission_id);
-  return
-      // 1. Creator has grant permission from other user
-      (creator != target_account
-       and wsv_query.hasAccountGrantablePermission(
-               creator, target_account, grantable))
-      or  // ----- Creator has role permission ---------
-      (perms_set
-       and (
-               // 2. Creator want to query his account, must have role
-               // permission
-               (creator == target_account
-                and perms_set.value().test(indiv_permission_id))
-               or  // 3. Creator has global permission to get any account
-               perms_set.value().test(all_permission_id)
-               or  // 4. Creator has domain permission
-               (getDomainFromName(creator) == getDomainFromName(target_account)
-                and perms_set.value().test(domain_permission_id))));
+  if (not perms_set) {
+    return false;
+  }
+
+  auto &set = perms_set.value();
+  // Creator want to query his account, must have role
+  // permission
+  return (creator == target_account and set.test(indiv_permission_id)) or
+      // Creator has global permission to get any account
+      set.test(all_permission_id) or
+      // Creator has domain permission
+      (getDomainFromName(creator) == getDomainFromName(target_account)
+       and set.test(domain_permission_id));
 }
+
 bool QueryProcessingFactory::validate(
     const shared_model::interface::BlocksQuery &query) {
   return checkAccountRolePermission(

--- a/shared_model/interfaces/impl/permissions.cpp
+++ b/shared_model/interfaces/impl/permissions.cpp
@@ -28,23 +28,6 @@ namespace shared_model {
         return Role::COUNT;
       }
 
-      Grantable permissionOf(Role g) {
-        switch (g) {
-          case Role::kAddMySignatory:
-            return Grantable::kAddMySignatory;
-          case Role::kRemoveMySignatory:
-            return Grantable::kRemoveMySignatory;
-          case Role::kSetMyQuorum:
-            return Grantable::kSetMyQuorum;
-          case Role::kSetMyAccountDetail:
-            return Grantable::kSetMyAccountDetail;
-          case Role::kTransferMyAssets:
-            return Grantable::kTransferMyAssets;
-          default:;
-        }
-        return Grantable::COUNT;
-      }
-
       bool isValid(Role perm) noexcept {
         auto p = static_cast<size_t>(perm);
         return p < static_cast<size_t>(Role::COUNT);

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -73,8 +73,6 @@ namespace shared_model {
       };
 
       Role permissionFor(Grantable);
-      // TODO(@l4l) 19/06/18: Remove with IR-1452
-      Grantable permissionOf(Role);
 
       /**
        * @param perm protocol object for checking

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -237,20 +237,15 @@ TEST_F(ClientServerTest, SendQueryWhenValid) {
   EXPECT_CALL(*wsv_query, getSignatories("admin@test"))
       .WillRepeatedly(Return(signatories));
 
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          "admin@test",
-          "test@test",
-          shared_model::interface::permissions::permissionOf(
-              shared_model::interface::permissions::Role::kGetMyAccDetail)))
-      .WillOnce(Return(true));
-
   EXPECT_CALL(*wsv_query, getAccountDetail("test@test"))
       .WillOnce(Return(boost::make_optional(std::string("value"))));
 
+  const std::vector<std::string> kRole{"role"};
   EXPECT_CALL(*wsv_query, getAccountRoles("admin@test"))
-      .WillOnce(Return(boost::none));
+      .WillOnce(Return(boost::make_optional(kRole)));
+  EXPECT_CALL(*wsv_query, getRolePermissions(kRole[0]))
+      .WillOnce(Return(shared_model::interface::RolePermissionSet{
+          shared_model::interface::permissions::Role::kGetAllAccDetail}));
 
   auto query = QueryBuilder()
                    .createdTime(iroha::time::now())
@@ -270,15 +265,6 @@ TEST_F(ClientServerTest, SendQueryWhenStatefulInvalid) {
 
   EXPECT_CALL(*wsv_query, getSignatories("admin@test"))
       .WillRepeatedly(Return(signatories));
-
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          "admin@test",
-          "test@test",
-          shared_model::interface::permissions::permissionOf(
-              shared_model::interface::permissions::Role::kGetMyAccDetail)))
-      .WillOnce(Return(false));
 
   EXPECT_CALL(*wsv_query, getAccountRoles("admin@test"))
       .WillOnce(Return(boost::none));

--- a/test/module/irohad/execution/CMakeLists.txt
+++ b/test/module/irohad/execution/CMakeLists.txt
@@ -17,3 +17,10 @@ target_link_libraries(command_validate_execute_test
     command_execution
     shared_model_stateless_validation
     )
+
+addtest(query_execution_test query_execution_test.cpp)
+target_link_libraries(query_execution_test
+    query_execution
+    shared_model_interfaces
+    shared_model_stateless_validation
+    )

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -193,11 +193,6 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  // EXPECT_CALL(
-  //     *wsv_query,
-  //     hasAccountGrantablePermission(
-  //         creator, accountB->accountId(), permissionOf(Role::kGetMyAccount)))
-  //     .WillOnce(Return(true));
 
   // Should be called once, after successful stateful validation
   EXPECT_CALL(*wsv_query, getAccount(accountB->accountId()))

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -154,12 +154,6 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
       shared_model::proto::AccountBuilder().accountId("b@domain").build();
   auto creator = "a@domain";
 
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          creator, account.accountId(), permissionOf(Role::kGetMyAccount)))
-      .WillOnce(Return(false));
-
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
@@ -199,11 +193,11 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  EXPECT_CALL(
-      *wsv_query,
-      hasAccountGrantablePermission(
-          creator, accountB->accountId(), permissionOf(Role::kGetMyAccount)))
-      .WillOnce(Return(true));
+  // EXPECT_CALL(
+  //     *wsv_query,
+  //     hasAccountGrantablePermission(
+  //         creator, accountB->accountId(), permissionOf(Role::kGetMyAccount)))
+  //     .WillOnce(Return(true));
 
   // Should be called once, after successful stateful validation
   EXPECT_CALL(*wsv_query, getAccount(accountB->accountId()))
@@ -211,6 +205,9 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   std::vector<std::string> roles = {"user"};
   EXPECT_CALL(*wsv_query, getAccountRoles(_)).WillRepeatedly(Return(roles));
+  EXPECT_CALL(*wsv_query, getRolePermissions(_))
+      .WillOnce(Return(shared_model::interface::RolePermissionSet(
+          {shared_model::interface::permissions::Role::kGetAllAccounts})));
 
   iroha::protocol::QueryResponse response;
 
@@ -296,10 +293,6 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  creator, accountb_id, permissionOf(Role::kGetMyAccAst)))
-      .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(boost::none));
 
@@ -415,10 +408,6 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
   auto creator = "a@domain";
   EXPECT_CALL(*wsv_query, getSignatories(creator))
       .WillRepeatedly(Return(signatories));
-  EXPECT_CALL(*wsv_query,
-              hasAccountGrantablePermission(
-                  creator, "b@domain", permissionOf(Role::kGetMySignatories)))
-      .WillOnce(Return(false));
   EXPECT_CALL(*wsv_query, getAccountRoles(creator))
       .WillOnce(Return(boost::none));
 

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -15,13 +15,6 @@
 # limitations under the License.
 #
 
-addtest(query_execution_test query_execution.cpp)
-target_link_libraries(query_execution_test
-    query_execution
-    shared_model_interfaces
-    shared_model_stateless_validation
-    )
-
 addtest(chain_validation_test chain_validation_test.cpp)
 target_link_libraries(chain_validation_test
     chain_validator


### PR DESCRIPTION
### Description of the Change

For some reason Queries are checked against Grantable permissions (Grantable are only for commands). This pr removes redundant code (checking in execution, checking in EXPECT_CALL's, test for grantable perms) also `permissions::permissionOf` removal is there 

### Benefits

The lesser useless code the happier people are

### Possible Drawbacks 

None?
