### PR TITLE
BFT-aware Synchronizer

### DIFF
--- a/irohad/consensus/CMakeLists.txt
+++ b/irohad/consensus/CMakeLists.txt
@@ -1,26 +1,18 @@
-#
-# Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
-# http://soramitsu.co.jp
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(yac)
 
 add_library(consensus_round
     impl/round.cpp
     )
-
 target_link_libraries(consensus_round
+    boost
+    )
+
+add_library(gate_object
+    impl/gate_object.cpp
+    )
+target_link_libraries(gate_object
     boost
     )

--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -22,11 +22,13 @@ namespace iroha {
     /// Current pair is valid
     struct PairValid {
       std::shared_ptr<shared_model::interface::Block> block;
+      consensus::Round round;
     };
 
     /// Network votes for another pair and round
     struct VoteOther {
       std::shared_ptr<shared_model::interface::Block> block;
+      consensus::Round round;
     };
 
     /// Reject on proposal

--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CONSENSUS_GATE_OBJECT_HPP
+#define CONSENSUS_GATE_OBJECT_HPP
+
+#include <boost/variant.hpp>
+
+#include "consensus/round.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class Block;
+  }  // namespace interface
+}  // namespace shared_model
+
+namespace iroha {
+  namespace consensus {
+
+    /// Current pair is valid
+    struct PairValid {
+      std::shared_ptr<shared_model::interface::Block> block;
+    };
+
+    /// Network votes for another pair and round
+    struct VoteOther {
+      std::shared_ptr<shared_model::interface::Block> block;
+    };
+
+    /// Reject on proposal
+    struct ProposalReject {
+      consensus::Round round;
+    };
+
+    /// Reject on block
+    struct BlockReject {
+      consensus::Round round;
+    };
+
+    /// Agreement on <None, None>
+    struct AgreementOnNone {
+      consensus::Round round;
+    };
+
+    using GateObject = boost::variant<PairValid,
+                                      VoteOther,
+                                      ProposalReject,
+                                      BlockReject,
+                                      AgreementOnNone>;
+
+  }  // namespace consensus
+}  // namespace iroha
+
+extern template class boost::variant<iroha::consensus::PairValid,
+                                     iroha::consensus::VoteOther,
+                                     iroha::consensus::ProposalReject,
+                                     iroha::consensus::BlockReject,
+                                     iroha::consensus::AgreementOnNone>;
+
+#endif  // CONSENSUS_GATE_OBJECT_HPP

--- a/irohad/consensus/impl/gate_object.cpp
+++ b/irohad/consensus/impl/gate_object.cpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "consensus/gate_object.hpp"
+
+using GateObject = iroha::consensus::GateObject;
+
+template GateObject::~variant();
+template GateObject::variant(GateObject &&);
+template GateObject::variant(const GateObject &);
+template void GateObject::destroy_content();
+template int GateObject::which() const;
+template void GateObject::indicate_which(int);
+template bool GateObject::using_backup() const;
+template GateObject::convert_copy_into::convert_copy_into(void *);

