### PR TITLE
Fix the rest of thread scheduling issues for torii service test

### DIFF
--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -208,12 +208,8 @@ TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {
     tx_request.set_tx_hash(
         shared_model::crypto::toBinaryString(tx_hashes.at(i)));
     iroha::protocol::ToriiResponse toriiResponse;
-    auto resub_counter(resubscribe_attempts);
-    do {
-      client.Status(tx_request, toriiResponse);
-    } while (toriiResponse.tx_status()
-                 != iroha::protocol::TxStatus::NOT_RECEIVED
-             and --resub_counter);
+    // this test does not require the fix for thread scheduling issues
+    client.Status(tx_request, toriiResponse);
     ASSERT_EQ(toriiResponse.tx_status(),
               iroha::protocol::TxStatus::NOT_RECEIVED);
   }
@@ -388,14 +384,12 @@ TEST_F(ToriiServiceTest, CheckHash) {
     iroha::protocol::TxStatusRequest tx_request;
     tx_request.set_tx_hash(shared_model::crypto::toBinaryString(hash));
     iroha::protocol::ToriiResponse toriiResponse;
+    const auto binary_hash = shared_model::crypto::toBinaryString(hash);
     auto resub_counter(resubscribe_attempts);
     do {
       client.Status(tx_request, toriiResponse);
-    } while (toriiResponse.tx_hash()
-                 != shared_model::crypto::toBinaryString(hash)
-             and --resub_counter);
-    ASSERT_EQ(toriiResponse.tx_hash(),
-              shared_model::crypto::toBinaryString(hash));
+    } while (toriiResponse.tx_hash() != binary_hash and --resub_counter);
+    ASSERT_EQ(toriiResponse.tx_hash(), binary_hash);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The time showed us that the rest of torii_service_test s also require the fix for thread scheduling issues on slow machines like our CI environment. 

The idea behind the fix is emulating client behavior while getting tx statuses - resubscribing.

### Benefits

Passing tests in a various environments.
Test behavior now is a bit closer to the behavior of a real Iroha user.


### Possible Drawbacks 

None. 

### Usage Examples or Tests

```
cmake -H. -Bbuild
cmake --build build --target torii_service_test
cd build
ctest -R torii_service_test --output-on-failure
```
