### PR TITLE
Command Service Empty TxList Fix

### DIFF
--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -161,6 +161,10 @@ namespace torii {
             },
             [this, &tx_list](auto &error) {
               auto &txs = tx_list.transactions();
+              if (txs.empty()) {
+                log_->warn("Received empty transaction sequence");
+                return;
+              }
               // form an error message, shared between all txs in a sequence
               auto first_tx_blob =
                   shared_model::proto::makeBlob(txs[0].payload());


### PR DESCRIPTION
Signed-off-by: Akvinikym <anarant12@gmail.com>

### Description of the Change

Though case, when Command Service receives empty transaction list should be possible, still mechanism to avoid segfault must be introduced.

### Benefits

No segfault here anymore.

### Possible Drawbacks 

None