### PR TITLE
New transaction status: rejected before

### DIFF
--- a/irohad/model/transaction_response.hpp
+++ b/irohad/model/transaction_response.hpp
@@ -36,6 +36,8 @@ namespace iroha {
         MST_EXPIRED,
         /// transaction is not in handler map
         NOT_RECEIVED,
+        /// transaction was rejected in some of previous rounds
+        REJECTED_BEFORE,
       };
 
       Status current_status{};

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -78,7 +78,8 @@ namespace torii {
                     shared_model::interface::StatelessFailedTxResponse,
                     shared_model::interface::StatefulFailedTxResponse,
                     shared_model::interface::CommittedTxResponse,
-                    shared_model::interface::MstExpiredResponse>::value;
+                    shared_model::interface::MstExpiredResponse,
+                    shared_model::interface::RejectedBeforeTxResponse>::value;
 
   rxcpp::observable<
       std::shared_ptr<shared_model::interface::TransactionResponse>>

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -179,6 +179,10 @@ namespace iroha {
           builder = builder.enoughSignaturesCollected();
           break;
         };
+        case TxStatusType::kRejectedBefore: {
+          builder = builder.rejectedBefore();
+          break;
+        };
       }
       status_bus_->publish(builder.build());
     }

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -72,7 +72,10 @@ namespace iroha {
         kMstExpired,
         kNotReceived,
         kMstPending,
-        kEnoughSignaturesCollected
+        kEnoughSignaturesCollected,
+        kRejectedBefore, ///< This transaction has already been submitted, but
+                         ///< failed stateful validation. It can not be applied
+                         ///< for execution any more (see IR-1769).
       };
       /**
        * Publish status of transaction

--- a/shared_model/backend/protobuf/impl/proto_tx_status_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_tx_status_factory.cpp
@@ -76,6 +76,13 @@ ProtoTxStatusFactory::FactoryReturnType ProtoTxStatusFactory::makeRejected(
   return wrap(fillCommon(hash, error, iroha::protocol::TxStatus::REJECTED));
 }
 
+ProtoTxStatusFactory::FactoryReturnType
+ProtoTxStatusFactory::makeRejectedBefore(TransactionHashType hash,
+                                         ErrorMessageType error) {
+  return wrap(
+      fillCommon(hash, error, iroha::protocol::TxStatus::REJECTED_BEFORE));
+}
+
 // -----------------------------| Rest statuses |-------------------------------
 
 ProtoTxStatusFactory::FactoryReturnType ProtoTxStatusFactory::makeMstExpired(

--- a/shared_model/backend/protobuf/proto_tx_status_factory.hpp
+++ b/shared_model/backend/protobuf/proto_tx_status_factory.hpp
@@ -38,6 +38,9 @@ namespace shared_model {
       FactoryReturnType makeRejected(TransactionHashType,
                                      ErrorMessageType) override;
 
+      FactoryReturnType makeRejectedBefore(TransactionHashType,
+                                           ErrorMessageType) override;
+
       // --------------------------| Rest statuses |----------------------------
 
       FactoryReturnType makeMstExpired(TransactionHashType,

--- a/shared_model/backend/protobuf/transaction_responses/impl/proto_tx_response.cpp
+++ b/shared_model/backend/protobuf/transaction_responses/impl/proto_tx_response.cpp
@@ -89,7 +89,8 @@ namespace shared_model {
           [](const MstExpiredResponse &) { return 5; },
           // following types are the final ones
           [](const CommittedTxResponse &) { return max_priority; },
-          [](const RejectedTxResponse &) { return max_priority; });
+          [](const RejectedTxResponse &) { return max_priority; },
+          [](const RejectedBeforeTxResponse &) { return max_priority; });
     }
   };  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction_responses/proto_concrete_tx_response.hpp
+++ b/shared_model/backend/protobuf/transaction_responses/proto_concrete_tx_response.hpp
@@ -10,6 +10,7 @@
 #include "interfaces/transaction_responses/mst_expired_response.hpp"
 #include "interfaces/transaction_responses/mst_pending_response.hpp"
 #include "interfaces/transaction_responses/not_received_tx_response.hpp"
+#include "interfaces/transaction_responses/rejected_before_tx_response.hpp"
 #include "interfaces/transaction_responses/rejected_tx_response.hpp"
 #include "interfaces/transaction_responses/stateful_failed_tx_response.hpp"
 #include "interfaces/transaction_responses/stateful_valid_tx_response.hpp"
@@ -42,6 +43,9 @@ namespace shared_model {
                                              iroha::protocol::ToriiResponse>;
     using RejectedTxResponse = TrivialProto<interface::RejectTxResponse,
                                             iroha::protocol::ToriiResponse>;
+    using RejectedBeforeTxResponse =
+        TrivialProto<interface::RejectedBeforeTxResponse,
+                     iroha::protocol::ToriiResponse>;
 
     // ---------------------------| Rest statuses |-----------------------------
 

--- a/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
+++ b/shared_model/backend/protobuf/transaction_responses/proto_tx_response.hpp
@@ -33,7 +33,8 @@ namespace shared_model {
                          MstExpiredResponse,
                          NotReceivedTxResponse,
                          MstPendingResponse,
-                         EnoughSignaturesCollectedResponse>;
+                         EnoughSignaturesCollectedResponse,
+                         RejectedBeforeTxResponse>;
 
       /// Type with list of types in ResponseVariantType
       using ProtoResponseListType = ProtoResponseVariantType::types;
@@ -85,7 +86,8 @@ namespace boost {
             shared_model::proto::MstExpiredResponse,
             shared_model::proto::NotReceivedTxResponse,
             shared_model::proto::MstPendingResponse,
-            shared_model::proto::EnoughSignaturesCollectedResponse>;
+            shared_model::proto::EnoughSignaturesCollectedResponse,
+            shared_model::proto::RejectedBeforeTxResponse>;
 }
 
 #endif  // IROHA_PROTO_TX_RESPONSE_HPP

--- a/shared_model/builders/protobuf/transaction_responses/proto_transaction_status_builder.cpp
+++ b/shared_model/builders/protobuf/transaction_responses/proto_transaction_status_builder.cpp
@@ -95,6 +95,12 @@ namespace shared_model {
       return copy;
     }
 
+    TransactionStatusBuilder TransactionStatusBuilder::rejectedBefore() {
+      TransactionStatusBuilder copy(*this);
+      copy.tx_response_.set_tx_status(iroha::protocol::TxStatus::REJECTED_BEFORE);
+      return copy;
+    }
+
     TransactionStatusBuilder TransactionStatusBuilder::txHash(
         const crypto::Hash &hash) {
       TransactionStatusBuilder copy(*this);

--- a/shared_model/builders/protobuf/transaction_responses/proto_transaction_status_builder.hpp
+++ b/shared_model/builders/protobuf/transaction_responses/proto_transaction_status_builder.hpp
@@ -46,6 +46,8 @@ namespace shared_model {
 
       TransactionStatusBuilder mstExpired();
 
+      TransactionStatusBuilder rejectedBefore();
+
       TransactionStatusBuilder txHash(const crypto::Hash &hash);
 
       TransactionStatusBuilder errorMsg(const std::string &msg);

--- a/shared_model/builders/transaction_responses/transaction_status_builder.hpp
+++ b/shared_model/builders/transaction_responses/transaction_status_builder.hpp
@@ -91,6 +91,12 @@ namespace shared_model {
         return copy;
       }
 
+      TransactionStatusBuilder rejectedBefore() {
+        TransactionStatusBuilder copy(*this);
+        copy.builder_ = this->builder_.rejectedBefore();
+        return copy;
+      }
+
       TransactionStatusBuilder txHash(const crypto::Hash &hash) {
         TransactionStatusBuilder copy(*this);
         copy.builder_ = this->builder_.txHash(hash);

--- a/shared_model/interfaces/iroha_internal/tx_status_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/tx_status_factory.hpp
@@ -60,6 +60,10 @@ namespace shared_model {
       virtual FactoryReturnType makeRejected(TransactionHashType,
                                              ErrorMessageType) = 0;
 
+      /// Creates rejected before transaction status
+      virtual FactoryReturnType makeRejectedBefore(TransactionHashType,
+                                                   ErrorMessageType) = 0;
+
       // --------------------------| Rest statuses |----------------------------
 
       /// Creates transaction expired status

--- a/shared_model/interfaces/transaction_responses/impl/tx_response.cpp
+++ b/shared_model/interfaces/transaction_responses/impl/tx_response.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/transaction_responses/mst_expired_response.hpp"
 #include "interfaces/transaction_responses/mst_pending_response.hpp"
 #include "interfaces/transaction_responses/not_received_tx_response.hpp"
+#include "interfaces/transaction_responses/rejected_before_tx_response.hpp"
 #include "interfaces/transaction_responses/rejected_tx_response.hpp"
 #include "interfaces/transaction_responses/stateful_failed_tx_response.hpp"
 #include "interfaces/transaction_responses/stateful_valid_tx_response.hpp"

--- a/shared_model/interfaces/transaction_responses/rejected_before_tx_response.hpp
+++ b/shared_model/interfaces/transaction_responses/rejected_before_tx_response.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_REJECTED_BEFORE_TX_RESPONSE_HPP
+#define IROHA_REJECTED_BEFORE_TX_RESPONSE_HPP
+
+#include "interfaces/transaction_responses/abstract_tx_response.hpp"
+
+namespace shared_model {
+  namespace interface {
+    /**
+     * This transaction has already been submitted, but failed stateful
+     * validation. It can not be applied for execution any more (see IR-1769).
+     */
+    class RejectedBeforeTxResponse
+        : public AbstractTxResponse<RejectedBeforeTxResponse> {
+     private:
+      std::string className() const override {
+        return "RejectedBeforeTxResponse";
+      }
+    };
+
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_REJECTED_BEFORE_TX_RESPONSE_HPP

