### PR TITLE
Prevent replay attack on MST state sharing

### DIFF
--- a/irohad/ametsuchi/tx_cache_response.hpp
+++ b/irohad/ametsuchi/tx_cache_response.hpp
@@ -23,6 +23,9 @@ namespace iroha {
        * response classes
        */
       struct HashContainer {
+        HashContainer() = default;
+        HashContainer(HashType h) : hash(h) {}
+
         HashType hash;
       };
     }  // namespace tx_cache_response_details
@@ -33,19 +36,25 @@ namespace iroha {
        * The class means that corresponding transaction was successfully
        * committed in the ledger
        */
-      class Committed : public tx_cache_response_details::HashContainer {};
+      struct Committed : public tx_cache_response_details::HashContainer {
+        using HashContainer::HashContainer;
+      };
 
       /**
        * The class means that corresponding transaction was rejected by the
        * network
        */
-      class Rejected : public tx_cache_response_details::HashContainer {};
+      struct Rejected : public tx_cache_response_details::HashContainer {
+        using HashContainer::HashContainer;
+      };
 
       /**
        * The class means that corresponding transaction doesn't appear in the
        * ledger
        */
-      class Missing : public tx_cache_response_details::HashContainer {};
+      struct Missing : public tx_cache_response_details::HashContainer {
+        using HashContainer::HashContainer;
+      };
     }  // namespace tx_cache_status_responses
 
     /// Sum type of all possible concrete responses from the tx cache

