### PR TITLE
Use shared_ptr in tbb instead of unique

### DIFF
--- a/cmake/Modules/Findtbb.cmake
+++ b/cmake/Modules/Findtbb.cmake
@@ -48,3 +48,10 @@ set_target_properties(tbb PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${tbb_INCLUDE_DIR}
     IMPORTED_LOCATION ${tbb_LIBRARY}
     )
+
+if (NOT TBB_USE_GLIBCXX_VERSION AND UNIX AND NOT APPLE AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # https://www.threadingbuildingblocks.org/docs/help/reference/appendices/known_issues/linux_os.html
+  string(REPLACE "." "0" TBB_USE_GLIBCXX_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+  set_target_properties(tbb PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "TBB_USE_GLIBCXX_VERSION=${TBB_USE_GLIBCXX_VERSION}")
+endif()


### PR DESCRIPTION
### Description of the Change

<s>I don't really now why CI is able to compile it, but tbb::concurrent_queue doesn't really allow unique_ptr [due to try_pop signature](https://msdn.microsoft.com/en-us/library/ee355358.aspx#concurrent_queue__try_pop_method)</s>

It seems that the issue is in clang & tbb itself referenced below

### Benefits

Able to compile with clang compiler
