### PR TITLE
Fix non-determinism in client test

### DIFF
--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -45,6 +45,16 @@ using namespace shared_model::proto;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
+
+/**
+Here we imitate the behavior of StatusStram client but on a bit lower level. So
+the do-while cycle imitates client resubscription to the stream. Stream
+"expiration" is a valid designed case (see pr #1615 for the details).
+
+The number of attempts (3) is a magic constant here. The idea behind this number
+is the following: only one resubscription is usually enough to pass the test; if
+three resubscribes were not enough, then most likely there is another bug.
+ */
 constexpr uint32_t status_read_attempts = 3;
 
 class ClientServerTest : public testing::Test {

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -45,6 +45,7 @@ using namespace shared_model::proto;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
+constexpr unsigned status_read_attempts = 3;
 
 class ClientServerTest : public testing::Test {
  public:
@@ -183,12 +184,21 @@ TEST_F(ClientServerTest, SendTxWhenStatelessInvalid) {
 
   ASSERT_EQ(iroha_cli::CliClient(ip, port).sendTx(shm_tx).answer,
             iroha_cli::CliClient::OK);
-  auto tx_hash = shm_tx.hash();
-  auto res = iroha_cli::CliClient(ip, port).getTxStatus(
-      shared_model::crypto::toBinaryString(tx_hash));
-  ASSERT_EQ(res.answer.tx_status(),
+  auto getAnswer = [&]() {
+    return iroha_cli::CliClient(ip, port)
+        .getTxStatus(shared_model::crypto::toBinaryString(shm_tx.hash()))
+        .answer;
+  };
+  decltype(getAnswer()) answer;
+  unsigned read_attempt_counter(status_read_attempts);
+  do {
+    answer = getAnswer();
+  } while (answer.tx_status()
+               != iroha::protocol::TxStatus::STATELESS_VALIDATION_FAILED
+           and --read_attempt_counter);
+  ASSERT_EQ(answer.tx_status(),
             iroha::protocol::TxStatus::STATELESS_VALIDATION_FAILED);
-  ASSERT_NE(res.answer.error_message().size(), 0);
+  ASSERT_NE(answer.error_message().size(), 0);
 }
 
 /**
@@ -239,10 +249,18 @@ TEST_F(ClientServerTest, SendTxWhenStatefulInvalid) {
                            "index '2' did not pass verification with "
                            "error 'CommandError'";
 
-  // check it really failed with specific message
-  auto answer =
-      client.getTxStatus(shared_model::crypto::toBinaryString(tx.hash()))
-          .answer;
+  auto getAnswer = [&]() {
+    return client.getTxStatus(shared_model::crypto::toBinaryString(tx.hash()))
+        .answer;
+  };
+  decltype(getAnswer()) answer;
+  unsigned read_attempt_counter(status_read_attempts);
+  do {
+    // check it really failed with specific message
+    answer = getAnswer();
+  } while (answer.tx_status()
+               != iroha::protocol::TxStatus::STATEFUL_VALIDATION_FAILED
+           and --read_attempt_counter);
   ASSERT_EQ(answer.tx_status(),
             iroha::protocol::TxStatus::STATEFUL_VALIDATION_FAILED);
   ASSERT_EQ(answer.error_message(), stringified_error);

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -45,7 +45,7 @@ using namespace shared_model::proto;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
-constexpr unsigned status_read_attempts = 3;
+constexpr uint32_t status_read_attempts = 3;
 
 class ClientServerTest : public testing::Test {
  public:
@@ -190,7 +190,7 @@ TEST_F(ClientServerTest, SendTxWhenStatelessInvalid) {
         .answer;
   };
   decltype(getAnswer()) answer;
-  unsigned read_attempt_counter(status_read_attempts);
+  auto read_attempt_counter(status_read_attempts);
   do {
     answer = getAnswer();
   } while (answer.tx_status()
@@ -254,7 +254,7 @@ TEST_F(ClientServerTest, SendTxWhenStatefulInvalid) {
         .answer;
   };
   decltype(getAnswer()) answer;
-  unsigned read_attempt_counter(status_read_attempts);
+  auto read_attempt_counter(status_read_attempts);
   do {
     // check it really failed with specific message
     answer = getAnswer();

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -34,7 +34,7 @@ using namespace iroha::torii;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
-constexpr unsigned resubscribe_attempts = 3;
+constexpr uint32_t resubscribe_attempts = 3;
 
 using iroha::Commit;
 
@@ -409,7 +409,7 @@ TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
   // (Committed in this case) will be received. We start request before
   // transaction sending so we need in a separate thread for it.
   std::thread t([&] {
-    unsigned resub_counter(resubscribe_attempts);
+    auto resub_counter(resubscribe_attempts);
     iroha::protocol::TxStatusRequest tx_request;
     tx_request.set_tx_hash(txhash);
     do {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -34,6 +34,15 @@ using namespace iroha::torii;
 using namespace std::chrono_literals;
 constexpr std::chrono::milliseconds initial_timeout = 1s;
 constexpr std::chrono::milliseconds nonfinal_timeout = 2 * 10s;
+
+/**
+The do-while cycle imitates client resubscription to the stream. Stream
+"expiration" is a valid designed case (see pr #1615 for the details).
+
+The number of attempts (3) is a magic constant here. The idea behind this number
+is the following: only one resubscription is usually enough to pass the test; if
+three resubscribes were not enough, then most likely there is another bug.
+ */
 constexpr uint32_t resubscribe_attempts = 3;
 
 using iroha::Commit;


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The client test was failing on slow machines (CI).
The nature of failure was described and fixed in https://github.com/hyperledger/iroha/pull/1615 (please take a look for the details).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Non-failing test.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 

```diff
cmake -H. -Bbuild
cd build
make torii_service_test
while test_bin/client_test ; do :; done
+this loop should not be broken up with the error from linux build https://jenkins.soramitsu.co.jp/blue/organizations/jenkins/iroha%2Firoha-hyperledger/detail/PR-1597/39/pipeline/42
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
