### PR TITLE
Mock builder introduction

### DIFF
--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
+
 #include <boost/range/any_range.hpp>
 #include <string>
 #include <vector>

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -6,9 +6,11 @@
 #ifndef IROHA_VALIDATION_UTILS
 #define IROHA_VALIDATION_UTILS
 
-#include <boost/range/any_range.hpp>
 #include <string>
 #include <vector>
+
+#include <boost/range/any_range.hpp>
+
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -41,4 +43,4 @@ namespace iroha {
   }  // namespace validation
 }  // namespace iroha
 
-#endif
+#endif  // IROHA_VALIDATION_UTILS

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#pragma once
+#ifndef IROHA_VALIDATION_UTILS
+#define IROHA_VALIDATION_UTILS
 
 #include <boost/range/any_range.hpp>
 #include <string>
@@ -39,3 +40,5 @@ namespace iroha {
 
   }  // namespace validation
 }  // namespace iroha
+
+#endif

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -1,29 +1,15 @@
-#
-# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
-# http://soramitsu.co.jp
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 addtest(chain_validation_test chain_validation_test.cpp)
 target_link_libraries(chain_validation_test
     chain_validator
-    shared_model_stateless_validation
-    shared_model_proto_backend
+    shared_model_default_builders
     )
 
 addtest(stateful_validator_test stateful_validator_test.cpp)
 target_link_libraries(stateful_validator_test
-  stateful_validator
-  shared_model_default_builders
-  )
+    stateful_validator
+    shared_model_default_builders
+    # shared_model_interfaces
+    )

--- a/test/module/irohad/validation/CMakeLists.txt
+++ b/test/module/irohad/validation/CMakeLists.txt
@@ -11,5 +11,4 @@ addtest(stateful_validator_test stateful_validator_test.cpp)
 target_link_libraries(stateful_validator_test
     stateful_validator
     shared_model_default_builders
-    # shared_model_interfaces
     )

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -1,40 +1,22 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "builders/common_objects/peer_builder.hpp"
-#include "builders/protobuf/common_objects/proto_peer_builder.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/consensus/yac/yac_mocks.hpp"
-#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+#include "module/shared_model/interface_mocks.hpp"
 #include "validation/impl/chain_validator_impl.hpp"
-#include "validators/field_validator.hpp"
 
 using namespace iroha;
 using namespace iroha::validation;
 using namespace iroha::ametsuchi;
 
+using ::testing::_;
 using ::testing::A;
 using ::testing::ByRef;
 using ::testing::InvokeArgument;
 using ::testing::Return;
