### PR TITLE
Create thread once at GossipPropagation

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -320,6 +320,7 @@ void Irohad::initMstProcessor() {
     // cli parameters
     auto mst_propagation = std::make_shared<GossipPropagationStrategy>(
         storage,
+        rxcpp::observe_on_new_thread(),
         std::chrono::seconds(5) /*emitting period*/,
         2 /*amount per once*/);
     auto mst_time = std::make_shared<MstTimeProviderImpl>();

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
@@ -45,6 +45,7 @@ namespace iroha {
      * @param amount of peers emitted per once
      */
     GossipPropagationStrategy(PeerProviderFactory peer_factory,
+                              rxcpp::observe_on_one_worker emit_worker,
                               std::chrono::milliseconds period,
                               uint32_t amount);
 

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
@@ -71,6 +71,11 @@ namespace iroha {
      */
     std::vector<size_t> non_visited;
 
+    /**
+     * Worker that performs internal loop handling
+     */
+    rxcpp::observe_on_one_worker emit_worker;
+
     /*
      * Observable for the emitting propagated data
      */

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
@@ -41,6 +41,7 @@ namespace iroha {
     /**
      * Initialize strategy with
      * @param peer_factory is a provider of peer list
+     * @param emit_worker is the coordinator for the data emitting
      * @param period of emitting data in ms
      * @param amount of peers emitted per once
      */

--- a/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
+++ b/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
@@ -25,6 +25,7 @@ namespace iroha {
       uint32_t amount)
       : peer_factory(peer_factory),
         non_visited({}),
+        emit_worker(rxcpp::observe_on_new_thread()),
         emitent(rxcpp::observable<>::interval(steady_clock::now(), period)
                     .map([this, amount](int) {
                       PropagationData vec;
@@ -38,10 +39,11 @@ namespace iroha {
                             };
                           });
                       return vec;
-                    })) {}
+                    })
+                    .subscribe_on(emit_worker)) {}
 
   rxcpp::observable<PropagationData> GossipPropagationStrategy::emitter() {
-    return emitent.subscribe_on(rxcpp::observe_on_new_thread());
+    return emitent;
   }
 
   GossipPropagationStrategy::~GossipPropagationStrategy() {

--- a/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
+++ b/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
@@ -21,11 +21,12 @@ namespace iroha {
 
   GossipPropagationStrategy::GossipPropagationStrategy(
       PeerProviderFactory peer_factory,
+      rxcpp::observe_on_one_worker emit_worker,
       std::chrono::milliseconds period,
       uint32_t amount)
       : peer_factory(peer_factory),
         non_visited({}),
-        emit_worker(rxcpp::observe_on_new_thread()),
+        emit_worker(emit_worker),
         emitent(rxcpp::observable<>::interval(steady_clock::now(), period)
                     .map([this, amount](int) {
                       PropagationData vec;

--- a/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
@@ -188,7 +188,7 @@ TEST(GossipPropagationStrategyTest, MultipleSubsEmission) {
           std::shared_ptr<iroha::ametsuchi::PeerQuery>(query))));
   EXPECT_CALL(*query, getLedgerPeers()).WillRepeatedly(testing::Return(peers));
   GossipPropagationStrategy strategy(
-      pbfactory, rxcpp::observe_on_event_loop(), 1ms, amount);
+      pbfactory, rxcpp::observe_on_new_thread(), 1ms, amount);
 
   // Create separate subscriber for every thread
   // Use result[i] as storage for emitent for i-th one

--- a/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
@@ -79,7 +79,8 @@ PropagationData subscribeAndEmit(boost::optional<PropagationData> data,
   EXPECT_CALL(*pbfactory, createPeerQuery())
       .WillRepeatedly(testing::Return(boost::make_optional(
           std::shared_ptr<iroha::ametsuchi::PeerQuery>(query))));
-  GossipPropagationStrategy strategy(pbfactory, period, amount);
+  GossipPropagationStrategy strategy(
+      pbfactory, rxcpp::observe_on_event_loop(), period, amount);
   return subscribeAndEmit(strategy, take);
 }
 
@@ -186,7 +187,8 @@ TEST(GossipPropagationStrategyTest, MultipleSubsEmission) {
       .WillRepeatedly(testing::Return(boost::make_optional(
           std::shared_ptr<iroha::ametsuchi::PeerQuery>(query))));
   EXPECT_CALL(*query, getLedgerPeers()).WillRepeatedly(testing::Return(peers));
-  GossipPropagationStrategy strategy(pbfactory, 1ms, amount);
+  GossipPropagationStrategy strategy(
+      pbfactory, rxcpp::observe_on_event_loop(), 1ms, amount);
 
   // Create separate subscriber for every thread
   // Use result[i] as storage for emitent for i-th one


### PR DESCRIPTION
### Description of the Change

Before, GossipPropagationStrategy has created threads on each `emitter`. This pr resolves it by adding separate thread as a member field

### Benefits

No redundant threads are created

### Possible Drawbacks 

None

### Usage Examples or Tests

It is not trivial to write test for that fix. This behavior might be observed in a debugger via thread information
