### PR TITLE
Ordering service (pre-on-demand version) in ITF & Fake Peer

### DIFF
--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -16,7 +16,7 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
     ::grpc::ServerContext *context,
     const iroha::protocol::Proposal *request,
     ::google::protobuf::Empty *response) {
-  async_call_->log_->info("receive proposal");
+  async_call_->log_->info("received a proposal");
 
   auto proposal_res = factory_->createProposal(*request);
   proposal_res.match(

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(integration_framework
     integration_framework/iroha_instance.cpp
     integration_framework/fake_peer/fake_peer.cpp
     integration_framework/fake_peer/yac_network_notifier.cpp
+    integration_framework/fake_peer/ordering_service_network_notifier.cpp
+    integration_framework/fake_peer/ordering_gate_network_notifier.cpp
     common_constants.cpp
     )
 target_link_libraries(integration_framework

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(integration_framework
     shared_model_cryptography_model
     server_runner
     mst_transport
+    ordering_service
     )
 
 target_include_directories(integration_framework PUBLIC ${PROJECT_SOURCE_DIR}/test)

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -12,16 +12,18 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "cryptography/keypair.hpp"
+#include "framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp"
+#include "framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp"
 #include "framework/result_fixture.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "main/server_runner.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 #include "network/impl/async_grpc_client.hpp"
+#include "ordering/impl/ordering_gate_transport_grpc.hpp"
+#include "ordering/impl/ordering_service_transport_grpc.hpp"
 
 using namespace shared_model::crypto;
 using namespace framework::expected;
-
-using YacStateMessage = integration_framework::YacNetworkNotifier::StateMessagePtr;
 
 static std::shared_ptr<shared_model::interface::Peer> createPeer(
     const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
@@ -76,10 +78,18 @@ namespace integration_framework {
                                                       transaction_batch_factory,
                                                       keypair_->publicKey())),
         yac_transport_(std::make_shared<YacTransport>(async_call_)),
+        os_transport_(std::make_shared<OsTransport>(transaction_batch_factory,
+                                                    async_call_)),
+        og_transport_(
+            std::make_shared<OgTransport>(real_peer_->address(), async_call_)),
         yac_network_notifier_(std::make_shared<YacNetworkNotifier>()),
+        os_network_notifier_(std::make_shared<OsNetworkNotifier>()),
+        og_network_notifier_(std::make_shared<OgNetworkNotifier>()),
         yac_crypto_(std::make_shared<iroha::consensus::yac::CryptoProviderImpl>(
             *keypair_, common_objects_factory)) {
     yac_transport_->subscribe(yac_network_notifier_);
+    os_transport_->subscribe(os_network_notifier_);
+    og_transport_->subscribe(og_network_notifier_);
     log_ = logger::log(
         "IntegrationTestFramework "
         "(fake peer at "
@@ -95,6 +105,8 @@ namespace integration_framework {
     internal_server_ = std::make_unique<ServerRunner>(getAddress());
     internal_server_->append(yac_transport_)
         .append(mst_transport_)
+        .append(os_transport_)
+        .append(og_transport_)
         .run()
         .match(
             [this](const iroha::expected::Result<int, std::string>::ValueType
@@ -123,8 +135,16 @@ namespace integration_framework {
     return *keypair_;
   }
 
-  rxcpp::observable<YacStateMessage> FakePeer::get_yac_states_observable() {
+  rxcpp::observable<FakePeer::YacStatePtr> FakePeer::get_yac_states_observable() {
     return yac_network_notifier_->get_observable();
+  }
+
+  rxcpp::observable<FakePeer::OsBatchPtr> FakePeer::get_os_batches_observable() {
+    return os_network_notifier_->get_observable();
+  }
+
+  rxcpp::observable<FakePeer::OgProposalPtr> FakePeer::get_og_proposals_observable() {
+    return og_network_notifier_->get_observable();
   }
 
   void FakePeer::enableAgreeAllProposals() {
@@ -172,7 +192,7 @@ namespace integration_framework {
     yac_transport_->sendState(*real_peer_, state);
   }
 
-  void FakePeer::voteForTheSame(const YacStateMessage &incoming_votes) {
+  void FakePeer::voteForTheSame(const FakePeer::YacStatePtr &incoming_votes) {
     using iroha::consensus::yac::VoteMessage;
     log_->debug("Got a YAC state message with {} votes.",
                 incoming_votes->size());
@@ -200,6 +220,17 @@ namespace integration_framework {
           return makeVote(incoming_vote.hash);
         });
     sendYacState(my_votes);
+  }
+
+  void FakePeer::sendProposal(
+      std::unique_ptr<shared_model::interface::Proposal> proposal) {
+    os_transport_->publishProposal(std::move(proposal),
+                                   {real_peer_->address()});
+  }
+
+  void FakePeer::sendBatch(
+      const std::shared_ptr<shared_model::interface::TransactionBatch> &batch) {
+    og_transport_->propagateBatch(batch);
   }
 
 }  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -135,21 +135,21 @@ namespace integration_framework {
     return *keypair_;
   }
 
-  rxcpp::observable<FakePeer::YacStatePtr> FakePeer::get_yac_states_observable() {
+  rxcpp::observable<FakePeer::YacStatePtr> FakePeer::getYacStatesObservable() {
     return yac_network_notifier_->get_observable();
   }
 
-  rxcpp::observable<FakePeer::OsBatchPtr> FakePeer::get_os_batches_observable() {
+  rxcpp::observable<FakePeer::OsBatchPtr> FakePeer::getOsBatchesObservable() {
     return os_network_notifier_->get_observable();
   }
 
-  rxcpp::observable<FakePeer::OgProposalPtr> FakePeer::get_og_proposals_observable() {
+  rxcpp::observable<FakePeer::OgProposalPtr> FakePeer::getOgProposalsObservable() {
     return og_network_notifier_->get_observable();
   }
 
   void FakePeer::enableAgreeAllProposals() {
     if (!proposal_agreer_subscription_.is_subscribed()) {
-      proposal_agreer_subscription_ = get_yac_states_observable().subscribe(
+      proposal_agreer_subscription_ = getYacStatesObservable().subscribe(
           [this](auto &&message) { this->voteForTheSame(message); });
     };
   }

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -21,7 +21,9 @@ namespace shared_model {
   }
   namespace interface {
     class CommonObjectsFactory;
+    class Proposal;
     class Transaction;
+    class TransactionBatch;
     class TransactionBatchParser;
     class TransactionBatchFactory;
   }  // namespace interface
@@ -40,12 +42,19 @@ namespace iroha {
       class NetworkImpl;
       class YacCryptoProvider;
       class YacHash;
-    }
+    }  // namespace yac
+  }    // namespace consensus
+  namespace ordering {
+    class OrderingGateTransportGrpc;
+    class OrderingServiceTransportGrpc;
   }
 }  // namespace iroha
 class ServerRunner;
 
 namespace integration_framework {
+  class OsNetworkNotifier;
+  class OgNetworkNotifier;
+  class YacNetworkNotifier;
 
   /**
    * A lightweight implementation of iroha peer network interface for inter-peer
@@ -57,6 +66,11 @@ namespace integration_framework {
         shared_model::interface::AbstractTransportFactory<
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
+    using YacStatePtr =
+        std::shared_ptr<const std::vector<iroha::consensus::yac::VoteMessage>>;
+    using OgProposalPtr = std::shared_ptr<shared_model::interface::Proposal>;
+    using OsBatchPtr =
+        std::shared_ptr<shared_model::interface::TransactionBatch>;
 
     /**
      * Constructor.
@@ -109,17 +123,20 @@ namespace integration_framework {
     void disableAgreeAllProposals();
 
     /// Get the observable of YAC states received by this peer.
-    rxcpp::observable<YacNetworkNotifier::StateMessagePtr>
-    get_yac_states_observable();
+    rxcpp::observable<YacStatePtr> get_yac_states_observable();
+
+    /// Get the observable of OS batches received by this peer.
+    rxcpp::observable<OsBatchPtr> get_os_batches_observable();
+
+    /// Get the observable of OG proposals received by this peer.
+    rxcpp::observable<OgProposalPtr> get_og_proposals_observable();
 
     /**
      * Send the real peer votes from this peer analogous to the provided ones.
      *
      * @param incoming_votes - the votes to take as the base.
      */
-    void voteForTheSame(
-        const integration_framework::YacNetworkNotifier::StateMessagePtr
-            &incoming_votes);
+    void voteForTheSame(const YacStatePtr &incoming_votes);
 
     /**
      * Make a signature of the provided hash.
@@ -137,9 +154,18 @@ namespace integration_framework {
     void sendYacState(
         const std::vector<iroha::consensus::yac::VoteMessage> &state);
 
+    void sendProposal(
+        std::unique_ptr<shared_model::interface::Proposal> proposal);
+
+    void sendBatch(
+        const std::shared_ptr<shared_model::interface::TransactionBatch>
+            &batch);
+
    private:
     using MstTransport = iroha::network::MstTransportGrpc;
     using YacTransport = iroha::consensus::yac::NetworkImpl;
+    using OsTransport = iroha::ordering::OrderingServiceTransportGrpc;
+    using OgTransport = iroha::ordering::OrderingGateTransportGrpc;
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 
     std::shared_ptr<shared_model::interface::CommonObjectsFactory>
@@ -158,9 +184,14 @@ namespace integration_framework {
 
     std::shared_ptr<MstTransport> mst_transport_;
     std::shared_ptr<YacTransport> yac_transport_;
-    std::unique_ptr<ServerRunner> internal_server_;
+    std::shared_ptr<OsTransport> os_transport_;
+    std::shared_ptr<OgTransport> og_transport_;
 
     std::shared_ptr<YacNetworkNotifier> yac_network_notifier_;
+    std::shared_ptr<OsNetworkNotifier> os_network_notifier_;
+    std::shared_ptr<OgNetworkNotifier> og_network_notifier_;
+
+    std::unique_ptr<ServerRunner> internal_server_;
 
     std::shared_ptr<iroha::consensus::yac::YacCryptoProvider> yac_crypto_;
 

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -123,13 +123,13 @@ namespace integration_framework {
     void disableAgreeAllProposals();
 
     /// Get the observable of YAC states received by this peer.
-    rxcpp::observable<YacStatePtr> get_yac_states_observable();
+    rxcpp::observable<YacStatePtr> getYacStatesObservable();
 
     /// Get the observable of OS batches received by this peer.
-    rxcpp::observable<OsBatchPtr> get_os_batches_observable();
+    rxcpp::observable<OsBatchPtr> getOsBatchesObservable();
 
     /// Get the observable of OG proposals received by this peer.
-    rxcpp::observable<OgProposalPtr> get_og_proposals_observable();
+    rxcpp::observable<OgProposalPtr> getOgProposalsObservable();
 
     /**
      * Send the real peer votes from this peer analogous to the provided ones.

--- a/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp"
+
+#include "interfaces/iroha_internal/transaction_batch.hpp"
+
+namespace integration_framework {
+
+  void OgNetworkNotifier::onProposal(OgNetworkNotifier::ProposalPtr proposal) {
+    proposals_subject_.get_subscriber().on_next(std::move(proposal));
+  }
+
+  rxcpp::observable<OgNetworkNotifier::ProposalPtr>
+  OgNetworkNotifier::get_observable() {
+    return proposals_subject_.get_observable();
+  }
+
+}  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FAKE_PEER_OG_NETWORK_NOTIFIER_HPP_
+#define FAKE_PEER_OG_NETWORK_NOTIFIER_HPP_
+
+#include <rxcpp/rx.hpp>
+
+#include "consensus/yac/transport/yac_network_interface.hpp"
+#include "network/ordering_gate_transport.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class Proposal;
+  }
+}  // namespace shared_model
+
+namespace integration_framework {
+
+  class OgNetworkNotifier final
+      : public iroha::network::OrderingGateNotification {
+   public:
+    using Proposal = shared_model::interface::Proposal;
+    using ProposalPtr = std::shared_ptr<Proposal>;
+
+    void onProposal(ProposalPtr proposal) override;
+
+    rxcpp::observable<ProposalPtr> get_observable();
+
+   private:
+    rxcpp::subjects::subject<ProposalPtr> proposals_subject_;
+  };
+
+}  // namespace integration_framework
+
+#endif /* FAKE_PEER_OG_NETWORK_NOTIFIER_HPP_ */

--- a/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
@@ -6,10 +6,11 @@
 #ifndef FAKE_PEER_OG_NETWORK_NOTIFIER_HPP_
 #define FAKE_PEER_OG_NETWORK_NOTIFIER_HPP_
 
+#include "network/ordering_gate_transport.hpp"
+
 #include <rxcpp/rx.hpp>
 
 #include "consensus/yac/transport/yac_network_interface.hpp"
-#include "network/ordering_gate_transport.hpp"
 
 namespace shared_model {
   namespace interface {

--- a/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/ordering_gate_network_notifier.hpp
@@ -10,8 +10,6 @@
 
 #include <rxcpp/rx.hpp>
 
-#include "consensus/yac/transport/yac_network_interface.hpp"
-
 namespace shared_model {
   namespace interface {
     class Proposal;

--- a/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.cpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp"
+
+#include "interfaces/iroha_internal/transaction_batch.hpp"
+
+namespace integration_framework {
+
+  void OsNetworkNotifier::onBatch(std::unique_ptr<TransactionBatch> batch) {
+    auto batch_ptr = std::shared_ptr<TransactionBatch>(batch.release());
+    batches_subject_.get_subscriber().on_next(std::move(batch_ptr));
+  }
+
+  rxcpp::observable<OsNetworkNotifier::TransactionBatchPtr>
+  OsNetworkNotifier::get_observable() {
+    return batches_subject_.get_observable();
+  }
+
+}  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.cpp
@@ -10,7 +10,7 @@
 namespace integration_framework {
 
   void OsNetworkNotifier::onBatch(std::unique_ptr<TransactionBatch> batch) {
-    auto batch_ptr = std::shared_ptr<TransactionBatch>(batch.release());
+    std::shared_ptr<TransactionBatch> batch_ptr = std::move(batch);
     batches_subject_.get_subscriber().on_next(std::move(batch_ptr));
   }
 

--- a/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FAKE_PEER_OS_NETWORK_NOTIFIER_HPP_
+#define FAKE_PEER_OS_NETWORK_NOTIFIER_HPP_
+
+#include <rxcpp/rx.hpp>
+
+#include "consensus/yac/transport/yac_network_interface.hpp"
+#include "network/ordering_service_transport.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class TransactionBatch;
+  }
+}  // namespace shared_model
+
+namespace integration_framework {
+
+  class OsNetworkNotifier final
+      : public iroha::network::OrderingServiceNotification {
+   public:
+    using TransactionBatch = shared_model::interface::TransactionBatch;
+    using TransactionBatchPtr = std::shared_ptr<TransactionBatch>;
+
+    void onBatch(std::unique_ptr<TransactionBatch> batch) override;
+
+    rxcpp::observable<TransactionBatchPtr> get_observable();
+
+   private:
+    rxcpp::subjects::subject<TransactionBatchPtr> batches_subject_;
+  };
+
+}  // namespace integration_framework
+
+#endif /* FAKE_PEER_OS_NETWORK_NOTIFIER_HPP_ */

--- a/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/ordering_service_network_notifier.hpp
@@ -6,10 +6,11 @@
 #ifndef FAKE_PEER_OS_NETWORK_NOTIFIER_HPP_
 #define FAKE_PEER_OS_NETWORK_NOTIFIER_HPP_
 
+#include "network/ordering_service_transport.hpp"
+
 #include <rxcpp/rx.hpp>
 
 #include "consensus/yac/transport/yac_network_interface.hpp"
-#include "network/ordering_service_transport.hpp"
 
 namespace shared_model {
   namespace interface {

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -37,6 +37,8 @@
 #include "module/shared_model/validators/always_valid_validators.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 #include "network/impl/async_grpc_client.hpp"
+#include "ordering/impl/ordering_gate_transport_grpc.hpp"
+#include "ordering/impl/ordering_service_transport_grpc.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 using namespace shared_model::crypto;
@@ -107,6 +109,13 @@ namespace integration_framework {
                 shared_model::interface::TransactionBatchFactoryImpl>()),
         yac_transport_(
             std::make_shared<iroha::consensus::yac::NetworkImpl>(async_call_)),
+        os_transport_(
+            std::make_shared<iroha::ordering::OrderingServiceTransportGrpc>(
+                transaction_batch_factory_, async_call_)),
+        og_transport_(
+            std::make_shared<iroha::ordering::OrderingGateTransportGrpc>(
+                kLocalHost + ":" + std::to_string(internal_port_),
+                async_call_)),
         cleanup_on_exit_(cleanup_on_exit) {}
 
   IntegrationTestFramework::~IntegrationTestFramework() {
@@ -510,6 +519,19 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::sendQuery(
       const shared_model::proto::Query &qry) {
     sendQuery(qry, [](const auto &) {});
+    return *this;
+  }
+
+  IntegrationTestFramework &IntegrationTestFramework::sendProposal(
+      std::unique_ptr<shared_model::interface::Proposal> proposal) {
+    os_transport_->publishProposal(std::move(proposal),
+                                   {this_peer_->address()});
+    return *this;
+  }
+
+  IntegrationTestFramework &IntegrationTestFramework::sendBatch(
+      const std::shared_ptr<shared_model::interface::TransactionBatch> &batch) {
+    og_transport_->propagateBatch(batch);
     return *this;
   }
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -123,7 +123,7 @@ namespace integration_framework {
     }
   }
 
-  std::future<std::shared_ptr<FakePeer>> IntegrationTestFramework::addInitailPeer(
+  std::future<std::shared_ptr<FakePeer>> IntegrationTestFramework::addInitialPeer(
       const boost::optional<Keypair> &key) {
     fake_peers_promises_.emplace_back(std::promise<std::shared_ptr<FakePeer>>(),
                                       key);

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -51,6 +51,10 @@ namespace iroha {
   }    // namespace consensus
   namespace network {
     class MstTransportGrpc;
+    class OrderingServiceTransport;
+  }
+  namespace ordering {
+    class OrderingGateTransportGrpc;
   }
   namespace validation {
     struct VerifiedProposalAndErrors;
@@ -250,6 +254,23 @@ namespace integration_framework {
     IntegrationTestFramework &sendQuery(const shared_model::proto::Query &qry);
 
     /**
+     * Send proposal to this peer' s ordering service.
+     * @param proposal - the proposal to send
+     * @return this
+     */
+    IntegrationTestFramework &sendProposal(
+        std::unique_ptr<shared_model::interface::Proposal> proposal);
+
+    /**
+     * Send a batch of transactions to this peer's ordering service.
+     * @param batch - the batch to send
+     * @return this
+     */
+    IntegrationTestFramework &sendBatch(
+        const std::shared_ptr<shared_model::interface::TransactionBatch>
+            &batch);
+
+    /**
      * Send MST state message to this peer.
      * @param src_key - the key of the peer which the message appears to come
      * from
@@ -410,6 +431,8 @@ namespace integration_framework {
         transaction_batch_factory_;
     std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
     std::shared_ptr<iroha::consensus::yac::YacNetwork> yac_transport_;
+    std::shared_ptr<iroha::network::OrderingServiceTransport> os_transport_;
+    std::shared_ptr<iroha::ordering::OrderingGateTransportGrpc> og_transport_;
 
     std::shared_ptr<shared_model::interface::Peer> this_peer_;
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -254,19 +254,11 @@ namespace integration_framework {
      */
     IntegrationTestFramework &sendQuery(const shared_model::proto::Query &qry);
 
-    /**
-     * Send proposal to this peer' s ordering service.
-     * @param proposal - the proposal to send
-     * @return this
-     */
+    /// Send proposal to this peer' s ordering service.
     IntegrationTestFramework &sendProposal(
         std::unique_ptr<shared_model::interface::Proposal> proposal);
 
-    /**
-     * Send a batch of transactions to this peer's ordering service.
-     * @param batch - the batch to send
-     * @return this
-     */
+    /// Send a batch of transactions to this peer's ordering service.
     IntegrationTestFramework &sendBatch(
         const std::shared_ptr<shared_model::interface::TransactionBatch>
             &batch);

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -104,7 +104,7 @@ namespace integration_framework {
 
     ~IntegrationTestFramework();
 
-    std::future<std::shared_ptr<FakePeer>> addInitailPeer(
+    std::future<std::shared_ptr<FakePeer>> addInitialPeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
 
     /**

--- a/test/integration/acceptance/basic_mst_state_propagation.cpp
+++ b/test/integration/acceptance/basic_mst_state_propagation.cpp
@@ -36,7 +36,7 @@ class BasicMstPropagationFixture : public AcceptanceFixture {
         fake_peers_futures;
     std::generate_n(std::back_inserter(fake_peers_futures),
                     num_fake_peers,
-                    [this] { return itf_->addInitailPeer({}); });
+                    [this] { return itf_->addInitialPeer({}); });
 
     itf_->setInitialState(kAdminKeypair);
 


### PR DESCRIPTION
### Description of the Change

This patch adds the OS&OG testing facilities to ITF. It is now possible to send these messages to ITF peer & get the ones sent by it to any fake peer.

### Benefits

New feature.

### Possible Drawbacks 

Bugs.