### PR TITLE
Java bindings package name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ properties([parameters([
   choice(choices: 'Debug\nRelease', description: 'Iroha build type', name: 'build_type'),
   booleanParam(defaultValue: false, description: 'Build Java bindings', name: 'JavaBindings'),
   choice(choices: 'Release\nDebug', description: 'Java bindings build type', name: 'JBBuildType'),
+  string(defaultValue: 'jp.co.soramitsu.iroha', description: 'Java bindings package name', name: 'JBPackageName'),
   booleanParam(defaultValue: false, description: 'Build Python bindings', name: 'PythonBindings'),
   choice(choices: 'Release\nDebug', description: 'Python bindings build type', name: 'PBBuildType'),
   choice(choices: 'python3\npython2', description: 'Python bindings version', name: 'PBVersion'),
@@ -410,7 +411,7 @@ pipeline {
                   ['PARALLELISM': params.PARALLELISM])
                 if (params.JavaBindings) {
                   iC.inside("-v /tmp/${env.GIT_COMMIT}/bindings-artifact:/tmp/bindings-artifact") {
-                    bindings.doJavaBindings('linux', params.JBBuildType)
+                    bindings.doJavaBindings('linux', params.JBPackageName, params.JBBuildType)
                   }
                 }
                 if (params.PythonBindings) {
@@ -469,7 +470,7 @@ pipeline {
             script {
               def bindings = load ".jenkinsci/bindings.groovy"
               if (params.JavaBindings) {
-                bindings.doJavaBindings('windows', params.JBBuildType)
+                bindings.doJavaBindings('windows', params.JBPackageName, params.JBBuildType)
               }
               if (params.PythonBindings) {
                 bindings.doPythonBindings('windows', params.PBBuildType)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
This adds an option to set Java bindings package name in Jenkins CI builds. It defaults to 'jp.co.soramitsu.iroha'. To change it either change the default name in Jenkinsfile or login into Jenkins and run appropriate branch build with 'Build with parameters' with package name of your choice.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Package name manipulation is useful for importing resulting bindings into other Java projects that requires certain naming
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
An example of a zip-packaged bindings with custom package name can be found on our artifacts server: https://artifact.soramitsu.co.jp/iroha/bindings/java/java-bindings-Release-windows-20180628-fd3344.zip
