### PR TITLE
Rename tx hashes to reduced hashes

### DIFF
--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -182,7 +182,7 @@ namespace iroha {
         } else {
           // find the batch end in proposal's transactions
           auto batch_end_hash =
-              current_tx_it->batchMeta()->get()->transactionHashes().back();
+              current_tx_it->batchMeta()->get()->reducedHashes().back();
           auto batch_end_it =
               std::find_if(current_tx_it, txs_end, [&batch_end_hash](auto &tx) {
                 return tx.reducedHash() == batch_end_hash;

--- a/shared_model/backend/protobuf/batch_meta.hpp
+++ b/shared_model/backend/protobuf/batch_meta.hpp
@@ -34,10 +34,10 @@ namespace shared_model {
                                    ->index();
               return static_cast<interface::types::BatchType>(which);
             }},
-            transaction_hashes_{[this] {
+            reduced_hashes_{[this] {
               return boost::accumulate(
-                  proto_->tx_hashes(),
-                  TransactionHashesType{},
+                  proto_->reduced_hashes(),
+                  ReducedHashesType{},
                   [](auto &&acc, const auto &hash) {
                     acc.emplace_back(hash);
                     return std::forward<decltype(acc)>(acc);
@@ -51,8 +51,8 @@ namespace shared_model {
       interface::types::BatchType type() const override {
         return *type_;
       };
-      const TransactionHashesType &transactionHashes() const override {
-        return *transaction_hashes_;
+      const ReducedHashesType &reducedHashes() const override {
+        return *reduced_hashes_;
       };
 
      private:
@@ -61,7 +61,7 @@ namespace shared_model {
 
       Lazy<interface::types::BatchType> type_;
 
-      const Lazy<TransactionHashesType> transaction_hashes_;
+      const Lazy<ReducedHashesType> reduced_hashes_;
     };  // namespace proto
   }     // namespace proto
 }  // namespace shared_model

--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -119,7 +119,7 @@ namespace shared_model {
                   iroha::protocol::Transaction::Payload::BatchMeta::BatchType>(
                   type));
           for (const auto &hash : hashes) {
-            tx.mutable_payload()->mutable_batch()->add_tx_hashes(
+            tx.mutable_payload()->mutable_batch()->add_reduced_hashes(
                 crypto::toBinaryString(hash));
           }
         });

--- a/shared_model/interfaces/iroha_internal/batch_meta.hpp
+++ b/shared_model/interfaces/iroha_internal/batch_meta.hpp
@@ -24,24 +24,24 @@ namespace shared_model {
             .init("BatchMeta")
             .append("Type",
                     type() == types::BatchType::ATOMIC ? "ATOMIC" : "ORDERED")
-            .appendAll(transactionHashes(),
+            .appendAll(reducedHashes(),
                        [](auto &hash) { return hash.toString(); })
             .finalize();
       }
       /// type of hashes collection
-      using TransactionHashesType = std::vector<interface::types::HashType>;
+      using ReducedHashesType = std::vector<interface::types::HashType>;
 
       /**
        * @return Hashes of transactions to fetch
        */
-      virtual const TransactionHashesType &transactionHashes() const = 0;
+      virtual const ReducedHashesType &reducedHashes() const = 0;
       /**
        * Checks equality of objects inside
        * @param rhs - other wrapped value
        * @return true, if wrapped objects are same
        */
       bool operator==(const ModelType &rhs) const override {
-        return boost::equal(transactionHashes(), rhs.transactionHashes())
+        return boost::equal(reducedHashes(), rhs.reducedHashes())
             and type() == rhs.type();
       }
     };

--- a/shared_model/interfaces/iroha_internal/transaction_sequence.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_sequence.cpp
@@ -36,7 +36,7 @@ namespace shared_model {
       validation::Answer result;
       for (const auto &tx : transactions) {
         if (auto meta = tx->batchMeta()) {
-          auto hashes = meta.get()->transactionHashes();
+          auto hashes = meta.get()->reducedHashes();
           auto batch_hash = TransactionBatch::calculateReducedBatchHash(hashes);
           extracted_batches[batch_hash].push_back(tx);
         } else {

--- a/shared_model/schema/transaction.proto
+++ b/shared_model/schema/transaction.proto
@@ -16,7 +16,8 @@ message Transaction {
         ORDERED = 1;
       }
       BatchType type = 1;
-      repeated bytes tx_hashes = 2;
+      // array of reduced hashes of all txs from the batch
+      repeated bytes reduced_hashes = 2;
     }
     message ReducedPayload{
       repeated Command commands = 1;
@@ -24,7 +25,9 @@ message Transaction {
       uint64 created_time = 3;
       uint32 quorum = 4;
     }
+    // transcation fields
     ReducedPayload reduced_payload = 1;
+    // batch meta fields if tx belong to any batch
     oneof optional_batch_meta{
       BatchMeta batch = 5;
     }

--- a/shared_model/validators/transactions_collection/batch_order_validator.cpp
+++ b/shared_model/validators/transactions_collection/batch_order_validator.cpp
@@ -24,18 +24,18 @@ namespace shared_model {
       }
       // beginning of a batch
       if (not batch1) {
-        if (batch2.get()->transactionHashes().size() == 0) {
+        if (batch2.get()->reducedHashes().size() == 0) {
           return (boost::format("Tx %s has a batch of 0 transactions")
                   % tr2.value()->hash().hex())
               .str();
         }
-        if (batch2.get()->transactionHashes().front()
+        if (batch2.get()->reducedHashes().front()
             != tr2.value()->reducedHash()) {
           return (boost::format("Tx %s is a first transaction of a batch, but "
                                 "it's reduced hash %s doesn't match the first "
                                 "reduced hash in batch %s")
                   % tr2.value()->hash().hex()
-                  % batch2.get()->transactionHashes().front().hex()
+                  % batch2.get()->reducedHashes().front().hex()
                   % tr2.value()->reducedHash().hex())
               .str();
         }
@@ -43,26 +43,26 @@ namespace shared_model {
       }
       // end of a batch
       if (not batch2) {
-        if (batch1.get()->transactionHashes().back()
+        if (batch1.get()->reducedHashes().back()
             != tr1.value()->reducedHash()) {
           return (boost::format("Tx %s is a last transaction of a batch, but "
                                 "it's reduced hash %s doesn't match the last "
                                 "reduced hash in batch %s")
                   % tr1.value()->hash().hex()
-                  % batch1.get()->transactionHashes().back().hex()
+                  % batch1.get()->reducedHashes().back().hex()
                   % tr1.value()->reducedHash().hex())
               .str();
         }
         return "";
       }
       // inside of a batch
-      auto it1 = boost::find(batch1.get()->transactionHashes(),
+      auto it1 = boost::find(batch1.get()->reducedHashes(),
                              tr1.value()->reducedHash());
-      auto it2 = boost::find(batch2.get()->transactionHashes(),
+      auto it2 = boost::find(batch2.get()->reducedHashes(),
                              tr2.value()->reducedHash());
-      if (it1 == end(batch1.get()->transactionHashes())
-          or it2 == end(batch2.get()->transactionHashes())
-          or next(it1) == end(batch1.get()->transactionHashes())
+      if (it1 == end(batch1.get()->reducedHashes())
+          or it2 == end(batch2.get()->reducedHashes())
+          or next(it1) == end(batch1.get()->reducedHashes())
           or *next(it1) != *it2) {
         // end of the bach and beginning of the next
         if (canFollow(tr1, boost::none) == ""

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -564,7 +564,7 @@ class FieldValidatorTest : public ValidatorsTest {
     iroha::protocol::Transaction::Payload::BatchMeta meta;
     meta.set_type(iroha::protocol::Transaction::Payload::BatchMeta::BatchType::
                       Transaction_Payload_BatchMeta_BatchType_ATOMIC);
-    meta.add_tx_hashes("tst");
+    meta.add_reduced_hashes("tst");
     std::vector<FieldTestCase> all_cases;
     all_cases.push_back(makeTestCase(
         "batch meta test", &FieldValidatorTest::batch_meta, meta, true, ""));


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Tx hashes variable is ambiguous in batch meta. Transaction has two hashes: hash and reduced hash, thus reduced hashes is more meaningful name to this field
### Benefits

Better naming

### Possible Drawbacks 

None
