### PR TITLE
Jenkins on-demand AWS agents

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -85,6 +85,9 @@ def doDebugBuild(coverageEnabled=false) {
       """
       sh "cmake --build build -- -j${parallelism}"
       sh "ccache --show-stats"
+      if ( coverageEnabled ) {
+        sh "cmake --build build --target coverage.init.info"
+      }
       def testExitCode = sh(script: """cd build && ctest --output-on-failure""", returnStatus: true)
       if (testExitCode != 0) {
         currentBuild.result = "UNSTABLE"
@@ -104,6 +107,9 @@ def doDebugBuild(coverageEnabled=false) {
               -Dsonar.github.pullRequest=${CHANGE_ID}
           """
         }
+        sh "cmake --build build --target coverage.info"
+        sh "python /tmp/lcov_cobertura.py build/reports/coverage.info -o build/reports/coverage.xml"
+        cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/build/reports/coverage.xml', conditionalCoverageTargets: '75, 50, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '75, 50, 0', maxNumberOfBuilds: 50, methodCoverageTargets: '75, 50, 0', onlyStable: false, zoomCoverageChart: false
       }
     }
   }

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -85,9 +85,6 @@ def doDebugBuild(coverageEnabled=false) {
       """
       sh "cmake --build build -- -j${parallelism}"
       sh "ccache --show-stats"
-      if ( coverageEnabled ) {
-        sh "cmake --build build --target coverage.init.info"
-      }
       def testExitCode = sh(script: """cd build && ctest --output-on-failure""", returnStatus: true)
       if (testExitCode != 0) {
         currentBuild.result = "UNSTABLE"
@@ -107,9 +104,6 @@ def doDebugBuild(coverageEnabled=false) {
               -Dsonar.github.pullRequest=${CHANGE_ID}
           """
         }
-        sh "cmake --build build --target coverage.info"
-        sh "python /tmp/lcov_cobertura.py build/reports/coverage.info -o build/reports/coverage.xml"
-        cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/build/reports/coverage.xml', conditionalCoverageTargets: '75, 50, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '75, 50, 0', maxNumberOfBuilds: 50, methodCoverageTargets: '75, 50, 0', onlyStable: false, zoomCoverageChart: false
       }
     }
   }

--- a/.jenkinsci/selected-branches-coverage.groovy
+++ b/.jenkinsci/selected-branches-coverage.groovy
@@ -1,13 +1,7 @@
 #!/usr/bin/env groovy
 
