### PR TITLE
Feature/oneof block

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -17,13 +17,14 @@
 
 #include <gflags/gflags.h>
 #include <rapidjson/istreamwrapper.h>
-#include <rapidjson/rapidjson.h>
 #include <boost/filesystem.hpp>
 #include <iostream>
 
+#include "backend/protobuf/proto_block_json_converter.hpp"
 #include "backend/protobuf/queries/proto_query.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "client.hpp"
+#include "common/result.hpp"
 #include "converters/protobuf/json_proto_converter.hpp"
 #include "crypto/keys_manager_impl.hpp"
 #include "grpc_response_handler.hpp"
@@ -122,9 +123,19 @@ int main(int argc, char *argv[]) {
     // Convert to json
     std::ofstream output_file("genesis.block");
     auto bl = shared_model::proto::Block(
-        iroha::model::converters::PbBlockFactory().serialize(block));
-    output_file << shared_model::converters::protobuf::modelToJson(bl);
-    logger->info("File saved to genesis.block");
+        iroha::model::converters::PbBlockFactory().serialize(block).block_v1());
+
+    shared_model::proto::ProtoBlockJsonConverter().serialize(bl).match(
+        [&logger,
+         &output_file](const iroha::expected::Value<std::string> &json) {
+          output_file << json.value;
+          logger->info("File saved to genesis.block");
+        },
+        [&logger](const auto &error) {
+          // should not get here
+          logger->error("error while parsing serializing genesis block");
+          std::exit(EXIT_FAILURE);
+        });
   }
   // Create new pub/priv key, register in Iroha Network
   else if (FLAGS_new_account) {

--- a/irohad/main/impl/raw_block_loader.cpp
+++ b/irohad/main/impl/raw_block_loader.cpp
@@ -33,7 +33,7 @@ namespace iroha {
 
     boost::optional<std::shared_ptr<Block>> BlockLoader::parseBlock(
         const std::string &data) {
-      return jsonToProto<iroha::protocol::Block>(data) | [](auto &&block) {
+      return jsonToProto<iroha::protocol::Block_v1>(data) | [](auto &&block) {
         return boost::optional<std::shared_ptr<Block>>(
             std::make_shared<shared_model::proto::Block>(std::move(block)));
       };

--- a/irohad/model/converters/impl/pb_block_factory.cpp
+++ b/irohad/model/converters/impl/pb_block_factory.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include <boost/assert.hpp>
 #include "model/converters/pb_block_factory.hpp"
+#include <boost/assert.hpp>
 #include "model/converters/pb_common.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
 
@@ -27,15 +27,16 @@ namespace iroha {
       protocol::Block PbBlockFactory::serialize(
           const model::Block &block) const {
         protocol::Block pb_block{};
+        auto *pb_block_v1 = pb_block.mutable_block_v1();
 
-        auto pl = pb_block.mutable_payload();
+        auto pl = pb_block_v1->mutable_payload();
         pl->set_tx_number(block.txs_number);
         pl->set_height(block.height);
         pl->set_prev_block_hash(block.prev_hash.to_string());
         pl->set_created_time(block.created_ts);
 
         for (const auto &sig_obj : block.sigs) {
-          auto sig = pb_block.add_signatures();
+          auto sig = pb_block_v1->add_signatures();
           sig->set_public_key(sig_obj.pubkey.to_string());
           sig->set_signature(sig_obj.signature.to_string());
         }
@@ -56,7 +57,9 @@ namespace iroha {
       model::Block PbBlockFactory::deserialize(
           protocol::Block const &pb_block) const {
         model::Block block{};
-        const auto &pl = pb_block.payload();
+        BOOST_ASSERT_MSG(pb_block.has_block_v1(),
+                         "Incompatible version of the block is used");
+        const auto &pl = pb_block.block_v1().payload();
 
         // in proto we use uint32, but txs_number is uint16
         auto txn_max = std::numeric_limits<decltype(block.txs_number)>::max();
@@ -69,7 +72,7 @@ namespace iroha {
         block.prev_hash = hash256_t::from_string(pl.prev_block_hash());
         block.created_ts = pl.created_time();
 
-        for (const auto &pb_sig : pb_block.signatures()) {
+        for (const auto &pb_sig : pb_block.block_v1().signatures()) {
           model::Signature sig;
           sig.signature = sig_t::from_string(pb_sig.signature());
           sig.pubkey = pubkey_t::from_string(pb_sig.public_key());
@@ -91,7 +94,7 @@ namespace iroha {
                     block.rejected_transactions_hashes.back().begin());
         }
 
-        block.hash = iroha::hash(pb_block);
+        block.hash = iroha::hash(pb_block.block_v1());
 
         return block;
       }

--- a/irohad/model/sha3_hash.cpp
+++ b/irohad/model/sha3_hash.cpp
@@ -33,7 +33,7 @@ namespace iroha {
 
   hash256_t hash(const model::Block &block) {
     auto &&pb_dat = block_factory.serialize(block);
-    return hash(pb_dat);
+    return hash(pb_dat.block_v1());
   }
 
   hash256_t hash(const model::Query &query) {

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -27,7 +27,7 @@ namespace shared_model {
   namespace proto {
     class Block final : public interface::Block {
      public:
-      using TransportType = iroha::protocol::Block;
+      using TransportType = iroha::protocol::Block_v1;
 
       Block(Block &&o) noexcept;
       Block &operator=(Block &&o) noexcept = default;
@@ -59,7 +59,7 @@ namespace shared_model {
 
       typename interface::Block::ModelType *clone() const override;
 
-      const iroha::protocol::Block &getTransport() const;
+      const iroha::protocol::Block_v1 &getTransport() const;
 
       ~Block() override;
 

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -23,7 +23,7 @@ namespace shared_model {
       Impl &operator=(Impl &&o) noexcept = delete;
 
       TransportType proto_;
-      iroha::protocol::Block::Payload &payload_{*proto_.mutable_payload()};
+      iroha::protocol::Block_v1::Payload &payload_{*proto_.mutable_payload()};
 
       std::vector<proto::Transaction> transactions_{[this] {
         return std::vector<proto::Transaction>(
@@ -134,7 +134,7 @@ namespace shared_model {
       return impl_->payload_blob_;
     }
 
-    const iroha::protocol::Block &Block::getTransport() const {
+    const iroha::protocol::Block_v1 &Block::getTransport() const {
       return impl_->proto_;
     }
 

--- a/shared_model/backend/protobuf/impl/proto_block_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_factory.cpp
@@ -21,7 +21,7 @@ ProtoBlockFactory::unsafeCreateBlock(
     interface::types::TimestampType created_time,
     const interface::types::TransactionsCollectionType &txs,
     const interface::types::HashCollectionType &rejected_hashes) {
-  iroha::protocol::Block block;
+  iroha::protocol::Block_v1 block;
   auto *block_payload = block.mutable_payload();
   block_payload->set_height(height);
   block_payload->set_prev_block_hash(crypto::toBinaryString(prev_hash));
@@ -50,7 +50,7 @@ iroha::expected::Result<std::unique_ptr<shared_model::interface::Block>,
                         std::string>
 ProtoBlockFactory::createBlock(iroha::protocol::Block block) {
   std::unique_ptr<shared_model::interface::Block> proto_block =
-      std::make_unique<Block>(std::move(block));
+      std::make_unique<Block>(std::move(block.block_v1()));
 
   auto errors = validator_->validate(*proto_block);
   if (errors) {

--- a/shared_model/backend/protobuf/impl/proto_block_json_converter.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_json_converter.cpp
@@ -16,7 +16,9 @@ using namespace shared_model::proto;
 iroha::expected::Result<interface::types::JsonType, std::string>
 ProtoBlockJsonConverter::serialize(const interface::Block &block) const
     noexcept {
-  const auto &proto_block = static_cast<const Block &>(block).getTransport();
+  const auto &proto_block_v1 = static_cast<const Block &>(block).getTransport();
+  iroha::protocol::Block proto_block;
+  *proto_block.mutable_block_v1() = proto_block_v1;
   std::string result;
   auto status =
       google::protobuf::util::MessageToJsonString(proto_block, &result);
@@ -36,6 +38,6 @@ ProtoBlockJsonConverter::deserialize(
     return iroha::expected::makeError(status.error_message());
   }
   std::unique_ptr<interface::Block> result =
-      std::make_unique<Block>(std::move(block));
+      std::make_unique<Block>(std::move(block.block_v1()));
   return iroha::expected::makeValue(std::move(result));
 }

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -260,7 +260,7 @@ shared_model::proto::ProtoQueryResponseFactory::createBlockQueryResponse(
                                      &protocol_query_response) {
     iroha::protocol::BlockResponse *protocol_specific_response =
         protocol_query_response.mutable_block_response();
-    *protocol_specific_response->mutable_block() =
+    *protocol_specific_response->mutable_block()->mutable_block_v1() =
         static_cast<shared_model::proto::Block *>(block.get())->getTransport();
   });
 }

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     BlockResponse::BlockResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           block_response_{proto_->block_response()},
-          block_{[this] { return Block(block_response_.block()); }} {}
+          block_{[this] { return Block(block_response_.block().block_v1()); }} {}
 
     template BlockResponse::BlockResponse(BlockResponse::TransportType &);
     template BlockResponse::BlockResponse(const BlockResponse::TransportType &);

--- a/shared_model/schema/block.proto
+++ b/shared_model/schema/block.proto
@@ -8,7 +8,7 @@ package iroha.protocol;
 import "primitive.proto";
 import "transaction.proto";
 
-message Block {
+message Block_v1 {
   // everything that should be signed:
   message Payload {
     repeated Transaction transactions = 1;
@@ -26,4 +26,10 @@ message Block {
 
   Payload payload = 1;
   repeated Signature signatures = 2;
+}
+
+message Block {
+  oneof block_version {
+    Block_v1 block_v1 = 1;
+  }
 }

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -90,11 +90,13 @@ class BlockQueryTest : public AmetsuchiTest {
                       .build();
 
     for (const auto &b : {std::move(block1), std::move(block2)}) {
-      file->add(b.height(),
-                iroha::stringToBytes(
-                    shared_model::converters::protobuf::modelToJson(b)));
-      index->index(b);
-      blocks_total++;
+      converter->serialize(b).match(
+          [this, &b](const iroha::expected::Value<std::string> &json) {
+            file->add(b.height(), iroha::stringToBytes(json.value));
+            index->index(b);
+            blocks_total++;
+          },
+          [](const auto &error) { FAIL() << error.error; });
     }
   }
 

--- a/test/module/irohad/torii/torii_service_query_test.cpp
+++ b/test/module/irohad/torii/torii_service_query_test.cpp
@@ -100,8 +100,9 @@ TEST_F(ToriiQueryServiceTest, FetchBlocksWhenValidQuery) {
           .finish());
 
   iroha::protocol::Block block;
-  block.mutable_payload()->set_height(123);
-  auto proto_block = std::make_unique<shared_model::proto::Block>(block);
+  block.mutable_block_v1()->mutable_payload()->set_height(123);
+  auto proto_block =
+      std::make_unique<shared_model::proto::Block>(block.block_v1());
   std::shared_ptr<shared_model::interface::BlockQueryResponse> block_response =
       shared_model::proto::ProtoQueryResponseFactory().createBlockQueryResponse(
           std::move(proto_block));

--- a/test/module/shared_model/builders/protobuf/builder_templates/block_template.hpp
+++ b/test/module/shared_model/builders/protobuf/builder_templates/block_template.hpp
@@ -48,7 +48,7 @@ namespace shared_model {
       template <int s>
       using NextBuilder = TemplateBlockBuilder<S | (1 << s), SV, BT>;
 
-      iroha::protocol::Block block_;
+      iroha::protocol::Block_v1 block_;
       SV stateless_validator_;
 
       template <int Sp, typename SVp, typename BTp>
@@ -118,7 +118,7 @@ namespace shared_model {
         auto tx_number = block_.payload().transactions().size();
         block_.mutable_payload()->set_tx_number(tx_number);
 
-        auto result = Block(iroha::protocol::Block(block_));
+        auto result = Block(iroha::protocol::Block_v1(block_));
         auto answer = stateless_validator_.validate(result);
 
         if (answer.hasErrors()) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Before it was:

```
message Block {
  // block_v1 fields
}
```

From now on it will be
```
message Block_v1 {
// block_v1 fields
}

message Block {
  oneof block_version {
    Block_v1 block_v1 = 1;
  }
}
```

Such changes would allow us to introduce Block_v2 and further versions, by simply adding them to oneof in Block message. Internally we will be able to recognize and manage different version of the blocks.

### Benefits

Iroha will be able to process different versions of the blocks.

### Possible Drawbacks 

None