### PR TITLE
Remove PermissionSet constraints

### DIFF
--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -250,24 +250,6 @@ namespace shared_model {
       }
     }
 
-    void FieldValidator::validateRolePermissions(
-        ReasonsGroupType &reason,
-        const interface::RolePermissionSet &permissions) const {
-      if (permissions.none()) {
-        reason.second.push_back(
-            "Permission set should contain at least one permission");
-      }
-    }
-
-    void FieldValidator::validateGrantablePermissions(
-        ReasonsGroupType &reason,
-        const interface::GrantablePermissionSet &permissions) const {
-      if (permissions.none()) {
-        reason.second.push_back(
-            "Permission set should contain at least one permission");
-      }
-    }
-
     void FieldValidator::validateQuorum(
         ReasonsGroupType &reason,
         const interface::types::QuorumType &quorum) const {

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -116,14 +116,6 @@ namespace shared_model {
           ReasonsGroupType &reason,
           const interface::permissions::Grantable &permission) const;
 
-      void validateRolePermissions(
-          ReasonsGroupType &reason,
-          const interface::RolePermissionSet &permissions) const;
-
-      void validateGrantablePermissions(
-          ReasonsGroupType &reason,
-          const interface::GrantablePermissionSet &permissions) const;
-
       void validateQuorum(ReasonsGroupType &reason,
                           const interface::types::QuorumType &quorum) const;
 

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -22,7 +22,7 @@
 #include <boost/variant/static_visitor.hpp>
 
 #include "backend/protobuf/permissions.hpp"
-#include "interfaces/transaction.hpp"
+#include "backend/protobuf/transaction.hpp"
 #include "validators/answer.hpp"
 
 namespace shared_model {
@@ -118,6 +118,14 @@ namespace shared_model {
         addInvalidCommand(reason, "CreateRole");
 
         validator_.validateRoleId(reason, cr.roleName());
+        for (auto i : static_cast<const shared_model::proto::CreateRole &>(cr)
+                          .getTransport()
+                          .create_role()
+                          .permissions()) {
+          validator_.validateRolePermission(
+              reason,
+              static_cast<shared_model::interface::permissions::Role>(i));
+        }
 
         return reason;
       }

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -118,7 +118,6 @@ namespace shared_model {
         addInvalidCommand(reason, "CreateRole");
 
         validator_.validateRoleId(reason, cr.roleName());
-        validator_.validateRolePermissions(reason, cr.rolePermissions());
 
         return reason;
       }

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -98,7 +98,9 @@ TEST_F(CreateRole, EmptyPerms) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx({})), checkStatelessInvalid);
+      .sendTxAwait(complete(baseTx({})), [](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1);
+      });
 }
 
 /**

--- a/test/module/shared_model/validators/transaction_validator_test.cpp
+++ b/test/module/shared_model/validators/transaction_validator_test.cpp
@@ -51,8 +51,26 @@ TEST_F(TransactionValidatorTest, EmptyTransactionTest) {
   tx.mutable_payload()->set_created_time(created_time);
   shared_model::validation::DefaultTransactionValidator transaction_validator;
   auto result = proto::Transaction(iroha::protocol::Transaction(tx));
-  auto answer =
-      transaction_validator.validate(result);
+  auto answer = transaction_validator.validate(result);
+  ASSERT_EQ(answer.getReasonsMap().size(), 1);
+}
+
+/**
+ * @given transaction without any commands
+ * @when commands validator is invoked
+ * @then answer has error about empty transaction
+ */
+TEST_F(TransactionValidatorTest, InvalidCreateRolePermission) {
+  auto tx = generateEmptyTransaction();
+  tx.mutable_payload()->set_created_time(created_time);
+  iroha::protocol::Command cmd;
+  cmd.mutable_create_role()->set_role_name("role");
+  cmd.mutable_create_role()->add_permissions(
+      static_cast<iroha::protocol::RolePermission>(-1));
+  *tx.mutable_payload()->add_commands() = std::move(cmd);
+  shared_model::validation::DefaultTransactionValidator transaction_validator;
+  auto result = proto::Transaction(iroha::protocol::Transaction(tx));
+  auto answer = transaction_validator.validate(result);
   ASSERT_EQ(answer.getReasonsMap().size(), 1);
 }
 
@@ -85,8 +103,7 @@ TEST_F(TransactionValidatorTest, StatelessValidTest) {
 
   shared_model::validation::DefaultTransactionValidator transaction_validator;
   auto result = proto::Transaction(iroha::protocol::Transaction(tx));
-  auto answer =
-      transaction_validator.validate(result);
+  auto answer = transaction_validator.validate(result);
 
   ASSERT_FALSE(answer.hasErrors()) << answer.reason();
 }
@@ -121,8 +138,7 @@ TEST_F(TransactionValidatorTest, StatelessInvalidTest) {
 
   shared_model::validation::DefaultTransactionValidator transaction_validator;
   auto result = proto::Transaction(iroha::protocol::Transaction(tx));
-  auto answer =
-      transaction_validator.validate(result);
+  auto answer = transaction_validator.validate(result);
 
   // in total there should be number_of_commands + 1 reasons of bad answer:
   // number_of_commands for each command + 1 for transaction metadata


### PR DESCRIPTION
### Description of the Change

Remove PermissionSet constraints so it's possible to perform `CreateRole` with empty permission set (in other words role doesn't have to have any permission)

### Benefits

Possible to create role without rights

### Possible Drawbacks 

None?

### Usage Examples or Tests

`make create_role_test && test_bin/create_role_test`
