### PR TITLE
Fix tests for createRole with empty set of permissions

### DIFF
--- a/shared_model/packages/javascript/tests/txbuilder.js
+++ b/shared_model/packages/javascript/tests/txbuilder.js
@@ -128,7 +128,7 @@ test('ModelTransactionBuilder tests', function (t) {
   validPermissions.set(iroha.Role_kAddPeer)
   validPermissions.set(iroha.Role_kAddAssetQty)
 
-  t.throws(() => correctTx.createRole('new_user_role', emptyPerm).build(), /Permission set should contain at least one permission/, 'Should throw Permission set should contain at least one permission')
+  t.doesNotThrow(() => correctTx.createRole('new_user_role', emptyPerm).build(), null, 'Should not throw any exceptions')
   t.throws(() => correctTx.createRole('', validPermissions).build(), /Wrongly formed role_id, passed value: ''/, 'Should throw Wrongly formed role_id')
   t.throws(() => correctTx.createRole('@@@', validPermissions).build(), /Wrongly formed role_id, passed value: '@@@'/, 'Should throw Wrongly formed role_id')
   t.throws(() => correctTx.createRole('new_user_role', '').build(), /argument 3 of type 'shared_model::interface::RolePermissionSet/, 'Should throw ...argument 3 of type...')

--- a/test/module/shared_model/bindings/BuilderTest.java
+++ b/test/module/shared_model/bindings/BuilderTest.java
@@ -819,11 +819,8 @@ public class BuilderTest {
 
     @Test
     void createRoleEmptyPermissions() {
-        RolePermissionSet permissions = new RolePermissionSet();
-
-        ModelTransactionBuilder builder = new ModelTransactionBuilder();
-        builder.createRole("new_role", permissions);
-        assertThrows(IllegalArgumentException.class, builder::build);
+        UnsignedTx tx = builder.createRole("new_role", new RolePermissionSet()).build();
+        assertTrue(checkProtoTx(proto(tx)));
     }
 
     /* ====================== DetachRole Tests ====================== */

--- a/test/module/shared_model/bindings/builder-test.py
+++ b/test/module/shared_model/bindings/builder-test.py
@@ -532,8 +532,8 @@ class BuilderTest(unittest.TestCase):
         self.base().createRole(name, iroha.RolePermissionSet([iroha.Role_kReceive, iroha.Role_kGetRoles])).build()
 
   def test_create_role_with_empty_permissions(self):
-    with self.assertRaises(ValueError):
-      self.base().createRole("user", iroha.RolePermissionSet([])).build()
+    tx = self.builder.createRole("user", iroha.RolePermissionSet([])).build()
+    self.assertTrue(self.check_proto_tx(self.proto(tx)))
 
   # ====================== DetachRole Tests ======================
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The behavior of createRole command was changed, so the tests had to be updated.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Fixed tests.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None ?

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

```
cmake -H. -Bbuild -DSWIG_PYTHON=ON -DSWIG_JAVA=ON -DSWIG_NODE=ON
cmake --build build --target irohajava
cmake --build build --target irohapy
cmake --build build --target python_tests
cmake --build build --target irohanode
cd build
ctest -R "(java|python)" --output-on-failure
```



<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->



<!-- Explain what other alternates were considered and why the proposed version was selected -->
