### PR TITLE
Fix error message for Peer's address

### DIFF
--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -132,9 +132,10 @@ namespace shared_model {
         const interface::types::AddressType &address) const {
       if (not std::regex_match(address, peer_address_regex_)) {
         auto message =
-            (boost::format("Wrongly formed peer address, passed value: '%s'. "
-                           "Field should have valid IPv4 format or be a valid "
-                           "hostname following RFC1123 specification")
+            (boost::format(
+                 "Wrongly formed peer address, passed value: '%s'. "
+                 "Field should have 'host:port' format where host is IPv4 or a "
+                 "hostname following RFC1035, RFC1123 specifications")
              % address)
                 .str();
         reason.second.push_back(std::move(message));


### PR DESCRIPTION
### Description of the Change

Corrects error message for Peer's address in stateless validation

### Benefits

Fixes #1467
