### PR TITLE
Increase presision lifetime in insertAsset

### DIFF
--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -204,12 +204,13 @@ namespace iroha {
 
     WsvCommandResult PostgresWsvCommand::insertAsset(
         const shared_model::interface::Asset &asset) {
+      auto precision = asset.precision();
       soci::statement st = sql_.prepare
           << "INSERT INTO asset(asset_id, domain_id, \"precision\", data) "
              "VALUES (:id, :domain_id, :precision, NULL)";
       st.exchange(soci::use(asset.assetId()));
       st.exchange(soci::use(asset.domainId()));
-      st.exchange(soci::use(asset.precision()));
+      st.exchange(soci::use(precision));
 
       auto msg = [&] {
         return (boost::format("failed to insert asset, asset id: '%s', "


### PR DESCRIPTION
### Description of the Change

`soci::use` uses the lvalue variables. The precision in insertAsset was passed as temporary an thus used after its scope ending. The pr is extends the precision lifetime

### Benefits

Minus one bug

### Possible Drawbacks 

None
