### PR TITLE
Add more acceptance tests for SetAccountDetail

### DIFF
--- a/test/integration/acceptance/set_account_detail_test.cpp
+++ b/test/integration/acceptance/set_account_detail_test.cpp
@@ -52,7 +52,7 @@ class SetAccountDetail : public AcceptanceFixture {
  * C274
  * @given a user without can_set_detail permission
  * @when execute tx with SetAccountDetail command aimed to the user
- * @then there is the tx in proposal
+ * @then there is the tx in block
  */
 TEST_F(SetAccountDetail, Self) {
   IntegrationTestFramework(1)
@@ -69,16 +69,17 @@ TEST_F(SetAccountDetail, Self) {
  * C273
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with inexistent user
- * @then there is no tx in proposal
+ * @then there is no tx in block
  */
 TEST_F(SetAccountDetail, NonExistentUser) {
+  const std::string kInexistent = "inexistent@" + kDomain;
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms({interface::permissions::Role::kSetDetail}))
       .skipProposal()
       .skipBlock()
       .sendTxAwait(
-          complete(baseTx("inexistent@" + kDomain, kKey, kValue)),
+          complete(baseTx(kInexistent, kKey, kValue)),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 0); });
 }
 
@@ -112,7 +113,7 @@ TEST_F(SetAccountDetail, WithoutNoPerm) {
 /**
  * @given a pair of users and first one with can_set_detail perm
  * @when the first one tries to use SetAccountDetail on the second
- * @then there is the tx in proposal
+ * @then there is the tx in block
  */
 TEST_F(SetAccountDetail, WithPerm) {
   auto second_user_tx = makeSecondUser();
@@ -172,64 +173,69 @@ TEST_F(SetAccountDetail, WithGrantablePerm) {
  * C276
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with max key
- * @then there is no tx in proposal
+ * @then there is the tx in block
  */
-TEST_F(SetAccountDetail, HugeKey) {
+TEST_F(SetAccountDetail, BigPossibleKey) {
+  const std::string kBigKey = std::string(64, 'a');
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTxAwait(
-          complete(baseTx(kUserId, std::string(64, 'a'), kValue)),
-          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+      .sendTxAwait(complete(baseTx(kUserId, kBigKey, kValue)), [](auto &block) {
+        ASSERT_EQ(block->transactions().size(), 1);
+      });
 }
 
 /**
  * C277
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with empty key
- * @then there is no tx in proposal
+ * @then there is no tx in block
  */
 TEST_F(SetAccountDetail, EmptyKey) {
+  const std::string kEmptyKey = "";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx(kUserId, "", kValue)), checkStatelessInvalid);
+      .sendTx(complete(baseTx(kUserId, kEmptyKey, kValue)),
+              checkStatelessInvalid);
 }
 
 /**
  * C278
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with empty value
- * @then there is no tx in proposal
+ * @then there is no tx in block
  */
 TEST_F(SetAccountDetail, EmptyValue) {
+  const std::string kEmptyValue = "";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTxAwait(complete(baseTx(kUserId, kKey, "")), [](auto &block) {
-        ASSERT_EQ(block->transactions().size(), 1);
-      });
+      .sendTxAwait(
+          complete(baseTx(kUserId, kKey, kEmptyValue)),
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
 }
 
 /**
  * C279
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with huge both key and value
- * @then there is no tx in proposal
+ * @then there is no tx in block
  */
 TEST_F(SetAccountDetail, HugeKeyValue) {
+  const std::string kHugeKey = std::string(10000, 'a');
+  const std::string kHugeValue = std::string(10000, 'b');
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipBlock()
-      .sendTx(complete(baseTx(
-                  kUserId, std::string(10000, 'a'), std::string(10000, 'b'))),
+      .sendTx(complete(baseTx(kUserId, kHugeKey, kHugeValue)),
               checkStatelessInvalid);
 }


### PR DESCRIPTION
### Description of the Change

Add more acceptance tests for SetAccountDetail, since some was already added in #1452 

### Benefits

More coverage

### Possible Drawbacks 

None

### Usage Examples or Tests *[optional]*

`test_bin/set_account_detail_test`
