### PR TITLE
Fix compiling errors on clang

### DIFF
--- a/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
+++ b/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
@@ -43,7 +43,7 @@ namespace iroha {
                       auto range = boost::irange(0u, amount);
                       // push until find empty element
                       std::find_if_not(
-                          range.begin(), range.end(), [this, &vec](auto) {
+                          range.begin(), range.end(), [this, &vec](int) {
                             return this->visit() | [&vec](auto e) -> bool {
                               vec.push_back(e);
                               return true;  // proceed

--- a/shared_model/validators/signable_validator.hpp
+++ b/shared_model/validators/signable_validator.hpp
@@ -35,14 +35,13 @@ namespace shared_model {
 
       Answer validate(const Model &model,
                       interface::types::TimestampType current_timestamp) const {
-        return validateImpl(
-            model, [this, current_timestamp](const auto &model) {
-              return ModelValidator::validate(model, current_timestamp);
-            });
+        return validateImpl(model, [&, current_timestamp](const auto &model) {
+          return ModelValidator::validate(model, current_timestamp);
+        });
       }
 
       Answer validate(const Model &model) const {
-        return validateImpl(model, [this](const auto &model) {
+        return validateImpl(model, [&](const auto &model) {
           return ModelValidator::validate(model);
         });
       }

--- a/shared_model/validators/signable_validator.hpp
+++ b/shared_model/validators/signable_validator.hpp
@@ -35,15 +35,15 @@ namespace shared_model {
 
       Answer validate(const Model &model,
                       interface::types::TimestampType current_timestamp) const {
-        return validateImpl(model, [&, current_timestamp](const auto &model) {
-          return ModelValidator::validate(model, current_timestamp);
-        });
+        auto f = [&, current_timestamp](const Model &m) {
+          return ModelValidator::validate(m, current_timestamp);
+        };
+        return validateImpl(model, f);
       }
 
       Answer validate(const Model &model) const {
-        return validateImpl(model, [&](const auto &model) {
-          return ModelValidator::validate(model);
-        });
+        auto f = [&](const Model &m) { return ModelValidator::validate(m); };
+        return validateImpl(model, f);
       }
 
      private:

--- a/shared_model/validators/signable_validator.hpp
+++ b/shared_model/validators/signable_validator.hpp
@@ -35,15 +35,14 @@ namespace shared_model {
 
       Answer validate(const Model &model,
                       interface::types::TimestampType current_timestamp) const {
-        auto f = [&, current_timestamp](const Model &m) {
+        return validateImpl(model, [&, current_timestamp](const Model &m) {
           return ModelValidator::validate(m, current_timestamp);
-        };
-        return validateImpl(model, f);
+        });
       }
 
       Answer validate(const Model &model) const {
-        auto f = [&](const Model &m) { return ModelValidator::validate(m); };
-        return validateImpl(model, f);
+        return validateImpl(
+            model, [&](const Model &m) { return ModelValidator::validate(m); });
       }
 
      private:


### PR DESCRIPTION
### Description of the Change

`this` capture in `SignableValidator`, since it required in only half of the cases. <s>The second is related to gtest specific issue. That was noticed earlier by @kamilsa </s>

**upd:** seems our current compiler cannot deal with that -_- we need to discuss workarounds
**upd2:** it seems gtest 1.8 isn't compatible for now

### Benefits

clang finishes compilation successfully 

### Possible Drawbacks 

None
