### PR TITLE
Block loader endpoint fuzzing

### DIFF
--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -70,3 +70,12 @@ target_link_libraries(retrieve_block_fuzz
   shared_model_default_builders
   protobuf-mutator
   )
+
+add_executable(retrieve_blocks_fuzz retrieve_blocks_fuzz.cpp)
+target_link_libraries(retrieve_blocks_fuzz
+  gtest::gtest
+  gmock::gmock
+  block_loader_service
+  shared_model_default_builders
+  protobuf-mutator
+  )

--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -61,3 +61,12 @@ target_link_libraries(request_proposal_fuzz
   on_demand_ordering_service_transport_grpc
   protobuf-mutator
   )
+
+add_executable(retrieve_block_fuzz retrieve_block_fuzz.cpp)
+target_link_libraries(retrieve_block_fuzz
+  gtest::gtest
+  gmock::gmock
+  block_loader_service
+  shared_model_default_builders
+  protobuf-mutator
+  )

--- a/test/fuzzing/block_loader_fixture.hpp
+++ b/test/fuzzing/block_loader_fixture.hpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_BLOCK_LOADER_FIXTURE_HPP
+#define IROHA_BLOCK_LOADER_FIXTURE_HPP
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <libfuzzer/libfuzzer_macro.h>
+
+#include "consensus/consensus_block_cache.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
+#include "network/impl/block_loader_service.hpp"
+
+using namespace testing;
+
+namespace fuzzing {
+
+  struct BlockLoaderFixture {
+    std::shared_ptr<NiceMock<iroha::ametsuchi::MockBlockQuery>> storage_;
+    std::shared_ptr<NiceMock<iroha::ametsuchi::MockBlockQueryFactory>>
+        block_query_factory_;
+    std::shared_ptr<iroha::consensus::ConsensusResultCache> block_cache_;
+    std::shared_ptr<iroha::network::BlockLoaderService> block_loader_service_;
+
+    BlockLoaderFixture() {
+      // BlockLoaderService produces lots of error logs about missing blocks
+      spdlog::set_level(spdlog::level::critical);
+
+      storage_ = std::make_shared<NiceMock<iroha::ametsuchi::MockBlockQuery>>();
+      block_query_factory_ =
+          std::make_shared<NiceMock<iroha::ametsuchi::MockBlockQueryFactory>>();
+      block_cache_ = std::make_shared<iroha::consensus::ConsensusResultCache>();
+      block_loader_service_ =
+          std::make_shared<iroha::network::BlockLoaderService>(
+              block_query_factory_, block_cache_);
+      EXPECT_CALL(*block_query_factory_, createBlockQuery())
+          .WillRepeatedly(Return(boost::make_optional(
+              std::shared_ptr<iroha::ametsuchi::BlockQuery>(storage_))));
+    }
+  };
+
+}  // namespace fuzzing
+
+#endif  // IROHA_BLOCK_LOADER_FIXTURE_HPP

--- a/test/fuzzing/retrieve_block_fuzz.cpp
+++ b/test/fuzzing/retrieve_block_fuzz.cpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "block_loader_fixture.hpp"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
+  static fuzzing::BlockLoaderFixture fixture;
+
+  if (size < 1) {
+    return 0;
+  }
+
+  iroha::network::proto::BlockRequest request;
+  if (protobuf_mutator::libfuzzer::LoadProtoInput(true, data, size, &request)) {
+    grpc::ServerContext context;
+    iroha::protocol::Block response;
+    fixture.block_loader_service_->retrieveBlock(&context, &request, &response);
+  }
+
+  return 0;
+}

--- a/test/fuzzing/retrieve_blocks_fuzz.cpp
+++ b/test/fuzzing/retrieve_blocks_fuzz.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "block_loader_fixture.hpp"
+
+class MockServerWriter
+    : public grpc::ServerWriterInterface<iroha::protocol::Block> {
+ public:
+  MOCK_METHOD0(SendInitialMetadata, void(void));
+  MOCK_METHOD2(Write,
+               bool(const iroha::protocol::Block &msg, grpc::WriteOptions));
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
+  static fuzzing::BlockLoaderFixture fixture;
+
+  if (size < 1) {
+    return 0;
+  }
+
+  iroha::network::proto::BlocksRequest request;
+  if (protobuf_mutator::libfuzzer::LoadProtoInput(true, data, size, &request)) {
+    grpc::ServerContext context;
+    MockServerWriter writer;
+    fixture.block_loader_service_->retrieveBlocks(&context, &request, nullptr);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Fuzzing for block loader endpoints (**retrieveBlock** and **retrieveBlocks**).

### Benefits
Another endpoint is covered by fuzzing.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Hard to support until fuzzing in CI is not ready.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 
```cmake -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++  -DFUZZING=ON ..
make retrieve_block_fuzz
make retrieve_blocks_fuzz
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
