### PR TITLE
Laziness is removed from Commands

### DIFF
--- a/shared_model/backend/protobuf/commands/impl/proto_add_asset_quantity.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_asset_quantity.cpp
@@ -12,9 +12,7 @@ namespace shared_model {
     AddAssetQuantity::AddAssetQuantity(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           add_asset_quantity_{proto_->add_asset_quantity()},
-          amount_{[this] {
-            return interface::Amount(add_asset_quantity_.amount());
-          }} {}
+          amount_{add_asset_quantity_.amount()} {}
 
     // TODO 30/05/2018 andrei Reduce boilerplate code in variant classes
     template AddAssetQuantity::AddAssetQuantity(
@@ -35,7 +33,7 @@ namespace shared_model {
     }
 
     const interface::Amount &AddAssetQuantity::amount() const {
-      return *amount_;
+      return amount_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     AddPeer::AddPeer(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           add_peer_{proto_->add_peer()},
-          peer_{[this] { return proto::Peer(add_peer_.peer()); }} {}
+          peer_{proto::Peer(add_peer_.peer())} {}
 
     template AddPeer::AddPeer(AddPeer::TransportType &);
     template AddPeer::AddPeer(const AddPeer::TransportType &);
@@ -23,7 +23,7 @@ namespace shared_model {
     AddPeer::AddPeer(AddPeer &&o) noexcept : AddPeer(std::move(o.proto_)) {}
 
     const interface::Peer &AddPeer::peer() const {
-      return *peer_;
+      return peer_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     AddPeer::AddPeer(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           add_peer_{proto_->add_peer()},
-          peer_{proto::Peer(add_peer_.peer())} {}
+          peer_{add_peer_.peer()} {}
 
     template AddPeer::AddPeer(AddPeer::TransportType &);
     template AddPeer::AddPeer(const AddPeer::TransportType &);

--- a/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
@@ -12,9 +12,7 @@ namespace shared_model {
     AddSignatory::AddSignatory(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           add_signatory_{proto_->add_signatory()},
-          pubkey_{[this] {
-            return interface::types::PubkeyType(add_signatory_.public_key());
-          }} {}
+          pubkey_{interface::types::PubkeyType(add_signatory_.public_key())} {}
 
     template AddSignatory::AddSignatory(AddSignatory::TransportType &);
     template AddSignatory::AddSignatory(const AddSignatory::TransportType &);
@@ -31,7 +29,7 @@ namespace shared_model {
     }
 
     const interface::types::PubkeyType &AddSignatory::pubkey() const {
-      return *pubkey_;
+      return pubkey_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     AddSignatory::AddSignatory(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           add_signatory_{proto_->add_signatory()},
-          pubkey_{interface::types::PubkeyType(add_signatory_.public_key())} {}
+          pubkey_{add_signatory_.public_key()} {}
 
     template AddSignatory::AddSignatory(AddSignatory::TransportType &);
     template AddSignatory::AddSignatory(const AddSignatory::TransportType &);

--- a/shared_model/backend/protobuf/commands/impl/proto_command.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_command.cpp
@@ -66,8 +66,7 @@ namespace shared_model {
                 std::forward<decltype(ar)>(ar), which);
       }()};
 
-      CommandVariantType ivariant_{
-          [this] { return CommandVariantType(variant_); }()};
+      CommandVariantType ivariant_{variant_};
     };
 
     Command::Command(const Command &o) : Command(*o.impl_->proto_) {}

--- a/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
@@ -12,9 +12,7 @@ namespace shared_model {
     CreateAccount::CreateAccount(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           create_account_{proto_->create_account()},
-          pubkey_{[this] {
-            return interface::types::PubkeyType(create_account_.public_key());
-          }} {}
+          pubkey_{interface::types::PubkeyType(create_account_.public_key())} {}
 
     template CreateAccount::CreateAccount(CreateAccount::TransportType &);
     template CreateAccount::CreateAccount(const CreateAccount::TransportType &);
@@ -27,7 +25,7 @@ namespace shared_model {
         : CreateAccount(std::move(o.proto_)) {}
 
     const interface::types::PubkeyType &CreateAccount::pubkey() const {
-      return *pubkey_;
+      return pubkey_;
     }
 
     const interface::types::AccountNameType &CreateAccount::accountName()

--- a/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     CreateAccount::CreateAccount(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           create_account_{proto_->create_account()},
-          pubkey_{interface::types::PubkeyType(create_account_.public_key())} {}
+          pubkey_{create_account_.public_key()} {}
 
     template CreateAccount::CreateAccount(CreateAccount::TransportType &);
     template CreateAccount::CreateAccount(const CreateAccount::TransportType &);

--- a/shared_model/backend/protobuf/commands/impl/proto_create_asset.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_asset.cpp
@@ -12,7 +12,8 @@ namespace shared_model {
     CreateAsset::CreateAsset(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           create_asset_{proto_->create_asset()},
-          precision_{[this] { return create_asset_.precision(); }} {}
+          precision_{
+              static_cast<const PrecisionType>(create_asset_.precision())} {}
 
     template CreateAsset::CreateAsset(CreateAsset::TransportType &);
     template CreateAsset::CreateAsset(const CreateAsset::TransportType &);
@@ -32,7 +33,7 @@ namespace shared_model {
     }
 
     const CreateAsset::PrecisionType &CreateAsset::precision() const {
-      return *precision_;
+      return precision_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
@@ -15,16 +15,14 @@ namespace shared_model {
     CreateRole::CreateRole(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           create_role_{proto_->create_role()},
-          role_permissions_{[this] {
-            return boost::accumulate(
-                create_role_.permissions(),
-                interface::RolePermissionSet{},
-                [](auto &&acc, const auto &perm) {
-                  acc.set(permissions::fromTransport(
-                      static_cast<iroha::protocol::RolePermission>(perm)));
-                  return std::forward<decltype(acc)>(acc);
-                });
-          }} {}
+          role_permissions_{boost::accumulate(
+              create_role_.permissions(),
+              interface::RolePermissionSet{},
+              [](auto &&acc, const auto &perm) {
+                acc.set(permissions::fromTransport(
+                    static_cast<iroha::protocol::RolePermission>(perm)));
+                return std::forward<decltype(acc)>(acc);
+              })} {}
 
     template CreateRole::CreateRole(CreateRole::TransportType &);
     template CreateRole::CreateRole(const CreateRole::TransportType &);
@@ -40,7 +38,7 @@ namespace shared_model {
     }
 
     const interface::RolePermissionSet &CreateRole::rolePermissions() const {
-      return *role_permissions_;
+      return role_permissions_;
     }
 
     std::string CreateRole::toString() const {

--- a/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
@@ -12,9 +12,8 @@ namespace shared_model {
     RemoveSignatory::RemoveSignatory(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           remove_signatory_{proto_->remove_signatory()},
-          pubkey_{[this] {
-            return interface::types::PubkeyType(remove_signatory_.public_key());
-          }} {}
+          pubkey_{
+              interface::types::PubkeyType(remove_signatory_.public_key())} {}
 
     template RemoveSignatory::RemoveSignatory(RemoveSignatory::TransportType &);
     template RemoveSignatory::RemoveSignatory(
@@ -33,7 +32,7 @@ namespace shared_model {
     }
 
     const interface::types::PubkeyType &RemoveSignatory::pubkey() const {
-      return *pubkey_;
+      return pubkey_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
@@ -12,8 +12,7 @@ namespace shared_model {
     RemoveSignatory::RemoveSignatory(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           remove_signatory_{proto_->remove_signatory()},
-          pubkey_{
-              interface::types::PubkeyType(remove_signatory_.public_key())} {}
+          pubkey_{remove_signatory_.public_key()} {}
 
     template RemoveSignatory::RemoveSignatory(RemoveSignatory::TransportType &);
     template RemoveSignatory::RemoveSignatory(

--- a/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     SubtractAssetQuantity::SubtractAssetQuantity(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           subtract_asset_quantity_{proto_->subtract_asset_quantity()},
-          amount_{interface::Amount(subtract_asset_quantity_.amount())} {}
+          amount_{subtract_asset_quantity_.amount()} {}
 
     template SubtractAssetQuantity::SubtractAssetQuantity(
         SubtractAssetQuantity::TransportType &);

--- a/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
@@ -12,9 +12,7 @@ namespace shared_model {
     SubtractAssetQuantity::SubtractAssetQuantity(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           subtract_asset_quantity_{proto_->subtract_asset_quantity()},
-          amount_{[this] {
-            return interface::Amount(subtract_asset_quantity_.amount());
-          }} {}
+          amount_{interface::Amount(subtract_asset_quantity_.amount())} {}
 
     template SubtractAssetQuantity::SubtractAssetQuantity(
         SubtractAssetQuantity::TransportType &);
@@ -36,7 +34,7 @@ namespace shared_model {
     }
 
     const interface::Amount &SubtractAssetQuantity::amount() const {
-      return *amount_;
+      return amount_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
@@ -12,8 +12,7 @@ namespace shared_model {
     TransferAsset::TransferAsset(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           transfer_asset_{proto_->transfer_asset()},
-          amount_{
-              [this] { return interface::Amount(transfer_asset_.amount()); }} {}
+          amount_{interface::Amount(transfer_asset_.amount())} {}
 
     template TransferAsset::TransferAsset(TransferAsset::TransportType &);
     template TransferAsset::TransferAsset(const TransferAsset::TransportType &);
@@ -26,7 +25,7 @@ namespace shared_model {
         : TransferAsset(std::move(o.proto_)) {}
 
     const interface::Amount &TransferAsset::amount() const {
-      return *amount_;
+      return amount_;
     }
 
     const interface::types::AssetIdType &TransferAsset::assetId() const {

--- a/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     TransferAsset::TransferAsset(CommandType &&command)
         : CopyableProto(std::forward<CommandType>(command)),
           transfer_asset_{proto_->transfer_asset()},
-          amount_{interface::Amount(transfer_asset_.amount())} {}
+          amount_{transfer_asset_.amount()} {}
 
     template TransferAsset::TransferAsset(TransferAsset::TransportType &);
     template TransferAsset::TransferAsset(const TransferAsset::TransportType &);

--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_ADD_ASSET_QUANTITY_HPP
@@ -23,7 +11,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
 #include "interfaces/common_objects/amount.hpp"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -44,15 +31,10 @@ namespace shared_model {
       const interface::Amount &amount() const override;
 
      private:
-      // lazy
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::AddAssetQuantity &add_asset_quantity_;
 
-      const Lazy<interface::Amount> amount_;
+      const interface::Amount amount_;
     };
-
   }  // namespace proto
 }  // namespace shared_model
 

--- a/shared_model/backend/protobuf/commands/proto_add_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_peer.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_ADD_PEER_HPP
@@ -40,12 +28,8 @@ namespace shared_model {
       const interface::Peer &peer() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::AddPeer &add_peer_;
-      const Lazy<proto::Peer> peer_;
+      const proto::Peer peer_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
@@ -1,28 +1,15 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_ADD_SIGNATORY_HPP
 #define IROHA_PROTO_ADD_SIGNATORY_HPP
 
-#include "interfaces/commands/add_signatory.hpp"
-
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
 #include "cryptography/public_key.hpp"
+#include "interfaces/commands/add_signatory.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -42,13 +29,9 @@ namespace shared_model {
       const interface::types::PubkeyType &pubkey() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::AddSignatory &add_signatory_;
 
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_append_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_append_role.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_APPEND_ROLE_HPP

--- a/shared_model/backend/protobuf/commands/proto_create_account.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_account.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_CREATE_ACCOUNT_HPP
@@ -45,13 +33,9 @@ namespace shared_model {
       const interface::types::DomainIdType &domainId() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::CreateAccount &create_account_;
 
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_asset.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_CREATE_ASSET_HPP
@@ -43,13 +31,9 @@ namespace shared_model {
       const PrecisionType &precision() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::CreateAsset &create_asset_;
 
-      const Lazy<PrecisionType> precision_;
+      const PrecisionType precision_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_domain.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_domain.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_CREATE_DOMAIN_HPP

--- a/shared_model/backend/protobuf/commands/proto_create_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_role.hpp
@@ -1,20 +1,7 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 #ifndef IROHA_PROTO_CREATE_ROLE_HPP
 #define IROHA_PROTO_CREATE_ROLE_HPP
 
@@ -43,13 +30,9 @@ namespace shared_model {
       std::string toString() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::CreateRole &create_role_;
 
-      const Lazy<interface::RolePermissionSet> role_permissions_;
+      const interface::RolePermissionSet role_permissions_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_detach_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_detach_role.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_DETACH_ROLE_HPP

--- a/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_GRANT_PERMISSION_HPP

--- a/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
@@ -1,28 +1,15 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_REMOVE_SIGNATORY_HPP
 #define IROHA_PROTO_REMOVE_SIGNATORY_HPP
 
-#include "interfaces/commands/remove_signatory.hpp"
-
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
 #include "cryptography/public_key.hpp"
+#include "interfaces/commands/remove_signatory.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -44,13 +31,9 @@ namespace shared_model {
       const interface::types::PubkeyType &pubkey() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::RemoveSignatory &remove_signatory_;
 
-      const Lazy<interface::types::PubkeyType> pubkey_;
+      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_REVOKE_PERMISSION_HPP

--- a/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
@@ -1,27 +1,14 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_SET_ACCOUNT_DETAIL_HPP
 #define IROHA_PROTO_SET_ACCOUNT_DETAIL_HPP
 
-#include "interfaces/commands/set_account_detail.hpp"
-
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
+#include "interfaces/commands/set_account_detail.hpp"
 
 namespace shared_model {
   namespace proto {

--- a/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
@@ -28,10 +28,6 @@ namespace shared_model {
       interface::types::QuorumType newQuorum() const override;
 
      private:
-      // lazy
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::SetAccountQuorum &set_account_quorum_;
     };
 

--- a/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
@@ -1,29 +1,15 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_SUBTRACT_ASSET_QUANTITY_HPP
 #define IROHA_PROTO_SUBTRACT_ASSET_QUANTITY_HPP
 
-#include "interfaces/commands/subtract_asset_quantity.hpp"
-
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
+#include "interfaces/commands/subtract_asset_quantity.hpp"
 #include "interfaces/common_objects/amount.hpp"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -44,13 +30,9 @@ namespace shared_model {
       const interface::Amount &amount() const override;
 
      private:
-      // lazy
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::SubtractAssetQuantity &subtract_asset_quantity_;
 
-      const Lazy<interface::Amount> amount_;
+      const interface::Amount amount_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_PROTO_TRANSFER_ASSET_HPP
@@ -48,13 +36,9 @@ namespace shared_model {
       const interface::types::DescriptionType &description() const override;
 
      private:
-      // lazy
-      template <typename Value>
-      using Lazy = detail::LazyInitializer<Value>;
-
       const iroha::protocol::TransferAsset &transfer_asset_;
 
-      const Lazy<interface::Amount> amount_;
+      const interface::Amount amount_;
     };
 
   }  // namespace proto


### PR DESCRIPTION
### Description of the Change

Lazy is not needed in a set of shared model objects, so it is getting removed. In this PR, it is removed from Commands.

### Benefits

No Lazy overhead.

### Possible Drawbacks 

None.