### PR TITLE
ITF: added fake peer synchronizer calls observable getters

### DIFF
--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -31,7 +31,7 @@ namespace iroha {
       auto YacVoteStorage::getProposalStorage(const Round &round) {
         return std::find_if(proposal_storages_.begin(),
                             proposal_storages_.end(),
-                            [&round](auto storage) {
+                            [&round](const auto &storage) {
                               return storage.getStorageKey() == round;
                             });
       }

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -206,6 +206,18 @@ namespace integration_framework {
       return og_network_notifier_->getObservable();
     }
 
+    rxcpp::observable<LoaderBlockRequest>
+    FakePeer::getLoaderBlockRequestObservable() {
+      ensureInitialized();
+      return synchronizer_transport_->getLoaderBlockRequestObservable();
+    }
+
+    rxcpp::observable<LoaderBlocksRequest>
+    FakePeer::getLoaderBlocksRequestObservable() {
+      ensureInitialized();
+      return synchronizer_transport_->getLoaderBlocksRequestObservable();
+    }
+
     std::shared_ptr<shared_model::interface::Signature> FakePeer::makeSignature(
         const shared_model::crypto::Blob &hash) const {
       auto bare_signature =

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -106,8 +106,19 @@ namespace integration_framework {
           + getAddress() + ")");
     }
 
+    FakePeer &FakePeer::initialize() {
+      BOOST_VERIFY_MSG(!initialized_, "Already initialized!");
+      // here comes the initialization of members requiring shared_from_this()
+      synchronizer_transport_ =
+          std::make_shared<LoaderGrpc>(shared_from_this());
+
+      initialized_ = true;
+      return *this;
+    }
+
     FakePeer &FakePeer::setBehaviour(
         const std::shared_ptr<Behaviour> &behaviour) {
+      ensureInitialized();
       behaviour_ = behaviour;
       behaviour_->adopt(shared_from_this());
       return *this;
@@ -119,6 +130,7 @@ namespace integration_framework {
 
     FakePeer &FakePeer::setBlockStorage(
         const std::shared_ptr<BlockStorage> &block_storage) {
+      ensureInitialized();
       if (block_storage_) {
         block_storage_->claimNotUsingPeer(shared_from_this());
       }
@@ -128,6 +140,7 @@ namespace integration_framework {
     }
 
     FakePeer &FakePeer::removeBlockStorage() {
+      ensureInitialized();
       if (block_storage_) {
         block_storage_->claimNotUsingPeer(shared_from_this());
       }
@@ -143,9 +156,8 @@ namespace integration_framework {
     }
 
     void FakePeer::run() {
+      ensureInitialized();
       // start instance
-      synchronizer_transport_ =
-          std::make_shared<LoaderGrpc>(shared_from_this());
       log_->info("starting listening server");
       internal_server_ = std::make_unique<ServerRunner>(getAddress());
       internal_server_->append(yac_transport_)
@@ -280,6 +292,10 @@ namespace integration_framework {
     size_t FakePeer::sendBlocksRequest(const LoaderBlocksRequest &request) {
       return synchronizer_transport_->sendBlocksRequest(real_peer_->address(),
                                                         request);
+    }
+
+    void FakePeer::ensureInitialized() {
+      BOOST_VERIFY_MSG(initialized_, "Instance not initialized!");
     }
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -61,6 +61,11 @@ namespace integration_framework {
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory);
 
+      /// Initialization method.
+      /// \attention Must be called prior to any other instance method (except
+      /// for constructor).
+      FakePeer &initialize();
+
       /// Assign the given behaviour to this fake peer.
       FakePeer &setBehaviour(const std::shared_ptr<Behaviour> &behaviour);
 
@@ -148,6 +153,11 @@ namespace integration_framework {
       using OgTransport = iroha::ordering::OrderingGateTransportGrpc;
       using AsyncCall =
           iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
+
+      /// Ensure the initialize() method was called.
+      void ensureInitialized();
+
+      bool initialized_{false};
 
       std::shared_ptr<shared_model::interface::CommonObjectsFactory>
           common_objects_factory_;

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
@@ -6,6 +6,7 @@
 #ifndef INTEGRATION_FRAMEWORK_FAKE_PEER_LOADER_GRPC_HPP_
 #define INTEGRATION_FRAMEWORK_FAKE_PEER_LOADER_GRPC_HPP_
 
+#include <rxcpp/rx.hpp>
 #include "framework/integration_framework/fake_peer/types.hpp"
 #include "loader.grpc.pb.h"
 #include "logger/logger.hpp"
@@ -17,6 +18,20 @@ namespace integration_framework {
      public:
       explicit LoaderGrpc(const std::shared_ptr<FakePeer> &fake_peer);
 
+      bool sendBlockRequest(const std::string &dest_address,
+                            const LoaderBlockRequest &request);
+
+      size_t sendBlocksRequest(const std::string &dest_address,
+                               const LoaderBlocksRequest &request);
+
+      /// Get the observable of block requests.
+      rxcpp::observable<LoaderBlockRequest> getLoaderBlockRequestObservable();
+
+      /// Get the observable of blocks requests.
+      rxcpp::observable<LoaderBlocksRequest> getLoaderBlocksRequestObservable();
+
+      // --------------| iroha::network::proto::Loader::Service |--------------
+
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,
           const iroha::network::proto::BlocksRequest *request,
@@ -27,14 +42,12 @@ namespace integration_framework {
           const iroha::network::proto::BlockRequest *request,
           iroha::protocol::Block *response) override;
 
-      bool sendBlockRequest(const std::string &dest_address,
-                            const LoaderBlockRequest &request);
-
-      size_t sendBlocksRequest(const std::string &dest_address,
-                               const LoaderBlocksRequest &request);
-
      private:
       std::weak_ptr<FakePeer> fake_peer_wptr_;
+
+      rxcpp::subjects::subject<LoaderBlockRequest> block_requests_subject_;
+      rxcpp::subjects::subject<LoaderBlocksRequest> blocks_requests_subject_;
+
       logger::Logger log_;
     };
   }

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
@@ -18,9 +18,23 @@ namespace integration_framework {
      public:
       explicit LoaderGrpc(const std::shared_ptr<FakePeer> &fake_peer);
 
+      /**
+       * Send a `retrieveBlock' request to the peer at given address.
+       *
+       * @param dest_address - the destination of the request.
+       * @param request - the data of the request.
+       * @return true if the grpc request succeeded, false otherwise.
+       */
       bool sendBlockRequest(const std::string &dest_address,
                             const LoaderBlockRequest &request);
 
+      /**
+       * Send a `retrieveBlocks' request to the peer at given address.
+       *
+       * @param dest_address - the destination of the request.
+       * @param request - the data of the request.
+       * @return the number of received in reply blocks.
+       */
       size_t sendBlocksRequest(const std::string &dest_address,
                                const LoaderBlocksRequest &request);
 
@@ -32,11 +46,13 @@ namespace integration_framework {
 
       // --------------| iroha::network::proto::Loader::Service |--------------
 
+      /// Handler of grpc retrieveBlocks calls.
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,
           const iroha::network::proto::BlocksRequest *request,
           ::grpc::ServerWriter<iroha::protocol::Block> *writer) override;
 
+      /// Handler of grpc retrieveBlock calls.
       grpc::Status retrieveBlock(
           ::grpc::ServerContext *context,
           const iroha::network::proto::BlockRequest *request,

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -149,6 +149,7 @@ namespace integration_framework {
                                      transaction_factory_,
                                      batch_parser_,
                                      transaction_batch_factory_);
+      fake_peer->initialize();
       fake_peers_.emplace_back(fake_peer);
       promise_and_key.first.set_value(fake_peer);
     }


### PR DESCRIPTION
### Description of the Change

Methods to get observables on fake peer's synchronizer calls.

### Benefits

Additional handles for testing.

### Possible Drawbacks 

bugs.