### PR TITLE
Add test for running Iroha with --overwrite-ledger flag

### DIFF
--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -63,9 +63,34 @@ class IrohadTest : public AcceptanceFixture {
   }
 
   void launchIroha() {
-    iroha_process_.emplace(irohad_executable.string() + setDefaultParams());
+    launchIroha(setDefaultParams());
+  }
+
+  void launchIroha(std::string parameters) {
+    iroha_process_.emplace(irohad_executable.string() + parameters);
     std::this_thread::sleep_for(kTimeout);
     ASSERT_TRUE(iroha_process_->running());
+  }
+
+  void launchIroha(const boost::optional<std::string> &config_path,
+                   const boost::optional<std::string> &genesis_block,
+                   const boost::optional<std::string> &keypair_path,
+                   const boost::optional<std::string> &additional_params) {
+    launchIroha(
+        params(config_path, genesis_block, keypair_path, additional_params));
+  }
+
+  int getBlockCount() {
+    int block_count = 0;
+
+    for (directory_iterator itr(blockstore_path_); itr != directory_iterator();
+         ++itr) {
+      if (is_regular_file(itr->path())) {
+        ++block_count;
+      }
+    }
+
+    return block_count;
   }
 
   void TearDown() override {
@@ -80,16 +105,49 @@ class IrohadTest : public AcceptanceFixture {
 
   std::string params(const boost::optional<std::string> &config_path,
                      const boost::optional<std::string> &genesis_block,
-                     const boost::optional<std::string> &keypair_path) {
+                     const boost::optional<std::string> &keypair_path,
+                     const boost::optional<std::string> &additional_params) {
     std::string res;
     config_path | [&res](auto &&s) { res += " --config " + s; };
     genesis_block | [&res](auto &&s) { res += " --genesis_block " + s; };
     keypair_path | [&res](auto &&s) { res += " --keypair_name " + s; };
+    additional_params | [&res](auto &&s) { res += " " + s; };
     return res;
   }
 
   std::string setDefaultParams() {
-    return params(config_copy_, path_genesis_.string(), path_keypair_.string());
+    return params(
+        config_copy_, path_genesis_.string(), path_keypair_.string(), {});
+  }
+
+  iroha::protocol::ToriiResponse sendDefaultTx(
+      boost::optional<shared_model::crypto::Keypair> key_pair) {
+    iroha::protocol::TxStatusRequest tx_request;
+    iroha::protocol::ToriiResponse torii_response;
+
+    auto tx = complete(baseTx(kAdminId).setAccountQuorum(kAdminId, 1),
+                       key_pair.get());
+    tx_request.set_tx_hash(shared_model::crypto::toBinaryString(tx.hash()));
+
+    auto client = torii::CommandSyncClient(kAddress, kPort);
+    client.Torii(tx.getTransport());
+
+    auto resub_counter(resubscribe_attempts);
+    const auto committed_status = iroha::protocol::TxStatus::COMMITTED;
+    do {
+      std::this_thread::sleep_for(resubscribe_timeout);
+      client.Status(tx_request, torii_response);
+    } while (torii_response.tx_status() != committed_status
+             and --resub_counter);
+
+    return torii_response;
+  }
+
+  void sendDefaultTxAndCheck(
+      boost::optional<shared_model::crypto::Keypair> key_pair) {
+    iroha::protocol::ToriiResponse torii_response;
+    torii_response = sendDefaultTx(key_pair);
+    ASSERT_EQ(torii_response.tx_status(), iroha::protocol::TxStatus::COMMITTED);
   }
 
  private:
@@ -176,28 +234,13 @@ TEST_F(IrohadTest, RunIrohad) {
  */
 TEST_F(IrohadTest, SendTx) {
   launchIroha();
+
   auto key_manager = iroha::KeysManagerImpl(kAdminId, path_example_);
   auto key_pair = key_manager.loadKeys();
   ASSERT_TRUE(key_pair);
 
-  iroha::protocol::TxStatusRequest tx_request;
-  iroha::protocol::ToriiResponse torii_response;
-
-  auto tx =
-      complete(baseTx(kAdminId).setAccountQuorum(kAdminId, 1), key_pair.get());
-  tx_request.set_tx_hash(shared_model::crypto::toBinaryString(tx.hash()));
-
-  auto client = torii::CommandSyncClient(kAddress, kPort);
-  client.Torii(tx.getTransport());
-
-  auto resub_counter(resubscribe_attempts);
-  const auto committed_status = iroha::protocol::TxStatus::COMMITTED;
-  do {
-    std::this_thread::sleep_for(resubscribe_timeout);
-    client.Status(tx_request, torii_response);
-  } while (torii_response.tx_status() != committed_status and --resub_counter);
-
-  ASSERT_EQ(torii_response.tx_status(), committed_status);
+  SCOPED_TRACE("From send transaction test");
+  sendDefaultTxAndCheck(key_pair);
 }
 
 /**
@@ -223,4 +266,64 @@ TEST_F(IrohadTest, SendQuery) {
         framework::SpecifiedVisitor<shared_model::interface::RolesResponse>(),
         resp.get());
   });
+}
+
+/**
+ * Test verifies that after restarting Iroha with --overwrite-ledger flag there
+ * will be only one block in blockstorage
+ * @given running Iroha with some transactions in storage
+ * @when Iroha is shutdown and restarted with --overwrite-ledger flag
+ * @then blockstorage should have height equal to 1 block and can commit
+ * transactions
+ */
+TEST_F(IrohadTest, RestartWithOverwriteLedger) {
+  launchIroha();
+
+  auto key_manager = iroha::KeysManagerImpl(kAdminId, path_example_);
+  auto key_pair = key_manager.loadKeys();
+  ASSERT_TRUE(key_pair);
+
+  SCOPED_TRACE("From restart with --overwrite-ledger flag test");
+  sendDefaultTxAndCheck(key_pair);
+
+  iroha_process_->terminate();
+
+  launchIroha(config_copy_,
+              path_genesis_.string(),
+              path_keypair_.string(),
+              std::string("--overwrite-ledger"));
+
+  ASSERT_EQ(getBlockCount(), 1);
+
+  SCOPED_TRACE("From restart with --overwrite-ledger flag test");
+  sendDefaultTxAndCheck(key_pair);
+}
+
+/**
+ * Test verifies that after common restart of Iroha it will keep height
+ * @given running Iroha with some transactions in storage
+ * @when Iroha is restarted without reinitializing blockchain
+ * @then height of blockchain should be equal to the height before restart and
+ * Iroha should commit transactions
+ */
+TEST_F(IrohadTest, RestartWithoutResetting) {
+  launchIroha();
+
+  auto key_manager = iroha::KeysManagerImpl(kAdminId, path_example_);
+  auto key_pair = key_manager.loadKeys();
+  ASSERT_TRUE(key_pair);
+
+  SCOPED_TRACE("From restart without resetting test");
+  sendDefaultTxAndCheck(key_pair);
+
+  int height = getBlockCount();
+
+  iroha_process_->terminate();
+
+  launchIroha(config_copy_, {}, path_keypair_.string(), {});
+
+  ASSERT_EQ(getBlockCount(), height);
+
+  SCOPED_TRACE("From restart without resetting test");
+  sendDefaultTxAndCheck(key_pair);
 }

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -66,7 +66,7 @@ class IrohadTest : public AcceptanceFixture {
     launchIroha(setDefaultParams());
   }
 
-  void launchIroha(std::string parameters) {
+  void launchIroha(const std::string &parameters) {
     iroha_process_.emplace(irohad_executable.string() + parameters);
     std::this_thread::sleep_for(kTimeout);
     ASSERT_TRUE(iroha_process_->running());


### PR DESCRIPTION
Signed-off-by: Vadim Reutskiy <reutskiy@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Added two tests:
1. Test, which starts Iroha, adds transaction, restarts with --overwrite-ledger flags and checks that there is only one block in blockstorage and Iroha still can add transactions.
2. Test, which starts Iroha, adds transaction, restarts Iroha checks that amount of blocks in blockstorage is the same as before restart and Iroha still can add transactions.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Now system tests can check correctness of restarting Iroha both with keeping blocks in blockstorage and with wiping all data and rewriting ledger from the beginning.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
Target: irohad_test
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->