### PR TITLE
Refactor chain validator

### DIFF
--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -53,7 +53,7 @@ namespace iroha {
               rxcpp::observable<>::iterate(blocks, rxcpp::identity_immediate());
 
           if (blocks.back()->hash() == hash
-              and validator_->validateChain(chain, *storage)) {
+              and validator_->validateAndApply(chain, *storage)) {
             mutable_factory_->commit(std::move(storage));
 
             return {chain, SynchronizationOutcomeType::kCommit};
@@ -82,7 +82,7 @@ namespace iroha {
       auto commit = rxcpp::observable<>::just(commit_message);
       SynchronizationEvent result;
 
-      if (validator_->validateChain(commit, *storage)) {
+      if (validator_->validateAndApply(commit, *storage)) {
         mutable_factory_->commit(std::move(storage));
 
         result = {commit, SynchronizationOutcomeType::kCommit};

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -29,8 +29,6 @@ namespace iroha {
      public:
       virtual ~ChainValidator() = default;
 
-      // TODO andrei 16.10.18 IR-1761 Rename methods in validators
-
       /**
        * Try to apply the blocks from observable to the storage.
        *

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -32,17 +32,17 @@ namespace iroha {
       // TODO andrei 16.10.18 IR-1761 Rename methods in validators
 
       /**
-       * Validate method provide chain validation for application it to ledger.
+       * Try to apply the blocks from observable to the storage.
        *
-       * Chain validation will validate all signatures of new blocks
+       * While applying the blocks it will validate all their signatures
        * and related meta information such as previous hash, height and
        * other meta information
        * @param blocks - observable with all blocks, that should be applied
        * atomically
-       * @param storage - storage that may be modified during loading
-       * @return true if commit is valid, false otherwise
+       * @param storage - storage to which the blocks are applied
+       * @return true if commit is valid and successfully applied, false otherwise
        */
-      virtual bool validateChain(
+      virtual bool validateAndApply(
           rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
               blocks,
           ametsuchi::MutableStorage &storage) const = 0;

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -20,7 +20,7 @@ namespace iroha {
         : supermajority_checker_(supermajority_checker),
           log_(logger::log("ChainValidator")) {}
 
-    bool ChainValidatorImpl::validateChain(
+    bool ChainValidatorImpl::validateAndApply(
         rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
             blocks,
         ametsuchi::MutableStorage &storage) const {

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -37,7 +37,7 @@ namespace iroha {
       ChainValidatorImpl(std::shared_ptr<consensus::yac::SupermajorityChecker>
                              supermajority_checker);
 
-      bool validateChain(
+      bool validateAndApply(
           rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
               blocks,
           ametsuchi::MutableStorage &storage) const override;

--- a/test/integration/validation/chain_validator_storage_test.cpp
+++ b/test/integration/validation/chain_validator_storage_test.cpp
@@ -102,7 +102,7 @@ namespace iroha {
     auto createAndValidateChain(
         std::vector<std::shared_ptr<shared_model::interface::Block>> chain) {
       auto ms = createMutableStorage();
-      return validator->validateChain(rxcpp::observable<>::iterate(chain), *ms);
+      return validator->validateAndApply(rxcpp::observable<>::iterate(chain), *ms);
     }
 
     std::shared_ptr<validation::ChainValidatorImpl> validator;

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -108,7 +108,7 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-  EXPECT_CALL(*chain_validator, validateChain(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _)).WillOnce(Return(true));
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
 
@@ -151,7 +151,7 @@ TEST_F(SynchronizerTest, ValidWhenBadStorage) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(0);
 
-  EXPECT_CALL(*chain_validator, validateChain(_, _)).Times(0);
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _)).Times(0);
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_)).Times(0);
 
@@ -185,7 +185,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
 
-  EXPECT_CALL(*chain_validator, validateChain(_, _))
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _))
       .WillOnce(Return(false))
       .WillOnce(Return(true));
 
@@ -232,7 +232,7 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
   EXPECT_CALL(*consensus_gate, on_commit())
       .WillOnce(Return(rxcpp::observable<>::empty<network::Commit>()));
-  EXPECT_CALL(*chain_validator, validateChain(_, _))
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _))
       .WillOnce(Return(false))
       .WillOnce(testing::Invoke([](auto chain, auto &) {
         // emulate chain check
@@ -282,7 +282,7 @@ TEST_F(SynchronizerTest, RetrieveBlockTwoFailures) {
       .WillRepeatedly(Return(commit_message_blocks));
 
   // fail the chain validation two times so that synchronizer will try more
-  EXPECT_CALL(*chain_validator, validateChain(_, _))
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _))
       .WillOnce(Return(false))
       .WillOnce(Return(false))
       .WillOnce(Return(false))

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -85,7 +85,7 @@ TEST_F(ChainValidationTest, ValidCase) {
   EXPECT_CALL(*storage, apply(blocks, _))
       .WillOnce(InvokeArgument<1>(ByRef(*block), ByRef(*query), ByRef(hash)));
 
-  ASSERT_TRUE(validator->validateChain(blocks, *storage));
+  ASSERT_TRUE(validator->validateAndApply(blocks, *storage));
   ASSERT_EQ(block->signatures(), block_signatures);
 }
 
@@ -109,7 +109,7 @@ TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
       .WillOnce(
           InvokeArgument<1>(ByRef(*block), ByRef(*query), ByRef(another_hash)));
 
-  ASSERT_FALSE(validator->validateChain(blocks, *storage));
+  ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
 }
 
 /**
@@ -128,6 +128,6 @@ TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
   EXPECT_CALL(*storage, apply(blocks, _))
       .WillOnce(InvokeArgument<1>(ByRef(*block), ByRef(*query), ByRef(hash)));
 
-  ASSERT_FALSE(validator->validateChain(blocks, *storage));
+  ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
   ASSERT_EQ(block->signatures(), block_signatures);
 }

--- a/test/module/irohad/validation/validation_mocks.hpp
+++ b/test/module/irohad/validation/validation_mocks.hpp
@@ -38,7 +38,7 @@ namespace iroha {
     class MockChainValidator : public ChainValidator {
      public:
       MOCK_CONST_METHOD2(
-          validateChain,
+          validateAndApply,
           bool(rxcpp::observable<
                    std::shared_ptr<shared_model::interface::Block>>,
                ametsuchi::MutableStorage &));


### PR DESCRIPTION
### Description of the Change

Before this change the ChainValidator method validateChain was implicitly used to apply the commits to the main World State, but neither the class, nor the function name, nor its description corresponded to such usage. In this change I tried to put these in accordance.

### Benefits

Improved readability.

### Possible Drawbacks 

I hope there are none.