### PR TITLE
Fix ToriiService Streaming Full Pipeline Test

### DIFF
--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -34,6 +34,7 @@ using namespace iroha::torii;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
+constexpr unsigned resubscibe_attempts = 3;
 
 using iroha::Commit;
 
@@ -408,9 +409,14 @@ TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
   // (Committed in this case) will be received. We start request before
   // transaction sending so we need in a separate thread for it.
   std::thread t([&] {
+    unsigned resub_counter(resubscibe_attempts);
     iroha::protocol::TxStatusRequest tx_request;
     tx_request.set_tx_hash(txhash);
-    client.StatusStream(tx_request, torii_response);
+    do {
+      client.StatusStream(tx_request, torii_response);
+    } while (torii_response.back().tx_status()
+                 != iroha::protocol::TxStatus::COMMITTED
+             and --resub_counter);
   });
 
   client.Torii(iroha_tx.getTransport());

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -34,7 +34,7 @@ using namespace iroha::torii;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
-constexpr unsigned resubscibe_attempts = 3;
+constexpr unsigned resubscribe_attempts = 3;
 
 using iroha::Commit;
 
@@ -409,7 +409,7 @@ TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
   // (Committed in this case) will be received. We start request before
   // transaction sending so we need in a separate thread for it.
   std::thread t([&] {
-    unsigned resub_counter(resubscibe_attempts);
+    unsigned resub_counter(resubscribe_attempts);
     iroha::protocol::TxStatusRequest tx_request;
     tx_request.set_tx_hash(txhash);
     do {


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The test (StreamingFullPipelineTest) was failing on slow machines. 
Investigation showed that the root cause was the way thread scheduler works, so the code was generally valid.

Streaming client resubscription is a fully valid use case of streaming service.
The client can resubscribe to the stream if the previous stream was ended unexpectedly for the client.
Unexpectedly means that client requests the hash of a transaction that was definitely sent to Iroha and the stream reaches its end with one of the following statuses: `NOT_RECEIVED`, `STATELESS_VALIDATION_SUCCESS`, `STATEFUL_VALIDATION_SUCCESS`.

Before the fix test client was not able to resubscribe to the stream. Now it can.

### Benefits

Legal test client behavior is implemented.
The test is not failing.

### Possible Drawbacks 

None

### Usage Examples or Tests 

```diff
cmake -H. -Bbuild
cd build
make torii_service_test
while test_bin/torii_service_test --gtest_filter=*ull* ; do :; done
+this loop should not be broken up by ASSERT_EQ(last_status, COMMITTED) error message
```
