### PR TITLE
Add getAccountAssetTransactions tests

### DIFF
--- a/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
@@ -46,5 +46,10 @@ namespace shared_model {
       return *ivariant_;
     }
 
+    const ErrorQueryResponse::ErrorMessageType &
+    ErrorQueryResponse::errorMessage() const {
+      return proto_->error_response().message();
+    }
+
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -56,6 +56,8 @@ namespace shared_model {
 
       const QueryErrorResponseVariantType &get() const override;
 
+      const ErrorMessageType &errorMessage() const override;
+
      private:
       /// lazy variant shortcut
       template <typename T>

--- a/shared_model/interfaces/query_responses/error_query_response.hpp
+++ b/shared_model/interfaces/query_responses/error_query_response.hpp
@@ -64,6 +64,14 @@ namespace shared_model {
        */
       virtual const QueryErrorResponseVariantType &get() const = 0;
 
+      /// Message type
+      using ErrorMessageType = std::string;
+
+      /**
+       * @return error message if present, otherwise - an empty string
+       */
+      virtual const ErrorMessageType &errorMessage() const = 0;
+
       // ------------------------| Primitive override |-------------------------
 
       std::string toString() const override;

--- a/shared_model/interfaces/query_responses/impl/error_query_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/error_query_response.cpp
@@ -10,7 +10,11 @@ namespace shared_model {
   namespace interface {
 
     std::string ErrorQueryResponse::toString() const {
-      return boost::apply_visitor(detail::ToStringVisitor(), get());
+      return detail::PrettyStringBuilder()
+          .init("ErrorQueryResponse")
+          .append(boost::apply_visitor(detail::ToStringVisitor(), get()))
+          .append("errorMessage", errorMessage())
+          .finalize();
     }
 
     bool ErrorQueryResponse::operator==(const ModelType &rhs) const {

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -91,7 +91,15 @@ addtest(set_account_detail_test set_account_detail_test.cpp)
 target_link_libraries(set_account_detail_test
     acceptance_fixture
     )
+
 addtest(get_roles_test get_roles_test.cpp)
 target_link_libraries(get_roles_test
+    acceptance_fixture
+    )
+
+addtest(get_account_asset_txs_test
+    get_account_asset_txs_test.cpp
+    )
+target_link_libraries(get_account_asset_txs_test
     acceptance_fixture
     )

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -95,49 +95,26 @@ template auto AcceptanceFixture::base<TestUnsignedQueryBuilder>(
     -> decltype(
         builder.creatorAccountId(std::string()).createdTime(uint64_t()));
 
-auto AcceptanceFixture::baseTx()
-    -> decltype(base(TestUnsignedTransactionBuilder(), std::string())) {
-  return base(TestUnsignedTransactionBuilder(), kUserId).quorum(1);
-}
-
 auto AcceptanceFixture::baseTx(
     const shared_model::interface::types::AccountIdType &account_id)
-    -> decltype(baseTx()) {
+    -> decltype(base(TestUnsignedTransactionBuilder(), std::string())) {
   return base(TestUnsignedTransactionBuilder(), account_id).quorum(1);
 }
 
-auto AcceptanceFixture::baseQry()
-    -> decltype(base(TestUnsignedQueryBuilder(), std::string())) {
-  return base(TestUnsignedQueryBuilder(), kUserId).queryCounter(nonce_counter);
+auto AcceptanceFixture::baseTx() -> decltype(baseTx(std::string())) {
+  return baseTx(kUserId);
 }
 
 auto AcceptanceFixture::baseQry(
     const shared_model::interface::types::AccountIdType &account_id)
-    -> decltype(baseQry()) {
+    -> decltype(base(TestUnsignedQueryBuilder(), std::string())) {
   return base(TestUnsignedQueryBuilder(), account_id)
       .queryCounter(nonce_counter);
 }
 
-template <typename Builder>
-auto AcceptanceFixture::complete(Builder builder) -> decltype(
-    builder.build()
-        .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
-        .finish()) {
-  return builder.build().signAndAddSignature(kUserKeypair).finish();
+auto AcceptanceFixture::baseQry() -> decltype(baseQry(std::string())) {
+  return baseQry(kUserId);
 }
-
-template auto AcceptanceFixture::complete<TestUnsignedTransactionBuilder>(
-    TestUnsignedTransactionBuilder builder)
-    -> decltype(
-        builder.build()
-            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
-            .finish());
-template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
-    TestUnsignedQueryBuilder builder)
-    -> decltype(
-        builder.build()
-            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
-            .finish());
 
 template <typename Builder>
 auto AcceptanceFixture::complete(Builder builder,
@@ -163,6 +140,22 @@ template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
         builder.build()
             .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
             .finish());
+
+template <typename Builder>
+auto AcceptanceFixture::complete(Builder builder)
+    -> decltype(complete(std::declval<Builder>(),
+                         std::declval<shared_model::crypto::Keypair>())) {
+  return complete(builder, kUserKeypair);
+}
+
+template auto AcceptanceFixture::complete<TestUnsignedTransactionBuilder>(
+    TestUnsignedTransactionBuilder builder)
+    -> decltype(complete(std::declval<TestUnsignedTransactionBuilder>(),
+                         std::declval<shared_model::crypto::Keypair>()));
+template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
+    TestUnsignedQueryBuilder builder)
+    -> decltype(complete(std::declval<TestUnsignedQueryBuilder>(),
+                         std::declval<shared_model::crypto::Keypair>()));
 
 iroha::time::time_t AcceptanceFixture::getUniqueTime() {
   return initial_time + nonce_counter++;

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -13,8 +13,9 @@ AcceptanceFixture::AcceptanceFixture()
     : kUser("user"),
       kRole("role"),
       kDomain(integration_framework::IntegrationTestFramework::kDefaultDomain),
-      kAssetId(integration_framework::IntegrationTestFramework::kAssetName + "#"
-             + integration_framework::IntegrationTestFramework::kDefaultDomain),
+      kAssetId(
+          integration_framework::IntegrationTestFramework::kAssetName + "#"
+          + integration_framework::IntegrationTestFramework::kDefaultDomain),
       kUserId(
           kUser + "@"
           + integration_framework::IntegrationTestFramework::kDefaultDomain),
@@ -73,28 +74,46 @@ shared_model::proto::Transaction AcceptanceFixture::makeUserWithPerms(
 }
 
 template <typename Builder>
-auto AcceptanceFixture::base(Builder builder) -> decltype(
-    builder.creatorAccountId(std::string()).createdTime(uint64_t())) {
-  return builder.creatorAccountId(kUserId).createdTime(getUniqueTime());
+auto AcceptanceFixture::base(
+    Builder builder,
+    const shared_model::interface::types::AccountIdType &account_id)
+    -> decltype(
+        builder.creatorAccountId(std::string()).createdTime(uint64_t())) {
+  return builder.creatorAccountId(account_id).createdTime(getUniqueTime());
 }
 
 template auto AcceptanceFixture::base<TestUnsignedTransactionBuilder>(
-    TestUnsignedTransactionBuilder builder)
+    TestUnsignedTransactionBuilder builder,
+    const shared_model::interface::types::AccountIdType &account_id)
     -> decltype(
         builder.creatorAccountId(std::string()).createdTime(uint64_t()));
 template auto AcceptanceFixture::base<TestUnsignedQueryBuilder>(
-    TestUnsignedQueryBuilder builder)
+    TestUnsignedQueryBuilder builder,
+    const shared_model::interface::types::AccountIdType &account_id)
     -> decltype(
         builder.creatorAccountId(std::string()).createdTime(uint64_t()));
 
 auto AcceptanceFixture::baseTx()
-    -> decltype(base(TestUnsignedTransactionBuilder())) {
-  return base(TestUnsignedTransactionBuilder()).quorum(1);
+    -> decltype(base(TestUnsignedTransactionBuilder(), std::string())) {
+  return base(TestUnsignedTransactionBuilder(), kUserId).quorum(1);
+}
+
+auto AcceptanceFixture::baseTx(
+    const shared_model::interface::types::AccountIdType &account_id)
+    -> decltype(baseTx()) {
+  return base(TestUnsignedTransactionBuilder(), account_id).quorum(1);
 }
 
 auto AcceptanceFixture::baseQry()
-    -> decltype(base(TestUnsignedQueryBuilder())) {
-  return base(TestUnsignedQueryBuilder()).queryCounter(nonce_counter);
+    -> decltype(base(TestUnsignedQueryBuilder(), std::string())) {
+  return base(TestUnsignedQueryBuilder(), kUserId).queryCounter(nonce_counter);
+}
+
+auto AcceptanceFixture::baseQry(
+    const shared_model::interface::types::AccountIdType &account_id)
+    -> decltype(baseQry()) {
+  return base(TestUnsignedQueryBuilder(), account_id)
+      .queryCounter(nonce_counter);
 }
 
 template <typename Builder>
@@ -113,6 +132,31 @@ template auto AcceptanceFixture::complete<TestUnsignedTransactionBuilder>(
             .finish());
 template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
     TestUnsignedQueryBuilder builder)
+    -> decltype(
+        builder.build()
+            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+            .finish());
+
+template <typename Builder>
+auto AcceptanceFixture::complete(Builder builder,
+                                 const shared_model::crypto::Keypair &keypair)
+    -> decltype(
+        builder.build()
+            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+            .finish()) {
+  return builder.build().signAndAddSignature(keypair).finish();
+}
+
+template auto AcceptanceFixture::complete<TestUnsignedTransactionBuilder>(
+    TestUnsignedTransactionBuilder builder,
+    const shared_model::crypto::Keypair &keypair)
+    -> decltype(
+        builder.build()
+            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+            .finish());
+template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
+    TestUnsignedQueryBuilder builder,
+    const shared_model::crypto::Keypair &keypair)
     -> decltype(
         builder.build()
             .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -80,7 +80,9 @@ auto AcceptanceFixture::base(
     Builder builder,
     const shared_model::interface::types::AccountIdType &account_id)
     -> decltype(
-        builder.creatorAccountId(std::string()).createdTime(uint64_t())) {
+        builder
+            .creatorAccountId(shared_model::interface::types::AccountIdType())
+            .createdTime(uint64_t())) {
   return builder.creatorAccountId(account_id).createdTime(getUniqueTime());
 }
 
@@ -88,12 +90,16 @@ template auto AcceptanceFixture::base<TestUnsignedTransactionBuilder>(
     TestUnsignedTransactionBuilder builder,
     const shared_model::interface::types::AccountIdType &account_id)
     -> decltype(
-        builder.creatorAccountId(std::string()).createdTime(uint64_t()));
+        builder
+            .creatorAccountId(shared_model::interface::types::AccountIdType())
+            .createdTime(uint64_t()));
 template auto AcceptanceFixture::base<TestUnsignedQueryBuilder>(
     TestUnsignedQueryBuilder builder,
     const shared_model::interface::types::AccountIdType &account_id)
     -> decltype(
-        builder.creatorAccountId(std::string()).createdTime(uint64_t()));
+        builder
+            .creatorAccountId(shared_model::interface::types::AccountIdType())
+            .createdTime(uint64_t()));
 
 auto AcceptanceFixture::baseTx(
     const shared_model::interface::types::AccountIdType &account_id)
@@ -101,7 +107,8 @@ auto AcceptanceFixture::baseTx(
   return base(TestUnsignedTransactionBuilder(), account_id).quorum(1);
 }
 
-auto AcceptanceFixture::baseTx() -> decltype(baseTx(std::string())) {
+auto AcceptanceFixture::baseTx()
+    -> decltype(baseTx(shared_model::interface::types::AccountIdType())) {
   return baseTx(kUserId);
 }
 
@@ -112,7 +119,8 @@ auto AcceptanceFixture::baseQry(
       .queryCounter(nonce_counter);
 }
 
-auto AcceptanceFixture::baseQry() -> decltype(baseQry(std::string())) {
+auto AcceptanceFixture::baseQry()
+    -> decltype(baseQry(shared_model::interface::types::AccountIdType())) {
   return baseQry(kUserId);
 }
 
@@ -142,20 +150,25 @@ template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
             .finish());
 
 template <typename Builder>
-auto AcceptanceFixture::complete(Builder builder)
-    -> decltype(complete(std::declval<Builder>(),
-                         std::declval<shared_model::crypto::Keypair>())) {
+auto AcceptanceFixture::complete(Builder builder) -> decltype(
+    builder.build()
+        .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+        .finish()) {
   return complete(builder, kUserKeypair);
 }
 
 template auto AcceptanceFixture::complete<TestUnsignedTransactionBuilder>(
     TestUnsignedTransactionBuilder builder)
-    -> decltype(complete(std::declval<TestUnsignedTransactionBuilder>(),
-                         std::declval<shared_model::crypto::Keypair>()));
+    -> decltype(
+        builder.build()
+            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+            .finish());
 template auto AcceptanceFixture::complete<TestUnsignedQueryBuilder>(
     TestUnsignedQueryBuilder builder)
-    -> decltype(complete(std::declval<TestUnsignedQueryBuilder>(),
-                         std::declval<shared_model::crypto::Keypair>()));
+    -> decltype(
+        builder.build()
+            .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
+            .finish());
 
 iroha::time::time_t AcceptanceFixture::getUniqueTime() {
   return initial_time + nonce_counter++;

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -31,7 +31,7 @@ AcceptanceFixture::AcceptanceFixture()
             status.get()));
       }),
       initial_time(iroha::time::now()),
-      nonce_counter(0) {}
+      nonce_counter(1) {}
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
     const shared_model::interface::types::AccountNameType &user,

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -13,7 +13,7 @@ AcceptanceFixture::AcceptanceFixture()
     : kUser("user"),
       kRole("role"),
       kDomain(integration_framework::IntegrationTestFramework::kDefaultDomain),
-      kAsset(integration_framework::IntegrationTestFramework::kAssetName + "#"
+      kAssetId(integration_framework::IntegrationTestFramework::kAssetName + "#"
              + integration_framework::IntegrationTestFramework::kDefaultDomain),
       kUserId(
           kUser + "@"

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -34,7 +34,8 @@ AcceptanceFixture::AcceptanceFixture()
       nonce_counter(0) {}
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
-    const std::string &user, const shared_model::crypto::PublicKey &key) {
+    const shared_model::interface::types::AccountNameType &user,
+    const shared_model::crypto::PublicKey &key) {
   return TestUnsignedTransactionBuilder()
       .createAccount(
           user,
@@ -47,9 +48,9 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUser(
 }
 
 TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
-    const std::string &user,
+    const shared_model::interface::types::AccountNameType &user,
     const shared_model::crypto::PublicKey &key,
-    const std::string &role_id,
+    const shared_model::interface::types::RoleIdType &role_id,
     const shared_model::interface::RolePermissionSet &perms) {
   const auto user_id = user + "@"
       + integration_framework::IntegrationTestFramework::kDefaultDomain;
@@ -61,7 +62,7 @@ TestUnsignedTransactionBuilder AcceptanceFixture::createUserWithPerms(
 }
 
 shared_model::proto::Transaction AcceptanceFixture::makeUserWithPerms(
-    const std::string &role_name,
+    const shared_model::interface::types::RoleIdType &role_name,
     const shared_model::interface::RolePermissionSet &perms) {
   return createUserWithPerms(kUser, kUserKeypair.publicKey(), role_name, perms)
       .build()

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -19,6 +19,7 @@ AcceptanceFixture::AcceptanceFixture()
       kUserId(
           kUser + "@"
           + integration_framework::IntegrationTestFramework::kDefaultDomain),
+      kAdminId(integration_framework::IntegrationTestFramework::kAdminId),
       kAdminKeypair(
           shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()),
       kUserKeypair(

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -139,6 +139,7 @@ class AcceptanceFixture : public ::testing::Test {
   const std::string kDomain;
   const std::string kAssetId;
   const std::string kUserId;
+  const std::string kAdminId;
   const shared_model::crypto::Keypair kAdminKeypair;
   const shared_model::crypto::Keypair kUserKeypair;
 

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -111,7 +111,7 @@ class AcceptanceFixture : public ::testing::Test {
   const std::string kUser;
   const std::string kRole;
   const std::string kDomain;
-  const std::string kAsset;
+  const std::string kAssetId;
   const std::string kUserId;
   const shared_model::crypto::Keypair kAdminKeypair;
   const shared_model::crypto::Keypair kUserKeypair;

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -84,25 +84,18 @@ class AcceptanceFixture : public ::testing::Test {
           builder.creatorAccountId(std::string()).createdTime(uint64_t()));
 
   /**
-   * Create valid base pre-built transaction with kUserId as transaction creator
-   * @return pre-built tx
-   */
-  auto baseTx()
-      -> decltype(base(TestUnsignedTransactionBuilder(), std::string()));
-
-  /**
    * Create valid base pre-built transaction with specified creator
    * @param account_id - account of transaction creator
    * @return pre-built tx
    */
   auto baseTx(const shared_model::interface::types::AccountIdType &account_id)
-      -> decltype(baseTx());
+      -> decltype(base(TestUnsignedTransactionBuilder(), std::string()));
 
   /**
-   * Create valid base pre-built query with kUserId as query creator
-   * @return pre-built query
+   * Create valid base pre-built transaction with kUserId as transaction creator
+   * @return pre-built tx
    */
-  auto baseQry() -> decltype(base(TestUnsignedQueryBuilder(), std::string()));
+  auto baseTx() -> decltype(baseTx(std::string()));
 
   /**
    * Create valid base pre-built query with specified query creator
@@ -110,7 +103,27 @@ class AcceptanceFixture : public ::testing::Test {
    * @return pre-built query
    */
   auto baseQry(const shared_model::interface::types::AccountIdType &account_id)
-      -> decltype(baseQry());
+      -> decltype(base(TestUnsignedQueryBuilder(), std::string()));
+
+  /**
+   * Create valid base pre-built query with kUserId as query creator
+   * @return pre-built query
+   */
+  auto baseQry() -> decltype(baseQry(std::string()));
+
+  /**
+   * Completes pre-built object with specified keypair for signing
+   * @tparam Builder - is a type of a pre-built object
+   * @param builder - is a pre-built object
+   * @param keypair - keypair used for signing
+   * @return built object
+   */
+  template <typename Builder>
+  auto complete(Builder builder, const shared_model::crypto::Keypair &keypair)
+      -> decltype(builder.build()
+                      .signAndAddSignature(
+                          std::declval<shared_model::crypto::Keypair>())
+                      .finish());
 
   /**
    * Completes pre-built object with kUserKeypair used for signing
@@ -118,17 +131,9 @@ class AcceptanceFixture : public ::testing::Test {
    * @return built object
    */
   template <typename Builder>
-  auto complete(Builder builder) -> decltype(
-      builder.build()
-          .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
-          .finish());
-
-  template <typename Builder>
-  auto complete(Builder builder, const shared_model::crypto::Keypair &keypair)
-      -> decltype(builder.build()
-                      .signAndAddSignature(
-                          std::declval<shared_model::crypto::Keypair>())
-                      .finish());
+  auto complete(Builder builder)
+      -> decltype(complete(std::declval<Builder>(),
+                           std::declval<shared_model::crypto::Keypair>()));
 
   /**
    * @return unique time for this fixture

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -77,23 +77,42 @@ class AcceptanceFixture : public ::testing::Test {
    * @return builder containing creator account id and created time
    */
   template <typename Builder>
-  auto base(Builder builder) -> decltype(
-      builder.creatorAccountId(std::string()).createdTime(uint64_t()));
+  auto base(Builder builder,
+            const shared_model::interface::types::AccountIdType &account_id)
+      -> decltype(
+          builder.creatorAccountId(std::string()).createdTime(uint64_t()));
 
   /**
-   * Create valid base pre-built transaction
+   * Create valid base pre-built transaction with kUserId as transaction creator
    * @return pre-built tx
    */
-  auto baseTx() -> decltype(base(TestUnsignedTransactionBuilder()));
+  auto baseTx()
+      -> decltype(base(TestUnsignedTransactionBuilder(), std::string()));
 
   /**
-   * Create valid base pre-built query
+   * Create valid base pre-built transaction with specified creator
+   * @param account_id - account of transaction creator
+   * @return pre-built tx
+   */
+  auto baseTx(const shared_model::interface::types::AccountIdType &account_id)
+      -> decltype(baseTx());
+
+  /**
+   * Create valid base pre-built query with kUserId as query creator
    * @return pre-built query
    */
-  auto baseQry() -> decltype(base(TestUnsignedQueryBuilder()));
+  auto baseQry() -> decltype(base(TestUnsignedQueryBuilder(), std::string()));
 
   /**
-   * Completes pre-built object
+   * Create valid base pre-built query with specified query creator
+   * @param account_id - account of query creator
+   * @return pre-built query
+   */
+  auto baseQry(const shared_model::interface::types::AccountIdType &account_id)
+      -> decltype(baseQry());
+
+  /**
+   * Completes pre-built object with kUserKeypair used for signing
    * @param builder is a pre-built object
    * @return built object
    */
@@ -102,6 +121,13 @@ class AcceptanceFixture : public ::testing::Test {
       builder.build()
           .signAndAddSignature(std::declval<shared_model::crypto::Keypair>())
           .finish());
+
+  template <typename Builder>
+  auto complete(Builder builder, const shared_model::crypto::Keypair &keypair)
+      -> decltype(builder.build()
+                      .signAndAddSignature(
+                          std::declval<shared_model::crypto::Keypair>())
+                      .finish());
 
   /**
    * @return unique time for this fixture

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -81,7 +81,9 @@ class AcceptanceFixture : public ::testing::Test {
   auto base(Builder builder,
             const shared_model::interface::types::AccountIdType &account_id)
       -> decltype(
-          builder.creatorAccountId(std::string()).createdTime(uint64_t()));
+          builder
+              .creatorAccountId(shared_model::interface::types::AccountIdType())
+              .createdTime(uint64_t()));
 
   /**
    * Create valid base pre-built transaction with specified creator
@@ -89,13 +91,15 @@ class AcceptanceFixture : public ::testing::Test {
    * @return pre-built tx
    */
   auto baseTx(const shared_model::interface::types::AccountIdType &account_id)
-      -> decltype(base(TestUnsignedTransactionBuilder(), std::string()));
+      -> decltype(base(TestUnsignedTransactionBuilder(),
+                       shared_model::interface::types::AccountIdType()));
 
   /**
    * Create valid base pre-built transaction with kUserId as transaction creator
    * @return pre-built tx
    */
-  auto baseTx() -> decltype(baseTx(std::string()));
+  auto baseTx()
+      -> decltype(baseTx(shared_model::interface::types::AccountIdType()));
 
   /**
    * Create valid base pre-built query with specified query creator
@@ -132,8 +136,10 @@ class AcceptanceFixture : public ::testing::Test {
    */
   template <typename Builder>
   auto complete(Builder builder)
-      -> decltype(complete(std::declval<Builder>(),
-                           std::declval<shared_model::crypto::Keypair>()));
+      -> decltype(builder.build()
+      .signAndAddSignature(
+          std::declval<shared_model::crypto::Keypair>())
+      .finish());
 
   /**
    * @return unique time for this fixture

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -75,6 +75,7 @@ class AcceptanceFixture : public ::testing::Test {
    * Add default user creator account id and current created time to builder
    * @tparam Builder type (transaction, query)
    * @param builder object to modify
+   * @param account_id - account of transaction creator
    * @return builder containing creator account id and created time
    */
   template <typename Builder>

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -36,7 +36,8 @@ class AcceptanceFixture : public ::testing::Test {
    * @return pre-built transaction
    */
   TestUnsignedTransactionBuilder createUser(
-      const std::string &user, const shared_model::crypto::PublicKey &key);
+      const shared_model::interface::types::AccountNameType &user,
+      const shared_model::crypto::PublicKey &key);
 
   /**
    * Creates a set of transactions for user creation with specified permissions
@@ -47,9 +48,9 @@ class AcceptanceFixture : public ::testing::Test {
    * @return pre-build transaction
    */
   TestUnsignedTransactionBuilder createUserWithPerms(
-      const std::string &user,
+      const shared_model::interface::types::AccountNameType &user,
       const shared_model::crypto::PublicKey &key,
-      const std::string &role_id,
+      const shared_model::interface::types::RoleIdType &role_id,
       const shared_model::interface::RolePermissionSet &perms);
 
   /**
@@ -59,7 +60,7 @@ class AcceptanceFixture : public ::testing::Test {
    * @return built tx and a hash of its payload
    */
   shared_model::proto::Transaction makeUserWithPerms(
-      const std::string &role_name,
+      const shared_model::interface::types::RoleIdType &role_name,
       const shared_model::interface::RolePermissionSet &perms);
 
   /**
@@ -134,12 +135,12 @@ class AcceptanceFixture : public ::testing::Test {
    */
   iroha::time::time_t getUniqueTime();
 
-  const std::string kUser;
-  const std::string kRole;
-  const std::string kDomain;
-  const std::string kAssetId;
-  const std::string kUserId;
-  const std::string kAdminId;
+  const shared_model::interface::types::AccountNameType kUser;
+  const shared_model::interface::types::RoleIdType kRole;
+  const shared_model::interface::types::DomainIdType kDomain;
+  const shared_model::interface::types::AssetIdType kAssetId;
+  const shared_model::interface::types::AccountIdType kUserId;
+  const shared_model::interface::types::AccountIdType kAdminId;
   const shared_model::crypto::Keypair kAdminKeypair;
   const shared_model::crypto::Keypair kUserKeypair;
 

--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -31,7 +31,7 @@ TEST_F(AddAssetQuantity, Basic) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, kAmount)))
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, kAmount)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
@@ -49,7 +49,7 @@ TEST_F(AddAssetQuantity, NoPermissions) {
       .sendTx(makeUserWithPerms({interface::permissions::Role::kGetMyTxs}))
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, kAmount)))
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, kAmount)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
@@ -68,7 +68,7 @@ TEST_F(AddAssetQuantity, NegativeAmount) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, "-1.0")),
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, "-1.0")),
               checkStatelessInvalid);
 }
 