--- a/irohad/ametsuchi/tx_cache_response.hpp
+++ b/irohad/ametsuchi/tx_cache_response.hpp
@@ -24,7 +24,7 @@ namespace iroha {
        */
       struct HashContainer {
         HashContainer() = default;
-        HashContainer(HashType h) : hash(h) {}
+        explicit HashContainer(const HashType &h) : hash(h) {}
 
         HashType hash;
       };

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -51,7 +51,7 @@ namespace iroha {
      public:
       MOCK_CONST_METHOD1(check,
                          iroha::ametsuchi::TxCacheStatusType(
-                             const shared_model::crypto::Hash &hash));
+                             const shared_model::crypto::Hash &));
 
       MOCK_CONST_METHOD1(
           check,
@@ -358,7 +358,7 @@ void Irohad::initMstProcessor() {
         transaction_factory,
         batch_parser,
         transaction_batch_factory_,
-        tx_presence_cache,
+        std::move(tx_presence_cache),
         keypair.publicKey());
     // TODO: IR-1317 @l4l (02/05/18) magics should be replaced with options via
     // cli parameters

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -45,20 +45,20 @@ using namespace std::chrono_literals;
 // TODO: @muratovv 12.11.2018 remove the mock after effective implementation
 // will be finished IR-1840
 #include <gmock/gmock.h>
-class MockTxPresenceCache : public iroha::ametsuchi::TxPresenceCache {
- public:
-  MOCK_CONST_METHOD1(check,
-                     iroha::ametsuchi::TxCacheStatusType(
-                         const shared_model::crypto::Hash &hash));
-
-  MOCK_CONST_METHOD1(
-      check,
-      iroha::ametsuchi::TxPresenceCache::BatchStatusCollectionType(
-          const shared_model::interface::TransactionBatch &));
-};
-
 namespace iroha {
   namespace ametsuchi {
+    class MockTxPresenceCache : public iroha::ametsuchi::TxPresenceCache {
+     public:
+      MOCK_CONST_METHOD1(check,
+                         iroha::ametsuchi::TxCacheStatusType(
+                             const shared_model::crypto::Hash &hash));
+
+      MOCK_CONST_METHOD1(
+          check,
+          iroha::ametsuchi::TxPresenceCache::BatchStatusCollectionType(
+              const shared_model::interface::TransactionBatch &));
+    };
+
     namespace tx_cache_status_responses {
       std::ostream &operator<<(std::ostream &os, const Committed &resp) {
         return os << resp.hash.toString();
@@ -349,6 +349,8 @@ void Irohad::initStatusBus() {
 void Irohad::initMstProcessor() {
   auto mst_completer = std::make_shared<DefaultCompleter>();
   auto mst_storage = std::make_shared<MstStorageStateImpl>(mst_completer);
+  auto tx_presence_cache =
+      std::make_shared<iroha::ametsuchi::MockTxPresenceCache>();
   std::shared_ptr<iroha::PropagationStrategy> mst_propagation;
   if (is_mst_supported_) {
     mst_transport = std::make_shared<iroha::network::MstTransportGrpc>(
@@ -356,6 +358,7 @@ void Irohad::initMstProcessor() {
         transaction_factory,
         batch_parser,
         transaction_batch_factory_,
+        tx_presence_cache,
         keypair.publicKey());
     // TODO: IR-1317 @l4l (02/05/18) magics should be replaced with options via
     // cli parameters

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -114,6 +114,13 @@ grpc::Status MstTransportGrpc::SendState(
     return grpc::Status::OK;
   }
 
+  if (new_state.isEmpty()) {
+    async_call_->log_->info(
+        "All transactions from received MST state have been processed already, "
+        "nothing to propagate to MST processor");
+    return grpc::Status::OK;
+  }
+
   if (auto subscriber = subscriber_.lock()) {
     subscriber->onNewState(source_key, std::move(new_state));
   } else {

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include "ametsuchi/tx_presence_cache.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
@@ -79,7 +80,7 @@ grpc::Status MstTransportGrpc::SendState(
     batch_factory_->createTransactionBatch(batch).match(
         [&](iroha::expected::Value<std::unique_ptr<
                 shared_model::interface::TransactionBatch>> &value) {
-          auto cache_presence = tx_presence_cache_->check(*(value.value));
+          auto cache_presence = tx_presence_cache_->check(*value.value);
           auto is_replay = std::any_of(
               cache_presence.begin(),
               cache_presence.end(),

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -9,6 +9,7 @@
 #include "mst.grpc.pb.h"
 #include "network/mst_transport.hpp"
 
+#include "ametsuchi/tx_presence_cache.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
@@ -35,6 +36,7 @@ namespace iroha {
               batch_parser,
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory,
+          std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache,
           shared_model::crypto::PublicKey my_key);
 
       /**
@@ -70,6 +72,7 @@ namespace iroha {
           batch_parser_;
       std::shared_ptr<shared_model::interface::TransactionBatchFactory>
           batch_factory_;
+      std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache_;
       /// source peer key for MST propogation messages
       const std::string my_key_;
     };

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -9,7 +9,6 @@
 #include "mst.grpc.pb.h"
 #include "network/mst_transport.hpp"
 
-#include "ametsuchi/tx_presence_cache.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
@@ -19,6 +18,11 @@
 #include "network/impl/async_grpc_client.hpp"
 
 namespace iroha {
+
+  namespace ametsuchi {
+    class TxPresenceCache;
+  }
+
   namespace network {
     class MstTransportGrpc : public MstTransport,
                              public transport::MstTransportGrpc::Service {

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_AMETSUCHI_MOCKS_HPP
@@ -339,6 +327,7 @@ namespace iroha {
     };
 
     class MockTxPresenceCache : public iroha::ametsuchi::TxPresenceCache {
+     public:
       MOCK_CONST_METHOD1(check,
                          iroha::ametsuchi::TxCacheStatusType(
                              const shared_model::crypto::Hash &hash));

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -10,6 +10,7 @@
 #include "backend/protobuf/proto_transport_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "module/shared_model/validators/validators.hpp"
@@ -45,12 +46,16 @@ TEST(TransportTest, SendAndReceive) {
       std::make_shared<shared_model::interface::TransactionBatchParserImpl>();
   auto batch_factory =
       std::make_shared<shared_model::interface::TransactionBatchFactoryImpl>();
+  auto tx_presence_cache =
+      std::make_shared<iroha::ametsuchi::MockTxPresenceCache>();
   auto my_key = makeKey();
-  auto transport = std::make_shared<MstTransportGrpc>(async_call_,
-                                                      std::move(tx_factory),
-                                                      std::move(parser),
-                                                      std::move(batch_factory),
-                                                      my_key.publicKey());
+  auto transport =
+      std::make_shared<MstTransportGrpc>(async_call_,
+                                         std::move(tx_factory),
+                                         std::move(parser),
+                                         std::move(batch_factory),
+                                         std::move(tx_presence_cache),
+                                         my_key.publicKey());
   auto notifications = std::make_shared<iroha::MockMstTransportNotification>();
   transport->subscribe(notifications);
 
@@ -87,17 +92,112 @@ TEST(TransportTest, SendAndReceive) {
   // we want to ensure that server side will call onNewState()
   // with same parameters as on the client side
   EXPECT_CALL(*notifications, onNewState(_, _))
-      .WillOnce(Invoke(
-          [&my_key, &cv, &state](const auto &from_key, auto const &target_state) {
-            EXPECT_EQ(my_key.publicKey(), from_key);
+      .WillOnce(Invoke([&my_key, &cv, &state](const auto &from_key,
+                                              auto const &target_state) {
+        EXPECT_EQ(my_key.publicKey(), from_key);
 
-            EXPECT_EQ(state, target_state);
-            cv.notify_one();
-          }));
+        EXPECT_EQ(state, target_state);
+        cv.notify_one();
+      }));
 
   transport->sendState(*peer, state);
   std::unique_lock<std::mutex> lock(mtx);
   cv.wait_for(lock, std::chrono::milliseconds(5000));
 
   server->Shutdown();
+}
+
+/**
+ * Checks that replayed transactions would not pass MST
+ * (receiving of already processed transactions would not cause new state
+ * generation)
+ * @given an instance of MstTransportGrpc
+ * @when exactly the same state reaches MST two times (in general, the state can
+ * be different but should contain exactly the same batch both times)
+ * @then for the first time the mock of tx_presence_cache says that the
+ * transactions of the batch are not found in cache, and mst produced and
+ * propagated new state that contains the batch. At the second time, the mock of
+ * tx_presence cache says that the transactions from the batch were previously
+ * rejected, so the state propagated via onNewState call would not contain the
+ * test batch.
+ */
+TEST(TransportTest, ReplayAttack) {
+  auto async_call_ = std::make_shared<
+      iroha::network::AsyncGrpcClient<google::protobuf::Empty>>();
+  std::unique_ptr<shared_model::validation::AbstractValidator<
+      shared_model::interface::Transaction>>
+      tx_validator =
+          std::make_unique<shared_model::validation::
+                               DefaultOptionalSignedTransactionValidator>();
+  auto tx_factory = std::make_shared<shared_model::proto::ProtoTransportFactory<
+      shared_model::interface::Transaction,
+      shared_model::proto::Transaction>>(std::move(tx_validator));
+  auto parser =
+      std::make_shared<shared_model::interface::TransactionBatchParserImpl>();
+  auto batch_factory =
+      std::make_shared<shared_model::interface::TransactionBatchFactoryImpl>();
+  auto tx_presence_cache =
+      std::make_shared<iroha::ametsuchi::MockTxPresenceCache>();
+  auto my_key = makeKey();
+  auto transport = std::make_shared<MstTransportGrpc>(async_call_,
+                                                      std::move(tx_factory),
+                                                      std::move(parser),
+                                                      std::move(batch_factory),
+                                                      tx_presence_cache,
+                                                      my_key.publicKey());
+
+  auto notifications = std::make_shared<iroha::MockMstTransportNotification>();
+  transport->subscribe(notifications);
+
+  auto batch = makeTestBatch(txBuilder(1), txBuilder(2));
+  auto state = iroha::MstState::empty();
+  state += addSignaturesFromKeyPairs(
+      addSignaturesFromKeyPairs(batch, 0, makeKey()), 1, makeKey());
+
+  EXPECT_CALL(*notifications, onNewState(_, _))
+      .Times(1)  // an empty state should not be propagated
+      .WillOnce(
+          Invoke([&batch](::testing::Unused, const iroha::MstState &state) {
+            auto batches = state.getBatches();
+            ASSERT_EQ(batches.size(), 1);
+            ASSERT_EQ(**batches.begin(), *batch);
+          }));
+
+  auto transactions = batch->transactions();
+  auto first_hash = transactions.at(0)->hash();
+  auto second_hash = transactions.at(0)->hash();
+  iroha::ametsuchi::TxPresenceCache::BatchStatusCollectionType
+      first_mock_response{
+          iroha::ametsuchi::tx_cache_status_responses::Missing{first_hash},
+          iroha::ametsuchi::tx_cache_status_responses::Missing{second_hash}};
+  iroha::ametsuchi::TxPresenceCache::BatchStatusCollectionType
+      second_mock_response{
+          iroha::ametsuchi::tx_cache_status_responses::Rejected{first_hash},
+          iroha::ametsuchi::tx_cache_status_responses::Rejected{second_hash}};
+
+  transport::MstState proto_state;
+  proto_state.set_source_peer_key(
+      shared_model::crypto::toBinaryString(my_key.publicKey()));
+
+  for (const auto &batch : state.getBatches()) {
+    for (const auto &tx : batch->transactions()) {
+      *proto_state.add_transactions() =
+          std::static_pointer_cast<shared_model::proto::Transaction>(tx)
+              ->getTransport();
+    }
+  }
+
+  grpc::ServerContext context;
+  google::protobuf::Empty response;
+
+  EXPECT_CALL(
+      *tx_presence_cache,
+      check(
+          ::testing::Matcher<const shared_model::interface::TransactionBatch &>(
+              _)))
+      .WillOnce(::testing::Return(first_mock_response))
+      .WillOnce(::testing::Return(second_mock_response));
+
+  transport->SendState(&context, &proto_state, &response);
+  transport->SendState(&context, &proto_state, &response);
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

A peer can receive the same MST state from the network more than once.
As the result, sometimes the same transaction was able to be committed multiple times.

### Benefits

Replays on MST state sharing are prevented.


### Possible Drawbacks 

Missing test. (in progress. to be updated soon)


### Usage Examples or Tests

Special test is under development. The pr will be updated soon
