### PR TITLE
ITF: consensus gate testing interface

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -326,6 +326,11 @@ namespace integration_framework {
         ->onExpiredBatches();
   }
 
+  rxcpp::observable<iroha::network::Commit>
+  IntegrationTestFramework::getYacOnCommitObservable() {
+    return iroha_instance_->getIrohaInstance()->getConsensusGate()->on_commit();
+  }
+
   IntegrationTestFramework &
   IntegrationTestFramework::subscribeForAllMstNotifications(
       std::shared_ptr<iroha::network::MstTransportNotification> notification) {

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -305,6 +305,8 @@ namespace integration_framework {
 
     rxcpp::observable<iroha::BatchPtr> getMstExpiredBatchesObserver();
 
+    rxcpp::observable<iroha::network::Commit> getYacOnCommitObservable();
+
     IntegrationTestFramework &subscribeForAllMstNotifications(
         std::shared_ptr<iroha::network::MstTransportNotification> notification);
 

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -69,6 +69,10 @@ namespace integration_framework {
       return mst_processor;
     }
 
+    auto &getConsensusGate() {
+      return consensus_gate;
+    }
+
     auto &getPeerCommunicationService() {
       return pcs;
     }


### PR DESCRIPTION
### Description of the Change

Added an interface to send YAC states to tested iroha instance and to listen for YacGate on_commit messages.

### Benefits

The ability to test consensus.

### Possible Drawbacks 

To be found.