### PR TITLE
Query Stateful Validation Error Codes

### DIFF
--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -41,6 +41,10 @@ namespace iroha {
     using QueryErrorType =
         shared_model::interface::QueryResponseFactory::ErrorQueryType;
 
+    using ErrorQueryResponse = shared_model::interface::ErrorQueryResponse;
+    using QueryErrorMessageType = ErrorQueryResponse::ErrorMessageType;
+    using QueryErrorCodeType = ErrorQueryResponse::ErrorCodeType;
+
     class PostgresQueryExecutorVisitor
         : public boost::static_visitor<QueryExecutorResult> {
      public:
@@ -129,12 +133,14 @@ namespace iroha {
       /**
        * Create a query error response and log it
        * @param error_type - type of query error
-       * @param error body as string message
+       * @param error_body - stringified error of the query
+       * @param error_code of the query
        * @return ptr to created error response
        */
       std::unique_ptr<shared_model::interface::QueryResponse>
       logAndReturnErrorResponse(iroha::ametsuchi::QueryErrorType error_type,
-                                std::string error_body) const;
+                                QueryErrorMessageType error_body,
+                                QueryErrorCodeType error_code) const;
 
       soci::session &sql_;
       KeyValueStorage &block_store_;

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -60,10 +60,13 @@ namespace iroha {
     std::unique_ptr<shared_model::interface::QueryResponse>
     QueryProcessorImpl::queryHandle(const shared_model::interface::Query &qry) {
       if (not checkSignatories(qry)) {
+        // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 3
+        // with a named constant
         return response_factory_->createErrorQueryResponse(
             shared_model::interface::QueryResponseFactory::ErrorQueryType::
                 kStatefulFailed,
             "query signatories did not pass validation",
+            3,
             qry.hash());
       }
 

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "backend/protobuf/proto_query_response_factory.hpp"
+
 #include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
@@ -117,10 +118,11 @@ shared_model::proto::ProtoQueryResponseFactory::createAccountResponse(
 std::unique_ptr<shared_model::interface::QueryResponse>
 shared_model::proto::ProtoQueryResponseFactory::createErrorQueryResponse(
     ErrorQueryType error_type,
-    std::string error_msg,
+    interface::ErrorQueryResponse::ErrorMessageType error_msg,
+    interface::ErrorQueryResponse::ErrorCodeType error_code,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
-      [error_type, error_msg = std::move(error_msg)](
+      [error_type, error_msg = std::move(error_msg), error_code](
           iroha::protocol::QueryResponse &protocol_query_response) mutable {
         iroha::protocol::ErrorResponse_Reason reason;
         switch (error_type) {
@@ -156,6 +158,7 @@ shared_model::proto::ProtoQueryResponseFactory::createErrorQueryResponse(
             protocol_query_response.mutable_error_response();
         protocol_specific_response->set_reason(reason);
         protocol_specific_response->set_message(std::move(error_msg));
+        protocol_specific_response->set_error_code(error_code);
       },
       query_hash);
 }

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -33,7 +33,8 @@ namespace shared_model {
 
       std::unique_ptr<interface::QueryResponse> createErrorQueryResponse(
           ErrorQueryType error_type,
-          std::string error_msg,
+          interface::ErrorQueryResponse::ErrorMessageType error_msg,
+          interface::ErrorQueryResponse::ErrorCodeType error_code,
           const crypto::Hash &query_hash) const override;
 
       std::unique_ptr<interface::QueryResponse> createSignatoriesResponse(

--- a/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
@@ -51,5 +51,9 @@ namespace shared_model {
       return proto_->error_response().message();
     }
 
+    ErrorQueryResponse::ErrorCodeType ErrorQueryResponse::errorCode() const {
+      return proto_->error_response().error_code();
+    }
+
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -58,6 +58,8 @@ namespace shared_model {
 
       const ErrorMessageType &errorMessage() const override;
 
+      ErrorCodeType errorCode() const override;
+
      private:
       /// lazy variant shortcut
       template <typename T>

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -13,6 +13,7 @@
 #include "interfaces/permissions.hpp"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "interfaces/query_responses/query_response.hpp"
+#include "interfaces/query_responses/error_query_response.hpp"
 
 namespace shared_model {
   namespace crypto {
@@ -92,12 +93,14 @@ namespace shared_model {
        * Create response for failed query
        * @param error_type - type of error to be inserted into the response
        * @param error_msg - message, which is to be set in the response
+       * @param error_code - stateful error code to be set in the response
        * @param query_hash - hash of the query, for which response is created
        * @return error response
        */
       virtual std::unique_ptr<QueryResponse> createErrorQueryResponse(
           ErrorQueryType error_type,
-          std::string error_msg,
+          ErrorQueryResponse::ErrorMessageType error_msg,
+          ErrorQueryResponse::ErrorCodeType error_code,
           const crypto::Hash &query_hash) const = 0;
 
       /**

--- a/shared_model/interfaces/query_responses/error_query_response.hpp
+++ b/shared_model/interfaces/query_responses/error_query_response.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_SHARED_MODEL_QUERY_ERROR_RESPONSE_HPP
@@ -77,9 +65,10 @@ namespace shared_model {
 
       /**
        * @return stateful error code of this query response:
-       *    0 - no stateful error
+       *    0 - error is in query's type, it is not a stateful one
        *    1 - internal error
        *    2 - not enough permissions
+       *    3 - invalid signatures
        */
       virtual ErrorCodeType errorCode() const = 0;
 

--- a/shared_model/interfaces/query_responses/error_query_response.hpp
+++ b/shared_model/interfaces/query_responses/error_query_response.hpp
@@ -72,6 +72,17 @@ namespace shared_model {
        */
       virtual const ErrorMessageType &errorMessage() const = 0;
 
+      /// Error code type
+      using ErrorCodeType = uint32_t;
+
+      /**
+       * @return stateful error code of this query response:
+       *    0 - no stateful error
+       *    1 - internal error
+       *    2 - not enough permissions
+       */
+      virtual ErrorCodeType errorCode() const = 0;
+
       // ------------------------| Primitive override |-------------------------
 
       std::string toString() const override;

--- a/shared_model/interfaces/query_responses/impl/error_query_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/error_query_response.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "interfaces/query_responses/error_query_response.hpp"
+
 #include "utils/visitor_apply_for_all.hpp"
 
 namespace shared_model {

--- a/shared_model/schema/qry_responses.proto
+++ b/shared_model/schema/qry_responses.proto
@@ -74,6 +74,7 @@ message ErrorResponse {
   }
   Reason reason = 1;
   string message = 2;
+  uint32 error_code = 3;
 }
 
 message SignatoriesResponse {

--- a/test/module/iroha-cli/client_test.cpp
+++ b/test/module/iroha-cli/client_test.cpp
@@ -440,6 +440,7 @@ TEST_F(ClientServerTest, SendQueryWhenStatefulInvalid) {
                        shared_model::interface::QueryResponseFactory::
                            ErrorQueryType::kStatefulFailed,
                        "",
+                       1,
                        query.hash())
                    .release();
 

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -192,7 +192,7 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
 
   auto *r = query_response_factory
                 ->createErrorQueryResponse(
-                    ErrorQueryType::kStatefulFailed, "", model_query.hash())
+                    ErrorQueryType::kStatefulFailed, "", 2, model_query.hash())
                 .release();
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
@@ -332,7 +332,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   auto *r = query_response_factory
                 ->createErrorQueryResponse(
-                    ErrorQueryType::kStatefulFailed, "", model_query.hash())
+                    ErrorQueryType::kStatefulFailed, "", 2, model_query.hash())
                 .release();
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
@@ -435,7 +435,7 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
 
   auto *r = query_response_factory
                 ->createErrorQueryResponse(
-                    ErrorQueryType::kStatefulFailed, "", model_query.hash())
+                    ErrorQueryType::kStatefulFailed, "", 2, model_query.hash())
                 .release();
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))


### PR DESCRIPTION
### Description of the Change

Commands have set of stateful validation error codes, but queries still had just error messages. This PR introduces error codes, described in the following [POW](https://soramitsu.atlassian.net/wiki/spaces/IS/pages/439189508/POW+N+075+Stateful+response).

### Benefits

Unified way to pass error message to the client.

### Possible Drawbacks 

None.