@@ -84,7 +84,7 @@ TEST_F(AddAssetQuantity, ZeroAmount) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, "0.0")),
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, "0.0")),
               checkStatelessInvalid);
 }
 
@@ -105,12 +105,12 @@ TEST_F(AddAssetQuantity, Uint256DestOverflow) {
       .skipProposal()
       .skipBlock()
       // Add first half of the maximum
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, uint256_halfmax)))
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, uint256_halfmax)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       // Add second half of the maximum
-      .sendTx(complete(baseTx().addAssetQuantity(kAsset, uint256_halfmax)))
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, uint256_halfmax)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+
+using namespace shared_model;
+using namespace integration_framework;
+using namespace shared_model::interface::permissions;
+
+class AccountAssetTxsFixture : public AcceptanceFixture {
+ public:
+  std::unique_ptr<IntegrationTestFramework> itf_;
+
+  const interface::types::AccountNameType target_account_name_ = "target";
+
+  interface::types::AccountIdType
+
+  IntegrationTestFramework &prepareState(
+      const interface::RolePermissionSet &permissions) {
+    auto perms = permissions;
+    perms.set(interface::permissions::Role::kAddAssetQty);
+    perms.set(interface::permissions::Role::kSubtractAssetQty);
+    perms.set(interface::permissions::Role::kReceive);
+    perms.set(interface::permissions::Role::kTransfer);
+    return itf_->sendTx(makeUserWithPerms(perms))
+        .skipProposal()
+        .checkBlock(
+            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+  }
+
+
+
+ protected:
+  void SetUp() override {
+    itf_ = std::make_unique<IntegrationTestFramework>(1);
+    itf_->setInitialState(kAdminKeypair);
+  }
+
+  //  void TearDown() override {}
+};
+
+TEST_F(AccountAssetTxsFixture, Basic) {
+  prepareState({interface::permissions::Role::kSetQuorum})
+      .sendTx(complete(baseTx().setAccountQuorum(kUserId, 1)))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+  auto x = 2;
+  ASSERT_EQ(x, 2);
+}

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -85,13 +85,13 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
           auto end = tx_hashes_.end();
           ASSERT_NE(std::find(begin, end, tx.hash()), end);
         }