-def selectedBranchesCoverage(branches, PRCoverage=true) {
-	// trigger coverage if branch is either develop or master, or it is a PR
-	if (PRCoverage) {
-		return env.GIT_LOCAL_BRANCH in branches || env.CHANGE_ID != null
-	}
-	else {
-		return env.GIT_LOCAL_BRANCH in branches
-	}
+def selectedBranchesCoverage(branches) {
+	return env.GIT_LOCAL_BRANCH in branches
 }
 
 return this

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ properties([parameters([
   choice(choices: 'Release\nDebug', description: 'Android bindings build type', name: 'ABBuildType'),
   choice(choices: 'arm64-v8a\narmeabi-v7a\narmeabi\nx86_64\nx86', description: 'Android bindings platform', name: 'ABPlatform'),
   booleanParam(defaultValue: true, description: 'Build docs', name: 'Doxygen'),
-  string(defaultValue: '4', description: 'How much parallelism should we exploit. "4" is optimal for machines with modest amount of memory and at least 4 cores', name: 'PARALLELISM')])])
+  string(defaultValue: '8', description: 'How much parallelism should we exploit. "4" is optimal for machines with modest amount of memory and at least 4 cores', name: 'PARALLELISM')])])
 
 
 pipeline {
@@ -172,6 +172,7 @@ pipeline {
           steps {
             script {
               def coverageEnabled = false
+              coverage = load ".jenkinsci/selected-branches-coverage.groovy"
               if (!params.x86_64_linux && (coverage.selectedBranchesCoverage(['develop', 'master', 'dev']))) {
                 coverageEnabled = true
               }
@@ -363,8 +364,6 @@ pipeline {
         beforeAgent true
         expression { return params.Doxygen }
       }
-      // build docs on any vacant node. Prefer `x86_64` over
-      // others as nodes are more powerful
       agent { label 'docker-build-agent' }
       steps {
         script {
@@ -375,7 +374,7 @@ pipeline {
             "$platform-develop-build",
             "${env.GIT_RAW_BASE_URL}/${env.GIT_COMMIT}/docker/develop/Dockerfile",
             "${env.GIT_RAW_BASE_URL}/${env.GIT_PREVIOUS_COMMIT}/docker/develop/Dockerfile",
-            "${env.GIT_RAW_BASE_URL}/develop/docker/develop/Dockerfile",
+            "${env.GIT_RAW_BASE_URL}/dev/docker/develop/Dockerfile",
             ['PARALLELISM': params.PARALLELISM])
           iC.inside() {
             doxygen.doDoxygen()
@@ -413,7 +412,7 @@ pipeline {
                   "$platform-develop-build",
                   "${env.GIT_RAW_BASE_URL}/${env.GIT_COMMIT}/docker/develop/Dockerfile",
                   "${env.GIT_RAW_BASE_URL}/${env.GIT_PREVIOUS_COMMIT}/docker/develop/Dockerfile",
-                  "${env.GIT_RAW_BASE_URL}/develop/docker/develop/Dockerfile",
+                  "${env.GIT_RAW_BASE_URL}/dev/docker/develop/Dockerfile",
                   ['PARALLELISM': params.PARALLELISM])
                 if (params.JavaBindings) {
                   iC.inside("-v /tmp/${env.GIT_COMMIT}/bindings-artifact:/tmp/bindings-artifact") {
@@ -431,7 +430,7 @@ pipeline {
                   "android-${params.ABPlatform}-${params.ABBuildType}",
                   "${env.GIT_RAW_BASE_URL}/${env.GIT_COMMIT}/docker/android/Dockerfile",
                   "${env.GIT_RAW_BASE_URL}/${env.GIT_PREVIOUS_COMMIT}/docker/android/Dockerfile",
-                  "${env.GIT_RAW_BASE_URL}/develop/docker/android/Dockerfile",
+                  "${env.GIT_RAW_BASE_URL}/dev/docker/android/Dockerfile",
                   ['PARALLELISM': params.PARALLELISM, 'PLATFORM': params.ABPlatform, 'BUILD_TYPE': params.ABBuildType])
                 sh "curl -L -o /tmp/${env.GIT_COMMIT}/entrypoint.sh ${env.GIT_RAW_BASE_URL}/${env.GIT_COMMIT}/docker/android/entrypoint.sh"
                 sh "chmod +x /tmp/${env.GIT_COMMIT}/entrypoint.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ properties([parameters([
   choice(choices: 'Release\nDebug', description: 'Android bindings build type', name: 'ABBuildType'),
   choice(choices: 'arm64-v8a\narmeabi-v7a\narmeabi\nx86_64\nx86', description: 'Android bindings platform', name: 'ABPlatform'),
   booleanParam(defaultValue: true, description: 'Build docs', name: 'Doxygen'),
-  string(defaultValue: '8', description: 'How much parallelism should we exploit. "4" is optimal for machines with modest amount of memory and at least 4 cores', name: 'PARALLELISM')])])
+  string(defaultValue: '8', description: 'Expect ~3GB memory consumtion per CPU core', name: 'PARALLELISM')])])
 
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,7 +267,7 @@ pipeline {
             beforeAgent true
             expression { return params.x86_64_linux }
           }
-          agent { label 'x86_64' }
+          agent { label 'docker-build-agent' }
           steps {
             script {
               def releaseBuild = load ".jenkinsci/release-build.groovy"


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
- Replace static Jenkins build agents with on-demand ones
- Disable code coverage for all branches but `master`. It consumes a significant amount of time during the build, while coverage metric is not as useful as planned initially.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
- Reduce infrastructure monthly bill by executing builds on AWS agents that are started up on-demand and shut down after a certain timeout if no builds are running on it
- Faster builds due to disabled coverage
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
- Slightly higher latency between "Start build" event sent to Jenkins and actual execution of the build as AWS agent requires some time for initialization. Although, not relevant in case an agent is already up and running
- `ccache` build cache is not available anymore as each agent starts up with a clean hard drive. However, this should not be a problem as the current utilization of the cache is pretty low already. That is because of many concurrent builds running on the same copy of the cache. The solution is to have a separate version of the cache for each PR/branch but that is not practically possible.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->