### PR TITLE
Feature/tx status bus

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -71,6 +71,7 @@ find_package(Boost 1.65.0 REQUIRED
     COMPONENTS
     filesystem
     system
+    thread
     )
 add_library(boost INTERFACE IMPORTED)
 set_target_properties(boost PROPERTIES

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -49,7 +49,7 @@ RUN set -e; \
     git clone https://github.com/boostorg/boost /tmp/boost; \
     (cd /tmp/boost ; git checkout 436ad1dfcfc7e0246141beddd11c8a4e9c10b146); \
     (cd /tmp/boost ; git submodule update --init --recursive); \
-    (cd /tmp/boost ; /tmp/boost/bootstrap.sh --with-libraries=system,filesystem); \
+    (cd /tmp/boost ; /tmp/boost/bootstrap.sh --with-libraries=system,filesystem,thread); \
     (cd /tmp/boost ; /tmp/boost/b2 headers); \
     (cd /tmp/boost ; /tmp/boost/b2 cxxflags="-std=c++14" -j ${PARALLELISM} install --prefix=/opt/dependencies/boost); \
     ldconfig; \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -49,7 +49,7 @@ RUN set -e; \
     git clone https://github.com/boostorg/boost /tmp/boost; \
     (cd /tmp/boost ; git checkout 436ad1dfcfc7e0246141beddd11c8a4e9c10b146); \
     (cd /tmp/boost ; git submodule update --init --recursive); \
-    (cd /tmp/boost ; /tmp/boost/bootstrap.sh --with-libraries=system,filesystem); \
+    (cd /tmp/boost ; /tmp/boost/bootstrap.sh --with-libraries=system,filesystem,thread); \
     (cd /tmp/boost ; /tmp/boost/b2 headers); \
     (cd /tmp/boost ; /tmp/boost/b2 cxxflags="-std=c++14" -j ${PARALLELISM} install); \
     ldconfig; \

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -15,6 +15,7 @@
 #include "multi_sig_transactions/mst_time_provider_impl.hpp"
 #include "multi_sig_transactions/storage/mst_storage_impl.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
+#include "torii/impl/status_bus_impl.hpp"
 #include "validators/field_validator.hpp"
 
 using namespace iroha;
@@ -74,6 +75,7 @@ void Irohad::init() {
   initConsensusGate();
   initSynchronizer();
   initPeerCommunicationService();
+  initStatusBus();
   initMstProcessor();
 
   // Torii
@@ -233,6 +235,11 @@ void Irohad::initPeerCommunicationService() {
   log_->info("[Init] => pcs");
 }
 
+void Irohad::initStatusBus() {
+  status_bus_ = std::make_shared<StatusBusImpl>();
+  log_->info("[Init] => Tx status bus");
+}
+
 void Irohad::initMstProcessor() {
   if (is_mst_supported_) {
     auto mst_transport = std::make_shared<MstTransportGrpc>();
@@ -257,11 +264,15 @@ void Irohad::initMstProcessor() {
  * Initializing transaction command service
  */
 void Irohad::initTransactionCommandService() {
-  auto tx_processor =
-      std::make_shared<TransactionProcessorImpl>(pcs, mst_processor);
+  auto tx_processor = std::make_shared<TransactionProcessorImpl>(
+      pcs, mst_processor, status_bus_);
 
-  command_service = std::make_shared<::torii::CommandService>(
-      tx_processor, storage, std::chrono::seconds(1), 2 * proposal_delay_);
+  command_service =
+      std::make_shared<::torii::CommandService>(tx_processor,
+                                                storage,
+                                                status_bus_,
+                                                std::chrono::seconds(1),
+                                                2 * proposal_delay_);
 
   log_->info("[Init] => command service");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -133,6 +133,8 @@ class Irohad {
 
   virtual void initPeerCommunicationService();
 
+  virtual void initStatusBus();
+
   virtual void initMstProcessor();
 
   virtual void initTransactionCommandService();
@@ -187,6 +189,8 @@ class Irohad {
 
   // mst
   std::shared_ptr<iroha::MstProcessor> mst_processor;
+
+  std::shared_ptr<iroha::torii::StatusBus> status_bus_;
 
   // transaction service
   std::shared_ptr<torii::CommandService> command_service;

--- a/irohad/torii/CMakeLists.txt
+++ b/irohad/torii/CMakeLists.txt
@@ -38,3 +38,11 @@ target_link_libraries(torii_service
     shared_model_stateless_validation
     processors
     )
+
+add_library(status_bus
+    impl/status_bus_impl.cpp
+    )
+target_link_libraries(status_bus
+    rxcpp
+    shared_model_interfaces
+    )

--- a/irohad/torii/impl/status_bus_impl.cpp
+++ b/irohad/torii/impl/status_bus_impl.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "torii/impl/status_bus_impl.hpp"
+
+namespace iroha {
+  namespace torii {
+    StatusBusImpl::StatusBusImpl(rxcpp::observe_on_one_worker worker)
+        : worker_(worker), subject_(worker_) {}
+
+    void StatusBusImpl::publish(StatusBus::Objects resp) {
+      subject_.get_subscriber().on_next(resp);
+    }
+
+    rxcpp::observable<StatusBus::Objects> StatusBusImpl::statuses() {
+      return subject_.get_observable();
+    }
+  }  // namespace torii
+}  // namespace iroha

--- a/irohad/torii/impl/status_bus_impl.hpp
+++ b/irohad/torii/impl/status_bus_impl.hpp
@@ -22,6 +22,7 @@ namespace iroha {
       /// Subscribers will be invoked in separate thread
       rxcpp::observable<StatusBus::Objects> statuses() override;
 
+      // Need to create once, otherwise will create thread for each subscriber
       rxcpp::observe_on_one_worker worker_;
       rxcpp::subjects::synchronize<StatusBus::Objects, decltype(worker_)>
           subject_;

--- a/irohad/torii/impl/status_bus_impl.hpp
+++ b/irohad/torii/impl/status_bus_impl.hpp
@@ -1,0 +1,32 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TORII_STATUS_BUS_IMPL
+#define TORII_STATUS_BUS_IMPL
+
+#include "torii/status_bus.hpp"
+
+namespace iroha {
+  namespace torii {
+    /**
+     * StatusBus implementation
+     */
+    class StatusBusImpl : public StatusBus {
+     public:
+      StatusBusImpl(
+          rxcpp::observe_on_one_worker worker = rxcpp::observe_on_new_thread());
+
+      void publish(StatusBus::Objects) override;
+      /// Subscribers will be invoked in separate thread
+      rxcpp::observable<StatusBus::Objects> statuses() override;
+
+      rxcpp::observe_on_one_worker worker_;
+      rxcpp::subjects::synchronize<StatusBus::Objects, decltype(worker_)>
+          subject_;
+    };
+  }  // namespace torii
+}  // namespace iroha
+
+#endif  // TORII_STATUS_BUS_IMPL

--- a/irohad/torii/processor/CMakeLists.txt
+++ b/irohad/torii/processor/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(processors PUBLIC
     mst_processor
     shared_model_proto_builders
     query_execution
+    status_bus
     )

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "torii/processor/transaction_processor_impl.hpp"
@@ -50,10 +38,12 @@ namespace iroha {
 
     TransactionProcessorImpl::TransactionProcessorImpl(
         std::shared_ptr<PeerCommunicationService> pcs,
-        std::shared_ptr<MstProcessor> mst_processor)
-        : pcs_(std::move(pcs)), mst_processor_(std::move(mst_processor)) {
-      log_ = logger::log("TxProcessor");
-
+        std::shared_ptr<MstProcessor> mst_processor,
+        std::shared_ptr<iroha::torii::StatusBus> status_bus)
+        : pcs_(std::move(pcs)),
+          mst_processor_(std::move(mst_processor)),
+          status_bus_(std::move(status_bus)),
+          log_(logger::log("TxProcessor")) {
       // notify about stateless success
       pcs_->on_proposal().subscribe([this](auto model_proposal) {
         for (const auto &tx : model_proposal->transactions()) {
@@ -61,8 +51,7 @@ namespace iroha {
           log_->info("on proposal stateless success: {}", hash.hex());
           // different on_next() calls (this one and below) can happen in
           // different threads and we don't expect emitting them concurrently
-          std::lock_guard<std::mutex> lock(notifier_mutex_);
-          notifier_.get_subscriber().on_next(
+          status_bus_->publish(
               shared_model::builder::DefaultTransactionStatusBuilder()
                   .statelessValidationSuccess()
                   .txHash(hash)
@@ -80,7 +69,7 @@ namespace iroha {
             for (const auto &tx_error : errors) {
               auto error_msg = composeErrorMessage(tx_error);
               log_->info(error_msg);
-              notifier_.get_subscriber().on_next(
+              status_bus_->publish(
                   shared_model::builder::DefaultTransactionStatusBuilder()
                       .statefulValidationFailed()
                       .txHash(tx_error.second)
@@ -92,7 +81,7 @@ namespace iroha {
                  proposal_and_errors->first->transactions()) {
               log_->info("on stateful validation success: {}",
                          successful_tx.hash().hex());
-              notifier_.get_subscriber().on_next(
+              status_bus_->publish(
                   shared_model::builder::DefaultTransactionStatusBuilder()
                       .statefulValidationSuccess()
                       .txHash(successful_tx.hash())
@@ -119,7 +108,7 @@ namespace iroha {
                 std::lock_guard<std::mutex> lock(notifier_mutex_);
                 for (const auto &tx_hash : current_txs_hashes_) {
                   log_->info("on commit committed: {}", tx_hash.hex());
-                  notifier_.get_subscriber().on_next(
+                  status_bus_->publish(
                       shared_model::builder::DefaultTransactionStatusBuilder()
                           .committed()
                           .txHash(tx_hash)
@@ -137,7 +126,7 @@ namespace iroha {
       mst_processor_->onExpiredTransactions().subscribe([this](auto &&tx) {
         log_->info("MST tx expired");
         std::lock_guard<std::mutex> lock(notifier_mutex_);
-        this->notifier_.get_subscriber().on_next(
+        this->status_bus_->publish(
             shared_model::builder::DefaultTransactionStatusBuilder()
                 .mstExpired()
                 .txHash(tx->hash())
@@ -174,12 +163,6 @@ namespace iroha {
           }
         }
       }
-    }
-
-    rxcpp::observable<
-        std::shared_ptr<shared_model::interface::TransactionResponse>>
-    TransactionProcessorImpl::transactionNotifier() {
-      return notifier_.get_observable();
     }
 
   }  // namespace torii

--- a/irohad/torii/processor/transaction_processor.hpp
+++ b/irohad/torii/processor/transaction_processor.hpp
@@ -54,14 +54,6 @@ namespace iroha {
           const shared_model::interface::TransactionSequence
               &transaction_sequence) const = 0;
 
-      /**
-       * Subscribers will be notified with transaction status
-       * @return observable for subscribing
-       */
-      virtual rxcpp::observable<
-          std::shared_ptr<shared_model::interface::TransactionResponse>>
-      transactionNotifier() = 0;
-
       virtual ~TransactionProcessor() = default;
     };
   }  // namespace torii

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -25,6 +25,7 @@
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "network/peer_communication_service.hpp"
 #include "torii/processor/transaction_processor.hpp"
+#include "torii/status_bus.hpp"
 
 namespace iroha {
   namespace torii {
@@ -33,10 +34,12 @@ namespace iroha {
       /**
        * @param pcs - provide information proposals and commits
        * @param mst_processor is a handler for multisignature transactions
+       * @param status_bus is a common notifier for tx statuses
        */
       TransactionProcessorImpl(
           std::shared_ptr<network::PeerCommunicationService> pcs,
-          std::shared_ptr<MstProcessor> mst_processor);
+          std::shared_ptr<MstProcessor> mst_processor,
+          std::shared_ptr<iroha::torii::StatusBus> status_bus);
 
       void transactionHandle(
           std::shared_ptr<shared_model::interface::Transaction> transaction)
@@ -46,10 +49,6 @@ namespace iroha {
           const shared_model::interface::TransactionSequence
               &transaction_sequence) const override;
 
-      rxcpp::observable<
-          std::shared_ptr<shared_model::interface::TransactionResponse>>
-      transactionNotifier() override;
-
      private:
       // connections
       std::shared_ptr<network::PeerCommunicationService> pcs_;
@@ -57,6 +56,8 @@ namespace iroha {
       // processing
       std::shared_ptr<MstProcessor> mst_processor_;
       std::vector<shared_model::interface::types::HashType> current_txs_hashes_;
+
+      std::shared_ptr<iroha::torii::StatusBus> status_bus_;
 
       // internal
       rxcpp::subjects::subject<

--- a/irohad/torii/status_bus.hpp
+++ b/irohad/torii/status_bus.hpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TORII_STATUS_BUS
+#define TORII_STATUS_BUS
+
+#include <rxcpp/rx.hpp>
+#include "interfaces/transaction_responses/tx_response.hpp"
+
+namespace iroha {
+  namespace torii {
+    /**
+     * Interface of bus for transaction statuses
+     */
+    class StatusBus {
+     public:
+      virtual ~StatusBus() = default;
+
+      /// Objects that represent status to operate with
+      using Objects =
+          std::shared_ptr<shared_model::interface::TransactionResponse>;
+
+      /**
+       * Shares object among the bus subscribers
+       * @param object to share
+       * note: guaranteed to be non-blocking call
+       */
+      virtual void publish(Objects) = 0;
+
+      /**
+       * @return observable over objects in bus
+       */
+      virtual rxcpp::observable<Objects> statuses() = 0;
+    };
+  }  // namespace torii
+}  // namespace iroha
+
+#endif  // TORII_STATUS_BUS

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -64,6 +64,10 @@ namespace integration_framework {
       return crypto_signer_;
     }
 
+    auto getStatusBus() {
+      return status_bus_;
+    }
+
     void run() override {
       internal_server = std::make_unique<ServerRunner>(
           "127.0.0.1:" + std::to_string(internal_port_));

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -19,6 +19,7 @@
 #include "execution/query_execution_impl.hpp"
 #include "main/server_runner.hpp"
 #include "torii/command_service.hpp"
+#include "torii/impl/status_bus_impl.hpp"
 #include "torii/processor/query_processor_impl.hpp"
 #include "torii/processor/transaction_processor_impl.hpp"
 #include "torii/query_service.hpp"
@@ -74,8 +75,10 @@ class ClientServerTest : public testing::Test {
     EXPECT_CALL(*mst, onExpiredTransactionsImpl())
         .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
 
+    auto status_bus = std::make_shared<iroha::torii::StatusBusImpl>();
     auto tx_processor =
-        std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock, mst);
+        std::make_shared<iroha::torii::TransactionProcessorImpl>(
+            pcsMock, mst, status_bus);
 
     auto pb_tx_factory =
         std::make_shared<iroha::model::converters::PbTransactionFactory>();
@@ -89,8 +92,11 @@ class ClientServerTest : public testing::Test {
 
     //----------- Server run ----------------
     runner
-        ->append(std::make_unique<torii::CommandService>(
-            tx_processor, storage, initial_timeout, nonfinal_timeout))
+        ->append(std::make_unique<torii::CommandService>(tx_processor,
+                                                         storage,
+                                                         status_bus,
+                                                         initial_timeout,
+                                                         nonfinal_timeout))
         .append(std::make_unique<torii::QueryService>(qpi))
         .run()
         .match(

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -1,26 +1,17 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_TORII_MOCKS_HPP
 #define IROHA_TORII_MOCKS_HPP
 
-#include "torii/processor/query_processor.hpp"
-
 #include <gmock/gmock.h>
+
+#include "interfaces/query_responses/block_query_response.hpp"
+#include "interfaces/query_responses/query_response.hpp"
+#include "torii/processor/query_processor.hpp"
+#include "torii/status_bus.hpp"
 
 namespace iroha {
   namespace torii {
@@ -35,6 +26,12 @@ namespace iroha {
           rxcpp::observable<
               std::shared_ptr<shared_model::interface::BlockQueryResponse>>(
               const shared_model::interface::BlocksQuery &));
+    };
+
+    class MockStatusBus : public StatusBus {
+     public:
+      MOCK_METHOD1(publish, void(StatusBus::Objects));
+      MOCK_METHOD0(statuses, rxcpp::observable<StatusBus::Objects>());
     };
   }  // namespace torii
 }  // namespace iroha

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -1,18 +1,7 @@
-/*
-Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "builders/protobuf/block.hpp"
 #include "builders/protobuf/proposal.hpp"
@@ -28,6 +17,7 @@ limitations under the License.
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "torii/command_client.hpp"
 #include "torii/command_service.hpp"
+#include "torii/impl/status_bus_impl.hpp"
 #include "torii/processor/transaction_processor_impl.hpp"
 
 constexpr size_t TimesToriiBlocking = 5;
@@ -108,8 +98,10 @@ class ToriiServiceTest : public testing::Test {
     EXPECT_CALL(*mst, onExpiredTransactionsImpl())
         .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
 
+    auto status_bus = std::make_shared<iroha::torii::StatusBusImpl>();
     auto tx_processor =
-        std::make_shared<iroha::torii::TransactionProcessorImpl>(pcsMock, mst);
+        std::make_shared<iroha::torii::TransactionProcessorImpl>(
+            pcsMock, mst, status_bus);
 
     EXPECT_CALL(*block_query, getTxByHashSync(_))
         .WillRepeatedly(Return(boost::none));
@@ -117,8 +109,11 @@ class ToriiServiceTest : public testing::Test {
 
     //----------- Server run ----------------
     runner
-        ->append(std::make_unique<torii::CommandService>(
-            tx_processor, storage, initial_timeout, nonfinal_timeout))
+        ->append(std::make_unique<torii::CommandService>(tx_processor,
+                                                         storage,
+                                                         status_bus,
+                                                         initial_timeout,
+                                                         nonfinal_timeout))
         .run()
         .match(
             [this](iroha::expected::Value<int> port) {


### PR DESCRIPTION
### Description of the Change

- Add StatusBus interface
- Add StatusBusImpl based on manual working with std::thread
- Use StatusBus for sharing tx statuses among CommandService and TransactionProcessor
- Introduce boost::thread dependency for boost::barrier 
- ITF::sendTx synchronize is based on StatusBus

### Benefits

Cleaner architecture, some work delegate to other unit, lesser RC issues in tests

### Possible Drawbacks

None