-      });
+      }) << "Actual response: "
+         << response.toString();
     };
   }
 
   auto checkQueryStatefulInvalid() {
     return [](auto &response) {
-      std::cout << response.toString() << std::endl;
       ASSERT_NO_THROW({
         const auto &error_response = boost::apply_visitor(
             framework::SpecifiedVisitor<interface::ErrorQueryResponse>(),
@@ -99,7 +99,8 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
         boost::apply_visitor(framework::SpecifiedVisitor<
                                  interface::StatefulFailedErrorResponse>(),
                              error_response.get());
-      });
+      }) << "Actual response: "
+         << response.toString();
     };
   }
 
@@ -112,7 +113,8 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
         boost::apply_visitor(framework::SpecifiedVisitor<
                                  interface::StatelessFailedErrorResponse>(),
                              error_response.get());
-      });
+      }) << "Actual response: "
+         << response.toString();
     };
   }
 
@@ -423,7 +425,8 @@ TEST_F(AccountAssetTxsFixture, AnothersTxsWithMyTxsPermission) {
 }
 
 /**
- * C343 Get account transactions from another domain having CanGetAllAccountAssetTransactions permission
+ * C343 Get account transactions from another domain having
+ * CanGetAllAccountAssetTransactions permission
  * @given a user with kGetAllAccAstTxs permission
  * @when the user tries to retrieve a list of asset transactions with account id
  * of a user from another domain

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 
 using namespace shared_model;
@@ -14,24 +15,106 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
  public:
   std::unique_ptr<IntegrationTestFramework> itf_;
 
-  const interface::types::AccountNameType target_account_name_ = "target";
-
-  interface::types::AccountIdType
+  AccountAssetTxsFixture()
+      : kSecondDomain("second"),
+        kSpectator("spectator"),
+        kCloseSpectatorId(kSpectator + "@" + kDomain),
+        kRemoteSpectatorId(kSpectator + "@" + kSecondDomain),
+        kSpectatorKeypair(
+            crypto::DefaultCryptoAlgorithmType::generateKeypair()) {}
 
   IntegrationTestFramework &prepareState(
-      const interface::RolePermissionSet &permissions) {
-    auto perms = permissions;
-    perms.set(interface::permissions::Role::kAddAssetQty);
-    perms.set(interface::permissions::Role::kSubtractAssetQty);
-    perms.set(interface::permissions::Role::kReceive);
-    perms.set(interface::permissions::Role::kTransfer);
-    return itf_->sendTx(makeUserWithPerms(perms))
-        .skipProposal()
-        .checkBlock(
-            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+      const interface::RolePermissionSet &target_permissions = {},
+      const interface::RolePermissionSet &spectator_permissions = {}) {
+    auto full_target_permissions = target_permissions;
+    full_target_permissions.set(Role::kReceive);
+    full_target_permissions.set(Role::kTransfer);
+    full_target_permissions.set(Role::kAddAssetQty);
+    full_target_permissions.set(Role::kSubtractAssetQty);
+
+    // Add asset to admin and transfer to target account
+    auto prepare_tx_1 = complete(
+        baseTx(kAdminId)
+            .addAssetQuantity(kAssetId, "20000.0")
+            .transferAsset(kAdminId, kUserId, kAssetId, "incoming", "500.0"),
+        kAdminKeypair);
+
+    // Transfer assets back to admin
+    auto prepare_tx_2 = complete(baseTx().transferAsset(
+        kUserId, kAdminId, kAssetId, "outgoing", "500.0"));
+
+    // inside prepareState we can use lambda for such assert, since prepare
+    // transactions are not going to fail
+    auto block_with_tx = [](auto &block) {
+      ASSERT_EQ(block->transactions().size(), 1);
+    };
+
+    tx_hashes_.push_back(prepare_tx_1.hash());
+    tx_hashes_.push_back(prepare_tx_2.hash());
+    return itf_
+        ->sendTxAwait(makeUserWithPerms(full_target_permissions), block_with_tx)
+        .sendTxAwait(
+            complete(baseTx(kAdminId)
+                         .createRole(kSpectator, spectator_permissions)
+                         .createDomain(kSecondDomain, kSpectator)
+                         .createAccount(kSpectator,
+                                        kSecondDomain,
+                                        kSpectatorKeypair.publicKey())
+                         .createAccount(
+                             kSpectator, kDomain, kSpectatorKeypair.publicKey())
+                         .appendRole(kCloseSpectatorId, kSpectator)
+                         .detachRole(kCloseSpectatorId,
+                                     IntegrationTestFramework::kDefaultRole),
+                     kAdminKeypair),
+            block_with_tx)
+        .sendTxAwait(prepare_tx_1, block_with_tx)
+        .sendTxAwait(prepare_tx_2, block_with_tx);
   }
 
+  auto checkAllHashesReceived() {
+    return [this](const proto::QueryResponse &response) {
+      ASSERT_NO_THROW({
+        const auto &resp = boost::apply_visitor(
+            framework::SpecifiedVisitor<interface::TransactionsResponse>(),
+            response.get());
 
+        const auto &transactions = resp.transactions();
+        ASSERT_EQ(boost::size(transactions), tx_hashes_.size());
+        for (const auto &tx : transactions) {
+          auto begin = tx_hashes_.begin();
+          auto end = tx_hashes_.end();
+          ASSERT_NE(std::find(begin, end, tx.hash()), end);
+        }
+      });
+    };
+  }
+
+  auto checkQueryStatefulInvalid() {
+    return [](auto &response) {
+      std::cout << response.toString() << std::endl;
+      ASSERT_NO_THROW({
+        const auto &error_response = boost::apply_visitor(
+            framework::SpecifiedVisitor<interface::ErrorQueryResponse>(),
+            response.get());
+        boost::apply_visitor(framework::SpecifiedVisitor<
+                                 interface::StatefulFailedErrorResponse>(),
+                             error_response.get());
+      });
+    };
+  }
+
+  auto checkQueryStatelessInvalid() {
+    return [](auto &response) {
+      ASSERT_NO_THROW({
+        const auto &error_response = boost::apply_visitor(
+            framework::SpecifiedVisitor<interface::ErrorQueryResponse>(),
+            response.get());
+        boost::apply_visitor(framework::SpecifiedVisitor<
+                                 interface::StatelessFailedErrorResponse>(),
+                             error_response.get());
+      });
+    };
+  }
 
  protected:
   void SetUp() override {
@@ -39,15 +122,318 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
     itf_->setInitialState(kAdminKeypair);
   }
 
-  //  void TearDown() override {}
+  const interface::types::DomainIdType kSecondDomain;
+  const interface::types::AccountNameType kSpectator;
+  const interface::types::AccountIdType kCloseSpectatorId;
+  const interface::types::AccountIdType kRemoteSpectatorId;
+  const crypto::Keypair kSpectatorKeypair;
+
+  std::vector<interface::types::HashType> tx_hashes_;
 };
 
-TEST_F(AccountAssetTxsFixture, Basic) {
-  prepareState({interface::permissions::Role::kSetQuorum})
-      .sendTx(complete(baseTx().setAccountQuorum(kUserId, 1)))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
-  auto x = 2;
-  ASSERT_EQ(x, 2);
+/**
+ * C344 Get account transactions from a non-existing account
+ * @given a user with kGetAllAccAstTxs permission
+ * @when tries to retrieve a list of asset transactions from a non-existing
+ * account id
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ *
+ * TODO igor-egorov, 2018-08-21, IR-1631, wrong response (it returns
+ * TransactionsResponse instead of ErrorQueryResponse)
+ */
+TEST_F(AccountAssetTxsFixture,
+       DISABLED_ReadNonExistingAccountHavingAllTxsPermission) {
+  const interface::types::AccountIdType non_existing = "nonexisting@" + kDomain;
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendQuery(complete(baseQry().getAccountAssetTransactions(non_existing,
+                                                                kAssetId)),
+                 checkQueryStatefulInvalid());
+}
+
+/**
+ * C345 Pass an empty account id
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions from an
+ * account with empty id
+ * @then the query recognized as stateless invalid
+ */
+TEST_F(AccountAssetTxsFixture, ReadEmptyAccountHavingAllTxsPermission) {
+  const interface::types::AccountIdType empty = "";
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(empty, kAssetId)),
+          checkQueryStatelessInvalid());
+}
+
+/**
+ * C346 Pass an empty asset id
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of own asset transactions specifying
+ * empty asset id
+ * @then the query recognized as stateless invalid
+ */
+TEST_F(AccountAssetTxsFixture, ReadEmptyAssetHavingAllTxsPermission) {
+  const interface::types::AssetIdType empty = "";
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, empty)),
+          checkQueryStatelessInvalid());
+}
+
+/**
+ * C347 Pass a non existing asset id
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries tor retrieve a list of own asset transactions specifying
+ * a non-existing asset id
+ * @then the query recognized as stateful invalid
+ *
+ * TODO igor-egorov, 2018-08-21, IR-1631, wrong response (it returns
+ * TransactionsResponse instead of ErrorQueryResponse)
+ */
+TEST_F(AccountAssetTxsFixture,
+       DISABLED_ReadNonExistingAssetHavingAllTxsPermission) {
+  const interface::types::AssetIdType non_existing = "nonexisting#" + kDomain;
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendQuery(complete(baseQry().getAccountAssetTransactions(kUserId,
+                                                                non_existing)),
+                 checkQueryStatefulInvalid());
+}
+
+/**
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of own asset transactions, which
+ * contain a transaction with addAssetQuantity command
+ * @then all transactions are shown
+ *
+ * TODO igor-egorov, 2018-08-21, IR-1632, wrong response (response does not
+ * contain transaction with addAssetQuantity command)
+ */
+TEST_F(AccountAssetTxsFixture, DISABLED_OwnTxsIncludingAddAssetQuantity) {
+  auto tx = complete(baseTx().addAssetQuantity(kAssetId, "200.0"));
+  tx_hashes_.push_back(tx.hash());
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendTxAwait(
+          tx, [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+          checkAllHashesReceived());
+}
+
+/**
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of own asset transactions, which
+ * contain a transaction with subtractAssetQuantity command
+ * @then all transactions are shown
+ *
+ * TODO igor-egorov, 2018-08-21, IR-1632, wrong response (response does not
+ * contain transaction with subtractAssetQuantity command)
+ */
+TEST_F(AccountAssetTxsFixture, DISABLED_OwnTxsIncludingSubtractAssetQuantity) {
+  auto tx = complete(baseTx()
+                         .addAssetQuantity(kAssetId, "200.0")
+                         .subtractAssetQuantity(kAssetId, "100.0"));
+  tx_hashes_.push_back(tx.hash());
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendTxAwait(
+          tx, [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+          checkAllHashesReceived());
+}
+
+/*
+ * Below are test cases that check different combinations of permission modes
+ * (1 - no permissions,   2 - can_get_my_*,
+ *  3 - can_get_domain_*, 4 - can_get_all_*)
+ * combined with different accounts as query source
+ * (1 - an account who was transferring or receiving assets (target account),
+ *  2 - an account from the same domain as target account,
+ *  3 - an account from domain that different to domain of target account).
+ */
+
+/**
+ * C348 Get my transactions with a CanGetMyAccountAssetTransactions permission
+ * @given a user with kGetMyAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with own
+ * account id
+ * @then all transactions are shown to the user
+ */
+TEST_F(AccountAssetTxsFixture, OwnTxsWithMyTxsPermission) {
+  prepareState({Role::kGetMyAccAstTxs})
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+          checkAllHashesReceived());
+}
+
+/**
+ * C339 Get my transactions without CanGetMyAccountAssetTransactions permission
+ * @given a user without any query permission
+ * @when the user tries to retrieve a list of asset transactions with own
+ * account id
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture, OwnTxsWithoutAnyPermission) {
+  prepareState().sendQuery(
+      complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+      checkQueryStatefulInvalid());
+}
+
+/**
+ * @given a user without any query permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from the same domain
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture, AnothersTxsWithoutAnyPermission) {
+  prepareState().sendQuery(
+      complete(baseQry(kCloseSpectatorId)
+                   .getAccountAssetTransactions(kUserId, kAssetId),
+               kSpectatorKeypair),
+      checkQueryStatefulInvalid());
+}
+
+/**
+ * @given a user without any query permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of user from another domain
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture,
+       AnothersTxsFromDifferentDomainWithoutAnyPermission) {
+  prepareState().sendQuery(
+      complete(baseQry(kRemoteSpectatorId)
+                   .getAccountAssetTransactions(kUserId, kAssetId),
+               kSpectatorKeypair),
+      checkQueryStatefulInvalid());
+}
+
+/**
+ * C340 Get my transactions with only CanGetDomainAccountAssetTransactions
+ * permission
+ * @given a user with kGetDomainAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with own
+ * account id
+ * @then all transactions are shown
+ */
+TEST_F(AccountAssetTxsFixture, OwnTxsWithDomainTxsPermission) {
+  prepareState({Role::kGetDomainAccAstTxs})
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+          checkAllHashesReceived());
+}
+
+/**
+ * C341 Get my transactions with only CanGetAllAccountAssetTransactions
+ * permission
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with own
+ * account id
+ * @then all transactions are shown
+ */
+TEST_F(AccountAssetTxsFixture, OwnTxsWithAllTxsPermission) {
+  prepareState({Role::kGetAllAccAstTxs})
+      .sendQuery(
+          complete(baseQry().getAccountAssetTransactions(kUserId, kAssetId)),
+          checkAllHashesReceived());
+}
+
+/**
+ * Get another's transactions from a different domain with kGetMyAccAstTxs
+ * permission
+ * @given a user with kGetMyAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from another domain
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture,
+       AnothersTxsFromDifferentDomainWithMyTxsPermission) {
+  prepareState({}, {Role::kGetMyAccAstTxs})
+      .sendQuery(complete(baseQry(kRemoteSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkQueryStatefulInvalid());
+}
+
+/**
+ * Get another's transactions from a different domain with kGetDomainAccAstTxs
+ * permission
+ * @given a user with kGetDomainAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from another domain
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture,
+       AnothersTxsFromDifferentDomainWithDomainTxsPermission) {
+  prepareState({}, {Role::kGetDomainAccAstTxs})
+      .sendQuery(complete(baseQry(kRemoteSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkQueryStatefulInvalid());
+}
+
+/**
+ * C342 Get account transactions from the domain having
+ * CanGetDomainAccountAssetTransactions permission
+ * @given a user with kGetDomainAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from the same domain
+ * @then all transactions are shown
+ */
+TEST_F(AccountAssetTxsFixture, AnothersTxsWithDomainTxsPermission) {
+  prepareState({}, {Role::kGetDomainAccAstTxs})
+      .sendQuery(complete(baseQry(kCloseSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkAllHashesReceived());
+}
+
+/**
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from the same domain
+ * @then all transactions are shown
+ */
+TEST_F(AccountAssetTxsFixture, AnothersTxsWithAllTxsPermission) {
+  prepareState({}, {Role::kGetAllAccAstTxs})
+      .sendQuery(complete(baseQry(kCloseSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkAllHashesReceived());
+}
+
+/**
+ * @given a user with kGetMyAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from the same domain
+ * @then no transactions are shown. Query should be recognized as stateful
+ * invalid
+ */
+TEST_F(AccountAssetTxsFixture, AnothersTxsWithMyTxsPermission) {
+  prepareState({}, {Role::kGetMyAccAstTxs})
+      .sendQuery(complete(baseQry(kCloseSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkQueryStatefulInvalid());
+}
+
+/**
+ * C343 Get account transactions from another domain having CanGetAllAccountAssetTransactions permission
+ * @given a user with kGetAllAccAstTxs permission
+ * @when the user tries to retrieve a list of asset transactions with account id
+ * of a user from another domain
+ * @then all transactions are shown
+ */
+TEST_F(AccountAssetTxsFixture,
+       AnothersTxsFromDifferentDomainWithAllTxsPermission) {
+  prepareState({}, {Role::kGetAllAccAstTxs})
+      .sendQuery(complete(baseQry(kRemoteSpectatorId)
+                              .getAccountAssetTransactions(kUserId, kAssetId),
+                          kSpectatorKeypair),
+                 checkAllHashesReceived());
 }

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -24,6 +24,20 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
         kSpectatorKeypair(
             crypto::DefaultCryptoAlgorithmType::generateKeypair()) {}
 
+  /**
+   * Prepare state of ledger:
+   * - create accounts of target user, close and remote spectators (close
+   *   spectator - another user from the same domain as the domain of target
+   *   user account, remote - a user from domain different to domain of target
+   *   user account).
+   * - execute transfer asset from admin to target account
+   * - execute transfer asset from target to admin account
+   *
+   * @param target_permissions - set of query permissions for target account
+   * @param spectator_permissions - set of query permisisons for spectators'
+   * accounts
+   * @return reference to ITF
+   */
   IntegrationTestFramework &prepareState(
       const interface::RolePermissionSet &target_permissions = {},
       const interface::RolePermissionSet &spectator_permissions = {}) {
@@ -72,6 +86,10 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
         .sendTxAwait(prepare_tx_2, block_with_tx);
   }
 
+  /**
+   * @return a lambda that verifies that query response contains all the hashes
+   * of transactions related to the tested pair of account id and asset id
+   */
   auto checkAllHashesReceived() {
     return [this](const proto::QueryResponse &response) {
       ASSERT_NO_THROW({
@@ -91,6 +109,10 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
     };
   }
 
+  /**
+   * @return a lambda that verifies that query response says the query was
+   * stateful invalid
+   */
   auto checkQueryStatefulInvalid() {
     return [](auto &response) {
       ASSERT_TRUE(boost::apply_visitor(
@@ -101,6 +123,10 @@ class AccountAssetTxsFixture : public AcceptanceFixture {
     };
   }
 
+  /**
+   * @return a lambda that verifies that query response says the query was
+   * stateless invalid
+   */
   auto checkQueryStatelessInvalid() {
     return [](auto &response) {
       ASSERT_TRUE(boost::apply_visitor(

--- a/test/integration/acceptance/get_account_assets_test.cpp
+++ b/test/integration/acceptance/get_account_assets_test.cpp
@@ -31,13 +31,13 @@ class GetAccountAssets : public AcceptanceFixture {
 
   /// Create command for adding assets
   auto addAssets() {
-    return complete(AcceptanceFixture::baseTx().addAssetQuantity(kAsset, "1"));
+    return complete(AcceptanceFixture::baseTx().addAssetQuantity(kAssetId, "1"));
   }
 
   /// Create command for removing assets
   auto removeAssets() {
     return complete(
-        AcceptanceFixture::baseTx().subtractAssetQuantity(kAsset, "1"));
+        AcceptanceFixture::baseTx().subtractAssetQuantity(kAssetId, "1"));
   }
 
   /**

--- a/test/integration/acceptance/grantable_permissions_fixture.cpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.cpp
@@ -149,21 +149,20 @@ shared_model::proto::Query GrantablePermissionsFixture::querySignatories(
     const shared_model::interface::types::AccountNameType &account_name,
     const shared_model::crypto::Keypair &account_key) {
   const std::string account_id = account_name + "@" + kDomain;
-  return complete(baseQuery(account_id).getSignatories(account_id),
-                  account_key);
+  return complete(baseQry(account_id).getSignatories(account_id), account_key);
 }
 
 shared_model::proto::Query GrantablePermissionsFixture::queryAccount(
     const shared_model::interface::types::AccountNameType &account_name,
     const shared_model::crypto::Keypair &account_key) {
   const auto account_id = account_name + "@" + kDomain;
-  return complete(baseQuery(account_id).getAccount(account_id), account_key);
+  return complete(baseQry(account_id).getAccount(account_id), account_key);
 }
 
 shared_model::proto::Query GrantablePermissionsFixture::queryAccountDetail(
     const shared_model::interface::types::AccountNameType &account_name,
     const shared_model::crypto::Keypair &account_key) {
   const auto account_id = account_name + "@" + kDomain;
-  return complete(baseQuery(account_id).getAccountDetail(account_id),
+  return complete(baseQry(account_id).getAccountDetail(account_id),
                   account_key);
 }

--- a/test/integration/acceptance/grantable_permissions_fixture.hpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.hpp
@@ -265,43 +265,6 @@ class GrantablePermissionsFixture : public AcceptanceFixture {
     };
   }
 
-  /**
-   * Prepare base transaction
-   * @param account_id - account of transaction creator
-   * @return transaction builder
-   */
-  auto baseTx(const shared_model::interface::types::AccountIdType &account_id) {
-    return TxBuilder()
-        .creatorAccountId(account_id)
-        .createdTime(getUniqueTime())
-        .quorum(1);
-  }
-
-  /**
-   * Prepare base query
-   * @param account_id - account of query creator
-   * @return query builder
-   */
-  auto baseQuery(
-      const shared_model::interface::types::AccountIdType &account_id,
-      const shared_model::interface::types::CounterType &query_counter = 1) {
-    return shared_model::proto::QueryBuilder()
-        .creatorAccountId(account_id)
-        .createdTime(getUniqueTime())
-        .queryCounter(query_counter);
-  }
-
-  /**
-   * Build and sign the transaction
-   * @param builder - semi-built transaction builder
-   * @param keypair - key to sign the transaction
-   * @return - built and signed transaction
-   */
-  template <typename Builder>
-  auto complete(Builder builder, const shared_model::crypto::Keypair &keypair) {
-    return builder.build().signAndAddSignature(keypair).finish();
-  }
-
   const std::string kAccount1 = "accountone";
   const std::string kAccount2 = "accounttwo";
 

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -241,10 +241,10 @@ namespace grantables {
               .createdTime(f.getUniqueTime())
               .creatorAccountId(itf.kAdminId)
               .quorum(1)
-              .addAssetQuantity(f.kAsset, "9000.0")
+              .addAssetQuantity(f.kAssetId, "9000.0")
               .transferAsset(itf.kAdminId,
                              f.kAccount1 + "@" + f.kDomain,
-                             f.kAsset,
+                             f.kAssetId,
                              "init top up",
                              "8000.0")
               .build()

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -30,7 +30,7 @@ class SubtractAssetQuantity : public AcceptanceFixture {
    * @return built tx that adds kAmount assets to the users
    */
   auto replenish() {
-    return complete(baseTx().addAssetQuantity(kAsset, kAmount));
+    return complete(baseTx().addAssetQuantity(kAssetId, kAmount));
   }
 
   const std::string kAmount = "1.0";
@@ -50,7 +50,7 @@ TEST_F(SubtractAssetQuantity, Everything) {
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAsset, kAmount)))
+      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, kAmount)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
@@ -72,7 +72,7 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAsset, "2.0")))
+      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "2.0")))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
@@ -93,7 +93,7 @@ TEST_F(SubtractAssetQuantity, NoPermissions) {
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAsset, kAmount)))
+      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, kAmount)))
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
@@ -115,7 +115,7 @@ TEST_F(SubtractAssetQuantity, NegativeAmount) {
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAsset, "-1.0")),
+      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "-1.0")),
               checkStatelessInvalid);
 }
 
