### PR TITLE
Change log order

### DIFF
--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -103,12 +103,12 @@ namespace iroha {
 
   void FairMstProcessor::onPropagate(
       const PropagationStrategy::PropagationData &data) {
-    log_->info("Propagate new data[{}]", data.size());
     auto current_time = time_provider_->getCurrentTime();
     std::for_each(
         data.begin(), data.end(), [this, &current_time](const auto &peer) {
           auto diff = storage_->getDiffState(peer, current_time);
           if (not diff.isEmpty()) {
+            log_->info("Propagate new data[{}]", data.size());
             transport_->sendState(*peer, diff);
           }
         });

--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -106,7 +106,7 @@ namespace iroha {
     auto current_time = time_provider_->getCurrentTime();
     auto size = data.size();
     std::for_each(
-        data.begin(), data.end(), [this, &current_time, &size](const auto &peer) {
+        data.begin(), data.end(), [this, &current_time, size](const auto &peer) {
           auto diff = storage_->getDiffState(peer, current_time);
           if (not diff.isEmpty()) {
             log_->info("Propagate new data[{}]", size);

--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -104,11 +104,12 @@ namespace iroha {
   void FairMstProcessor::onPropagate(
       const PropagationStrategy::PropagationData &data) {
     auto current_time = time_provider_->getCurrentTime();
+    auto size = data.size();
     std::for_each(
-        data.begin(), data.end(), [this, &current_time](const auto &peer) {
+        data.begin(), data.end(), [this, &current_time, &size](const auto &peer) {
           auto diff = storage_->getDiffState(peer, current_time);
           if (not diff.isEmpty()) {
-            log_->info("Propagate new data[{}]", data.size());
+            log_->info("Propagate new data[{}]", size);
             transport_->sendState(*peer, diff);
           }
         });


### PR DESCRIPTION
### Description of the Change

Iroha used to produce something like:
```
[2018-08-28 14:24:40.335785000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:24:45.339160000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:24:50.330393000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:24:55.332114000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:25:00.328946000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:25:05.338611000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:25:10.332539000][th:295648][info] FairMstProcessor Propagate new data[2]
[2018-08-28 14:25:15.331939000][th:295648][info] FairMstProcessor Propagate new data[2]
```
even when there was no propagation. 

### Benefits

This PR fixes the order of logs.

### Possible Drawbacks 

None