### PR TITLE
Nexus artifact server

### DIFF
--- a/.jenkinsci/artifacts.groovy
+++ b/.jenkinsci/artifacts.groovy
@@ -1,10 +1,8 @@
 #!/usr/bin/env groovy
 
-def uploadArtifacts(filePaths, uploadPath, artifactServers=['artifact.soramitsu.co.jp']) {
-  def baseUploadPath = 'files'
+def uploadArtifacts(filePaths, uploadPath, artifactServers=['nexus.iroha.tech']) {
   def filePathsConverted = []
   agentType = sh(script: 'uname', returnStdout: true).trim()
-  uploadPath = baseUploadPath + uploadPath
   filePaths.each {
     fp = sh(script: "ls -d ${it} | tr '\n' ','", returnStdout: true).trim()
     filePathsConverted.addAll(fp.split(','))
@@ -24,32 +22,22 @@ def uploadArtifacts(filePaths, uploadPath, artifactServers=['artifact.soramitsu.
       sh "gpg --yes --batch --no-tty --import ${CI_GPG_PRIVKEY} || true"
     }
     filePathsConverted.each {
-      sh "echo put ${it} $uploadPath >> \$(pwd)/batch.txt;"
+      sh "echo ${it} >> \$(pwd)/batch.txt;"
       sh "$shaSumBinary ${it} | cut -d' ' -f1 > \$(pwd)/\$(basename ${it}).sha256"
       sh "$md5SumBinary ${it} | cut -d' ' -f1 > \$(pwd)/\$(basename ${it}).md5"
       // TODO @bakhtin 30.05.18 IR-1384. Make gpg command options and paths compatible with Windows OS.
       if (!agentType.contains('MSYS_NT')) {
-        sh "echo \"${CI_GPG_MASTERKEY}\" | $gpgKeyBinary -o \$(pwd)/\$(basename ${it}).asc ${it}"
-        sh "echo put \$(pwd)/\$(basename ${it}).asc $uploadPath >> \$(pwd)/batch.txt;"
+        sh "echo \"${CI_GPG_MASTERKEY}\" | $gpgKeyBinary -o \$(pwd)/\$(basename ${it}).ascfile ${it}"
+        sh "echo \$(pwd)/\$(basename ${it}).ascfile >> \$(pwd)/batch.txt;"
       }
-      sh "echo put \$(pwd)/\$(basename ${it}).sha256 $uploadPath >> \$(pwd)/batch.txt;"
-      sh "echo put \$(pwd)/\$(basename ${it}).md5 $uploadPath >> \$(pwd)/batch.txt;"
+      sh "echo \$(pwd)/\$(basename ${it}).sha256 >> \$(pwd)/batch.txt;"
+      sh "echo \$(pwd)/\$(basename ${it}).md5 >> \$(pwd)/batch.txt;"
     }
   }
-  // mkdirs recursively
-  uploadPath = uploadPath.split('/')
-  def p = ''
-  sh "> \$(pwd)/mkdirs.txt"
-  uploadPath.each {
-    p += "/${it}"
-    sh("echo -mkdir $p >> \$(pwd)/mkdirs.txt")
-  }
 
-  sshagent(['jenkins-artifact']) {
-    sh "ssh-agent"
+  withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
     artifactServers.each {
-      sh "sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -b \$(pwd)/mkdirs.txt jenkins@${it} || true"
-      sh "sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -b \$(pwd)/batch.txt jenkins@${it}"
+      sh(script: "while read line; do curl -v -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file \$line https://${it}/repository/artifacts/${uploadPath}/ ; done < \$(pwd)/batch.txt")
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,7 @@ pipeline {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]
-                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
+                      artifacts.uploadArtifacts(filePaths, sprintf('iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
                     }
                   }
                   finally {
@@ -355,7 +355,7 @@ pipeline {
                       def artifacts = load ".jenkinsci/artifacts.groovy"
                       def commit = env.GIT_COMMIT
                       filePaths = [ '\$(pwd)/build/*.tar.gz' ]
-                      artifacts.uploadArtifacts(filePaths, sprintf('/iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
+                      artifacts.uploadArtifacts(filePaths, sprintf('iroha/macos/%1$s-%2$s-%3$s', [GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6)]))
                     }
                   }
                   finally {
@@ -458,15 +458,15 @@ pipeline {
                 def commit = env.GIT_COMMIT
                 if (params.JavaBindings) {
                   javaBindingsFilePaths = [ '/tmp/${GIT_COMMIT}/bindings-artifact/java-bindings-*.zip' ]
-                  artifacts.uploadArtifacts(javaBindingsFilePaths, '/iroha/bindings/java')
+                  artifacts.uploadArtifacts(javaBindingsFilePaths, 'iroha/bindings/java')
                 }
                 if (params.PythonBindings) {
                   pythonBindingsFilePaths = [ '/tmp/${GIT_COMMIT}/bindings-artifact/python-bindings-*.zip' ]
-                  artifacts.uploadArtifacts(pythonBindingsFilePaths, '/iroha/bindings/python')
+                  artifacts.uploadArtifacts(pythonBindingsFilePaths, 'iroha/bindings/python')
                 }
                 if (params.AndroidBindings) {
                   androidBindingsFilePaths = [ '/tmp/${GIT_COMMIT}/bindings-artifact/android-bindings-*.zip' ]
-                  artifacts.uploadArtifacts(androidBindingsFilePaths, '/iroha/bindings/android')
+                  artifacts.uploadArtifacts(androidBindingsFilePaths, 'iroha/bindings/android')
                 }
               }
             }
@@ -500,11 +500,11 @@ pipeline {
                 def commit = env.GIT_COMMIT
                 if (params.JavaBindings) {
                   javaBindingsFilePaths = [ '/tmp/${GIT_COMMIT}/bindings-artifact/java-bindings-*.zip' ]
-                  artifacts.uploadArtifacts(javaBindingsFilePaths, '/iroha/bindings/java')
+                  artifacts.uploadArtifacts(javaBindingsFilePaths, 'iroha/bindings/java')
                 }
                 if (params.PythonBindings) {
                   pythonBindingsFilePaths = [ '/tmp/${GIT_COMMIT}/bindings-artifact/python-bindings-*.zip' ]
-                  artifacts.uploadArtifacts(pythonBindingsFilePaths, '/iroha/bindings/python')
+                  artifacts.uploadArtifacts(pythonBindingsFilePaths, 'iroha/bindings/python')
                 }
               }
             }


### PR DESCRIPTION
Signed-off-by: Alexey Rodionov <rodionov@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Move all our artifacts (bindings, libraries, binaries) to new Nexus-server (nexus.iroha.tech)

### Benefits

Modern artifact storing system

### Possible Drawbacks 

artifacts.soramitsu.co.jp will be removed in the future

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