@@ -134,7 +134,7 @@ TEST_F(SubtractAssetQuantity, ZeroAmount) {
       .sendTx(replenish())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAsset, "0.0")),
+      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "0.0")),
               checkStatelessInvalid);
 }
 

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -49,12 +49,12 @@ class TransferAsset : public AcceptanceFixture {
   }
 
   proto::Transaction addAssets(const std::string &amount) {
-    return complete(baseTx().addAssetQuantity(kAsset, amount));
+    return complete(baseTx().addAssetQuantity(kAssetId, amount));
   }
 
   proto::Transaction makeTransfer(const std::string &amount) {
     return complete(
-        baseTx().transferAsset(kUserId, kUser2Id, kAsset, kDesc, amount));
+        baseTx().transferAsset(kUserId, kUser2Id, kAssetId, kDesc, amount));
   }
 
   proto::Transaction makeTransfer() {
@@ -133,7 +133,7 @@ TEST_F(TransferAsset, NonexistentDest) {
       .sendTxAwait(makeFirstUser(), check(1))
       .sendTxAwait(addAssets(), check(1))
       .sendTxAwait(complete(baseTx().transferAsset(
-                       kUserId, nonexistent, kAsset, kDesc, kAmount)),
+                       kUserId, nonexistent, kAssetId, kDesc, kAmount)),
                    check(0))
       .done();
 }
