### PR TITLE
block and proposal creation benchmark

### DIFF
--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -11,3 +11,16 @@ target_link_libraries(benchmark_example
     benchmark
     shared_model_stateless_validation
     )
+
+add_executable(bm_proto_creation
+        bm_proto_creation.cpp
+        )
+
+target_include_directories(bm_proto_creation PUBLIC
+        ${PROJECT_SOURCE_DIR}/test)
+
+target_link_libraries(bm_proto_creation
+        benchmark
+        shared_model_proto_backend
+        )
+

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -13,14 +13,15 @@ target_link_libraries(benchmark_example
     )
 
 add_executable(bm_proto_creation
-        bm_proto_creation.cpp
-        )
+    bm_proto_creation.cpp
+    )
 
 target_include_directories(bm_proto_creation PUBLIC
-        ${PROJECT_SOURCE_DIR}/test)
+    ${PROJECT_SOURCE_DIR}/test
+    )
 
 target_link_libraries(bm_proto_creation
-        benchmark
-        shared_model_proto_backend
-        )
+    benchmark
+    shared_model_proto_backend
+    )
 

--- a/test/benchmark/bm_proto_creation.cpp
+++ b/test/benchmark/bm_proto_creation.cpp
@@ -10,7 +10,10 @@
  * which can be visibly slow.
  *
  * The purpose of this benchmark is to keep track of performance costs related
- * to blocks and proposals copying/moving
+ * to blocks and proposals copying/moving.
+ * 
+ * Each benchmark runs transaction() and commands() call to 
+ * initialize possibly lazy fields.
  */
 
 #include <benchmark/benchmark.h>

--- a/test/benchmark/bm_proto_creation.cpp
+++ b/test/benchmark/bm_proto_creation.cpp
@@ -100,6 +100,18 @@ BENCHMARK_F(BlockBenchmark, MoveTest)(benchmark::State &state) {
   }
 }
 
