### PR TITLE
Synchronize OnDemand OS ConnectionManager propagation data

### DIFF
--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -5,36 +5,72 @@
 
 #include "ordering/impl/on_demand_connection_manager.hpp"
 
+#include <chrono>
+
 #include <boost/range/combine.hpp>
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "ordering/impl/on_demand_common.hpp"
+
+/// The time to wait for the up-to-date propagation data arrives through
+/// propagation_params_observable (see constructor) when we got a request for a
+/// round that is newer than our propagation data
+static constexpr std::chrono::milliseconds kPropagationDataWaitTimeout(10);
 
 using namespace iroha::ordering;
 
 OnDemandConnectionManager::OnDemandConnectionManager(
     std::shared_ptr<transport::OdOsNotificationFactory> factory,
-    rxcpp::observable<CurrentPeers> peers)
+    rxcpp::observable<PropagationParams> propagation_params_observable)
     : log_(logger::log("OnDemandConnectionManager")),
       factory_(std::move(factory)),
-      subscription_(peers.subscribe([this](const auto &peers) {
-        // exclusive lock
-        std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+      subscription_(propagation_params_observable.subscribe(
+          [this](const auto &propagation_params) {
+            // exclusive lock
+            std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
-        this->initializeConnections(peers);
-      })) {}
+            this->initializeConnections(propagation_params);
+          })) {}
 
 OnDemandConnectionManager::OnDemandConnectionManager(
     std::shared_ptr<transport::OdOsNotificationFactory> factory,
-    rxcpp::observable<CurrentPeers> peers,
-    CurrentPeers initial_peers)
-    : OnDemandConnectionManager(std::move(factory), peers) {
-  // using start_with(initial_peers) results in deadlock
-  initializeConnections(initial_peers);
+    rxcpp::observable<PropagationParams> propagation_params_observable,
+    PropagationParams inital_propagation_params)
+    : OnDemandConnectionManager(std::move(factory),
+                                propagation_params_observable) {
+  // using start_with(inital_propagation_params) results in deadlock
+  initializeConnections(inital_propagation_params);
 }
 
-void OnDemandConnectionManager::onBatches(consensus::Round round,
+void OnDemandConnectionManager::onBatches(const consensus::Round round,
                                           CollectionType batches) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+
+  // check if we have appropriate propagation data:
+  if (current_round_ != round) {
+    if (round < current_round_) {
+      log_->debug(
+          "Got a batch to propagate for round {0}, while current round is {1}! "
+          "Will send the batch to round {1}.",
+          round.toString(),
+          current_round_.toString());
+    } else if (current_round_ < round) {
+      log_->debug(
+          "Got a batch to propagate for round {0}, while current round is {1}! "
+          "Will wait till current round updates.",
+          round.toString(),
+          current_round_.toString());
+      if (!propagation_data_update_cv_.wait_for(
+              lock, kPropagationDataWaitTimeout, [this, &round] {
+                return not(this->current_round_ < round);
+              })) {
+        log_->debug(
+            "Reached timeout waiting for the propagation data for at least {} "
+            "round. Will drop the batch.",
+            round.toString());
+        return;
+      }
+    }
+  }
 
   /*
    * Transactions are always sent to the round after the next round (+2)
@@ -56,13 +92,13 @@ void OnDemandConnectionManager::onBatches(consensus::Round round,
     connections_.peers[type]->onBatches(round, batches);
   };
 
-  propagate(
-      kCurrentRoundRejectConsumer,
-      {round.block_round, currentRejectRoundConsumer(round.reject_round)});
+  propagate(kCurrentRoundRejectConsumer,
+            {current_round_.block_round,
+             currentRejectRoundConsumer(current_round_.reject_round)});
   propagate(kNextRoundRejectConsumer,
-            {round.block_round + 1, kNextRejectRoundConsumer});
+            {current_round_.block_round + 1, kNextRejectRoundConsumer});
   propagate(kNextRoundCommitConsumer,
-            {round.block_round + 2, kNextCommitRoundConsumer});
+            {current_round_.block_round + 2, kNextCommitRoundConsumer});
 }
 
 boost::optional<OnDemandConnectionManager::ProposalType>
@@ -77,12 +113,14 @@ OnDemandConnectionManager::onRequestProposal(consensus::Round round) {
 }
 
 void OnDemandConnectionManager::initializeConnections(
-    const CurrentPeers &peers) {
+    const PropagationParams &propagation_params) {
   auto create_assign = [this](auto &ptr, auto &peer) {
     ptr = factory_->create(*peer);
   };
 
-  for (auto &&pair : boost::combine(connections_.peers, peers.peers)) {
+  for (auto &&pair :
+       boost::combine(connections_.peers, propagation_params.peers)) {
     create_assign(boost::get<0>(pair), boost::get<1>(pair));
   }
+  current_round_ = propagation_params.current_round;
 }

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -80,6 +80,19 @@ namespace iroha {
        */
       void initializeConnections(const PropagationParams &peers);
 
+      /**
+       * Match the requested round and the current propagation data round.
+       * Will warn if the newer round is actually used and wait for the newer
+       * propagation data if the requested round is newer than current.
+       *
+       * @param request_round - the round an operation was requested for.
+       * @param lock - the lock used for this operation. Must be locked.
+       * @return true if we have the appropriate propagation data to proceed
+       *    with the operation, false otherwise.
+       */
+      template <typename Lock>
+      bool verifyPropagtionData(consensus::Round request_round, Lock &lock);
+
       logger::Logger log_;
       std::shared_ptr<transport::OdOsNotificationFactory> factory_;
       rxcpp::composite_subscription subscription_;


### PR DESCRIPTION
### Description of the Change

This change makes OdOs Connection Manager aware of the round for which its destination peers are valid. Now it will wait for the peers data to update if the batch it gets has a newer round, or set the destination of the batch to an actual round if the requested destination is outdated.

### Benefits

Aimed at mitigation of (one of causes of) [the lost proposal bug|https://soramitsu.atlassian.net/browse/IR-1888].

### Possible Drawbacks 

Bugs!