### PR TITLE
Restrict storage lifetime in simulator and synchronizer

### DIFF
--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -27,6 +27,7 @@
 
 namespace iroha {
   namespace synchronizer {
+
     class SynchronizerImpl : public Synchronizer {
      public:
       SynchronizerImpl(
@@ -52,32 +53,8 @@ namespace iroha {
       rxcpp::composite_subscription subscription_;
 
       logger::Logger log_;
-
-      /**
-       * Creates a temporary storage out of the provided factory
-       * @return pointer to created storage
-       */
-      std::unique_ptr<ametsuchi::MutableStorage> createTemporaryStorage() const;
-
-      /**
-       * Process block, which can be applied to current storage directly:
-       *   - apply block and commit result to Ametsuchi
-       *   - notify the subscriber about commit
-       * @param commit_message to be applied
-       */
-      void processApplicableBlock(
-          std::shared_ptr<shared_model::interface::Block> commit_message) const;
-
-      /**
-       * Download part of chain, which is missed on this peer, from another; try
-       * until success
-       * @param commit_message - top of chain to be downloaded
-       * @return observable with missed part of the chain
-       */
-      rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-      downloadMissingChain(
-          std::shared_ptr<shared_model::interface::Block> commit_message) const;
     };
+
   }  // namespace synchronizer
 }  // namespace iroha
 

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -25,6 +25,7 @@ using namespace iroha::network;
 using namespace framework::test_subscriber;
 
 using ::testing::_;
+using ::testing::ByMove;
 using ::testing::DefaultValue;
 using ::testing::Return;
 
@@ -102,7 +103,7 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(2);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
@@ -146,7 +147,8 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
 
   DefaultValue<
       expected::Result<std::unique_ptr<MutableStorage>, std::string>>::Clear();
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
+  EXPECT_CALL(*mutable_factory, createMutableStorage())
+      .WillOnce(Return(ByMove(expected::makeError("Connection was closed"))));
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(0);
 
@@ -179,7 +181,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(2);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
@@ -228,7 +230,7 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(2);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
   EXPECT_CALL(*consensus_gate, on_commit())
       .WillOnce(Return(rxcpp::observable<>::empty<
@@ -273,7 +275,7 @@ TEST_F(SynchronizerTest, RetrieveBlockTwoFailures) {
 
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(2);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
 - Restrict storage lifetime to callback in simulator and synchronizer. This prevents storage deadlocks, since resources are released before calling `on_next`, which in turn calls subscribers callbacks.
 - Refactor `operator|` bind calls and `match` calls to remove null pointers using `boost::get`.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No more deadlocks when storage connection is closed
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
`boost::get` calls are hard to read, a task will be created to refactor `Result` class.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
