### PR TITLE
Renamed Client Services

### DIFF
--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -75,7 +75,7 @@ namespace torii {
     void swap(CommandSyncClient &lhs, CommandSyncClient &rhs);
     std::string ip_;
     size_t port_;
-    std::unique_ptr<iroha::protocol::CommandService::Stub> stub_;
+    std::unique_ptr<iroha::protocol::CommandService_v1::Stub> stub_;
     logger::Logger log_;
   };
 

--- a/irohad/torii/impl/command_client.cpp
+++ b/irohad/torii/impl/command_client.cpp
@@ -28,7 +28,7 @@ namespace torii {
   CommandSyncClient::CommandSyncClient(const std::string &ip, size_t port)
       : ip_(ip),
         port_(port),
-        stub_(iroha::network::createClient<iroha::protocol::CommandService>(
+        stub_(iroha::network::createClient<iroha::protocol::CommandService_v1>(
             ip + ":" + std::to_string(port))),
         log_(logger::log("CommandSyncClient")) {}
 
@@ -56,7 +56,8 @@ namespace torii {
     return stub_->Torii(&context, tx, &a);
   }
 
-  grpc::Status CommandSyncClient::ListTorii(const iroha::protocol::TxList &tx_list) const {
+  grpc::Status CommandSyncClient::ListTorii(
+      const iroha::protocol::TxList &tx_list) const {
     google::protobuf::Empty a;
     grpc::ClientContext context;
     return stub_->ListTorii(&context, tx_list, &a);

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -21,7 +21,7 @@
 
 namespace torii {
   class CommandServiceTransportGrpc
-      : public iroha::protocol::CommandService::Service {
+      : public iroha::protocol::CommandService_v1::Service {
    public:
     using TransportFactoryType =
         shared_model::interface::AbstractTransportFactory<

--- a/irohad/torii/impl/query_client.cpp
+++ b/irohad/torii/impl/query_client.cpp
@@ -23,7 +23,7 @@ namespace torii_utils {
   QuerySyncClient::QuerySyncClient(const std::string &ip, size_t port)
       : ip_(ip),
         port_(port),
-        stub_(iroha::network::createClient<iroha::protocol::QueryService>(
+        stub_(iroha::network::createClient<iroha::protocol::QueryService_v1>(
             ip + ":" + std::to_string(port))) {}
 
   QuerySyncClient::QuerySyncClient(const QuerySyncClient &rhs)

--- a/irohad/torii/query_client.hpp
+++ b/irohad/torii/query_client.hpp
@@ -56,7 +56,7 @@ namespace torii_utils {
 
     std::string ip_;
     size_t port_;
-    std::unique_ptr<iroha::protocol::QueryService::Stub> stub_;
+    std::unique_ptr<iroha::protocol::QueryService_v1::Stub> stub_;
   };
   /**
    * QueryAsyncClient

--- a/irohad/torii/query_service.hpp
+++ b/irohad/torii/query_service.hpp
@@ -36,7 +36,7 @@ namespace torii {
    * ToriiServiceHandler::(SomeMethod)Handler calls a corresponding method in
    * this class.
    */
-  class QueryService : public iroha::protocol::QueryService::Service {
+  class QueryService : public iroha::protocol::QueryService_v1::Service {
    public:
     QueryService(std::shared_ptr<iroha::torii::QueryProcessor> query_processor);
 

--- a/shared_model/schema/endpoint.proto
+++ b/shared_model/schema/endpoint.proto
@@ -33,7 +33,7 @@ message ToriiResponse {
   uint32 error_code = 5;
 }
 
-message TxStatusRequest{
+message TxStatusRequest {
   bytes tx_hash = 1;
 }
 
@@ -41,14 +41,14 @@ message TxList {
   repeated Transaction transactions = 1;
 }
 
-service CommandService {
+service CommandService_v1 {
   rpc Torii (Transaction) returns (google.protobuf.Empty);
   rpc ListTorii (TxList) returns (google.protobuf.Empty);
   rpc Status (TxStatusRequest) returns (ToriiResponse);
   rpc StatusStream(TxStatusRequest) returns (stream ToriiResponse);
 }
 
-service QueryService {
+service QueryService_v1 {
   rpc Find (Query) returns (QueryResponse);
   rpc FetchCommits (BlocksQuery) returns (stream BlockQueryResponse);
 }

--- a/test/module/irohad/main/server_runner_test.cpp
+++ b/test/module/irohad/main/server_runner_test.cpp
@@ -34,14 +34,14 @@ auto port_visitor = iroha::make_visitor(
 TEST(ServerRunnerTest, SamePortNoReuse) {
   ServerRunner first_runner((address % 0).str());
   auto first_query_service =
-      std::make_shared<iroha::protocol::QueryService::Service>();
+      std::make_shared<iroha::protocol::QueryService_v1::Service>();
   auto result = first_runner.append(first_query_service).run();
   auto port = boost::apply_visitor(port_visitor, result);
   ASSERT_NE(0, port);
 
   ServerRunner second_runner((address % port).str(), false);
   auto second_query_service =
-      std::make_shared<iroha::protocol::QueryService::Service>();
+      std::make_shared<iroha::protocol::QueryService_v1::Service>();
   result = second_runner.append(second_query_service).run();
   port = boost::apply_visitor(port_visitor, result);
   ASSERT_EQ(0, port);
@@ -55,14 +55,14 @@ TEST(ServerRunnerTest, SamePortNoReuse) {
 TEST(ServerRunnerTest, SamePortWithReuse) {
   ServerRunner first_runner((address % 0).str());
   auto first_query_service =
-      std::make_shared<iroha::protocol::QueryService::Service>();
+      std::make_shared<iroha::protocol::QueryService_v1::Service>();
   auto result = first_runner.append(first_query_service).run();
   auto port = boost::apply_visitor(port_visitor, result);
   ASSERT_NE(0, port);
 
   ServerRunner second_runner((address % port).str(), true);
   auto second_query_service =
-      std::make_shared<iroha::protocol::QueryService::Service>();
+      std::make_shared<iroha::protocol::QueryService_v1::Service>();
   result = second_runner.append(second_query_service).run();
   port = boost::apply_visitor(port_visitor, result);
   ASSERT_NE(0, port);


### PR DESCRIPTION
### Description of the Change

To prepare Iroha for backward compatibility, `CommandService` and `QueryService` should be given version tags, `1_0` in this case.

### Benefits

One more step to BC.

### Possible Drawbacks 

Harder to read?