### PR TITLE
Pimpl for QueryResponse

### DIFF
--- a/iroha-cli/impl/query_response_handler.cpp
+++ b/iroha-cli/impl/query_response_handler.cpp
@@ -19,6 +19,7 @@
 #include "backend/protobuf/commands/proto_command.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/query_responses/proto_transaction_response.hpp"
 #include "interfaces/permissions.hpp"
 #include "logger/logger.hpp"
 #include "model/converters/pb_common.hpp"

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -7,6 +7,9 @@
 #include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/transaction.hpp"
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/amount.hpp"
 
 namespace {
   /**

--- a/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
@@ -4,57 +4,87 @@
  */
 
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/query_responses/proto_account_asset_response.hpp"
+#include "backend/protobuf/query_responses/proto_account_detail_response.hpp"
+#include "backend/protobuf/query_responses/proto_account_response.hpp"
+#include "backend/protobuf/query_responses/proto_asset_response.hpp"
+#include "backend/protobuf/query_responses/proto_error_query_response.hpp"
+#include "backend/protobuf/query_responses/proto_role_permissions_response.hpp"
+#include "backend/protobuf/query_responses/proto_roles_response.hpp"
+#include "backend/protobuf/query_responses/proto_signatories_response.hpp"
+#include "backend/protobuf/query_responses/proto_transaction_response.hpp"
 #include "common/byteutils.hpp"
+#include "utils/reference_holder.hpp"
 #include "utils/variant_deserializer.hpp"
 
-using Variant =
-    shared_model::proto::QueryResponse::ProtoQueryResponseVariantType;
-template Variant::~variant();
-template Variant::variant(Variant &&);
-template void Variant::destroy_content();
-template int Variant::which() const;
-template void Variant::indicate_which(int);
-template bool Variant::using_backup() const;
+namespace {
+  /// type of proto variant
+  using ProtoQueryResponseVariantType =
+      boost::variant<shared_model::proto::AccountAssetResponse,
+                     shared_model::proto::AccountDetailResponse,
+                     shared_model::proto::AccountResponse,
+                     shared_model::proto::ErrorQueryResponse,
+                     shared_model::proto::SignatoriesResponse,
+                     shared_model::proto::TransactionsResponse,
+                     shared_model::proto::AssetResponse,
+                     shared_model::proto::RolesResponse,
+                     shared_model::proto::RolePermissionsResponse>;
+
+  /// list of types in variant
+  using ProtoQueryResponseListType = ProtoQueryResponseVariantType::types;
+}  // namespace
 
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    QueryResponse::QueryResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          variant_{[this] {
-            auto &&ar = *proto_;
-            int which = ar.GetDescriptor()
-                            ->FindFieldByNumber(ar.response_case())
-                            ->index();
-            return shared_model::detail::
-                variant_impl<ProtoQueryResponseListType>::template load<
-                    ProtoQueryResponseVariantType>(
-                    std::forward<decltype(ar)>(ar), which);
-          }},
-          ivariant_{detail::makeLazyInitializer(
-              [this] { return QueryResponseVariantType(*variant_); })},
-          hash_{[this] {
-            return interface::types::HashType(
-                iroha::hexstringToBytestring(proto_->query_hash()).get());
-          }} {}
+    struct QueryResponse::Impl {
+      explicit Impl(const TransportType &ref) : proto_{ref} {}
+      explicit Impl(TransportType &&ref) : proto_{std::move(ref)} {}
 
-    template QueryResponse::QueryResponse(QueryResponse::TransportType &);
-    template QueryResponse::QueryResponse(const QueryResponse::TransportType &);
-    template QueryResponse::QueryResponse(QueryResponse::TransportType &&);
+      detail::ReferenceHolder<TransportType> proto_;
+
+      const ProtoQueryResponseVariantType variant_{[this] {
+        auto &&ar = *proto_;
+        int which =
+            ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
+        return shared_model::detail::variant_impl<ProtoQueryResponseListType>::
+            template load<ProtoQueryResponseVariantType>(
+                std::forward<decltype(ar)>(ar), which);
+      }()};
+
+      const QueryResponseVariantType ivariant_{variant_};
+
+      const crypto::Hash hash_{
+          iroha::hexstringToBytestring(proto_->query_hash()).get()};
+    };
 
     QueryResponse::QueryResponse(const QueryResponse &o)
-        : QueryResponse(o.proto_) {}
+        : QueryResponse(*o.impl_->proto_) {}
+    QueryResponse::QueryResponse(QueryResponse &&o) noexcept = default;
 
-    QueryResponse::QueryResponse(QueryResponse &&o) noexcept
-        : QueryResponse(std::move(o.proto_)) {}
+    QueryResponse::QueryResponse(const TransportType &ref) {
+      impl_ = std::make_unique<Impl>(ref);
+    }
+    QueryResponse::QueryResponse(TransportType &&ref) {
+      impl_ = std::make_unique<Impl>(std::move(ref));
+    }
+
+    QueryResponse::~QueryResponse() = default;
 
     const QueryResponse::QueryResponseVariantType &QueryResponse::get() const {
-      return *ivariant_;
+      return impl_->ivariant_;
     }
 
     const interface::types::HashType &QueryResponse::queryHash() const {
-      return *hash_;
+      return impl_->hash_;
+    }
+
+    const QueryResponse::TransportType &QueryResponse::getTransport() const {
+      return *impl_->proto_;
+    }
+
+    QueryResponse *QueryResponse::clone() const {
+      return new QueryResponse(*impl_->proto_);
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -1,96 +1,43 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_SHARED_MODEL_PROTO_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_QUERY_RESPONSE_HPP
 
-#include "backend/protobuf/query_responses/proto_account_asset_response.hpp"
-#include "backend/protobuf/query_responses/proto_account_detail_response.hpp"
-#include "backend/protobuf/query_responses/proto_account_response.hpp"
-#include "backend/protobuf/query_responses/proto_asset_response.hpp"
-#include "backend/protobuf/query_responses/proto_error_query_response.hpp"
-#include "backend/protobuf/query_responses/proto_role_permissions_response.hpp"
-#include "backend/protobuf/query_responses/proto_roles_response.hpp"
-#include "backend/protobuf/query_responses/proto_signatories_response.hpp"
-#include "backend/protobuf/query_responses/proto_transaction_response.hpp"
-
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/query_response.hpp"
+
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
-    class QueryResponse final
-        : public CopyableProto<interface::QueryResponse,
-                               iroha::protocol::QueryResponse,
-                               QueryResponse> {
+    class QueryResponse final : public interface::QueryResponse {
      public:
-      /// type of proto variant
-      using ProtoQueryResponseVariantType =
-          boost::variant<AccountAssetResponse,
-                         AccountDetailResponse,
-                         AccountResponse,
-                         ErrorQueryResponse,
-                         SignatoriesResponse,
-                         TransactionsResponse,
-                         AssetResponse,
-                         RolesResponse,
-                         RolePermissionsResponse>;
-
-      /// list of types in variant
-      using ProtoQueryResponseListType = ProtoQueryResponseVariantType::types;
-
-      template <typename QueryResponseType>
-      explicit QueryResponse(QueryResponseType &&queryResponse);
+      using TransportType = iroha::protocol::QueryResponse;
 
       QueryResponse(const QueryResponse &o);
-
       QueryResponse(QueryResponse &&o) noexcept;
+
+      explicit QueryResponse(const TransportType &queryResponse);
+      explicit QueryResponse(TransportType &&queryResponse);
+
+      ~QueryResponse() override;
 
       const QueryResponseVariantType &get() const override;
 
       const interface::types::HashType &queryHash() const override;
 
+      const TransportType &getTransport() const;
+
+     protected:
+      QueryResponse *clone() const override;
+
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      using LazyVariantType = Lazy<ProtoQueryResponseVariantType>;
-
-      const LazyVariantType variant_;
-
-      const Lazy<QueryResponseVariantType> ivariant_;
-
-      const Lazy<interface::types::HashType> hash_;
+      struct Impl;
+      std::unique_ptr<Impl> impl_;
     };
   }  // namespace proto
 }  // namespace shared_model
-
-namespace boost {
-  extern template class variant<shared_model::proto::AccountAssetResponse,
-                                shared_model::proto::AccountDetailResponse,
-                                shared_model::proto::AccountResponse,
-                                shared_model::proto::ErrorQueryResponse,
-                                shared_model::proto::SignatoriesResponse,
-                                shared_model::proto::TransactionsResponse,
-                                shared_model::proto::AssetResponse,
-                                shared_model::proto::RolesResponse,
-                                shared_model::proto::RolePermissionsResponse>;
-}
 
 #endif  // IROHA_SHARED_MODEL_PROTO_QUERY_RESPONSE_HPP

--- a/test/integration/acceptance/add_signatory_test.cpp
+++ b/test/integration/acceptance/add_signatory_test.cpp
@@ -7,6 +7,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/signatories_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;

--- a/test/integration/acceptance/get_account_assets_test.cpp
+++ b/test/integration/acceptance/get_account_assets_test.cpp
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "query_permission_test_ast.hpp"
+#include "interfaces/query_responses/account_asset_response.hpp"
 #include "query_permission_fixture.hpp"
+#include "query_permission_test_ast.hpp"
 
 using namespace common_constants;
 using AccountAssetsFixture = QueryPermissionFixture<QueryPermissionAssets>;

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -10,6 +10,7 @@
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "utils/query_error_response_visitor.hpp"
+#include "interfaces/query_responses/account_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;

--- a/test/integration/acceptance/get_asset_info_test.cpp
+++ b/test/integration/acceptance/get_asset_info_test.cpp
@@ -9,6 +9,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/asset_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 using namespace integration_framework;

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -9,6 +9,7 @@
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/permissions.hpp"
+#include "interfaces/query_responses/error_responses/stateful_failed_error_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;

--- a/test/integration/acceptance/get_roles_test.cpp
+++ b/test/integration/acceptance/get_roles_test.cpp
@@ -9,6 +9,8 @@
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/permissions.hpp"
+#include "interfaces/query_responses/error_query_response.hpp"
+#include "interfaces/query_responses/error_responses/stateful_failed_error_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -10,6 +10,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 using namespace integration_framework;

--- a/test/integration/acceptance/grantable_permissions_fixture.hpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.hpp
@@ -13,6 +13,9 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/account_detail_response.hpp"
+#include "interfaces/query_responses/account_response.hpp"
+#include "interfaces/query_responses/signatories_response.hpp"
 
 class GrantablePermissionsFixture : public AcceptanceFixture {
  public:

--- a/test/integration/acceptance/queries_acceptance_test.cpp
+++ b/test/integration/acceptance/queries_acceptance_test.cpp
@@ -10,6 +10,7 @@
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/permissions.hpp"
+#include "interfaces/query_responses/roles_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 using namespace integration_framework;

--- a/test/integration/acceptance/query_permission_test_acc_details.cpp
+++ b/test/integration/acceptance/query_permission_test_acc_details.cpp
@@ -5,6 +5,7 @@
 
 #include <regex>
 
+#include "interfaces/query_responses/account_detail_response.hpp"
 #include "query_permission_test_acc_details.hpp"
 
 using namespace common_constants;

--- a/test/integration/acceptance/query_permission_test_ast.cpp
+++ b/test/integration/acceptance/query_permission_test_ast.cpp
@@ -5,12 +5,13 @@
 
 #include "query_permission_test_ast.hpp"
 
+#include "interfaces/query_responses/account_asset_response.hpp"
 #include "module/shared_model/builders/common_objects/account_asset_builder.hpp"
 #include "module/shared_model/builders/protobuf/common_objects/proto_account_asset_builder.hpp"
 
-using shared_model::proto::AccountAssetBuilder;
-using shared_model::proto::AccountAsset;
 using shared_model::interface::Amount;
+using shared_model::proto::AccountAsset;
+using shared_model::proto::AccountAssetBuilder;
 using namespace common_constants;
 
 QueryPermissionAssets::QueryPermissionAssets()
@@ -41,7 +42,7 @@ IntegrationTestFramework &QueryPermissionAssets::prepareState(
       fixture, spectator_permissions, target_permissions);
 
   // Add assets to target user
-  for(const auto &asset : account_assets_) {
+  for (const auto &asset : account_assets_) {
     const std::string asset_id = asset.assetId();
     const auto domain_sep = std::find(asset_id.cbegin(), asset_id.cend(), '#');
     const std::string asset_name(asset_id.cbegin(), domain_sep);

--- a/test/integration/acceptance/query_permission_test_ast.hpp
+++ b/test/integration/acceptance/query_permission_test_ast.hpp
@@ -6,6 +6,7 @@
 #ifndef QUERY_PERMISSION_TEST_AST_HPP_
 #define QUERY_PERMISSION_TEST_AST_HPP_
 
+#include "backend/protobuf/common_objects/account_asset.hpp"
 #include "query_permission_test_base.hpp"
 
 using namespace shared_model;
@@ -14,7 +15,6 @@ using namespace shared_model::interface::permissions;
 
 class QueryPermissionAssets final : public QueryPermissionTestBase {
  public:
-
   QueryPermissionAssets();
 
   /**
@@ -49,6 +49,5 @@ class QueryPermissionAssets final : public QueryPermissionTestBase {
 
   std::vector<shared_model::proto::AccountAsset> account_assets_;
 };
-
 
 #endif /* QUERY_PERMISSION_TEST_AST_HPP_ */

--- a/test/integration/acceptance/query_permission_test_ast_txs.cpp
+++ b/test/integration/acceptance/query_permission_test_ast_txs.cpp
@@ -5,6 +5,8 @@
 
 #include "query_permission_test_ast_txs.hpp"
 
+#include "interfaces/query_responses/transactions_response.hpp"
+
 using namespace common_constants;
 
 QueryPermissionAssetTxs::QueryPermissionAssetTxs()

--- a/test/integration/acceptance/query_permission_test_signatories.cpp
+++ b/test/integration/acceptance/query_permission_test_signatories.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "query_permission_test_signatories.hpp"
+#include "interfaces/query_responses/signatories_response.hpp"
 
 using namespace common_constants;
 
@@ -29,7 +30,7 @@ IntegrationTestFramework &QueryPermissionSignatories::prepareState(
       fixture, spectator_permissions, target_permissions);
 
   // Add assets to target user
-  for(const auto &public_key : user_signatories_) {
+  for (const auto &public_key : user_signatories_) {
     itf.sendTxAwait(fixture.complete(fixture.baseTx(kUserId).addSignatory(
                                          kUserId, public_key),
                                      kUserKeypair),

--- a/test/integration/acceptance/query_permission_test_txs.cpp
+++ b/test/integration/acceptance/query_permission_test_txs.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "query_permission_test_txs.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
 
 using namespace common_constants;
 
@@ -42,7 +43,7 @@ IntegrationTestFramework &QueryPermissionTxs::prepareState(
   auto &itf = QueryPermissionTestBase::prepareState(
       fixture, spectator_permissions, target_permissions);
 
-  for (const auto& tx : user_transactions) {
+  for (const auto &tx : user_transactions) {
     itf.sendTxAwait(tx, getBlockTransactionsAmountChecker(1));
   }
 

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -6,6 +6,7 @@
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -11,6 +11,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
+#include "interfaces/query_responses/account_asset_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 using namespace integration_framework;

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -9,6 +9,7 @@
 
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
+#include "interfaces/query_responses/account_response.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 
 using namespace integration_framework;

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -9,6 +9,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
 
 using namespace std::string_literals;
 using namespace integration_framework;

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -12,7 +12,11 @@
 
 #include "backend/protobuf/proto_query_response_factory.hpp"
 #include "backend/protobuf/proto_transport_factory.hpp"
+#include "backend/protobuf/query_responses/proto_account_asset_response.hpp"
+#include "backend/protobuf/query_responses/proto_account_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/query_responses/proto_signatories_response.hpp"
+#include "backend/protobuf/query_responses/proto_transaction_response.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -20,9 +20,10 @@
 #include <gtest/gtest.h>
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/irange.hpp>
+#include "backend/protobuf/query_responses/proto_error_query_response.hpp"
+#include "common/byteutils.hpp"
 #include "cryptography/hash.hpp"
 #include "framework/specified_visitor.hpp"
-#include "common/byteutils.hpp"
 
 /**
  * @given protobuf's QueryResponse with different responses and some hash

--- a/test/regression/query_test.cpp
+++ b/test/regression/query_test.cpp
@@ -9,6 +9,8 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
+#include "interfaces/query_responses/error_query_response.hpp"
+#include "interfaces/query_responses/error_responses/stateless_failed_error_response.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"
 
 template <typename BaseType>

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -23,6 +23,7 @@
 #include "framework/common_constants.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "framework/specified_visitor.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
 
 using namespace common_constants;
 using shared_model::interface::permissions::Role;
@@ -101,8 +102,7 @@ TEST(RegressionTest, StateRecovery) {
                 .createRole(kRole, {Role::kReceive})
                 .appendRole(kUserId, kRole)
                 .addAssetQuantity(kAssetId, "133.0")
-                .transferAsset(
-                    kAdminId, kUserId, kAssetId, "descrs", "97.8")
+                .transferAsset(kAdminId, kUserId, kAssetId, "descrs", "97.8")
                 .quorum(1)
                 .build()
                 .signAndAddSignature(kAdminKeypair)
@@ -177,6 +177,5 @@ TEST(RegressionTest, DoubleCallOfDone) {
  * @then no exceptions are risen
  */
 TEST(RegressionTest, DestructionOfNonInitializedItf) {
-  integration_framework::IntegrationTestFramework itf(
-      1, {}, true);
+  integration_framework::IntegrationTestFramework itf(1, {}, true);
 }


### PR DESCRIPTION
### Description of the Change

This PR introduces Pimpl idiom for QueryResponse class. This is last shared_model object to be pimpled for now.

### Benefits

Faster build.

### Possible Drawbacks 

None.