### PR TITLE
Fix startup flags logic (--genesis_block & --overwrite_ledger)

### DIFF
--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -150,6 +150,24 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
+  /*
+   * The logic implemented below is reflected in the following truth table.
+   *
+  +------------+--------------+------------------+---------------+---------+
+  | Blockstore | New genesis  | Overwrite ledger | Genesis block | Message |
+  | presence   | block is set | flag is set      | that is used  |         |
+  +------------+--------------+------------------+---------------+---------+
+  | 0          | 1            | 0                | new           |         |
+  | 0          | 1            | 1                | new           | warning |
+  | 1          | 1            | 0                | old           | warning |
+  | 1          | 1            | 1                | new           |         |
+  | 0          | 0            | 0                | none          | error   |
+  | 0          | 0            | 1                | none          | error   |
+  | 1          | 0            | 0                | old           |         |
+  | 1          | 0            | 1                | old           | warning |
+  +------------+--------------+------------------+---------------+---------+
+   */
+
   /// if there are any blocks in blockstore, then true
   bool blockstore = irohad.storage->getBlockQuery()->getTopBlockHeight() != 0;
 

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -150,47 +150,60 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  // Check if genesis block path was specified
-  if (not FLAGS_genesis_block.empty()) {
-    // If it is so, read genesis block and store it to iroha storage
-    iroha::main::BlockLoader loader;
-    auto file = loader.loadFile(FLAGS_genesis_block);
-    auto block = loader.parseBlock(file.value());
+  /// if there are any blocks in blockstore, then true
+  bool blockstore = irohad.storage->getBlockQuery()->getTopBlockHeight() != 0;
 
-    // Check that provided genesis block file was correct
-    if (not block) {
-      // Abort execution if not
-      log->error("Failed to parse genesis block");
-      return EXIT_FAILURE;
+  /// genesis block file is specified as launch parameter
+  bool genesis = not FLAGS_genesis_block.empty();
+
+  /// overwrite ledger flag was set as launch parameter
+  bool overwrite = FLAGS_overwrite_ledger;
+
+  if (genesis) {  // genesis block file is specified
+    if (blockstore and not overwrite) {
+      log->warn(
+          "Passed genesis block will be ignored without --overwrite_ledger "
+          "flag. Restoring existing state.");
+    } else {
+      iroha::main::BlockLoader loader;
+      auto file = loader.loadFile(FLAGS_genesis_block);
+      auto block = loader.parseBlock(file.value());
+
+      if (not block) {
+        log->error("Failed to parse genesis block.");
+        return EXIT_FAILURE;
+      }
+
+      if (not blockstore and overwrite) {
+        log->warn(
+            "Blockstore is empty - there is nothing to overwrite. Inserting "
+            "new genesis block.");
+      }
+
+      // clear previous storage if any
+      irohad.dropStorage();
+      // reset ordering service persistent counter
+      irohad.resetOrderingService();
+
+      irohad.storage->insertBlock(*block.value());
+      log->info("Genesis block inserted, number of transactions: {}",
+                block.value()->transactions().size());
     }
-
-    // check if ledger data already existing
-    auto ledger_not_empty =
-        irohad.storage->getBlockQuery()->getTopBlockHeight() != 0;
-
-    // Check if force flag to overwrite ledger is specified
-    if (ledger_not_empty && not FLAGS_overwrite_ledger) {
+  } else {  // genesis block file is not specified
+    if (not blockstore) {
       log->error(
-          "Block store not empty. Use '--overwrite_ledger' to force "
-          "overwrite it. Shutting down...");
+          "Cannot restore nor create new state. Blockstore is empty. No "
+          "genesis block is provided. Please pecify new genesis block using "
+          "--genesis_block parameter.");
       return EXIT_FAILURE;
+    } else {
+      if (overwrite) {
+        log->warn(
+            "No new genesis block is specified - blockstore cannot be "
+            "overwritten. If you want overwrite ledger state, please "
+            "specify new genesis block using --genesis_block parameter.");
+      }
     }
-
-    // TODO igor-egorov, 2018-08-10, IR-1569, create system test for
-    // --overwrite-ledger option
-
-    // clear previous storage if any
-    irohad.dropStorage();
-
-    // reset ordering service persistent counter
-    irohad.resetOrderingService();
-
-    log->info("Block is parsed");
-
-    // Applying transactions from genesis block to iroha storage
-    irohad.storage->insertBlock(*block.value());
-    log->info("Genesis block inserted, number of transactions: {}",
-              block.value()->transactions().size());
   }
 
   // check if at least one block is available in the ledger
@@ -198,9 +211,11 @@ int main(int argc, char *argv[]) {
       [](const auto &) { return true; },
       [](iroha::expected::Error<std::string> &) { return false; });
 
-  if (not blocks_exist) {
+  if (not blocks_exist) {  // may happen only in case of bug or zero disk space
     log->error(
-        "There are no blocks in the ledger. Use --genesis_block parameter.");
+        "You should have never seen this message. There are no blocks in the "
+        "ledger.  Unable to start. Try to specify --genesis_block and "
+        "--overwrite_ledger parameters at the same time.");
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

This is a better implementation of #1776.

The problem is that CI needs to be able to launch `irohad` that will restore the existing state with the same set of flags as that was passed at the first launch.

The new way of launch parameters handling is implemented. All the possible cases is covered.

The new truth table is below:
![image](https://user-images.githubusercontent.com/36847043/48899324-5d09e200-ee60-11e8-9cfa-f7cd27cca576.png)


For a better understanding of changes made in code please take a look at two execution flowcharts (old and new one).
#### Old execution flow
![old_flow](https://user-images.githubusercontent.com/36847043/48899420-9cd0c980-ee60-11e8-9e26-508e4b3bd6f1.png)
#### New execution flow
![new_flow](https://user-images.githubusercontent.com/36847043/48899434-a5290480-ee60-11e8-920f-7132b375bc86.png)


### Benefits

Nothing is changed in already exposed API.
No unexpected behavior is added.
All the combinations of three parameters (presence of blockstore, presence of new genesis_block, presence of overwrite_ledger flag) are covered.


### Possible Drawbacks 

None?

### Usage Examples or Tests

```
cmake -H. -Bbuild
cd build
make irohad_test
test_bin/irohad_test
```
