### PR TITLE
Proto Validation for Block

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -29,6 +29,7 @@
 #include "torii/impl/command_service_impl.hpp"
 #include "torii/impl/status_bus_impl.hpp"
 #include "validators/field_validator.hpp"
+#include "validators/protobuf/proto_block_validator.hpp"
 #include "validators/protobuf/proto_query_validator.hpp"
 #include "validators/protobuf/proto_transaction_validator.hpp"
 
@@ -260,7 +261,8 @@ void Irohad::initSimulator() {
       //  are validated in the ordering gate, where they are received from the
       //  ordering service.
       std::make_unique<
-          shared_model::validation::DefaultUnsignedBlockValidator>());
+          shared_model::validation::DefaultUnsignedBlockValidator>(),
+      std::make_unique<shared_model::validation::ProtoBlockValidator>());
   simulator = std::make_shared<Simulator>(ordering_gate,
                                           stateful_validator,
                                           storage,

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -17,6 +17,7 @@
 
 #include "main/impl/block_loader_init.hpp"
 #include "validators/default_validator.hpp"
+#include "validators/protobuf/proto_block_validator.hpp"
 
 using namespace iroha;
 using namespace iroha::ametsuchi;
@@ -33,8 +34,8 @@ auto BlockLoaderInit::createLoader(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     std::shared_ptr<BlockQueryFactory> block_query_factory) {
   shared_model::proto::ProtoBlockFactory factory(
-      std::make_unique<
-          shared_model::validation::DefaultSignedBlockValidator>());
+      std::make_unique<shared_model::validation::DefaultSignedBlockValidator>(),
+      std::make_unique<shared_model::validation::ProtoBlockValidator>());
   return std::make_shared<BlockLoaderImpl>(
       peer_query_factory, block_query_factory, std::move(factory));
 }

