### PR TITLE
ITF: Fake Peer

### DIFF
--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(test_subscriber_testing
 add_library(integration_framework
     integration_framework/integration_test_framework.cpp
     integration_framework/iroha_instance.cpp
+    integration_framework/fake_peer/fake_peer.cpp
     )
 target_link_libraries(integration_framework
     application

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -25,12 +25,17 @@ add_library(integration_framework
     integration_framework/integration_test_framework.cpp
     integration_framework/iroha_instance.cpp
     integration_framework/fake_peer/fake_peer.cpp
+    integration_framework/fake_peer/yac_network_notifier.cpp
     )
 target_link_libraries(integration_framework
     application
     integration_framework_config_helper
     command_client
     query_client
+    yac_transport
+    shared_model_cryptography_model
+    server_runner
+    mst_transport
     )
 
 target_include_directories(integration_framework PUBLIC ${PROJECT_SOURCE_DIR}/test PRIVATE "${gmock_INCLUDE_DIR};${gtest_INCLUDE_DIR}")

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -92,7 +92,15 @@ namespace integration_framework {
     // start instance
     log_->info("starting listening server");
     internal_server_ = std::make_unique<ServerRunner>(getAddress());
-    internal_server_->append(yac_transport_).append(mst_transport_).run();
+    internal_server_->append(yac_transport_)
+        .append(mst_transport_)
+        .run()
+        .match(
+            [this](const iroha::expected::Result<int, std::string>::ValueType
+                       &val) {
+              log_->debug("started server on port {}", val.value);
+            },
+            [this](const auto &err) { log_->error("coul not start server!"); });
   }
 
   void FakePeer::subscribeForMstNotifications(

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -135,6 +135,14 @@ namespace integration_framework {
 
   void FakePeer::voteForTheSame(const YacStateMessage &incoming_votes) {
     using iroha::consensus::yac::VoteMessage;
+    log_->debug("Got a YAC state message with {} votes.",
+                incoming_votes->size());
+    if (incoming_votes->size() > 1) {
+      // TODO mboldyrev 24/10/2018: rework ignoring states for accepted commits
+      log_->debug("Ignoring state with multiple votes, "
+          "because it probably refers to an accepted commit.");
+      return;
+    }
     std::vector<VoteMessage> my_votes;
     my_votes.reserve(incoming_votes->size());
     std::transform(

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -5,6 +5,7 @@
 
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 
+#include <boost/assert.hpp>
 #include "consensus/yac/impl/yac_crypto_provider_impl.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
 #include "consensus/yac/yac_crypto_provider.hpp"
@@ -98,7 +99,13 @@ namespace integration_framework {
         .match(
             [this](const iroha::expected::Result<int, std::string>::ValueType
                        &val) {
-              log_->debug("started server on port {}", val.value);
+              const size_t bound_port = val.value;
+              BOOST_VERIFY_MSG(
+                  bound_port == internal_port_,
+                  ("Server started on port " + std::to_string(bound_port)
+                   + " instead of requested " + std::to_string(internal_port_)
+                   + "!")
+                      .c_str());
             },
             [this](const auto &err) { log_->error("coul not start server!"); });
   }

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/fake_peer/fake_peer.hpp"
+
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "cryptography/default_hash_provider.hpp"
+#include "cryptography/keypair.hpp"
+#include "main/server_runner.hpp"
+#include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
+#include "network/impl/async_grpc_client.hpp"
+
+using namespace shared_model::crypto;
+
+namespace integration_framework {
+
+  FakePeer::FakePeer(
+      const std::string &listen_ip,
+      size_t internal_port,
+      const boost::optional<Keypair> &key,
+      std::shared_ptr<TransportFactoryType> transaction_factory,
+      std::shared_ptr<shared_model::interface::TransactionBatchParser>
+          batch_parser,
+      std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+          transaction_batch_factory)
+      : listen_ip_(listen_ip),
+        internal_port_(internal_port),
+        keypair_(std::make_unique<Keypair>(
+            key.value_or(DefaultCryptoAlgorithmType::generateKeypair()))),
+        mst_transport_(std::make_shared<iroha::network::MstTransportGrpc>(
+            std::make_shared<
+                iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(),
+            transaction_factory,
+            batch_parser,
+            transaction_batch_factory,
+            keypair_->publicKey())),
+        log_(logger::log("IntegrationTestFramework (fake peer at "
+                         + getAddress() + ")")) {}
+
+  void FakePeer::run() {
+    // start instance
+    log_->info("starting listening server");
+    internal_server_ = std::make_unique<ServerRunner>(getAddress());
+    internal_server_->append(mst_transport_).run();
+  }
+
+  void FakePeer::subscribeForMstNotifications(
+      std::shared_ptr<iroha::network::MstTransportNotification> notification) {
+    return mst_transport_->subscribe(notification);
+  }
+
+  std::string FakePeer::getAddress() const {
+    return listen_ip_ + ":" + std::to_string(internal_port_);
+  }
+
+  const Keypair &FakePeer::getKeypair() const {
+    return *keypair_.get();
+  }
+
+}  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -113,7 +113,7 @@ namespace integration_framework {
   }
 
   const Keypair &FakePeer::getKeypair() const {
-    return *keypair_.get();
+    return *keypair_;
   }
 
   rxcpp::observable<YacStateMessage> FakePeer::get_yac_states_observable() {

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -5,14 +5,45 @@
 
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 
+#include "consensus/yac/impl/yac_crypto_provider_impl.hpp"
+#include "consensus/yac/transport/impl/network_impl.hpp"
+#include "consensus/yac/yac_crypto_provider.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "cryptography/keypair.hpp"
+#include "framework/result_fixture.hpp"
+#include "interfaces/common_objects/common_objects_factory.hpp"
 #include "main/server_runner.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 #include "network/impl/async_grpc_client.hpp"
 
 using namespace shared_model::crypto;
+using namespace framework::expected;
+
+using YacStateMessage = integration_framework::YacNetworkNotifier::StateMessagePtr;
+
+static std::shared_ptr<shared_model::interface::Peer> createPeer(
+    const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        &common_objects_factory,
+    const std::string &address,
+    const PublicKey &key) {
+  std::shared_ptr<shared_model::interface::Peer> peer;
+  common_objects_factory->createPeer(address, key)
+      .match(
+          [&peer](iroha::expected::Result<
+                  std::unique_ptr<shared_model::interface::Peer>,
+                  std::string>::ValueType &result) {
+            peer = std::move(result.value);
+          },
+          [&address](const iroha::expected::Result<
+              std::unique_ptr<shared_model::interface::Peer>,
+              std::string>::ErrorType &error) {
+            BOOST_THROW_EXCEPTION(
+                std::runtime_error("Failed to create peer object for peer "
+                                   + address + ". " + error.error));
+          });
+  return peer;
+}
 
 namespace integration_framework {
 
@@ -20,30 +51,48 @@ namespace integration_framework {
       const std::string &listen_ip,
       size_t internal_port,
       const boost::optional<Keypair> &key,
+      const std::shared_ptr<shared_model::interface::Peer> &real_peer,
+      const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+          &common_objects_factory,
       std::shared_ptr<TransportFactoryType> transaction_factory,
       std::shared_ptr<shared_model::interface::TransactionBatchParser>
           batch_parser,
       std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-          transaction_batch_factory)
-      : listen_ip_(listen_ip),
+          transaction_batch_factory,
+      bool agree_all_proposals)
+      : common_objects_factory_(common_objects_factory),
+        listen_ip_(listen_ip),
         internal_port_(internal_port),
         keypair_(std::make_unique<Keypair>(
             key.value_or(DefaultCryptoAlgorithmType::generateKeypair()))),
-        mst_transport_(std::make_shared<iroha::network::MstTransportGrpc>(
-            std::make_shared<
-                iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(),
-            transaction_factory,
-            batch_parser,
-            transaction_batch_factory,
-            keypair_->publicKey())),
-        log_(logger::log("IntegrationTestFramework (fake peer at "
-                         + getAddress() + ")")) {}
+        this_peer_(createPeer(
+            common_objects_factory, getAddress(), keypair_->publicKey())),
+        real_peer_(real_peer),
+        async_call_(std::make_shared<AsyncCall>()),
+        mst_transport_(std::make_shared<MstTransport>(async_call_,
+                                                      transaction_factory,
+                                                      batch_parser,
+                                                      transaction_batch_factory,
+                                                      keypair_->publicKey())),
+        yac_transport_(std::make_shared<YacTransport>(async_call_)),
+        yac_network_notifier_(std::make_shared<YacNetworkNotifier>()),
+        yac_crypto_(std::make_shared<iroha::consensus::yac::CryptoProviderImpl>(
+            *keypair_, common_objects_factory)) {
+    yac_network_notifier_->subscribe(yac_transport_);
+    log_ = logger::log(
+        "IntegrationTestFramework "
+        "(fake peer at "
+        + getAddress() + ")");
+    if (agree_all_proposals) {
+      enableAgreeAllProposals();
+    }
+  }
 
   void FakePeer::run() {
     // start instance
     log_->info("starting listening server");
     internal_server_ = std::make_unique<ServerRunner>(getAddress());
-    internal_server_->append(mst_transport_).run();
+    internal_server_->append(yac_transport_).append(mst_transport_).run();
   }
 
   void FakePeer::subscribeForMstNotifications(
@@ -57,6 +106,62 @@ namespace integration_framework {
 
   const Keypair &FakePeer::getKeypair() const {
     return *keypair_.get();
+  }
+
+  rxcpp::observable<YacStateMessage> FakePeer::get_yac_states_observable() {
+    return yac_network_notifier_->get_observable();
+  }
+
+  void FakePeer::enableAgreeAllProposals() {
+    if (!proposal_agreer_subscription_.is_subscribed()) {
+      proposal_agreer_subscription_ = get_yac_states_observable().subscribe(
+          [this](auto &&message) { this->voteForTheSame(message); });
+    };
+  }
+
+  void FakePeer::disableAgreeAllProposals() {
+    if (proposal_agreer_subscription_.is_subscribed()) {
+      proposal_agreer_subscription_.unsubscribe();
+    };
+  }
+
+  void FakePeer::voteForTheSame(const YacStateMessage &incoming_votes) {
+    using iroha::consensus::yac::VoteMessage;
+    std::vector<VoteMessage> my_votes;
+    my_votes.reserve(incoming_votes->size());
+    std::transform(
+        incoming_votes->cbegin(),
+        incoming_votes->cend(),
+        std::back_inserter(my_votes),
+        [this](const VoteMessage &incoming_vote) {
+          log_->debug(
+              "Sending agreement for proposal (Round ({}, {}), hash ({}, {})).",
+              incoming_vote.hash.vote_round.block_round,
+              incoming_vote.hash.vote_round.reject_round,
+              incoming_vote.hash.vote_hashes.proposal_hash,
+              incoming_vote.hash.vote_hashes.block_hash);
+          iroha::consensus::yac::YacHash my_yac_hash = incoming_vote.hash;
+          // make block signature by its hash
+          auto my_block_signature =
+              shared_model::crypto::DefaultCryptoAlgorithmType::sign(
+                  shared_model::crypto::Blob(
+                      my_yac_hash.vote_hashes.block_hash),
+                  *keypair_);
+          common_objects_factory_
+              ->createSignature(keypair_->publicKey(), my_block_signature)
+              .match(
+                  [&my_yac_hash](
+                      iroha::expected::Value<std::unique_ptr<
+                          shared_model::interface::Signature>> &sig) {
+                    my_yac_hash.block_signature = std::move(sig.value);
+                  },
+                  [this](iroha::expected::Error<std::string> &reason) {
+                    log_->error("Cannot build vote signature: {}",
+                                reason.error);
+                  });
+          return yac_crypto_->getVote(my_yac_hash);
+        });
+    yac_transport_->sendState(*real_peer_, my_votes);
   }
 
 }  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -169,7 +169,8 @@ namespace integration_framework {
     log_->debug("Got a YAC state message with {} votes.",
                 incoming_votes->size());
     if (incoming_votes->size() > 1) {
-      // TODO mboldyrev 24/10/2018: rework ignoring states for accepted commits
+      // TODO mboldyrev 24/10/2018 IR-1821: rework ignoring states for accepted
+      //                                    commits
       log_->debug(
           "Ignoring state with multiple votes, "
           "because it probably refers to an accepted commit.");

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -147,7 +147,8 @@ namespace integration_framework {
               signature_with_pubkey = std::move(sig.value);
             },
             [this](iroha::expected::Error<std::string> &reason) {
-              log_->error("Cannot build signature: {}", reason.error);
+              BOOST_THROW_EXCEPTION(std::runtime_error(
+                  "Cannot build signature: " + reason.error));
             });
     return signature_with_pubkey;
   }

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -10,14 +10,17 @@
 #include <string>
 
 #include <boost/core/noncopyable.hpp>
+#include "framework/integration_framework/fake_peer/yac_network_notifier.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "logger/logger.hpp"
+#include "network/impl/async_grpc_client.hpp"
 
 namespace shared_model {
   namespace crypto {
     class Keypair;
   }
   namespace interface {
+    class CommonObjectsFactory;
     class Transaction;
     class TransactionBatchParser;
     class TransactionBatchFactory;
@@ -32,6 +35,12 @@ namespace iroha {
     class MstTransportGrpc;
     class MstTransportNotification;
   }  // namespace network
+  namespace consensus {
+    namespace yac {
+      class NetworkImpl;
+      class YacCryptoProvider;
+    }
+  }
 }  // namespace iroha
 class ServerRunner;
 
@@ -44,14 +53,19 @@ namespace integration_framework {
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
 
-    FakePeer(const std::string &listen_ip,
-             size_t internal_port,
-             const boost::optional<shared_model::crypto::Keypair> &key,
-             std::shared_ptr<TransportFactoryType> transaction_factory,
-             std::shared_ptr<shared_model::interface::TransactionBatchParser>
-                 batch_parser,
-             std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-                 transaction_batch_factory);
+    FakePeer(
+        const std::string &listen_ip,
+        size_t internal_port,
+        const boost::optional<shared_model::crypto::Keypair> &key,
+        const std::shared_ptr<shared_model::interface::Peer> &real_peer,
+        const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+            &common_objects_factory,
+        std::shared_ptr<TransportFactoryType> transaction_factory,
+        std::shared_ptr<shared_model::interface::TransactionBatchParser>
+            batch_parser,
+        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+            transaction_batch_factory,
+        bool agree_all_proposals = true);
 
     void run();
 
@@ -62,12 +76,46 @@ namespace integration_framework {
 
     const shared_model::crypto::Keypair &getKeypair() const;
 
+    void enableAgreeAllProposals();
+
+    void disableAgreeAllProposals();
+
+    rxcpp::observable<YacNetworkNotifier::StateMessagePtr>
+    get_yac_states_observable();
+
+    void voteForTheSame(
+        const integration_framework::YacNetworkNotifier::StateMessagePtr
+            &incoming_votes);
+
    private:
+    using MstTransport = iroha::network::MstTransportGrpc;
+    using YacTransport = iroha::consensus::yac::NetworkImpl;
+    using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
+
+    std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        common_objects_factory_;
+
     const std::string listen_ip_;
     size_t internal_port_;
     std::unique_ptr<shared_model::crypto::Keypair> keypair_;
-    std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
+
+    std::shared_ptr<shared_model::interface::Peer>
+        this_peer_;  //< this fake instance
+    std::shared_ptr<shared_model::interface::Peer>
+        real_peer_;  //< the real instance
+
+    std::shared_ptr<AsyncCall> async_call_;
+
+    std::shared_ptr<MstTransport> mst_transport_;
+    std::shared_ptr<YacTransport> yac_transport_;
     std::unique_ptr<ServerRunner> internal_server_;
+
+    std::shared_ptr<YacNetworkNotifier> yac_network_notifier_;
+
+    std::shared_ptr<iroha::consensus::yac::YacCryptoProvider> yac_crypto_;
+
+    rxcpp::subscription proposal_agreer_subscription_;
+
     logger::Logger log_;
   };
 

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INTEGRATION_FRAMEWORK_FAKE_PEER_HPP_
+#define INTEGRATION_FRAMEWORK_FAKE_PEER_HPP_
+
+#include <memory>
+#include <string>
+
+#include <boost/core/noncopyable.hpp>
+#include "interfaces/iroha_internal/abstract_transport_factory.hpp"
+#include "logger/logger.hpp"
+
+namespace shared_model {
+  namespace crypto {
+    class Keypair;
+  }
+  namespace interface {
+    class Transaction;
+    class TransactionBatchParser;
+    class TransactionBatchFactory;
+  }  // namespace interface
+}  // namespace shared_model
+
+namespace iroha {
+  namespace protocol {
+    class Transaction;
+  }
+  namespace network {
+    class MstTransportGrpc;
+    class MstTransportNotification;
+  }  // namespace network
+}  // namespace iroha
+class ServerRunner;
+
+namespace integration_framework {
+
+  class FakePeer final : public boost::noncopyable {
+   public:
+    using TransportFactoryType =
+        shared_model::interface::AbstractTransportFactory<
+            shared_model::interface::Transaction,
+            iroha::protocol::Transaction>;
+
+    FakePeer(const std::string &listen_ip,
+             size_t internal_port,
+             const boost::optional<shared_model::crypto::Keypair> &key,
+             std::shared_ptr<TransportFactoryType> transaction_factory,
+             std::shared_ptr<shared_model::interface::TransactionBatchParser>
+                 batch_parser,
+             std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+                 transaction_batch_factory);
+
+    void run();
+
+    void subscribeForMstNotifications(
+        std::shared_ptr<iroha::network::MstTransportNotification> notification);
+
+    std::string getAddress() const;
+
+    const shared_model::crypto::Keypair &getKeypair() const;
+
+   private:
+    const std::string listen_ip_;
+    size_t internal_port_;
+    std::unique_ptr<shared_model::crypto::Keypair> keypair_;
+    std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
+    std::unique_ptr<ServerRunner> internal_server_;
+    logger::Logger log_;
+  };
+
+}  // namespace integration_framework
+
+#endif /* INTEGRATION_FRAMEWORK_FAKE_PEER_HPP_ */

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -39,6 +39,7 @@ namespace iroha {
     namespace yac {
       class NetworkImpl;
       class YacCryptoProvider;
+      class YacHash;
     }
   }
 }  // namespace iroha
@@ -86,6 +87,15 @@ namespace integration_framework {
     void voteForTheSame(
         const integration_framework::YacNetworkNotifier::StateMessagePtr
             &incoming_votes);
+
+    std::shared_ptr<shared_model::interface::Signature> makeSignature(
+        const shared_model::crypto::Blob &hash) const;
+
+    iroha::consensus::yac::VoteMessage makeVote(
+        const iroha::consensus::yac::YacHash &yac_hash);
+
+    void sendYacState(
+        const std::vector<iroha::consensus::yac::VoteMessage> &state);
 
    private:
     using MstTransport = iroha::network::MstTransportGrpc;

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -47,6 +47,10 @@ class ServerRunner;
 
 namespace integration_framework {
 
+  /**
+   * A lightweight implementation of iroha peer network interface for inter-peer
+   * communications testing.
+   */
   class FakePeer final : public boost::noncopyable {
    public:
     using TransportFactoryType =
@@ -54,6 +58,19 @@ namespace integration_framework {
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
 
+    /**
+     * Constructor.
+     *
+     * @param listen_ip - IP on which this fake peer should listen
+     * @param internal_port - the port for internal commulications
+     * @param key - the keypair of this peer
+     * @param real_peer - the main tested peer managed by ITF
+     * @param common_objects_factory - common_objects_factory
+     * @param transaction_factory - transaction_factory
+     * @param batch_parser - batch_parser
+     * @param transaction_batch_factory - transaction_batch_factory
+     * @param gree_all_proposals - whether this peer should agree all proposals
+     */
     FakePeer(
         const std::string &listen_ip,
         size_t internal_port,
@@ -68,32 +85,55 @@ namespace integration_framework {
             transaction_batch_factory,
         bool agree_all_proposals = true);
 
+    /// Start the fake peer.
     void run();
 
+    /**
+     * Subscribe for mst notifications.
+     *
+     * @param notification - the object to subscribe
+     */
     void subscribeForMstNotifications(
         std::shared_ptr<iroha::network::MstTransportNotification> notification);
 
+    /// Get the address:port string of this peer.
     std::string getAddress() const;
 
+    /// Get the keypair of this peer.
     const shared_model::crypto::Keypair &getKeypair() const;
 
+    /// Make this peer agree all proposals.
     void enableAgreeAllProposals();
 
+    /// Stop this peer from agreeing all proposals.
     void disableAgreeAllProposals();
 
+    /// Get the observable of YAC states received by this peer.
     rxcpp::observable<YacNetworkNotifier::StateMessagePtr>
     get_yac_states_observable();
 
+    /**
+     * Send the real peer votes from this peer analogous to the provided ones.
+     *
+     * @param incoming_votes - the votes to take as the base.
+     */
     void voteForTheSame(
         const integration_framework::YacNetworkNotifier::StateMessagePtr
             &incoming_votes);
 
+    /**
+     * Make a signature of the provided hash.
+     *
+     * @param hash - the hash to sign
+     */
     std::shared_ptr<shared_model::interface::Signature> makeSignature(
         const shared_model::crypto::Blob &hash) const;
 
+    /// Make a vote from this peer for the provided YAC hash.
     iroha::consensus::yac::VoteMessage makeVote(
         const iroha::consensus::yac::YacHash &yac_hash);
 
+    /// Send the main peer the given YAC state.
     void sendYacState(
         const std::vector<iroha::consensus::yac::VoteMessage> &state);
 
@@ -110,9 +150,9 @@ namespace integration_framework {
     std::unique_ptr<shared_model::crypto::Keypair> keypair_;
 
     std::shared_ptr<shared_model::interface::Peer>
-        this_peer_;  //< this fake instance
+        this_peer_;  ///< this fake instance
     std::shared_ptr<shared_model::interface::Peer>
-        real_peer_;  //< the real instance
+        real_peer_;  ///< the real instance
 
     std::shared_ptr<AsyncCall> async_call_;
 

--- a/test/framework/integration_framework/fake_peer/yac_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/yac_network_notifier.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/fake_peer/yac_network_notifier.hpp"
+
+#include "consensus/yac/messages.hpp"
+#include "consensus/yac/transport/impl/network_impl.hpp"
+#include "consensus/yac/transport/yac_network_interface.hpp"
+
+namespace integration_framework {
+
+  void YacNetworkNotifier::subscribe(
+      const std::shared_ptr<iroha::consensus::yac::NetworkImpl>
+          &yac_transport) {
+    yac_transport->subscribe(shared_from_this());
+  }
+
+  void YacNetworkNotifier::onState(YacNetworkNotifier::StateMessage state) {
+    auto state_ptr = std::make_shared<const StateMessage>(std::move(state));
+    votes_subject_.get_subscriber().on_next(state_ptr);
+  }
+
+  rxcpp::observable<YacNetworkNotifier::StateMessagePtr>
+  YacNetworkNotifier::get_observable() {
+    return votes_subject_.get_observable();
+  }
+
+}  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/yac_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/yac_network_notifier.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FAKE_PEER_YAC_NETWORK_NOTIFIER_HPP_
+#define FAKE_PEER_YAC_NETWORK_NOTIFIER_HPP_
+
+#include <rxcpp/rx.hpp>
+
+#include "consensus/yac/transport/yac_network_interface.hpp"
+
+namespace iroha {
+  namespace consensus {
+    namespace yac {
+      class NetworkImpl;
+      struct VoteMessage;
+    }  // namespace yac
+  }  // namespace consensus
+}  // namespace iroha
+
+namespace integration_framework {
+
+  class YacNetworkNotifier final
+      : public iroha::consensus::yac::YacNetworkNotifications,
+        public std::enable_shared_from_this<YacNetworkNotifier> {
+   public:
+    using StateMessage = std::vector<iroha::consensus::yac::VoteMessage>;
+    using StateMessagePtr = std::shared_ptr<const StateMessage>;
+
+    void subscribe(const std::shared_ptr<iroha::consensus::yac::NetworkImpl>
+                       &yac_transport);
+
+    void onState(StateMessage state) override;
+
+    rxcpp::observable<StateMessagePtr> get_observable();
+
+   private:
+    rxcpp::subjects::subject<StateMessagePtr> votes_subject_;
+  };
+
+}  // namespace integration_framework
+
+#endif /* FAKE_PEER_YAC_NETWORK_NOTIFIER_HPP_ */

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -120,6 +120,8 @@ namespace integration_framework {
         kLocalHost,
         getNextPort<kDefaultInternalPort>(),
         key,
+        this_peer_,
+        common_objects_factory_,
         transaction_factory_,
         batch_parser_,
         transaction_batch_factory_);

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -316,13 +316,19 @@ namespace integration_framework {
     return *this;
   }
 
+  IntegrationTestFramework &IntegrationTestFramework::sendTxWithoutValidation(
+      const shared_model::proto::Transaction &tx) {
+    log_->info("sending transaction");
+    log_->debug(tx.toString());
+
+    command_client_.Torii(tx.getTransport());
+    return *this;
+  }
+
   IntegrationTestFramework &IntegrationTestFramework::sendTx(
       const shared_model::proto::Transaction &tx,
       std::function<void(const shared_model::proto::TransactionResponse &)>
           validation) {
-    log_->info("sending transaction");
-    log_->debug(tx.toString());
-
     // Required for StatusBus synchronization
     boost::barrier bar1(2);
     auto bar2 = std::make_shared<boost::barrier>(2);
@@ -338,7 +344,7 @@ namespace integration_framework {
           }
         });
 
-    command_client_.Torii(tx.getTransport());
+    sendTxWithoutValidation(tx);
     // make sure that the first (stateless) status has come
     bar1.wait();
     // fetch status of transaction

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -72,8 +72,7 @@ namespace integration_framework {
   IntegrationTestFramework::IntegrationTestFramework(
       size_t maximum_proposal_size,
       const boost::optional<std::string> &dbname,
-      std::function<void(integration_framework::IntegrationTestFramework &)>
-          deleter,
+      bool cleanup_on_exit,
       bool mst_support,
       const std::string &block_store_path,
       milliseconds proposal_waiting,
@@ -103,11 +102,11 @@ namespace integration_framework {
         transaction_batch_factory_(
             std::make_shared<
                 shared_model::interface::TransactionBatchFactoryImpl>()),
-        deleter_(deleter) {}
+        cleanup_on_exit_(cleanup_on_exit) {}
 
   IntegrationTestFramework::~IntegrationTestFramework() {
-    if (deleter_) {
-      deleter_(*this);
+    if (cleanup_on_exit_) {
+      cleanup();
     }
     // the code below should be executed anyway in order to prevent app hang
     if (iroha_instance_ and iroha_instance_->getIrohaInstance()) {
@@ -550,6 +549,11 @@ namespace integration_framework {
 
   void IntegrationTestFramework::done() {
     log_->info("done");
+    cleanup();
+  }
+
+  void IntegrationTestFramework::cleanup() {
+    log_->info("removing storage");
     if (iroha_instance_->getIrohaInstance()
         and iroha_instance_->getIrohaInstance()->storage) {
       iroha_instance_->getIrohaInstance()->storage->dropStorage();

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -304,6 +304,17 @@ namespace integration_framework {
         ->onExpiredBatches();
   }
 
+  IntegrationTestFramework &
+  IntegrationTestFramework::subscribeForAllMstNotifications(
+      std::shared_ptr<iroha::network::MstTransportNotification> notification) {
+    std::for_each(fake_peers_.cbegin(),
+                  fake_peers_.cend(),
+                  [&notification](const auto &fake_peer) {
+                    fake_peer->subscribeForMstNotifications(notification);
+                  });
+    return *this;
+  }
+
   IntegrationTestFramework &IntegrationTestFramework::getTxStatus(
       const shared_model::crypto::Hash &hash,
       std::function<void(const shared_model::proto::TransactionResponse &)>

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -22,6 +22,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "datetime/time.hpp"
+#include "framework/integration_framework/fake_peer/fake_peer.hpp"
 #include "framework/integration_framework/iroha_instance.hpp"
 #include "framework/integration_framework/test_irohad.hpp"
 #include "framework/result_fixture.hpp"
@@ -114,6 +115,19 @@ namespace integration_framework {
     }
   }
 
+  std::shared_ptr<FakePeer> IntegrationTestFramework::addInitailPeer(
+      const boost::optional<Keypair> &key) {
+    auto fake_peer = std::make_shared<FakePeer>(
+        kLocalHost,
+        getNextPort<kDefaultInternalPort>(),
+        key,
+        transaction_factory_,
+        batch_parser_,
+        transaction_batch_factory_);
+    fake_peers_.emplace_back(fake_peer);
+    return fake_peer;
+  }
+
   shared_model::proto::Block IntegrationTestFramework::defaultBlock(
       const shared_model::crypto::Keypair &key) const {
     shared_model::interface::RolePermissionSet all_perms{};
@@ -121,7 +135,7 @@ namespace integration_framework {
       auto perm = static_cast<shared_model::interface::permissions::Role>(i);
       all_perms.set(perm);
     }
-    auto genesis_tx =
+    auto genesis_tx_builder =
         shared_model::proto::TransactionBuilder()
             .creatorAccountId(kAdminId)
             .createdTime(iroha::time::now())
@@ -131,10 +145,14 @@ namespace integration_framework {
             .createDomain(kDefaultDomain, kDefaultRole)
             .createAccount(kAdminName, kDefaultDomain, key.publicKey())
             .createAsset(kAssetName, kDefaultDomain, 1)
-            .quorum(1)
-            .build()
-            .signAndAddSignature(key)
-            .finish();
+            .quorum(1);
+    // add fake peers
+    for (const auto &fake_peer : fake_peers_) {
+      genesis_tx_builder = genesis_tx_builder.addPeer(
+          fake_peer->getAddress(), fake_peer->getKeypair().publicKey());
+    };
+    auto genesis_tx =
+        genesis_tx_builder.build().signAndAddSignature(key).finish();
     auto genesis_block =
         shared_model::proto::BlockBuilder()
             .transactions(
@@ -183,7 +201,9 @@ namespace integration_framework {
       const shared_model::crypto::Keypair &keypair) {
     log_->info("init state");
     // peer initialization
-    common_objects_factory_->createPeer(kLocalHost, keypair.publicKey())
+    common_objects_factory_
+        ->createPeer(kLocalHost + ":" + std::to_string(internal_port_),
+                     keypair.publicKey())
         .match(
             [this](iroha::expected::Result<
                    std::unique_ptr<shared_model::interface::Peer>,
@@ -251,9 +271,16 @@ namespace integration_framework {
           queue_cond.notify_all();
         });
 
+
+    if (fake_peers_.size() > 0) {
+      log_->info("starting fake iroha peers");
+      for (auto &fake_peer : fake_peers_) {
+        fake_peer->run();
+      }
+    }
     // start instance
+    log_->info("starting main iroha instance");
     iroha_instance_->run();
-    log_->info("run iroha");
   }
 
   rxcpp::observable<std::shared_ptr<iroha::MstState>>

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -114,19 +114,33 @@ namespace integration_framework {
     }
   }
 
-  std::shared_ptr<FakePeer> IntegrationTestFramework::addInitailPeer(
+  std::future<std::shared_ptr<FakePeer>> IntegrationTestFramework::addInitailPeer(
       const boost::optional<Keypair> &key) {
-    auto fake_peer = std::make_shared<FakePeer>(
-        kLocalHost,
-        getNextPort<kDefaultInternalPort>(),
-        key,
-        this_peer_,
-        common_objects_factory_,
-        transaction_factory_,
-        batch_parser_,
-        transaction_batch_factory_);
-    fake_peers_.emplace_back(fake_peer);
-    return fake_peer;
+    fake_peers_promises_.emplace_back(std::promise<std::shared_ptr<FakePeer>>(),
+                                      key);
+    return fake_peers_promises_.back().first.get_future();
+  }
+
+  void IntegrationTestFramework::makeFakePeers() {
+    if (fake_peers_promises_.size() == 0) {
+      return;
+    }
+    log_->info("creating fake iroha peers");
+    assert(this_peer_ && "this_peer_ is needed for fake peers initialization, "
+        "but not set");
+    for (auto &promise_and_key : fake_peers_promises_) {
+      auto fake_peer =
+          std::make_shared<FakePeer>(kLocalHost,
+                                     getNextPort<kDefaultInternalPort>(),
+                                     promise_and_key.second,
+                                     this_peer_,
+                                     common_objects_factory_,
+                                     transaction_factory_,
+                                     batch_parser_,
+                                     transaction_batch_factory_);
+      fake_peers_.emplace_back(fake_peer);
+      promise_and_key.first.set_value(fake_peer);
+    }
   }
 
   shared_model::proto::Block IntegrationTestFramework::defaultBlock(
@@ -169,8 +183,11 @@ namespace integration_framework {
 
   IntegrationTestFramework &IntegrationTestFramework::setInitialState(
       const Keypair &keypair) {
-    return setInitialState(keypair,
-                           IntegrationTestFramework::defaultBlock(keypair));
+    initPipeline(keypair);
+    iroha_instance_->makeGenesis(IntegrationTestFramework::defaultBlock(keypair));
+    log_->info("added genesis block");
+    subscribeQueuesAndRun();
+    return *this;
   }
 
   IntegrationTestFramework &IntegrationTestFramework::setMstGossipParams(
@@ -230,6 +247,8 @@ namespace integration_framework {
     iroha_instance_->initPipeline(keypair, maximum_proposal_size_);
     log_->info("created pipeline");
     iroha_instance_->getIrohaInstance()->resetOrderingService();
+
+    makeFakePeers();
   }
 
   void IntegrationTestFramework::subscribeQueuesAndRun() {

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -372,7 +372,7 @@ namespace integration_framework {
         transaction_batch_factory_;
     std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
 
-    std::unique_ptr<shared_model::interface::Peer> this_peer_;
+    std::shared_ptr<shared_model::interface::Peer> this_peer_;
 
    private:
     logger::Logger log_ = logger::log("IntegrationTestFramework");

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -63,17 +63,14 @@ namespace integration_framework {
      * @param proposal_waiting - maximum time of waiting before next proposal
      * @param block_waiting - maximum time of waiting before appearing next
      * committed block
-     * @param destructor_lambda - (default nullptr) Pointer to function which
-     * receives pointer to constructed instance of Integration Test Framework.
-     * If specified, then will be called instead of default destructor's code
+     * @param cleanup_on_exit - whether to clean resources on exit
      * @param mst_support enables multisignature tx support
      * @param block_store_path specifies path where blocks will be stored
      */
     explicit IntegrationTestFramework(
         size_t maximum_proposal_size,
         const boost::optional<std::string> &dbname = boost::none,
-        std::function<void(IntegrationTestFramework &)> deleter =
-            [](IntegrationTestFramework &itf) { itf.done(); },
+        bool cleanup_on_exit = true,
         bool mst_support = false,
         const std::string &block_store_path =
             (boost::filesystem::temp_directory_path()
@@ -331,6 +328,9 @@ namespace integration_framework {
                         const WaitTime &wait,
                         const std::string &error_reason);
 
+    /// Cleanup the resources
+    void cleanup();
+
     tbb::concurrent_queue<ProposalType> proposal_queue_;
     tbb::concurrent_queue<ProposalType> verified_proposal_queue_;
     tbb::concurrent_queue<BlockType> block_queue_;
@@ -378,7 +378,7 @@ namespace integration_framework {
     logger::Logger log_ = logger::log("IntegrationTestFramework");
     std::mutex queue_mu;
     std::condition_variable queue_cond;
-    std::function<void(IntegrationTestFramework &)> deleter_;
+    bool cleanup_on_exit_;
     std::vector<std::shared_ptr<FakePeer>> fake_peers_;
   };
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -25,6 +25,7 @@
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
 #include "logger/logger.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
+#include "network/mst_transport.hpp"
 #include "torii/command_client.hpp"
 #include "torii/query_client.hpp"
 
@@ -287,6 +288,9 @@ namespace integration_framework {
     rxcpp::observable<iroha::BatchPtr> getMstPreparedBatchesObserver();
 
     rxcpp::observable<iroha::BatchPtr> getMstExpiredBatchesObserver();
+
+    IntegrationTestFramework &subscribeForAllMstNotifications(
+        std::shared_ptr<iroha::network::MstTransportNotification> notification);
 
     /**
      * Request next status of the transaction

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -82,7 +82,7 @@ namespace integration_framework {
 
     ~IntegrationTestFramework();
 
-    std::shared_ptr<FakePeer> addInitailPeer(
+    std::future<std::shared_ptr<FakePeer>> addInitailPeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
 
     /**
@@ -375,10 +375,15 @@ namespace integration_framework {
     std::shared_ptr<shared_model::interface::Peer> this_peer_;
 
    private:
+    void makeFakePeers();
+
     logger::Logger log_ = logger::log("IntegrationTestFramework");
     std::mutex queue_mu;
     std::condition_variable queue_cond;
     bool cleanup_on_exit_;
+    std::vector<std::pair<std::promise<std::shared_ptr<FakePeer>>,
+                          boost::optional<shared_model::crypto::Keypair>>>
+        fake_peers_promises_;
     std::vector<std::shared_ptr<FakePeer>> fake_peers_;
   };
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -132,6 +132,14 @@ namespace integration_framework {
         const shared_model::crypto::Keypair &keypair);
 
     /**
+     * Send transaction to Iroha without wating for proposal and validating its
+     * status
+     * @param tx - transaction to send
+     */
+    IntegrationTestFramework &sendTxWithoutValidation(
+        const shared_model::proto::Transaction &tx);
+
+    /**
      * Send transaction to Iroha and validate its status
      * @param tx - transaction for sending
      * @param validation - callback for transaction status validation that

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -45,6 +45,8 @@ namespace integration_framework {
 
   using std::chrono::milliseconds;
 
+  class FakePeer;
+
   class IntegrationTestFramework {
    private:
     using ProposalType = std::shared_ptr<shared_model::interface::Proposal>;
@@ -81,6 +83,9 @@ namespace integration_framework {
         milliseconds tx_response_waiting = milliseconds(10000));
 
     ~IntegrationTestFramework();
+
+    std::shared_ptr<FakePeer> addInitailPeer(
+        const boost::optional<shared_model::crypto::Keypair> &key);
 
     /**
      * Construct default genesis block.
@@ -362,6 +367,7 @@ namespace integration_framework {
     std::mutex queue_mu;
     std::condition_variable queue_cond;
     std::function<void(IntegrationTestFramework &)> deleter_;
+    std::vector<std::shared_ptr<FakePeer>> fake_peers_;
   };
 
   template <typename Queue, typename ObjectType, typename WaitTime>

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -149,3 +149,10 @@ addtest(get_role_permissions_test
 target_link_libraries(get_role_permissions_test
     acceptance_fixture
     )
+
+addtest(basic_mst_state_propagation_test
+    basic_mst_state_propagation.cpp
+    )
+target_link_libraries(basic_mst_state_propagation_test
+    acceptance_fixture
+    )

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/integration_test_framework.hpp"
+//#include "framework/integration_framework/fake_peer.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
+
+using namespace shared_model;
+using namespace integration_framework;
+using namespace shared_model::interface::permissions;
+
+using ::testing::_;
+using ::testing::Invoke;
+
+static constexpr std::chrono::milliseconds kMstStateWaitingTime(10000);
+
+class BasicMstPropagationFixture : public AcceptanceFixture {
+ public:
+  std::unique_ptr<IntegrationTestFramework> itf_;
+
+  /**
+   * Prepare state of ledger:
+   * - create fake iroha peers
+   * - create account of target user
+   * - add assets to admin
+   *
+   * @param num_fake_peers - the amount of fake peers to create
+   * @return reference to ITF
+   */
+  IntegrationTestFramework &prepareState(size_t num_fake_peers) {
+    std::generate_n(std::back_inserter(fake_peers_), num_fake_peers, [this]() {
+      return itf_->addInitailPeer({});
+    });
+    itf_->setInitialState(kAdminKeypair);
+
+    auto permissions =
+        interface::RolePermissionSet({Role::kReceive, Role::kTransfer});
+
+    // inside prepareState we can use lambda for such assert, since prepare
+    // transactions are not going to fail
+    auto block_with_tx = [](auto &block) {
+      ASSERT_EQ(block->transactions().size(), 1);
+    };
+
+    return itf_->sendTxAwait(makeUserWithPerms(permissions), block_with_tx)
+        .sendTxAwait(
+            complete(baseTx(kAdminId).addAssetQuantity(kAssetId, "20000.0"),
+                     kAdminKeypair),
+            block_with_tx);
+  }
+
+ protected:
+  void SetUp() override {
+    itf_ = std::make_unique<IntegrationTestFramework>(
+        1, boost::none, true, true);
+  }
+
+  std::vector<std::shared_ptr<integration_framework::FakePeer>> fake_peers_;
+};
+
+/**
+ * Check that after sending a not fully signed transaction, an MST state
+ * propagtes to another peer
+ * @given a not fully signed transaction
+ * @when such transaction is sent to one of two iroha peers in the network
+ * @then that peer propagates MST state to another peer
+ */
+TEST_F(BasicMstPropagationFixture,
+       MstStateOfTransactionWithoutAllSignaturesPropagtesToOtherPeer) {
+  auto notifications_getter = std::make_shared<iroha::MockMstTransportNotification>();
+  std::mutex mst_mutex;
+  std::unique_lock<std::mutex> mst_lock(mst_mutex);
+  std::condition_variable mst_cv;
+  EXPECT_CALL(*notifications_getter, onNewState(_, _))
+      .WillOnce(Invoke(
+          [&mst_lock, &mst_cv](const auto &from_key, auto const &target_state) {
+            mst_lock.unlock();
+            mst_cv.notify_one();
+          }));
+  prepareState(1)
+      .subscribeForAllMstNotifications(notifications_getter)
+      .sendTxWithoutValidation(complete(
+          baseTx(kAdminId)
+              .transferAsset(kAdminId, kUserId, kAssetId, "income", "500.0")
+              .quorum(2),
+          kAdminKeypair));
+  EXPECT_FALSE(mst_cv.wait_for(mst_lock, kMstStateWaitingTime)
+               == std::cv_status::timeout)
+      << "Reached timeout waiting for MST State.";
+}

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -48,7 +48,7 @@ class BasicMstPropagationFixture : public AcceptanceFixture {
         fake_peers_futures.begin(),
         fake_peers_futures.end(),
         std::back_inserter(fake_peers_),
-        [this](auto &fake_peer_future) {
+        [](auto &fake_peer_future) {
           assert(fake_peer_future.valid() && "fake peer must be ready");
           return fake_peer_future.get();
         });

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -15,7 +15,7 @@ using namespace shared_model::interface::permissions;
 using ::testing::_;
 using ::testing::Invoke;
 
-static constexpr std::chrono::milliseconds kMstStateWaitingTime(10000);
+static constexpr std::chrono::seconds kMstStateWaitingTime(10);
 
 class BasicMstPropagationFixture : public AcceptanceFixture {
  public:

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "framework/integration_framework/integration_test_framework.hpp"
-//#include "framework/integration_framework/fake_peer.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -36,7 +36,7 @@ class BasicMstPropagationFixture : public AcceptanceFixture {
         fake_peers_futures;
     std::generate_n(std::back_inserter(fake_peers_futures),
                     num_fake_peers,
-                    [this]() { return itf_->addInitailPeer({}); });
+                    [this] { return itf_->addInitailPeer({}); });
 
     itf_->setInitialState(kAdminKeypair);
 

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -16,7 +16,7 @@ using namespace shared_model;
 
 class MstPipelineTest : public AcceptanceFixture {
  public:
-  MstPipelineTest() : mst_itf_{1, {}, [](auto &i) { i.done(); }, true} {}
+  MstPipelineTest() : mst_itf_{1, {}, true, true} {}
 
   /**
    * Creates a mst user

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -63,7 +63,7 @@ TEST(RegressionTest, SequentialInitialization) {
             .substr(0, 8);
   {
     integration_framework::IntegrationTestFramework(
-        1, dbname, [](auto &) {}, false, path)
+        1, dbname, false, false, path)
         .setInitialState(kAdminKeypair)
         .sendTx(tx, check_enough_signatures_collected_status)
         .skipProposal()
@@ -75,7 +75,7 @@ TEST(RegressionTest, SequentialInitialization) {
   }
   {
     integration_framework::IntegrationTestFramework(
-        1, dbname, [](auto &itf) { itf.done(); }, false, path)
+        1, dbname, true, false, path)
         .setInitialState(kAdminKeypair)
         .sendTx(tx, check_enough_signatures_collected_status)
         .checkProposal(checkProposal)
@@ -143,7 +143,7 @@ TEST(RegressionTest, StateRecovery) {
 
   {
     integration_framework::IntegrationTestFramework(
-        1, dbname, [](auto &) {}, false, path)
+        1, dbname, false, false, path)
         .setInitialState(kAdminKeypair)
         .sendTx(tx)
         .checkProposal(checkOne)
@@ -153,7 +153,7 @@ TEST(RegressionTest, StateRecovery) {
   }
   {
     integration_framework::IntegrationTestFramework(
-        1, dbname, [](auto &itf) { itf.done(); }, false, path)
+        1, dbname, true, false, path)
         .recoverState(kAdminKeypair)
         .sendQuery(makeQuery(2, kAdminKeypair), checkQuery);
   }
@@ -177,5 +177,5 @@ TEST(RegressionTest, DoubleCallOfDone) {
  */
 TEST(RegressionTest, DestructionOfNonInitializedItf) {
   integration_framework::IntegrationTestFramework itf(
-      1, {}, [](auto &itf) { itf.done(); });
+      1, {}, true);
 }


### PR DESCRIPTION
### Description of the Change

A class for iroha peer simulation. Currently it supports blind agreement on any proposal and interfaces for getting YAC and MST events.

### Benefits

More possible testing scenarios.

### Possible Drawbacks 

To be found.