### PR TITLE
Fix failure after empty block

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -184,6 +184,12 @@ void Irohad::initOrderingGate() {
  */
 void Irohad::initSimulator() {
   auto block_factory = std::make_unique<shared_model::proto::ProtoBlockFactory>(
+      //  Block factory in simulator uses UnsignedBlockValidator because it is
+      //  not required to check signatures of block here, as they will be
+      //  checked when supermajority of peers will sign the block. It is also
+      //  not required to validate signatures of transactions here because they
+      //  are validated in the ordering gate, where they are received from the
+      //  ordering service.
       std::make_unique<
           shared_model::validation::DefaultUnsignedBlockValidator>());
   simulator = std::make_shared<Simulator>(ordering_gate,

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -184,7 +184,8 @@ void Irohad::initOrderingGate() {
  */
 void Irohad::initSimulator() {
   auto block_factory = std::make_unique<shared_model::proto::ProtoBlockFactory>(
-      std::make_unique<shared_model::validation::BlockVariantValidator>());
+      std::make_unique<
+          shared_model::validation::DefaultUnsignedBlockValidator>());
   simulator = std::make_shared<Simulator>(ordering_gate,
                                           stateful_validator,
                                           storage,

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -26,26 +26,26 @@ using namespace iroha::network;
 auto BlockLoaderInit::createService(
     std::shared_ptr<BlockQueryFactory> block_query_factory,
     std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache) {
-  return std::make_shared<BlockLoaderService>(block_query_factory,
-                                              std::move(consensus_result_cache));
+  return std::make_shared<BlockLoaderService>(
+      block_query_factory, std::move(consensus_result_cache));
 }
 
 auto BlockLoaderInit::createLoader(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     std::shared_ptr<BlockQueryFactory> block_query_factory) {
   shared_model::proto::ProtoBlockFactory factory(
-      std::make_unique<shared_model::validation::BlockVariantValidator>());
-  return std::make_shared<BlockLoaderImpl>(peer_query_factory,
-                                           block_query_factory,
-                                           std::move(factory));
+      std::make_unique<
+          shared_model::validation::DefaultSignedBlockValidator>());
+  return std::make_shared<BlockLoaderImpl>(
+      peer_query_factory, block_query_factory, std::move(factory));
 }
 
 std::shared_ptr<BlockLoader> BlockLoaderInit::initBlockLoader(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     std::shared_ptr<BlockQueryFactory> block_query_factory,
     std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache) {
-  service = createService(block_query_factory,
-                          std::move(consensus_result_cache));
+  service =
+      createService(block_query_factory, std::move(consensus_result_cache));
   loader = createLoader(peer_query_factory, block_query_factory);
   return loader;
 }

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -48,7 +48,7 @@ namespace iroha {
        * @return block on success, nullopt on failure
        * TODO 14/02/17 (@l4l) IR-960 rework method with returning result
        */
-      virtual boost::optional<shared_model::interface::BlockVariant>
+      virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
       retrieveBlock(
           const shared_model::crypto::PublicKey &peer_pubkey,
           const shared_model::interface::types::HashType &block_hash) = 0;

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -34,25 +34,6 @@ namespace {
   const char *kTopBlockRetrieveFail = "Failed to retrieve top block";
   const char *kPeerRetrieveFail = "Failed to retrieve peers";
   const char *kPeerFindFail = "Failed to find requested peer";
-
-  /**
-   * If @param block_variant contains block, return it.
-   * If empty block return error
-   */
-  iroha::expected::Result<std::shared_ptr<Block>, std::string> getNonEmptyBlock(
-      const BlockVariant &block_variant) {
-    return iroha::visit_in_place(
-        block_variant,
-        [](const std::shared_ptr<Block> &block)
-            -> iroha::expected::Result<std::shared_ptr<Block>, std::string> {
-          return iroha::expected::makeValue(block);
-        },
-        [](const std::shared_ptr<EmptyBlock> &)
-            -> iroha::expected::Result<std::shared_ptr<Block>, std::string> {
-          return iroha::expected::makeError(
-              "Block does not contain transactions");
-        });
-  }
 }  // namespace
 
 BlockLoaderImpl::BlockLoaderImpl(
@@ -66,61 +47,59 @@ BlockLoaderImpl::BlockLoaderImpl(
 
 rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
     const PublicKey &peer_pubkey) {
-  return rxcpp::observable<>::create<
-      std::shared_ptr<Block>>([this, peer_pubkey](auto subscriber) {
-    std::shared_ptr<Block> top_block;
-    block_query_factory_->createBlockQuery() |
-        [this, &top_block](const auto &block_query) {
-          block_query->getTopBlock().match(
-              [&top_block](
-                  expected::Value<
-                      std::shared_ptr<shared_model::interface::Block>> block) {
-                top_block = block.value;
+  return rxcpp::observable<>::create<std::shared_ptr<Block>>(
+      [this, peer_pubkey](auto subscriber) {
+        std::shared_ptr<Block> top_block;
+        block_query_factory_->createBlockQuery() |
+            [this, &top_block](const auto &block_query) {
+              block_query->getTopBlock().match(
+                  [&top_block](expected::Value<
+                               std::shared_ptr<shared_model::interface::Block>>
+                                   block) { top_block = block.value; },
+                  [this](expected::Error<std::string> error) {
+                    log_->error("{}: {}", kTopBlockRetrieveFail, error.error);
+                  });
+            };
+        if (not top_block) {
+          subscriber.on_completed();
+          return;
+        }
+
+        auto peer = this->findPeer(peer_pubkey);
+        if (not peer) {
+          log_->error(kPeerNotFound);
+          subscriber.on_completed();
+          return;
+        }
+
+        proto::BlocksRequest request;
+        grpc::ClientContext context;
+        protocol::Block block;
+
+        // request next block to our top
+        request.set_height(top_block->height() + 1);
+
+        auto reader =
+            this->getPeerStub(**peer).retrieveBlocks(&context, request);
+        while (reader->Read(&block)) {
+          auto proto_block = block_factory_.createBlock(std::move(block));
+          proto_block.match(
+              [&subscriber](
+                  iroha::expected::Value<std::unique_ptr<Block>> &result) {
+                subscriber.on_next(std::move(result.value));
               },
-              [this](expected::Error<std::string> error) {
-                log_->error("{}: {}", kTopBlockRetrieveFail, error.error);
+              [this,
+               &context](const iroha::expected::Error<std::string> &error) {
+                log_->error(error.error);
+                context.TryCancel();
               });
-        };
-    if (not top_block) {
-      subscriber.on_completed();
-      return;
-    }
-
-    auto peer = this->findPeer(peer_pubkey);
-    if (not peer) {
-      log_->error(kPeerNotFound);
-      subscriber.on_completed();
-      return;
-    }
-
-    proto::BlocksRequest request;
-    grpc::ClientContext context;
-    protocol::Block block;
-
-    // request next block to our top
-    request.set_height(top_block->height() + 1);
-
-    auto reader = this->getPeerStub(**peer).retrieveBlocks(&context, request);
-    while (reader->Read(&block)) {
-      auto proto_block =
-          block_factory_.createBlock(std::move(block)) | getNonEmptyBlock;
-      proto_block.match(
-          [&subscriber](
-              iroha::expected::Value<
-                  std::shared_ptr<shared_model::interface::Block>> &result) {
-            subscriber.on_next(std::move(result.value));
-          },
-          [this, &context](const iroha::expected::Error<std::string> &error) {
-            log_->error(error.error);
-            context.TryCancel();
-          });
-    }
-    reader->Finish();
-    subscriber.on_completed();
-  });
+        }
+        reader->Finish();
+        subscriber.on_completed();
+      });
 }
 
-boost::optional<BlockVariant> BlockLoaderImpl::retrieveBlock(
+boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
     const PublicKey &peer_pubkey, const types::HashType &block_hash) {
   auto peer = findPeer(peer_pubkey);
   if (not peer) {
@@ -144,11 +123,11 @@ boost::optional<BlockVariant> BlockLoaderImpl::retrieveBlock(
   auto result = block_factory_.createBlock(std::move(block));
 
   return result.match(
-      [](iroha::expected::Value<BlockVariant> &v) {
-        return boost::make_optional(std::move(v.value));
+      [](iroha::expected::Value<std::unique_ptr<Block>> &v) {
+        return boost::make_optional(std::shared_ptr<Block>(std::move(v.value)));
       },
       [this](const iroha::expected::Error<std::string> &e)
-          -> boost::optional<BlockVariant> {
+          -> boost::optional<std::shared_ptr<Block>> {
         log_->error(e.error);
         return boost::none;
       });

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -56,7 +56,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
                   [&top_block](expected::Value<
                                std::shared_ptr<shared_model::interface::Block>>
                                    block) { top_block = block.value; },
-                  [this](expected::Error<std::string> error) {
+                  [this](const expected::Error<std::string>& error) {
                     log_->error("{}: {}", kTopBlockRetrieveFail, error.error);
                   });
             };

--- a/irohad/network/impl/block_loader_impl.hpp
+++ b/irohad/network/impl/block_loader_impl.hpp
@@ -41,7 +41,8 @@ namespace iroha {
       retrieveBlocks(
           const shared_model::crypto::PublicKey &peer_pubkey) override;
 
-      boost::optional<shared_model::interface::BlockVariant> retrieveBlock(
+      boost::optional<std::shared_ptr<shared_model::interface::Block>>
+      retrieveBlock(
           const shared_model::crypto::PublicKey &peer_pubkey,
           const shared_model::interface::types::HashType &block_hash) override;
 

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -22,7 +22,7 @@
 
 namespace shared_model {
   namespace interface {
-    class BlockVariant;
+    class Block;
     class Proposal;
   }  // namespace interface
 }  // namespace shared_model
@@ -46,7 +46,7 @@ namespace iroha {
        * Emit blocks made from proposals
        * @return
        */
-      virtual rxcpp::observable<shared_model::interface::BlockVariant>
+      virtual rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       on_block() = 0;
 
       virtual ~BlockCreator() = default;

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -110,15 +110,16 @@ namespace iroha {
         log_->error("Unable to query top block height");
         return;
       }
-      auto block = block_factory_->unsafeCreateBlock(height,
-                                                     last_block->hash(),
-                                                     proposal.createdTime(),
-                                                     proposal.transactions());
-      crypto_signer_->sign(block);
+      std::shared_ptr<shared_model::interface::Block> block =
+          block_factory_->unsafeCreateBlock(height,
+                                            last_block->hash(),
+                                            proposal.createdTime(),
+                                            proposal.transactions());
+      crypto_signer_->sign(*block);
       block_notifier_.get_subscriber().on_next(block);
     }
 
-    rxcpp::observable<shared_model::interface::BlockVariant>
+    rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
     Simulator::on_block() {
       return block_notifier_.get_observable();
     }

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -45,15 +45,15 @@ namespace iroha {
       void process_verified_proposal(
           const shared_model::interface::Proposal &proposal) override;
 
-      rxcpp::observable<shared_model::interface::BlockVariant> on_block()
-          override;
+      rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
+      on_block() override;
 
      private:
       // internal
       rxcpp::subjects::subject<
           std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>>
           notifier_;
-      rxcpp::subjects::subject<shared_model::interface::BlockVariant>
+      rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
           block_notifier_;
 
       rxcpp::composite_subscription proposal_subscription_;

--- a/shared_model/backend/protobuf/impl/proto_block_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_factory.cpp
@@ -6,16 +6,16 @@
 #include "backend/protobuf/proto_block_factory.hpp"
 
 #include "backend/protobuf/block.hpp"
-#include "backend/protobuf/empty_block.hpp"
 
 using namespace shared_model::proto;
 
 ProtoBlockFactory::ProtoBlockFactory(
     std::unique_ptr<shared_model::validation::AbstractValidator<
-        shared_model::interface::BlockVariant>> validator)
+        shared_model::interface::Block>> validator)
     : validator_(std::move(validator)){};
 
-shared_model::interface::BlockVariant ProtoBlockFactory::unsafeCreateBlock(
+std::unique_ptr<shared_model::interface::Block>
+ProtoBlockFactory::unsafeCreateBlock(
     interface::types::HeightType height,
     const interface::types::HashType &prev_hash,
     interface::types::TimestampType created_time,
@@ -26,27 +26,21 @@ shared_model::interface::BlockVariant ProtoBlockFactory::unsafeCreateBlock(
   block_payload->set_prev_block_hash(crypto::toBinaryString(prev_hash));
   block_payload->set_created_time(created_time);
 
-  if (not txs.empty()) {
-    std::for_each(
-        std::begin(txs), std::end(txs), [block_payload](const auto &tx) {
-          auto *transaction = block_payload->add_transactions();
-          (*transaction) = static_cast<const Transaction &>(tx).getTransport();
-        });
-    return std::make_shared<shared_model::proto::Block>(std::move(block));
-  }
-
-  return std::make_shared<shared_model::proto::EmptyBlock>(std::move(block));
+  std::for_each(
+      std::begin(txs), std::end(txs), [block_payload](const auto &tx) {
+        auto *transaction = block_payload->add_transactions();
+        (*transaction) = static_cast<const Transaction &>(tx).getTransport();
+      });
+  return std::make_unique<shared_model::proto::Block>(std::move(block));
 }
 
-iroha::expected::Result<shared_model::interface::BlockVariant, std::string>
+iroha::expected::Result<std::unique_ptr<shared_model::interface::Block>,
+                        std::string>
 ProtoBlockFactory::createBlock(iroha::protocol::Block block) {
-  interface::BlockVariant proto_block;
-  if (block.payload().transactions().empty()) {
-    proto_block = std::make_shared<EmptyBlock>(std::move(block));
-  } else {
-    proto_block = std::make_shared<Block>(std::move(block));
-  }
-  auto errors = validator_->validate(proto_block);
+  std::unique_ptr<shared_model::interface::Block> proto_block =
+      std::make_unique<Block>(std::move(block));
+
+  auto errors = validator_->validate(*proto_block);
   if (errors) {
     return iroha::expected::makeError(errors.reason());
   }

--- a/shared_model/backend/protobuf/proto_block_factory.hpp
+++ b/shared_model/backend/protobuf/proto_block_factory.hpp
@@ -21,9 +21,9 @@ namespace shared_model {
      public:
       explicit ProtoBlockFactory(
           std::unique_ptr<shared_model::validation::AbstractValidator<
-              shared_model::interface::BlockVariant>> validator);
+              shared_model::interface::Block>> validator);
 
-      interface::BlockVariant unsafeCreateBlock(
+      std::unique_ptr<interface::Block> unsafeCreateBlock(
           interface::types::HeightType height,
           const interface::types::HashType &prev_hash,
           interface::types::TimestampType created_time,
@@ -36,12 +36,12 @@ namespace shared_model {
        * @return BlockVariant with block.
        *         Error if block is empty, or if it is invalid
        */
-      iroha::expected::Result<interface::BlockVariant, std::string> createBlock(
-          iroha::protocol::Block block);
+      iroha::expected::Result<std::unique_ptr<interface::Block>, std::string>
+      createBlock(iroha::protocol::Block block);
 
      private:
       std::unique_ptr<shared_model::validation::AbstractValidator<
-          shared_model::interface::BlockVariant>>
+          shared_model::interface::Block>>
           validator_;
     };
   }  // namespace proto

--- a/shared_model/interfaces/iroha_internal/unsafe_block_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/unsafe_block_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_UNSAFE_BLOCK_FACTORY_HPP
 #define IROHA_UNSAFE_BLOCK_FACTORY_HPP
 
-#include "interfaces/iroha_internal/block_variant.hpp"
+#include "interfaces/iroha_internal/block.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -15,15 +15,15 @@ namespace shared_model {
      */
     class UnsafeBlockFactory {
      public:
-       /**
-        * Create block without any validation
-        * @param height - block height
-        * @param prev_hash - hash of the previous block
-        * @param created_time - time the block is created
-        * @param txs - list of transactions. If it empty, EmptyBlock is creted
-        * @return BlockVariant with block or empty block
-        */
-      virtual BlockVariant unsafeCreateBlock(
+      /**
+       * Create block without any validation
+       * @param height - block height
+       * @param prev_hash - hash of the previous block
+       * @param created_time - time the block is created
+       * @param txs - list of transactions. If it empty, EmptyBlock is creted
+       * @return BlockVariant with block or empty block
+       */
+      virtual std::unique_ptr<Block> unsafeCreateBlock(
           types::HeightType height,
           const types::HashType &prev_hash,
           types::TimestampType created_time,

--- a/shared_model/validators/abstract_validator.hpp
+++ b/shared_model/validators/abstract_validator.hpp
@@ -14,7 +14,7 @@ namespace shared_model {
     template <typename Model>
     class AbstractValidator {
      public:
-      virtual Answer validate(const Model &m) = 0;
+      virtual Answer validate(const Model &m) const = 0;
 
       virtual ~AbstractValidator() = default;
     };

--- a/shared_model/validators/block_validator.hpp
+++ b/shared_model/validators/block_validator.hpp
@@ -10,6 +10,7 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "validators/abstract_validator.hpp"
 #include "validators/answer.hpp"
 #include "validators/container_validator.hpp"
 
@@ -23,7 +24,8 @@ namespace shared_model {
     class BlockValidator
         : public ContainerValidator<interface::Block,
                                     FieldValidator,
-                                    TransactionsCollectionValidator> {
+                                    TransactionsCollectionValidator>,
+          public AbstractValidator<interface::Block> {
      public:
       using ContainerValidator<
           interface::Block,
@@ -34,7 +36,7 @@ namespace shared_model {
        * @param block
        * @return Answer containing found error if any
        */
-      Answer validate(const interface::Block &block) const {
+      Answer validate(const interface::Block &block) const override {
         return ContainerValidator<interface::Block,
                                   FieldValidator,
                                   TransactionsCollectionValidator>::

--- a/shared_model/validators/block_variant_validator.hpp
+++ b/shared_model/validators/block_variant_validator.hpp
@@ -20,7 +20,8 @@ namespace shared_model {
         : public shared_model::validation::AbstractValidator<
               shared_model::interface::BlockVariant> {
      public:
-      Answer validate(const shared_model::interface::BlockVariant &m) override {
+      Answer validate(
+          const shared_model::interface::BlockVariant &m) const override {
         return validator_.validate(m);
       }
 

--- a/shared_model/validators/default_validator.hpp
+++ b/shared_model/validators/default_validator.hpp
@@ -106,7 +106,8 @@ namespace shared_model {
         ProposalValidator<FieldValidator, DefaultSignedTransactionsValidator>;
 
     /**
-     * Block validator which checks blocks WITHOUT signatures
+     * Block validator which checks blocks WITHOUT signatures. Note that it does
+     * not check transactions' signatures as well
      */
     using DefaultUnsignedBlockValidator =
         BlockValidator<FieldValidator, DefaultUnsignedTransactionsValidator>;

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -135,7 +135,6 @@ namespace integration_framework {
         ->getPeerCommunicationService()
         ->on_proposal()
         .subscribe([this](auto proposal) {
-          log_->info("Before push to proposal queue");
           proposal_queue_.push(proposal);
           log_->info("proposal");
           queue_cond.notify_all();

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -100,6 +100,8 @@ TEST_F(CreateAccount, ExistingName) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](const auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -114,10 +116,9 @@ TEST_F(CreateAccount, MaxLenName) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().createAccount(
-          std::string(32, 'a'), kDomain, kNewUserKeypair.publicKey())))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          complete(baseTx().createAccount(
+              std::string(32, 'a'), kDomain, kNewUserKeypair.publicKey())),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .done();
 }

--- a/test/integration/acceptance/create_asset_test.cpp
+++ b/test/integration/acceptance/create_asset_test.cpp
@@ -105,7 +105,9 @@ TEST_F(CreateAssetFixture, ExistingName) {
           // reason
           [](auto &vproposal) {
             ASSERT_EQ(vproposal->transactions().size(), 0);
-          });
+          })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
 }
 
 /**
@@ -130,7 +132,9 @@ TEST_F(CreateAssetFixture, ExistingNameDifferentPrecision) {
           // reason
           [](auto &vproposal) {
             ASSERT_EQ(vproposal->transactions().size(), 0);
-          });
+          })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
 }
 
 /**
@@ -153,7 +157,9 @@ TEST_F(CreateAssetFixture, WithoutPermission) {
           // reason
           [](auto &vproposal) {
             ASSERT_EQ(vproposal->transactions().size(), 0);
-          });
+          })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
 }
 
 /**
@@ -176,7 +182,9 @@ TEST_F(CreateAssetFixture, ValidNonExistingDomain) {
           // reason
           [](auto &vproposal) {
             ASSERT_EQ(vproposal->transactions().size(), 0);
-          });
+          })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
 }
 
 /**
@@ -187,10 +195,9 @@ TEST_F(CreateAssetFixture, ValidNonExistingDomain) {
 TEST_F(CreateAssetFixture, InvalidDomain) {
   IntegrationTestFramework itf(1);
   itf.setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms())
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+      .sendTxAwait(makeUserWithPerms(), [](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1);
+      });
   for (const auto &domain : kIllegalDomainNames) {
     itf.sendTx(complete(baseTx().createAsset(kAssetName, domain, kPrecision)),
                checkStatelessInvalid);

--- a/test/integration/acceptance/create_domain_test.cpp
+++ b/test/integration/acceptance/create_domain_test.cpp
@@ -31,11 +31,9 @@ TEST_F(CreateDomain, Basic) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().createDomain(kNewDomain, kRole)))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .done();
+      .sendTxAwait(
+          complete(baseTx().createDomain(kNewDomain, kRole)),
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
 }
 
 /**
@@ -54,6 +52,8 @@ TEST_F(CreateDomain, NoPermissions) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -74,6 +74,8 @@ TEST_F(CreateDomain, NoRole) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -94,6 +96,8 @@ TEST_F(CreateDomain, ExistingName) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -114,9 +118,8 @@ TEST_F(CreateDomain, MaxLenName) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx().createDomain(maxLongDomain, kRole)))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          complete(baseTx().createDomain(maxLongDomain, kRole)),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .done();
 }

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -69,6 +69,8 @@ TEST_F(CreateRole, HaveNoPerms) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -174,6 +176,7 @@ TEST_F(CreateRole, ExistingRole) {
       .sendTx(
           complete(baseTx({interface::permissions::Role::kGetMyTxs}, kNewRole)))
       .skipProposal()
-      .checkVerifiedProposal(
-          [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); });
+      .checkVerifiedProposal([](auto &proposal) {
+        ASSERT_EQ(proposal->transactions().size(), 0);
+      });
 }

--- a/test/integration/acceptance/grant_permission_test.cpp
+++ b/test/integration/acceptance/grant_permission_test.cpp
@@ -32,6 +32,8 @@ TEST_F(GrantablePermissionsFixture, GrantToInexistingAccount) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -54,20 +56,18 @@ TEST_F(GrantablePermissionsFixture, GrantAddSignatoryPermission) {
   itf.setInitialState(kAdminKeypair);
   auto &x = createTwoAccounts(
       itf, {Role::kAddMySignatory, Role::kGetMySignatories}, {Role::kReceive});
-  x.sendTx(grantPermission(kAccount1,
-                           kAccount1Keypair,
-                           kAccount2,
-                           permissions::Grantable::kAddMySignatory))
-      .skipProposal()
-      .checkBlock(
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+  x.sendTxAwait(grantPermission(kAccount1,
+                                kAccount1Keypair,
+                                kAccount2,
+                                permissions::Grantable::kAddMySignatory),
+                [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       // Add signatory
-      .sendTx(permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::addSignatory,
-          kAccount2,
-          kAccount2Keypair,
-          kAccount1))
-      .checkBlock(
+      .sendTxAwait(
+          permitteeModifySignatory(
+              &TestUnsignedTransactionBuilder::addSignatory,
+              kAccount2,
+              kAccount2Keypair,
+              kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(querySignatories(kAccount1, kAccount1Keypair),
                  check_if_signatory_is_contained)
@@ -102,29 +102,27 @@ TEST_F(GrantablePermissionsFixture, GrantRemoveSignatoryPermission) {
                               kAccount2,
                               permissions::Grantable::kAddMySignatory))
       .skipProposal()
+      .skipVerifiedProposal()
       .skipBlock()
-      .sendTx(grantPermission(kAccount1,
-                              kAccount1Keypair,
-                              kAccount2,
-                              permissions::Grantable::kRemoveMySignatory))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          grantPermission(kAccount1,
+                          kAccount1Keypair,
+                          kAccount2,
+                          permissions::Grantable::kRemoveMySignatory),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .sendTx(permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::addSignatory,
-          kAccount2,
-          kAccount2Keypair,
-          kAccount1))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          permitteeModifySignatory(
+              &TestUnsignedTransactionBuilder::addSignatory,
+              kAccount2,
+              kAccount2Keypair,
+              kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .sendTx(permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::removeSignatory,
-          kAccount2,
-          kAccount2Keypair,
-          kAccount1))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          permitteeModifySignatory(
+              &TestUnsignedTransactionBuilder::removeSignatory,
+              kAccount2,
+              kAccount2Keypair,
+              kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(querySignatories(kAccount1, kAccount1Keypair),
                  check_if_signatory_is_not_contained)
@@ -170,9 +168,8 @@ TEST_F(GrantablePermissionsFixture, GrantSetQuorumPermission) {
           kAccount1))
       .skipProposal()
       .skipBlock()
-      .sendTx(setQuorum(kAccount2, kAccount2Keypair, kAccount1, 2))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          setQuorum(kAccount2, kAccount2Keypair, kAccount1, 2),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(queryAccount(kAccount1, kAccount1Keypair),
                  check_quorum_quantity)
@@ -203,13 +200,12 @@ TEST_F(GrantablePermissionsFixture, GrantSetAccountDetailPermission) {
       .skipProposal()
       .checkBlock(
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      .sendTx(setAccountDetail(kAccount2,
-                               kAccount2Keypair,
-                               kAccount1,
-                               kAccountDetailKey,
-                               kAccountDetailValue))
-      .skipProposal()
-      .checkBlock(
+      .sendTxAwait(
+          setAccountDetail(kAccount2,
+                           kAccount2Keypair,
+                           kAccount1,
+                           kAccountDetailKey,
+                           kAccountDetailValue),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(queryAccountDetail(kAccount1, kAccount1Keypair),
                  check_account_detail)

--- a/test/integration/acceptance/grant_permission_test.cpp
+++ b/test/integration/acceptance/grant_permission_test.cpp
@@ -273,6 +273,8 @@ TEST_F(GrantablePermissionsFixture, GrantWithoutGrantPermissions) {
         .checkVerifiedProposal([](auto &proposal) {
           ASSERT_EQ(proposal->transactions().size(), 0);
         })
+        .checkBlock(
+            [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
         .done();
   }
 }
@@ -303,5 +305,7 @@ TEST_F(GrantablePermissionsFixture, GrantMoreThanOnce) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -331,14 +331,11 @@ namespace grantables {
         .skipVerifiedProposal()
         .checkBlock(
             [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendTx(
+        .sendTxAwait(
             gpf::revokePermission(gpf::kAccount1,
                                   gpf::kAccount1Keypair,
                                   gpf::kAccount2,
-                                  this->grantable_type_.grantable_permission_))
-        .skipProposal()
-        .skipVerifiedProposal()
-        .checkBlock(
+                                  this->grantable_type_.grantable_permission_),
             // permission was successfully revoked
             [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
     auto last_check_tx = this->grantable_type_.testTransaction(*this);
@@ -355,6 +352,8 @@ namespace grantables {
         .checkProposal([](auto &proposal) {
           ASSERT_EQ(proposal->transactions().size(), 1);
         })
+        .skipVerifiedProposal()
+        .skipBlock()
         .getTxStatus(last_check_tx.hash(),
                      [](auto &status) {
                        auto message = status.errorMessage();

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -38,6 +38,8 @@ TEST_F(GrantablePermissionsFixture, RevokeFromNonExistingAccount) {
       .checkVerifiedProposal(
           // transaction is not stateful valid (kAccount2 does not exist)
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -75,6 +77,8 @@ TEST_F(GrantablePermissionsFixture, RevokeTwice) {
       .checkVerifiedProposal(
           // permission cannot be revoked twice
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -125,6 +129,8 @@ TEST_F(GrantablePermissionsFixture, DISABLED_RevokeWithoutPermission) {
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 1); })
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -78,6 +78,8 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -101,6 +103,8 @@ TEST_F(SubtractAssetQuantity, NoPermissions) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }
 
@@ -116,9 +120,7 @@ TEST_F(SubtractAssetQuantity, NegativeAmount) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(replenish())
-      .skipProposal()
-      .skipBlock()
+      .sendTxAwait(replenish(), [](auto &) {})
       .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "-1.0")),
               checkStatelessInvalid);
 }
@@ -135,9 +137,7 @@ TEST_F(SubtractAssetQuantity, ZeroAmount) {
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(replenish())
-      .skipProposal()
-      .skipBlock()
+      .sendTxAwait(replenish(), [](auto &) {})
       .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "0.0")),
               checkStatelessInvalid);
 }
@@ -155,13 +155,12 @@ TEST_F(SubtractAssetQuantity, NonexistentAsset) {
       .skipProposal()
       .skipVerifiedProposal()
       .skipBlock()
-      .sendTx(replenish())
-      .skipProposal()
-      .skipVerifiedProposal()
-      .skipBlock()
+      .sendTxAwait(replenish(), [](auto &) {})
       .sendTx(complete(baseTx().subtractAssetQuantity(nonexistent, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(
+          [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
       .done();
 }

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -123,6 +123,7 @@ TEST_F(TransferAsset, WithoutCanReceive) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 
@@ -137,11 +138,12 @@ TEST_F(TransferAsset, NonexistentDest) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser(), check(1))
       .sendTxAwait(addAssets(), check(1))
-      .sendTx(complete(
-          baseTx().transferAsset(kUserId, nonexistent, kAssetId, kDesc, kAmount)))
+      .sendTx(complete(baseTx().transferAsset(
+          kUserId, nonexistent, kAssetId, kDesc, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 
@@ -162,6 +164,7 @@ TEST_F(TransferAsset, NonexistentAsset) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 
@@ -277,6 +280,7 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -102,6 +102,7 @@ TEST_F(TransferAsset, WithoutCanTransfer) {
       .sendTx(makeTransfer())
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 
@@ -251,6 +252,7 @@ TEST_F(TransferAsset, MoreThanHas) {
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
+      .checkBlock(check(0))
       .done();
 }
 

--- a/test/integration/pipeline/CMakeLists.txt
+++ b/test/integration/pipeline/CMakeLists.txt
@@ -17,9 +17,7 @@
 
 addtest(pipeline_test pipeline_test.cpp)
 target_link_libraries(pipeline_test
-    integration_framework
-    shared_model_stateless_validation
-    shared_model_proto_builders
+    acceptance_fixture
     )
 
 addtest(batch_pipeline_test batch_pipeline_test.cpp)

--- a/test/integration/pipeline/batch_pipeline_test.cpp
+++ b/test/integration/pipeline/batch_pipeline_test.cpp
@@ -236,6 +236,9 @@ TEST_F(BatchPipelineTest, InvalidAtomicBatch) {
       })
       .checkVerifiedProposal([](const auto verified_proposal) {
         ASSERT_THAT(verified_proposal->transactions(), IsEmpty());
+      })
+      .checkBlock([](const auto block) {
+        ASSERT_THAT(block->transactions(), IsEmpty());
       });
 }
 

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -24,24 +24,69 @@
 #include "framework/batch_helper.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
-constexpr auto kAdmin = "admin@test";
-const shared_model::crypto::Keypair kAdminKeypair =
-    shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
+using ::testing::IsEmpty;
 
+class PipelineIntegrationTest : public AcceptanceFixture {
+ public:
+  /**
+   * prepares signed transaction with CreateDomain command
+   * @param domain_name name of the domain
+   * @return Transaction with CreateDomain command
+   */
+  auto prepareCreateDomainTransaction(std::string domain_name = "domain") {
+    return shared_model::proto::TransactionBuilder()
+        .createdTime(getUniqueTime())
+        .quorum(1)
+        .creatorAccountId(kAdminId)
+        .createDomain(domain_name, "user")
+        .build()
+        .signAndAddSignature(kAdminKeypair)
+        .finish();
+  }
+
+  /**
+   * prepares transaction sequence
+   * @param tx_size the size of transaction sequence
+   * @return  transaction sequence
+   */
+  auto prepareTransactionSequence(size_t tx_size) {
+    shared_model::interface::types::SharedTxsCollectionType txs;
+
+    for (size_t i = 0; i < tx_size; i++) {
+      auto &&tx = prepareCreateDomainTransaction(std::string("domain")
+                                                 + std::to_string(i));
+      txs.push_back(
+          std::make_shared<shared_model::proto::Transaction>(std::move(tx)));
+    }
+
+    auto tx_sequence_result =
+        shared_model::interface::TransactionSequence::createTransactionSequence(
+            txs,
+            shared_model::validation::DefaultSignedTransactionsValidator());
+
+    return framework::expected::val(tx_sequence_result).value().value;
+  }
+
+ protected:
+  const std::string kAdminId = "admin@test";
+  const shared_model::crypto::Keypair kAdminKeypair =
+      shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
+};
 /**
  * @given GetAccount query with non-existing user
  * AND default-initialized IntegrationTestFramework
  * @when query is sent to the framework
  * @then query response is ErrorResponse with STATEFUL_INVALID reason
  */
-TEST(PipelineIntegrationTest, SendQuery) {
+TEST_F(PipelineIntegrationTest, SendQuery) {
   auto query = shared_model::proto::QueryBuilder()
                    .createdTime(iroha::time::now())
-                   .creatorAccountId(kAdmin)
+                   .creatorAccountId(kAdminId)
                    .queryCounter(1)
-                   .getAccount(kAdmin)
+                   .getAccount(kAdminId)
                    .build()
                    .signAndAddSignature(
                        // TODO: 30/03/17 @l4l use keygen adapter IR-1189
@@ -62,28 +107,12 @@ TEST(PipelineIntegrationTest, SendQuery) {
 }
 
 /**
- * prepares signed transaction with CreateDomain command
- * @param domain_name name of the domain
- * @return Transaction with CreateDomain command
- */
-auto prepareCreateDomainTransaction(std::string domain_name = "domain") {
-  return shared_model::proto::TransactionBuilder()
-      .createdTime(iroha::time::now())
-      .quorum(1)
-      .creatorAccountId(kAdmin)
-      .createDomain(domain_name, "user")
-      .build()
-      .signAndAddSignature(kAdminKeypair)
-      .finish();
-}
-
-/**
  * @given some user
  * @when sending sample CreateDomain transaction to the ledger
  * @then receive STATELESS_VALIDATION_SUCCESS status on that tx AND
  * tx is committed, thus non-empty verified proposal
  */
-TEST(PipelineIntegrationTest, SendTx) {
+TEST_F(PipelineIntegrationTest, SendTx) {
   auto tx = prepareCreateDomainTransaction();
 
   auto check_stateless_valid = [](auto &status) {
@@ -114,35 +143,13 @@ TEST(PipelineIntegrationTest, SendTx) {
 }
 
 /**
- * prepares transaction sequence
- * @param tx_size the size of transaction sequence
- * @return  transaction sequence
- */
-auto prepareTransactionSequence(size_t tx_size) {
-  shared_model::interface::types::SharedTxsCollectionType txs;
-
-  for (size_t i = 0; i < tx_size; i++) {
-    auto &&tx = prepareCreateDomainTransaction(std::string("domain")
-                                               + std::to_string(i));
-    txs.push_back(
-        std::make_shared<shared_model::proto::Transaction>(std::move(tx)));
-  }
-
-  auto tx_sequence_result =
-      shared_model::interface::TransactionSequence::createTransactionSequence(
-          txs, shared_model::validation::DefaultSignedTransactionsValidator());
-
-  return framework::expected::val(tx_sequence_result).value().value;
-}
-
-/**
  * @given some user
  * @when sending sample create domain transactions to the ledger
  * @then receive STATELESS_VALIDATION_SUCCESS status on that transactions,
  * all transactions are passed to proposal and appear in verified proposal and
  * block
  */
-TEST(PipelineIntegrationTest, SendTxSequence) {
+TEST_F(PipelineIntegrationTest, SendTxSequence) {
   size_t tx_size = 5;
   const auto &tx_sequence = prepareTransactionSequence(tx_size);
 
@@ -180,7 +187,7 @@ TEST(PipelineIntegrationTest, SendTxSequence) {
  * ledger using sendTxSequence await method
  * @then all transactions appear in the block
  */
-TEST(PipelineIntegrationTest, SendTxSequenceAwait) {
+TEST_F(PipelineIntegrationTest, SendTxSequenceAwait) {
   size_t tx_size = 5;
   const auto &tx_sequence = prepareTransactionSequence(tx_size);
 
@@ -192,4 +199,34 @@ TEST(PipelineIntegrationTest, SendTxSequenceAwait) {
       .setInitialState(kAdminKeypair)
       .sendTxSequenceAwait(tx_sequence, check_block)
       .done();
+}
+
+/**
+ * Check that after no transactions were committed we are able to send and apply
+ * new transactions
+ *
+ * @given createFirstDomain and createSecondDomain transactions
+ * @when first domain is created second time
+ * @then block with no transactions is created @and after that
+ * createSecondDomain transaction can be executed and applied
+ */
+TEST_F(PipelineIntegrationTest, SuccessfulCommitAfterEmptyBlock) {
+  auto createFirstDomain = [this] {
+    return prepareCreateDomainTransaction("domain1");
+  };
+  auto createSecondDomain = [this] {
+    return prepareCreateDomainTransaction("domain2");
+  };
+
+  integration_framework::IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTxAwait(
+          createFirstDomain(),
+          [](const auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendTxAwait(
+          createFirstDomain(),
+          [](const auto &block) { ASSERT_EQ(block->transactions().size(), 0); })
+      .sendTxAwait(createSecondDomain(), [](const auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1);
+      });
 }

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -27,8 +27,6 @@
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
-using ::testing::IsEmpty;
-
 class PipelineIntegrationTest : public AcceptanceFixture {
  public:
   /**
@@ -207,8 +205,8 @@ TEST_F(PipelineIntegrationTest, SendTxSequenceAwait) {
  *
  * @given createFirstDomain and createSecondDomain transactions
  * @when first domain is created second time
- * @then block with no transactions is created @and after that
- * createSecondDomain transaction can be executed and applied
+ * @then block with no transactions is created
+ * AND after that createSecondDomain transaction can be executed and applied
  */
 TEST_F(PipelineIntegrationTest, SuccessfulCommitAfterEmptyBlock) {
   auto createFirstDomain = [this] {

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -126,9 +126,7 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
 
   // make blocks
   EXPECT_CALL(*block_creator, on_block())
-      .WillOnce(Return(
-          rxcpp::observable<>::just<shared_model::interface::BlockVariant>(
-              expected_block)));
+      .WillOnce(Return(rxcpp::observable<>::just(expected_block)));
 
   init();
 
@@ -179,9 +177,7 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
 
   // make blocks
   EXPECT_CALL(*block_creator, on_block())
-      .WillOnce(Return(
-          rxcpp::observable<>::just<shared_model::interface::BlockVariant>(
-              expected_block)));
+      .WillOnce(Return(rxcpp::observable<>::just(expected_block)));
 
   init();
 }
@@ -194,9 +190,7 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
 TEST_F(YacGateTest, LoadBlockWhenDifferentCommit) {
   // make blocks
   EXPECT_CALL(*block_creator, on_block())
-      .WillOnce(Return(
-          rxcpp::observable<>::just<shared_model::interface::BlockVariant>(
-              expected_block)));
+      .WillOnce(Return(rxcpp::observable<>::just(expected_block)));
 
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
@@ -246,7 +240,7 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommit) {
   auto sig = actual_block->signatures().begin();
   auto &pubkey = sig->publicKey();
   EXPECT_CALL(*block_loader, retrieveBlock(pubkey, actual_block->hash()))
-      .WillOnce(Return(shared_model::interface::BlockVariant{actual_block}));
+      .WillOnce(Return(actual_block));
 
   init();
 
@@ -294,9 +288,7 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommitFailFirst) {
 
   // make blocks
   EXPECT_CALL(*block_creator, on_block())
-      .WillOnce(Return(
-          rxcpp::observable<>::just<shared_model::interface::BlockVariant>(
-              expected_block)));
+      .WillOnce(Return(rxcpp::observable<>::just(expected_block)));
 
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
@@ -327,7 +319,7 @@ TEST_F(YacGateTest, LoadBlockWhenDifferentCommitFailFirst) {
   auto &pubkey = sig->publicKey();
   EXPECT_CALL(*block_loader, retrieveBlock(pubkey, expected_block->hash()))
       .WillOnce(Return(boost::none))
-      .WillOnce(Return(shared_model::interface::BlockVariant{expected_block}));
+      .WillOnce(Return(expected_block));
 
   init();
 

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -64,10 +64,11 @@ namespace iroha {
           retrieveBlocks,
           rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>(
               const shared_model::crypto::PublicKey &));
-      MOCK_METHOD2(retrieveBlock,
-                   boost::optional<shared_model::interface::BlockVariant>(
-                       const shared_model::crypto::PublicKey &,
-                       const shared_model::interface::types::HashType &));
+      MOCK_METHOD2(
+          retrieveBlock,
+          boost::optional<std::shared_ptr<shared_model::interface::Block>>(
+              const shared_model::crypto::PublicKey &,
+              const shared_model::interface::types::HashType &));
     };
 
     class MockOrderingGate : public OrderingGate {

--- a/test/module/irohad/simulator/simulator_mocks.hpp
+++ b/test/module/irohad/simulator/simulator_mocks.hpp
@@ -27,8 +27,9 @@ namespace iroha {
      public:
       MOCK_METHOD1(process_verified_proposal,
                    void(const shared_model::interface::Proposal &));
-      MOCK_METHOD0(on_block,
-                   rxcpp::observable<shared_model::interface::BlockVariant>());
+      MOCK_METHOD0(
+          on_block,
+          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>());
     };
   }  // namespace simulator
 }  // namespace iroha

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -167,15 +167,9 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
 
   auto block_wrapper =
       make_test_subscriber<CallExact>(simulator->on_block(), 1);
-  block_wrapper.subscribe([&proposal](const auto &block_variant) {
-    ASSERT_EQ(block_variant.height(), proposal->height());
-    ASSERT_NO_THROW({
-      auto block = boost::apply_visitor(
-          framework::SpecifiedVisitor<
-              std::shared_ptr<shared_model::interface::Block>>(),
-          block_variant);
-      ASSERT_EQ(block->transactions(), proposal->transactions());
-    });
+  block_wrapper.subscribe([&proposal](const auto block) {
+    ASSERT_EQ(block->height(), proposal->height());
+    ASSERT_EQ(block->transactions(), proposal->transactions());
   });
 
   simulator->process_proposal(*proposal);

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -151,7 +151,7 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
                        std::shared_ptr<shared_model::interface::Proposal>>()));
 
   EXPECT_CALL(*shared_model::crypto::crypto_signer_expecter,
-              sign(A<shared_model::interface::BlockVariant &>()))
+              sign(A<shared_model::interface::Block &>()))
       .Times(1);
 
   init();
@@ -305,7 +305,7 @@ TEST_F(SimulatorTest, RightNumberOfFailedTxs) {
                        std::shared_ptr<shared_model::interface::Proposal>>()));
 
   EXPECT_CALL(*shared_model::crypto::crypto_signer_expecter,
-              sign(A<shared_model::interface::BlockVariant &>()))
+              sign(A<shared_model::interface::Block &>()))
       .Times(1);
 
   init();

--- a/test/module/shared_model/backend_proto/proto_block_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_block_factory_test.cpp
@@ -39,11 +39,7 @@ TEST_F(ProtoBlockFactoryTest, UnsafeBlockCreation) {
   std::vector<shared_model::proto::Transaction> txs;
   txs.emplace_back(iroha::protocol::Transaction{});
 
-  auto block_variant =
-      factory->unsafeCreateBlock(height, prev_hash, created_time, txs);
-
-  auto block = boost::get<std::shared_ptr<shared_model::interface::Block>>(
-      block_variant);
+  auto block = factory->unsafeCreateBlock(height, prev_hash, created_time, txs);
 
   ASSERT_EQ(block->height(), height);
   ASSERT_EQ(block->createdTime(), created_time);

--- a/test/module/shared_model/cryptography/crypto_model_signer_mock.hpp
+++ b/test/module/shared_model/cryptography/crypto_model_signer_mock.hpp
@@ -56,22 +56,22 @@ namespace shared_model {
 
     template <>
     template <>
-    void CryptoModelSigner<>::sign<shared_model::proto::Block>(
-        shared_model::proto::Block &signable) const noexcept {
+    void CryptoModelSigner<>::sign<shared_model::interface::Block>(
+        shared_model::interface::Block &signable) const noexcept {
       crypto_signer_expecter->sign(signable);
     }
 
     template <>
     template <>
-    void CryptoModelSigner<>::sign<shared_model::proto::Query>(
-        shared_model::proto::Query &signable) const noexcept {
+    void CryptoModelSigner<>::sign<shared_model::interface::Query>(
+        shared_model::interface::Query &signable) const noexcept {
       crypto_signer_expecter->sign(signable);
     }
 
     template <>
     template <>
-    void CryptoModelSigner<>::sign<shared_model::proto::Transaction>(
-        shared_model::proto::Transaction &signable) const noexcept {
+    void CryptoModelSigner<>::sign<shared_model::interface::Transaction>(
+        shared_model::interface::Transaction &signable) const noexcept {
       crypto_signer_expecter->sign(signable);
     }
 

--- a/test/module/shared_model/validators/validators.hpp
+++ b/test/module/shared_model/validators/validators.hpp
@@ -40,7 +40,7 @@ namespace shared_model {
     class MockBlockValidator
         : public AbstractValidator<interface::BlockVariant> {
      public:
-      MOCK_METHOD1(validate, Answer(const interface::BlockVariant &));
+      MOCK_CONST_METHOD1(validate, Answer(const interface::BlockVariant &));
     };
 
   }  // namespace validation

--- a/test/module/shared_model/validators/validators.hpp
+++ b/test/module/shared_model/validators/validators.hpp
@@ -37,10 +37,9 @@ namespace shared_model {
       }
     };
 
-    class MockBlockValidator
-        : public AbstractValidator<interface::BlockVariant> {
+    class MockBlockValidator : public AbstractValidator<interface::Block> {
      public:
-      MOCK_CONST_METHOD1(validate, Answer(const interface::BlockVariant &));
+      MOCK_CONST_METHOD1(validate, Answer(const interface::Block &));
     };
 
   }  // namespace validation

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -63,7 +63,9 @@ TEST(RegressionTest, SequentialInitialization) {
         .skipProposal()
         .checkVerifiedProposal([](auto &proposal) {
           ASSERT_EQ(proposal->transactions().size(), 0);
-        });
+        })
+        .checkBlock(
+            [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
   }
   {
     integration_framework::IntegrationTestFramework(1, dbname)
@@ -73,6 +75,8 @@ TEST(RegressionTest, SequentialInitialization) {
         .checkVerifiedProposal([](auto &proposal) {
           ASSERT_EQ(proposal->transactions().size(), 0);
         })
+        .checkBlock(
+            [](auto block) { ASSERT_EQ(block->transactions().size(), 0); })
         .done();
   }
 }
@@ -131,24 +135,17 @@ TEST(RegressionTest, StateRecovery) {
 
   {
     integration_framework::IntegrationTestFramework(
-        1,
-        dbname,
-        [](auto &) {},
-        false,
-        path)
+        1, dbname, [](auto &) {}, false, path)
         .setInitialState(kAdminKeypair)
         .sendTx(tx)
         .checkProposal(checkOne)
+        .checkVerifiedProposal(checkOne)
         .checkBlock(checkOne)
         .sendQuery(makeQuery(1, kAdminKeypair), checkQuery);
   }
   {
     integration_framework::IntegrationTestFramework(
-        1,
-        dbname,
-        [](auto &itf) { itf.done(); },
-        false,
-        path)
+        1, dbname, [](auto &itf) { itf.done(); }, false, path)
         .recoverState(kAdminKeypair)
         .sendQuery(makeQuery(2, kAdminKeypair), checkQuery)
         .done();


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR fixes a bug of failure of transactions commitment after the situation where simulator returns empty block. Also this is the first step of removing empty block entity from the iroha

Now simulator always produces Block instead of BlockVariant

### Benefits

Now we can execute transactions after empty block

### Possible Drawbacks 

None

### Usage Examples or Tests

New test checking successful commitment was added to pipeline test