### PR TITLE
Fix rare-case amount overflows

### DIFF
--- a/shared_model/utils/amount_utils.hpp
+++ b/shared_model/utils/amount_utils.hpp
@@ -29,9 +29,6 @@ namespace shared_model {
   }  // namespace interface
 
   namespace detail {
-    boost::multiprecision::uint256_t increaseValuePrecision(
-        const boost::multiprecision::uint256_t &value, int degree);
-
     /**
      * Sums up two amounts.
      * Result is returned

--- a/test/module/shared_model/amount_utils_test.cpp
+++ b/test/module/shared_model/amount_utils_test.cpp
@@ -122,3 +122,22 @@ TEST_F(AmountTest, LeadingZeroPlusTest) {
         FAIL() << *e.error;
       });
 }
+
+TEST_F(AmountTest, PrecisionOverflow) {
+  const std::string &uint256_halfmax =
+      "723700557733226221397318656304299424082937404160253525246609900049457060"
+      "2495";
+
+  shared_model::interface::Amount a(uint256_halfmax), b("1.00");
+
+  auto c = a + b;
+  c.match(
+      [](const iroha::expected::Value<
+          std::shared_ptr<shared_model::interface::Amount>> &c_value) {
+        FAIL() << c_value.value->intValue().str();
+      },
+      [](const iroha::expected::Error<std::shared_ptr<std::string>> &e) {
+        std::cout << *e.error << std::endl;
+        SUCCEED() << *e.error;
+      });
+}

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -269,6 +269,14 @@ class FieldValidatorTest : public ValidatorsTest {
 
   std::vector<FieldTestCase> amount_test_cases{
       {"valid_amount", [&] { amount = "100"; }, true, ""},
+      {"overflow_amount",
+       [&] { amount = std::string(79, '1'); },
+       false,
+       "Amount value overflow"},
+      {"overflow_amount",
+       [&] { amount = std::string(39, '1') + '.' + std::string(40, '1'); },
+       false,
+       "Amount value overflow"},
       {"zero_amount",
        [&] { amount = "0"; },
        false,


### PR DESCRIPTION
### Description of the Change

- Makes overflowed amounts stateless invalid
- Fix increaseValuePrecision overflow 
- Refactor amount_utils a bit
- Add related tests

### Benefits

Lesser bugs, bigger coverage

### Possible Drawbacks 

Pretty much poor-readable code

### Alternate Designs

Part of the fixes (with whole amout_utils, actually) can be simplified with just checked cpp_int. Though I don't think, whether enabling exceptions is a good idea (and it seems that they are disabled).