### PR TITLE
Fix storage connection disposal

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -35,7 +35,6 @@ namespace iroha {
         : top_hash_(top_hash),
           sql_(std::move(sql)),
           wsv_(std::make_shared<PostgresWsvQuery>(*sql_, factory)),
-          executor_(std::make_shared<PostgresWsvCommand>(*sql_)),
           block_index_(std::make_unique<PostgresBlockIndex>(*sql_)),
           command_executor_(std::make_shared<PostgresCommandExecutor>(*sql_)),
           committed(false),

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -59,7 +59,6 @@ namespace iroha {
 
       std::unique_ptr<soci::session> sql_;
       std::shared_ptr<WsvQuery> wsv_;
-      std::shared_ptr<WsvCommand> executor_;
       std::unique_ptr<BlockIndex> block_index_;
       std::shared_ptr<CommandExecutor> command_executor_;
 

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -21,6 +21,17 @@ namespace iroha {
           converter_(std::move(converter)),
           log_(logger::log("PostgresBlockQuery")) {}
 
+    PostgresBlockQuery::PostgresBlockQuery(
+        std::unique_ptr<soci::session> sql,
+        KeyValueStorage &file_store,
+        std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
+            converter)
+        : psql_(std::move(sql)),
+          sql_(*psql_),
+          block_store_(file_store),
+          converter_(std::move(converter)),
+          log_(logger::log("PostgresBlockQuery")) {}
+
     std::vector<BlockQuery::wBlock> PostgresBlockQuery::getBlocks(
         shared_model::interface::types::HeightType height, uint32_t count) {
       shared_model::interface::types::HeightType last_id =

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -30,6 +30,12 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
               converter);
 
+      PostgresBlockQuery(
+          std::unique_ptr<soci::session> sql,
+          KeyValueStorage &file_store,
+          std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
+              converter);
+
       std::vector<wTransaction> getAccountTransactions(
           const shared_model::interface::types::AccountIdType &account_id)
           override;
@@ -95,6 +101,7 @@ namespace iroha {
                        std::string>
       getBlock(shared_model::interface::types::HeightType id) const;
 
+      std::unique_ptr<soci::session> psql_;
       soci::session &sql_;
 
       KeyValueStorage &block_store_;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -68,6 +68,14 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
         : sql_(sql), factory_(factory), log_(logger::log("PostgresWsvQuery")) {}
 
+    PostgresWsvQuery::PostgresWsvQuery(
+        std::unique_ptr<soci::session> sql,
+        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
+        : psql_(std::move(sql)),
+          sql_(*psql_),
+          factory_(factory),
+          log_(logger::log("PostgresWsvQuery")) {}
+
     bool PostgresWsvQuery::hasAccountGrantablePermission(
         const AccountIdType &permitee_account_id,
         const AccountIdType &account_id,

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -34,6 +34,11 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
               factory);
 
+      PostgresWsvQuery(
+          std::unique_ptr<soci::session> sql,
+          std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+              factory);
+
       boost::optional<std::vector<shared_model::interface::types::RoleIdType>>
       getAccountRoles(const shared_model::interface::types::AccountIdType
                           &account_id) override;
@@ -87,6 +92,7 @@ namespace iroha {
           shared_model::interface::permissions::Grantable permission) override;
 
      private:
+      std::unique_ptr<soci::session> psql_;
       soci::session &sql_;
       std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory_;
       logger::Logger log_;

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -92,6 +92,8 @@ namespace iroha {
           shared_model::interface::permissions::Grantable permission) override;
 
      private:
+      // TODO andrei 24.09.2018: IR-1718 Consistent soci::session fields in
+      // storage classes
       std::unique_ptr<soci::session> psql_;
       soci::session &sql_;
       std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory_;

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -187,13 +187,7 @@ namespace iroha {
         auto &db = dbname.value();
         std::unique_lock<std::shared_timed_mutex> lock(drop_mutex);
         log_->info("Drop database {}", db);
-        std::vector<std::shared_ptr<soci::session>> connections;
-        for (size_t i = 0; i < pool_size_; i++) {
-          connections.push_back(std::make_shared<soci::session>(*connection_));
-          connections[i]->close();
-        }
-        connections.clear();
-        connection_.reset();
+        freeConnections();
         soci::session sql(soci::postgresql,
                           postgres_options_.optionsStringWithoutDbName());
         // perform dropping
@@ -205,6 +199,21 @@ namespace iroha {
       // erase blocks
       log_->info("drop block store");
       block_store_->dropAll();
+    }
+
+    void StorageImpl::freeConnections() {
+      if (connection_ == nullptr) {
+        log_->warn("Tried to free connections without active connection");
+        return;
+      }
+      std::vector<std::shared_ptr<soci::session>> connections;
+      for (size_t i = 0; i < pool_size_; i++) {
+        connections.push_back(std::make_shared<soci::session>(*connection_));
+        connections[i]->close();
+        log_->debug("Closed connection {}", i);
+      }
+      connections.clear();
+      connection_.reset();
     }
 
     expected::Result<bool, std::string> StorageImpl::createDatabaseIfNotExist(
@@ -327,73 +336,35 @@ namespace iroha {
       storage->committed = true;
     }
 
-    namespace {
-      /**
-       * Deleter for an object which uses connection_pool
-       * @tparam Query object type to delete
-       */
-      template <typename Query>
-      class Deleter {
-       public:
-        Deleter(std::shared_ptr<soci::connection_pool> conn, size_t pool_pos)
-            : conn_(std::move(conn)), pool_pos_(pool_pos) {}
-
-        void operator()(Query *q) const {
-          if (conn_ != nullptr) {
-            conn_->give_back(pool_pos_);
-          }
-          delete q;
-        }
-
-       private:
-        std::shared_ptr<soci::connection_pool> conn_;
-        const size_t pool_pos_;
-      };
-
-      /**
-       * Factory method for query object creation which uses connection_pool
-       * @tparam Query object type to create
-       * @param conn is pointer to connection pool for getting and releasing
-       * the session
-       * @param drop_mutex is mutex for preventing connection destruction
-       *        during the function
-       * @param log is a logger
-       * @param args - various other arguments needed to initalize Query object
-       * @return pointer to created query object
-       * note: blocks until connection can be leased from the pool
-       */
-      template <typename Query, typename... QueryArgs>
-      std::shared_ptr<Query> setupQuery(
-          std::shared_ptr<soci::connection_pool> conn,
-          std::shared_timed_mutex &drop_mutex,
-          const logger::Logger &log,
-          QueryArgs &&... args) {
-        std::shared_lock<std::shared_timed_mutex> lock(drop_mutex);
-        if (conn == nullptr) {
-          log->warn("Storage was deleted, cannot perform setup");
-          return nullptr;
-        }
-        auto pool_pos = conn->lease();
-        soci::session &session = conn->at(pool_pos);
-        lock.unlock();
-        return {new Query(session, std::forward<QueryArgs>(args)...),
-                Deleter<Query>(std::move(conn), pool_pos)};
-      }
-    }  // namespace
-
     std::shared_ptr<WsvQuery> StorageImpl::getWsvQuery() const {
-      return setupQuery<PostgresWsvQuery>(
-          connection_, drop_mutex, log_, factory_);
+      std::shared_lock<std::shared_timed_mutex> lock(drop_mutex);
+      if (not connection_) {
+        log_->info("connection to database is not initialised");
+        return nullptr;
+      }
+      return std::make_shared<PostgresWsvQuery>(
+          std::make_unique<soci::session>(*connection_), factory_);
     }
 
     std::shared_ptr<BlockQuery> StorageImpl::getBlockQuery() const {
-      return setupQuery<PostgresBlockQuery>(
-          connection_, drop_mutex, log_, *block_store_, converter_);
+      std::shared_lock<std::shared_timed_mutex> lock(drop_mutex);
+      if (not connection_) {
+        log_->info("connection to database is not initialised");
+        return nullptr;
+      }
+      return std::make_shared<PostgresBlockQuery>(
+          std::make_unique<soci::session>(*connection_),
+          *block_store_,
+          converter_);
     }
 
     rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
     StorageImpl::on_commit() {
       return notifier_.get_observable();
+    }
+
+    StorageImpl::~StorageImpl() {
+      freeConnections();
     }
 
     const std::string &StorageImpl::drop_ = R"(

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -89,6 +89,8 @@ namespace iroha {
 
       void dropStorage() override;
 
+      void freeConnections() override;
+
       void commit(std::unique_ptr<MutableStorage> mutableStorage) override;
 
       std::shared_ptr<WsvQuery> getWsvQuery() const override;
@@ -97,6 +99,8 @@ namespace iroha {
 
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       on_commit() override;
+
+      ~StorageImpl() override;
 
      protected:
       StorageImpl(std::string block_store_dir,

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -79,10 +79,10 @@ namespace iroha {
     TemporaryWsvImpl::SavepointWrapperImpl::SavepointWrapperImpl(
         const iroha::ametsuchi::TemporaryWsvImpl &wsv,
         std::string savepoint_name)
-        : sql_{wsv.sql_},
+        : sql_{*wsv.sql_},
           savepoint_name_{std::move(savepoint_name)},
           is_released_{false} {
-      *sql_ << "SAVEPOINT " + savepoint_name_ + ";";
+      sql_ << "SAVEPOINT " + savepoint_name_ + ";";
     };
 
     void TemporaryWsvImpl::SavepointWrapperImpl::release() {
@@ -91,9 +91,9 @@ namespace iroha {
 
     TemporaryWsvImpl::SavepointWrapperImpl::~SavepointWrapperImpl() {
       if (not is_released_) {
-        *sql_ << "ROLLBACK TO SAVEPOINT " + savepoint_name_ + ";";
+        sql_ << "ROLLBACK TO SAVEPOINT " + savepoint_name_ + ";";
       } else {
-        *sql_ << "RELEASE SAVEPOINT " + savepoint_name_ + ";";
+        sql_ << "RELEASE SAVEPOINT " + savepoint_name_ + ";";
       }
     }
 

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -39,14 +39,15 @@ namespace iroha {
         ~SavepointWrapperImpl() override;
 
        private:
-        std::shared_ptr<soci::session> sql_;
+        soci::session &sql_;
         std::string savepoint_name_;
         bool is_released_;
       };
 
-      explicit TemporaryWsvImpl(std::unique_ptr<soci::session> sql,
-                                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-                                factory);
+      explicit TemporaryWsvImpl(
+          std::unique_ptr<soci::session> sql,
+          std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+              factory);
 
       expected::Result<void, validation::CommandError> apply(
           const shared_model::interface::Transaction &,
@@ -60,7 +61,7 @@ namespace iroha {
       ~TemporaryWsvImpl() override;
 
      private:
-      std::shared_ptr<soci::session> sql_;
+      std::unique_ptr<soci::session> sql_;
       std::shared_ptr<WsvQuery> wsv_;
       std::unique_ptr<CommandExecutor> command_executor_;
 

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include "ametsuchi/block_query_factory.hpp"
-#include "ametsuchi/os_persistent_state_factory.hpp"
 #include "ametsuchi/mutable_factory.hpp"
+#include "ametsuchi/os_persistent_state_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "common/result.hpp"
@@ -76,6 +76,8 @@ namespace iroha {
        * Tables and the database will be removed too
        */
       virtual void dropStorage() = 0;
+
+      virtual void freeConnections() = 0;
 
       virtual ~Storage() = default;
     };

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -370,3 +370,9 @@ void Irohad::run() {
           },
           [&](const expected::Error<std::string> &e) { log_->error(e.error); });
 }
+
+Irohad::~Irohad() {
+  // TODO andrei 17.09.18: IR-1710 Verify that all components' destructors are
+  // called in irohad destructor
+  storage->freeConnections();
+}

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -108,7 +108,7 @@ class Irohad {
    */
   virtual void run();
 
-  virtual ~Irohad() = default;
+  virtual ~Irohad();
 
  protected:
   // -----------------------| component initialization |------------------------

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -284,6 +284,7 @@ namespace iroha {
                         std::shared_ptr<shared_model::interface::Block>> &));
       MOCK_METHOD0(reset, void(void));
       MOCK_METHOD0(dropStorage, void(void));
+      MOCK_METHOD0(freeConnections, void(void));
 
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       on_commit() override {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Add freeConnections method, which disposes all currently used connections. Due to storage shared pointer not being released in irohad destructor, method has to be manually called in irohad destructor.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No more leftover databases after tests, since they drop without issues now.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Storage shared pointer is still used by some components. It should be verified that all components are destroyed when irohad destructor is called.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
