### PR TITLE
Fix stateful validator execution time

### DIFF
--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -153,7 +153,8 @@ namespace iroha {
         validation::TransactionsErrors &transactions_errors_log,
         const logger::Logger &log,
         const shared_model::interface::TransactionBatchParser &batch_parser) {
-      std::vector<uint8_t> validation_results;
+      std::vector<bool> validation_results;
+      validation_results.reserve(boost::size(txs));
 
       for (auto batch : batch_parser.parseBatches(txs)) {
         auto validation = [&](auto &tx) {

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -166,13 +166,16 @@ namespace iroha {
           // check all batch's transactions for validness
           auto savepoint = temporary_wsv.createSavepoint(
               "batch_" + batch.front().hash().hex());
-          if (boost::algorithm::all_of(batch, validation)) {
-            // batch is successful; join with result and release savepoint
-            validation_results.insert(
-                validation_results.end(), boost::size(batch), true);
+          bool validation_result = false;
 
+          if (boost::algorithm::all_of(batch, validation)) {
+            // batch is successful; release savepoint
+            validation_result = true;
             savepoint->release();
           }
+
+          validation_results.insert(
+              validation_results.end(), boost::size(batch), validation_result);
         } else {
           for (const auto &tx : batch) {
             validation_results.push_back(validation(tx));


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
`boost::join` calls were causing longer execution time in stateful validation. Using a `vector` for filtering restores execution time as is was before using `boost::join`.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Normal execution time.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->