### PR TITLE
Reuse Peer in mst.proto

### DIFF
--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -54,7 +54,7 @@ grpc::Status MstTransportGrpc::SendState(
   auto from = std::make_shared<shared_model::proto::Peer>(
       shared_model::proto::PeerBuilder()
           .address(peer.address())
-          .pubkey(shared_model::crypto::PublicKey(peer.pubkey()))
+          .pubkey(shared_model::crypto::PublicKey(peer.peer_key()))
           .build());
   subscriber_.lock()->onNewState(std::move(from), std::move(newState));
 
@@ -76,7 +76,7 @@ void MstTransportGrpc::sendState(const shared_model::interface::Peer &to,
 
   transport::MstState protoState;
   auto peer = protoState.mutable_peer();
-  peer->set_pubkey(shared_model::crypto::toBinaryString(to.pubkey()));
+  peer->set_peer_key(shared_model::crypto::toBinaryString(to.pubkey()));
   peer->set_address(to.address());
   for (auto &tx : providing_state.getTransactions()) {
     auto addtxs = protoState.add_transactions();

--- a/schema/mst.proto
+++ b/schema/mst.proto
@@ -2,17 +2,12 @@ syntax = "proto3";
 package iroha.network.transport;
 
 import "block.proto";
+import "primitive.proto";
 import "google/protobuf/empty.proto";
-
-// TODO: @l4l (04/05/18) remove in favor of primitive.proto IR-1321
-message Peer {
-    bytes pubkey = 1;
-    string address = 2;
-}
 
 message MstState {
     repeated iroha.protocol.Transaction transactions = 1;
-    Peer peer = 2;
+    iroha.protocol.Peer peer = 2;
 }
 
 service MstTransportGrpc {


### PR DESCRIPTION
### Description of the Change

Reusing peer in mst.proto

### Benefits

Less code duplication in schema

### Possible Drawbacks 

Worse extensionability of mst.proto
