### PR TITLE
Java bindings fix

### DIFF
--- a/test/module/shared_model/bindings/QueryTest.java
+++ b/test/module/shared_model/bindings/QueryTest.java
@@ -548,7 +548,7 @@ public class QueryTest {
 
     @Test
     void getAccountDetailWithNoArgs() {
-        UnsignedQuery query = base().getAccountDetail();
+        UnsignedQuery query = base().getAccountDetail().build();
         assertTrue(checkProtoQuery(proto(query)));
     }
 }


### PR DESCRIPTION
### Description of the Change

Java bindings were not tested appropriately because of a little bug in tests. Now, it's fixed

### Benefits

All tests are passed

### Possible Drawbacks 

None