### PR TITLE
Fix the replay test after `common constants' merging

### DIFF
--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -9,6 +9,7 @@
 
 using namespace integration_framework;
 using namespace shared_model;
+using namespace common_constants;
 
 #define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
 


### PR DESCRIPTION
### Description of the Change

Commit 1b1966b broke the replay test, because the common constants were moved to a namespace. In this PR I just add the missing namespace using.

### Benefits
Fixed test.

### Possible Drawbacks 
One more line of code to maintain.