### PR TITLE
Skip EnoughSig response in processBatch

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -10,6 +10,7 @@
 #include "ametsuchi/block_query.hpp"
 #include "common/byteutils.hpp"
 #include "common/is_any.hpp"
+#include "common/visitor.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
@@ -133,7 +134,14 @@ namespace torii {
     const auto &txs = batch->transactions();
     std::for_each(txs.begin(), txs.end(), [this](const auto &tx) {
       const auto &tx_hash = tx->hash();
-      if (cache_->findItem(tx_hash) and tx->quorum() < 2) {
+      auto found = cache_->findItem(tx_hash);
+      if (found
+          and iroha::visit_in_place(
+                  found.value()->get(),
+                  [](const shared_model::interface::
+                         EnoughSignaturesCollectedResponse &) { return false; },
+                  [](auto &) { return true; })
+          and tx->quorum() < 2) {
         log_->warn("Found transaction {} in cache, ignoring", tx_hash.hex());
         return;
       }

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -135,6 +135,8 @@ namespace torii {
     std::for_each(txs.begin(), txs.end(), [this](const auto &tx) {
       const auto &tx_hash = tx->hash();
       auto found = cache_->findItem(tx_hash);
+      // StatlessValid status goes only after EnoughSignaturesCollectedResponse
+      // So doesn't skip publishing status after it
       if (found
           and iroha::visit_in_place(
                   found.value()->get(),

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -45,15 +45,6 @@ namespace iroha {
           mst_processor_(std::move(mst_processor)),
           status_bus_(std::move(status_bus)),
           log_(logger::log("TxProcessor")) {
-      // notify about stateless success
-      pcs_->on_proposal().subscribe([this](auto model_proposal) {
-        for (const auto &tx : model_proposal->transactions()) {
-          const auto &hash = tx.hash();
-          log_->info("on proposal stateless success: {}", hash.hex());
-          this->publishStatus(TxStatusType::kStatelessValid, hash);
-        }
-      });
-
       // process stateful validation results
       pcs_->on_verified_proposal().subscribe(
           [this](std::shared_ptr<validation::VerifiedProposalAndErrors>

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -39,8 +39,6 @@ class TransactionProcessorTest : public ::testing::Test {
     pcs = std::make_shared<MockPeerCommunicationService>();
     mp = std::make_shared<MockMstProcessor>();
 
-    EXPECT_CALL(*pcs, on_proposal())
-        .WillRepeatedly(Return(prop_notifier.get_observable()));
     EXPECT_CALL(*pcs, on_commit())
         .WillRepeatedly(Return(commit_notifier.get_observable()));
     EXPECT_CALL(*pcs, on_verified_proposal())
@@ -126,8 +124,6 @@ class TransactionProcessorTest : public ::testing::Test {
       shared_model::proto::TransactionStatusBuilder>
       status_builder;
 
-  rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Proposal>>
-      prop_notifier;
   rxcpp::subjects::subject<SynchronizationEvent> commit_notifier;
   rxcpp::subjects::subject<
       std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>>
@@ -140,7 +136,8 @@ class TransactionProcessorTest : public ::testing::Test {
  * @given transaction processor
  * @when transactions passed to processor compose proposal which is sent to peer
  * communication service
- * @then for every transaction in batches STATELESS_VALID status is returned
+ * @then for every transaction in batches ENOUGH_SIGNATURES_COLLECTED status is
+ * returned
  */
 TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
   std::vector<shared_model::proto::Transaction> txs;
@@ -150,7 +147,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
   }
 
   EXPECT_CALL(*status_bus, publish(_))
-      .Times(proposal_size * 2)
+      .Times(proposal_size)
       .WillRepeatedly(testing::Invoke([this](auto response) {
         status_map[response->transactionHash()] = response;
       }));
@@ -167,18 +164,16 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalTest) {
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
       TestProposalBuilder().transactions(txs).build());
 
-  prop_notifier.get_subscriber().on_next(proposal);
-  prop_notifier.get_subscriber().on_completed();
-
-  SCOPED_TRACE("Stateless valid status verification");
-  validateStatuses<shared_model::interface::StatelessValidTxResponse>(txs);
+  SCOPED_TRACE("Enough signatures collected status verification");
+  validateStatuses<shared_model::interface::EnoughSignaturesCollectedResponse>(
+      txs);
 }
 
 /**
  * @given transactions from the same batch
  * @when transactions sequence is created and propagated
  * AND all transactions were returned by pcs in proposal notifier
- * @then all transactions in batches have stateless valid status
+ * @then all transactions in batches have ENOUGH_SIGNATURES_COLLECTED status
  */
 TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalBatchTest) {
   using namespace shared_model::validation;
@@ -188,7 +183,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalBatchTest) {
       framework::batch::createValidBatch(proposal_size).transactions();
 
   EXPECT_CALL(*status_bus, publish(_))
-      .Times(proposal_size * 2)
+      .Times(proposal_size)
       .WillRepeatedly(testing::Invoke([this](auto response) {
         status_map[response->transactionHash()] = response;
       }));
@@ -221,11 +216,8 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalBatchTest) {
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
       TestProposalBuilder().transactions(proto_transactions).build());
 
-  prop_notifier.get_subscriber().on_next(proposal);
-  prop_notifier.get_subscriber().on_completed();
-
-  SCOPED_TRACE("Stateless valid status verification");
-  validateStatuses<shared_model::interface::StatelessValidTxResponse>(
+  SCOPED_TRACE("Enough signatures collected status verification");
+  validateStatuses<shared_model::interface::EnoughSignaturesCollectedResponse>(
       proto_transactions);
 }
 
@@ -236,6 +228,61 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnProposalBatchTest) {
  * @then for every transaction in bathces STATEFUL_VALID status is returned
  */
 TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
+  std::vector<shared_model::proto::Transaction> txs;
+  for (size_t i = 0; i < proposal_size; i++) {
+    auto &&tx = addSignaturesFromKeyPairs(baseTestTx(), makeKey());
+    txs.push_back(tx);
+  }
+
+  EXPECT_CALL(*status_bus, publish(_))
+      .Times(txs.size() * 2)
+      .WillRepeatedly(testing::Invoke([this](auto response) {
+        status_map[response->transactionHash()] = response;
+      }));
+
+  EXPECT_CALL(*mp, propagateBatchImpl(_)).Times(0);
+  EXPECT_CALL(*pcs, propagate_batch(_)).Times(txs.size());
+
+  for (const auto &tx : txs) {
+    tp->batchHandle(framework::batch::createBatchFromSingleTransaction(
+        std::shared_ptr<shared_model::interface::Transaction>(clone(tx))));
+  }
+
+  // 1. Create proposal and notify transaction processor about it
+  auto proposal = std::make_shared<shared_model::proto::Proposal>(
+      TestProposalBuilder().transactions(txs).build());
+
+  // empty transactions errors - all txs are valid
+  verified_prop_notifier.get_subscriber().on_next(
+      std::make_shared<iroha::validation::VerifiedProposalAndErrors>(
+          std::make_pair(proposal, iroha::validation::TransactionsErrors{})));
+
+  auto block = TestBlockBuilder().transactions(txs).build();
+
+  // 2. Create block and notify transaction processor about it
+  rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
+      blocks_notifier;
+
+  commit_notifier.get_subscriber().on_next(SynchronizationEvent{
+      blocks_notifier.get_observable(), SynchronizationOutcomeType::kCommit});
+
+  blocks_notifier.get_subscriber().on_next(
+      std::shared_ptr<shared_model::interface::Block>(clone(block)));
+  // Note blocks_notifier hasn't invoked on_completed, so
+  // transactions are not commited
+
+  SCOPED_TRACE("Stateful Valid status verification");
+  validateStatuses<shared_model::interface::StatefulValidTxResponse>(txs);
+}
+
+/**
+ * @given transaction processor
+ * @when transactions compose proposal which is sent to peer
+ * communication service @and all transactions composed the block @and were
+ * committed
+ * @then for every transaction COMMIT status is returned
+ */
+TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
   std::vector<shared_model::proto::Transaction> txs;
   for (size_t i = 0; i < proposal_size; i++) {
     auto &&tx = addSignaturesFromKeyPairs(baseTestTx(), makeKey());
@@ -259,68 +306,6 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
   // 1. Create proposal and notify transaction processor about it
   auto proposal = std::make_shared<shared_model::proto::Proposal>(
       TestProposalBuilder().transactions(txs).build());
-
-  prop_notifier.get_subscriber().on_next(proposal);
-  prop_notifier.get_subscriber().on_completed();
-
-  // empty transactions errors - all txs are valid
-  verified_prop_notifier.get_subscriber().on_next(
-      std::make_shared<iroha::validation::VerifiedProposalAndErrors>(
-          std::make_pair(proposal, iroha::validation::TransactionsErrors{})));
-
-  auto block = TestBlockBuilder().transactions(txs).build();
-
-  // 2. Create block and notify transaction processor about it
-  rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
-      blocks_notifier;
-
-  commit_notifier.get_subscriber().on_next(SynchronizationEvent{
-      blocks_notifier.get_observable(), SynchronizationOutcomeType::kCommit});
-
-  blocks_notifier.get_subscriber().on_next(
-      std::shared_ptr<shared_model::interface::Block>(clone(block)));
-  // Note blocks_notifier hasn't invoked on_completed, so
-  // transactions are not commited
-
-  SCOPED_TRACE("Stateful Valid status verification");
-  validateStatuses<shared_model::interface::StatefulValidTxResponse>(
-      txs);
-}
-
-/**
- * @given transaction processor
- * @when transactions compose proposal which is sent to peer
- * communication service @and all transactions composed the block @and were
- * committed
- * @then for every transaction COMMIT status is returned
- */
-TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
-  std::vector<shared_model::proto::Transaction> txs;
-  for (size_t i = 0; i < proposal_size; i++) {
-    auto &&tx = addSignaturesFromKeyPairs(baseTestTx(), makeKey());
-    txs.push_back(tx);
-  }
-
-  EXPECT_CALL(*status_bus, publish(_))
-      .Times(txs.size() * 4)
-      .WillRepeatedly(testing::Invoke([this](auto response) {
-        status_map[response->transactionHash()] = response;
-      }));
-
-  EXPECT_CALL(*mp, propagateBatchImpl(_)).Times(0);
-  EXPECT_CALL(*pcs, propagate_batch(_)).Times(txs.size());
-
-  for (const auto &tx : txs) {
-    tp->batchHandle(framework::batch::createBatchFromSingleTransaction(
-        std::shared_ptr<shared_model::interface::Transaction>(clone(tx))));
-  }
-
-  // 1. Create proposal and notify transaction processor about it
-  auto proposal = std::make_shared<shared_model::proto::Proposal>(
-      TestProposalBuilder().transactions(txs).build());
-
-  prop_notifier.get_subscriber().on_next(proposal);
-  prop_notifier.get_subscriber().on_completed();
 
   // empty transactions errors - all txs are valid
   verified_prop_notifier.get_subscriber().on_next(
@@ -375,7 +360,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
   // Plus all transactions from block will
   // be committed and corresponding status will be sent
   EXPECT_CALL(*status_bus, publish(_))
-      .Times(proposal_size * 2 + block_size)
+      .Times(proposal_size + block_size)
       .WillRepeatedly(testing::Invoke([this](auto response) {
         status_map[response->transactionHash()] = response;
       }));
@@ -384,9 +369,6 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
       TestProposalBuilder()
           .transactions(boost::join(block_txs, invalid_txs))
           .build());
-
-  prop_notifier.get_subscriber().on_next(proposal);
-  prop_notifier.get_subscriber().on_completed();
 
   // trigger the verified event with txs, which we want to fail, as errors
   auto verified_proposal = std::make_shared<shared_model::proto::Proposal>(
@@ -429,11 +411,12 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
  * @when transaction_processor handle the batch
  * @then checks that batch is relayed to MST
  */
-TEST_F(TransactionProcessorTest, MultisigTransactionToMST) {
+TEST_F(TransactionProcessorTest, MultisigTransactionToMst) {
   auto &&tx = addSignaturesFromKeyPairs(baseTestTx(2), makeKey());
 
   auto &&after_mst = framework::batch::createBatchFromSingleTransaction(
       std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
+  EXPECT_CALL(*status_bus, publish(_)).Times(1);
   EXPECT_CALL(*mp, propagateBatchImpl(_)).Times(1);
 
   tp->batchHandle(std::move(after_mst));
@@ -452,6 +435,7 @@ TEST_F(TransactionProcessorTest, MultisigTransactionFromMst) {
   auto &&after_mst = framework::batch::createBatchFromSingleTransaction(
       std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
 
+  EXPECT_CALL(*status_bus, publish(_)).Times(1);
   EXPECT_CALL(*pcs, propagate_batch(_)).Times(1);
   mst_prepared_notifier.get_subscriber().on_next(after_mst);
 }


### PR DESCRIPTION
### Description of the Change

Redundant warning was generated in CommandService due to EnoughSignaturesCollectedResponse response, these pr omit that

### Benefits

Less warnings on normal flow

### Usage Examples or Tests

Just run any acceptance test. Before there's a message "CommandService: Found transaction ...", even though the transaction pass the validation. With that pr there's no such warning
