### PR TITLE
Fix bug with 100% peer load

### DIFF
--- a/cmake/Modules/Findrxcpp.cmake
+++ b/cmake/Modules/Findrxcpp.cmake
@@ -9,7 +9,7 @@ find_package_handle_standard_args(rxcpp DEFAULT_MSG
 
 
 set(URL https://github.com/Reactive-Extensions/rxcpp.git)
-set(VERSION 1b2e0589f19cb34d8cd58803677701dcf2161876)
+set(VERSION a7d5856385f126e874db6010d9dbfd37290c61de)
 set_target_description(rxcpp "Library for reactive programming" ${URL} ${VERSION})
 
 

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -145,7 +145,7 @@ RUN set -e; \
 # install rxcpp
 RUN set -e; \
     git clone https://github.com/Reactive-Extensions/RxCpp /tmp/RxCpp; \
-    (cd /tmp/RxCpp ; git checkout 1b2e0589f19cb34d8cd58803677701dcf2161876); \
+    (cd /tmp/RxCpp ; git checkout a7d5856385f126e874db6010d9dbfd37290c61de); \
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -H/tmp/RxCpp \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -137,7 +137,7 @@ RUN set -e; \
 # install rxcpp
 RUN set -e; \
     git clone https://github.com/Reactive-Extensions/RxCpp /tmp/RxCpp; \
-    (cd /tmp/RxCpp ; git checkout 1b2e0589f19cb34d8cd58803677701dcf2161876); \
+    (cd /tmp/RxCpp ; git checkout a7d5856385f126e874db6010d9dbfd37290c61de); \
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -H/tmp/RxCpp \

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/optional.hpp>
 #include <cmath>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "common/result.hpp"
 #include "common/types.hpp"

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_AMETSUCHI_H
 #define IROHA_AMETSUCHI_H
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include <vector>
 
 #include "ametsuchi/block_query_factory.hpp"

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -21,7 +21,7 @@
 #include <boost/optional.hpp>
 #include <memory>
 #include <mutex>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "consensus/yac/cluster_order.hpp"  //  for ClusterOrdering
 #include "consensus/yac/messages.hpp"       // because messages passed by value

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_YAC_GATE_HPP
 #define IROHA_YAC_GATE_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "consensus/yac/storage/storage_result.hpp"
 #include "network/consensus_gate.hpp"
 

--- a/irohad/model/commit.hpp
+++ b/irohad/model/commit.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_COMMIT_HPP
 #define IROHA_COMMIT_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 namespace iroha {
   using OldCommit = rxcpp::observable<model::Block>;

--- a/irohad/model/queries/responses/transactions_response.hpp
+++ b/irohad/model/queries/responses/transactions_response.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_TRANSACTIONS_RESPONSE_HPP
 #define IROHA_TRANSACTIONS_RESPONSE_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "model/transaction.hpp"
 
 namespace iroha {

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -19,7 +19,7 @@
 #define IROHA_BLOCK_LOADER_HPP
 
 #include <memory>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_ORDERING_SERVICE_HPP
 #define IROHA_ORDERING_SERVICE_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "network/peer_communication_service.hpp"
 

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -10,7 +10,7 @@
 
 #include <shared_mutex>
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 namespace iroha {
   namespace ordering {

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -11,7 +11,7 @@
 #include <shared_mutex>
 
 #include <boost/variant.hpp>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_BLOCK_CREATOR_HPP
 #define IROHA_BLOCK_CREATOR_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 namespace shared_model {
   namespace interface {

--- a/irohad/simulator/verified_proposal_creator.hpp
+++ b/irohad/simulator/verified_proposal_creator.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 #define IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "validation/stateful_validator_common.hpp"
 
 namespace shared_model {

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_SYNCHRONIZER_HPP
 #define IROHA_SYNCHRONIZER_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "network/peer_communication_service.hpp"
 #include "synchronizer/synchronizer_common.hpp"

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 #include "interfaces/iroha_internal/block.hpp"
 

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -6,7 +6,7 @@
 #ifndef TORII_COMMAND_SERVICE_HPP
 #define TORII_COMMAND_SERVICE_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -18,7 +18,7 @@
 #ifndef IROHA_CHAIN_VALIDATOR_HPP
 #define IROHA_CHAIN_VALIDATOR_HPP
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 
 namespace shared_model {
   namespace interface {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,7 +97,7 @@ parts:
     after: [cmake]
   rxcpp:
     source: https://github.com/Reactive-Extensions/RxCpp.git
-    source-commit: 1b2e0589f19cb34d8cd58803677701dcf2161876
+    source-commit: a7d5856385f126e874db6010d9dbfd37290c61de
     plugin: cmake
     after: [cmake]
   rapidjson:

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -20,7 +20,7 @@
 
 #include <functional>
 #include <memory>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include <utility>
 
 namespace framework {

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "consensus/consensus_block_cache.hpp"
 #include "consensus/yac/impl/yac_gate_impl.hpp"
 #include "consensus/yac/storage/yac_proposal_storage.hpp"

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <rxcpp/rx-observable.hpp>
+#include <rxcpp/rx.hpp>
 #include "datetime/time.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"


### PR DESCRIPTION
Signed-off-by: Akvinikym <anarant12@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Bug with 100%+ Iroha node overload was appearing because of block streaming service, which was based into RxCpp blocking observable. In version, used in current Iroha, it had a serious issue - spinlock - which was addressed here and fixed August 6 2018. So, this pull request updated a version of RxCpp up to the current one.

### Benefits

No more useless node overload.

### Possible Drawbacks 

With the current RxCpp version it seems that it is not sufficient to `#include <rxcpp/rx-observable.hpp>`, but a whole `#include <rxcpp/rx.hpp>`, which can theoretically lead to increased compilation time.

### Usage Examples or Tests

The use case can be tested manually through Python's scripts `blocks-query.py`, which is to launched first, and then `tx-example.py`. Because of subscription to blocks in the first script, the 100% load appeared before fixing the bug. Now, it isn't.