--- a/shared_model/backend/protobuf/impl/proto_block_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_factory.cpp
@@ -11,8 +11,12 @@ using namespace shared_model::proto;
 
 ProtoBlockFactory::ProtoBlockFactory(
     std::unique_ptr<shared_model::validation::AbstractValidator<
-        shared_model::interface::Block>> validator)
-    : validator_(std::move(validator)){};
+        shared_model::interface::Block>> interface_validator,
+    std::unique_ptr<
+        shared_model::validation::AbstractValidator<iroha::protocol::Block>>
+        proto_validator)
+    : interface_validator_{std::move(interface_validator)},
+      proto_validator_{std::move(proto_validator)} {}
 
 std::unique_ptr<shared_model::interface::Block>
 ProtoBlockFactory::unsafeCreateBlock(
@@ -49,12 +53,15 @@ ProtoBlockFactory::unsafeCreateBlock(
 iroha::expected::Result<std::unique_ptr<shared_model::interface::Block>,
                         std::string>
 ProtoBlockFactory::createBlock(iroha::protocol::Block block) {
-  std::unique_ptr<shared_model::interface::Block> proto_block =
-      std::make_unique<Block>(std::move(block.block_v1()));
-
-  auto errors = validator_->validate(*proto_block);
-  if (errors) {
+  if (auto errors = proto_validator_->validate(block)) {
     return iroha::expected::makeError(errors.reason());
   }
+
+  std::unique_ptr<shared_model::interface::Block> proto_block =
+      std::make_unique<Block>(std::move(block.block_v1()));
+  if (auto errors = interface_validator_->validate(*proto_block)) {
+    return iroha::expected::makeError(errors.reason());
+  }
+
   return iroha::expected::makeValue(std::move(proto_block));
 }

--- a/shared_model/backend/protobuf/proto_block_factory.hpp
+++ b/shared_model/backend/protobuf/proto_block_factory.hpp
@@ -19,9 +19,11 @@ namespace shared_model {
      */
     class ProtoBlockFactory : public interface::UnsafeBlockFactory {
      public:
-      explicit ProtoBlockFactory(
+      ProtoBlockFactory(
           std::unique_ptr<shared_model::validation::AbstractValidator<
-              shared_model::interface::Block>> validator);
+              shared_model::interface::Block>> interface_validator,
+          std::unique_ptr<shared_model::validation::AbstractValidator<
+              iroha::protocol::Block>> proto_validator);
 
       std::unique_ptr<interface::Block> unsafeCreateBlock(
           interface::types::HeightType height,
@@ -34,7 +36,7 @@ namespace shared_model {
        * Create block variant
        *
        * @param block - proto block from which block variant is created
-       * @return BlockVariant with block.
+       * @return Pointer to block.
        *         Error if block is invalid
        */
       iroha::expected::Result<std::unique_ptr<interface::Block>, std::string>
@@ -43,7 +45,10 @@ namespace shared_model {
      private:
       std::unique_ptr<shared_model::validation::AbstractValidator<
           shared_model::interface::Block>>
-          validator_;
+          interface_validator_;
+      std::unique_ptr<
+          shared_model::validation::AbstractValidator<iroha::protocol::Block>>
+          proto_validator_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/validators/CMakeLists.txt
+++ b/shared_model/validators/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(shared_model_stateless_validation
         field_validator.cpp
         transactions_collection/transactions_collection_validator.cpp
         transactions_collection/batch_order_validator.cpp
+        protobuf/proto_block_validator.cpp
         )
 
 target_link_libraries(shared_model_stateless_validation

--- a/shared_model/validators/protobuf/proto_block_validator.cpp
+++ b/shared_model/validators/protobuf/proto_block_validator.cpp
@@ -1,0 +1,32 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "validators/protobuf/proto_block_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+    Answer ProtoBlockValidator::validateProtoBlock(
+        const iroha::protocol::Block &block) const {
+      Answer answer;
+      std::string tx_reason_name = "Protobuf Block";
+      ReasonsGroupType reason{tx_reason_name, GroupedReasons()};
+
+      // make sure version one_of field of the Block is set
+      if (block.block_version_case()
+          == iroha::protocol::Block::BLOCK_VERSION_NOT_SET) {
+        reason.second.emplace_back("Block version is not set");
+        answer.addReason(std::move(reason));
+        return answer;
+      }
+
+      return answer;
+    }
+
+    Answer ProtoBlockValidator::validate(
+        const iroha::protocol::Block &block) const {
+      return validateProtoBlock(block);
+    }
+  }  // namespace validation
+}  // namespace shared_model

--- a/shared_model/validators/protobuf/proto_block_validator.cpp
+++ b/shared_model/validators/protobuf/proto_block_validator.cpp
@@ -7,7 +7,7 @@
 
 namespace shared_model {
   namespace validation {
-    Answer ProtoBlockValidator::validateProtoBlock(
+    Answer ProtoBlockValidator::validate(
         const iroha::protocol::Block &block) const {
       Answer answer;
       std::string tx_reason_name = "Protobuf Block";
@@ -22,11 +22,6 @@ namespace shared_model {
       }
 
       return answer;
-    }
-
-    Answer ProtoBlockValidator::validate(
-        const iroha::protocol::Block &block) const {
-      return validateProtoBlock(block);
     }
   }  // namespace validation
 }  // namespace shared_model

--- a/shared_model/validators/protobuf/proto_block_validator.hpp
+++ b/shared_model/validators/protobuf/proto_block_validator.hpp
@@ -6,37 +6,20 @@
 #ifndef IROHA_PROTO_BLOCK_VALIDATOR_HPP
 #define IROHA_PROTO_BLOCK_VALIDATOR_HPP
 
-#include "validators/abstract_validator.hpp"
-
 #include "block.pb.h"
+#include "validators/abstract_validator.hpp"
 
 namespace shared_model {
   namespace validation {
     class ProtoBlockValidator
         : public AbstractValidator<iroha::protocol::Block> {
      private:
-      Answer validateProtoBlock(const iroha::protocol::Block &block) const {
-        Answer answer;
-        std::string tx_reason_name = "Protobuf Block";
-        ReasonsGroupType reason{tx_reason_name, GroupedReasons()};
-
-        // make sure version one_of field of the Block is set
-        if (block.block_version_case()
-            == iroha::protocol::Block::BLOCK_VERSION_NOT_SET) {
-          reason.second.emplace_back("Block version is not set");
-          answer.addReason(std::move(reason));
-          return answer;
-        }
-
-        return answer;
-      }
+      Answer validateProtoBlock(const iroha::protocol::Block &block) const;
 
      public:
-      Answer validate(const iroha::protocol::Block &block) const override {
-        return validateProtoBlock(block);
-      }
+      Answer validate(const iroha::protocol::Block &block) const override;
     };
-  };  // namespace validation
+  }  // namespace validation
 }  // namespace shared_model
 
 #endif  // IROHA_PROTO_BLOCK_VALIDATOR_HPP

--- a/shared_model/validators/protobuf/proto_block_validator.hpp
+++ b/shared_model/validators/protobuf/proto_block_validator.hpp
@@ -13,9 +13,6 @@ namespace shared_model {
   namespace validation {
     class ProtoBlockValidator
         : public AbstractValidator<iroha::protocol::Block> {
-     private:
-      Answer validateProtoBlock(const iroha::protocol::Block &block) const;
-
      public:
       Answer validate(const iroha::protocol::Block &block) const override;
     };

--- a/shared_model/validators/protobuf/proto_block_validator.hpp
+++ b/shared_model/validators/protobuf/proto_block_validator.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PROTO_BLOCK_VALIDATOR_HPP
+#define IROHA_PROTO_BLOCK_VALIDATOR_HPP
+
+#include "validators/abstract_validator.hpp"
+
+#include "block.pb.h"
+
+namespace shared_model {
+  namespace validation {
+    class ProtoBlockValidator
+        : public AbstractValidator<iroha::protocol::Block> {
+     private:
+      Answer validateProtoBlock(const iroha::protocol::Block &block) const {
+        Answer answer;
+        std::string tx_reason_name = "Protobuf Block";
+        ReasonsGroupType reason{tx_reason_name, GroupedReasons()};
+
+        // make sure version one_of field of the Block is set
+        if (block.block_version_case()
+            == iroha::protocol::Block::BLOCK_VERSION_NOT_SET) {
+          reason.second.emplace_back("Block version is not set");
+          answer.addReason(std::move(reason));
+          return answer;
+        }
+
+        return answer;
+      }
+
+     public:
+      Answer validate(const iroha::protocol::Block &block) const override {
+        return validateProtoBlock(block);
+      }
+    };
+  };  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_PROTO_BLOCK_VALIDATOR_HPP

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -69,7 +69,9 @@ class BlockLoaderTest : public testing::Test {
     loader = std::make_shared<BlockLoaderImpl>(
         peer_query_factory,
         block_query_factory,
-        shared_model::proto::ProtoBlockFactory(std::move(validator_ptr)));
+        shared_model::proto::ProtoBlockFactory(
+            std::move(validator_ptr),
+            std::make_unique<MockValidator<iroha::protocol::Block>>()));
     service =
         std::make_shared<BlockLoaderService>(block_query_factory, block_cache);
 

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -32,9 +32,9 @@ using namespace framework::test_subscriber;
 using ::testing::_;
 using ::testing::A;
 using ::testing::Invoke;
+using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnArg;
-using ::testing::NiceMock;
 
 using wBlock = std::shared_ptr<shared_model::interface::Block>;
 
@@ -56,7 +56,9 @@ class SimulatorTest : public ::testing::Test {
             std::shared_ptr<iroha::ametsuchi::BlockQuery>(query))));
     block_factory = std::make_unique<shared_model::proto::ProtoBlockFactory>(
         std::make_unique<shared_model::validation::MockValidator<
-            shared_model::interface::Block>>());
+            shared_model::interface::Block>>(),
+        std::make_unique<
+            shared_model::validation::MockValidator<iroha::protocol::Block>>());
   }
 
   void TearDown() override {
@@ -307,7 +309,8 @@ TEST_F(SimulatorTest, SomeFailingTxs) {
   for (auto rejected_tx = txs.begin() + 1; rejected_tx != txs.end();
        ++rejected_tx) {
     verified_proposal_and_errors->rejected_transactions.emplace(
-        rejected_tx->hash(), validation::CommandError{"SomeCommand", 1, "", true});
+        rejected_tx->hash(),
+        validation::CommandError{"SomeCommand", 1, "", true});
   }
   shared_model::proto::Block block = makeBlock(proposal->height() - 1);
 

--- a/test/module/shared_model/backend_proto/proto_block_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_block_factory_test.cpp
@@ -16,14 +16,14 @@ using namespace shared_model;
 class ProtoBlockFactoryTest : public ::testing::Test {
  public:
   std::unique_ptr<proto::ProtoBlockFactory> factory;
-  validation::MockValidator<interface::Block> *validator;
 
   ProtoBlockFactoryTest() {
-    auto validator_ptr =
+    auto interface_validator =
         std::make_unique<validation::MockValidator<interface::Block>>();
-    validator = validator_ptr.get();
-    factory =
-        std::make_unique<proto::ProtoBlockFactory>(std::move(validator_ptr));
+    auto proto_validator =
+        std::make_unique<validation::MockValidator<iroha::protocol::Block>>();
+    factory = std::make_unique<proto::ProtoBlockFactory>(
+        std::move(interface_validator), std::move(proto_validator));
   }
 };
 

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -69,3 +69,11 @@ target_link_libraries(proto_transaction_validator_test
     shared_model_proto_backend
     shared_model_stateless_validation
     )
+
+addtest(proto_block_validator_test
+    protobuf/proto_block_validator_test.cpp
+    )
+target_link_libraries(proto_block_validator_test
+    shared_model_proto_backend
+    shared_model_stateless_validation
+    )

--- a/test/module/shared_model/validators/protobuf/proto_block_validator_test.cpp
+++ b/test/module/shared_model/validators/protobuf/proto_block_validator_test.cpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "validators/protobuf/proto_block_validator.hpp"
+#include <gmock/gmock-matchers.h>
+#include "block.pb.h"
+#include "module/shared_model/validators/validators_fixture.hpp"
+
+using testing::HasSubstr;
+
+class ProtoBlockValidatorTest : public ValidatorsTest {
+ public:
+  shared_model::validation::ProtoBlockValidator validator;
+};
+
+/**
+ * @given protocol block object with unset version field
+ * @when validating this object
+ * @then corresponding error is returned
+ */
+TEST_F(ProtoBlockValidatorTest, UnsetVersion) {
+  iroha::protocol::Block invalid_block;
+
+  auto answer = validator.validate(invalid_block);
+  ASSERT_TRUE(answer.hasErrors());
+  ASSERT_THAT(answer.reason(), HasSubstr("Block version is not set"));
+}
+
+/**
+ * @given valid protocol block object
+ * @when validating this object
+ * @then validation is successful
+ */
+TEST_F(ProtoBlockValidatorTest, ValidBlock) {
+  iroha::protocol::Block valid_block;
+
+  iroha::protocol::Block_v1 versioned_block;
+  *valid_block.mutable_block_v1() = versioned_block;
+
+  auto answer = validator.validate(valid_block);
+  ASSERT_FALSE(answer.hasErrors());
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

After one_of version field was added to Block, it started needing a protocol validation, which would check, if this field is set.

### Benefits

Ill-formed Blocks are not allowed

### Possible Drawbacks 

None.

### Usage Examples or Tests *[optional]*

`proto_block_validator_test` was added.