+BENCHMARK_F(BlockBenchmark, CloneTest)(benchmark::State &st) {
+  auto block = complete_builder.build();
+
+  while (st.KeepRunning()) {
+    auto copy = clone(block);
+
+    for (const auto &tx : copy->transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
 BENCHMARK_F(ProposalBenchmark, CopyTest)(benchmark::State &st) {
   auto proposal = complete_builder.build();
 
@@ -119,6 +131,18 @@ BENCHMARK_F(ProposalBenchmark, MoveTest)(benchmark::State &state) {
     shared_model::proto::Proposal copy(std::move(proposal.getTransport()));
 
     for (const auto &tx : copy.transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
+BENCHMARK_F(ProposalBenchmark, CloneTest)(benchmark::State &st) {
+  auto proposal = complete_builder.build();
+
+  while (st.KeepRunning()) {
+    auto copy = clone(proposal);
+
+    for (const auto &tx : copy->transactions()) {
       benchmark::DoNotOptimize(tx.commands());
     }
   }

--- a/test/benchmark/bm_proto_creation.cpp
+++ b/test/benchmark/bm_proto_creation.cpp
@@ -1,0 +1,127 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * When passing through the pipeline, we need to form proposal
+ * out of transactions and then make blocks out of it. This results in several
+ * transformations of underlying transport implementation,
+ * which can be visibly slow.
+ *
+ * The purpose of this benchmark is to keep track of performance costs related
+ * to blocks and proposals copying/moving
+ */
+
+#include <benchmark/benchmark.h>
+
+#include "backend/protobuf/block.hpp"
+#include "builders/protobuf/block.hpp"
+#include "builders/protobuf/transaction.hpp"
+#include "datetime/time.hpp"
+#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "module/shared_model/validators/validators.hpp"
+
+class BlockBenchmark : public benchmark::Fixture {
+ public:
+  // Block cannot be copy-assigned, that's why the state is kept in a builder
+  TestBlockBuilder complete_builder;
+
+  void SetUp(benchmark::State &st) override {
+    TestBlockBuilder builder;
+    TestTransactionBuilder txbuilder;
+
+    auto base_tx = txbuilder.createdTime(iroha::time::now()).quorum(1);
+
+    for (int i = 0; i < 5; i++) {
+      base_tx.transferAsset("player@one", "player@two", "coin", "", "5.00");
+    }
+
+    std::vector<shared_model::proto::Transaction> txs;
+
+    for (int i = 0; i < 100; i++) {
+      txs.push_back(base_tx.build());
+    }
+
+    complete_builder =
+        builder.createdTime(iroha::time::now()).height(1).transactions(txs);
+  }
+};
+
+class ProposalBenchmark : public benchmark::Fixture {
+ public:
+  // Block cannot be copy-assigned, that's why state is kept in a builder
+  TestProposalBuilder complete_builder;
+
+  void SetUp(benchmark::State &st) override {
+    TestProposalBuilder builder;
+    TestTransactionBuilder txbuilder;
+
+    auto base_tx = txbuilder.createdTime(iroha::time::now()).quorum(1);
+
+    for (int i = 0; i < 5; i++) {
+      base_tx.transferAsset("player@one", "player@two", "coin", "", "5.00");
+    }
+
+    std::vector<shared_model::proto::Transaction> txs;
+
+    for (int i = 0; i < 100; i++) {
+      txs.push_back(base_tx.build());
+    }
+
+    complete_builder =
+        builder.createdTime(iroha::time::now()).height(1).transactions(txs);
+  }
+};
+
+BENCHMARK_F(BlockBenchmark, CopyTest)(benchmark::State &st) {
+  auto block = complete_builder.build();
+
+  while (st.KeepRunning()) {
+    shared_model::proto::Block copy(block.getTransport());
+
+    for (const auto &tx : copy.transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
+BENCHMARK_F(BlockBenchmark, MoveTest)(benchmark::State &state) {
+  auto block = complete_builder.build();
+
+  while (state.KeepRunning()) {
+    shared_model::proto::Block copy(std::move(block.getTransport()));
+
+    for (const auto &tx : copy.transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
+BENCHMARK_F(ProposalBenchmark, CopyTest)(benchmark::State &st) {
+  auto proposal = complete_builder.build();
+
+  while (st.KeepRunning()) {
+    shared_model::proto::Proposal copy(proposal.getTransport());
+
+    for (const auto &tx : copy.transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
+BENCHMARK_F(ProposalBenchmark, MoveTest)(benchmark::State &state) {
+  auto proposal = complete_builder.build();
+
+  while (state.KeepRunning()) {
+    shared_model::proto::Proposal copy(std::move(proposal.getTransport()));
+
+    for (const auto &tx : copy.transactions()) {
+      benchmark::DoNotOptimize(tx.commands());
+    }
+  }
+}
+
+BENCHMARK_MAIN();

--- a/test/benchmark/bm_proto_creation.cpp
+++ b/test/benchmark/bm_proto_creation.cpp
@@ -25,7 +25,12 @@
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
-#include "module/shared_model/validators/validators.hpp"
+
+/// number of commands in a single transaction
+constexpr int number_of_commands = 5;
+
+/// number of transactions in a single block
+constexpr int number_of_txs = 100;
 
 class BlockBenchmark : public benchmark::Fixture {
  public:
@@ -38,13 +43,13 @@ class BlockBenchmark : public benchmark::Fixture {
 
     auto base_tx = txbuilder.createdTime(iroha::time::now()).quorum(1);
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < number_of_commands; i++) {
       base_tx.transferAsset("player@one", "player@two", "coin", "", "5.00");
     }
 
     std::vector<shared_model::proto::Transaction> txs;
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < number_of_txs; i++) {
       txs.push_back(base_tx.build());
     }
 
@@ -64,13 +69,13 @@ class ProposalBenchmark : public benchmark::Fixture {
 
     auto base_tx = txbuilder.createdTime(iroha::time::now()).quorum(1);
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < number_of_commands; i++) {
       base_tx.transferAsset("player@one", "player@two", "coin", "", "5.00");
     }
 
     std::vector<shared_model::proto::Transaction> txs;
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < number_of_txs; i++) {
       txs.push_back(base_tx.build());
     }
 


### PR DESCRIPTION
### Description of the Change

This Pull Request adds benchmark for creation of blocks and proposal in various ways (move, copy, clone). We found this to be a considerable cpu bottleneck when profiling the pipeline. The first step in the elimination of that bottleneck is to provide some way to measure the performance of such operations.

https://soramitsu.atlassian.net/wiki/spaces/IS/pages/55968207/How+to+run+test

### Benefits

Benchmarks allow understanding the performance cost of the changes.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

API change for block or proposal may make these benchmarks useless