### PR TITLE
Stateful Error Response to Log

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -18,17 +18,15 @@ namespace iroha {
   namespace ametsuchi {
     MutableStorageImpl::MutableStorageImpl(
         shared_model::interface::types::HashType top_hash,
+        std::shared_ptr<PostgresCommandExecutor> cmd_executor,
         std::unique_ptr<soci::session> sql,
-        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
-        std::shared_ptr<shared_model::interface::PermissionToString>
-            perm_converter)
+        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
         : top_hash_(top_hash),
           sql_(std::move(sql)),
           peer_query_(std::make_unique<PeerQueryWsv>(
               std::make_shared<PostgresWsvQuery>(*sql_, std::move(factory)))),
           block_index_(std::make_unique<PostgresBlockIndex>(*sql_)),
-          command_executor_(std::make_shared<PostgresCommandExecutor>(
-              *sql_, std::move(perm_converter))),
+          command_executor_(std::move(cmd_executor)),
           committed(false),
           log_(logger::log("MutableStorage")) {
       *sql_ << "BEGIN";

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -19,13 +19,16 @@ namespace iroha {
     MutableStorageImpl::MutableStorageImpl(
         shared_model::interface::types::HashType top_hash,
         std::unique_ptr<soci::session> sql,
-        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
+        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
+        std::shared_ptr<shared_model::interface::PermissionToString>
+            perm_converter)
         : top_hash_(top_hash),
           sql_(std::move(sql)),
           peer_query_(std::make_unique<PeerQueryWsv>(
               std::make_shared<PostgresWsvQuery>(*sql_, std::move(factory)))),
           block_index_(std::make_unique<PostgresBlockIndex>(*sql_)),
-          command_executor_(std::make_shared<PostgresCommandExecutor>(*sql_)),
+          command_executor_(std::make_shared<PostgresCommandExecutor>(
+              *sql_, std::move(perm_converter))),
           committed(false),
           log_(logger::log("MutableStorage")) {
       *sql_ << "BEGIN";

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -13,6 +13,7 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
+#include "interfaces/permission_to_string.hpp"
 #include "logger/logger.hpp"
 
 namespace iroha {
@@ -27,7 +28,9 @@ namespace iroha {
           shared_model::interface::types::HashType top_hash,
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-              factory);
+              factory,
+          std::shared_ptr<shared_model::interface::PermissionToString>
+              perm_converter);
 
       bool apply(const shared_model::interface::Block &block) override;
 

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -13,8 +13,13 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
-#include "interfaces/permission_to_string.hpp"
 #include "logger/logger.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class PermissionToString;
+  }
+}  // namespace shared_model
 
 namespace iroha {
   namespace ametsuchi {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -15,15 +15,10 @@
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "logger/logger.hpp"
 
-namespace shared_model {
-  namespace interface {
-    class PermissionToString;
-  }
-}  // namespace shared_model
-
 namespace iroha {
   namespace ametsuchi {
     class BlockIndex;
+    class PostgresCommandExecutor;
 
     class MutableStorageImpl : public MutableStorage {
       friend class StorageImpl;
@@ -31,11 +26,10 @@ namespace iroha {
      public:
       MutableStorageImpl(
           shared_model::interface::types::HashType top_hash,
+          std::shared_ptr<PostgresCommandExecutor> cmd_executor,
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-              factory,
-          std::shared_ptr<shared_model::interface::PermissionToString>
-              perm_converter);
+              factory);
 
       bool apply(const shared_model::interface::Block &block) override;
 

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -296,6 +296,14 @@ namespace {
                          : PreparedStatement::noValidationPrefix);
     cmd % command_name;
   }
+
+  /**
+   * Get a pretty string builder initialized for query arguments append
+   * @return string builder
+   */
+  shared_model::detail::PrettyStringBuilder getQueryArgsStringBuilder() {
+    return shared_model::detail::PrettyStringBuilder().init("Query arguments");
+  }
 }  // namespace
 
 namespace iroha {
@@ -788,8 +796,7 @@ namespace iroha {
       cmd = (cmd % account_id % asset_id % precision % amount);
 
       auto str_args = [&account_id, &asset_id, &amount, precision] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("asset_id", asset_id)
             .append("amount", amount)
@@ -812,8 +819,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % peer.pubkey().hex() % peer.address());
 
       auto str_args = [&peer] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("peer", peer.toString())
             .finalize();
       };
@@ -832,8 +838,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % pubkey);
 
       auto str_args = [&account_id, &pubkey] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("pubkey", pubkey)
             .finalize();
@@ -853,8 +858,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % role_name);
 
       auto str_args = [&account_id, &role_name] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("role_name", role_name)
             .finalize();
@@ -878,8 +882,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % domain_id % pubkey);
 
       auto str_args = [&account_id, &domain_id, &pubkey] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("domain_id", domain_id)
             .append("pubkey", pubkey)
@@ -902,8 +905,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % asset_id % domain_id % precision);
 
       auto str_args = [&domain_id, &asset_id, precision] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("domain_id", domain_id)
             .append("asset_id", asset_id)
             .append("precision", std::to_string(precision))
@@ -924,8 +926,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % domain_id % default_role);
 
       auto str_args = [&domain_id, &default_role] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("domain_id", domain_id)
             .append("default_role", default_role)
             .finalize();
@@ -948,8 +949,7 @@ namespace iroha {
       auto str_args = [&role_id, &perm_str] {
         // TODO [IR-1889] Akvinikym 21.11.18: integrate
         // PermissionSet::toString() instead of bit string, when it is created
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("role_id", role_id)
             .append("perm_str", perm_str)
             .finalize();
@@ -969,8 +969,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % role_name);
 
       auto str_args = [&account_id, &role_name] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("role_name", role_name)
             .finalize();
@@ -997,12 +996,11 @@ namespace iroha {
       cmd =
           (cmd % creator_account_id_ % permittee_account_id % perm_str % perm);
 
-      auto str_args = [&creator_account_id_ = creator_account_id_,
+      auto str_args = [&creator_account_id = creator_account_id_,
                        &permittee_account_id,
                        permission = perm_converter_->toString(permission)] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
-            .append("creator_account_id_", creator_account_id_)
+        return getQueryArgsStringBuilder()
+            .append("creator_account_id_", creator_account_id)
             .append("permittee_account_id", permittee_account_id)
             .append("permission", permission)
             .finalize();
@@ -1023,8 +1021,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % pubkey);
 
       auto str_args = [&account_id, &pubkey] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("pubkey", pubkey)
             .finalize();
@@ -1054,12 +1051,11 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % permittee_account_id % perms
              % without_perm_str);
 
-      auto str_args = [&creator_account_id_ = creator_account_id_,
+      auto str_args = [&creator_account_id = creator_account_id_,
                        &permittee_account_id,
                        permission = perm_converter_->toString(permission)] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
-            .append("creator_account_id_", creator_account_id_)
+        return getQueryArgsStringBuilder()
+            .append("creator_account_id_", creator_account_id)
             .append("permittee_account_id", permittee_account_id)
             .append("permission", permission)
             .finalize();
@@ -1092,8 +1088,7 @@ namespace iroha {
              % empty_json);
 
       auto str_args = [&account_id, &key, &value] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("key", key)
             .append("value", value)
@@ -1115,8 +1110,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % quorum);
 
       auto str_args = [&account_id, quorum] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
+        return getQueryArgsStringBuilder()
             .append("account_id", account_id)
             .append("quorum", std::to_string(quorum))
             .finalize();
@@ -1136,13 +1130,12 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % asset_id % precision % amount);
 
-      auto str_args = [&creator_account_id_ = creator_account_id_,
+      auto str_args = [&creator_account_id = creator_account_id_,
                        &asset_id,
                        &amount,
                        precision] {
-        return shared_model::detail::PrettyStringBuilder()
-            .init("Query arguments")
-            .append("creator_account_id", creator_account_id_)
+        return getQueryArgsStringBuilder()
+            .append("creator_account_id", creator_account_id)
             .append("asset_id", asset_id)
             .append("amount", amount)
             .append("precision", std::to_string(precision))
@@ -1170,8 +1163,7 @@ namespace iroha {
 
       auto str_args =
           [&src_account_id, &dest_account_id, &asset_id, &amount, precision] {
-            return shared_model::detail::PrettyStringBuilder()
-                .init("Query arguments")
+            return getQueryArgsStringBuilder()
                 .append("src_account_id", src_account_id)
                 .append("dest_account_id", dest_account_id)
                 .append("asset_id", asset_id)

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -26,6 +26,7 @@
 #include "interfaces/commands/subtract_asset_quantity.hpp"
 #include "interfaces/commands/transfer_asset.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/permission_to_string.hpp"
 
 namespace {
   struct PreparedStatement {
@@ -160,7 +161,7 @@ namespace {
    * Get an error code from the text SQL error
    * @param command_name - name of the failed command
    * @param error - string error, which SQL gave out
-   * @param query_args - lambda to get a string representation of query
+   * @param query_args - callable to get a string representation of query
    * arguments
    * @return command_error structure
    */
@@ -198,7 +199,7 @@ namespace {
    * @param sql - connection on which to execute statement
    * @param cmd - sql query to be executed
    * @param command_name - which command executes a query
-   * @param query_args - lambda to get a string representation of query
+   * @param query_args - callable to get a string representation of query
    * arguments
    * @return CommandResult with command name and error message
    */
@@ -779,7 +780,7 @@ namespace iroha {
 
       cmd = (cmd % account_id % asset_id % precision % amount);
 
-      auto str_args = [&account_id, &asset_id, &amount, precision]() {
+      auto str_args = [&account_id, &asset_id, &amount, precision] {
         return (boost::format(
                     "account_id: %s, asset_id: %s, amount: %s, precision: %d")
                 % account_id % asset_id % amount % precision)
@@ -800,7 +801,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % peer.pubkey().hex() % peer.address());
 
-      auto str_args = [&peer]() {
+      auto str_args = [&peer] {
         return (boost::format("peer: %s") % peer.toString()).str();
       };
 
@@ -817,7 +818,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % pubkey);
 
-      auto str_args = [&account_id, &pubkey]() {
+      auto str_args = [&account_id, &pubkey] {
         return (boost::format("account_id: %s, pubkey: %s") % account_id
                 % pubkey)
             .str();
@@ -836,7 +837,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % role_name);
 
-      auto str_args = [&account_id, &role_name]() {
+      auto str_args = [&account_id, &role_name] {
         return (boost::format("account_id: %s, role_name: %s") % account_id
                 % role_name)
             .str();
@@ -859,7 +860,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % domain_id % pubkey);
 
-      auto str_args = [&account_id, &domain_id, &pubkey]() {
+      auto str_args = [&account_id, &domain_id, &pubkey] {
         return (boost::format("account_id: %s, domain_id: %s, pubkey: %s")
                 % account_id % domain_id % pubkey)
             .str();
@@ -880,7 +881,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % asset_id % domain_id % precision);
 
-      auto str_args = [&domain_id, &asset_id, precision]() {
+      auto str_args = [&domain_id, &asset_id, precision] {
         return (boost::format("domain_id: %s, asset_id: %s, precision: %d")
                 % domain_id % asset_id % precision)
             .str();
@@ -899,7 +900,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % domain_id % default_role);
 
-      auto str_args = [&domain_id, &default_role]() {
+      auto str_args = [&domain_id, &default_role] {
         return (boost::format("domain_id: %s, default_role: %s") % domain_id
                 % default_role)
             .str();
@@ -919,7 +920,9 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % role_id % perm_str);
 
-      auto str_args = [&role_id, &perm_str]() {
+      auto str_args = [&role_id, &perm_str] {
+        // TODO [IR-1889] Akvinikym 21.11.18: integrate
+        // PermissionSet::toString() instead of bit string, when it is created
         return (boost::format("role_id: %s, perm_str: %s") % role_id % perm_str)
             .str();
       };
@@ -937,7 +940,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % role_name);
 
-      auto str_args = [&account_id, &role_name]() {
+      auto str_args = [&account_id, &role_name] {
         return (boost::format("account_id: %s, role_name: %s") % account_id
                 % role_name)
             .str();
@@ -966,7 +969,7 @@ namespace iroha {
 
       auto str_args = [&creator_account_id_ = creator_account_id_,
                        &permittee_account_id,
-                       permission = perm_converter_->toString(permission)]() {
+                       permission = perm_converter_->toString(permission)] {
         return (boost::format("creator_account_id_: %s, permittee_account_id: "
                               "%s, permission: %s")
                 % creator_account_id_ % permittee_account_id % permission)
@@ -987,7 +990,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % pubkey);
 
-      auto str_args = [&account_id, &pubkey]() {
+      auto str_args = [&account_id, &pubkey] {
         return (boost::format("account_id: %s, pubkey: %s") % account_id
                 % pubkey)
             .str();
@@ -1019,7 +1022,7 @@ namespace iroha {
 
       auto str_args = [&creator_account_id_ = creator_account_id_,
                        &permittee_account_id,
-                       permission = perm_converter_->toString(permission)]() {
+                       permission = perm_converter_->toString(permission)] {
         return (boost::format("creator_account_id_: %s, permittee_account_id: "
                               "%s, permission: %s")
                 % creator_account_id_ % permittee_account_id % permission)
@@ -1052,7 +1055,7 @@ namespace iroha {
       cmd = (cmd % creator_account_id_ % account_id % json % filled_json % val
              % empty_json);
 
-      auto str_args = [&account_id, &key, &value]() {
+      auto str_args = [&account_id, &key, &value] {
         return (boost::format("account_id: %s, key: %s, value: %s") % account_id
                 % key % value)
             .str();
@@ -1072,7 +1075,7 @@ namespace iroha {
 
       cmd = (cmd % creator_account_id_ % account_id % quorum);
 
-      auto str_args = [&account_id, quorum]() {
+      auto str_args = [&account_id, quorum] {
         return (boost::format("account_id: %s, quorum: %d") % account_id
                 % quorum)
             .str();
@@ -1095,7 +1098,7 @@ namespace iroha {
       auto str_args = [&creator_account_id_ = creator_account_id_,
                        &asset_id,
                        &amount,
-                       precision]() {
+                       precision] {
         return (boost::format("creator_account_id_: %s, asset_id: %s, amount: "
                               "%s, precision: %d")
                 % creator_account_id_ % asset_id % amount % precision)
@@ -1122,7 +1125,7 @@ namespace iroha {
              % asset_id % precision % amount);
 
       auto str_args =
-          [&src_account_id, &dest_account_id, &asset_id, &amount, precision]() {
+          [&src_account_id, &dest_account_id, &asset_id, &amount, precision] {
             return (boost::format("src_account_id: %s, dest_account_id: %s, "
                                   "asset_id: %s, amount: %s, precision: %d")
                     % src_account_id % dest_account_id % asset_id % amount

--- a/irohad/ametsuchi/impl/postgres_command_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.hpp
@@ -8,13 +8,17 @@
 
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
+#include "interfaces/permission_to_string.hpp"
 
 namespace iroha {
   namespace ametsuchi {
 
     class PostgresCommandExecutor : public CommandExecutor {
      public:
-      PostgresCommandExecutor(soci::session &transaction);
+      PostgresCommandExecutor(
+          soci::session &transaction,
+          std::shared_ptr<shared_model::interface::PermissionToString>
+              perm_converter);
 
       void setCreatorAccountId(
           const shared_model::interface::types::AccountIdType
@@ -78,6 +82,8 @@ namespace iroha {
       bool do_validation_;
 
       shared_model::interface::types::AccountIdType creator_account_id_;
+      std::shared_ptr<shared_model::interface::PermissionToString>
+          perm_converter_;
 
       // 14.09.18 nickaleks: IR-1708 Load SQL from separate files
       static const std::string addAssetQuantityBase;

--- a/irohad/ametsuchi/impl/postgres_command_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.hpp
@@ -8,7 +8,12 @@
 
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
-#include "interfaces/permission_to_string.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class PermissionToString;
+  }
+}  // namespace shared_model
 
 namespace iroha {
   namespace ametsuchi {

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -99,9 +99,9 @@ namespace iroha {
                   [](expected::Error<std::string> &) {
                     return shared_model::interface::types::HashType("");
                   }),
+              std::make_shared<PostgresCommandExecutor>(*sql, perm_converter_),
               std::move(sql),
-              factory_,
-              perm_converter_));
+              factory_));
     }
 
     boost::optional<std::shared_ptr<PeerQuery>> StorageImpl::createPeerQuery()

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -74,7 +74,8 @@ namespace iroha {
       auto sql = std::make_unique<soci::session>(*connection_);
 
       return expected::makeValue<std::unique_ptr<TemporaryWsv>>(
-          std::make_unique<TemporaryWsvImpl>(std::move(sql), factory_));
+          std::make_unique<TemporaryWsvImpl>(
+              std::move(sql), factory_, perm_converter_));
     }
 
     expected::Result<std::unique_ptr<MutableStorage>, std::string>
@@ -99,7 +100,8 @@ namespace iroha {
                     return shared_model::interface::types::HashType("");
                   }),
               std::move(sql),
-              factory_));
+              factory_,
+              perm_converter_));
     }
 
     boost::optional<std::shared_ptr<PeerQuery>> StorageImpl::createPeerQuery()

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -15,9 +15,12 @@ namespace iroha {
   namespace ametsuchi {
     TemporaryWsvImpl::TemporaryWsvImpl(
         std::unique_ptr<soci::session> sql,
-        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory)
+        std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
+        std::shared_ptr<shared_model::interface::PermissionToString>
+            perm_converter)
         : sql_(std::move(sql)),
-          command_executor_(std::make_unique<PostgresCommandExecutor>(*sql_)),
+          command_executor_(std::make_unique<PostgresCommandExecutor>(
+              *sql_, std::move(perm_converter))),
           log_(logger::log("TemporaryWSV")) {
       *sql_ << "BEGIN";
     }

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/commands/command.hpp"
+#include "interfaces/permission_to_string.hpp"
 #include "interfaces/transaction.hpp"
 
 namespace iroha {

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -54,25 +54,23 @@ namespace iroha {
             soci::use(boost::size(keys_range), "signatures_count"),
             soci::use(transaction.creatorAccountId(), "account_id");
       } catch (const std::exception &e) {
-        log_->error(
-            "Transaction %s failed signatures validation with db error: %s",
-            transaction.toString(),
-            e.what());
+        auto error_str = "Transaction " + transaction.toString()
+            + " failed signatures validation with db error: " + e.what();
         // TODO [IR-1816] Akvinikym 29.10.18: substitute error code magic number
         // with named constant
-        return expected::makeError(
-            validation::CommandError{"signatures validation", 1, false});
+        return expected::makeError(validation::CommandError{
+            "signatures validation", 1, error_str, false});
       }
 
       if (signatories_valid and *signatories_valid) {
         return {};
       } else {
-        log_->error("Transaction %s failed signatures validation",
-                    transaction.toString());
+        auto error_str = "Transaction " + transaction.toString()
+            + " failed signatures validation";
         // TODO [IR-1816] Akvinikym 29.10.18: substitute error code magic number
         // with named constant
-        return expected::makeError(
-            validation::CommandError{"signatures validation", 2, false});
+        return expected::makeError(validation::CommandError{
+            "signatures validation", 2, error_str, false});
       }
     }
 
@@ -105,6 +103,7 @@ namespace iroha {
                          [i, &cmd_error](expected::Error<CommandError> &error) {
                            cmd_error = {error.error.command_name,
                                         error.error.error_code,
+                                        error.error.error_extra,
                                         true,
                                         i};
                            return false;

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -11,8 +11,13 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
-#include "interfaces/permission_to_string.hpp"
 #include "logger/logger.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class PermissionToString;
+  }
+}  // namespace shared_model
 
 namespace iroha {
 

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -11,6 +11,7 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
+#include "interfaces/permission_to_string.hpp"
 #include "logger/logger.hpp"
 
 namespace iroha {
@@ -35,7 +36,9 @@ namespace iroha {
       TemporaryWsvImpl(
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-              factory);
+              factory,
+          std::shared_ptr<shared_model::interface::PermissionToString>
+              perm_converter);
 
       expected::Result<void, validation::CommandError> apply(
           const shared_model::interface::Transaction &transaction) override;

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -26,15 +26,16 @@ namespace iroha {
         if (not cmd_error.tx_passed_initial_validation) {
           return (boost::format("Stateful validation error: transaction %s "
                                 "did not pass initial verification: "
-                                "checking '%s', error code '%d'")
-                  % tx_hash % cmd_error.name % cmd_error.error_code)
+                                "checking '%s', error code '%d', message: %s")
+                  % tx_hash % cmd_error.name % cmd_error.error_code
+                  % cmd_error.error_extra)
               .str();
         }
         return (boost::format("Stateful validation error in transaction %s: "
                               "command '%s' with index '%d' did not pass "
-                              "verification with code '%d'")
+                              "verification with code '%d', message: %s")
                 % tx_hash % cmd_error.name % cmd_error.index
-                % cmd_error.error_code)
+                % cmd_error.error_code % cmd_error.error_extra)
             .str();
       }
     }  // namespace

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -24,16 +24,18 @@ namespace iroha {
         const auto tx_hash = tx_hash_and_error.first.hex();
         const auto &cmd_error = tx_hash_and_error.second;
         if (not cmd_error.tx_passed_initial_validation) {
-          return (boost::format("Stateful validation error: transaction %s "
-                                "did not pass initial verification: "
-                                "checking '%s', error code '%d', message: %s")
+          return (boost::format(
+                      "Stateful validation error: transaction %s "
+                      "did not pass initial verification: "
+                      "checking '%s', error code '%d', query arguments: %s")
                   % tx_hash % cmd_error.name % cmd_error.error_code
                   % cmd_error.error_extra)
               .str();
         }
-        return (boost::format("Stateful validation error in transaction %s: "
-                              "command '%s' with index '%d' did not pass "
-                              "verification with code '%d', message: %s")
+        return (boost::format(
+                    "Stateful validation error in transaction %s: "
+                    "command '%s' with index '%d' did not pass "
+                    "verification with code '%d', query arguments: %s")
                 % tx_hash % cmd_error.name % cmd_error.index
                 % cmd_error.error_code % cmd_error.error_extra)
             .str();

--- a/irohad/validation/stateful_validator_common.hpp
+++ b/irohad/validation/stateful_validator_common.hpp
@@ -34,6 +34,9 @@ namespace iroha {
       /// Error code, with which the command failed
       uint32_t error_code;
 
+      /// Extra information about error for developers to be placed into the log
+      std::string error_extra;
+
       /// Shows, if transaction has passed initial validation
       bool tx_passed_initial_validation;
 
@@ -41,13 +44,11 @@ namespace iroha {
       size_t index = 0;
     };
 
-
     /// Collection of transactions errors - a map from the failed transaction
     /// hash to the description of failed command.
     using TransactionHash = shared_model::crypto::Hash;
-    using TransactionsErrors = std::unordered_map<TransactionHash,
-                                                  CommandError,
-                                                  TransactionHash::Hasher>;
+    using TransactionsErrors = std::
+        unordered_map<TransactionHash, CommandError, TransactionHash::Hasher>;
     using TransactionError = TransactionsErrors::value_type;
 
     /// Type of verified proposal and errors appeared in the process; first

--- a/shared_model/interfaces/permissions.hpp
+++ b/shared_model/interfaces/permissions.hpp
@@ -98,6 +98,7 @@ namespace shared_model {
       PermissionSet(std::initializer_list<Perm> list);
       explicit PermissionSet(const std::string &bitstring);
 
+      // TODO [IR-1889] Akvinikym 21.11.18: introduce toString() method
       std::string toBitstring() const;
 
       static size_t size();

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -303,9 +303,10 @@ TEST_F(ClientServerTest, SendTxWhenStatefulInvalid) {
   verified_proposal_and_errors
       ->verified_proposal = std::make_unique<shared_model::proto::Proposal>(
       TestProposalBuilder().height(0).createdTime(iroha::time::now()).build());
-  verified_proposal_and_errors->rejected_transactions.emplace(std::make_pair(
-      tx.hash(),
-      iroha::validation::CommandError{cmd_name, error_code, true, cmd_index}));
+  verified_proposal_and_errors->rejected_transactions.emplace(
+      std::make_pair(tx.hash(),
+                     iroha::validation::CommandError{
+                         cmd_name, error_code, "", true, cmd_index}));
   verified_prop_notifier.get_subscriber().on_next(verified_proposal_and_errors);
 
   auto getAnswer = [&]() {

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -6,6 +6,7 @@
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_query_executor.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
+#include "backend/protobuf/proto_permission_to_string.hpp"
 #include "framework/result_fixture.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
@@ -50,7 +51,8 @@ namespace iroha {
                 shared_model::validation::FieldValidator>>();
         query = std::make_unique<PostgresWsvQuery>(*sql, factory);
         PostgresCommandExecutor::prepareStatements(*sql);
-        executor = std::make_unique<PostgresCommandExecutor>(*sql);
+        executor =
+            std::make_unique<PostgresCommandExecutor>(*sql, perm_converter);
 
         *sql << init_;
       }
@@ -121,6 +123,10 @@ namespace iroha {
 
       std::unique_ptr<WsvQuery> query;
       std::unique_ptr<CommandExecutor> executor;
+
+      std::shared_ptr<shared_model::interface::PermissionToString>
+          perm_converter =
+              std::make_shared<shared_model::proto::ProtoPermissionToString>();
 
       std::string uint256_halfmax =
           "57896044618658097711785492504343953926634992332820282019728792003956"

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -192,18 +192,19 @@ namespace iroha {
     TEST_F(AddAccountAssetTest, Valid) {
       addAsset();
       addAllPerms();
-      ASSERT_TRUE(val(
-          execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())))));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())))));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
-      ASSERT_TRUE(val(
-          execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())))));
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
       ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
@@ -216,20 +217,21 @@ namespace iroha {
      */
     TEST_F(AddAccountAssetTest, NoPerms) {
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
 
-      auto cmd_result =
-          execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())));
+      auto cmd_result = execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
           account->accountId(), asset_amount_one_zero, asset_id, "1"};
@@ -242,11 +244,11 @@ namespace iroha {
      * @then account asset fails to be added
      */
     TEST_F(AddAccountAssetTest, InvalidAsset) {
-      auto cmd_result =
-          execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())),
-                  true);
+      auto cmd_result = execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true);
 
       std::vector<std::string> query_args{
           account->accountId(), asset_amount_one_zero, asset_id, "1"};
@@ -1676,30 +1678,32 @@ namespace iroha {
     TEST_F(SubtractAccountAssetTest, Valid) {
       addAllPerms();
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
       ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
-      ASSERT_TRUE(val(
-          execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())))));
+      ASSERT_TRUE(val(execute(buildCommand(
+          TestTransactionBuilder()
+              .subtractAssetQuantity(asset_id, asset_amount_one_zero)
+              .creatorAccountId(account->accountId())))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1709,20 +1713,21 @@ namespace iroha {
      */
     TEST_F(SubtractAccountAssetTest, NoPerms) {
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
 
-      auto cmd_result =
-          execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())));
+      auto cmd_result = execute(buildCommand(
+          TestTransactionBuilder()
+              .subtractAssetQuantity(asset_id, asset_amount_one_zero)
+              .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
           account->accountId(), asset_id, asset_amount_one_zero, "1"};
@@ -1730,7 +1735,8 @@ namespace iroha {
 
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1740,10 +1746,10 @@ namespace iroha {
      */
     TEST_F(SubtractAccountAssetTest, NoAsset) {
       addAllPerms();
-      auto cmd_result =
-          execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
-                                   .creatorAccountId(account->accountId())));
+      auto cmd_result = execute(buildCommand(
+          TestTransactionBuilder()
+              .subtractAssetQuantity(asset_id, asset_amount_one_zero)
+              .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
           account->accountId(), asset_id, asset_amount_one_zero, "1"};
@@ -1776,11 +1782,11 @@ namespace iroha {
     TEST_F(SubtractAccountAssetTest, NotEnoughAsset) {
       addAllPerms();
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto cmd_result =
           execute(buildCommand(TestTransactionBuilder()
                                    .subtractAssetQuantity(asset_id, "2.0")
@@ -1851,20 +1857,21 @@ namespace iroha {
       addAllPerms();
       addAllPerms(account2->accountId(), "all2");
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
       ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
@@ -1876,10 +1883,12 @@ namespace iroha {
                                                  asset_amount_one_zero)))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
       account_asset = query->getAccountAsset(account2->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1918,10 +1927,12 @@ namespace iroha {
                       account2->accountId())));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
       account_asset = query->getAccountAsset(account2->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero,
+                account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1937,8 +1948,11 @@ namespace iroha {
                                                  "desc",
                                                  asset_amount_one_zero)));
 
-      std::vector<std::string> query_args{
-          account->accountId(), account2->accountId(), asset_id, asset_amount_one_zero, "1"};
+      std::vector<std::string> query_args{account->accountId(),
+                                          account2->accountId(),
+                                          asset_id,
+                                          asset_amount_one_zero,
+                                          "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 2, query_args);
     }
 
@@ -1951,30 +1965,43 @@ namespace iroha {
       addAllPerms();
       addAllPerms(account2->accountId(), "all2");
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
-      auto cmd_result = execute(
-          buildCommand(TestTransactionBuilder().transferAsset(
-              "some@domain", account2->accountId(), asset_id, "desc", asset_amount_one_zero)),
-          true);
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
+      auto cmd_result =
+          execute(buildCommand(TestTransactionBuilder().transferAsset(
+                      "some@domain",
+                      account2->accountId(),
+                      asset_id,
+                      "desc",
+                      asset_amount_one_zero)),
+                  true);
 
       {
-        std::vector<std::string> query_args{
-            "some@domain", account2->accountId(), asset_id, asset_amount_one_zero, "1"};
+        std::vector<std::string> query_args{"some@domain",
+                                            account2->accountId(),
+                                            asset_id,
+                                            asset_amount_one_zero,
+                                            "1"};
         CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 3, query_args);
       }
 
-      cmd_result = execute(
-          buildCommand(TestTransactionBuilder().transferAsset(
-              account->accountId(), "some@domain", asset_id, "desc", asset_amount_one_zero)),
-          true);
+      cmd_result = execute(buildCommand(TestTransactionBuilder().transferAsset(
+                               account->accountId(),
+                               "some@domain",
+                               asset_id,
+                               "desc",
+                               asset_amount_one_zero)),
+                           true);
 
       {
-        std::vector<std::string> query_args{
-            account->accountId(), "some@domain", asset_id, asset_amount_one_zero, "1"};
+        std::vector<std::string> query_args{account->accountId(),
+                                            "some@domain",
+                                            asset_id,
+                                            asset_amount_one_zero,
+                                            "1"};
         CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 4, query_args);
       }
     }
@@ -1994,8 +2021,11 @@ namespace iroha {
                                                  "desc",
                                                  asset_amount_one_zero)));
 
-      std::vector<std::string> query_args{
-          account->accountId(), account2->accountId(), asset_id, asset_amount_one_zero, "1"};
+      std::vector<std::string> query_args{account->accountId(),
+                                          account2->accountId(),
+                                          asset_id,
+                                          asset_amount_one_zero,
+                                          "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 5, query_args);
     }
 
@@ -2008,11 +2038,11 @@ namespace iroha {
       addAllPerms();
       addAllPerms(account2->accountId(), "all2");
       addAsset();
-      ASSERT_TRUE(
-          val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
-                                       .creatorAccountId(account->accountId())),
-                      true)));
+      ASSERT_TRUE(val(execute(
+          buildCommand(TestTransactionBuilder()
+                           .addAssetQuantity(asset_id, asset_amount_one_zero)
+                           .creatorAccountId(account->accountId())),
+          true)));
       auto cmd_result = execute(buildCommand(
           TestTransactionBuilder().transferAsset(account->accountId(),
                                                  account2->accountId(),

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -115,10 +115,10 @@ namespace iroha {
     cmd_result, expected_code, expected_substrings)  \
   auto error = err(cmd_result);                      \
   ASSERT_TRUE(error);                                \
-  ASSERT_EQ(error->error.error_code, expected_code); \
+  EXPECT_EQ(error->error.error_code, expected_code); \
   auto str_error = error->error.error_extra;         \
   for (auto substring : expected_substrings) {       \
-    ASSERT_THAT(str_error, HasSubstr(substring));    \
+    EXPECT_THAT(str_error, HasSubstr(substring));    \
   }
 
       const std::string role = "role";
@@ -139,10 +139,11 @@ namespace iroha {
           perm_converter =
               std::make_shared<shared_model::proto::ProtoPermissionToString>();
 
-      std::string uint256_halfmax =
+      const std::string uint256_halfmax =
           "57896044618658097711785492504343953926634992332820282019728792003956"
           "5648"
           "19966.0";  // 2**255
+      const std::string asset_amount_one_zero = "1.0";
     };
 
     class AddAccountAssetTest : public CommandExecutorTest {
@@ -193,15 +194,15 @@ namespace iroha {
       addAllPerms();
       ASSERT_TRUE(val(
           execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, "1.0")
+                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())))));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
       ASSERT_TRUE(val(
           execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, "1.0")
+                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
@@ -217,21 +218,21 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
 
       auto cmd_result =
           execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, "1.0")
+                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
-          account->accountId(), "1.0", asset_id, "1"};
+          account->accountId(), asset_amount_one_zero, asset_id, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 2, query_args);
     }
 
@@ -243,12 +244,12 @@ namespace iroha {
     TEST_F(AddAccountAssetTest, InvalidAsset) {
       auto cmd_result =
           execute(buildCommand(TestTransactionBuilder()
-                                   .addAssetQuantity(asset_id, "1.0")
+                                   .addAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())),
                   true);
 
       std::vector<std::string> query_args{
-          account->accountId(), "1.0", asset_id, "1"};
+          account->accountId(), asset_amount_one_zero, asset_id, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 3, query_args);
     }
 
@@ -1677,16 +1678,16 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
@@ -1694,11 +1695,11 @@ namespace iroha {
       ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
       ASSERT_TRUE(val(
           execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, "1.0")
+                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1710,26 +1711,26 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
 
       auto cmd_result =
           execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, "1.0")
+                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
-          account->accountId(), asset_id, "1.0", "1"};
+          account->accountId(), asset_id, asset_amount_one_zero, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 2, query_args);
 
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1741,11 +1742,11 @@ namespace iroha {
       addAllPerms();
       auto cmd_result =
           execute(buildCommand(TestTransactionBuilder()
-                                   .subtractAssetQuantity(asset_id, "1.0")
+                                   .subtractAssetQuantity(asset_id, asset_amount_one_zero)
                                    .creatorAccountId(account->accountId())));
 
       std::vector<std::string> query_args{
-          account->accountId(), asset_id, "1.0", "1"};
+          account->accountId(), asset_id, asset_amount_one_zero, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 3, query_args);
     }
 
@@ -1777,7 +1778,7 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto cmd_result =
@@ -1852,16 +1853,16 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto account_asset =
           query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
@@ -1872,13 +1873,13 @@ namespace iroha {
                                                  account2->accountId(),
                                                  asset_id,
                                                  "desc",
-                                                 "1.0")))));
+                                                 asset_amount_one_zero)))));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
       account_asset = query->getAccountAsset(account2->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1912,15 +1913,15 @@ namespace iroha {
                           account2->accountId(),
                           asset_id,
                           "desc",
-                          "1.0")),
+                          asset_amount_one_zero)),
                       false,
                       account2->accountId())));
       account_asset = query->getAccountAsset(account->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
       account_asset = query->getAccountAsset(account2->accountId(), asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("1.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance().toStringRepr());
     }
 
     /**
@@ -1934,10 +1935,10 @@ namespace iroha {
                                                  account2->accountId(),
                                                  asset_id,
                                                  "desc",
-                                                 "1.0")));
+                                                 asset_amount_one_zero)));
 
       std::vector<std::string> query_args{
-          account->accountId(), account2->accountId(), asset_id, "1.0", "1"};
+          account->accountId(), account2->accountId(), asset_id, asset_amount_one_zero, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 2, query_args);
     }
 
@@ -1952,28 +1953,28 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto cmd_result = execute(
           buildCommand(TestTransactionBuilder().transferAsset(
-              "some@domain", account2->accountId(), asset_id, "desc", "1.0")),
+              "some@domain", account2->accountId(), asset_id, "desc", asset_amount_one_zero)),
           true);
 
       {
         std::vector<std::string> query_args{
-            "some@domain", account2->accountId(), asset_id, "1.0", "1"};
+            "some@domain", account2->accountId(), asset_id, asset_amount_one_zero, "1"};
         CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 3, query_args);
       }
 
       cmd_result = execute(
           buildCommand(TestTransactionBuilder().transferAsset(
-              account->accountId(), "some@domain", asset_id, "desc", "1.0")),
+              account->accountId(), "some@domain", asset_id, "desc", asset_amount_one_zero)),
           true);
 
       {
         std::vector<std::string> query_args{
-            account->accountId(), "some@domain", asset_id, "1.0", "1"};
+            account->accountId(), "some@domain", asset_id, asset_amount_one_zero, "1"};
         CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 4, query_args);
       }
     }
@@ -1991,10 +1992,10 @@ namespace iroha {
                                                  account2->accountId(),
                                                  asset_id,
                                                  "desc",
-                                                 "1.0")));
+                                                 asset_amount_one_zero)));
 
       std::vector<std::string> query_args{
-          account->accountId(), account2->accountId(), asset_id, "1.0", "1"};
+          account->accountId(), account2->accountId(), asset_id, asset_amount_one_zero, "1"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 5, query_args);
     }
 
@@ -2009,7 +2010,7 @@ namespace iroha {
       addAsset();
       ASSERT_TRUE(
           val(execute(buildCommand(TestTransactionBuilder()
-                                       .addAssetQuantity(asset_id, "1.0")
+                                       .addAssetQuantity(asset_id, asset_amount_one_zero)
                                        .creatorAccountId(account->accountId())),
                       true)));
       auto cmd_result = execute(buildCommand(

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -78,7 +78,7 @@ namespace iroha {
         query_executor = storage;
         PostgresCommandExecutor::prepareStatements(*sql);
         executor =
-            std::make_unique<PostgresCommandExecutor>(*sql);
+            std::make_unique<PostgresCommandExecutor>(*sql, perm_converter);
         pending_txs_storage = std::make_shared<MockPendingTransactionStorage>();
 
         auto result = execute(buildCommand(TestTransactionBuilder().createRole(
@@ -190,6 +190,10 @@ namespace iroha {
 
       std::shared_ptr<shared_model::interface::QueryResponseFactory>
           query_response_factory;
+
+      std::shared_ptr<shared_model::interface::PermissionToString>
+          perm_converter =
+              std::make_shared<shared_model::proto::ProtoPermissionToString>();
     };
 
     class BlocksQueryExecutorTest : public QueryExecutorTest {};

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -305,7 +305,7 @@ TEST_F(SimulatorTest, SomeFailingTxs) {
   for (auto rejected_tx = txs.begin() + 1; rejected_tx != txs.end();
        ++rejected_tx) {
     verified_proposal_and_errors->rejected_transactions.emplace(
-        rejected_tx->hash(), validation::CommandError{"SomeCommand", 1, true});
+        rejected_tx->hash(), validation::CommandError{"SomeCommand", 1, "", true});
   }
   shared_model::proto::Block block = makeBlock(proposal->height() - 1);
 

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -392,7 +392,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
   for (size_t i = 0; i < invalid_txs.size(); ++i) {
     validation_result->rejected_transactions.emplace(
         invalid_txs[i].hash(),
-        iroha::validation::CommandError{"SomeCommandName", 1, true, i});
+        iroha::validation::CommandError{"SomeCommandName", 1, "", true, i});
   }
   verified_prop_notifier.get_subscriber().on_next(validation_result);
 

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -337,7 +337,7 @@ TEST_F(ToriiServiceTest, StatusWhenBlocking) {
   uint32_t error_code = 3;
   validation_result->rejected_transactions.emplace(
       failed_tx_hash,
-      iroha::validation::CommandError{cmd_name, error_code, true, cmd_index});
+      iroha::validation::CommandError{cmd_name, error_code, "", true, cmd_index});
   verified_prop_notifier_.get_subscriber().on_next(validation_result);
 
   // create commit from block notifier's observable

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -199,7 +199,8 @@ TEST_F(Validator, SomeTxsFail) {
           .build();
 
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(invalid_tx))))
-      .WillOnce(Return(iroha::expected::makeError(CommandError{"", 2, false})));
+      .WillOnce(Return(iroha::expected::makeError(
+          CommandError{"", 2, "account_id: doge@account", true})));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(valid_tx))))
       .WillRepeatedly(Return(iroha::expected::Value<void>({})));
 
@@ -211,6 +212,9 @@ TEST_F(Validator, SomeTxsFail) {
   ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
                 ->second.error_code,
             2);
+  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
+                ->second.error_extra,
+            "account_id: doge@account");
 }
 
 /**
@@ -274,8 +278,8 @@ TEST_F(Validator, Batches) {
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[2]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[3]))))
-      .WillOnce(
-          Return(iroha::expected::makeError(CommandError({"", 2, false}))));
+      .WillOnce(Return(iroha::expected::makeError(
+          CommandError({"", 2, "account_id: doge@account", false}))));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[5]))))
       .WillOnce(Return(iroha::expected::Value<void>({})));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs[6]))))
@@ -289,4 +293,7 @@ TEST_F(Validator, Batches) {
   ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
                 ->second.error_code,
             2);
+  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
+                ->second.error_extra,
+            "account_id: doge@account");
 }

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -225,7 +225,8 @@ TEST_F(Validator, SomeTxsFail) {
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs.at(0)))))
       .WillRepeatedly(Return(iroha::expected::Value<void>({})));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs.at(1)))))
-      .WillOnce(Return(iroha::expected::makeError(CommandError{"", sample_error_code, sample_error_extra, true})));
+      .WillOnce(Return(iroha::expected::makeError(
+          CommandError{"", sample_error_code, sample_error_extra, true})));
   EXPECT_CALL(*temp_wsv_mock, apply(Eq(ByRef(txs.at(2)))))
       .WillRepeatedly(Return(iroha::expected::Value<void>({})));
 


### PR DESCRIPTION
### Description of the Change

Completely removing the stateful error message was a bad idea, because clients now do not have an ability to track down actual query parameters, hidden behind the error code. So, this PR introduces output of query parameters to the log.

### Benefits

More verbose output to developers.

### Possible Drawbacks 

None

### Usage Examples or Tests

`postgres_executor_test` is updated with query parameters checks.