### PR TITLE
Schema update for queries with lists of transactions

### DIFF
--- a/shared_model/backend/protobuf/CMakeLists.txt
+++ b/shared_model/backend/protobuf/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(shared_model_proto_backend
     queries/impl/proto_get_pending_transactions.cpp
     queries/impl/proto_blocks_query.cpp
     queries/impl/proto_query_payload_meta.cpp
+    queries/impl/proto_tx_pagination_meta.cpp
     )
 
 if (IROHA_ROOT_PROJECT)

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
@@ -5,6 +5,8 @@
 
 #include "backend/protobuf/queries/proto_get_account_asset_transactions.hpp"
 
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
+
 namespace shared_model {
   namespace proto {
 
@@ -37,6 +39,12 @@ namespace shared_model {
     const interface::types::AssetIdType &GetAccountAssetTransactions::assetId()
         const {
       return account_asset_transactions_.asset_id();
+    }
+
+    std::unique_ptr<interface::TxPaginationMeta>
+    GetAccountAssetTransactions::paginationMeta() const {
+      return std::make_unique<TxPaginationMeta>(
+          account_asset_transactions_.pagination_meta());
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
@@ -14,7 +14,8 @@ namespace shared_model {
     GetAccountAssetTransactions::GetAccountAssetTransactions(QueryType &&query)
         : CopyableProto(std::forward<QueryType>(query)),
           account_asset_transactions_{
-              proto_->payload().get_account_asset_transactions()} {}
+              proto_->payload().get_account_asset_transactions()},
+          pagination_meta_{account_asset_transactions_.pagination_meta()} {}
 
     template GetAccountAssetTransactions::GetAccountAssetTransactions(
         GetAccountAssetTransactions::TransportType &);
@@ -41,10 +42,9 @@ namespace shared_model {
       return account_asset_transactions_.asset_id();
     }
 
-    std::unique_ptr<interface::TxPaginationMeta>
+    const interface::TxPaginationMeta &
     GetAccountAssetTransactions::paginationMeta() const {
-      return std::make_unique<TxPaginationMeta>(
-          account_asset_transactions_.pagination_meta());
+      return pagination_meta_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
@@ -5,6 +5,8 @@
 
 #include "backend/protobuf/queries/proto_get_account_transactions.hpp"
 
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
+
 namespace shared_model {
   namespace proto {
 
@@ -31,6 +33,12 @@ namespace shared_model {
     const interface::types::AccountIdType &GetAccountTransactions::accountId()
         const {
       return account_transactions_.account_id();
+    }
+
+    std::unique_ptr<interface::TxPaginationMeta>
+    GetAccountTransactions::paginationMeta() const {
+      return std::make_unique<TxPaginationMeta>(
+          account_transactions_.pagination_meta());
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
@@ -13,7 +13,8 @@ namespace shared_model {
     template <typename QueryType>
     GetAccountTransactions::GetAccountTransactions(QueryType &&query)
         : CopyableProto(std::forward<QueryType>(query)),
-          account_transactions_{proto_->payload().get_account_transactions()} {}
+          account_transactions_{proto_->payload().get_account_transactions()},
+          pagination_meta_{account_transactions_.pagination_meta()} {}
 
     template GetAccountTransactions::GetAccountTransactions(
         GetAccountTransactions::TransportType &);
@@ -35,10 +36,9 @@ namespace shared_model {
       return account_transactions_.account_id();
     }
 
-    std::unique_ptr<interface::TxPaginationMeta>
-    GetAccountTransactions::paginationMeta() const {
-      return std::make_unique<TxPaginationMeta>(
-          account_transactions_.pagination_meta());
+    const interface::TxPaginationMeta &GetAccountTransactions::paginationMeta()
+        const {
+      return pagination_meta_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
+
+#include "cryptography/hash.hpp"
+
+namespace types = shared_model::interface::types;
+
+using namespace shared_model::proto;
+
+TxPaginationMeta::TxPaginationMeta(const TransportType &query)
+    : CopyableProto(query) {}
+
+/*
+TxPaginationMeta::TxPaginationMeta(TransportType &&query)
+    : CopyableProto(std::move<TransportType>(query)) {}
+*/
+
+TxPaginationMeta::TxPaginationMeta(const TxPaginationMeta &o)
+    : TxPaginationMeta(*o.proto_) {}
+
+TxPaginationMeta::TxPaginationMeta(TxPaginationMeta &&o) noexcept
+    : CopyableProto(std::move(*o.proto_)) {}
+
+types::TransactionsNumberType TxPaginationMeta::pageSize() const {
+  return proto_->page_size();
+}
+
+boost::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
+  return {proto_->opt_first_tx_hash_case(),
+          types::HashType(proto_->first_tx_hash())};
+}

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -30,6 +30,9 @@ types::TransactionsNumberType TxPaginationMeta::pageSize() const {
 }
 
 boost::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
-  return {proto_->opt_first_tx_hash_case(),
-          types::HashType(proto_->first_tx_hash())};
+  if (proto_->opt_first_tx_hash_case()
+      == TransportType::OptFirstTxHashCase::OPT_FIRST_TX_HASH_NOT_SET) {
+    return boost::none;
+  }
+  return types::HashType(proto_->first_tx_hash());
 }

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -14,10 +14,9 @@ using namespace shared_model::proto;
 TxPaginationMeta::TxPaginationMeta(const TransportType &query)
     : CopyableProto(query) {}
 
-/*
 TxPaginationMeta::TxPaginationMeta(TransportType &&query)
-    : CopyableProto(std::move<TransportType>(query)) {}
-*/
+    : CopyableProto(
+          static_cast<std::remove_reference<TransportType>::type &&>(query)) {}
 
 TxPaginationMeta::TxPaginationMeta(const TxPaginationMeta &o)
     : TxPaginationMeta(*o.proto_) {}

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -40,6 +40,9 @@ namespace shared_model {
 
       const interface::types::AssetIdType &assetId() const override;
 
+      std::unique_ptr<interface::TxPaginationMeta> paginationMeta()
+          const override;
+
      private:
       // ------------------------------| fields |-------------------------------
 

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -19,6 +19,7 @@
 #define IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "interfaces/queries/get_account_asset_transactions.hpp"
 #include "queries.pb.h"
 
@@ -40,14 +41,14 @@ namespace shared_model {
 
       const interface::types::AssetIdType &assetId() const override;
 
-      std::unique_ptr<interface::TxPaginationMeta> paginationMeta()
-          const override;
+      const interface::TxPaginationMeta &paginationMeta() const override;
 
      private:
       // ------------------------------| fields |-------------------------------
 
       const iroha::protocol::GetAccountAssetTransactions
           &account_asset_transactions_;
+      const TxPaginationMeta pagination_meta_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
@@ -38,6 +38,9 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
+      std::unique_ptr<interface::TxPaginationMeta> paginationMeta()
+          const override;
+
      private:
       // ------------------------------| fields |-------------------------------
 

--- a/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
@@ -19,6 +19,7 @@
 #define IROHA_GET_ACCOUNT_TRANSACTIONS_H
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "interfaces/queries/get_account_transactions.hpp"
 #include "queries.pb.h"
 
@@ -38,13 +39,13 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
-      std::unique_ptr<interface::TxPaginationMeta> paginationMeta()
-          const override;
+      const interface::TxPaginationMeta &paginationMeta() const override;
 
      private:
       // ------------------------------| fields |-------------------------------
 
       const iroha::protocol::GetAccountTransactions &account_transactions_;
+      const TxPaginationMeta pagination_meta_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -20,8 +20,8 @@ namespace shared_model {
                                iroha::protocol::TxPaginationMeta,
                                TxPaginationMeta> {
      public:
-      TxPaginationMeta(const TransportType &query);
-      //TxPaginationMeta(TransportType &&query);
+      explicit TxPaginationMeta(const TransportType &query);
+      //explicit TxPaginationMeta(TransportType &&query);
       TxPaginationMeta(const TxPaginationMeta &o);
       TxPaginationMeta(TxPaginationMeta &&o) noexcept;
 

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -21,7 +21,7 @@ namespace shared_model {
                                TxPaginationMeta> {
      public:
       explicit TxPaginationMeta(const TransportType &query);
-      //explicit TxPaginationMeta(TransportType &&query);
+      explicit TxPaginationMeta(TransportType &&query);
       TxPaginationMeta(const TxPaginationMeta &o);
       TxPaginationMeta(TxPaginationMeta &&o) noexcept;
 

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
+#define IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
+
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "interfaces/queries/tx_pagination_meta.hpp"
+#include "queries.pb.h"
+
+namespace shared_model {
+  namespace proto {
+
+    /// Provides query metadata for any transaction list pagination.
+    class TxPaginationMeta final
+        : public CopyableProto<interface::TxPaginationMeta,
+                               iroha::protocol::TxPaginationMeta,
+                               TxPaginationMeta> {
+     public:
+      TxPaginationMeta(const TransportType &query);
+      //TxPaginationMeta(TransportType &&query);
+      TxPaginationMeta(const TxPaginationMeta &o);
+      TxPaginationMeta(TxPaginationMeta &&o) noexcept;
+
+      interface::types::TransactionsNumberType pageSize() const override;
+
+      boost::optional<interface::types::HashType> firstTxHash() const override;
+    };
+  }  // namespace proto
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP

--- a/shared_model/interfaces/CMakeLists.txt
+++ b/shared_model/interfaces/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(shared_model_interfaces
     queries/impl/get_pending_transactions.cpp
     queries/impl/blocks_query.cpp
     queries/impl/query_payload_meta.cpp
+    queries/impl/tx_pagination_meta.cpp
     common_objects/impl/amount.cpp
     common_objects/impl/signature.cpp
     common_objects/impl/peer.cpp

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -75,7 +75,7 @@ namespace shared_model {
       using AccountDetailKeyType = std::string;
       /// Type of account detail value
       using AccountDetailValueType = std::string;
-      /// Type of a number of transactions in block
+      /// Type of a number of transactions in block and query responce page
       using TransactionsNumberType = uint16_t;
       /// Type of the transfer message
       using DescriptionType = std::string;

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -75,7 +75,7 @@ namespace shared_model {
       using AccountDetailKeyType = std::string;
       /// Type of account detail value
       using AccountDetailValueType = std::string;
-      /// Type of a number of transactions in block and query responce page
+      /// Type of a number of transactions in block and query response page
       using TransactionsNumberType = uint16_t;
       /// Type of the transfer message
       using DescriptionType = std::string;

--- a/shared_model/interfaces/queries/get_account_asset_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_asset_transactions.hpp
@@ -18,11 +18,14 @@
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_ASSET_TRANSACTIONS_HPP
 
+#include <memory>
+
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
   namespace interface {
+    class TxPaginationMeta;
 
     /**
      * Query for getting transactions of given asset of an account
@@ -38,6 +41,9 @@ namespace shared_model {
        * @return assetId of requested transactions
        */
       virtual const types::AccountIdType &assetId() const = 0;
+
+      /// Get the query pagination metadata.
+      virtual std::unique_ptr<TxPaginationMeta> paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/get_account_asset_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_asset_transactions.hpp
@@ -43,7 +43,7 @@ namespace shared_model {
       virtual const types::AccountIdType &assetId() const = 0;
 
       /// Get the query pagination metadata.
-      virtual std::unique_ptr<TxPaginationMeta> paginationMeta() const = 0;
+      virtual const TxPaginationMeta &paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/get_account_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_transactions.hpp
@@ -18,11 +18,15 @@
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_TRANSACTIONS_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_TRANSACTIONS_HPP
 
+#include <memory>
+
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
   namespace interface {
+    class TxPaginationMeta;
+
     /**
      * Query for getting transactions of account
      */
@@ -33,6 +37,9 @@ namespace shared_model {
        * @return account_id of requested transactions
        */
       virtual const types::AccountIdType &accountId() const = 0;
+
+      /// Get the query pagination metadata.
+      virtual std::unique_ptr<TxPaginationMeta> paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/get_account_transactions.hpp
+++ b/shared_model/interfaces/queries/get_account_transactions.hpp
@@ -39,7 +39,7 @@ namespace shared_model {
       virtual const types::AccountIdType &accountId() const = 0;
 
       /// Get the query pagination metadata.
-      virtual std::unique_ptr<TxPaginationMeta> paginationMeta() const = 0;
+      virtual const TxPaginationMeta &paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/queries/get_account_asset_transactions.hpp"
 
+#include "interfaces/queries/tx_pagination_meta.hpp"
+
 namespace shared_model {
   namespace interface {
 
@@ -13,6 +15,7 @@ namespace shared_model {
           .init("GetAccountAssetTransactions")
           .append("account_id", accountId())
           .append("asset_id", assetId())
+          .append("pagination_meta", paginationMeta()->toString())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
@@ -15,7 +15,7 @@ namespace shared_model {
           .init("GetAccountAssetTransactions")
           .append("account_id", accountId())
           .append("asset_id", assetId())
-          .append("pagination_meta", paginationMeta()->toString())
+          .append("pagination_meta", paginationMeta().toString())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_transactions.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/queries/get_account_transactions.hpp"
 
+#include "interfaces/queries/tx_pagination_meta.hpp"
+
 namespace shared_model {
   namespace interface {
 
@@ -12,6 +14,7 @@ namespace shared_model {
       return detail::PrettyStringBuilder()
           .init("GetAccountTransactions")
           .append("account_id", accountId())
+          .append("pagination_meta", paginationMeta()->toString())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_transactions.cpp
@@ -14,7 +14,7 @@ namespace shared_model {
       return detail::PrettyStringBuilder()
           .init("GetAccountTransactions")
           .append("account_id", accountId())
-          .append("pagination_meta", paginationMeta()->toString())
+          .append("pagination_meta", paginationMeta().toString())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "interfaces/queries/tx_pagination_meta.hpp"
+
+#include "cryptography/hash.hpp"
+
+using namespace shared_model::interface;
+
+bool TxPaginationMeta::operator==(const ModelType &rhs) const {
+  return pageSize() == rhs.pageSize() and firstTxHash() == rhs.firstTxHash();
+}
+
+std::string TxPaginationMeta::toString() const {
+  auto pretty_builder = detail::PrettyStringBuilder()
+                            .init("TxPaginationMeta")
+                            .append("page_size", std::to_string(pageSize()));
+  auto first_tx_hash = firstTxHash();
+  if (first_tx_hash) {
+    pretty_builder = std::move(
+        pretty_builder.append("first_tx_hash", first_tx_hash->toString()));
+  }
+  return pretty_builder.finalize();
+}

--- a/shared_model/interfaces/queries/tx_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/tx_pagination_meta.hpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP
+#define IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP
+
+#include <boost/optional.hpp>
+#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+
+    /// Provides query metadata for any transaction list pagination.
+    class TxPaginationMeta : public ModelPrimitive<TxPaginationMeta> {
+     public:
+
+      /// Get the requested page size.
+      virtual types::TransactionsNumberType pageSize() const = 0;
+
+      /// Get the first requested transaction hash, if provided.
+      virtual boost::optional<types::HashType> firstTxHash() const = 0;
+
+      std::string toString() const override;
+
+      bool operator==(const ModelType &rhs) const override;
+    };
+  }  // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP

--- a/shared_model/interfaces/queries/tx_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/tx_pagination_meta.hpp
@@ -27,6 +27,7 @@ namespace shared_model {
 
       bool operator==(const ModelType &rhs) const override;
     };
+
   }  // namespace interface
 }  // namespace shared_model
 

--- a/shared_model/schema/queries.proto
+++ b/shared_model/schema/queries.proto
@@ -8,6 +8,13 @@ package iroha.protocol;
 
 import "primitive.proto";
 
+message TxPaginationMeta {
+  uint32 page_size = 1;
+  oneof opt_first_tx_hash {
+    string first_tx_hash = 2;
+  }
+}
+
 message GetAccount {
   string account_id = 1;
 }
@@ -18,11 +25,13 @@ message GetSignatories {
 
 message GetAccountTransactions {
   string account_id = 1;
+  TxPaginationMeta pagination_meta = 2;
 }
 
 message GetAccountAssetTransactions {
   string account_id = 1;
   string asset_id = 2;
+  TxPaginationMeta pagination_meta = 3;
 }
 
 message GetTransactions {

--- a/shared_model/utils/string_builder.cpp
+++ b/shared_model/utils/string_builder.cpp
@@ -8,6 +8,13 @@
 namespace shared_model {
   namespace detail {
 
+    const std::string PrettyStringBuilder::beginBlockMarker = "[";
+    const std::string PrettyStringBuilder::endBlockMarker = "]";
+    const std::string PrettyStringBuilder::keyValueSeparator = "=";
+    const std::string PrettyStringBuilder::singleFieldsSeparator = ",";
+    const std::string PrettyStringBuilder::initSeparator = ":";
+    const std::string PrettyStringBuilder::spaceSeparator = " ";
+
     PrettyStringBuilder &PrettyStringBuilder::init(const std::string &name) {
       result_.append(name);
       result_.append(initSeparator);

--- a/shared_model/utils/string_builder.hpp
+++ b/shared_model/utils/string_builder.hpp
@@ -89,12 +89,12 @@ namespace shared_model {
 
      private:
       std::string result_;
-      const std::string beginBlockMarker = "[";
-      const std::string endBlockMarker = "]";
-      const std::string keyValueSeparator = "=";
-      const std::string singleFieldsSeparator = ",";
-      const std::string initSeparator = ":";
-      const std::string spaceSeparator = " ";
+      static const std::string beginBlockMarker;
+      static const std::string endBlockMarker;
+      static const std::string keyValueSeparator;
+      static const std::string singleFieldsSeparator;
+      static const std::string initSeparator;
+      static const std::string spaceSeparator;
     };
   }  // namespace detail
 }  // namespace shared_model

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -382,5 +382,11 @@ namespace shared_model {
       return boost::none;
     }
 
+    void FieldValidator::validateTxPaginationMeta(
+        ReasonsGroupType &reason,
+        const interface::TxPaginationMeta &tx_pagination_meta) const {
+      // TODO mboldyrev 27.11.2018, IR-26 IR-27: implement validation
+    }
+
   }  // namespace validation
 }  // namespace shared_model

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -20,6 +20,7 @@ namespace shared_model {
     class Amount;
     class BatchMeta;
     class Peer;
+    class TxPaginationMeta;
   }  // namespace interface
 
   namespace validation {
@@ -159,6 +160,10 @@ namespace shared_model {
 
       void validateHash(ReasonsGroupType &reason,
                         const crypto::Hash &hash) const;
+
+      void validateTxPaginationMeta(
+          ReasonsGroupType &reason,
+          const interface::TxPaginationMeta &tx_pagination_meta) const;
 
      private:
       const static std::string account_name_pattern_;

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -19,6 +19,7 @@
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/queries/proto_query_payload_meta.hpp"
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "module/shared_model/validators/validators_fixture.hpp"
@@ -584,6 +585,9 @@ class FieldValidatorTest : public ValidatorsTest {
       //                   "more than max")
   };
 
+  // TODO mboldyrev 27.11.2018, IR-25: add the test cases
+  std::vector<FieldTestCase> tx_pagination_meta_test_cases;
+
   /**************************************************************************/
 
   /// Create no-operation validator
@@ -678,7 +682,13 @@ class FieldValidatorTest : public ValidatorsTest {
           &FieldValidator::validateBatchMeta,
           &FieldValidatorTest::batch_meta,
           [](auto &&x) { return shared_model::proto::BatchMeta(x); },
-          batch_meta_test_cases)};
+          batch_meta_test_cases),
+      makeTransformValidator(
+          "pagination_meta",
+          &FieldValidator::validateTxPaginationMeta,
+          &FieldValidatorTest::tx_pagination_meta,
+          [](auto &&x) { return proto::TxPaginationMeta(x); },
+          tx_pagination_meta_test_cases)};
 };
 
 /**

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -75,6 +75,9 @@ class ValidatorsTest : public ::testing::Test {
     field_setters["peer"] = [&](auto refl, auto msg, auto field) {
       refl->MutableMessage(msg, field)->CopyFrom(peer);
     };
+    field_setters["pagination_meta"] = [&](auto refl, auto msg, auto field) {
+      refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
+    };
   }
 
   /**
@@ -192,6 +195,7 @@ class ValidatorsTest : public ::testing::Test {
     quorum = 2;
     peer.set_address(address_localhost);
     peer.set_peer_key(public_key);
+    tx_pagination_meta.set_page_size(10);
   }
 
   size_t public_key_size{0};
@@ -224,6 +228,7 @@ class ValidatorsTest : public ::testing::Test {
   iroha::protocol::Peer peer;
   decltype(iroha::time::now()) created_time;
   iroha::protocol::QueryPayloadMeta meta;
+  iroha::protocol::TxPaginationMeta tx_pagination_meta;
 
   // List all used fields in commands
   std::unordered_map<


### PR DESCRIPTION
### Description of the Change

[IR-20](https://jira.hyperledger.org/projects/IR/issues/IR-20)
This change adds the pagination metadata to some queries that request transaction lists: GetAccountTransactions and GetAccountAssetTransactions. It does not concern GetPendingTransactions as it is expected to be rewritten soon.

### Benefits

A small step towards great feature.

### Possible Drawbacks 

bugs.

### Usage Examples or Tests

When a client requests some sort of transaction list, the request must include pagination metadata. That one _must_ have the page size set  to the maximum amount of transactions the client wants to get at once, and _may_ have the first transaction hash field set to the hash of the transaction, from which the returned list is supposed to start.