--- a/shared_model/interfaces/transaction_responses/tx_response.hpp
+++ b/shared_model/interfaces/transaction_responses/tx_response.hpp
@@ -24,6 +24,7 @@ namespace shared_model {
     class NotReceivedTxResponse;
     class MstPendingResponse;
     class EnoughSignaturesCollectedResponse;
+    class RejectedBeforeTxResponse;
 
     /**
      * TransactionResponse is a status of transaction in system
@@ -52,7 +53,8 @@ namespace shared_model {
                                        MstExpiredResponse,
                                        NotReceivedTxResponse,
                                        MstPendingResponse,
-                                       EnoughSignaturesCollectedResponse>;
+                                       EnoughSignaturesCollectedResponse,
+                                       RejectedBeforeTxResponse>;
 
       /// Type of transaction hash
       using TransactionHashType = interface::types::HashType;

--- a/shared_model/interfaces/transaction_responses/tx_response_variant.hpp
+++ b/shared_model/interfaces/transaction_responses/tx_response_variant.hpp
@@ -11,17 +11,18 @@
 #include <boost/variant.hpp>
 
 namespace boost {
-    extern template class variant<
-            const shared_model::interface::StatelessFailedTxResponse &,
-            const shared_model::interface::StatelessValidTxResponse &,
-            const shared_model::interface::StatefulFailedTxResponse &,
-            const shared_model::interface::StatefulValidTxResponse &,
-            const shared_model::interface::RejectTxResponse &,
-            const shared_model::interface::CommittedTxResponse &,
-            const shared_model::interface::MstExpiredResponse &,
-            const shared_model::interface::NotReceivedTxResponse &,
-            const shared_model::interface::MstPendingResponse &,
-            const shared_model::interface::EnoughSignaturesCollectedResponse &>;
+  extern template class variant<
+      const shared_model::interface::StatelessFailedTxResponse &,
+      const shared_model::interface::StatelessValidTxResponse &,
+      const shared_model::interface::StatefulFailedTxResponse &,
+      const shared_model::interface::StatefulValidTxResponse &,
+      const shared_model::interface::RejectTxResponse &,
+      const shared_model::interface::CommittedTxResponse &,
+      const shared_model::interface::MstExpiredResponse &,
+      const shared_model::interface::NotReceivedTxResponse &,
+      const shared_model::interface::MstPendingResponse &,
+      const shared_model::interface::EnoughSignaturesCollectedResponse &,
+      const shared_model::interface::RejectedBeforeTxResponse &>;
 }
 
 #endif  // IROHA_SHARED_MODEL_TX_RESPONSE_VARIANT_HPP

--- a/shared_model/schema/endpoint.proto
+++ b/shared_model/schema/endpoint.proto
@@ -23,6 +23,7 @@ enum TxStatus {
   NOT_RECEIVED = 7;
   MST_PENDING = 8;
   ENOUGH_SIGNATURES_COLLECTED = 9;
+  REJECTED_BEFORE = 10;
 }
 
 message ToriiResponse {

--- a/test/module/shared_model/builders/transaction_responses/transaction_response_builder_test.cpp
+++ b/test/module/shared_model/builders/transaction_responses/transaction_response_builder_test.cpp
@@ -55,7 +55,10 @@ using TransactionResponsTypes =
                          &BuilderType::mstExpired>,
                      TransactionResponseBuilderTestCase<
                          shared_model::interface::NotReceivedTxResponse,
-                         &BuilderType::notReceived> >;
+                         &BuilderType::notReceived>,
+                     TransactionResponseBuilderTestCase<
+                         shared_model::interface::RejectedBeforeTxResponse,
+                         &BuilderType::rejectedBefore> >;
 TYPED_TEST_CASE(TransactionResponseBuilderTest, TransactionResponsTypes);
 
 /**


### PR DESCRIPTION
### Description of the Change

New transaction status means that this transaction has already been submitted, but failed stateful validation. Such transaction can not be applied for execution any more.

### Benefits

Fulfilling the need for the new status.

### Possible Drawbacks 

To be found.