### PR TITLE
Fix spdlog segfault

### DIFF
--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -37,22 +37,23 @@ namespace logger {
     return red("<--- " + string);
   }
 
-  static void setGlobalPattern() {
-    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%F] %n %v");
+  static void setGlobalPattern(spdlog::logger &logger) {
+    logger.set_pattern("[%Y-%m-%d %H:%M:%S.%F] %n %v");
   }
 
-  static void setDebugPattern() {
-    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%F][th:%t][%l] %n %v");
+  static void setDebugPattern(spdlog::logger &logger) {
+    logger.set_pattern("[%Y-%m-%d %H:%M:%S.%F][th:%t][%l] %n %v");
   }
 
   static std::shared_ptr<spdlog::logger> createLogger(const std::string &tag,
                                                       bool debug_mode = true) {
+    auto logger = spdlog::stdout_color_mt(tag);
     if (debug_mode) {
-      setDebugPattern();
+      setDebugPattern(*logger);
     } else {
-      setGlobalPattern();
+      setGlobalPattern(*logger);
     }
-    return spdlog::stdout_color_mt(tag);
+    return logger;
   }
 
   Logger log(const std::string &tag) {

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -57,6 +57,8 @@ namespace logger {
   }
 
   Logger log(const std::string &tag) {
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
     auto logger = spdlog::get(tag);
     if (logger == nullptr) {
       logger = createLogger(tag);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

set_pattern could be called simultaneously from several threads affecting global context.
The similar issue - https://github.com/gabime/spdlog/issues/419

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

No segfault caused by spdlog configuring. 
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 

```diff
cmake -H. -Bbuild
cd build
make create_role_test
while test_bin/create_role_test ; do :; done
+the loop should not be interrupted by spdlog set_pattern segfault anymore
```
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

thanks to @lebdron