### PR TITLE
Adding a link to documentation

### DIFF
--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -73,7 +73,7 @@ Configuring Iroha Network
 
 .. note:: To keep things simple, in this guide we will create a network
   containing only one node. To understand how to run several peers, follow
-  this guide.
+  `this guide. <github.com/hyperledger/iroha/tree/master/deploy/ansible>`_
 
 Now we need to configure our Iroha network. This includes creating a
 configuration file, generating keypairs for a users, writing a list of peers


### PR DESCRIPTION
Adding a link following the issue #1173

Signed-off-by: Sara <lira.lemur@gmail.com>

### Description of the Change

Adding a missing link to instructions on creating multiple Iroha peers: https://github.com/hyperledger/iroha/tree/master/deploy/ansible

### Benefits

Better documentation

### Possible Drawbacks 

None