### PR TITLE
Nano Fix: YAC vote storage - find proposal predicate takes constref

### DIFF
--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -31,7 +31,7 @@ namespace iroha {
       auto YacVoteStorage::getProposalStorage(const Round &round) {
         return std::find_if(proposal_storages_.begin(),
                             proposal_storages_.end(),
-                            [&round](auto storage) {
+                            [&round](const auto &storage) {
                               return storage.getStorageKey() == round;
                             });
       }


### PR DESCRIPTION
### Description of the Change

[IR-1912](https://soramitsu.atlassian.net/projects/IR/issues/IR-1912)
I stumbled upon this when investigating a [segfault](https://pastebin.com/L0nJZDMc) in `YacProposalStorage`. After this fix the segfault never occurred again.
The change seems very simple: a `find_if` predicate is made to take its argument by constref to avoid copying.

### Benefits

Removed unneeded copying, and somehow fixed segfault (not yet sure about that).

### Possible Drawbacks 

Bugs.