### PR TITLE
A test for basic case of transaction replay attack

### DIFF
--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -149,3 +149,10 @@ addtest(get_role_permissions_test
 target_link_libraries(get_role_permissions_test
     acceptance_fixture
     )
+
+addtest(replay_test
+    replay_test.cpp
+    )
+target_link_libraries(replay_test
+    acceptance_fixture
+    )

--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+
+using namespace integration_framework;
+using namespace shared_model;
+
+#define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
+
+class ReplayFixture : public AcceptanceFixture {
+ public:
+  ReplayFixture() : itf(1) {}
+
+  void SetUp() override {
+    auto create_user_tx =
+        complete(baseTx(kAdminId)
+                     .createAccount(kUser, kDomain, kUserKeypair.publicKey())
+                     .addAssetQuantity(kAssetId, "10000.0"),
+                 kAdminKeypair);
+    itf.setInitialState(kAdminKeypair).sendTxAwait(create_user_tx, check(1));
+  }
+
+  IntegrationTestFramework itf;
+};
+
+// TODO igor-egorov, 07 Nov 2018, enable the test, IR-1773 & IR-1838
+/**
+ * Basic case of transaction replay attack
+ * @given an initialized ITF and a transaction
+ * @when the transaction is sent to ITF twice
+ * @then the second submission should be rejected
+ */
+TEST_F(ReplayFixture, DISABLED_BasicTxReplay) {
+  auto transfer_tx = complete(
+      baseTx(kAdminId).transferAsset(kAdminId, kUserId, kAssetId, "", "1.0"),
+      kAdminKeypair);
+
+  itf.sendTxAwait(transfer_tx, check(1)); // should be committed
+  itf.sendTxAwait(transfer_tx, check(0)); // should not
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Adds a test that sends the same transaction (copies are bit-exact) two times and expects that the second transaction should not be processed and committed.

### Benefits

Increased coverage.

### Possible Drawbacks 

The test is disabled now. It should be enabled after IR-1773 and IR-1838.

The test is to be expanded by adding the same cases about MST transactions and states.

### Usage Examples or Tests

```
make replay_test
test_bin/replay_test
```
