### PR TITLE
Print user-defined objects to log directly

### DIFF
--- a/iroha-cli/impl/query_response_handler.cpp
+++ b/iroha-cli/impl/query_response_handler.cpp
@@ -191,7 +191,7 @@ namespace iroha_cli {
 
       auto cmds = tx.commands();
       std::for_each(cmds.begin(), cmds.end(), [this](auto &cmd) {
-        log_->info(prefix.at(kDefault), cmd.toString());
+        log_->info(prefix.at(kDefault), cmd);
       });
     });
   }

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -99,7 +99,7 @@ namespace iroha {
       if (block_str) {
         blockId = std::stoull(block_str.get());
       } else {
-        log_->info("No block with transaction {}", hash.toString());
+        log_->info("No block with transaction {}", hash);
       }
       return blockId;
     }

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -44,7 +44,7 @@ namespace iroha {
         auto hash = hash_provider_->makeHash(*block);
         log_->info("vote for block ({}, {})",
                    hash.vote_hashes.proposal_hash,
-                   block->hash().toString());
+                   block->hash());
         auto order = orderer_->getOrdering(hash);
         if (not order) {
           log_->error("ordering doesn't provide peers => pass round");

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -19,11 +19,10 @@ using namespace iroha::network;
 
 using iroha::ConstRefState;
 
-void sendStateAsyncImpl(
-    const shared_model::interface::Peer &to,
-    ConstRefState state,
-    const std::string &sender_key,
-    AsyncGrpcClient<google::protobuf::Empty> &async_call);
+void sendStateAsyncImpl(const shared_model::interface::Peer &to,
+                        ConstRefState state,
+                        const std::string &sender_key,
+                        AsyncGrpcClient<google::protobuf::Empty> &async_call);
 
 MstTransportGrpc::MstTransportGrpc(
     std::shared_ptr<AsyncGrpcClient<google::protobuf::Empty>> async_call,
@@ -58,7 +57,7 @@ MstTransportGrpc::deserializeTransactions(const transport::MstState *request) {
                       &error) {
                 async_call_->log_->info(
                     "Transaction deserialization failed: hash {}, {}",
-                    error.error.hash.toString(),
+                    error.error.hash,
                     error.error.error);
                 return false;
               });

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -208,7 +208,7 @@ bool OnDemandOrderingServiceImpl::batchAlreadyProcessed(
   auto tx_statuses = tx_cache_->check(batch);
   if (not tx_statuses) {
     // TODO andrei 30.11.18 IR-51 Handle database error
-    log_->warn("Check tx presence database error. Batch: {}", batch.toString());
+    log_->warn("Check tx presence database error. Batch: {}", batch);
     return true;
   }
   // if any transaction is commited or rejected, batch was already processed

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -46,7 +46,7 @@ OnDemandOsServerGrpc::deserializeTransactions(
               [&](const iroha::expected::Error<TransportFactoryType::Error>
                       &error) {
                 log_->info("Transaction deserialization failed: hash {}, {}",
-                           error.error.hash.toString(),
+                           error.error.hash,
                            error.error.error);
                 return false;
               });

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -103,7 +103,7 @@ namespace torii {
     using ResponsePtrType =
         std::shared_ptr<shared_model::interface::TransactionResponse>;
     auto initial_status = cache_->findItem(hash).value_or([&] {
-      log_->debug("tx is not received: {}", hash.toString());
+      log_->debug("tx is not received: {}", hash);
       return status_factory_->makeNotReceived(hash);
     }());
     return status_bus_

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -118,7 +118,7 @@ namespace iroha {
         this->pcs_->propagate_batch(batch);
       });
       mst_processor_->onExpiredBatches().subscribe([this](auto &&batch) {
-        log_->info("MST batch {} is expired", batch->reducedHash().toString());
+        log_->info("MST batch {} is expired", batch->reducedHash());
         for (auto &&tx : batch->transactions()) {
           this->publishStatus(TxStatusType::kMstExpired, tx->hash());
         }

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -1,27 +1,25 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_SPDLOG_LOGGER_LOGGER_HPP
 #define IROHA_SPDLOG_LOGGER_LOGGER_HPP
 
-#include <spdlog/spdlog.h>
 #include <memory>
 #include <numeric>  // for std::accumulate
 #include <string>
+
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
+
+/// Allows to log objects, which has toString() method without calling it, e.g.
+/// log.info("{}", myObject)
+template <typename StreamType, typename T>
+auto operator<<(StreamType &os, const T &object)
+    -> decltype(os << object.toString()) {
+  return os << object.toString();
+}
 
 namespace logger {
 

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -13,7 +13,7 @@
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
-/// Allows to log objects, which has toString() method without calling it, e.g.
+/// Allows to log objects, which have toString() method without calling it, e.g.
 /// log.info("{}", myObject)
 template <typename StreamType, typename T>
 auto operator<<(StreamType &os, const T &object)

--- a/shared_model/interfaces/queries/query.hpp
+++ b/shared_model/interfaces/queries/query.hpp
@@ -7,7 +7,6 @@
 #define IROHA_SHARED_MODEL_QUERY_HPP
 
 #include <boost/variant/variant_fwd.hpp>
-
 #include "interfaces/base/signable.hpp"
 #include "interfaces/common_objects/types.hpp"
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -359,7 +359,7 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::sendTxWithoutValidation(
       const shared_model::proto::Transaction &tx) {
     log_->info("sending transaction");
-    log_->debug(tx.toString());
+    log_->debug("{}", tx);
 
     command_client_.Torii(tx.getTransport());
     return *this;
@@ -499,7 +499,7 @@ namespace integration_framework {
       std::function<void(const shared_model::proto::QueryResponse &)>
           validation) {
     log_->info("send query");
-    log_->debug(qry.toString());
+    log_->debug("{}", qry);
 
     iroha::protocol::QueryResponse response;
     query_client_.Find(qry.getTransport(), response);

--- a/test/module/shared_model/interface_test.cpp
+++ b/test/module/shared_model/interface_test.cpp
@@ -21,7 +21,7 @@ class TransactionFixture : public ::testing::Test {
   logger::Logger log = logger::log("TransactionFixture");
 
   auto makeTx() {
-    log->info("keypair = {}, timestemp = {}", keypair.toString(), time);
+    log->info("keypair = {}, timestemp = {}", keypair, time);
     return std::make_shared<shared_model::proto::Transaction>(
         shared_model::proto::TransactionBuilder()
             .createdTime(time)


### PR DESCRIPTION
### Description of the Change

Previously, user-defined objects were printed into the log via calling their `toString()` method, which is not very efficient. This PR introduces an ability to log such objects directly, and their `toString()` will be called only if level of logging meets the one turned on.

### Benefits

No more additional logging overhead when unnecessary.

### Possible Drawbacks 

None.