### PR TITLE
Return set in MstState::getBatch

### DIFF
--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -44,30 +44,24 @@ namespace iroha {
   }
 
   bool MstState::operator==(const MstState &rhs) const {
-    const auto &lhs_batches = getBatches();
-    const auto &rhs_batches = rhs.getBatches();
-
-    return std::equal(lhs_batches.begin(),
-                      lhs_batches.end(),
-                      rhs_batches.begin(),
-                      rhs_batches.end(),
-                      [](const auto &l, const auto &r) { return *l == *r; });
+    return std::find_if(internal_state_.begin(),
+                        internal_state_.end(),
+                        [&rhs](auto &i) {
+                          return rhs.internal_state_.find(i)
+                              != rhs.internal_state_.end();
+                        })
+        != internal_state_.end();
   }
 
   bool MstState::isEmpty() const {
     return internal_state_.empty();
   }
 
-  std::vector<DataType> MstState::getBatches() const {
-    std::vector<DataType> result(internal_state_.begin(),
-                                 internal_state_.end());
-    // sorting is provided for clear comparison of states
-    // TODO: 15/08/2018 @muratovv Rework return type with set IR-1621
-    std::sort(
-        result.begin(), result.end(), [](const auto &left, const auto &right) {
-          return left->reducedHash().hex() < right->reducedHash().hex();
-        });
-    return result;
+  std::unordered_set<DataType,
+                     iroha::model::PointerBatchHasher<DataType>,
+                     BatchHashEquality>
+  MstState::getBatches() const {
+    return {internal_state_.begin(), internal_state_.end()};
   }
 
   MstState MstState::eraseByTime(const TimeType &time) {

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -126,7 +126,10 @@ namespace iroha {
     /**
      * @return the batches from the state
      */
-    std::vector<DataType> getBatches() const;
+    std::unordered_set<DataType,
+                       iroha::model::PointerBatchHasher<DataType>,
+                       BatchHashEquality>
+    getBatches() const;
 
     /**
      * Erase expired batches

--- a/test/module/irohad/multi_sig_transactions/state_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/state_test.cpp
@@ -25,7 +25,7 @@ TEST(StateTest, CreateState) {
       makeTestBatch(txBuilder(1)), 0, makeSignature("1", "pub_key_1"));
   state += tx;
   ASSERT_EQ(1, state.getBatches().size());
-  ASSERT_EQ(*tx, *state.getBatches().at(0));
+  ASSERT_EQ(*tx, **state.getBatches().begin());
 }
 
 /**
@@ -49,7 +49,7 @@ TEST(StateTest, UpdateExistingState) {
   ASSERT_EQ(1, state.getBatches().size());
 
   auto merged_tx = addSignatures(base_tx, 0, first_signature, second_signature);
-  ASSERT_EQ(*merged_tx, *state.getBatches().at(0));
+  ASSERT_EQ(*merged_tx, **state.getBatches().begin());
 }
 
 /**
@@ -201,7 +201,7 @@ TEST(StateTest, DifferenceTest) {
   MstState diff = state1 - state2;
   ASSERT_EQ(1, diff.getBatches().size());
   auto expected_batch = addSignatures(common_batch, 0, first_signature);
-  ASSERT_EQ(*expected_batch, *diff.getBatches().at(0));
+  ASSERT_EQ(*expected_batch, **diff.getBatches().begin());
 }
 
 /**
@@ -231,8 +231,7 @@ TEST(StateTest, UpdateTxUntillQuorum) {
       makeTestBatch(txBuilder(1, time, quorum)), 0, makeSignature("3", "3"));
   ASSERT_EQ(0, state_after_three_txes.updated_state_->getBatches().size());
   ASSERT_EQ(1, state_after_three_txes.completed_state_->getBatches().size());
-  ASSERT_TRUE(state_after_three_txes.completed_state_->getBatches()
-                  .front()
+  ASSERT_TRUE((*state_after_three_txes.completed_state_->getBatches().begin())
                   ->hasAllSignatures());
   ASSERT_EQ(0, state.getBatches().size());
 }
@@ -304,7 +303,7 @@ TEST(StateTest, TimeIndexInsertionByTx) {
 
   auto expired_state = state.eraseByTime(time + 1);
   ASSERT_EQ(1, expired_state.getBatches().size());
-  ASSERT_EQ(*prepared_batch, *expired_state.getBatches().at(0));
+  ASSERT_EQ(*prepared_batch, **expired_state.getBatches().begin());
   ASSERT_EQ(0, state.getBatches().size());
 }
 

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -49,7 +49,7 @@ TEST_F(PendingTxsStorageFixture, FixutureSelfCheck) {
 
   *state += transactions;
   ASSERT_EQ(state->getBatches().size(), 1) << "Failed to prepare MST state";
-  ASSERT_EQ(state->getBatches().front()->transactions().size(), 2)
+  ASSERT_EQ((*state->getBatches().begin())->transactions().size(), 2)
       << "Test batch contains wrong amount of transactions";
 }
 


### PR DESCRIPTION
### Description of the Change

MstState::getBatch now returns `std::unordered_set`

### Benefits

Probably quite faster, since there's no need in sorting now.

### Possible Drawbacks 

None?
