### PR TITLE
Add tests for GetRolePermissions query

### DIFF
--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -135,3 +135,10 @@ addtest(get_asset_info_test
 target_link_libraries(get_asset_info_test
     acceptance_fixture
     )
+
+addtest(get_role_permissions_test
+    get_role_permissions_test.cpp
+    )
+target_link_libraries(get_role_permissions_test
+    acceptance_fixture
+    )

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "backend/protobuf/transaction.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/specified_visitor.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/permissions.hpp"
+
+using namespace integration_framework;
+using namespace shared_model;
+
+TEST_F(AcceptanceFixture, CanGetRolePermissions) {
+  auto checkQuery = [](auto &queryResponse) {
+    ASSERT_NO_THROW(boost::apply_visitor(
+        framework::SpecifiedVisitor<
+            shared_model::interface::RolePermissionsResponse>(),
+        queryResponse.get()));
+  };
+
+  auto query = complete(baseQry().getRolePermissions(kRole));
+
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms(
+          {shared_model::interface::permissions::Role::kGetRoles}))
+      .skipProposal()
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(boost::size(block->transactions()), 1); })
+      .sendQuery(query, checkQuery);
+}
+
+TEST_F(AcceptanceFixture, CanNotGetRolePermissions) {
+  auto checkQuery = [](auto &queryResponse) {
+    ASSERT_NO_THROW({
+      boost::apply_visitor(
+          framework::SpecifiedVisitor<
+              shared_model::interface::StatefulFailedErrorResponse>(),
+          boost::apply_visitor(
+              framework::SpecifiedVisitor<
+                  shared_model::interface::ErrorQueryResponse>(),
+              queryResponse.get())
+              .get());
+    });
+  };
+
+  auto query = complete(baseQry().getRolePermissions(kRole));
+
+  IntegrationTestFramework(1)
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms({}))
+      .skipProposal()
+      .checkVerifiedProposal(
+          [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 1); })
+      .checkBlock(
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(query, checkQuery);
+}

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -51,7 +51,7 @@ TEST_F(AcceptanceFixture, CanNotGetRolePermissions) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeUserWithPerms({}),
-          [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 1); })
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(query,
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -14,17 +14,17 @@ using namespace integration_framework;
 using namespace shared_model;
 
 /**
- * Get role permissions by user with allowed GetRoles permission
- * @given user with kGetRoles permission
- * @when user send query with getRolePermissions request
+ * C369 Get role permissions by user with allowed GetRoles permission
+ * @given a user with kGetRoles permission
+ * @when the user send query with getRolePermissions request
  * @then there is a valid RolePermissionsResponse
  */
 TEST_F(AcceptanceFixture, CanGetRolePermissions) {
-  auto checkQuery = [](auto &queryResponse) {
+  auto check_query = [](auto &query_response) {
     ASSERT_NO_THROW(boost::apply_visitor(
         framework::SpecifiedVisitor<
             shared_model::interface::RolePermissionsResponse>(),
-        queryResponse.get()));
+        query_response.get()));
   };
 
   auto query = complete(baseQry().getRolePermissions(kRole));
@@ -34,14 +34,14 @@ TEST_F(AcceptanceFixture, CanGetRolePermissions) {
       .sendTxAwait(
           makeUserWithPerms(
               {shared_model::interface::permissions::Role::kGetRoles}),
-          [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 1); })
-      .sendQuery(query, checkQuery);
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(query, check_query);
 }
 
 /**
- * Get role permissions without allowed GetRoles permission
- * @given user without kGetRoles permission
- * @when user send query with getRolePermissions request
+ * C370 Get role permissions without allowed GetRoles permission
+ * @given a user without kGetRoles permission
+ * @when the user send query with getRolePermissions request
  * @then query should be recognized as stateful invalid
  */
 TEST_F(AcceptanceFixture, CanNotGetRolePermissions) {

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -17,7 +17,7 @@ using namespace shared_model;
  * Get role permissions by user with allowed GetRoles permission
  * @given user with kGetRoles permission
  * @when user send query with getRolePermissions request
- * @then Iroha should
+ * @then there is a valid RolePermissionsResponse
  */
 TEST_F(AcceptanceFixture, CanGetRolePermissions) {
   auto checkQuery = [](auto &queryResponse) {


### PR DESCRIPTION
Signed-off-by: Vadim Reutskiy reutskiy@soramitsu.co.jp

### Description of the Change
Add two tests:
1. For successful query of role permissions for user with GetRoles permission 
2. For unsuccessful query of role permissions for user without GetRoles permission 

### Benefits
GetRolePermissions query is covered by tests

### Possible Drawbacks 
None

### Usage Examples or Tests
Target: get_role_permissions_test
