### PR TITLE
OnDemand OS: propagate outdated batches

### DIFF
--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -56,6 +56,17 @@ OnDemandOrderingGate::OnDemandOrderingGate(
                   current_round_.block_round, current_round_.reject_round, {});
             }));
       })),
+      outdated_batches_subscription_(
+          ordering_service_->get_outdated_proposals_observable().subscribe(
+              [this](OnDemandOrderingService::BatchesForRoundNotification
+                         batches_for_round) {
+                log_->info("Propagating {} batch(es) intended for round {}.",
+                           batches_for_round->batches.size(),
+                           batches_for_round->round.toString());
+                for (const auto &batch : batches_for_round->batches) {
+                  this->propagateBatch(batch);
+                }
+              })),
       proposal_factory_(std::move(factory)),
       current_round_(initial_round) {}
 

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -62,6 +62,7 @@ namespace iroha {
       std::shared_ptr<OnDemandOrderingService> ordering_service_;
       std::shared_ptr<transport::OdOsNotification> network_client_;
       rxcpp::composite_subscription events_subscription_;
+      rxcpp::composite_subscription outdated_batches_subscription_;
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;
 

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -41,6 +41,9 @@ namespace iroha {
 
       void onCollaborationOutcome(consensus::Round round) override;
 
+      rxcpp::observable<BatchesForRoundNotification>
+      get_outdated_proposals_observable() const override;
+
       // ----------------------- | OdOsNotification | --------------------------
 
       void onBatches(consensus::Round, CollectionType batches) override;
@@ -106,6 +109,9 @@ namespace iroha {
 
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;
+
+      rxcpp::subjects::subject<BatchesForRoundNotification>
+          outdated_proposals_subject_;
 
       /**
        * Logger instance

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -8,6 +8,8 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include <rxcpp/rx.hpp>
+
 namespace iroha {
   namespace ordering {
 
@@ -16,11 +18,25 @@ namespace iroha {
      */
     class OnDemandOrderingService : public transport::OdOsNotification {
      public:
+      struct BatchesForRound final {
+        CollectionType batches;
+        consensus::Round round;
+      };
+      using BatchesForRoundNotification =
+          std::shared_ptr<const BatchesForRound>;
+
       /**
        * Method which should be invoked on outcome of collaboration for round
        * @param round - proposal round which has started
        */
       virtual void onCollaborationOutcome(consensus::Round round) = 0;
+
+      /**
+       * Provides an observable for received batches proposed for already closed
+       * rounds.
+       */
+      virtual rxcpp::observable<BatchesForRoundNotification>
+      get_outdated_proposals_observable() const = 0;
     };
 
   }  // namespace ordering

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -26,6 +26,8 @@ using ::testing::Truly;
 struct OnDemandOrderingGateTest : public ::testing::Test {
   void SetUp() override {
     ordering_service = std::make_shared<MockOnDemandOrderingService>();
+    EXPECT_CALL(*ordering_service, get_outdated_proposals_observable())
+        .Times(testing::AnyNumber());
     notification = std::make_shared<MockOdOsNotification>();
     auto ufactory = std::make_unique<MockUnsafeProposalFactory>();
     factory = ufactory.get();

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -31,12 +31,21 @@ namespace iroha {
     }  // namespace transport
 
     struct MockOnDemandOrderingService : public OnDemandOrderingService {
+      MockOnDemandOrderingService() {
+        ON_CALL(*this, get_outdated_proposals_observable())
+            .WillByDefault(testing::Return(
+                rxcpp::observable<>::never<BatchesForRoundNotification>()));
+      }
+
       MOCK_METHOD2(onBatches, void(consensus::Round, CollectionType));
 
       MOCK_METHOD1(onRequestProposal,
                    boost::optional<ProposalType>(consensus::Round));
 
       MOCK_METHOD1(onCollaborationOutcome, void(consensus::Round));
+
+      MOCK_CONST_METHOD0(get_outdated_proposals_observable,
+                         rxcpp::observable<BatchesForRoundNotification>());
     };
 
   }  // namespace ordering


### PR DESCRIPTION
### Description of the Change

This change makes an OnDemand Ordering Service (ODOS) send the batches it got for some rounds that are closed for incoming batches to the currently open rounds on corresponding peers.

### Benefits

Some proposals that otherwise would be lost now get used.

### Possible Drawbacks 

To be researched.