### PR TITLE
Move signatories validation to SQL

### DIFF
--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -5,10 +5,11 @@
 
 #include "ametsuchi/impl/temporary_wsv_impl.hpp"
 
+#include <boost/format.hpp>
 #include "ametsuchi/impl/postgres_command_executor.hpp"
-#include "ametsuchi/impl/postgres_wsv_command.hpp"
-#include "ametsuchi/impl/postgres_wsv_query.hpp"
+#include "cryptography/public_key.hpp"
 #include "interfaces/commands/command.hpp"
+#include "interfaces/transaction.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -16,18 +17,61 @@ namespace iroha {
         std::unique_ptr<soci::session> sql,
         std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
         : sql_(std::move(sql)),
-          wsv_(std::make_shared<PostgresWsvQuery>(*sql_, factory)),
           command_executor_(std::make_unique<PostgresCommandExecutor>(*sql_)),
           log_(logger::log("TemporaryWSV")) {
       *sql_ << "BEGIN";
     }
 
+    expected::Result<void, validation::CommandError>
+    TemporaryWsvImpl::validateSignatures(
+        const shared_model::interface::Transaction &transaction) {
+      auto keys_range = transaction.signatures()
+          | boost::adaptors::transformed(
+                            [](const auto &s) { return s.publicKey().hex(); });
+      auto keys = std::accumulate(
+          std::next(std::begin(keys_range)),
+          std::end(keys_range),
+          keys_range.front(),
+          [](auto acc, const auto &val) { return acc + "'), ('" + val; });
+      // not using bool since it is not supported by SOCI
+      boost::optional<uint32_t> signatories_valid;
+
+      boost::format query(R"(SELECT sum(count) = :signatures_count
+                          AND sum(quorum) <= :signatures_count
+                  FROM
+                      (SELECT count(public_key)
+                      FROM ( VALUES ('%s') ) AS CTE1(public_key)
+                      WHERE public_key IN
+                          (SELECT public_key
+                          FROM account_has_signatory
+                          WHERE account_id = :account_id ) ) AS CTE2(count),
+                          (SELECT quorum
+                          FROM account
+                          WHERE account_id = :account_id) AS CTE3(quorum))");
+
+      try {
+        *sql_ << (query % keys).str(), soci::into(signatories_valid),
+            soci::use(boost::size(keys_range), "signatures_count"),
+            soci::use(transaction.creatorAccountId(), "account_id");
+      } catch (const std::exception &e) {
+        log_->error(e.what());
+      }
+
+      if (signatories_valid and *signatories_valid) {
+        return {};
+      } else {
+        return expected::makeError(validation::CommandError{
+            "signatures validation",
+            "possible reasons: database error, no account, number of "
+            "signatures is less than account quorum, signatures are not a "
+            "subset of account signatories",
+            false});
+      }
+    }
+
     expected::Result<void, validation::CommandError> TemporaryWsvImpl::apply(
-        const shared_model::interface::Transaction &tx,
-        std::function<expected::Result<void, validation::CommandError>(
-            const shared_model::interface::Transaction &, WsvQuery &)>
-            apply_function) {
-      const auto &tx_creator = tx.creatorAccountId();
+        const shared_model::interface::Transaction &transaction) {
+      const auto &tx_creator = transaction.creatorAccountId();
       command_executor_->setCreatorAccountId(tx_creator);
       command_executor_->doValidation(true);
       auto execute_command =
@@ -38,12 +82,13 @@ namespace iroha {
 
       auto savepoint_wrapper = createSavepoint("savepoint_temp_wsv");
 
-      return apply_function(tx, *wsv_) |
+      return validateSignatures(transaction) |
                  [savepoint = std::move(savepoint_wrapper),
                   &execute_command,
-                  &tx]() -> expected::Result<void, validation::CommandError> {
+                  &transaction]()
+                 -> expected::Result<void, validation::CommandError> {
         // check transaction's commands validity
-        const auto &commands = tx.commands();
+        const auto &commands = transaction.commands();
         validation::CommandError cmd_error;
         for (size_t i = 0; i < commands.size(); ++i) {
           // in case of failed command, rollback and return

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -46,6 +46,10 @@ namespace iroha {
       ~TemporaryWsvImpl() override;
 
      private:
+      /**
+       * Verifies whether transaction has at least quorum signatures and they
+       * are a subset of creator account signatories
+       */
       expected::Result<void, validation::CommandError> validateSignatures(
           const shared_model::interface::Transaction &transaction);
 

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -1,27 +1,15 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_TEMPORARY_WSV_IMPL_HPP
 #define IROHA_TEMPORARY_WSV_IMPL_HPP
 
-#include <soci/soci.h>
-
-#include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/temporary_wsv.hpp"
+
+#include <soci/soci.h>
+#include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "logger/logger.hpp"
 
@@ -50,10 +38,7 @@ namespace iroha {
               factory);
 
       expected::Result<void, validation::CommandError> apply(
-          const shared_model::interface::Transaction &,
-          std::function<expected::Result<void, validation::CommandError>(
-              const shared_model::interface::Transaction &, WsvQuery &)>
-              function) override;
+          const shared_model::interface::Transaction &transaction) override;
 
       std::unique_ptr<TemporaryWsv::SavepointWrapper> createSavepoint(
           const std::string &name) override;
@@ -61,8 +46,10 @@ namespace iroha {
       ~TemporaryWsvImpl() override;
 
      private:
+      expected::Result<void, validation::CommandError> validateSignatures(
+          const shared_model::interface::Transaction &transaction);
+
       std::unique_ptr<soci::session> sql_;
-      std::shared_ptr<WsvQuery> wsv_;
       std::unique_ptr<CommandExecutor> command_executor_;
 
       logger::Logger log_;

--- a/irohad/ametsuchi/temporary_wsv.hpp
+++ b/irohad/ametsuchi/temporary_wsv.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_TEMPORARYWSV_HPP
@@ -20,8 +8,7 @@
 
 #include <functional>
 
-#include "ametsuchi/wsv_command.hpp"
-#include "ametsuchi/wsv_query.hpp"
+#include "common/result.hpp"
 #include "validation/stateful_validator_common.hpp"
 
 namespace shared_model {
@@ -54,17 +41,11 @@ namespace iroha {
 
       /**
        * Applies a transaction to current state
-       * using logic specified in function
        * @param transaction Transaction to be applied
-       * @param function Function that specifies the logic used to apply the
-       * transaction
        * @return True if transaction was successfully applied, false otherwise
        */
       virtual expected::Result<void, validation::CommandError> apply(
-          const shared_model::interface::Transaction &,
-          std::function<expected::Result<void, validation::CommandError>(
-              const shared_model::interface::Transaction &, WsvQuery &)>
-              function) = 0;
+          const shared_model::interface::Transaction &transaction) = 0;
 
       /**
        * Create a savepoint for wsv state
@@ -75,9 +56,8 @@ namespace iroha {
           const std::string &name) = 0;
 
       virtual ~TemporaryWsv() = default;
-
     };
-  }     // namespace ametsuchi
+  }  // namespace ametsuchi
 }  // namespace iroha
 
 #endif  // IROHA_TEMPORARYWSV_HPP

--- a/irohad/validation/stateful_validator_common.hpp
+++ b/irohad/validation/stateful_validator_common.hpp
@@ -6,6 +6,8 @@
 #ifndef IROHA_STATEFUL_VALIDATOR_COMMON_HPP
 #define IROHA_STATEFUL_VALIDATOR_COMMON_HPP
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "interfaces/common_objects/types.hpp"

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -31,6 +31,7 @@
 #include "ametsuchi/storage.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "ametsuchi/temporary_wsv.hpp"
+#include "ametsuchi/wsv_command.hpp"
 #include "ametsuchi/wsv_query.hpp"
 #include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"
@@ -194,12 +195,9 @@ namespace iroha {
 
     class MockTemporaryWsv : public TemporaryWsv {
      public:
-      MOCK_METHOD2(
-          apply,
-          expected::Result<void, validation::CommandError>(
-              const shared_model::interface::Transaction &,
-              std::function<expected::Result<void, validation::CommandError>(
-                  const shared_model::interface::Transaction &, WsvQuery &)>));
+      MOCK_METHOD1(apply,
+                   expected::Result<void, validation::CommandError>(
+                       const shared_model::interface::Transaction &));
       MOCK_METHOD1(
           createSavepoint,
           std::unique_ptr<TemporaryWsv::SavepointWrapper>(const std::string &));

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -161,7 +161,7 @@ TEST_F(Validator, AllTxsValid) {
               std::vector<shared_model::proto::Transaction>{tx, tx, tx})
           .build();
 
-  EXPECT_CALL(*temp_wsv_mock, apply(_, _))
+  EXPECT_CALL(*temp_wsv_mock, apply(_))
       .WillRepeatedly(Return(iroha::expected::Value<void>({})));
 
   auto verified_proposal_and_errors = sfv->validate(proposal, *temp_wsv_mock);
@@ -196,9 +196,9 @@ TEST_F(Validator, SomeTxsFail) {
               valid_tx, invalid_tx, valid_tx})
           .build();
 
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(invalid_tx)), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(invalid_tx))))
       .WillOnce(Return(iroha::expected::Error<CommandError>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(valid_tx)), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(valid_tx))))
       .WillRepeatedly(Return(iroha::expected::Value<void>({})));
 
   auto verified_proposal_and_errors = sfv->validate(proposal, *temp_wsv_mock);
@@ -260,17 +260,17 @@ TEST_F(Validator, Batches) {
   // calls to validate transactions, one per each transaction except those,
   // which are in failed atomic batch - there only calls before the failed
   // transaction are needed
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[0])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[0]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[1])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[1]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[2])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[2]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[3])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[3]))))
       .WillOnce(Return(iroha::expected::Error<CommandError>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[5])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[5]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
-  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[6])), _))
+  EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[6]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
 
   auto verified_proposal_and_errors = sfv->validate(proposal, *temp_wsv_mock);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Move stateful signatures validation to SQL.
1. Reduce the number of database queries. Single query used to perform the required validation.
2. Reduce the number of data fetches. Since signatories are not required to be fetched from database, only a single fetch is done instead of number of signatures.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Increased performance. Execution time of bm_pipeline benchmark on a test machine was 5000ms before, and the changes have brought it down to 4500ms.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
More ambiguous error message since a single error type is returned from the database.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
