### PR TITLE
Fix send tx sequence method

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -135,6 +135,7 @@ namespace integration_framework {
         ->getPeerCommunicationService()
         ->on_proposal()
         .subscribe([this](auto proposal) {
+          log_->info("Before push to proposal queue");
           proposal_queue_.push(proposal);
           log_->info("proposal");
           queue_cond.notify_all();
@@ -236,7 +237,9 @@ namespace integration_framework {
     log_->info("send transactions");
     const auto &transactions = tx_sequence.transactions();
 
-    boost::barrier bar(2);
+    std::mutex m;
+    std::condition_variable cv;
+    bool processed = false;
 
     // subscribe on status bus and save all stateless statuses into a vector
     std::vector<shared_model::proto::TransactionResponse> statuses;
@@ -265,7 +268,10 @@ namespace integration_framework {
               statuses.push_back(*std::static_pointer_cast<
                                  shared_model::proto::TransactionResponse>(s));
             },
-            [&bar] { bar.wait(); });
+            [&cv, &processed] {
+              processed = true;
+              cv.notify_all();
+            });
 
     // put all transactions to the TxList and send them to iroha
     iroha::protocol::TxList tx_list;
@@ -279,7 +285,10 @@ namespace integration_framework {
         tx_list);
 
     // make sure that the first (stateless) status is come
-    bar.wait();
+    {
+      std::unique_lock<std::mutex> lk(m);
+      cv.wait(lk, [&] { return processed; });
+    }
 
     validation(statuses);
     return *this;


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Due to unclear reasons boost::barrier throws segfault in send tx sequence test (once out from 100 runs on average). To avoid that it was replaced with std::condition_variable. 
### Benefits

No segfaults are thrown anymore(test was executed ~2000 times)

### Possible Drawbacks 

Inconsistency with `sendTx` method which still uses `boost::barrier`
