### PR TITLE
Laziness is removed from BatchMeta

### DIFF
--- a/shared_model/backend/protobuf/batch_meta.hpp
+++ b/shared_model/backend/protobuf/batch_meta.hpp
@@ -6,17 +6,11 @@
 #ifndef IROHA_PROTO_BATCH_META_HPP
 #define IROHA_PROTO_BATCH_META_HPP
 
-#include "interfaces/iroha_internal/batch_meta.hpp"
-
-#include <numeric>
-
 #include <boost/range/numeric.hpp>
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/util.hpp"
-#include "interfaces/common_objects/amount.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/iroha_internal/batch_meta.hpp"
 #include "transaction.pb.h"
-#include "utils/lazy_initializer.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -35,36 +29,31 @@ namespace shared_model {
                                    ->FindValueByNumber(proto_->type())
                                    ->index();
               return static_cast<interface::types::BatchType>(which);
-            }},
-            reduced_hashes_{[this] {
-              return boost::accumulate(
-                  proto_->reduced_hashes(),
-                  ReducedHashesType{},
-                  [](auto &&acc, const auto &hash) {
-                    acc.emplace_back(hash);
-                    return std::forward<decltype(acc)>(acc);
-                  });
-            }} {}
+            }()},
+            reduced_hashes_{
+                boost::accumulate(proto_->reduced_hashes(),
+                                  ReducedHashesType{},
+                                  [](auto &&acc, const auto &hash) {
+                                    acc.emplace_back(hash);
+                                    return std::forward<decltype(acc)>(acc);
+                                  })} {}
 
       BatchMeta(const BatchMeta &o) : BatchMeta(o.proto_) {}
 
       BatchMeta(BatchMeta &&o) noexcept : BatchMeta(std::move(o.proto_)) {}
 
       interface::types::BatchType type() const override {
-        return *type_;
+        return type_;
       };
       const ReducedHashesType &reducedHashes() const override {
-        return *reduced_hashes_;
+        return reduced_hashes_;
       };
 
      private:
-      template <typename T>
-      using Lazy = detail::LazyInitializer<T>;
+      interface::types::BatchType type_;
 
-      Lazy<interface::types::BatchType> type_;
-
-      const Lazy<ReducedHashesType> reduced_hashes_;
-    };  // namespace proto
-  }     // namespace proto
+      const ReducedHashesType reduced_hashes_;
+    };
+  }  // namespace proto
 }  // namespace shared_model
 #endif  // IROHA_PROTO_AMOUNT_HPP


### PR DESCRIPTION
### Description of the Change

Lazy is not needed in a set of shared model objects, so it is getting removed. In this PR, it is removed from BatchMeta.

### Benefits

No Lazy overhead

### Possible Drawbacks 

None.