### PR TITLE
Copy postgres healthcheck file to docker container

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y /tmp/iroha.deb; \
 
 WORKDIR /opt/iroha_data
 
-COPY entrypoint.sh /entrypoint.sh
-COPY wait-for-it.sh /wait-for-it.sh
+COPY entrypoint.sh wait-for-it.sh /
+RUN chmod +x /entrypoint.sh /wait-for-it.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/sbin/init"]

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -11,5 +11,6 @@ RUN apt-get install -y /tmp/iroha.deb; \
 WORKDIR /opt/iroha_data
 
 COPY entrypoint.sh /entrypoint.sh
+COPY wait-for-it.sh /wait-for-it.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/sbin/init"]


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

We now copy `wait-for-it.sh` file, which checks that Postgres is running, to a docker container.

### Benefits

Iroha won't start without Postgres

### Possible Drawbacks 

None