### PR TITLE
Refactor QueryProcessor interface

### DIFF
--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -27,7 +27,7 @@ namespace iroha {
      * @param hash - original query hash
      * @return QueryRepsonse
      */
-    std::shared_ptr<shared_model::interface::QueryResponse> buildStatefulError(
+    std::unique_ptr<shared_model::interface::QueryResponse> buildStatefulError(
         const shared_model::interface::types::HashType &hash) {
       return clone(
           shared_model::proto::TemplateQueryResponseBuilder<>()
@@ -78,32 +78,27 @@ namespace iroha {
     QueryProcessorImpl::checkSignatories<shared_model::interface::BlocksQuery>(
         const shared_model::interface::BlocksQuery &);
 
-    void QueryProcessorImpl::queryHandle(
-        std::shared_ptr<shared_model::interface::Query> qry) {
-      if (not checkSignatories(*qry)) {
-        auto response = buildStatefulError(qry->hash());
-        std::lock_guard<std::mutex> lock(notifier_mutex_);
-        subject_.get_subscriber().on_next(response);
-        return;
+    std::unique_ptr<shared_model::interface::QueryResponse>
+    QueryProcessorImpl::queryHandle(const shared_model::interface::Query &qry) {
+      if (not checkSignatories(qry)) {
+        return buildStatefulError(qry.hash());
       }
 
       const auto &wsv_query = storage_->getWsvQuery();
       auto qpf = QueryProcessingFactory(wsv_query, storage_->getBlockQuery());
-      auto qpf_response = qpf.validateAndExecute(*qry);
+      auto qpf_response = qpf.validateAndExecute(qry);
       auto qry_resp =
           std::static_pointer_cast<shared_model::proto::QueryResponse>(
               qpf_response);
-      std::lock_guard<std::mutex> lock(notifier_mutex_);
-      subject_.get_subscriber().on_next(
-          std::make_shared<shared_model::proto::QueryResponse>(
-              qry_resp->getTransport()));
+      return std::make_unique<shared_model::proto::QueryResponse>(
+          qry_resp->getTransport());
     }
 
     rxcpp::observable<
         std::shared_ptr<shared_model::interface::BlockQueryResponse>>
     QueryProcessorImpl::blocksQueryHandle(
-        std::shared_ptr<shared_model::interface::BlocksQuery> qry) {
-      if (not checkSignatories(*qry)) {
+        const shared_model::interface::BlocksQuery &qry) {
+      if (not checkSignatories(qry)) {
         auto response = buildBlocksQueryError("Wrong signatories");
         return rxcpp::observable<>::just(
             std::shared_ptr<shared_model::interface::BlockQueryResponse>(
@@ -111,18 +106,13 @@ namespace iroha {
       }
       const auto &wsv_query = storage_->getWsvQuery();
       auto qpf = QueryProcessingFactory(wsv_query, storage_->getBlockQuery());
-      if (not qpf.validate(*qry)) {
+      if (not qpf.validate(qry)) {
         auto response = buildBlocksQueryError("Stateful invalid");
         return rxcpp::observable<>::just(
             std::shared_ptr<shared_model::interface::BlockQueryResponse>(
                 response));
       }
       return blocksQuerySubject_.get_observable();
-    }
-
-    rxcpp::observable<std::shared_ptr<shared_model::interface::QueryResponse>>
-    QueryProcessorImpl::queryNotifier() {
-      return subject_.get_observable();
     }
 
   }  // namespace torii

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -27,7 +27,7 @@ namespace iroha {
      * @param hash - original query hash
      * @return QueryRepsonse
      */
-    std::unique_ptr<shared_model::interface::QueryResponse> buildStatefulError(
+    auto buildStatefulError(
         const shared_model::interface::types::HashType &hash) {
       return clone(
           shared_model::proto::TemplateQueryResponseBuilder<>()

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -34,8 +34,9 @@ namespace iroha {
     class QueryProcessor {
      public:
       /**
-       * Register client query
-       * @param query - client intent
+       * Perform client query
+       * @param qry - client intent
+       * @return resulted response
        */
       virtual std::unique_ptr<shared_model::interface::QueryResponse>
       queryHandle(const shared_model::interface::Query &qry) = 0;

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -37,8 +37,8 @@ namespace iroha {
        * Register client query
        * @param query - client intent
        */
-      virtual void queryHandle(
-          std::shared_ptr<shared_model::interface::Query> qry) = 0;
+      virtual std::unique_ptr<shared_model::interface::QueryResponse>
+      queryHandle(const shared_model::interface::Query &qry) = 0;
       /**
        * Register client blocks query
        * @param query - client intent
@@ -46,15 +46,7 @@ namespace iroha {
        */
       virtual rxcpp::observable<
           std::shared_ptr<shared_model::interface::BlockQueryResponse>>
-      blocksQueryHandle(
-          std::shared_ptr<shared_model::interface::BlocksQuery> qry) = 0;
-      /**
-       * Subscribe for query responses
-       * @return observable with query responses
-       */
-      virtual rxcpp::observable<
-          std::shared_ptr<shared_model::interface::QueryResponse>>
-      queryNotifier() = 0;
+      blocksQueryHandle(const shared_model::interface::BlocksQuery &qry) = 0;
 
       virtual ~QueryProcessor(){};
     };

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -44,8 +44,8 @@ namespace iroha {
        * Register client query
        * @param query - client intent
        */
-      void queryHandle(
-          std::shared_ptr<shared_model::interface::Query> qry) override;
+      std::unique_ptr<shared_model::interface::QueryResponse> queryHandle(
+          const shared_model::interface::Query &qry) override;
 
       /**
        * Register client block query
@@ -55,24 +55,13 @@ namespace iroha {
       rxcpp::observable<
           std::shared_ptr<shared_model::interface::BlockQueryResponse>>
       blocksQueryHandle(
-          std::shared_ptr<shared_model::interface::BlocksQuery> qry) override;
-
-      /**
-       * Subscribe for query responses
-       * @return observable with query responses
-       */
-      rxcpp::observable<std::shared_ptr<shared_model::interface::QueryResponse>>
-      queryNotifier() override;
+          const shared_model::interface::BlocksQuery &qry) override;
 
      private:
-      rxcpp::subjects::subject<
-          std::shared_ptr<shared_model::interface::QueryResponse>>
-          subject_;
       rxcpp::subjects::subject<
           std::shared_ptr<shared_model::interface::BlockQueryResponse>>
           blocksQuerySubject_;
       std::shared_ptr<ametsuchi::Storage> storage_;
-      std::mutex notifier_mutex_;
     };
   }  // namespace torii
 }  // namespace iroha

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -26,7 +26,7 @@ namespace iroha {
   namespace torii {
 
     /**
-     * QueryProcessor provides start point for queries in the whole system
+     * QueryProcessorImpl provides implementation of QueryProcessor
      */
     class QueryProcessorImpl : public QueryProcessor {
      public:
@@ -40,18 +40,9 @@ namespace iroha {
       template <class Q>
       bool checkSignatories(const Q &qry);
 
-      /**
-       * Register client query
-       * @param query - client intent
-       */
       std::unique_ptr<shared_model::interface::QueryResponse> queryHandle(
           const shared_model::interface::Query &qry) override;
 
-      /**
-       * Register client block query
-       * @param query - client intent
-       * @return observable with block query responses
-       */
       rxcpp::observable<
           std::shared_ptr<shared_model::interface::BlockQueryResponse>>
       blocksQueryHandle(

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -87,7 +87,7 @@ TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
                   Truly([this](const shared_model::interface::Query &rhs) {
                     return rhs == *query;
                   })))
-      .WillOnce(Invoke([this](auto &) { return getResponse(); }));
+      .WillOnce(Invoke([this](auto &) { return this->getResponse(); }));
   init();
 
   protocol::QueryResponse response;
@@ -105,7 +105,7 @@ TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
 TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   // two same queries => only first query handled by query processor
   EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Invoke([this](auto &) {
-    return getResponse();
+    return this->getResponse();
   }));
 
   init();

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -51,25 +51,25 @@ class QueryServiceTest : public ::testing::Test {
                 shared_model::crypto::DefaultCryptoAlgorithmType::
                     generateKeypair())
             .finish());
-
-    auto account = shared_model::proto::AccountBuilder()
-                       .accountId("a")
-                       .domainId("ru")
-                       .quorum(2)
-                       .build();
-
-    model_response = clone(TestQueryResponseBuilder()
-                               .accountResponse(account, {"user"})
-                               .queryHash(query->hash())
-                               .build());
   }
 
   void init() {
     query_service = std::make_shared<QueryService>(query_processor);
   }
 
+  std::unique_ptr<shared_model::proto::QueryResponse> getResponse() {
+    static auto account = shared_model::proto::AccountBuilder()
+                              .accountId("a")
+                              .domainId("ru")
+                              .quorum(2)
+                              .build();
+    return clone(TestQueryResponseBuilder()
+                     .accountResponse(account, {"user"})
+                     .queryHash(query->hash())
+                     .build());
+  }
+
   std::shared_ptr<shared_model::proto::Query> query;
-  std::shared_ptr<shared_model::proto::QueryResponse> model_response;
   std::shared_ptr<QueryService> query_service;
   std::shared_ptr<MockQueryProcessor> query_processor;
 };
@@ -81,60 +81,19 @@ class QueryServiceTest : public ::testing::Test {
  */
 TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
   // unique query => query handled by query processor
-  rxcpp::subjects::subject<
-      std::shared_ptr<shared_model::interface::QueryResponse>>
-      notifier;
-  EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(Return(notifier.get_observable()));
-  EXPECT_CALL(
-      *query_processor,
-      queryHandle(
-          // match by shared_ptr's content
-          Truly([this](std::shared_ptr<shared_model::interface::Query> rhs) {
-            return *rhs == *query;
-          })))
-      .WillOnce(Invoke([this, &notifier](auto q) {
-        notifier.get_subscriber().on_next(model_response);
-      }));
+  EXPECT_CALL(*query_processor,
+              queryHandle(
+                  // match by shared_ptr's content
+                  Truly([this](const shared_model::interface::Query &rhs) {
+                    return rhs == *query;
+                  })))
+      .WillOnce(Invoke([this](auto &) { return getResponse(); }));
   init();
 
   protocol::QueryResponse response;
   query_service->Find(query->getTransport(), response);
   auto resp = shared_model::proto::QueryResponse(response);
-  ASSERT_EQ(resp, *model_response);
-}
-
-/**
- * @given query and expected response
- * @when query is sent to query service and query_processor does not process
- * query
- * @then NOT_SUPPORTED error response is returned
- */
-TEST_F(QueryServiceTest, InvalidWhenUniqueHash) {
-  // unique query => query handled by query processor
-  rxcpp::subjects::subject<
-      std::shared_ptr<shared_model::interface::QueryResponse>>
-      notifier;
-  EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(Return(notifier.get_observable()));
-  EXPECT_CALL(
-      *query_processor,
-      queryHandle(
-          // match by shared_ptr's content
-          Truly([this](std::shared_ptr<shared_model::interface::Query> rhs) {
-            return *rhs == *query;
-          })))
-      .WillOnce(Return());
-  init();
-
-  protocol::QueryResponse response;
-  query_service->Find(query->getTransport(), response);
-  ASSERT_TRUE(response.has_error_response());
-  auto resp = shared_model::proto::QueryResponse(response);
-  ASSERT_TRUE(boost::apply_visitor(
-      shared_model::interface::QueryErrorResponseChecker<
-          shared_model::interface::NotSupportedErrorResponse>(),
-      resp.get()));
+  ASSERT_EQ(resp, *getResponse());
 }
 
 /**
@@ -145,10 +104,9 @@ TEST_F(QueryServiceTest, InvalidWhenUniqueHash) {
  */
 TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   // two same queries => only first query handled by query processor
-  EXPECT_CALL(*query_processor, queryNotifier())
-      .WillOnce(
-          Return(rxcpp::observable<>::empty<std::shared_ptr<QueryResponse>>()));
-  EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Return());
+  EXPECT_CALL(*query_processor, queryHandle(_)).WillOnce(Invoke([this](auto &) {
+    return getResponse();
+  }));
 
   init();
 

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -28,16 +28,13 @@ namespace iroha {
     class MockQueryProcessor : public QueryProcessor {
      public:
       MOCK_METHOD1(queryHandle,
-                   void(std::shared_ptr<shared_model::interface::Query>));
+                   std::unique_ptr<shared_model::interface::QueryResponse>(
+                       const shared_model::interface::Query &));
       MOCK_METHOD1(
           blocksQueryHandle,
           rxcpp::observable<
               std::shared_ptr<shared_model::interface::BlockQueryResponse>>(
-              std::shared_ptr<shared_model::interface::BlocksQuery>));
-      MOCK_METHOD0(
-          queryNotifier,
-          rxcpp::observable<
-              std::shared_ptr<shared_model::interface::QueryResponse>>());
+              const shared_model::interface::BlocksQuery &));
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/module/irohad/torii/torii_service_query_test.cpp
+++ b/test/module/irohad/torii/torii_service_query_test.cpp
@@ -33,10 +33,6 @@ class ToriiQueryServiceTest : public ::testing::Test {
 
     // ----------- Command Service --------------
     query_processor = std::make_shared<iroha::torii::MockQueryProcessor>();
-    EXPECT_CALL(*query_processor, queryNotifier())
-        .WillOnce(
-            Return(rxcpp::observable<>::empty<
-                   std::shared_ptr<shared_model::interface::QueryResponse>>()));
 
     //----------- Server run ----------------
     runner->append(std::make_unique<torii::QueryService>(query_processor))
@@ -91,12 +87,10 @@ TEST_F(ToriiQueryServiceTest, FetchBlocksWhenValidQuery) {
           .blockResponse(*proto_block)
           .build();
 
-  EXPECT_CALL(
-      *query_processor,
-      blocksQueryHandle(
-          Truly([&blocks_query](
-                    const std::shared_ptr<shared_model::interface::BlocksQuery>
-                        query) { return *query == *blocks_query; })))
+  EXPECT_CALL(*query_processor,
+              blocksQueryHandle(Truly([&blocks_query](auto &query) {
+                return query == *blocks_query;
+              })))
       .WillOnce(Return(rxcpp::observable<>::just(block_response)));
 
   auto client = torii_utils::QuerySyncClient(ip, port);


### PR DESCRIPTION
### Description of the Change

Since simple queries are performed in synchronous manner there's a reason in queryNotifier removing and returning the response at queryHandle call. Also some functions was refactored, so they accept reference, instead of shared_ptr.

### Benefits

Code is simpler

### Possible Drawbacks 

None?