--- a/irohad/consensus/yac/CMakeLists.txt
+++ b/irohad/consensus/yac/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(yac
     logger
     hash
     consensus_round
+    gate_object
     )
 
 add_library(yac_transport

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -115,11 +115,12 @@ namespace iroha {
           log_->info("consensus: commit top block: height {}, hash {}",
                      block->height(),
                      block->hash().hex());
-          return rxcpp::observable<>::just<GateObject>(PairValid{block});
+          return rxcpp::observable<>::just<GateObject>(
+              PairValid{block, current_hash_.vote_round});
         }
         log_->info("Voted for another block, waiting for sync");
         return rxcpp::observable<>::just<GateObject>(
-            VoteOther{current_block_.value()});
+            VoteOther{current_block_.value(), current_hash_.vote_round});
       }
 
       rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleReject(

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -106,7 +106,7 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->debug("Consensus skipped round, voted for nothing");
           return rxcpp::observable<>::just<GateObject>(
-              network::AgreementOnNone{});
+              network::AgreementOnNone{current_block_.value()->height()});
         } else if (hash == current_hash_) {
           // if node has voted for the committed block
           // append signatures of other nodes
@@ -129,11 +129,11 @@ namespace iroha {
         if (not hash) {
           log_->info("Proposal reject since all hashes are different");
           return rxcpp::observable<>::just<GateObject>(
-              network::ProposalReject{});
+              network::ProposalReject{current_block_.value()->height()});
         }
         log_->info("Block reject since proposal hashes match");
         return rxcpp::observable<>::just<GateObject>(
-            network::BlockReject{current_block_.value()});
+            network::BlockReject{current_block_.value()->height()});
       }
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -106,7 +106,7 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->debug("Consensus skipped round, voted for nothing");
           return rxcpp::observable<>::just<GateObject>(
-              network::AgreementOnNone{current_block_.value()->height()});
+              network::AgreementOnNone{current_hash_.vote_round});
         } else if (hash == current_hash_) {
           // if node has voted for the committed block
           // append signatures of other nodes
@@ -129,11 +129,11 @@ namespace iroha {
         if (not hash) {
           log_->info("Proposal reject since all hashes are different");
           return rxcpp::observable<>::just<GateObject>(
-              network::ProposalReject{current_block_.value()->height()});
+              network::ProposalReject{current_hash_.vote_round});
         }
         log_->info("Block reject since proposal hashes match");
         return rxcpp::observable<>::just<GateObject>(
-            network::BlockReject{current_block_.value()->height()});
+            network::BlockReject{current_hash_.vote_round});
       }
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -106,7 +106,7 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->debug("Consensus skipped round, voted for nothing");
           return rxcpp::observable<>::just<GateObject>(
-              network::AgreementOnNone{current_hash_.vote_round});
+              AgreementOnNone{current_hash_.vote_round});
         } else if (hash == current_hash_) {
           // if node has voted for the committed block
           // append signatures of other nodes
@@ -115,12 +115,11 @@ namespace iroha {
           log_->info("consensus: commit top block: height {}, hash {}",
                      block->height(),
                      block->hash().hex());
-          return rxcpp::observable<>::just<GateObject>(
-              network::PairValid{block});
+          return rxcpp::observable<>::just<GateObject>(PairValid{block});
         }
         log_->info("Voted for another block, waiting for sync");
         return rxcpp::observable<>::just<GateObject>(
-            network::VoteOther{current_block_.value()});
+            VoteOther{current_block_.value()});
       }
 
       rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleReject(
@@ -129,11 +128,11 @@ namespace iroha {
         if (not hash) {
           log_->info("Proposal reject since all hashes are different");
           return rxcpp::observable<>::just<GateObject>(
-              network::ProposalReject{current_hash_.vote_round});
+              ProposalReject{current_hash_.vote_round});
         }
         log_->info("Block reject since proposal hashes match");
         return rxcpp::observable<>::just<GateObject>(
-            network::BlockReject{current_hash_.vote_round});
+            BlockReject{current_hash_.vote_round});
       }
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -33,17 +33,17 @@ namespace iroha {
 
     /// Reject on proposal
     struct ProposalReject {
-      shared_model::interface::types::HeightType height;
+      consensus::Round round;
     };
 
     /// Reject on block
     struct BlockReject {
-      shared_model::interface::types::HeightType height;
+      consensus::Round round;
     };
 
     /// Agreement on <None, None>
     struct AgreementOnNone {
-      shared_model::interface::types::HeightType height;
+      consensus::Round round;
     };
 
     /**
@@ -51,7 +51,7 @@ namespace iroha {
      */
     class ConsensusGate {
      public:
-      using Round = iroha::consensus::Round;
+      using Round = consensus::Round;
       /**
        * Providing data for consensus for voting
        * @param block is the block for which current node is voting

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -10,6 +10,7 @@
 #include <boost/variant.hpp>
 #include <rxcpp/rx.hpp>
 
+#include "consensus/gate_object.hpp"
 #include "consensus/round.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -22,31 +23,6 @@ namespace shared_model {
 
 namespace iroha {
   namespace network {
-    /// Current pair is valid
-    struct PairValid {
-      std::shared_ptr<shared_model::interface::Block> block;
-    };
-
-    /// Network votes for another pair and round
-    struct VoteOther {
-      std::shared_ptr<shared_model::interface::Block> block;
-    };
-
-    /// Reject on proposal
-    struct ProposalReject {
-      consensus::Round round;
-    };
-
-    /// Reject on block
-    struct BlockReject {
-      consensus::Round round;
-    };
-
-    /// Agreement on <None, None>
-    struct AgreementOnNone {
-      consensus::Round round;
-    };
-
     /**
      * Public api of consensus module
      */
@@ -64,12 +40,7 @@ namespace iroha {
               block,
           Round round) = 0;
 
-      // TODO(@l4l) 10/10/18: IR-1749 move instantiation to separate cpp
-      using GateObject = boost::variant<PairValid,
-                                        VoteOther,
-                                        ProposalReject,
-                                        BlockReject,
-                                        AgreementOnNone>;
+      using GateObject = consensus::GateObject;
 
       /**
        * @return emit gate responses

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -31,15 +31,19 @@ namespace iroha {
     };
 
     /// Reject on proposal
-    struct ProposalReject {};
+    struct ProposalReject {
+      shared_model::interface::types::HeightType height;
+    };
 
     /// Reject on block
     struct BlockReject {
-      std::shared_ptr<shared_model::interface::Block> block;
+      shared_model::interface::types::HeightType height;
     };
 
     /// Agreement on <None, None>
-    struct AgreementOnNone {};
+    struct AgreementOnNone {
+      shared_model::interface::types::HeightType height;
+    };
 
     /**
      * Public api of consensus module

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -7,6 +7,7 @@
 #define IROHA_CONSENSUS_GATE_HPP
 
 #include <boost/optional.hpp>
+#include <boost/variant.hpp>
 #include <rxcpp/rx.hpp>
 
 #include "consensus/round.hpp"

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -10,6 +10,7 @@
 #include <rxcpp/rx.hpp>
 
 #include "consensus/round.hpp"
+#include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
   namespace interface {

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -7,12 +7,10 @@
 #define IROHA_CONSENSUS_GATE_HPP
 
 #include <boost/optional.hpp>
-#include <boost/variant.hpp>
 #include <rxcpp/rx.hpp>
 
 #include "consensus/gate_object.hpp"
 #include "consensus/round.hpp"
-#include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
   namespace interface {

--- a/irohad/synchronizer/CMakeLists.txt
+++ b/irohad/synchronizer/CMakeLists.txt
@@ -6,4 +6,5 @@ target_link_libraries(synchronizer
     ametsuchi
     rxcpp
     logger
+    gate_object
     )

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -40,21 +40,21 @@ namespace iroha {
                       rxcpp::observable<>::empty<
                           std::shared_ptr<shared_model::interface::Block>>(),
                       SynchronizationOutcomeType::kReject,
-                      msg.height});
+                      msg.round});
                 },
                 [this](const network::BlockReject &msg) {
                   notifier_.get_subscriber().on_next(SynchronizationEvent{
                       rxcpp::observable<>::empty<
                           std::shared_ptr<shared_model::interface::Block>>(),
                       SynchronizationOutcomeType::kReject,
-                      msg.height});
+                      msg.round});
                 },
                 [this](const network::AgreementOnNone &msg) {
                   notifier_.get_subscriber().on_next(SynchronizationEvent{
                       rxcpp::observable<>::empty<
                           std::shared_ptr<shared_model::interface::Block>>(),
                       SynchronizationOutcomeType::kNothing,
-                      msg.height});
+                      msg.round});
                 });
           });
     }
@@ -86,9 +86,7 @@ namespace iroha {
               and validator_->validateChain(chain, *storage)) {
             mutable_factory_->commit(std::move(storage));
 
-            return {chain,
-                    SynchronizationOutcomeType::kCommit,
-                    commit_message->height()};
+            return {chain, SynchronizationOutcomeType::kCommit, {}};
           }
         }
       }
@@ -124,7 +122,7 @@ namespace iroha {
       notifier_.get_subscriber().on_next(
           SynchronizationEvent{rxcpp::observable<>::just(commit_message),
                                SynchronizationOutcomeType::kCommit,
-                               commit_message->height()});
+                               {}});
     }
 
     void SynchronizerImpl::processDifferent(

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -24,37 +24,36 @@ namespace iroha {
           block_loader_(std::move(blockLoader)),
           log_(logger::log("synchronizer")) {
       consensus_gate->onOutcome().subscribe(
-          subscription_, [this](network::ConsensusGate::GateObject object) {
+          subscription_, [this](consensus::GateObject object) {
             return this->processOutcome(object);
           });
     }
 
-    void SynchronizerImpl::processOutcome(
-        network::ConsensusGate::GateObject object) {
+    void SynchronizerImpl::processOutcome(consensus::GateObject object) {
       log_->info("processing consensus outcome");
       visit_in_place(
           object,
-          [this](const network::PairValid &msg) {
+          [this](const consensus::PairValid &msg) {
             this->processNext(msg.block);
           },
-          [this](const network::VoteOther &msg) {
+          [this](const consensus::VoteOther &msg) {
             this->processDifferent(msg.block);
           },
-          [this](const network::ProposalReject &msg) {
+          [this](const consensus::ProposalReject &msg) {
             notifier_.get_subscriber().on_next(SynchronizationEvent{
                 rxcpp::observable<>::empty<
                     std::shared_ptr<shared_model::interface::Block>>(),
                 SynchronizationOutcomeType::kReject,
                 msg.round});
           },
-          [this](const network::BlockReject &msg) {
+          [this](const consensus::BlockReject &msg) {
             notifier_.get_subscriber().on_next(SynchronizationEvent{
                 rxcpp::observable<>::empty<
                     std::shared_ptr<shared_model::interface::Block>>(),
                 SynchronizationOutcomeType::kReject,
                 msg.round});
           },
-          [this](const network::AgreementOnNone &msg) {
+          [this](const consensus::AgreementOnNone &msg) {
             notifier_.get_subscriber().on_next(SynchronizationEvent{
                 rxcpp::observable<>::empty<
                     std::shared_ptr<shared_model::interface::Block>>(),

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -26,8 +26,11 @@ namespace iroha {
 
       ~SynchronizerImpl() override;
 
-      void process_commit(std::shared_ptr<shared_model::interface::Block>
-                              commit_message) override;
+      std::unique_ptr<ametsuchi::MutableStorage> getStorage();
+      void processNext(
+          std::shared_ptr<shared_model::interface::Block> commit_message);
+      void processDifferent(
+          std::shared_ptr<shared_model::interface::Block> commit_message);
 
       rxcpp::observable<SynchronizationEvent> on_commit_chain() override;
 

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -26,7 +26,7 @@ namespace iroha {
 
       ~SynchronizerImpl() override;
 
-      void processOutcome(network::ConsensusGate::GateObject object) override;
+      void processOutcome(consensus::GateObject object) override;
       rxcpp::observable<SynchronizationEvent> on_commit_chain() override;
 
      private:

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -36,12 +36,17 @@ namespace iroha {
        */
       SynchronizationEvent downloadMissingBlocks(
           std::shared_ptr<shared_model::interface::Block> commit_message,
+          const consensus::Round &round,
           std::unique_ptr<ametsuchi::MutableStorage> storage);
 
       void processNext(
-          std::shared_ptr<shared_model::interface::Block> commit_message);
+          std::shared_ptr<shared_model::interface::Block> commit_message,
+          const consensus::Round &round);
       void processDifferent(
-          std::shared_ptr<shared_model::interface::Block> commit_message);
+          std::shared_ptr<shared_model::interface::Block> commit_message,
+          const consensus::Round &round);
+
+      boost::optional<std::unique_ptr<ametsuchi::MutableStorage>> getStorage();
 
       std::shared_ptr<validation::ChainValidator> validator_;
       std::shared_ptr<ametsuchi::MutableFactory> mutable_factory_;

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -26,7 +26,6 @@ namespace iroha {
 
       ~SynchronizerImpl() override;
 
-      std::unique_ptr<ametsuchi::MutableStorage> getStorage();
       void processNext(
           std::shared_ptr<shared_model::interface::Block> commit_message);
       void processDifferent(

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -26,11 +26,7 @@ namespace iroha {
 
       ~SynchronizerImpl() override;
 
-      void processNext(
-          std::shared_ptr<shared_model::interface::Block> commit_message);
-      void processDifferent(
-          std::shared_ptr<shared_model::interface::Block> commit_message);
-
+      void processOutcome(network::ConsensusGate::GateObject object) override;
       rxcpp::observable<SynchronizationEvent> on_commit_chain() override;
 
      private:
@@ -41,6 +37,11 @@ namespace iroha {
       SynchronizationEvent downloadMissingBlocks(
           std::shared_ptr<shared_model::interface::Block> commit_message,
           std::unique_ptr<ametsuchi::MutableStorage> storage);
+
+      void processNext(
+          std::shared_ptr<shared_model::interface::Block> commit_message);
+      void processDifferent(
+          std::shared_ptr<shared_model::interface::Block> commit_message);
 
       std::shared_ptr<validation::ChainValidator> validator_;
       std::shared_ptr<ametsuchi::MutableFactory> mutable_factory_;

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_SYNCHRONIZER_HPP
@@ -31,12 +19,6 @@ namespace iroha {
      */
     class Synchronizer {
      public:
-      /**
-       * Processing last committed block
-       */
-      virtual void process_commit(
-          std::shared_ptr<shared_model::interface::Block> commit_message) = 0;
-
       /**
        * After synchronization this observable emits zero or more blocks plus
        * outcome of synchronization

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -8,7 +8,7 @@
 
 #include <rxcpp/rx.hpp>
 
-#include "network/peer_communication_service.hpp"
+#include "network/consensus_gate.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 namespace iroha {
@@ -19,6 +19,12 @@ namespace iroha {
      */
     class Synchronizer {
      public:
+      /**
+       * Processing entry point for consensus outcome
+       */
+      virtual void processOutcome(
+          network::ConsensusGate::GateObject object) = 0;
+
       /**
        * After synchronization this observable emits zero or more blocks plus
        * outcome of synchronization

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -8,7 +8,7 @@
 
 #include <rxcpp/rx.hpp>
 
-#include "network/consensus_gate.hpp"
+#include "consensus/gate_object.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 namespace iroha {
@@ -22,8 +22,7 @@ namespace iroha {
       /**
        * Processing entry point for consensus outcome
        */
-      virtual void processOutcome(
-          network::ConsensusGate::GateObject object) = 0;
+      virtual void processOutcome(consensus::GateObject object) = 0;
 
       /**
        * After synchronization this observable emits zero or more blocks plus

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -27,7 +27,7 @@ namespace iroha {
      * Outcome, which was decided by synchronizer based on consensus result and
      * current local ledger state
      */
-    enum class SynchronizationOutcomeType { kCommit, kReject };
+    enum class SynchronizationOutcomeType { kCommit, kReject, kNothing };
 
     /**
      * Event, which is emitted by synchronizer, when it receives and processes
@@ -36,6 +36,7 @@ namespace iroha {
     struct SynchronizationEvent {
       Chain synced_blocks;
       SynchronizationOutcomeType sync_outcome;
+      shared_model::interface::types::HeightType height;
     };
 
   }  // namespace synchronizer

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -10,6 +10,7 @@
 
 #include <rxcpp/rx.hpp>
 
+#include "consensus/round.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {
@@ -36,7 +37,7 @@ namespace iroha {
     struct SynchronizationEvent {
       Chain synced_blocks;
       SynchronizationOutcomeType sync_outcome;
-      shared_model::interface::types::HeightType height;
+      consensus::Round round;
     };
 
   }  // namespace synchronizer

--- a/test/module/irohad/CMakeLists.txt
+++ b/test/module/irohad/CMakeLists.txt
@@ -1,16 +1,7 @@
-# Copyright 2018 Soramitsu Co., Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Reusable tests
 add_subdirectory(ametsuchi)
@@ -23,8 +14,7 @@ add_subdirectory(multi_sig_transactions)
 add_subdirectory(network)
 add_subdirectory(ordering)
 add_subdirectory(simulator)
-# TODO(@l4l) 11/10/18 IR-1754: uncomment
-# add_subdirectory(synchronizer)
+add_subdirectory(synchronizer)
 add_subdirectory(torii)
 add_subdirectory(validation)
 add_subdirectory(pending_txs_storage)

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -137,7 +137,7 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
   // verify that yac gate emit expected block
   auto gate_wrapper = make_test_subscriber<CallExact>(gate->onOutcome(), 1);
   gate_wrapper.subscribe([this](auto outcome) {
-    auto block = boost::get<PairValid>(outcome).block;
+    auto block = boost::get<iroha::consensus::PairValid>(outcome).block;
     ASSERT_EQ(block, expected_block);
 
     // verify that gate has put to cache block received from consensus

--- a/test/module/irohad/ordering/CMakeLists.txt
+++ b/test/module/irohad/ordering/CMakeLists.txt
@@ -1,16 +1,5 @@
-# Copyright 2017 Soramitsu Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 addtest(ordering_service_test ordering_service_test.cpp)
 target_link_libraries(ordering_service_test
@@ -24,6 +13,7 @@ target_link_libraries(ordering_gate_test
     ordering_service
     shared_model_cryptography_model
     shared_model_stateless_validation
+    consensus_round
     )
 
 addtest(on_demand_os_test on_demand_os_test.cpp)

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -152,7 +152,7 @@ class QueueBehaviorTest : public ::testing::Test {
                 std::make_shared<shared_model::proto::Block>(
                     TestBlockBuilder().height(height).build()))),
         SynchronizationOutcomeType::kCommit,
-        {}});
+        {height, 1}});
   }
 
   void pushProposal(HeightType height) {
@@ -212,7 +212,7 @@ TEST_F(QueueBehaviorTest, SendManyProposals) {
   commit_subject.get_subscriber().on_next(
       SynchronizationEvent{rxcpp::observable<>::just(block),
                            SynchronizationOutcomeType::kCommit,
-                           {}});
+                           {block->height(), 1}});
 
   ASSERT_TRUE(wrapper_after.validate());
 }

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -152,7 +152,7 @@ class QueueBehaviorTest : public ::testing::Test {
                 std::make_shared<shared_model::proto::Block>(
                     TestBlockBuilder().height(height).build()))),
         SynchronizationOutcomeType::kCommit,
-        0});
+        {}});
   }
 
   void pushProposal(HeightType height) {
@@ -212,7 +212,7 @@ TEST_F(QueueBehaviorTest, SendManyProposals) {
   commit_subject.get_subscriber().on_next(
       SynchronizationEvent{rxcpp::observable<>::just(block),
                            SynchronizationOutcomeType::kCommit,
-                           0});
+                           {}});
 
   ASSERT_TRUE(wrapper_after.validate());
 }

--- a/test/module/irohad/ordering/ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/ordering_gate_test.cpp
@@ -151,7 +151,8 @@ class QueueBehaviorTest : public ::testing::Test {
             std::static_pointer_cast<shared_model::interface::Block>(
                 std::make_shared<shared_model::proto::Block>(
                     TestBlockBuilder().height(height).build()))),
-        SynchronizationOutcomeType::kCommit});
+        SynchronizationOutcomeType::kCommit,
+        0});
   }
 
   void pushProposal(HeightType height) {
@@ -208,8 +209,10 @@ TEST_F(QueueBehaviorTest, SendManyProposals) {
       std::make_shared<shared_model::proto::Block>(
           TestBlockBuilder().height(2).build());
 
-  commit_subject.get_subscriber().on_next(SynchronizationEvent{
-      rxcpp::observable<>::just(block), SynchronizationOutcomeType::kCommit});
+  commit_subject.get_subscriber().on_next(
+      SynchronizationEvent{rxcpp::observable<>::just(block),
+                           SynchronizationOutcomeType::kCommit,
+                           0});
 
   ASSERT_TRUE(wrapper_after.validate());
 }

--- a/test/module/irohad/synchronizer/CMakeLists.txt
+++ b/test/module/irohad/synchronizer/CMakeLists.txt
@@ -6,4 +6,5 @@ target_link_libraries(synchronizer_test
     shared_model_stateless_validation
     shared_model_interfaces_factories
     shared_model_default_builders
+    consensus_round
     )

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -117,7 +117,7 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
     ASSERT_TRUE(block_wrapper.validate());
   });
 
-  gate_outcome.get_subscriber().on_next(PairValid{commit_message});
+  gate_outcome.get_subscriber().on_next(consensus::PairValid{commit_message});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -140,7 +140,7 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 0);
   wrapper.subscribe();
 
-  gate_outcome.get_subscriber().on_next(PairValid{commit_message});
+  gate_outcome.get_subscriber().on_next(consensus::PairValid{commit_message});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -173,7 +173,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
     ASSERT_TRUE(block_wrapper.validate());
   });
 
-  gate_outcome.get_subscriber().on_next(VoteOther{commit_message});
+  gate_outcome.get_subscriber().on_next(consensus::VoteOther{commit_message});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -198,7 +198,7 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe();
 
-  gate_outcome.get_subscriber().on_next(VoteOther{commit_message});
+  gate_outcome.get_subscriber().on_next(consensus::VoteOther{commit_message});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -236,7 +236,7 @@ TEST_F(SynchronizerTest, RetrieveBlockTwoFailures) {
     ASSERT_TRUE(block_wrapper.validate());
   });
 
-  gate_outcome.get_subscriber().on_next(VoteOther{commit_message});
+  gate_outcome.get_subscriber().on_next(consensus::VoteOther{commit_message});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -257,7 +257,8 @@ TEST_F(SynchronizerTest, RejectOutcome) {
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kReject);
   });
 
-  gate_outcome.get_subscriber().on_next(BlockReject{consensus::Round{}});
+  gate_outcome.get_subscriber().on_next(
+      consensus::BlockReject{consensus::Round{}});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -278,7 +279,8 @@ TEST_F(SynchronizerTest, NoneOutcome) {
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kNothing);
   });
 
-  gate_outcome.get_subscriber().on_next(AgreementOnNone{consensus::Round{}});
+  gate_outcome.get_subscriber().on_next(
+      consensus::AgreementOnNone{consensus::Round{}});
 
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -237,10 +237,9 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
 /**
  * @given initialized components
  * @when gate have got reject on block
- * @then synchronizer output is also reject with related block height
+ * @then synchronizer output is also reject
  */
 TEST_F(SynchronizerTest, RejectOutcome) {
-  constexpr int height = 1337;
   EXPECT_CALL(*consensus_gate, onOutcome())
       .WillOnce(Return(gate_outcome.get_observable()));
 
@@ -248,16 +247,15 @@ TEST_F(SynchronizerTest, RejectOutcome) {
 
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
-  wrapper.subscribe([height](auto commit_event) {
+  wrapper.subscribe([](auto commit_event) {
     auto block_wrapper =
         make_test_subscriber<CallExact>(commit_event.synced_blocks, 0);
     block_wrapper.subscribe();
     ASSERT_TRUE(block_wrapper.validate());
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kReject);
-    ASSERT_EQ(commit_event.height, height);
   });
 
-  gate_outcome.get_subscriber().on_next(BlockReject{height});
+  gate_outcome.get_subscriber().on_next(BlockReject{consensus::Round{}});
 
   ASSERT_TRUE(wrapper.validate());
 }
@@ -265,10 +263,9 @@ TEST_F(SynchronizerTest, RejectOutcome) {
 /**
  * @given initialized components
  * @when gate have got agreement on none
- * @then synchronizer output is also none with related block height
+ * @then synchronizer output is also none
  */
 TEST_F(SynchronizerTest, NoneOutcome) {
-  constexpr int height = 1337;
   EXPECT_CALL(*consensus_gate, onOutcome())
       .WillOnce(Return(gate_outcome.get_observable()));
 
@@ -276,16 +273,15 @@ TEST_F(SynchronizerTest, NoneOutcome) {
 
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
-  wrapper.subscribe([height](auto commit_event) {
+  wrapper.subscribe([](auto commit_event) {
     auto block_wrapper =
         make_test_subscriber<CallExact>(commit_event.synced_blocks, 0);
     block_wrapper.subscribe();
     ASSERT_TRUE(block_wrapper.validate());
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kNothing);
-    ASSERT_EQ(commit_event.height, height);
   });
 
-  gate_outcome.get_subscriber().on_next(AgreementOnNone{height});
+  gate_outcome.get_subscriber().on_next(AgreementOnNone{consensus::Round{}});
 
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -272,7 +272,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
   commit_notifier.get_subscriber().on_next(
       SynchronizationEvent{blocks_notifier.get_observable(),
                            SynchronizationOutcomeType::kCommit,
-                           0});
+                           {}});
 
   blocks_notifier.get_subscriber().on_next(
       std::shared_ptr<shared_model::interface::Block>(clone(block)));
@@ -327,7 +327,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
       rxcpp::observable<>::just(
           std::shared_ptr<shared_model::interface::Block>(clone(block))),
       SynchronizationOutcomeType::kCommit,
-      0};
+      {}};
   commit_notifier.get_subscriber().on_next(commit_event);
 
   SCOPED_TRACE("Committed status verification");
@@ -399,7 +399,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
       rxcpp::observable<>::just(
           std::shared_ptr<shared_model::interface::Block>(clone(block))),
       SynchronizationOutcomeType::kCommit,
-      0};
+      {}};
   commit_notifier.get_subscriber().on_next(commit_event);
 
   {

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -269,8 +269,10 @@ TEST_F(TransactionProcessorTest, TransactionProcessorBlockCreatedTest) {
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
       blocks_notifier;
 
-  commit_notifier.get_subscriber().on_next(SynchronizationEvent{
-      blocks_notifier.get_observable(), SynchronizationOutcomeType::kCommit});
+  commit_notifier.get_subscriber().on_next(
+      SynchronizationEvent{blocks_notifier.get_observable(),
+                           SynchronizationOutcomeType::kCommit,
+                           0});
 
   blocks_notifier.get_subscriber().on_next(
       std::shared_ptr<shared_model::interface::Block>(clone(block)));
@@ -324,7 +326,8 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
   SynchronizationEvent commit_event{
       rxcpp::observable<>::just(
           std::shared_ptr<shared_model::interface::Block>(clone(block))),
-      SynchronizationOutcomeType::kCommit};
+      SynchronizationOutcomeType::kCommit,
+      0};
   commit_notifier.get_subscriber().on_next(commit_event);
 
   SCOPED_TRACE("Committed status verification");
@@ -395,7 +398,8 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
   SynchronizationEvent commit_event{
       rxcpp::observable<>::just(
           std::shared_ptr<shared_model::interface::Block>(clone(block))),
-      SynchronizationOutcomeType::kCommit};
+      SynchronizationOutcomeType::kCommit,
+      0};
   commit_notifier.get_subscriber().on_next(commit_event);
 
   {

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -342,8 +342,8 @@ TEST_F(ToriiServiceTest, StatusWhenBlocking) {
   // create commit from block notifier's observable
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
       block_notifier_;
-  SynchronizationEvent commit{block_notifier_.get_observable(),
-                              SynchronizationOutcomeType::kCommit};
+  SynchronizationEvent commit{
+      block_notifier_.get_observable(), SynchronizationOutcomeType::kCommit, 0};
 
   // invoke on next of commit_notifier by sending new block to commit
   commit_notifier_.get_subscriber().on_next(commit);
@@ -491,8 +491,8 @@ TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
   // create commit from block notifier's observable
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
       block_notifier_;
-  SynchronizationEvent commit{block_notifier_.get_observable(),
-                              SynchronizationOutcomeType::kCommit};
+  SynchronizationEvent commit{
+      block_notifier_.get_observable(), SynchronizationOutcomeType::kCommit, 0};
 
   // invoke on next of commit_notifier by sending new block to commit
   commit_notifier_.get_subscriber().on_next(commit);

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -342,8 +342,9 @@ TEST_F(ToriiServiceTest, StatusWhenBlocking) {
   // create commit from block notifier's observable
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
       block_notifier_;
-  SynchronizationEvent commit{
-      block_notifier_.get_observable(), SynchronizationOutcomeType::kCommit, 0};
+  SynchronizationEvent commit{block_notifier_.get_observable(),
+                              SynchronizationOutcomeType::kCommit,
+                              {}};
 
   // invoke on next of commit_notifier by sending new block to commit
   commit_notifier_.get_subscriber().on_next(commit);
@@ -491,8 +492,9 @@ TEST_F(ToriiServiceTest, StreamingFullPipelineTest) {
   // create commit from block notifier's observable
   rxcpp::subjects::subject<std::shared_ptr<shared_model::interface::Block>>
       block_notifier_;
-  SynchronizationEvent commit{
-      block_notifier_.get_observable(), SynchronizationOutcomeType::kCommit, 0};
+  SynchronizationEvent commit{block_notifier_.get_observable(),
+                              SynchronizationOutcomeType::kCommit,
+                              {}};
 
   // invoke on next of commit_notifier by sending new block to commit
   commit_notifier_.get_subscriber().on_next(commit);


### PR DESCRIPTION
### Description of the Change

This pr fixes SynchronizerImpl to function with YacGateImpl, so it can handle ConsensusGate::GateObject and operate accordingly to the emitted variant.

### Benefits

One more step toward bft consensus

### Possible Drawbacks 

<s>Tests aren't fixed</s>
<s>`AgreementOnNone` isn't properly handled</s>
<s>No decision on behavior of reject cases</s>
