### PR TITLE
Fix regression test

### DIFF
--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
+#include "common/files.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
@@ -120,6 +121,13 @@ TEST(RegressionTest, StateRecovery) {
       (boost::filesystem::temp_directory_path() / "iroha-state-recovery-test")
           .string();
   const std::string dbname = "dbstatereq";
+
+  // Cleanup blockstore directory, because it may contain blocks from previous
+  // test launch if ITF was failed for some reason. If there are some blocks,
+  // then checkProposal will fail with "missed proposal" error, because of
+  // incorrect calculation of chain height.
+  iroha::remove_dir_contents(path);
+
   {
     integration_framework::IntegrationTestFramework(
         1, dbname, [](auto &) {}, false, path)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Regression test may fail in case of ITF fail during the previous run (for some reason).
In that case, block store was not empty and nobody did its cleanup, because of the exception.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Stability improved
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

regression_test

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs

Generally speaking, all the ITF tests need to be wrapped into test fixtures where the tearDown method will do block store cleanup for the cases when ITF throws an exception.

The suggested fix is a must-have fix for regression test because StateRecovery case does sequential initialization of two ITF instances. Any exception inside the first instance will prevent calling the destructor of the second instance and block store will be left dirty.

<!-- Explain what other alternates were considered and why the proposed version was selected -->
