### PR TITLE
Makefile for python libs example

### DIFF
--- a/example/python/Makefile
+++ b/example/python/Makefile
@@ -1,8 +1,12 @@
 #!/usr/bin/env make
 
-# generate proto files in current dir
+# sources
 PROTO_PATH = ../../shared_model/schema
 PROTO_FILES = $(wildcard $(PROTO_PATH)/*.proto)
+
+# targets
+PYTHON_GRPC_LIBS_PATH = .
+PYTHON_GRPC_LIBS_FILES = $(PYTHON_GRPC_LIBS_PATH)/endpoint_pb2_grpc.py
 PYTHON_PROTO_LIBS_PATH = .
 PYTHON_PROTO_LIBS_FILES = $(patsubst $(PROTO_PATH)/%.proto,$(PYTHON_PROTO_LIBS_PATH)/%_pb2.py,$(PROTO_FILES))
 
@@ -10,7 +14,10 @@ PYTHON_PROTO_LIBS_FILES = $(patsubst $(PROTO_PATH)/%.proto,$(PYTHON_PROTO_LIBS_P
 default: all
 
 .PHONY: all
-all: $(PYTHON_PROTO_LIBS_FILES)
+all: $(PYTHON_PROTO_LIBS_FILES) $(PYTHON_GRPC_LIBS_FILES)
 
 $(PYTHON_PROTO_LIBS_PATH)/%_pb2.py: $(PROTO_PATH)/%.proto
 	protoc --proto_path=$(PROTO_PATH) --python_out=$(PYTHON_PROTO_LIBS_PATH) $<
+
+$(PYTHON_GRPC_LIBS_PATH)/%_pb2_grpc.py: $(PROTO_PATH)/%.proto
+	python -m grpc_tools.protoc --proto_path=$(PROTO_PATH)  --grpc_python_out=$(PYTHON_PROTO_LIBS_PATH) $<

--- a/example/python/Makefile
+++ b/example/python/Makefile
@@ -1,0 +1,16 @@
+#!/usr/bin/env make
+
+# generate proto files in current dir
+PROTO_PATH = ../../shared_model/schema
+PROTO_FILES = $(wildcard $(PROTO_PATH)/*.proto)
+PYTHON_PROTO_LIBS_PATH = .
+PYTHON_PROTO_LIBS_FILES = $(patsubst $(PROTO_PATH)/%.proto,$(PYTHON_PROTO_LIBS_PATH)/%_pb2.py,$(PROTO_FILES))
+
+.PHONY: default
+default: all
+
+.PHONY: all
+all: $(PYTHON_PROTO_LIBS_FILES)
+
+$(PYTHON_PROTO_LIBS_PATH)/%_pb2.py: $(PROTO_PATH)/%.proto
+	protoc --proto_path=$(PROTO_PATH) --python_out=$(PYTHON_PROTO_LIBS_PATH) $<

--- a/example/python/prepare.sh
+++ b/example/python/prepare.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-cd $(dirname $0)
-
-# generate proto files in current dir
-protoc --proto_path=../../shared_model/schema --python_out=. ../../shared_model/schema/*.proto
-python -m grpc_tools.protoc --proto_path=../../shared_model/schema --python_out=. --grpc_python_out=. ../../shared_model/schema/endpoint.proto


### PR DESCRIPTION
### Description of the Change

Replaced `prepare.sh` with a Makefile.

### Benefits

Makefile is a standard way to generate something. It is also easier to extend and is smarter.

### Possible Drawbacks 

The user needs the `make` program, although it is hard to imagine one not having it.

### Usage Examples or Tests *[optional]*

`make`

### Alternate Designs *[optional]*

We could also use `CMake`, but while the project is not so big it seems an overkill.
