### PR TITLE
Laziness is removed from Query Responses

### DIFF
--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
@@ -12,10 +12,9 @@ namespace shared_model {
     AccountAssetResponse::AccountAssetResponse(
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          accountAssetResponse_{proto_->account_assets_response()},
-          accountAssets_{std::vector<proto::AccountAsset>{
-              accountAssetResponse_.account_assets().begin(),
-              accountAssetResponse_.account_assets().end()}} {}
+          account_asset_response_{proto_->account_assets_response()},
+          account_assets_{account_asset_response_.account_assets().begin(),
+                          account_asset_response_.account_assets().end()} {}
 
     template AccountAssetResponse::AccountAssetResponse(
         AccountAssetResponse::TransportType &);
@@ -32,7 +31,7 @@ namespace shared_model {
 
     const interface::types::AccountAssetCollectionType
     AccountAssetResponse::accountAssets() const {
-      return accountAssets_;
+      return account_assets_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
@@ -13,11 +13,9 @@ namespace shared_model {
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           accountAssetResponse_{proto_->account_assets_response()},
-          accountAssets_{[this] {
-            return std::vector<proto::AccountAsset>(
-                accountAssetResponse_.account_assets().begin(),
-                accountAssetResponse_.account_assets().end());
-          }} {}
+          accountAssets_{std::vector<proto::AccountAsset>{
+              accountAssetResponse_.account_assets().begin(),
+              accountAssetResponse_.account_assets().end()}} {}
 
     template AccountAssetResponse::AccountAssetResponse(
         AccountAssetResponse::TransportType &);
@@ -34,7 +32,7 @@ namespace shared_model {
 
     const interface::types::AccountAssetCollectionType
     AccountAssetResponse::accountAssets() const {
-      return *accountAssets_;
+      return accountAssets_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
@@ -5,6 +5,8 @@
 
 #include "backend/protobuf/query_responses/proto_account_response.hpp"
 
+#include <boost/range/numeric.hpp>
+
 namespace shared_model {
   namespace proto {
 
@@ -12,16 +14,14 @@ namespace shared_model {
     AccountResponse::AccountResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           accountResponse_{proto_->account_response()},
-          accountRoles_{[this] {
-            return boost::accumulate(
-                accountResponse_.account_roles(),
-                AccountRolesIdType{},
-                [](auto &&roles, const auto &role) {
-                  roles.push_back(interface::types::RoleIdType(role));
-                  return std::move(roles);
-                });
-          }},
-          account_{[this] { return Account(accountResponse_.account()); }} {}
+          accountRoles_{boost::accumulate(
+              accountResponse_.account_roles(),
+              AccountRolesIdType{},
+              [](auto &&roles, const auto &role) {
+                roles.push_back(interface::types::RoleIdType(role));
+                return std::move(roles);
+              })},
+          account_{Account(accountResponse_.account())} {}
 
     template AccountResponse::AccountResponse(AccountResponse::TransportType &);
     template AccountResponse::AccountResponse(
@@ -36,11 +36,11 @@ namespace shared_model {
         : AccountResponse(std::move(o.proto_)) {}
 
     const interface::Account &AccountResponse::account() const {
-      return *account_;
+      return account_;
     }
 
     const AccountResponse::AccountRolesIdType &AccountResponse::roles() const {
-      return *accountRoles_;
+      return accountRoles_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
@@ -13,15 +13,15 @@ namespace shared_model {
     template <typename QueryResponseType>
     AccountResponse::AccountResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          accountResponse_{proto_->account_response()},
-          accountRoles_{boost::accumulate(
-              accountResponse_.account_roles(),
+          account_response_{proto_->account_response()},
+          account_roles_{boost::accumulate(
+              account_response_.account_roles(),
               AccountRolesIdType{},
               [](auto &&roles, const auto &role) {
                 roles.push_back(interface::types::RoleIdType(role));
                 return std::move(roles);
               })},
-          account_{Account(accountResponse_.account())} {}
+          account_{account_response_.account()} {}
 
     template AccountResponse::AccountResponse(AccountResponse::TransportType &);
     template AccountResponse::AccountResponse(
@@ -40,7 +40,7 @@ namespace shared_model {
     }
 
     const AccountResponse::AccountRolesIdType &AccountResponse::roles() const {
-      return accountRoles_;
+      return account_roles_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     AssetResponse::AssetResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           assetResponse_{proto_->asset_response()},
-          asset_{[this] { return Asset(assetResponse_.asset()); }} {}
+          asset_{Asset{assetResponse_.asset()}} {}
 
     template AssetResponse::AssetResponse(AssetResponse::TransportType &);
     template AssetResponse::AssetResponse(const AssetResponse::TransportType &);
@@ -25,7 +25,7 @@ namespace shared_model {
         : AssetResponse(std::move(o.proto_)) {}
 
     const Asset &AssetResponse::asset() const {
-      return *asset_;
+      return asset_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     template <typename QueryResponseType>
     AssetResponse::AssetResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          assetResponse_{proto_->asset_response()},
-          asset_{assetResponse_.asset()} {}
+          asset_response_{proto_->asset_response()},
+          asset_{asset_response_.asset()} {}
 
     template AssetResponse::AssetResponse(AssetResponse::TransportType &);
     template AssetResponse::AssetResponse(const AssetResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     AssetResponse::AssetResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           assetResponse_{proto_->asset_response()},
-          asset_{Asset{assetResponse_.asset()}} {}
+          asset_{assetResponse_.asset()} {}
 
     template AssetResponse::AssetResponse(AssetResponse::TransportType &);
     template AssetResponse::AssetResponse(const AssetResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_error_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_error_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     BlockErrorResponse::BlockErrorResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           block_error_response{proto_->block_error_response()},
-          message_{[this] { return block_error_response.message(); }} {}
+          message_{block_error_response.message()} {}
 
     template BlockErrorResponse::BlockErrorResponse(
         BlockErrorResponse::TransportType &);
@@ -27,8 +27,9 @@ namespace shared_model {
     BlockErrorResponse::BlockErrorResponse(BlockErrorResponse &&o)
         : BlockErrorResponse(std::move(o.proto_)) {}
 
-    const interface::types::DescriptionType &BlockErrorResponse::message() const {
-      return *message_;
+    const interface::types::DescriptionType &BlockErrorResponse::message()
+        const {
+      return message_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
@@ -23,7 +23,7 @@ namespace shared_model {
                 template load<ProtoQueryResponseVariantType>(
                     std::forward<decltype(ar)>(ar), which);
           }()},
-          ivariant_{QueryResponseVariantType{variant_}} {}
+          ivariant_{variant_} {}
 
     template BlockQueryResponse::BlockQueryResponse(
         BlockQueryResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
@@ -5,6 +5,8 @@
 
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 
+#include "utils/variant_deserializer.hpp"
+
 namespace shared_model {
   namespace proto {
 
@@ -20,9 +22,8 @@ namespace shared_model {
                 ProtoQueryResponseVariantType::types>::
                 template load<ProtoQueryResponseVariantType>(
                     std::forward<decltype(ar)>(ar), which);
-          }},
-          ivariant_{detail::makeLazyInitializer(
-              [this] { return QueryResponseVariantType(*variant_); })} {}
+          }()},
+          ivariant_{QueryResponseVariantType{variant_}} {}
 
     template BlockQueryResponse::BlockQueryResponse(
         BlockQueryResponse::TransportType &);
@@ -39,7 +40,7 @@ namespace shared_model {
 
     const BlockQueryResponse::QueryResponseVariantType &
     BlockQueryResponse::get() const {
-      return *ivariant_;
+      return ivariant_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     BlockResponse::BlockResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           block_response_{proto_->block_response()},
-          block_{[this] { return Block(block_response_.block()); }} {}
+          block_{Block(block_response_.block())} {}
 
     template BlockResponse::BlockResponse(BlockResponse::TransportType &);
     template BlockResponse::BlockResponse(const BlockResponse::TransportType &);
@@ -25,7 +25,7 @@ namespace shared_model {
         : BlockResponse(std::move(o.proto_)) {}
 
     const Block &BlockResponse::block() const {
-      return *block_;
+      return block_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     BlockResponse::BlockResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           block_response_{proto_->block_response()},
-          block_{Block(block_response_.block())} {}
+          block_{block_response_.block()} {}
 
     template BlockResponse::BlockResponse(BlockResponse::TransportType &);
     template BlockResponse::BlockResponse(const BlockResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
@@ -24,9 +24,8 @@ namespace shared_model {
                 variant_impl<ProtoQueryErrorResponseListType>::template load<
                     ProtoQueryErrorResponseVariantType>(
                     std::forward<decltype(ar)>(ar), which);
-          }},
-          ivariant_{detail::makeLazyInitializer(
-              [this] { return QueryErrorResponseVariantType(*variant_); })} {}
+          }()},
+          ivariant_{QueryErrorResponseVariantType{variant_}} {}
 
     template ErrorQueryResponse::ErrorQueryResponse(
         ErrorQueryResponse::TransportType &);
@@ -43,7 +42,7 @@ namespace shared_model {
 
     const ErrorQueryResponse::QueryErrorResponseVariantType &
     ErrorQueryResponse::get() const {
-      return *ivariant_;
+      return ivariant_;
     }
 
     const ErrorQueryResponse::ErrorMessageType &

--- a/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "backend/protobuf/query_responses/proto_role_permissions_response.hpp"
+
 #include <boost/range/numeric.hpp>
 #include "backend/protobuf/permissions.hpp"
 #include "utils/string_builder.hpp"
@@ -16,17 +17,14 @@ namespace shared_model {
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           rolePermissionsResponse_{proto_->role_permissions_response()},
-          rolePermissions_{[this] {
-            return boost::accumulate(
-                rolePermissionsResponse_.permissions(),
-                interface::RolePermissionSet{},
-                [](auto &&permissions, const auto &permission) {
-                  permissions.set(permissions::fromTransport(
-                      static_cast<iroha::protocol::RolePermission>(
-                          permission)));
-                  return std::forward<decltype(permissions)>(permissions);
-                });
-          }} {}
+          rolePermissions_{boost::accumulate(
+              rolePermissionsResponse_.permissions(),
+              interface::RolePermissionSet{},
+              [](auto &&permissions, const auto &permission) {
+                permissions.set(permissions::fromTransport(
+                    static_cast<iroha::protocol::RolePermission>(permission)));
+                return std::forward<decltype(permissions)>(permissions);
+              })} {}
 
     template RolePermissionsResponse::RolePermissionsResponse(
         RolePermissionsResponse::TransportType &);
@@ -45,7 +43,7 @@ namespace shared_model {
 
     const interface::RolePermissionSet &
     RolePermissionsResponse::rolePermissions() const {
-      return *rolePermissions_;
+      return rolePermissions_;
     }
 
     std::string RolePermissionsResponse::toString() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
@@ -16,9 +16,9 @@ namespace shared_model {
     RolePermissionsResponse::RolePermissionsResponse(
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          rolePermissionsResponse_{proto_->role_permissions_response()},
-          rolePermissions_{boost::accumulate(
-              rolePermissionsResponse_.permissions(),
+          role_permissions_response_{proto_->role_permissions_response()},
+          role_permissions_{boost::accumulate(
+              role_permissions_response_.permissions(),
               interface::RolePermissionSet{},
               [](auto &&permissions, const auto &permission) {
                 permissions.set(permissions::fromTransport(
@@ -43,7 +43,7 @@ namespace shared_model {
 
     const interface::RolePermissionSet &
     RolePermissionsResponse::rolePermissions() const {
-      return rolePermissions_;
+      return role_permissions_;
     }
 
     std::string RolePermissionsResponse::toString() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "backend/protobuf/query_responses/proto_roles_response.hpp"
+
 #include <boost/range/numeric.hpp>
 
 namespace shared_model {
@@ -13,14 +14,12 @@ namespace shared_model {
     RolesResponse::RolesResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           rolesResponse_{proto_->roles_response()},
-          roles_{[this] {
-            return boost::accumulate(rolesResponse_.roles(),
-                                     RolesIdType{},
-                                     [](auto &&roles, const auto &role) {
-                                       roles.emplace_back(role);
-                                       return std::move(roles);
-                                     });
-          }} {}
+          roles_{boost::accumulate(rolesResponse_.roles(),
+                                   RolesIdType{},
+                                   [](auto &&roles, const auto &role) {
+                                     roles.emplace_back(role);
+                                     return std::move(roles);
+                                   })} {}
 
     template RolesResponse::RolesResponse(RolesResponse::TransportType &);
     template RolesResponse::RolesResponse(const RolesResponse::TransportType &);
@@ -33,7 +32,7 @@ namespace shared_model {
         : RolesResponse(std::move(o.proto_)) {}
 
     const RolesResponse::RolesIdType &RolesResponse::roles() const {
-      return *roles_;
+      return roles_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
@@ -13,8 +13,8 @@ namespace shared_model {
     template <typename QueryResponseType>
     RolesResponse::RolesResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          rolesResponse_{proto_->roles_response()},
-          roles_{boost::accumulate(rolesResponse_.roles(),
+          roles_response_{proto_->roles_response()},
+          roles_{boost::accumulate(roles_response_.roles(),
                                    RolesIdType{},
                                    [](auto &&roles, const auto &role) {
                                      roles.emplace_back(role);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
@@ -12,11 +12,9 @@ namespace shared_model {
     SignatoriesResponse::SignatoriesResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           signatoriesResponse_{proto_->signatories_response()},
-          keys_{[this] {
-            return interface::types::PublicKeyCollectionType(
-                signatoriesResponse_.keys().begin(),
-                signatoriesResponse_.keys().end());
-          }} {}
+          keys_{interface::types::PublicKeyCollectionType(
+              signatoriesResponse_.keys().begin(),
+              signatoriesResponse_.keys().end())} {}
 
     template SignatoriesResponse::SignatoriesResponse(
         SignatoriesResponse::TransportType &);
@@ -33,7 +31,7 @@ namespace shared_model {
 
     const interface::types::PublicKeyCollectionType &SignatoriesResponse::keys()
         const {
-      return *keys_;
+      return keys_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
@@ -12,9 +12,8 @@ namespace shared_model {
     SignatoriesResponse::SignatoriesResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           signatoriesResponse_{proto_->signatories_response()},
-          keys_{interface::types::PublicKeyCollectionType(
-              signatoriesResponse_.keys().begin(),
-              signatoriesResponse_.keys().end())} {}
+          keys_{signatoriesResponse_.keys().begin(),
+                signatoriesResponse_.keys().end()} {}
 
     template SignatoriesResponse::SignatoriesResponse(
         SignatoriesResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
@@ -11,9 +11,9 @@ namespace shared_model {
     template <typename QueryResponseType>
     SignatoriesResponse::SignatoriesResponse(QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          signatoriesResponse_{proto_->signatories_response()},
-          keys_{signatoriesResponse_.keys().begin(),
-                signatoriesResponse_.keys().end()} {}
+          signatories_response_{proto_->signatories_response()},
+          keys_{signatories_response_.keys().begin(),
+                signatories_response_.keys().end()} {}
 
     template SignatoriesResponse::SignatoriesResponse(
         SignatoriesResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
@@ -13,11 +13,9 @@ namespace shared_model {
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           transactionResponse_{proto_->transactions_response()},
-          transactions_{[this] {
-            return std::vector<proto::Transaction>(
-                transactionResponse_.transactions().begin(),
-                transactionResponse_.transactions().end());
-          }} {}
+          transactions_{std::vector<proto::Transaction>(
+              transactionResponse_.transactions().begin(),
+              transactionResponse_.transactions().end())} {}
 
     template TransactionsResponse::TransactionsResponse(
         TransactionsResponse::TransportType &);
@@ -34,7 +32,7 @@ namespace shared_model {
 
     interface::types::TransactionsCollectionType
     TransactionsResponse::transactions() const {
-      return *transactions_;
+      return transactions_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
@@ -12,9 +12,9 @@ namespace shared_model {
     TransactionsResponse::TransactionsResponse(
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          transactionResponse_{proto_->transactions_response()},
-          transactions_{transactionResponse_.transactions().begin(),
-                        transactionResponse_.transactions().end()} {}
+          transaction_response_{proto_->transactions_response()},
+          transactions_{transaction_response_.transactions().begin(),
+                        transaction_response_.transactions().end()} {}
 
     template TransactionsResponse::TransactionsResponse(
         TransactionsResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
@@ -13,9 +13,8 @@ namespace shared_model {
         QueryResponseType &&queryResponse)
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           transactionResponse_{proto_->transactions_response()},
-          transactions_{std::vector<proto::Transaction>(
-              transactionResponse_.transactions().begin(),
-              transactionResponse_.transactions().end())} {}
+          transactions_{transactionResponse_.transactions().begin(),
+                        transactionResponse_.transactions().end()} {}
 
     template TransactionsResponse::TransactionsResponse(
         TransactionsResponse::TransportType &);

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -6,14 +6,11 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ACCOUNT_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_ASSET_RESPONSE_HPP
 
-#include <boost/range/numeric.hpp>
-
 #include "backend/protobuf/common_objects/account_asset.hpp"
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -33,12 +30,9 @@ namespace shared_model {
           const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::AccountAssetResponse &accountAssetResponse_;
 
-      const Lazy<std::vector<AccountAsset>> accountAssets_;
+      const std::vector<AccountAsset> accountAssets_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -30,9 +30,9 @@ namespace shared_model {
           const override;
 
      private:
-      const iroha::protocol::AccountAssetResponse &accountAssetResponse_;
+      const iroha::protocol::AccountAssetResponse &account_asset_response_;
 
-      const std::vector<AccountAsset> accountAssets_;
+      const std::vector<AccountAsset> account_assets_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
@@ -10,7 +10,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/account_detail_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {

--- a/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
@@ -6,13 +6,10 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ACCOUNT_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_RESPONSE_HPP
 
-#include <boost/range/numeric.hpp>
-
 #include "backend/protobuf/common_objects/account.hpp"
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/account_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -33,14 +30,11 @@ namespace shared_model {
       const AccountRolesIdType &roles() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::AccountResponse &accountResponse_;
 
-      const Lazy<AccountRolesIdType> accountRoles_;
+      const AccountRolesIdType accountRoles_;
 
-      const Lazy<shared_model::proto::Account> account_;
+      const shared_model::proto::Account account_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
@@ -30,9 +30,9 @@ namespace shared_model {
       const AccountRolesIdType &roles() const override;
 
      private:
-      const iroha::protocol::AccountResponse &accountResponse_;
+      const iroha::protocol::AccountResponse &account_response_;
 
-      const AccountRolesIdType accountRoles_;
+      const AccountRolesIdType account_roles_;
 
       const shared_model::proto::Account account_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
@@ -10,7 +10,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/asset_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -29,12 +28,9 @@ namespace shared_model {
       const Asset &asset() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::AssetResponse &assetResponse_;
 
-      const Lazy<Asset> asset_;
+      const Asset asset_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
@@ -28,7 +28,7 @@ namespace shared_model {
       const Asset &asset() const override;
 
      private:
-      const iroha::protocol::AssetResponse &assetResponse_;
+      const iroha::protocol::AssetResponse &asset_response_;
 
       const Asset asset_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_block_error_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_error_response.hpp
@@ -9,7 +9,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/block_error_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -28,12 +27,9 @@ namespace shared_model {
       const interface::types::DescriptionType &message() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::BlockErrorResponse &block_error_response;
 
-      const Lazy<interface::types::DescriptionType> message_;
+      const interface::types::DescriptionType message_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
@@ -6,15 +6,12 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCK_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCK_QUERY_RESPONSE_HPP
 
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "backend/protobuf/query_responses/proto_block_error_response.hpp"
 #include "backend/protobuf/query_responses/proto_block_response.hpp"
-
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/query.hpp"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
-#include "utils/variant_deserializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -23,10 +20,6 @@ namespace shared_model {
                                iroha::protocol::BlockQueryResponse,
                                BlockQueryResponse> {
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
-      using LazyVariantType = Lazy<QueryResponseVariantType>;
       /// type of proto variant
       using ProtoQueryResponseVariantType =
           boost::variant<BlockResponse, BlockErrorResponse>;
@@ -42,8 +35,8 @@ namespace shared_model {
       const QueryResponseVariantType &get() const override;
 
      private:
-      const Lazy<ProtoQueryResponseVariantType> variant_;
-      const Lazy<QueryResponseVariantType> ivariant_;
+      const ProtoQueryResponseVariantType variant_;
+      const QueryResponseVariantType ivariant_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_block_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_response.hpp
@@ -10,7 +10,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/block_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -29,12 +28,9 @@ namespace shared_model {
       const Block &block() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::BlockResponse &block_response_;
 
-      const Lazy<Block> block_;
+      const Block block_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2017 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_SHARED_MODEL_PROTO_CONCRETE_ERROR_QUERY_RESPONSE_HPP

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -10,7 +10,6 @@
 #include "backend/protobuf/query_responses/proto_concrete_error_query_response.hpp"
 #include "interfaces/query_responses/error_query_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -47,15 +46,9 @@ namespace shared_model {
       const ErrorMessageType &errorMessage() const override;
 
      private:
-      /// lazy variant shortcut
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
+      const ProtoQueryErrorResponseVariantType variant_;
 
-      using LazyVariantType = Lazy<ProtoQueryErrorResponseVariantType>;
-
-      const LazyVariantType variant_;
-
-      const Lazy<QueryErrorResponseVariantType> ivariant_;
+      const QueryErrorResponseVariantType ivariant_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -7,7 +7,6 @@
 #define IROHA_SHARED_MODEL_PROTO_QUERY_RESPONSE_HPP
 
 #include "interfaces/query_responses/query_response.hpp"
-
 #include "qry_responses.pb.h"
 
 namespace shared_model {

--- a/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
@@ -29,9 +29,9 @@ namespace shared_model {
       std::string toString() const override;
 
      private:
-      const iroha::protocol::RolePermissionsResponse &rolePermissionsResponse_;
+      const iroha::protocol::RolePermissionsResponse &role_permissions_response_;
 
-      const interface::RolePermissionSet rolePermissions_;
+      const interface::RolePermissionSet role_permissions_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
@@ -9,7 +9,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/role_permissions.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -30,12 +29,9 @@ namespace shared_model {
       std::string toString() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::RolePermissionsResponse &rolePermissionsResponse_;
 
-      const Lazy<interface::RolePermissionSet> rolePermissions_;
+      const interface::RolePermissionSet rolePermissions_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
@@ -27,7 +27,7 @@ namespace shared_model {
       const RolesIdType &roles() const override;
 
      private:
-      const iroha::protocol::RolesResponse &rolesResponse_;
+      const iroha::protocol::RolesResponse &roles_response_;
 
       const RolesIdType roles_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
@@ -9,7 +9,6 @@
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/roles_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -28,12 +27,9 @@ namespace shared_model {
       const RolesIdType &roles() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::RolesResponse &rolesResponse_;
 
-      const Lazy<RolesIdType> roles_;
+      const RolesIdType roles_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
@@ -28,7 +28,7 @@ namespace shared_model {
       const interface::types::PublicKeyCollectionType &keys() const override;
 
      private:
-      const iroha::protocol::SignatoriesResponse &signatoriesResponse_;
+      const iroha::protocol::SignatoriesResponse &signatories_response_;
 
       const interface::types::PublicKeyCollectionType keys_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
@@ -6,12 +6,10 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_SIGNATORIES_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_SIGNATORIES_RESPONSE_HPP
 
-#include "interfaces/query_responses/signatories_response.hpp"
-
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "cryptography/public_key.hpp"
+#include "interfaces/query_responses/signatories_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -30,12 +28,9 @@ namespace shared_model {
       const interface::types::PublicKeyCollectionType &keys() const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::SignatoriesResponse &signatoriesResponse_;
 
-      const Lazy<interface::types::PublicKeyCollectionType> keys_;
+      const interface::types::PublicKeyCollectionType keys_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
@@ -30,7 +30,7 @@ namespace shared_model {
           const override;
 
      private:
-      const iroha::protocol::TransactionsResponse &transactionResponse_;
+      const iroha::protocol::TransactionsResponse &transaction_response_;
 
       const std::vector<proto::Transaction> transactions_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
@@ -11,7 +11,6 @@
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/query_responses/transactions_response.hpp"
 #include "qry_responses.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -31,12 +30,9 @@ namespace shared_model {
           const override;
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
-
       const iroha::protocol::TransactionsResponse &transactionResponse_;
 
-      const Lazy<std::vector<proto::Transaction>> transactions_;
+      const std::vector<proto::Transaction> transactions_;
     };
   }  // namespace proto
 }  // namespace shared_model


### PR DESCRIPTION
### Description of the Change

Lazy is not needed in a set of shared model objects, so it is getting removed. In this PR, it is removed from Query Responses.

### Benefits

No Lazy overhead.

### Possible Drawbacks 

None.