### PR TITLE
Fix last role detaching behavior

### DIFF
--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -1056,15 +1056,17 @@ namespace iroha {
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     auto command_name = "DetachRole";
     auto role_permissions = queries.getRolePermissions(command.roleName());
-    auto account_roles = queries.getAccountRoles(command.accountId());
+    auto account_roles = queries.getAccountRoles(creator_account_id);
+    auto subject_account_roles = queries.getAccountRoles(command.accountId());
 
-    if (not role_permissions or not account_roles) {
+    if (not role_permissions or not account_roles
+        or not subject_account_roles) {
       return makeCommandError(
           "is valid command validation failed: unable to query roles info",
           command_name);
     }
 
-    if (account_roles->size() == 1) {
+    if (subject_account_roles->size() == 1) {
       return makeCommandError(
           "is valid command validation failed: the last role cannot be "
           "detached",

--- a/irohad/execution/impl/command_executor.cpp
+++ b/irohad/execution/impl/command_executor.cpp
@@ -1056,11 +1056,19 @@ namespace iroha {
       const shared_model::interface::types::AccountIdType &creator_account_id) {
     auto command_name = "DetachRole";
     auto role_permissions = queries.getRolePermissions(command.roleName());
-    auto account_roles = queries.getAccountRoles(creator_account_id);
+    auto account_roles = queries.getAccountRoles(command.accountId());
 
-    if (not role_permissions or not account_roles
-        or account_roles->size() == 1) {
-      return makeCommandError("The last role cannot be detached", command_name);
+    if (not role_permissions or not account_roles) {
+      return makeCommandError(
+          "is valid command validation failed: unable to query roles info",
+          command_name);
+    }
+
+    if (account_roles->size() == 1) {
+      return makeCommandError(
+          "is valid command validation failed: the last role cannot be "
+          "detached",
+          command_name);
     }
 
     shared_model::interface::RolePermissionSet account_permissions{};

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -42,6 +42,7 @@ namespace integration_framework {
 
   const std::string IntegrationTestFramework::kDefaultDomain = "test";
   const std::string IntegrationTestFramework::kDefaultRole = "user";
+  const std::string IntegrationTestFramework::kAdminRole = "admin";
   const std::string IntegrationTestFramework::kAdminName = "admin";
   const std::string IntegrationTestFramework::kAdminId = "admin@test";
   const std::string IntegrationTestFramework::kAssetName = "coin";
@@ -80,9 +81,11 @@ namespace integration_framework {
             .creatorAccountId(kAdminId)
             .createdTime(iroha::time::now())
             .addPeer("0.0.0.0:50541", key.publicKey())
-            .createRole(kDefaultRole, all_perms)
+            .createRole(kDefaultRole, {})
+            .createRole(kAdminRole, all_perms)
             .createDomain(kDefaultDomain, kDefaultRole)
             .createAccount(kAdminName, kDefaultDomain, key.publicKey())
+            .appendRole(kAdminId, kAdminRole)
             .createAsset(kAssetName, kDefaultDomain, 1)
             .quorum(1)
             .build()

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -214,6 +214,7 @@ namespace integration_framework {
 
     static const std::string kDefaultDomain;
     static const std::string kDefaultRole;
+    static const std::string kAdminRole;
 
     static const std::string kAdminName;
     static const std::string kAdminId;

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -52,8 +52,6 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
   const auto user_id = user + "@"
       + integration_framework::IntegrationTestFramework::kDefaultDomain;
   return createUser(user, key)
-      .detachRole(user_id,
-                  integration_framework::IntegrationTestFramework::kDefaultRole)
       .createRole(role_id, perms)
       .appendRole(user_id, role_id);
 }

--- a/test/module/irohad/execution/command_validate_execute_test.cpp
+++ b/test/module/irohad/execution/command_validate_execute_test.cpp
@@ -1968,16 +1968,13 @@ class DetachRoleTest : public CommandValidateExecuteTest {
  */
 TEST_F(DetachRoleTest, ValidCase) {
   EXPECT_CALL(*wsv_query, getAccountRoles(kAdminId))
-      .WillOnce(Return(admin_roles));
+      .Times(2)
+      .WillRepeatedly(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getAccountRoles(kAccountId))
       .WillOnce(Return(role_list));
   EXPECT_CALL(*wsv_query, getRolePermissions(kAdminRole))
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Return(role_permissions));
-  EXPECT_CALL(*wsv_query, getRolePermissions(kDummyRole1))
-      .WillOnce(Return(role_permissions));
-  EXPECT_CALL(*wsv_query, getRolePermissions(kDummyRole2))
-      .WillOnce(Return(role_permissions));
   EXPECT_CALL(
       *wsv_command,
       deleteAccountRole(detach_role->accountId(), detach_role->roleName()))
@@ -2015,7 +2012,8 @@ TEST_F(DetachRoleTest, InvalidCaseWhenDeleteAccountRoleFails) {
 
 TEST_F(DetachRoleTest, InvalidCaseWhenLastRole) {
   EXPECT_CALL(*wsv_query, getAccountRoles(kAdminId))
-      .WillOnce(Return(admin_roles));
+      .Times(2)
+      .WillRepeatedly(Return(admin_roles));
   EXPECT_CALL(*wsv_query, getAccountRoles(kAccountId))
       .WillOnce(Return(std::vector<std::string>{kDummyRole1}));
   EXPECT_CALL(*wsv_query, getRolePermissions(kAdminRole))

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -88,6 +88,9 @@ TEST(RegressionTest, StateRecovery) {
                 .creatorAccountId("admin@test")
                 .createAccount("user", "test", userKeypair.publicKey())
                 .addAssetQuantity("admin@test", "coin#test", "133.0")
+                .appendRole(
+                    "user@test",
+                    integration_framework::IntegrationTestFramework::kAdminRole)
                 .transferAsset(
                     "admin@test", "user@test", "coin#test", "descrs", "97.8")
                 .quorum(1)


### PR DESCRIPTION
### Description of the Change

Fix role detaching of the last one.
ITF's default role now contain empty permission set and commands for new user creation doesn't have DetachRole

### Benefits

The last role cannot be removed now

### Possible Drawbacks 

None?
