### PR TITLE
Fix bug with node synchronization

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -88,7 +88,7 @@ namespace iroha {
                     hash_provider_->toModelHash(hash.value());
                 // iterate over peers who voted for the committed block
                 // TODO [IR-1753] Akvinikym 11.10.18: add exponential backoff
-                // for each peer iteration
+                // for each peer iteration and shuffle peers order
                 rxcpp::observable<>::iterate(commit_message.votes)
                     // allow other peers to apply commit
                     .flat_map([this, model_hash](auto vote) {

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -39,7 +39,8 @@ namespace iroha {
             [this](auto block) { this->vote(block); });
       }
 
-      void YacGateImpl::vote(std::shared_ptr<shared_model::interface::Block> block) {
+      void YacGateImpl::vote(
+          std::shared_ptr<shared_model::interface::Block> block) {
         auto hash = hash_provider_->makeHash(*block);
         log_->info("vote for block ({}, {})",
                    hash.vote_hashes.proposal_hash,
@@ -86,6 +87,8 @@ namespace iroha {
                 const auto model_hash =
                     hash_provider_->toModelHash(hash.value());
                 // iterate over peers who voted for the committed block
+                // TODO [IR-1753] Akvinikym 11.10.18: add exponential backoff
+                // for each peer iteration
                 rxcpp::observable<>::iterate(commit_message.votes)
                     // allow other peers to apply commit
                     .flat_map([this, model_hash](auto vote) {

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -79,6 +79,8 @@ grpc::Status BlockLoaderService::retrieveBlock(
 
   // cache missed: notify and try to fetch the block from block storage itself
   auto blocks = block_query_factory_->createBlockQuery() |
+      // TODO [IR-1757] Akvinikym 12.10.18: use block height to get one block
+      // instead of the whole chain
       [](const auto &block_query) { return block_query->getBlocksFrom(1); };
   auto found_block = std::find_if(
       std::begin(blocks), std::end(blocks), [&hash](const auto &block) {

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -58,23 +58,24 @@ grpc::Status BlockLoaderService::retrieveBlock(
 
   // try to fetch block from the consensus cache
   auto block = consensus_result_cache_->get();
-  if (block and block->hash() == hash) {
-    auto transport_block =
-        std::static_pointer_cast<shared_model::proto::Block>(block)
-            ->getTransport();
-    response->CopyFrom(transport_block);
-    return grpc::Status::OK;
-  } else if (not block) {
-    log_->info(
-        "Tried to retrieve a block from an empty cache: requested block hash "
-        "{}",
-        hash.hex());
-  } else {
+  if (block) {
+    if (block->hash() == hash) {
+      auto transport_block =
+          std::static_pointer_cast<shared_model::proto::Block>(block)
+              ->getTransport();
+      response->CopyFrom(transport_block);
+      return grpc::Status::OK;
+    }
     log_->info(
         "Requested to retrieve a block, but cache contains another block: "
         "requested {}, in cache {}",
         hash.hex(),
         block->hash().hex());
+  } else {
+    log_->info(
+        "Tried to retrieve a block from an empty cache: requested block hash "
+        "{}",
+        hash.hex());
   }
 
   // cache missed: notify and try to fetch the block from block storage itself

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -56,21 +56,42 @@ grpc::Status BlockLoaderService::retrieveBlock(
                         "Bad hash provided");
   }
 
-  // required block must be in the cache
+  // try to fetch block from the consensus cache
   auto block = consensus_result_cache_->get();
-  if (not block) {
-    log_->info("Requested to retrieve a block from an empty cache");
-    return grpc::Status(grpc::StatusCode::NOT_FOUND, "Cache is empty");
-  }
-  if (block->hash() != hash) {
+  if (block and block->hash() == hash) {
+    auto transport_block =
+        std::static_pointer_cast<shared_model::proto::Block>(block)
+            ->getTransport();
+    response->CopyFrom(transport_block);
+    return grpc::Status::OK;
+  } else if (not block) {
     log_->info(
-        "Requested to retrieve a block with hash other than the one in cache");
+        "Tried to retrieve a block from an empty cache: requested block hash "
+        "{}",
+        hash.hex());
+  } else {
+    log_->info(
+        "Requested to retrieve a block, but cache contains another block: "
+        "requested {}, in cache {}",
+        hash.hex(),
+        block->hash().hex());
+  }
+
+  // cache missed: notify and try to fetch the block from block storage itself
+  auto blocks = block_query_factory_->createBlockQuery() |
+      [](const auto &block_query) { return block_query->getBlocksFrom(1); };
+  auto found_block = std::find_if(
+      std::begin(blocks), std::end(blocks), [&hash](const auto &block) {
+        return block->hash() == hash;
+      });
+  if (found_block == std::end(blocks)) {
+    log_->error("Could not retrieve a block from block storage: requested {}",
+                hash.hex());
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "Block not found");
   }
 
-  auto transport_block =
-      std::static_pointer_cast<shared_model::proto::Block>(block)
-          ->getTransport();
-  response->CopyFrom(transport_block);
+  response->CopyFrom(
+      std::static_pointer_cast<shared_model::proto::Block>(*found_block)
+          ->getTransport());
   return grpc::Status::OK;
 }

--- a/irohad/network/impl/block_loader_service.hpp
+++ b/irohad/network/impl/block_loader_service.hpp
@@ -30,7 +30,7 @@ namespace iroha {
       explicit BlockLoaderService(
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<iroha::consensus::ConsensusResultCache>
-          consensus_result_cache);
+              consensus_result_cache);
 
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -311,8 +311,8 @@ TEST_F(BlockLoaderTest, ValidWhenBlockMissing) {
 }
 
 /**
- * @given block loader @and empty consensus cache
- * @when retrieveBlock is called with some hash
+ * @given block loader @and empty consensus cache @and two blocks in storage
+ * @when retrieveBlock is called with first block's hash
  * @then consensus cache is missed @and block loader tries to fetch block from
  * the storage
  */
@@ -335,4 +335,21 @@ TEST_F(BlockLoaderTest, ValidWithEmptyCache) {
   auto block = loader->retrieveBlock(peer_key, prev_block->hash());
   ASSERT_TRUE(block);
   ASSERT_EQ(block.value()->hash(), prev_block->hash());
+}
+
+/**
+ * @given block loader @and empty consensus cache @and no blocks in storage
+ * @when retrieveBlock is called with some block hash
+ * @then consensus cache is missed @and block storage is missed @and block
+ * loader returns nothing
+ */
+TEST_F(BlockLoaderTest, NoBlocksInStorage) {
+  EXPECT_CALL(*peer_query, getLedgerPeers())
+      .WillOnce(Return(std::vector<wPeer>{peer}));
+  EXPECT_CALL(*storage, getBlocksFrom(1))
+      .WillOnce(Return(
+          std::vector<std::shared_ptr<shared_model::interface::Block>>{}));
+
+  auto block = loader->retrieveBlock(peer_key, kPrevHash);
+  ASSERT_FALSE(block);
 }

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -117,6 +117,26 @@ class BlockLoaderTest : public testing::Test {
         .transactions(std::vector<decltype(tx)>{tx});
   }
 
+  auto getBaseBlockBuilder(const Hash &prev_hash) const {
+    auto tx = TestUnsignedTransactionBuilder()
+                  .creatorAccountId("account@domain")
+                  .setAccountQuorum("account@domain", 1)
+                  .createdTime(iroha::time::now())
+                  .quorum(1)
+                  .build()
+                  .signAndAddSignature(key)
+                  .finish();
+    return shared_model::proto::TemplateBlockBuilder<
+               (1 << shared_model::proto::TemplateBlockBuilder<>::total) - 1,
+               shared_model::validation::AlwaysValidValidator,
+               shared_model::proto::UnsignedWrapper<
+                   shared_model::proto::Block>>()
+        .height(1)
+        .prevHash(prev_hash)
+        .createdTime(iroha::time::now())
+        .transactions(std::vector<decltype(tx)>{tx});
+  }
+
   const Hash kPrevHash =
       Hash(std::string(DefaultCryptoAlgorithmType::kHashLength, '0'));
 
@@ -262,34 +282,57 @@ TEST_F(BlockLoaderTest, ValidWhenBlockPresent) {
 }
 
 /**
- * @given block loader @and consensus cache with a block
- * @when retrieveBlock is called with a different hash
- * @then nothing is returned @and block loader service does not ask storage
+ * @given block loader @and consensus cache with a block @and mocked storage
+ * with two blocks
+ * @when retrieveBlock is called with a hash of previous block
+ * @then consensus cache is missed @and block loader tries to fetch block from
+ * the storage
  */
 TEST_F(BlockLoaderTest, ValidWhenBlockMissing) {
-  // Request nonexisting block => failure
-  auto present = std::make_shared<shared_model::proto::Block>(
+  auto prev_block = std::make_shared<shared_model::proto::Block>(
       getBaseBlockBuilder().build().signAndAddSignature(key).finish());
-  block_cache->insert(present);
+  auto cur_block = std::make_shared<shared_model::proto::Block>(
+      getBaseBlockBuilder(prev_block->hash())
+          .build()
+          .signAndAddSignature(key)
+          .finish());
+  block_cache->insert(cur_block);
 
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
-  EXPECT_CALL(*storage, getBlocksFrom(_)).Times(0);
-  auto block = loader->retrieveBlock(peer_key, kPrevHash);
+  EXPECT_CALL(*storage, getBlocksFrom(1))
+      .WillOnce(
+          Return(std::vector<std::shared_ptr<shared_model::interface::Block>>{
+              prev_block, cur_block}));
 
-  ASSERT_FALSE(block);
+  auto block = loader->retrieveBlock(peer_key, prev_block->hash());
+  ASSERT_TRUE(block);
+  ASSERT_EQ(block.value()->hash(), prev_block->hash());
 }
 
 /**
  * @given block loader @and empty consensus cache
  * @when retrieveBlock is called with some hash
- * @then nothing is returned @and block loader service does not ask storage
+ * @then consensus cache is missed @and block loader tries to fetch block from
+ * the storage
  */
 TEST_F(BlockLoaderTest, ValidWithEmptyCache) {
+  auto prev_block = std::make_shared<shared_model::proto::Block>(
+      getBaseBlockBuilder().build().signAndAddSignature(key).finish());
+  auto cur_block = std::make_shared<shared_model::proto::Block>(
+      getBaseBlockBuilder(prev_block->hash())
+          .build()
+          .signAndAddSignature(key)
+          .finish());
+
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
-  EXPECT_CALL(*storage, getBlocksFrom(_)).Times(0);
+  EXPECT_CALL(*storage, getBlocksFrom(1))
+      .WillOnce(
+          Return(std::vector<std::shared_ptr<shared_model::interface::Block>>{
+              prev_block, cur_block}));
 
-  auto emptiness = loader->retrieveBlock(peer_key, kPrevHash);
-  ASSERT_FALSE(emptiness);
+  auto block = loader->retrieveBlock(peer_key, prev_block->hash());
+  ASSERT_TRUE(block);
+  ASSERT_EQ(block.value()->hash(), prev_block->hash());
 }


### PR DESCRIPTION
### Description of the Change

Bug appears, when one of nodes goes down and then tries to synchronize itself with other ones, but at least one commit was accepted during its down state, and new consensus round started. Then, it tried to download block from the last round, but on other peers this block was already substituted by a new one in consensus cache, leading to result that BlockLoader did not give it, taking that node into an infinite loop.
Bug fix makes BlockLoader to look to the BlockStorage after the cache missed.

### Benefits

This bug went away.

### Possible Drawbacks 

No.