### PR TITLE
Refactor tx presence cache with optional

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -95,9 +95,10 @@ namespace iroha {
       /**
        * Synchronously checks whether transaction with given hash is present in
        * any block
-       * @param hash - rejected transaction's hash
-       * @return TxCacheStatusType which returns status of transaction:
-       * Committed, Rejected or Missing
+       * @param hash - transaction's hash
+       * @return TxCacheStatusType which returns status (Committed, Rejected or
+       * Missing) of transaction if storage query was successful, boost::none
+       * otherwise
        */
       virtual boost::optional<TxCacheStatusType> checkTxPresence(
           const shared_model::crypto::Hash &hash) = 0;

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -1,27 +1,13 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_BLOCK_QUERY_HPP
 #define IROHA_BLOCK_QUERY_HPP
 
 #include <boost/optional.hpp>
-#include <cmath>
 #include <rxcpp/rx.hpp>
-
 #include "ametsuchi/tx_cache_response.hpp"
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/block.hpp"
@@ -113,7 +99,7 @@ namespace iroha {
        * @return TxCacheStatusType which returns status of transaction:
        * Committed, Rejected or Missing
        */
-      virtual TxCacheStatusType checkTxPresence(
+      virtual boost::optional<TxCacheStatusType> checkTxPresence(
           const shared_model::crypto::Hash &hash) = 0;
 
       /**

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -61,7 +61,7 @@ namespace iroha {
 
       uint32_t getTopBlockHeight() override;
 
-      TxCacheStatusType checkTxPresence(
+      boost::optional<TxCacheStatusType> checkTxPresence(
           const shared_model::crypto::Hash &hash) override;
 
       expected::Result<wBlock, std::string> getTopBlock() override;

--- a/irohad/ametsuchi/impl/tx_presence_cache_impl.cpp
+++ b/irohad/ametsuchi/impl/tx_presence_cache_impl.cpp
@@ -4,54 +4,58 @@
  */
 
 #include "ametsuchi/impl/tx_presence_cache_impl.hpp"
+
+#include "common/bind.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
-#include "tx_presence_cache_impl.hpp"
 
 namespace iroha {
   namespace ametsuchi {
     TxPresenceCacheImpl::TxPresenceCacheImpl(std::shared_ptr<Storage> storage)
         : storage_(std::move(storage)) {}
 
-    TxCacheStatusType TxPresenceCacheImpl::check(
+    boost::optional<TxCacheStatusType> TxPresenceCacheImpl::check(
         const shared_model::crypto::Hash &hash) const {
       auto res = memory_cache_.findItem(hash);
-      if (res != boost::none) {
-        return res.get();
+      if (res) {
+        return *res;
       }
       return checkInStorage(hash);
     }
 
-    TxPresenceCache::BatchStatusCollectionType TxPresenceCacheImpl::check(
+    boost::optional<TxPresenceCache::BatchStatusCollectionType>
+    TxPresenceCacheImpl::check(
         const shared_model::interface::TransactionBatch &batch) const {
       TxPresenceCache::BatchStatusCollectionType batch_statuses;
       for (const auto &tx : batch.transactions()) {
-        batch_statuses.emplace_back(check(tx->hash()));
+        if (auto status = check(tx->hash())) {
+          batch_statuses.emplace_back(*status);
+        } else {
+          return boost::none;
+        }
       }
       return batch_statuses;
     }
 
-    TxCacheStatusType TxPresenceCacheImpl::checkInStorage(
+    boost::optional<TxCacheStatusType> TxPresenceCacheImpl::checkInStorage(
         const shared_model::crypto::Hash &hash) const {
-      TxCacheStatusType cache_status_check;
-      auto check_status = storage_->getBlockQuery()->checkTxPresence(hash);
-      visit_in_place(check_status,
-                     [&](const tx_cache_status_responses::Committed &status) {
-                       memory_cache_.addItem(hash, status);
-                       cache_status_check = status;
-                     },
-                     [&](const tx_cache_status_responses::Rejected &status) {
-                       memory_cache_.addItem(hash, status);
-                       cache_status_check = status;
-                     },
-                     [&](const tx_cache_status_responses::Missing &status) {
-                       // don't put this hash into cache since "Missing" can
-                       // become "Committed" or "Rejected" later
-                       cache_status_check = status;
-                     });
-
-      return cache_status_check;
+      auto block_query = storage_->getBlockQuery();
+      if (not block_query) {
+        return boost::none;
+      }
+      return block_query->checkTxPresence(hash) |
+          [this, &hash](const auto &status) {
+            visit_in_place(status,
+                           [](const tx_cache_status_responses::Missing &) {
+                             // don't put this hash into cache since "Missing"
+                             // can become "Committed" or "Rejected" later
+                           },
+                           [this, &hash](const auto &status) {
+                             memory_cache_.addItem(hash, status);
+                           });
+            return status;
+          };
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
+++ b/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
@@ -17,10 +17,10 @@ namespace iroha {
      public:
       explicit TxPresenceCacheImpl(std::shared_ptr<Storage> storage);
 
-      TxCacheStatusType check(
+      boost::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const override;
 
-      BatchStatusCollectionType check(
+      boost::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch)
           const override;
 
@@ -30,7 +30,7 @@ namespace iroha {
        * @param hash to check
        * @return hash status
        */
-      TxCacheStatusType checkInStorage(
+      boost::optional<TxCacheStatusType> checkInStorage(
           const shared_model::crypto::Hash &hash) const;
 
       std::shared_ptr<Storage> storage_;

--- a/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
+++ b/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
@@ -28,7 +28,8 @@ namespace iroha {
       /**
        * Performs an actual storage request about hash status
        * @param hash to check
-       * @return hash status
+       * @return hash status if storage query was successful, boost::none
+       * otherwise
        */
       boost::optional<TxCacheStatusType> checkInStorage(
           const shared_model::crypto::Hash &hash) const;

--- a/irohad/ametsuchi/tx_presence_cache.hpp
+++ b/irohad/ametsuchi/tx_presence_cache.hpp
@@ -31,6 +31,8 @@ namespace iroha {
      public:
       /**
        * Check transaction status by hash
+       * @return transaction status if storage query was successful, boost::none
+       * otherwise
        */
       virtual boost::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const = 0;
@@ -41,6 +43,7 @@ namespace iroha {
       /**
        * Check batch status
        * @return a collection with answers about each transaction in the batch
+       * if storage queries were successful, boost::none otherwise
        */
       virtual boost::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch) const = 0;

--- a/irohad/ametsuchi/tx_presence_cache.hpp
+++ b/irohad/ametsuchi/tx_presence_cache.hpp
@@ -8,6 +8,7 @@
 
 #include <vector>
 
+#include <boost/optional.hpp>
 #include "ametsuchi/tx_cache_response.hpp"
 
 namespace shared_model {
@@ -31,7 +32,7 @@ namespace iroha {
       /**
        * Check transaction status by hash
        */
-      virtual TxCacheStatusType check(
+      virtual boost::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const = 0;
 
       /// response type which reflects status of each transaction in a batch
@@ -41,7 +42,7 @@ namespace iroha {
        * Check batch status
        * @return a collection with answers about each transaction in the batch
        */
-      virtual BatchStatusCollectionType check(
+      virtual boost::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch) const = 0;
 
       // TODO: 09/11/2018 @muratovv add method for processing collection of

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -82,7 +82,10 @@ grpc::Status MstTransportGrpc::SendState(
                 shared_model::interface::TransactionBatch>> &value) {
           auto cache_presence = tx_presence_cache_->check(*value.value);
           if (not cache_presence) {
-            // TODO handle
+            // TODO andrei 30.11.18 IR-51 Handle database error
+            async_call_->log_->warn(
+                "Check tx presence database error. Batch: {}",
+                value.value->toString());
             return;
           }
           auto is_replay = std::any_of(

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -81,9 +81,13 @@ grpc::Status MstTransportGrpc::SendState(
         [&](iroha::expected::Value<std::unique_ptr<
                 shared_model::interface::TransactionBatch>> &value) {
           auto cache_presence = tx_presence_cache_->check(*value.value);
+          if (not cache_presence) {
+            // TODO handle
+            return;
+          }
           auto is_replay = std::any_of(
-              cache_presence.begin(),
-              cache_presence.end(),
+              cache_presence->begin(),
+              cache_presence->end(),
               [](const auto &tx_status) {
                 return iroha::visit_in_place(
                     tx_status,

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -91,7 +91,7 @@ OnDemandOrderingGate::removeReplays(
   auto tx_is_not_processed = [this](const auto &tx) {
     auto tx_result = tx_cache_->check(tx.hash());
     if (not tx_result) {
-      // TODO handle
+      // TODO andrei 30.11.18 IR-51 Handle database error
       return false;
     }
     return iroha::visit_in_place(

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -90,8 +90,12 @@ OnDemandOrderingGate::removeReplays(
     shared_model::interface::Proposal &&proposal) const {
   auto tx_is_not_processed = [this](const auto &tx) {
     auto tx_result = tx_cache_->check(tx.hash());
+    if (not tx_result) {
+      // TODO handle
+      return false;
+    }
     return iroha::visit_in_place(
-        tx_result,
+        *tx_result,
         [](const ametsuchi::tx_cache_status_responses::Missing &) {
           return true;
         },

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -202,13 +202,19 @@ void OnDemandOrderingServiceImpl::tryErase() {
     round_queue_.pop();
   }
 }
+
 bool OnDemandOrderingServiceImpl::batchAlreadyProcessed(
     const shared_model::interface::TransactionBatch &batch) {
   auto tx_statuses = tx_cache_->check(batch);
+  if (not tx_statuses) {
+    // TODO handle
+    log_->warn("Check tx presence database error. Batch: {}", batch.toString());
+    return true;
+  }
   // if any transaction is commited or rejected, batch was already processed
   // Note: any_of returns false for empty sequence
   return std::any_of(
-      tx_statuses.begin(), tx_statuses.end(), [this](const auto &tx_status) {
+      tx_statuses->begin(), tx_statuses->end(), [this](const auto &tx_status) {
         if (iroha::ametsuchi::isAlreadyProcessed(tx_status)) {
           log_->warn("Duplicate transaction: {}",
                      iroha::ametsuchi::getHash(tx_status).hex());

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -207,7 +207,7 @@ bool OnDemandOrderingServiceImpl::batchAlreadyProcessed(
     const shared_model::interface::TransactionBatch &batch) {
   auto tx_statuses = tx_cache_->check(batch);
   if (not tx_statuses) {
-    // TODO handle
+    // TODO andrei 30.11.18 IR-51 Handle database error
     log_->warn("Check tx presence database error. Batch: {}", batch.toString());
     return true;
   }

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -54,9 +54,22 @@ namespace torii {
       return cached.value();
     }
 
+    auto block_query = storage_->getBlockQuery();
+    if (not block_query) {
+      // TODO handle
+      log_->warn("Could not create block query. Tx: {}", request.hex());
+      return status_factory_->makeNotReceived(request, "");
+    }
+
     auto status = storage_->getBlockQuery()->checkTxPresence(request);
+    if (not status) {
+      // TODO handle
+      log_->warn("Check tx presence database error. Tx: {}", request.hex());
+      return status_factory_->makeNotReceived(request, "");
+    }
+
     return iroha::visit_in_place(
-        status,
+        *status,
         [this,
          &request](const iroha::ametsuchi::tx_cache_status_responses::Missing &)
             -> std::shared_ptr<shared_model::interface::TransactionResponse> {

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -56,14 +56,14 @@ namespace torii {
 
     auto block_query = storage_->getBlockQuery();
     if (not block_query) {
-      // TODO handle
+      // TODO andrei 30.11.18 IR-51 Handle database error
       log_->warn("Could not create block query. Tx: {}", request.hex());
       return status_factory_->makeNotReceived(request, "");
     }
 
     auto status = storage_->getBlockQuery()->checkTxPresence(request);
     if (not status) {
-      // TODO handle
+      // TODO andrei 30.11.18 IR-51 Handle database error
       log_->warn("Check tx presence database error. Tx: {}", request.hex());
       return status_factory_->makeNotReceived(request, "");
     }

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -8,7 +8,6 @@
 
 #include <gmock/gmock.h>
 #include <boost/optional.hpp>
-
 #include "ametsuchi/block_query.hpp"
 #include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/key_value_storage.hpp"
@@ -173,7 +172,8 @@ namespace iroha {
       MOCK_METHOD1(getTopBlocks, std::vector<BlockQuery::wBlock>(uint32_t));
       MOCK_METHOD0(getTopBlock, expected::Result<wBlock, std::string>(void));
       MOCK_METHOD1(checkTxPresence,
-                   TxCacheStatusType(const shared_model::crypto::Hash &));
+                   boost::optional<TxCacheStatusType>(
+                       const shared_model::crypto::Hash &));
       MOCK_METHOD0(getTopBlockHeight, uint32_t(void));
     };
 
@@ -330,12 +330,12 @@ namespace iroha {
     class MockTxPresenceCache : public iroha::ametsuchi::TxPresenceCache {
      public:
       MOCK_CONST_METHOD1(check,
-                         iroha::ametsuchi::TxCacheStatusType(
+                         boost::optional<TxCacheStatusType>(
                              const shared_model::crypto::Hash &hash));
 
       MOCK_CONST_METHOD1(
           check,
-          iroha::ametsuchi::TxPresenceCache::BatchStatusCollectionType(
+          boost::optional<TxPresenceCache::BatchStatusCollectionType>(
               const shared_model::interface::TransactionBatch &));
     };
 

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -1,30 +1,18 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
+#include "ametsuchi/impl/postgres_block_query.hpp"
 
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
-#include <framework/specified_visitor.hpp>
-
 #include "ametsuchi/impl/postgres_block_index.hpp"
-#include "ametsuchi/impl/postgres_block_query.hpp"
 #include "backend/protobuf/proto_block_json_converter.hpp"
 #include "common/byteutils.hpp"
 #include "converters/protobuf/json_proto_converter.hpp"
 #include "framework/result_fixture.hpp"
+#include "framework/specified_visitor.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
@@ -358,7 +346,7 @@ TEST_F(BlockQueryTest, HasTxWithExistingHash) {
   for (const auto &hash : tx_hashes) {
     ASSERT_NO_THROW({
       auto status = boost::get<tx_cache_status_responses::Committed>(
-          blocks->checkTxPresence(hash));
+          *blocks->checkTxPresence(hash));
       ASSERT_EQ(status.hash, hash);
     });
   }
@@ -374,7 +362,7 @@ TEST_F(BlockQueryTest, HasTxWithMissingHash) {
   shared_model::crypto::Hash missing_tx_hash(zero_string);
   ASSERT_NO_THROW({
     auto status = boost::get<tx_cache_status_responses::Missing>(
-        blocks->checkTxPresence(missing_tx_hash));
+        *blocks->checkTxPresence(missing_tx_hash));
     ASSERT_EQ(status.hash, missing_tx_hash);
   });
 }
@@ -388,7 +376,7 @@ TEST_F(BlockQueryTest, HasTxWithMissingHash) {
 TEST_F(BlockQueryTest, HasTxWithRejectedHash) {
   ASSERT_NO_THROW({
     auto status = boost::get<tx_cache_status_responses::Rejected>(
-        blocks->checkTxPresence(rejected_hash));
+        *blocks->checkTxPresence(rejected_hash));
     ASSERT_EQ(status.hash, rejected_hash);
   });
 }

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -35,7 +35,8 @@ struct OnDemandOrderingGateTest : public ::testing::Test {
     ON_CALL(*tx_cache,
             check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
         .WillByDefault(
-            Return(iroha::ametsuchi::tx_cache_status_responses::Missing()));
+            Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
+                iroha::ametsuchi::tx_cache_status_responses::Missing())));
     ordering_gate =
         std::make_shared<OnDemandOrderingGate>(ordering_service,
                                                notification,
@@ -222,8 +223,8 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
       .WillOnce(Return(ByMove(std::move(arriving_proposal))));
   EXPECT_CALL(*tx_cache,
               check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
-      .WillOnce(
-          Return(iroha::ametsuchi::tx_cache_status_responses::Committed()));
+      .WillOnce(Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
+          iroha::ametsuchi::tx_cache_status_responses::Committed())));
   // expect proposal to be created without any transactions because it was
   // removed by tx cache
   EXPECT_CALL(

--- a/test/module/irohad/torii/torii_service_test.cpp
+++ b/test/module/irohad/torii/torii_service_test.cpp
@@ -220,7 +220,8 @@ TEST_F(ToriiServiceTest, StatusWhenTxWasNotReceivedBlocking) {
 
   ON_CALL(*block_query, checkTxPresence(_))
       .WillByDefault(
-          Return(iroha::ametsuchi::tx_cache_status_responses::Missing()));
+          Return(boost::make_optional<iroha::ametsuchi::TxCacheStatusType>(
+              iroha::ametsuchi::tx_cache_status_responses::Missing())));
 
   // create transactions, but do not send them
   for (size_t i = 0; i < TimesToriiBlocking; ++i) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
- Since it is not possible to create block query from storage after it has been dropped, each `getBlockQuery` call should be checked for `nullptr` after call.
- It is also possible to catch an exception when SQL query is executed. `PostgresBlockQuery::checkTxPresence` is refactored with try-catch for this reason.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Less possible segmentation faults and uncaught exceptions.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
More checks in code.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs *[optional]*
It is possible to use `Result` instead of optional in `PostgresBlockQuery::checkTxPresence`, however is will be more difficult to handle it in calling methods.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
