### PR TITLE
Change ordering gate cache remove interface to hashes

### DIFF
--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -27,7 +27,7 @@ OnDemandOrderingGate::OnDemandOrderingGate(
                        [this](const BlockEvent &block_event) {
                          // block committed, increment block round
                          current_round_ = block_event.round;
-                         cache_->remove(block_event.batches);
+                         cache_->remove(block_event.hashes);
                        },
                        [this](const EmptyEvent &empty) {
                          // no blocks committed, increment reject round

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -32,7 +32,7 @@ namespace iroha {
        */
       struct BlockEvent {
         consensus::Round round;
-        cache::OrderingGateCache::BatchesSetType batches;
+        cache::OrderingGateCache::HashesSetType hashes;
       };
 
       /**

--- a/irohad/ordering/impl/ordering_gate_cache/on_demand_cache.cpp
+++ b/irohad/ordering/impl/ordering_gate_cache/on_demand_cache.cpp
@@ -5,6 +5,8 @@
 
 #include "ordering/impl/ordering_gate_cache/on_demand_cache.hpp"
 
+#include "interfaces/iroha_internal/transaction_batch.hpp"
+
 using namespace iroha::ordering::cache;
 
 // TODO: IR-1864 13.11.18 kamilsa use nvi to separate business logic and locking
@@ -16,13 +18,16 @@ void OnDemandCache::addToBack(
   circ_buffer.back().insert(batches.begin(), batches.end());
 }
 
-void OnDemandCache::remove(
-    const OrderingGateCache::BatchesSetType &remove_batches) {
+void OnDemandCache::remove(const OrderingGateCache::HashesSetType &hashes) {
   std::unique_lock<std::shared_timed_mutex> lock(mutex_);
   for (auto &batches : circ_buffer) {
-    for (const auto &removed_batch : remove_batches) {
-      batches.erase(removed_batch);
-    };
+    for (auto it = batches.begin(); it != batches.end();) {
+      if (hashes.find(it->get()->reducedHash()) != hashes.end()) {
+        it = batches.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 }
 

--- a/irohad/ordering/impl/ordering_gate_cache/on_demand_cache.hpp
+++ b/irohad/ordering/impl/ordering_gate_cache/on_demand_cache.hpp
@@ -8,9 +8,9 @@
 
 #include "ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp"
 
-#include <boost/circular_buffer.hpp>
-#include <queue>
 #include <shared_mutex>
+
+#include <boost/circular_buffer.hpp>
 
 namespace iroha {
   namespace ordering {
@@ -22,7 +22,7 @@ namespace iroha {
 
         BatchesSetType pop() override;
 
-        void remove(const BatchesSetType &batches) override;
+        void remove(const HashesSetType &hashes) override;
 
         virtual const BatchesSetType &head() const override;
 

--- a/irohad/ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp
+++ b/irohad/ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp
@@ -12,7 +12,6 @@
 
 namespace shared_model {
   namespace interface {
-
     class TransactionBatch;
   }
 }  // namespace shared_model
@@ -45,24 +44,24 @@ namespace iroha {
             std::shared_ptr<shared_model::interface::TransactionBatch>,
             BatchPointerHasher>;
 
+        using HashesSetType =
+            std::unordered_set<shared_model::crypto::Hash,
+                               shared_model::crypto::Hash::Hasher>;
+
         /**
          * Concatenates batches from the tail of the queue with provided batches
-         * @param batches set of batches that are added to the queue
          */
         virtual void addToBack(const BatchesSetType &batches) = 0;
 
         /**
-         * Pops the head batches
-         * @return batches from the head
+         * Pops the head batches and returns them
          */
         virtual BatchesSetType pop() = 0;
 
         /**
-         * Remove provided batches from the head of the queue
-         * @param batches are the batches that are removed from the head of the
-         * queue
+         * Removes batches by provided hashes from the head of the queue
          */
-        virtual void remove(const BatchesSetType &batches) = 0;
+        virtual void remove(const HashesSetType &hashes) = 0;
 
         /**
          * Return the head batches

--- a/test/module/irohad/ordering/on_demand_cache_test.cpp
+++ b/test/module/irohad/ordering/on_demand_cache_test.cpp
@@ -128,7 +128,7 @@ TEST(OnDemandCache, Remove) {
    */
   ASSERT_THAT(cache.head(), UnorderedElementsAre(batch1, batch2, batch3));
 
-  cache.remove({batch2, batch3});
+  cache.remove({hash2, hash3});
   /**
    * 1. {batch1}
    * 2.

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -226,8 +226,8 @@ TEST_F(OnDemandOrderingGateTest, BatchesRemoveFromCache) {
   auto batch2 = createMockBatchWithHash(hash2);
 
   EXPECT_CALL(*cache, pop()).Times(1);
-  EXPECT_CALL(*cache, remove(UnorderedElementsAre(batch1, batch2))).Times(1);
+  EXPECT_CALL(*cache, remove(UnorderedElementsAre(hash1, hash2))).Times(1);
 
   rounds.get_subscriber().on_next(
-      OnDemandOrderingGate::BlockEvent{initial_round, {batch1, batch2}});
+      OnDemandOrderingGate::BlockEvent{initial_round, {hash1, hash2}});
 }

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -33,9 +33,9 @@ namespace iroha {
 
     namespace cache {
       struct MockOrderingGateCache : public OrderingGateCache {
-        MOCK_METHOD1(addToBack, void(const BatchesSetType &batches));
+        MOCK_METHOD1(addToBack, void(const BatchesSetType &));
         MOCK_METHOD0(pop, BatchesSetType());
-        MOCK_METHOD1(remove, void(const BatchesSetType &batches));
+        MOCK_METHOD1(remove, void(const HashesSetType &));
         MOCK_CONST_METHOD0(head, const BatchesSetType &());
         MOCK_CONST_METHOD0(tail, const BatchesSetType &());
       };


### PR DESCRIPTION

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Since it is not possible to create transaction batches from block transactions, because some transactions from ordered batches could be missing, hashes should be used in `BlockEvent` and cache `remove` method instead of batches.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Works with current blocks.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
More complex `remove` method implementation.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs *[optional]*
It might be possible to use `unordered_map<Hash, Batch>` in cache instead of `unordered_set<Batch>`, but it will lead to more changes, which do not seem necessary at the moment.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