-using ::testing::_;
-
-auto zero_string = std::string(32, '\0');
-auto fake_hash = shared_model::crypto::Hash(zero_string);
 
 class ChainValidationTest : public ::testing::Test {
  public:
@@ -45,16 +27,15 @@ class ChainValidationTest : public ::testing::Test {
     peers = std::vector<std::shared_ptr<shared_model::interface::Peer>>();
   }
 
-  /**
-   * Get block builder to build blocks for tests
-   * @return block builder
-   */
-  auto getBlockBuilder() const {
-    return TestBlockBuilder()
-        .transactions(std::vector<shared_model::proto::Transaction>{})
-        .height(1)
-        .prevHash(hash);
+  auto setupBlock(BlockMock &block) const {
+    EXPECT_CALL(block, height()).WillRepeatedly(Return(1));
+    EXPECT_CALL(block, prevHash()).WillRepeatedly(testing::ReturnRef(hash));
+    EXPECT_CALL(block, signatures()).WillRepeatedly(testing::Return(sigs));
+    EXPECT_CALL(block, payload()).WillRepeatedly(testing::ReturnRef(payload));
   }
+
+  std::array<SignatureMock, 0> sigs;
+  shared_model::crypto::Blob payload = shared_model::crypto::Blob("blob");
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;
 
@@ -74,7 +55,8 @@ class ChainValidationTest : public ::testing::Test {
  */
 TEST_F(ChainValidationTest, ValidCase) {
   // Valid previous hash, has supermajority, correct peers subset => valid
-  auto block = getBlockBuilder().build();
+  BlockMock block;
+  setupBlock(block);
 
   EXPECT_CALL(*supermajority_checker, hasSupermajority(block.signatures(), _))
       .WillOnce(Return(true));
@@ -94,7 +76,8 @@ TEST_F(ChainValidationTest, ValidCase) {
  */
 TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
   // Invalid previous hash, has supermajority, correct peers subset => invalid
-  auto block = getBlockBuilder().build();
+  BlockMock block;
+  setupBlock(block);
 
   shared_model::crypto::Hash another_hash =
       shared_model::crypto::Hash(std::string(32, '1'));
@@ -115,7 +98,8 @@ TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
  */
 TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
   // Valid previous hash, no supermajority, correct peers subset => invalid
-  auto block = getBlockBuilder().build();
+  BlockMock block;
+  setupBlock(block);
 
   EXPECT_CALL(*supermajority_checker, hasSupermajority(block.signatures(), _))
       .WillOnce(Return(false));
@@ -135,24 +119,19 @@ TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
  */
 TEST_F(ChainValidationTest, ValidWhenValidateChainFromOnePeer) {
   // Valid previous hash, has supermajority, correct peers subset => valid
-  auto block = std::make_shared<shared_model::proto::Block>(getBlockBuilder().build());
-  rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-      block_observable = rxcpp::observable<>::just(block).map([](auto &&x) {
-        return std::shared_ptr<shared_model::interface::Block>(x);
-      });
+  auto block = std::make_shared<BlockMock>();
+  setupBlock(*block);
 
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(Return(true));
 
   EXPECT_CALL(*query, getPeers()).WillOnce(Return(peers));
 
-  EXPECT_CALL(
-      *storage,
-      apply(testing::Truly([&](const shared_model::interface::Block &rhs) {
-              return rhs == *block;
-            }),
-            _))
+  EXPECT_CALL(*storage, apply(testing::Ref(*block), _))
       .WillOnce(InvokeArgument<1>(ByRef(*block), ByRef(*query), ByRef(hash)));
 
-  ASSERT_TRUE(validator->validateChain(block_observable, *storage));
+  ASSERT_TRUE(validator->validateChain(
+      rxcpp::observable<>::just(
+          std::static_pointer_cast<shared_model::interface::Block>(block)),
+      *storage));
 }

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -28,11 +28,12 @@ class ChainValidationTest : public ::testing::Test {
 
     EXPECT_CALL(*block, height()).WillRepeatedly(Return(1));
     EXPECT_CALL(*block, prevHash()).WillRepeatedly(testing::ReturnRef(hash));
-    EXPECT_CALL(*block, signatures()).WillRepeatedly(testing::Return(sigs));
+    EXPECT_CALL(*block, signatures())
+        .WillRepeatedly(
+            testing::Return(std::initializer_list<SignatureMock>{}));
     EXPECT_CALL(*block, payload()).WillRepeatedly(testing::ReturnRef(payload));
   }
 
-  std::array<SignatureMock, 0> sigs;
   shared_model::crypto::Blob payload{"blob"};
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -7,7 +7,6 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 
-#include "builders/protobuf/common_objects/proto_signature_builder.hpp"
 #include "common/result.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "interfaces/iroha_internal/batch_meta.hpp"

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -15,6 +15,7 @@
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "module/shared_model/interface_mocks.hpp"
 #include "validation/impl/stateful_validator_impl.hpp"
 #include "validation/stateful_validator.hpp"
 #include "validation/utils.hpp"
@@ -32,12 +33,7 @@ using ::testing::ReturnArg;
 
 class SignaturesSubset : public testing::Test {
  public:
-  auto makeSignature(PublicKey key, std::string sign) {
-    return shared_model::proto::SignatureBuilder()
-        .publicKey(key)
-        .signedData(Signed(sign))
-        .build();
-  }
+  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b"), PublicKey("c")};
 };
 
 /**
@@ -46,10 +42,10 @@ class SignaturesSubset : public testing::Test {
  * @then returned true
  */
 TEST_F(SignaturesSubset, Equal) {
-  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b"), PublicKey("c")};
-  std::vector<shared_model::proto::Signature> signatures;
-  for (const auto &k : keys) {
-    signatures.push_back(makeSignature(k, ""));
+  std::array<SignatureMock, 3> signatures;
+  for (size_t i = 0; i < signatures.size(); ++i) {
+    EXPECT_CALL(signatures[i], publicKey())
+        .WillRepeatedly(testing::ReturnRef(keys[i]));
   }
   ASSERT_TRUE(signaturesSubset(signatures, keys));
 }
@@ -61,13 +57,13 @@ TEST_F(SignaturesSubset, Equal) {
  * @then returned false
  */
 TEST_F(SignaturesSubset, Lesser) {
-  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b")};
-  std::vector<shared_model::proto::Signature> signatures;
-  for (const auto &k : keys) {
-    signatures.push_back(makeSignature(k, ""));
+  std::vector<PublicKey> subkeys{keys.begin(), keys.end() - 1};
+  std::array<SignatureMock, 3> signatures;
+  for (size_t i = 0; i < signatures.size(); ++i) {
+    EXPECT_CALL(signatures[i], publicKey())
+        .WillRepeatedly(testing::ReturnRef(keys[i]));
   }
-  signatures.push_back(makeSignature(PublicKey("c"), ""));
-  ASSERT_FALSE(signaturesSubset(signatures, keys));
+  ASSERT_FALSE(signaturesSubset(signatures, subkeys));
 }
 
 /**
@@ -76,12 +72,11 @@ TEST_F(SignaturesSubset, Lesser) {
  * @then returned true
  */
 TEST_F(SignaturesSubset, StrictSubset) {
-  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("b")};
-  std::vector<shared_model::proto::Signature> signatures;
-  for (const auto &k : keys) {
-    signatures.push_back(makeSignature(k, ""));
+  std::array<SignatureMock, 2> signatures;
+  for (size_t i = 0; i < signatures.size(); ++i) {
+    EXPECT_CALL(signatures[i], publicKey())
+        .WillRepeatedly(testing::ReturnRef(keys[i]));
   }
-  keys.push_back(PublicKey("c"));
   ASSERT_TRUE(signaturesSubset(signatures, keys));
 }
 
@@ -91,11 +86,13 @@ TEST_F(SignaturesSubset, StrictSubset) {
  * @then returned false
  */
 TEST_F(SignaturesSubset, PublickeyUniqueness) {
-  std::vector<PublicKey> keys{PublicKey("a"), PublicKey("a")};
-  std::vector<shared_model::proto::Signature> signatures;
-  signatures.push_back(makeSignature(PublicKey("a"), ""));
-  signatures.push_back(makeSignature(PublicKey("c"), ""));
-  ASSERT_FALSE(signaturesSubset(signatures, keys));
+  std::vector<PublicKey> repeated_keys{2, keys[0]};
+  std::array<SignatureMock, 2> signatures;
+  for (size_t i = 0; i < signatures.size(); ++i) {
+    EXPECT_CALL(signatures[i], publicKey())
+        .WillRepeatedly(testing::ReturnRef(keys[i]));
+  }
+  ASSERT_FALSE(signaturesSubset(signatures, repeated_keys));
 }
 
 class Validator : public testing::Test {

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "interfaces/iroha_internal/block.hpp"
+#include "interfaces/transaction.hpp"
+
+namespace iface = shared_model::interface;
+
+struct BlockMock : public iface::Block {
+  MOCK_CONST_METHOD0(txsNumber, iface::types::TransactionsNumberType());
+  MOCK_CONST_METHOD0(transactions, iface::types::TransactionsCollectionType());
+  MOCK_CONST_METHOD0(height, iface::types::HeightType());
+  MOCK_CONST_METHOD0(prevHash, const iface::types::HashType &());
+  MOCK_CONST_METHOD0(signatures, iface::types::SignatureRangeType());
+  MOCK_CONST_METHOD0(createdTime, iface::types::TimestampType());
+  MOCK_CONST_METHOD0(payload, const iface::types::BlobType &());
+  MOCK_CONST_METHOD0(blob, const iface::types::BlobType &());
+  MOCK_METHOD2(addSignature,
+               bool(const shared_model::crypto::Signed &signed_blob,
+                    const shared_model::crypto::PublicKey &public_key));
+  MOCK_CONST_METHOD0(clone, BlockMock *());
+};
+
+struct TransactionMock : public iface::Transaction {
+  MOCK_CONST_METHOD0(creatorAccountId, const iface::types::AccountIdType &());
+  MOCK_CONST_METHOD0(quorum, iface::types::QuorumType());
+  MOCK_CONST_METHOD0(commands, CommandsType());
+  MOCK_CONST_METHOD0(reduced_payload, const iface::types::BlobType &());
+  MOCK_CONST_METHOD0(batch_meta,
+                     boost::optional<std::shared_ptr<iface::BatchMeta>>());
+  MOCK_CONST_METHOD0(signatures, iface::types::SignatureRangeType());
+  MOCK_CONST_METHOD0(createdTime, iface::types::TimestampType());
+  MOCK_CONST_METHOD0(payload, const iface::types::BlobType &());
+  MOCK_CONST_METHOD0(blob, const iface::types::BlobType &());
+  MOCK_METHOD2(addSignature,
+               bool(const shared_model::crypto::Signed &signed_blob,
+                    const shared_model::crypto::PublicKey &public_key));
+  MOCK_CONST_METHOD0(clone, TransactionMock *());
+};
+
+struct SignatureMock : public iface::Signature {
+  MOCK_CONST_METHOD0(publicKey, const PublicKeyType &());
+  MOCK_CONST_METHOD0(signedData, const SignedType &());
+  MOCK_CONST_METHOD0(clone, SignatureMock *());
+};

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -21,8 +21,8 @@ struct BlockMock : public iface::Block {
   MOCK_CONST_METHOD0(payload, const iface::types::BlobType &());
   MOCK_CONST_METHOD0(blob, const iface::types::BlobType &());
   MOCK_METHOD2(addSignature,
-               bool(const shared_model::crypto::Signed &signed_blob,
-                    const shared_model::crypto::PublicKey &public_key));
+               bool(const shared_model::crypto::Signed &,
+                    const shared_model::crypto::PublicKey &));
   MOCK_CONST_METHOD0(clone, BlockMock *());
 };
 
@@ -38,8 +38,8 @@ struct TransactionMock : public iface::Transaction {
   MOCK_CONST_METHOD0(payload, const iface::types::BlobType &());
   MOCK_CONST_METHOD0(blob, const iface::types::BlobType &());
   MOCK_METHOD2(addSignature,
-               bool(const shared_model::crypto::Signed &signed_blob,
-                    const shared_model::crypto::PublicKey &public_key));
+               bool(const shared_model::crypto::Signed &,
+                    const shared_model::crypto::PublicKey &));
   MOCK_CONST_METHOD0(clone, TransactionMock *());
 };
 


### PR DESCRIPTION
### Description of the Change

Builders replaced with the mocked SM's interfaces in ChainValidator and in SignatureSubset test of the stateful validatior.

### Benefits

Less dependent from builders, cleaner code

### Possible Drawbacks 

None?
