### PR TITLE
Add SendTx and SendQuery system tests

### DIFF
--- a/libs/crypto/CMakeLists.txt
+++ b/libs/crypto/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(keys_manager
     )
 
 target_link_libraries(keys_manager
+    boost
     shared_model_cryptography
     logger
     )

--- a/libs/crypto/keys_manager.hpp
+++ b/libs/crypto/keys_manager.hpp
@@ -26,7 +26,7 @@ namespace shared_model {
   namespace crypto {
     class Keypair;
   }
-}
+}  // namespace shared_model
 
 namespace iroha {
   /**
@@ -37,25 +37,12 @@ namespace iroha {
     virtual ~KeysManager() = default;
 
     /**
-     * Create a new keypair and store it as is on disk
-     * @return false if create account failed
-     */
-    virtual bool createKeys() = 0;
-
-    /**
      * Create keys a new keypair and store it encrypted on disk
-     * @param pass_phrase is a password for the keys
+     * @param pass_phrase is used for private key encryption. Optional, default
+     * value is an empty string.
      * @return false if create account failed
      */
-    virtual bool createKeys(const std::string &pass_phrase) = 0;
-
-    /**
-     * Load plain-text keys associated with the manager, then validate loaded
-     * keypair by signing and verifying signature of test message
-     * @return nullopt if no keypair found locally, or verification failure;
-     *         related keypair otherwise
-     */
-    virtual boost::optional<shared_model::crypto::Keypair> loadKeys() = 0;
+    virtual bool createKeys(const std::string &pass_phrase = "") = 0;
 
     /**
      * Load encrypted keys associated with the manager, then validate loaded
@@ -65,7 +52,7 @@ namespace iroha {
      *         related keypair otherwise
      */
     virtual boost::optional<shared_model::crypto::Keypair> loadKeys(
-        const std::string &pass_phrase) = 0;
+        const std::string &pass_phrase = "") = 0;
   };
 
 }  // namespace iroha

--- a/libs/crypto/keys_manager.hpp
+++ b/libs/crypto/keys_manager.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_KEYS_MANAGER_HPP
@@ -21,12 +9,7 @@
 #include <string>
 
 #include <boost/optional.hpp>
