### PR TITLE
Fix json escaping

### DIFF
--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -5,6 +5,7 @@
 
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/format.hpp>
 
 #include "ametsuchi/impl/soci_utils.hpp"
@@ -1085,7 +1086,7 @@ namespace iroha {
         const shared_model::interface::SetAccountDetail &command) {
       auto &account_id = command.accountId();
       auto &key = command.key();
-      auto &value = command.value();
+      auto value = command.value();
       if (creator_account_id_.empty()) {
         // When creator is not known, it is genesis block
         creator_account_id_ = "genesis";
@@ -1093,6 +1094,7 @@ namespace iroha {
       std::string json = "{" + creator_account_id_ + "}";
       std::string empty_json = "{}";
       std::string filled_json = "{" + creator_account_id_ + ", " + key + "}";
+      boost::replace_all(value, "\"", "\\\"");
       std::string val = "\"" + value + "\"";
 
       boost::format cmd(R"(

--- a/test/integration/acceptance/set_account_detail_test.cpp
+++ b/test/integration/acceptance/set_account_detail_test.cpp
@@ -67,6 +67,44 @@ TEST_F(SetAccountDetail, Self) {
 }
 
 /**
+ * @given a user with can_set_detail perm
+ *        AND a json-object value with single quotes
+ * @when execute tx with SetAccountDetail command aimed to the user
+ * @then there is the tx in proposal
+ */
+TEST_F(SetAccountDetail, JsonObject) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(complete(baseTx(kUserId, kKey, "{'value' : ['abc', 'dca']}")))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
+ * @given a user with can_set_detail perm
+ *        AND a json-object value with double quotes
+ * @when execute tx with SetAccountDetail command aimed to the user
+ * @then there is the tx in proposal
+ */
+TEST_F(SetAccountDetail, JsonObjectDoubleQuotes) {
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTx(complete(baseTx(kUserId, kKey, R"({"value" : ["abc", "dca"]})")))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .done();
+}
+
+/**
  * @given a pair of users and first one without permissions
  * @when the first one tries to use SetAccountDetail on the second
  * @then there is an empty verified proposal


### PR DESCRIPTION
### Description of the Change

Double quotes need to be escaped (including user code) explicitly. This pr improves this by performing such actions internally. Couple of tests are also added

### Benefits

Cleaner interface

### Possible Drawbacks 

None
