### PR TITLE
Send tx sequence method in ITF

### DIFF
--- a/irohad/torii/impl/command_service.cpp
+++ b/irohad/torii/impl/command_service.cpp
@@ -371,7 +371,7 @@ namespace torii {
     log_->debug("{}: adding item to cache: {}, status {} ",
                 who,
                 hash.hex(),
-                response.tx_status());
+                iroha::protocol::TxStatus_Name(response.tx_status()));
     status_bus_->publish(
         std::make_shared<shared_model::proto::TransactionResponse>(
             std::move(response)));

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -228,48 +228,52 @@ namespace integration_framework {
       const shared_model::interface::TransactionSequence &tx_sequence,
       std::function<void(std::vector<shared_model::proto::TransactionResponse>
                              &)> validation) {
+    log_->info("send transactions");
     auto transactions = tx_sequence.transactions();
 
-    boost::barrier bar1(tx_sequence.transactions().size() + 1);
-    auto bar2 =
-        std::make_shared<boost::barrier>(tx_sequence.transactions().size() + 1);
+    boost::barrier bar(2);
 
     iroha_instance_->instance_->getStatusBus()
         ->statuses()
-        .filter([&](auto s) {
-          return std::find_if(transactions.begin(),
-                              transactions.end(),
-                              [&s](const auto tx) {
-                                return s->transactionHash() == tx->hash();
-                              })
-              == transactions.end();
+        .filter([transactions](auto s) {
+          // filter statuses for transactions from sequence
+          auto it = std::find_if(
+              transactions.begin(), transactions.end(), [&s](const auto tx) {
+                // check if status is either stateless valid or failed
+                bool is_stateless_status = iroha::visit_in_place(
+                    s->get(),
+                    [](const shared_model::interface::StatelessFailedTxResponse
+                           &stateless_failed_response) { return true; },
+                    [](const shared_model::interface::StatelessValidTxResponse
+                           &stateless_valid_response) { return true; },
+                    [](const auto &other_responses) { return false; });
+                return is_stateless_status
+                    and s->transactionHash() == tx->hash();
+              });
+          return it != transactions.end();
         })
-        .subscribe([&bar1, b2 = std::weak_ptr<boost::barrier>(bar2)](auto s) {
-          bar1.wait();
-          if (auto lock = b2.lock()) {
-            lock->wait();
-          }
-        });
+        .take(transactions.size())
+        .subscribe([](auto &&) {}, [&bar] { bar.wait(); });
 
+    // put all transactions to the TxList and send them to iroha
     iroha::protocol::TxList tx_list;
     for (const auto &tx : transactions) {
-      new (tx_list.add_transactions()) iroha::protocol::Transaction(
+      auto proto_tx =
           std::static_pointer_cast<shared_model::proto::Transaction>(tx)
-              ->getTransport());
+              ->getTransport();
+      *tx_list.add_transactions() = proto_tx;
     }
     iroha_instance_->getIrohaInstance()->getCommandService()->ListTorii(
         tx_list);
 
     // make sure that the first (stateless) status is come
-    bar1.wait();
-    // fetch status of transaction
+    bar.wait();
+
+    // collect all statuses and process them
     std::vector<shared_model::proto::TransactionResponse> statuses;
     for (const auto tx : transactions) {
       statuses.push_back(getTxStatus(tx->hash()));
     }
-    // make sure that the following statuses (stateful/commited)
-    // isn't reached the bus yet
-    bar2->wait();
 
     validation(statuses);
     return *this;

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -272,7 +272,9 @@ namespace integration_framework {
     // collect all statuses and process them
     std::vector<shared_model::proto::TransactionResponse> statuses;
     for (const auto tx : transactions) {
-      statuses.push_back(getTxStatus(tx->hash()));
+      getTxStatus(tx->hash(), [&statuses](const auto &status) {
+        statuses.push_back(status);
+      });
     }
 
     validation(statuses);
@@ -282,7 +284,10 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::sendTxSequenceAwait(
       const shared_model::interface::TransactionSequence &tx_sequence,
       std::function<void(const BlockType &)> check) {
-    sendTxSequence(tx_sequence).skipProposal().checkBlock(check);
+    sendTxSequence(tx_sequence)
+        .skipProposal()
+        .skipVerifiedProposal()
+        .checkBlock(check);
     return *this;
   }
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -275,6 +275,13 @@ namespace integration_framework {
     return *this;
   }
 
+  IntegrationTestFramework &IntegrationTestFramework::sendTxSequenceAwait(
+      const shared_model::interface::TransactionSequence &tx_sequence,
+      std::function<void(const BlockType &)> check) {
+    sendTxSequence(tx_sequence).skipProposal().checkBlock(check);
+    return *this;
+  }
+
   IntegrationTestFramework &IntegrationTestFramework::sendQuery(
       const shared_model::proto::Query &qry,
       std::function<void(const shared_model::proto::QueryResponse &)>

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -229,13 +229,13 @@ namespace integration_framework {
       std::function<void(std::vector<shared_model::proto::TransactionResponse>
                              &)> validation) {
     log_->info("send transactions");
-    auto transactions = tx_sequence.transactions();
+    const auto &transactions = tx_sequence.transactions();
 
     boost::barrier bar(2);
 
     iroha_instance_->instance_->getStatusBus()
         ->statuses()
-        .filter([transactions](auto s) {
+        .filter([&transactions](auto s) {
           // filter statuses for transactions from sequence
           auto it = std::find_if(
               transactions.begin(), transactions.end(), [&s](const auto tx) {

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -150,12 +150,11 @@ namespace integration_framework {
     IntegrationTestFramework &sendTxSequence(
         const shared_model::interface::TransactionSequence &tx_sequence,
         std::function<void(std::vector<shared_model::proto::TransactionResponse>
-                               &)> validation = [](const auto &) {
-          return true;
-        });
+                               &)> validation = [](const auto &) {});
 
     /**
-     * Send transactions to Iroha with awaiting proposal and without status validation
+     * Send transactions to Iroha with awaiting proposal and without status
+     * validation
      * @param tx_sequence - sequence for sending
      * @param check - callback for checking committed block
      * @return this

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -150,7 +150,9 @@ namespace integration_framework {
     IntegrationTestFramework &sendTxSequence(
         const shared_model::interface::TransactionSequence &tx_sequence,
         std::function<void(std::vector<shared_model::proto::TransactionResponse>
-                               &)> validation);
+                               &)> validation = [](const auto &) {
+          return true;
+        });
 
     /**
      * Check current status of transaction

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -154,6 +154,12 @@ namespace integration_framework {
           return true;
         });
 
+    /**
+     * Send transactions to Iroha with awaiting proposal and without status validation
+     * @param tx_sequence - sequence for sending
+     * @param check - callback for checking committed block
+     * @return this
+     */
     IntegrationTestFramework &sendTxSequenceAwait(
         const shared_model::interface::TransactionSequence &tx_sequence,
         std::function<void(const BlockType &)> check);

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -154,6 +154,10 @@ namespace integration_framework {
           return true;
         });
 
+    IntegrationTestFramework &sendTxSequenceAwait(
+        const shared_model::interface::TransactionSequence &tx_sequence,
+        std::function<void(const BlockType &)> check);
+
     /**
      * Check current status of transaction
      * @param hash - hash of transaction to check

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -20,6 +20,7 @@
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/iroha_instance.hpp"
 #include "framework/integration_framework/test_irohad.hpp"
+#include "interfaces/iroha_internal/transaction_sequence.hpp"
 #include "logger/logger.hpp"
 
 namespace shared_model {
@@ -138,6 +139,18 @@ namespace integration_framework {
     IntegrationTestFramework &sendTxAwait(
         const shared_model::proto::Transaction &tx,
         std::function<void(const BlockType &)> check);
+
+    /**
+     * Send transactions to Iroha and validate obtained statuses
+     * @param tx_sequence - transactions sequence
+     * @param validation - callback for transactions statuses validation.
+     * Applied to the vector of returned statuses
+     * @return this
+     */
+    IntegrationTestFramework &sendTxSequence(
+        const shared_model::interface::TransactionSequence &tx_sequence,
+        std::function<void(std::vector<shared_model::proto::TransactionResponse>
+                               &)> validation);
 
     /**
      * Check current status of transaction

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -137,7 +137,6 @@ TEST(PipelineIntegrationTest, SendTxSequence) {
 
   auto checkStatelessValid = [](auto &statuses) {
     for (const auto &status : statuses) {
-      std::cerr << status.toString() << std::endl;
       EXPECT_NO_THROW(boost::apply_visitor(
           framework::SpecifiedVisitor<
               shared_model::interface::StatelessValidTxResponse>(),

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -23,7 +23,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 
-constexpr auto kUser = "user@test";
+constexpr auto kAdmin = "user@test";
 constexpr auto kAsset = "asset#domain";
 const auto kAdminKeypair =
     shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
@@ -36,7 +36,7 @@ const auto kAdminKeypair =
 TEST(RegressionTest, SequentialInitialization) {
   auto tx = shared_model::proto::TransactionBuilder()
                 .createdTime(iroha::time::now())
-                .creatorAccountId(kUser)
+                .creatorAccountId(kAdmin)
                 .addAssetQuantity(kAsset, "1.0")
                 .quorum(1)
                 .build()

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -23,7 +23,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 
-constexpr auto kAdmin = "user@test";
+constexpr auto kUser = "user@test";
 constexpr auto kAsset = "asset#domain";
 const auto kAdminKeypair =
     shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
@@ -36,7 +36,7 @@ const auto kAdminKeypair =
 TEST(RegressionTest, SequentialInitialization) {
   auto tx = shared_model::proto::TransactionBuilder()
                 .createdTime(iroha::time::now())
-                .creatorAccountId(kAdmin)
+                .creatorAccountId(kUser)
                 .addAssetQuantity(kAsset, "1.0")
                 .quorum(1)
                 .build()


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR adds ability to send transaction sequences to the ITF and check stateless valid/invalid status

### Benefits

We can send sequences of transactions to the ITF

### Possible Drawbacks 

None

### Usage Examples or Tests

The test was added to pipeline test file