@@ -200,7 +200,7 @@ TEST_F(TransferAsset, EmptyDesc) {
       .sendTxAwait(makeSecondUser(), check(1))
       .sendTxAwait(addAssets(), check(1))
       .sendTxAwait(complete(baseTx().transferAsset(
-                       kUserId, kUser2Id, kAsset, "", kAmount)),
+                       kUserId, kUser2Id, kAssetId, "", kAmount)),
                    check(1))
       .done();
 }
@@ -219,7 +219,7 @@ TEST_F(TransferAsset, LongDesc) {
       .sendTxAwait(addAssets(), check(1))
       .sendTx(
           complete(baseTx().transferAsset(
-              kUserId, kUser2Id, kAsset, std::string(100000, 'a'), kAmount)),
+              kUserId, kUser2Id, kAssetId, std::string(100000, 'a'), kAmount)),
           checkStatelessInvalid)
       .done();
 }
@@ -278,7 +278,7 @@ TEST_F(TransferAsset, SourceIsDest) {
       .sendTxAwait(makeFirstUser(), check(1))
       .sendTxAwait(addAssets(), check(1))
       .sendTx(complete(baseTx().transferAsset(
-                  kUserId, kUserId, kAsset, kDesc, kAmount)),
+                  kUserId, kUserId, kAssetId, kDesc, kAmount)),
               checkStatelessInvalid);
 }
 

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -237,7 +237,6 @@ TEST_F(AcceptanceTest, TransactionValidSignedBlob) {
  * @then the response is STATELESS_VALIDATION_FAILED
  */
 TEST_F(AcceptanceTest, EmptySignatures) {
-  std::string kAccountId = "some@account";
   auto proto_tx = baseTx<TestTransactionBuilder>().build().getTransport();
   proto_tx.clear_signatures();
   auto tx = shared_model::proto::Transaction(proto_tx);

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -36,7 +36,7 @@ class AcceptanceTest : public AcceptanceFixture {
     return Builder()
         .createdTime(getUniqueTime())
         .creatorAccountId(kAdmin)
-        .addAssetQuantity(kAsset, "1.0")
+        .addAssetQuantity(kAssetId, "1.0")
         .quorum(1);
   }
 

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -39,11 +39,6 @@ class AcceptanceTest : public AcceptanceFixture {
         .addAssetQuantity(kAssetId, "1.0")
         .quorum(1);
   }
-
-  template <typename T>
-  auto complete(T t) {
-    return t.build().signAndAddSignature(kAdminKeypair).finish();
-  }
 };
 
 /**
@@ -56,7 +51,7 @@ TEST_F(AcceptanceTest, NonExistentCreatorAccountId) {
   const std::string kNonUser = "nonuser@test";
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(complete(baseTx<>().creatorAccountId(kNonUser)),
+      .sendTx(complete(baseTx<>().creatorAccountId(kNonUser), kAdminKeypair),
               checkStatelessValid)
       .checkProposal(checkProposal)
       .checkBlock(checkStatefulInvalid)
@@ -73,7 +68,8 @@ TEST_F(AcceptanceTest, Transaction1HourOld) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(complete(baseTx<>().createdTime(
-                  iroha::time::now(std::chrono::hours(-1)))),
+                           iroha::time::now(std::chrono::hours(-1))),
+                       kAdminKeypair),
               checkStatelessValid)
       .skipProposal()
       .checkBlock(checkStatefulValid)
@@ -90,7 +86,8 @@ TEST_F(AcceptanceTest, DISABLED_TransactionLess24HourOld) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(complete(baseTx<>().createdTime(iroha::time::now(
-                  std::chrono::hours(24) - std::chrono::minutes(1)))),
+                           std::chrono::hours(24) - std::chrono::minutes(1))),
+                       kAdminKeypair),
               checkStatelessValid)
       .skipProposal()
       .checkBlock(checkStatefulValid)
@@ -106,7 +103,8 @@ TEST_F(AcceptanceTest, TransactionMore24HourOld) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(complete(baseTx<>().createdTime(iroha::time::now(
-                  std::chrono::hours(24) + std::chrono::minutes(1)))),
+                           std::chrono::hours(24) + std::chrono::minutes(1))),
+                       kAdminKeypair),
               checkStatelessInvalid)
       .done();
 }
@@ -121,7 +119,8 @@ TEST_F(AcceptanceTest, Transaction5MinutesFromFuture) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(complete(baseTx<>().createdTime(iroha::time::now(
-                  std::chrono::minutes(5) - std::chrono::seconds(10)))),
+                           std::chrono::minutes(5) - std::chrono::seconds(10))),
+                       kAdminKeypair),
               checkStatelessValid)
       .skipProposal()
       .checkBlock(checkStatefulValid)
@@ -137,7 +136,8 @@ TEST_F(AcceptanceTest, Transaction10MinutesFromFuture) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(complete(baseTx<>().createdTime(
-                  iroha::time::now(std::chrono::minutes(10)))),
+                           iroha::time::now(std::chrono::minutes(10))),
+                       kAdminKeypair),
               checkStatelessInvalid)
       .done();
 }
@@ -228,7 +228,7 @@ TEST_F(AcceptanceTest, TransactionInvalidSignedBlob) {
 TEST_F(AcceptanceTest, TransactionValidSignedBlob) {
   integration_framework::IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTx(complete(baseTx<>()), checkStatelessValid)
+      .sendTx(complete(baseTx<>(), kAdminKeypair), checkStatelessValid)
       .skipProposal()
       .checkBlock(checkStatefulValid)
       .done();

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -328,7 +328,13 @@ TEST_F(ToriiServiceTest, StatusWhenBlocking) {
     tx_request.set_tx_hash(
         shared_model::crypto::toBinaryString(tx_hashes.at(i)));
     iroha::protocol::ToriiResponse toriiResponse;
-    client3.Status(tx_request, toriiResponse);
+
+    auto resub_counter(resubscribe_attempts);
+    do {
+      client3.Status(tx_request, toriiResponse);
+    } while (toriiResponse.tx_status()
+                 != iroha::protocol::TxStatus::STATEFUL_VALIDATION_SUCCESS
+             and --resub_counter);
 
     ASSERT_EQ(toriiResponse.tx_status(),
               iroha::protocol::TxStatus::STATEFUL_VALIDATION_SUCCESS);


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The pr introduces tests for getAccountAssetTransactions query.


### Benefits

Increased code coverage.
Two issues were revealed:
* [IR-1631 Wrong response on getAccountAssetTransactions query (a non-existing account or asset)](https://soramitsu.atlassian.net/browse/IR-1631)
* [IR-1632 Missing transactions in getAccountAssetTransactions query response](https://soramitsu.atlassian.net/browse/IR-1632)


### Possible Drawbacks 

None. The code is beautiful 😊

### Usage Examples or Tests

```
cmake -H. -Bbuild
cd build
make get_account_asset_txs_test
ctest -R get_account_asset_txs_test --output-on-failure
```
