### PR TITLE
Add fuzzing target for ordering gate

### DIFF
--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -37,3 +37,14 @@ target_link_libraries(find_fuzzing
   torii_service
   protobuf-mutator
   )
+
+add_executable(ordering_gate_fuzz ordering_gate_fuzz.cpp)
+target_link_libraries(ordering_gate_fuzz
+  rxcpp
+  gtest::gtest
+  gmock::gmock
+  on_demand_ordering_gate
+  shared_model_default_builders
+  shared_model_stateless_validation
+  protobuf-mutator
+)

--- a/test/fuzzing/ordering_gate_fuzz.cpp
+++ b/test/fuzzing/ordering_gate_fuzz.cpp
@@ -15,22 +15,21 @@ using namespace iroha::ordering;
 using namespace testing;
 
 struct OrderingGateFixture {
-  std::shared_ptr<OnDemandOrderingGate> ordering_gate_;
-
+  std::shared_ptr<shared_model::proto::ProtoBlockFactory> block_factory_;
   std::shared_ptr<MockOnDemandOrderingService> ordering_service_;
   std::shared_ptr<transport::MockOdOsNotification> network_client_;
+
   rxcpp::subjects::subject<OnDemandOrderingGate::BlockRoundEventType> rounds_;
   MockUnsafeProposalFactory *proposal_factory_;
+  std::shared_ptr<OnDemandOrderingGate> ordering_gate_;
   iroha::consensus::Round initial_round_ = {2, 1};
 
-  std::shared_ptr<shared_model::proto::ProtoBlockFactory> block_factory_;
+  OrderingGateFixture() :
+          block_factory_(std::make_shared<shared_model::proto::ProtoBlockFactory>(std::make_unique<
+                  shared_model::validation::DefaultUnsignedBlockValidator>())),
+          ordering_service_(std::make_shared<MockOnDemandOrderingService>()),
+          network_client_(std::make_shared<transport::MockOdOsNotification>()) {
 
-  OrderingGateFixture() {
-    block_factory_ = std::make_shared<shared_model::proto::ProtoBlockFactory>(std::make_unique<
-            shared_model::validation::DefaultUnsignedBlockValidator>());
-
-    ordering_service_ = std::make_shared<MockOnDemandOrderingService>();
-    network_client_ = std::make_shared<transport::MockOdOsNotification>();
     auto proposal_factory = std::make_unique<MockUnsafeProposalFactory>();
     proposal_factory_ = proposal_factory.get();
     ordering_gate_ = std::make_shared<OnDemandOrderingGate>(ordering_service_, network_client_,

--- a/test/fuzzing/ordering_gate_fuzz.cpp
+++ b/test/fuzzing/ordering_gate_fuzz.cpp
@@ -58,7 +58,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
                         ordering_gate_fixture.rounds_.get_subscriber().on_next(std::move(result.value));
                       },
                       [](const iroha::expected::Error<std::string> &error) {
-                        ordering_gate_fixture.rounds_.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent());
+                        // just ignore a bad case
                       });
   }
 

--- a/test/fuzzing/ordering_gate_fuzz.cpp
+++ b/test/fuzzing/ordering_gate_fuzz.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <memory>
+#include "libfuzzer/libfuzzer_macro.h"
+#include "ordering/impl/on_demand_ordering_gate.hpp"
+#include "module/irohad/ordering/ordering_mocks.hpp"
+#include "module/shared_model/interface_mocks.hpp"
+#include "backend/protobuf/proto_block_factory.hpp"
+#include "validators/default_validator.hpp"
+
+using namespace iroha::ordering;
+using namespace testing;
+
+struct OrderingGateFixture {
+  std::shared_ptr<OnDemandOrderingGate> ordering_gate_;
+
+  std::shared_ptr<MockOnDemandOrderingService> ordering_service_;
+  std::shared_ptr<transport::MockOdOsNotification> network_client_;
+  rxcpp::subjects::subject<OnDemandOrderingGate::BlockRoundEventType> rounds_;
+  MockUnsafeProposalFactory *proposal_factory_;
+  iroha::consensus::Round initial_round_ = {2, 1};
+
+  std::shared_ptr<shared_model::proto::ProtoBlockFactory> block_factory_;
+
+  OrderingGateFixture() {
+    block_factory_ = std::make_shared<shared_model::proto::ProtoBlockFactory>(std::make_unique<
+            shared_model::validation::DefaultUnsignedBlockValidator>());
+
+    ordering_service_ = std::make_shared<MockOnDemandOrderingService>();
+    network_client_ = std::make_shared<transport::MockOdOsNotification>();
+    auto proposal_factory = std::make_unique<MockUnsafeProposalFactory>();
+    proposal_factory_ = proposal_factory.get();
+    ordering_gate_ = std::make_shared<OnDemandOrderingGate>(ordering_service_, network_client_,
+                                                            rounds_.get_observable(),
+                                                            std::move(proposal_factory),
+                                                            initial_round_);
+
+    // to suppress "uninteresting" gmock warnings
+    EXPECT_CALL(*ordering_service_, onCollaborationOutcome(_)).Times(AtLeast(0));
+    EXPECT_CALL(*network_client_, onRequestProposal(_)).Times(AtLeast(0));
+    EXPECT_CALL(*proposal_factory_, unsafeCreateProposal(_, _, _)).Times(AtLeast(0));
+  }
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
+  static OrderingGateFixture ordering_gate_fixture;
+  if (size < 1) {
+    return 0;
+  }
+
+  iroha::protocol::Block block;
+  if (protobuf_mutator::libfuzzer::LoadProtoInput(true, data, size, &block)) {
+    auto iroha_block =
+            ordering_gate_fixture.block_factory_->createBlock(std::move(block));
+    iroha_block.match([](iroha::expected::Value<std::unique_ptr<shared_model::interface::Block>> &result) {
+                        ordering_gate_fixture.rounds_.get_subscriber().on_next(std::move(result.value));
+                      },
+                      [](const iroha::expected::Error<std::string> &error) {
+                        ordering_gate_fixture.rounds_.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent());
+                      });
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: luckychess <toobwn@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This pull request adds a fuzzing target for ordering gate.

### Benefits

<!-- What benefits will be realized by the code change? -->

One more possibility to find bugs and issues in the code.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

This code has to be built with mainstream clang (not an apple's one) and currently fuzzing option is not turned on by default - it makes this code hard to support.

### Usage Examples or Tests

Set compiler paths to your local clang binaries.
```
cmake -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++  -DFUZZING=ON ..
make ordering_gate_fuzz
```
Currently this test finds issues pretty quickly and they should be fixed - in a separate task.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->