-
-namespace shared_model {
-  namespace crypto {
-    class Keypair;
-  }
-}  // namespace shared_model
+#include "cryptography/keypair.hpp"
 
 namespace iroha {
   /**
@@ -37,22 +20,35 @@ namespace iroha {
     virtual ~KeysManager() = default;
 
     /**
-     * Create keys a new keypair and store it encrypted on disk
-     * @param pass_phrase is used for private key encryption. Optional, default
-     * value is an empty string.
-     * @return false if create account failed
+     * Create keys of a new keypair and store them on disk
+     * @return false if keys creation was failed
      */
-    virtual bool createKeys(const std::string &pass_phrase = "") = 0;
+    virtual bool createKeys() = 0;
+
+    /**
+     * Create keys of a new keypair and store it encrypted on disk
+     * @param pass_phrase is used for private key encryption
+     * @return false if keys creation was failed
+     */
+    virtual bool createKeys(const std::string &pass_phrase) = 0;
+
+    /**
+     * Load keys associated with the manager, then validate loaded keypair by
+     * signing and verifying the signature of a test message
+     * @return nullopt if no keypair found locally, or in case of verification
+     *         failure. Otherwise - the keypair will be returned
+     */
+    virtual boost::optional<shared_model::crypto::Keypair> loadKeys() = 0;
 
     /**
      * Load encrypted keys associated with the manager, then validate loaded
-     * keypair by signing and verifying signature of test message
+     * keypair by signing and verifying the signature of a test message
      * @param pass_phrase is a password for decryption
-     * @return nullopt if no keypair found locally, or verification failure;
-     *         related keypair otherwise
+     * @return nullopt if no keypair found locally, or in case of verification
+     *         failure. Otherwise - the keypair will be returned
      */
     virtual boost::optional<shared_model::crypto::Keypair> loadKeys(
-        const std::string &pass_phrase = "") = 0;
+        const std::string &pass_phrase) = 0;
   };
 
 }  // namespace iroha

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -48,6 +48,14 @@ namespace iroha {
         account_id_(account_id),
         log_(logger::log("KeysManagerImpl")) {}
 
+  /**
+   * Here we use an empty string as a default value of path to file,
+   * since there are usages of KeysManagerImpl with path passed as a part of
+   * account_id.
+   */
+  KeysManagerImpl::KeysManagerImpl(const std::string account_id)
+      : KeysManagerImpl(account_id, "") {}
+
   bool KeysManagerImpl::validate(const Keypair &keypair) const {
     try {
       auto test = Blob("12345");
@@ -78,6 +86,10 @@ namespace iroha {
     return contents;
   }
 
+  boost::optional<Keypair> KeysManagerImpl::loadKeys() {
+    return loadKeys("");
+  }
+
   boost::optional<Keypair> KeysManagerImpl::loadKeys(
       const std::string &pass_phrase) {
     auto public_key =
@@ -95,6 +107,10 @@ namespace iroha {
                            pass_phrase)));
 
     return validate(keypair) ? boost::make_optional(keypair) : boost::none;
+  }
+
+  bool KeysManagerImpl::createKeys() {
+    return createKeys("");
   }
 
   bool KeysManagerImpl::createKeys(const std::string &pass_phrase) {

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "crypto/keys_manager_impl.hpp"
@@ -53,8 +41,11 @@ namespace iroha {
    */
   static constexpr auto decrypt = encrypt<Blob::Bytes>;
 
-  KeysManagerImpl::KeysManagerImpl(const std::string &account_name)
-      : account_name_(std::move(account_name)),
+  KeysManagerImpl::KeysManagerImpl(
+      const std::string &account_id,
+      const boost::filesystem::path &path_to_keypair)
+      : path_to_keypair_(path_to_keypair),
+        account_id_(account_id),
         log_(logger::log("KeysManagerImpl")) {}
 
   bool KeysManagerImpl::validate(const Keypair &keypair) const {
@@ -73,55 +64,37 @@ namespace iroha {
     return true;
   }
 
-  bool KeysManagerImpl::loadFile(const std::string &filename,
-                                 std::string &res) {
-    std::ifstream file(filename);
+  boost::optional<std::string> KeysManagerImpl::loadFile(
+      const boost::filesystem::path &path) const {
+    auto file_path = path.string();
+    std::ifstream file(file_path);
     if (not file) {
-      log_->error("Cannot read '" + filename + "'");
-      return false;
+      log_->error("Cannot read '" + file_path + "'");
+      return {};
     }
-    file >> res;
-    return true;
-  }
 
-  boost::optional<Keypair> KeysManagerImpl::loadKeys() {
-    std::string pub_key;
-    std::string priv_key;
-
-    if (not loadFile(account_name_ + kPublicKeyExtension, pub_key)
-        or not loadFile(account_name_ + kPrivateKeyExtension, priv_key))
-      return boost::none;
-
-    Keypair keypair = Keypair(PublicKey(Blob::fromHexString(pub_key)),
-                              PrivateKey(Blob::fromHexString(priv_key)));
-
-    return this->validate(keypair) ? boost::make_optional(keypair)
-                                   : boost::none;
+    std::string contents;
+    file >> contents;
+    return boost::make_optional<std::string>(contents);
   }
 
   boost::optional<Keypair> KeysManagerImpl::loadKeys(
       const std::string &pass_phrase) {
-    std::string pub_key;
-    std::string priv_key;
+    auto public_key =
+        loadFile(path_to_keypair_ / (account_id_ + kPublicKeyExtension));
+    auto private_key =
+        loadFile(path_to_keypair_ / (account_id_ + kPrivateKeyExtension));
 
-    if (not loadFile(account_name_ + kPublicKeyExtension, pub_key)
-        or not loadFile(account_name_ + kPrivateKeyExtension, priv_key))
+    if (not public_key or not private_key) {
       return boost::none;
+    }
 
     Keypair keypair = Keypair(
-        PublicKey(Blob::fromHexString(pub_key)),
-        PrivateKey(decrypt(Blob::fromHexString(priv_key).blob(), pass_phrase)));
+        PublicKey(Blob::fromHexString(public_key.get())),
+        PrivateKey(decrypt(Blob::fromHexString(private_key.get()).blob(),
+                           pass_phrase)));
 
-    return this->validate(keypair) ? boost::make_optional(keypair)
-                                   : boost::none;
-  }
-
-  bool KeysManagerImpl::createKeys() {
-    Keypair keypair = DefaultCryptoAlgorithmType::generateKeypair();
-
-    auto pub = keypair.publicKey().hex();
-    auto priv = keypair.privateKey().hex();
-    return store(pub, priv);
+    return validate(keypair) ? boost::make_optional(keypair) : boost::none;
   }
 
   bool KeysManagerImpl::createKeys(const std::string &pass_phrase) {
@@ -134,8 +107,10 @@ namespace iroha {
   }
 
   bool KeysManagerImpl::store(const std::string &pub, const std::string &priv) {
-    std::ofstream pub_file(account_name_ + kPublicKeyExtension);
-    std::ofstream priv_file(account_name_ + kPrivateKeyExtension);
+    std::ofstream pub_file(
+        (path_to_keypair_ / (account_id_ + kPublicKeyExtension)).string());
+    std::ofstream priv_file(
+        (path_to_keypair_ / (account_id_ + kPrivateKeyExtension)).string());
     if (not pub_file or not priv_file) {
       return false;
     }

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -75,7 +75,7 @@ namespace iroha {
 
     std::string contents;
     file >> contents;
-    return boost::make_optional<std::string>(contents);
+    return contents;
   }
 
   boost::optional<Keypair> KeysManagerImpl::loadKeys(

--- a/libs/crypto/keys_manager_impl.hpp
+++ b/libs/crypto/keys_manager_impl.hpp
@@ -22,25 +22,24 @@ namespace iroha {
      * @param account_id - fully qualified account id, e.g. admin@test
      * @param path_to_keypair - path to directory that contains priv and pub key
      * of an account
-     *
-     * Here we use an empty string as a default value of path to file, since
-     * there are usages of KeysManagerImpl with path passed as a part of
-     * account_id.
      */
-    explicit KeysManagerImpl(
-        const std::string &account_id,
-        const boost::filesystem::path &path_to_keypair = "");
-
-    bool createKeys(const std::string &pass_phrase = "") override;
+    explicit KeysManagerImpl(const std::string &account_id,
+                             const boost::filesystem::path &path_to_keypair);
 
     /**
-     * Loads keypair from disk
-     * @param pass_phrase - pass phrase used for private key encryption.
-     * Optional, default is an empty string.
-     * @return boost optional of Keypair in case of success
+     * Initialize key manager for a specific account
+     * @param account_id - fully qualified account id, e.g. admin@test
      */
+    explicit KeysManagerImpl(const std::string account_id);
+
+    bool createKeys() override;
+
+    bool createKeys(const std::string &pass_phrase) override;
+
+    boost::optional<shared_model::crypto::Keypair> loadKeys() override;
+
     boost::optional<shared_model::crypto::Keypair> loadKeys(
-        const std::string &pass_phrase = "") override;
+        const std::string &pass_phrase) override;
 
     static const std::string kPublicKeyExtension;
     static const std::string kPrivateKeyExtension;

--- a/libs/crypto/keys_manager_impl.hpp
+++ b/libs/crypto/keys_manager_impl.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_KEYS_MANAGER_IMPL_HPP
@@ -20,6 +8,7 @@
 
 #include "crypto/keys_manager.hpp"
 
+#include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 #include "cryptography/keypair.hpp"
 #include "logger/logger.hpp"
@@ -28,14 +17,30 @@ namespace iroha {
 
   class KeysManagerImpl : public KeysManager {
    public:
-    explicit KeysManagerImpl(const std::string &account_name);
+    /**
+     * Initialize key manager for a specific account
+     * @param account_id - fully qualified account id, e.g. admin@test
+     * @param path_to_keypair - path to directory that contains priv and pub key
+     * of an account
+     *
+     * Here we use an empty string as a default value of path to file, since
+     * there are usages of KeysManagerImpl with path passed as a part of
+     * account_id.
+     */
+    explicit KeysManagerImpl(
+        const std::string &account_id,
+        const boost::filesystem::path &path_to_keypair = "");
 
-    bool createKeys() override;
-    bool createKeys(const std::string &pass_phrase) override;
+    bool createKeys(const std::string &pass_phrase = "") override;
 
-    boost::optional<shared_model::crypto::Keypair> loadKeys() override;
+    /**
+     * Loads keypair from disk
+     * @param pass_phrase - pass phrase used for private key encryption.
+     * Optional, default is an empty string.
+     * @return boost optional of Keypair in case of success
+     */
     boost::optional<shared_model::crypto::Keypair> loadKeys(
-        const std::string &pass_phrase) override;
+        const std::string &pass_phrase = "") override;
 
     static const std::string kPublicKeyExtension;
     static const std::string kPrivateKeyExtension;
@@ -49,12 +54,12 @@ namespace iroha {
     bool validate(const shared_model::crypto::Keypair &keypair) const;
 
     /**
-     * Tries to load file to the resulting string
-     * @param filename file to read from
-     * @param res is where result is stored
-     * @return true, if no problem with file reading
+     * Tries to read the file
+     * @param path - path to the target file
+     * @return file contents if reading was successful, otherwise - boost::none
      */
-    bool loadFile(const std::string &filename, std::string &res);
+    boost::optional<std::string> loadFile(
+        const boost::filesystem::path &path) const;
 
     /**
      * Stores strings, that represent public and private keys on disk
@@ -64,7 +69,8 @@ namespace iroha {
      */
     bool store(const std::string &pub, const std::string &priv);
 
-    std::string account_name_;
+    boost::filesystem::path path_to_keypair_;
+    std::string account_id_;
     logger::Logger log_;
   };
 }  // namespace iroha

--- a/test/module/libs/crypto/CMakeLists.txt
+++ b/test/module/libs/crypto/CMakeLists.txt
@@ -31,5 +31,4 @@ target_link_libraries(signature_test
 AddTest(keys_manager_test keys_manager_test.cpp)
 target_link_libraries(keys_manager_test
     keys_manager
-    boost
     )

--- a/test/module/libs/crypto/keys_manager_test.cpp
+++ b/test/module/libs/crypto/keys_manager_test.cpp
@@ -1,18 +1,7 @@
-/*
-Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "crypto/keys_manager.hpp"
 #include <gtest/gtest.h>

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -6,6 +6,11 @@ target_link_libraries(irohad_test
         rapidjson
         integration_framework_config_helper
         libs_common
+        shared_model_proto_backend
+        acceptance_fixture
+        command_client
+        query_client
+        keys_manager
         )
 add_dependencies(irohad_test irohad)
 add_definitions(-DPATHIROHAD="${PROJECT_BINARY_DIR}/bin")

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -1,33 +1,28 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
+#include <soci/postgresql/soci-postgresql.h>
+#include <soci/soci.h>
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 #include <boost/process.hpp>
-#include <soci/soci.h>
-#include <soci/postgresql/soci-postgresql.h>
 
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "common/files.hpp"
 #include "common/types.hpp"
+#include "crypto/keys_manager_impl.hpp"
+#include "framework/specified_visitor.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/roles_response.hpp"
 #include "main/iroha_conf_loader.hpp"
+#include "torii/command_client.hpp"
+#include "torii/query_client.hpp"
 
 // workaround for redefining -WERROR problem
 #undef RAPIDJSON_HAS_STDSTRING
@@ -39,10 +34,22 @@ using namespace boost::filesystem;
 using namespace std::chrono_literals;
 using iroha::operator|;
 
-class IrohadTest : public testing::Test {
+/**
+The do-while cycle imitates client resubscription to the stream. Stream
+"expiration" is a valid designed case (see pr #1615 for the details).
+
+The number of attempts (5) is a magic constant here. The idea behind this number
+is the following: five resubscription with 3 seconds timeout is usually enough
+to pass the test; if not - most likely there is another bug.
+ */
+constexpr uint32_t resubscribe_attempts = 5;
+const std::chrono::seconds resubscribe_timeout = std::chrono::seconds(3);
+
+class IrohadTest : public AcceptanceFixture {
  public:
+  IrohadTest() : kAddress("127.0.0.1"), kPort(50051) {}
+
   void SetUp() override {
-    timeout = 1s;
     setPaths();
     auto config = parse_iroha_config(path_config_.string());
     blockstore_path_ = (boost::filesystem::temp_directory_path()
@@ -66,7 +73,17 @@ class IrohadTest : public testing::Test {
     copy_file.write(config_copy_string.data(), config_copy_string.size());
   }
 
+  void launchIroha() {
+    iroha_process_.emplace(irohad_executable.string() + setDefaultParams());
+    std::this_thread::sleep_for(kTimeout);
+    ASSERT_TRUE(iroha_process_->running());
+  }
+
   void TearDown() override {
+    if (iroha_process_) {
+      iroha_process_->terminate();
+    }
+
     iroha::remove_dir_contents(blockstore_path_);
     dropPostgres();
     boost::filesystem::remove(config_copy_);
@@ -122,9 +139,13 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
 
  public:
   boost::filesystem::path irohad_executable;
-  std::chrono::milliseconds timeout = 1s;
+  const std::chrono::milliseconds kTimeout = std::chrono::seconds(1);
+  const std::string kAddress;
+  const uint16_t kPort;
 
- private:
+  boost::optional<child> iroha_process_;
+
+ protected:
   boost::filesystem::path path_irohad_;
   boost::filesystem::path path_example_;
   boost::filesystem::path path_config_;
@@ -135,15 +156,69 @@ DROP TABLE IF EXISTS index_by_id_height_asset;
   std::string config_copy_;
 };
 
-/*
+/**
  * @given path to irohad executable and paths to files irohad is needed to be
  * run (config, genesis block, keypair)
  * @when run irohad with all parameters it needs to operate as a full node
  * @then irohad should be started and running until timeout expired
  */
 TEST_F(IrohadTest, RunIrohad) {
-  child c(irohad_executable.string() + setDefaultParams());
-  std::this_thread::sleep_for(timeout);
-  ASSERT_TRUE(c.running());
-  c.terminate();
+  launchIroha();
+}
+
+/**
+ * Test verifies that a transaction can be sent to running iroha and committed
+ * @given running Iroha
+ * @when a client sends a transaction to Iroha
+ * @then the transaction is committed
+ */
+TEST_F(IrohadTest, SendTx) {
+  launchIroha();
+  auto key_manager = iroha::KeysManagerImpl(kAdminId, path_example_);
+  auto key_pair = key_manager.loadKeys();
+  ASSERT_TRUE(key_pair);
+
+  iroha::protocol::TxStatusRequest tx_request;
+  iroha::protocol::ToriiResponse torii_response;
+
+  auto tx =
+      complete(baseTx(kAdminId).setAccountQuorum(kAdminId, 1), key_pair.get());
+  tx_request.set_tx_hash(shared_model::crypto::toBinaryString(tx.hash()));
+
+  auto client = torii::CommandSyncClient(kAddress, kPort);
+  client.Torii(tx.getTransport());
+
+  auto resub_counter(resubscribe_attempts);
+  do {
+    std::this_thread::sleep_for(resubscribe_timeout);
+    client.Status(tx_request, torii_response);
+  } while (torii_response.tx_status() != iroha::protocol::TxStatus::COMMITTED
+           and --resub_counter);
+
+  ASSERT_EQ(torii_response.tx_status(), iroha::protocol::TxStatus::COMMITTED);
+}
+
+/**
+ * Test verifies that a query can be sent to and served by running Iroha
+ * @given running Iroha
+ * @when a client sends a query to Iroha
+ * @then the query is served and query response is received
+ */
+TEST_F(IrohadTest, SendQuery) {
+  launchIroha();
+  auto key_manager = iroha::KeysManagerImpl(kAdminId, path_example_);
+  auto key_pair = key_manager.loadKeys();
+  ASSERT_TRUE(key_pair);
+
+  iroha::protocol::QueryResponse response;
+  auto query = complete(baseQry(kAdminId).getRoles(), key_pair.get());
+  auto client = torii_utils::QuerySyncClient(kAddress, kPort);
+  client.Find(query.getTransport(), response);
+  auto resp = shared_model::proto::QueryResponse(response);
+
+  ASSERT_NO_THROW({
+    boost::apply_visitor(
+        framework::SpecifiedVisitor<shared_model::interface::RolesResponse>(),
+        resp.get());
+  });
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Add a test that:
* runs separate independent Iroha instance as our users do
* sends a transaction and awaits its committed status
* sends a query and verifies the query response

Additionally, the implementation of KeysManager was refactored.

### Benefits

Coverage is increased. 
No need to include tx-example.py to CI cycle.

### Possible Drawbacks 

None.

### Usage Examples or Tests

```
cmake -H. -Bbuild
cd build
make irohad_test
ctest -R irohad_test --output-on-failure
```
