### PR TITLE
ITF: PortGuard

### DIFF
--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(integration_framework
     integration_framework/iroha_instance.cpp
     integration_framework/fake_peer/fake_peer.cpp
     integration_framework/fake_peer/yac_network_notifier.cpp
+    integration_framework/port_guard.cpp
     common_constants.cpp
     )
 target_link_libraries(integration_framework

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -27,6 +27,7 @@
 #include "framework/common_constants.hpp"
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 #include "framework/integration_framework/iroha_instance.hpp"
+#include "framework/integration_framework/port_guard.hpp"
 #include "framework/integration_framework/test_irohad.hpp"
 #include "framework/result_fixture.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
@@ -61,13 +62,6 @@ namespace {
   constexpr size_t kDefaultToriiPort = 11501;
   constexpr size_t kDefaultInternalPort = 50541;
   constexpr size_t kMaxPort = 65535;
-
-  template <size_t default_port>
-  size_t getNextPort() {
-    static size_t increment = 0;
-    BOOST_VERIFY_MSG(increment <= kMaxPort, "The maximum port value reached");
-    return default_port + (++increment);
-  }
 }  // namespace
 
 namespace integration_framework {
@@ -81,8 +75,9 @@ namespace integration_framework {
       milliseconds proposal_waiting,
       milliseconds block_waiting,
       milliseconds tx_response_waiting)
-      : torii_port_(getNextPort<kDefaultToriiPort>()),
-        internal_port_(getNextPort<kDefaultInternalPort>()),
+      : port_guard_(std::make_unique<PortGuard>()),
+        torii_port_(port_guard_->getPort(kDefaultToriiPort)),
+        internal_port_(port_guard_->getPort(kDefaultInternalPort)),
         iroha_instance_(std::make_shared<IrohaInstance>(mst_support,
                                                         block_store_path,
                                                         kLocalHost,
@@ -136,7 +131,7 @@ namespace integration_framework {
     for (auto &promise_and_key : fake_peers_promises_) {
       auto fake_peer =
           std::make_shared<FakePeer>(kLocalHost,
-                                     getNextPort<kDefaultInternalPort>(),
+                                     port_guard_->getPort(kDefaultInternalPort),
                                      promise_and_key.second,
                                      this_peer_,
                                      common_objects_factory_,

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -62,6 +62,7 @@ namespace integration_framework {
   using std::chrono::milliseconds;
 
   class FakePeer;
+  class PortGuard;
 
   class IntegrationTestFramework {
    private:
@@ -373,6 +374,7 @@ namespace integration_framework {
     std::map<std::string, tbb::concurrent_queue<TxResponseType>>
         responses_queues_;
 
+    std::unique_ptr<PortGuard> port_guard_;
     size_t torii_port_;
     size_t internal_port_;
     std::shared_ptr<IrohaInstance> iroha_instance_;

--- a/test/framework/integration_framework/port_guard.cpp
+++ b/test/framework/integration_framework/port_guard.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/integration_framework/port_guard.hpp"
+
+#include <boost/assert.hpp>
+
+namespace integration_framework {
+
+  constexpr PortGuard::PortType PortGuard::kMaxPort;
+  PortGuard::UsedPorts PortGuard::all_used_ports_ = {};
+  std::mutex PortGuard::all_used_ports_mutex_ = {};
+
+  PortGuard::~PortGuard() {
+    std::lock_guard<std::mutex> lock(all_used_ports_mutex_);
+    BOOST_ASSERT_MSG(
+        ((all_used_ports_ | instance_used_ports_) ^ all_used_ports_).none(),
+        "Some ports used by this PortGuard instance are not set in ports "
+        "used by all instances!");
+    all_used_ports_ ^= instance_used_ports_;
+  }
+
+  boost::optional<PortGuard::PortType> PortGuard::tryGetPort(
+      const PortType &min_value, const PortType &max_value) {
+    std::lock_guard<std::mutex> lock(all_used_ports_mutex_);
+    PortType tested_port = min_value;
+    while (all_used_ports_.test(tested_port)) {
+      if (tested_port == max_value) {
+        return boost::none;
+      }
+      ++tested_port;
+    }
+    BOOST_ASSERT_MSG(!all_used_ports_.test(tested_port),
+                     "PortGuard chose an occupied port!");
+    BOOST_ASSERT_MSG(tested_port >= min_value && tested_port <= max_value,
+                     "PortGuard chose a port outside boundaries!");
+    instance_used_ports_.set(tested_port);
+    all_used_ports_.set(tested_port);
+    return tested_port;
+  }
+
+  PortGuard::PortType PortGuard::getPort(const PortType &min_value,
+                                         const PortType &max_value) {
+    boost::optional<PortType> opt_port = tryGetPort(min_value, max_value);
+    BOOST_VERIFY_MSG(
+        opt_port,
+        ("Could not get a port in interval [" + std::to_string(min_value) + ", "
+         + std::to_string(max_value) + "]!")
+            .c_str());
+    return *opt_port;
+  }
+
+  }  // namespace integration_framework

--- a/test/framework/integration_framework/port_guard.hpp
+++ b/test/framework/integration_framework/port_guard.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_INTEGRATION_FRAMEWORK_PORT_GUARD_HPP
+#define IROHA_INTEGRATION_FRAMEWORK_PORT_GUARD_HPP
+
+#include <bitset>
+#include <mutex>
+#include <cstdint>
+
+#include <boost/noncopyable.hpp>
+#include <boost/optional/optional.hpp>
+
+namespace integration_framework {
+
+  class PortGuard final : public boost::noncopyable {
+   public:
+    using PortType = uint16_t;
+
+    static constexpr PortType kMaxPort = 65535;
+
+    ~PortGuard();
+
+    /// Request a port in given boundaries, including them.
+    PortType getPort(const PortType &min_value,
+                     const PortType &max_value = kMaxPort);
+
+    /// Request a port in given boundaries, including them.
+    boost::optional<PortType> tryGetPort(const PortType &min_value,
+                                         const PortType &max_value = kMaxPort);
+
+   private:
+    using UsedPorts = std::bitset<kMaxPort>;
+
+    static UsedPorts all_used_ports_;
+    static std::mutex all_used_ports_mutex_;
+
+    UsedPorts instance_used_ports_;
+  };
+
+}
+
+#endif /* IROHA_INTEGRATION_FRAMEWORK_PORT_GUARD_HPP */


### PR DESCRIPTION
### Description of the Change

Meet integration_framework::PortGuard - a class that keeps track of ports you use in ITF tests! Just add an instance in your class where you allocate ports, and ask it for some in a given range. When your class dies (sorry), it will in its final moments mark the ports your instance requested as free.

### Benefits

It should make port reusing easier.

### Possible Drawbacks 

It uses locks for synchronization.