### PR TITLE
Feature/rejected txs index

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <rxcpp/rx.hpp>
 
+#include "ametsuchi/tx_cache_response.hpp"
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/transaction.hpp"
@@ -106,21 +107,13 @@ namespace iroha {
           const shared_model::crypto::Hash &hash) = 0;
 
       /**
-       * Synchronously checks whether transaction
-       * with given hash is present in any block
-       * @param hash - transaction hash
-       * @return true if transaction exists, false otherwise
-       */
-      virtual bool hasCommittedTxWithHash(
-          const shared_model::crypto::Hash &hash) = 0;
-
-      /**
-       * Synchronously checks whether rejected transaction's hash is present in
+       * Synchronously checks whether transaction with given hash is present in
        * any block
        * @param hash - rejected transaction's hash
-       * @return true if rejected transaction's hash exists, false otherwise
+       * @return TxCacheStatusType which returns status of transaction:
+       * Committed, Rejected or Missing
        */
-      virtual bool hasRejectedTxWithHash(
+      virtual TxCacheStatusType checkTxPresence(
           const shared_model::crypto::Hash &hash) = 0;
 
       /**

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -114,6 +114,15 @@ namespace iroha {
       virtual bool hasTxWithHash(const shared_model::crypto::Hash &hash) = 0;
 
       /**
+       * Synchronously checks whether rejected transaction's hash is present in
+       * any block
+       * @param hash - rejected transaction's hash
+       * @return true if rejected transaction's hash exists, false otherwise
+       */
+      virtual bool hasRejectedTxWithHash(
+          const shared_model::crypto::Hash &hash) = 0;
+
+      /**
        * Get the top-most block
        * @return result of Model Block or error message
        */

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -111,7 +111,8 @@ namespace iroha {
        * @param hash - transaction hash
        * @return true if transaction exists, false otherwise
        */
-      virtual bool hasTxWithHash(const shared_model::crypto::Hash &hash) = 0;
+      virtual bool hasCommittedTxWithHash(
+          const shared_model::crypto::Hash &hash) = 0;
 
       /**
        * Synchronously checks whether rejected transaction's hash is present in

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -247,6 +247,22 @@ namespace iroha {
       return getBlockId(hash) != boost::none;
     }
 
+    bool PostgresBlockQuery::hasRejectedTxWithHash(
+        const shared_model::crypto::Hash &hash) {
+      boost::optional<uint64_t> blockId = boost::none;
+      boost::optional<std::string> block_str;
+      const auto &hash_str = hash.hex();
+
+      sql_ << "SELECT height FROM height_by_rejected_hash WHERE hash = :hash",
+          soci::into(block_str), soci::use(hash_str);
+      if (block_str) {
+        blockId = std::stoull(block_str.get());
+      } else {
+        log_->info("No block with rejected transaction {}", hash.toString());
+      }
+      return (bool)blockId;
+    }
+
     uint32_t PostgresBlockQuery::getTopBlockHeight() {
       return block_store_.last_id();
     }

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -242,6 +242,17 @@ namespace iroha {
         };
     }
 
+    TxCacheStatusType PostgresBlockQuery::checkTxPresence(
+        const shared_model::crypto::Hash &hash) {
+      if (hasCommittedTxWithHash(hash)) {
+        return tx_cache_status_responses::Committed();
+      }
+      if (hasRejectedTxWithHash(hash)) {
+        return tx_cache_status_responses::Rejected();
+      }
+      return tx_cache_status_responses::Missing();
+    }
+
     bool PostgresBlockQuery::hasCommittedTxWithHash(
         const shared_model::crypto::Hash &hash) {
       return getBlockId(hash) != boost::none;

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -242,7 +242,7 @@ namespace iroha {
         };
     }
 
-    bool PostgresBlockQuery::hasTxWithHash(
+    bool PostgresBlockQuery::hasCommittedTxWithHash(
         const shared_model::crypto::Hash &hash) {
       return getBlockId(hash) != boost::none;
     }

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -61,9 +61,11 @@ namespace iroha {
 
       uint32_t getTopBlockHeight() override;
 
-      bool hasTxWithHash(const shared_model::crypto::Hash &hash) override;
+      bool hasCommittedTxWithHash(
+          const shared_model::crypto::Hash &hash) override;
 
-      bool hasRejectedTxWithHash(const shared_model::crypto::Hash &hash) override;
+      bool hasRejectedTxWithHash(
+          const shared_model::crypto::Hash &hash) override;
 
       expected::Result<wBlock, std::string> getTopBlock() override;
 

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -61,10 +61,7 @@ namespace iroha {
 
       uint32_t getTopBlockHeight() override;
 
-      bool hasCommittedTxWithHash(
-          const shared_model::crypto::Hash &hash) override;
-
-      bool hasRejectedTxWithHash(
+      TxCacheStatusType checkTxPresence(
           const shared_model::crypto::Hash &hash) override;
 
       expected::Result<wBlock, std::string> getTopBlock() override;
@@ -77,7 +74,6 @@ namespace iroha {
        */
       std::vector<shared_model::interface::types::HeightType> getBlockIds(
           const shared_model::interface::types::AccountIdType &account_id);
-
       /**
        * Returns block id which contains transaction with a given hash
        * @param hash - hash of transaction
@@ -104,6 +100,10 @@ namespace iroha {
       expected::Result<std::unique_ptr<shared_model::interface::Block>,
                        std::string>
       getBlock(shared_model::interface::types::HeightType id) const;
+
+      bool hasCommittedTxWithHash(const shared_model::crypto::Hash &hash);
+
+      bool hasRejectedTxWithHash(const shared_model::crypto::Hash &hash);
 
       std::unique_ptr<soci::session> psql_;
       soci::session &sql_;

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -63,7 +63,7 @@ namespace iroha {
 
       bool hasTxWithHash(const shared_model::crypto::Hash &hash) override;
 
-      bool hasRejectedTxWithHash(const shared_model::crypto::Hash &hash);
+      bool hasRejectedTxWithHash(const shared_model::crypto::Hash &hash) override;
 
       expected::Result<wBlock, std::string> getTopBlock() override;
 

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -63,6 +63,8 @@ namespace iroha {
 
       bool hasTxWithHash(const shared_model::crypto::Hash &hash) override;
 
+      bool hasRejectedTxWithHash(const shared_model::crypto::Hash &hash);
+
       expected::Result<wBlock, std::string> getTopBlock() override;
 
      private:

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -508,6 +508,12 @@ CREATE TABLE IF NOT EXISTS height_by_hash (
     hash varchar,
     height text
 );
+
+CREATE TABLE IF NOT EXISTS height_by_rejected_hash (
+  hash varchar,
+  height text
+);
+
 CREATE TABLE IF NOT EXISTS height_by_account_set (
     account_id text,
     height text

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -54,7 +54,7 @@ namespace torii {
       return cached.value();
     }
 
-    const bool is_present = storage_->getBlockQuery()->hasTxWithHash(request);
+    const bool is_present = storage_->getBlockQuery()->hasCommittedTxWithHash(request);
 
     if (is_present) {
       std::shared_ptr<shared_model::interface::TransactionResponse> response =

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -54,17 +54,20 @@ namespace torii {
       return cached.value();
     }
 
-    const bool is_present = storage_->getBlockQuery()->hasCommittedTxWithHash(request);
-
-    if (is_present) {
-      std::shared_ptr<shared_model::interface::TransactionResponse> response =
-          status_factory_->makeCommitted(request, "");
-      cache_->addItem(request, response);
-      return response;
-    } else {
-      log_->warn("Asked non-existing tx: {}", request.hex());
-      return status_factory_->makeNotReceived(request, "");
-    }
+    return iroha::visit_in_place(
+        storage_->getBlockQuery()->checkTxPresence(request),
+        [this,
+         &request](const iroha::ametsuchi::tx_cache_status_responses::Missing &)
+            -> std::shared_ptr<shared_model::interface::TransactionResponse> {
+          log_->warn("Asked non-existing tx: {}", request.hex());
+          return status_factory_->makeNotReceived(request, "");
+        },
+        [this, &request](const auto &) {
+          std::shared_ptr<shared_model::interface::TransactionResponse>
+              response = status_factory_->makeCommitted(request, "");
+          cache_->addItem(request, response);
+          return response;
+        });
   }
 
   /**

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -184,8 +184,10 @@ namespace iroha {
                        shared_model::interface::types::HeightType));
       MOCK_METHOD1(getTopBlocks, std::vector<BlockQuery::wBlock>(uint32_t));
       MOCK_METHOD0(getTopBlock, expected::Result<wBlock, std::string>(void));
-      MOCK_METHOD1(hasTxWithHash, bool(
-          const shared_model::crypto::Hash &hash));
+      MOCK_METHOD1(hasCommittedTxWithHash,
+                   bool(const shared_model::crypto::Hash &hash));
+      MOCK_METHOD1(hasRejectedTxWithHash,
+                   bool(const shared_model::crypto::Hash &hash));
       MOCK_METHOD0(getTopBlockHeight, uint32_t(void));
     };
 

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -184,10 +184,8 @@ namespace iroha {
                        shared_model::interface::types::HeightType));
       MOCK_METHOD1(getTopBlocks, std::vector<BlockQuery::wBlock>(uint32_t));
       MOCK_METHOD0(getTopBlock, expected::Result<wBlock, std::string>(void));
-      MOCK_METHOD1(hasCommittedTxWithHash,
-                   bool(const shared_model::crypto::Hash &hash));
-      MOCK_METHOD1(hasRejectedTxWithHash,
-                   bool(const shared_model::crypto::Hash &hash));
+      MOCK_METHOD1(checkTxPresence,
+                   TxCacheStatusType(const shared_model::crypto::Hash &));
       MOCK_METHOD0(getTopBlockHeight, uint32_t(void));
     };
 

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -184,7 +184,8 @@ namespace iroha {
                        shared_model::interface::types::HeightType));
       MOCK_METHOD1(getTopBlocks, std::vector<BlockQuery::wBlock>(uint32_t));
       MOCK_METHOD0(getTopBlock, expected::Result<wBlock, std::string>(void));
-      MOCK_METHOD1(hasTxWithHash, bool(const shared_model::crypto::Hash &hash));
+      MOCK_METHOD1(hasTxWithHash, bool(
+          const shared_model::crypto::Hash &hash));
       MOCK_METHOD0(getTopBlockHeight, uint32_t(void));
     };
 

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -68,7 +68,7 @@ class BlockQueryTest : public AmetsuchiTest {
                 std::vector<shared_model::proto::Transaction>({txn1_1, txn1_2}))
             .prevHash(shared_model::crypto::Hash(zero_string))
             .rejectedTransactions(std::vector<shared_model::crypto::Hash>{
-                rejected_hash1, rejected_hash2})
+                rejected_hash, rejected_hash2})
             .build();
 
     // First tx in block 1
@@ -112,8 +112,7 @@ class BlockQueryTest : public AmetsuchiTest {
   std::string creator2 = "user2@test";
   std::size_t blocks_total{0};
   std::string zero_string = std::string(32, '0');
-  shared_model::crypto::Hash rejected_hash1{"rejected_tx_hash1"};
-  shared_model::crypto::Hash rejected_hash2{"rejected_tx_hash2"};
+  shared_model::crypto::Hash rejected_hash{"rejected_tx_hash"};
 };
 
 /**
@@ -356,7 +355,7 @@ TEST_F(BlockQueryTest, GetTop2Blocks) {
  */
 TEST_F(BlockQueryTest, HasTxWithExistingHash) {
   for (const auto &hash : tx_hashes) {
-    EXPECT_TRUE(blocks->hasTxWithHash(hash));
+    EXPECT_TRUE(blocks->hasCommittedTxWithHash(hash));
   }
 }
 
@@ -368,7 +367,7 @@ TEST_F(BlockQueryTest, HasTxWithExistingHash) {
  */
 TEST_F(BlockQueryTest, HasTxWithInvalidHash) {
   shared_model::crypto::Hash invalid_tx_hash(zero_string);
-  EXPECT_FALSE(blocks->hasTxWithHash(invalid_tx_hash));
+  EXPECT_FALSE(blocks->hasCommittedTxWithHash(invalid_tx_hash));
 }
 
 /**
@@ -378,7 +377,7 @@ TEST_F(BlockQueryTest, HasTxWithInvalidHash) {
  * @then True is returned
  */
 TEST_F(BlockQueryTest, HasTxWithRejectedHash) {
-  EXPECT_TRUE(blocks->hasRejectedTxWithHash(rejected_hash1));
+  EXPECT_TRUE(blocks->hasRejectedTxWithHash(rejected_hash));
 }
 
 /**

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -67,6 +67,8 @@ class BlockQueryTest : public AmetsuchiTest {
             .transactions(
                 std::vector<shared_model::proto::Transaction>({txn1_1, txn1_2}))
             .prevHash(shared_model::crypto::Hash(zero_string))
+            .rejectedTransactions(std::vector<shared_model::crypto::Hash>{
+                rejected_hash1, rejected_hash2})
             .build();
 
     // First tx in block 1
@@ -110,6 +112,8 @@ class BlockQueryTest : public AmetsuchiTest {
   std::string creator2 = "user2@test";
   std::size_t blocks_total{0};
   std::string zero_string = std::string(32, '0');
+  shared_model::crypto::Hash rejected_hash1{"rejected_tx_hash1"};
+  shared_model::crypto::Hash rejected_hash2{"rejected_tx_hash2"};
 };
 
 /**
@@ -365,6 +369,27 @@ TEST_F(BlockQueryTest, HasTxWithExistingHash) {
 TEST_F(BlockQueryTest, HasTxWithInvalidHash) {
   shared_model::crypto::Hash invalid_tx_hash(zero_string);
   EXPECT_FALSE(blocks->hasTxWithHash(invalid_tx_hash));
+}
+
+/**
+ * @given block store with preinserted blocks containing rejected_hash1 in one
+ * of the block
+ * @when hasRejectedTxWithHash is invoked on existing rejected hash
+ * @then True is returned
+ */
+TEST_F(BlockQueryTest, HasTxWithRejectedHash) {
+  EXPECT_TRUE(blocks->hasRejectedTxWithHash(rejected_hash1));
+}
+
+/**
+ * @given block store with preinserted blocks containing rejected_hash1 in one
+ * of the block
+ * @when hasRejectedTxWithHash is invoked on non-existing rejected hash
+ * @then False is returned
+ */
+TEST_F(BlockQueryTest, HasTxWithNonExistingRejectedHash) {
+  shared_model::crypto::Hash invalid_tx_hash(zero_string);
+  EXPECT_FALSE(blocks->hasRejectedTxWithHash(invalid_tx_hash));
 }
 
 /**

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -67,8 +67,8 @@ class BlockQueryTest : public AmetsuchiTest {
             .transactions(
                 std::vector<shared_model::proto::Transaction>({txn1_1, txn1_2}))
             .prevHash(shared_model::crypto::Hash(zero_string))
-            .rejectedTransactions(std::vector<shared_model::crypto::Hash>{
-                rejected_hash, rejected_hash2})
+            .rejectedTransactions(
+                std::vector<shared_model::crypto::Hash>{rejected_hash})
             .build();
 
     // First tx in block 1


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

We should be able to check whether transaction has been processed by ledger, even if it was rejected. This PR adds this functionality by adding hasRejectedTxWithHash query in block query. In future it can be used by committed transactions cache.
### Benefits

Now we have all means to implement fair implementation of committed transactions cache

### Possible Drawbacks 

None

### Usage Examples or Tests

Corresponding tests on block query were provided