### PR TITLE
Fix uncommitted cache

### DIFF
--- a/test/module/irohad/ordering/on_demand_cache_test.cpp
+++ b/test/module/irohad/ordering/on_demand_cache_test.cpp
@@ -119,8 +119,8 @@ TEST(OnDemandCache, Remove) {
   auto tx2 = createMockTransactionWithHash(hash2);
   auto tx3 = createMockTransactionWithHash(hash3);
 
-  auto batch1 = createMockBatchWithTransactions({tx1, tx2});
-  auto batch2 = createMockBatchWithTransactions({tx3});
+  auto batch1 = createMockBatchWithTransactions({tx1, tx2}, "abc");
+  auto batch2 = createMockBatchWithTransactions({tx3}, "123");
 
   cache.addToBack({batch1, batch2});
   cache.pop();

--- a/test/module/irohad/ordering/on_demand_cache_test.cpp
+++ b/test/module/irohad/ordering/on_demand_cache_test.cpp
@@ -104,7 +104,8 @@ TEST(OnDemandCache, Pop) {
 
 /**
  * @given cache with batch1, batch2, and batch3 on the top
- * @when remove({batch2, batch3}) is invoked
+ * @when remove({hash1}) is invoked, where hash1 is the hash of transactions
+ * from batch1
  * @then only batch1 remains on the head of the queue
  */
 TEST(OnDemandCache, Remove) {
@@ -114,25 +115,28 @@ TEST(OnDemandCache, Remove) {
   shared_model::interface::types::HashType hash2("hash2");
   shared_model::interface::types::HashType hash3("hash3");
 
-  auto batch1 = createMockBatchWithHash(hash1);
-  auto batch2 = createMockBatchWithHash(hash2);
-  auto batch3 = createMockBatchWithHash(hash3);
+  auto tx1 = createMockTransactionWithHash(hash1);
+  auto tx2 = createMockTransactionWithHash(hash2);
+  auto tx3 = createMockTransactionWithHash(hash3);
 
-  cache.addToBack({batch1, batch2, batch3});
+  auto batch1 = createMockBatchWithTransactions({tx1, tx2});
+  auto batch2 = createMockBatchWithTransactions({tx3});
+
+  cache.addToBack({batch1, batch2});
   cache.pop();
   cache.pop();
   /**
-   * 1. {batch1, batch2, batch3}
+   * 1. {batch1, batch2}
    * 2.
    * 3.
    */
-  ASSERT_THAT(cache.head(), UnorderedElementsAre(batch1, batch2, batch3));
+  ASSERT_THAT(cache.head(), UnorderedElementsAre(batch1, batch2));
 
-  cache.remove({hash2, hash3});
+  cache.remove({hash1});
   /**
    * 1. {batch1}
    * 2.
    * 3.
    */
-  ASSERT_THAT(cache.head(), ElementsAre(batch1));
+  ASSERT_THAT(cache.head(), ElementsAre(batch2));
 }

--- a/test/module/irohad/ordering/on_demand_cache_test.cpp
+++ b/test/module/irohad/ordering/on_demand_cache_test.cpp
@@ -103,10 +103,10 @@ TEST(OnDemandCache, Pop) {
 }
 
 /**
- * @given cache with batch1, batch2, and batch3 on the top
+ * @given cache with batch1 and batch2 on the top
  * @when remove({hash1}) is invoked, where hash1 is the hash of transactions
  * from batch1
- * @then only batch1 remains on the head of the queue
+ * @then only batch2 remains on the head of the queue
  */
 TEST(OnDemandCache, Remove) {
   OnDemandCache cache;
@@ -134,7 +134,7 @@ TEST(OnDemandCache, Remove) {
 
   cache.remove({hash1});
   /**
-   * 1. {batch1}
+   * 1. {batch2}
    * 2.
    * 3.
    */

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -7,6 +7,7 @@
 #define IROHA_SHARED_MODEL_INTERFACE_MOCKS_HPP
 
 #include <gmock/gmock.h>
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/public_key.hpp"
 #include "cryptography/signed.hpp"
 #include "interfaces/commands/command.hpp"
@@ -71,6 +72,23 @@ struct MockTransaction : public shared_model::interface::Transaction {
       boost::optional<std::shared_ptr<shared_model::interface::BatchMeta>>());
 };
 
+/**
+ * Creates mock transaction with provided hash
+ * @param hash -- const ref to hash to be returned by the transaction
+ * @return shared_ptr for transaction
+ */
+auto createMockTransactionWithHash(
+    const shared_model::interface::types::HashType &hash) {
+  using ::testing::NiceMock;
+  using ::testing::ReturnRefOfCopy;
+
+  auto res = std::make_shared<NiceMock<MockTransaction>>();
+
+  ON_CALL(*res, hash()).WillByDefault(ReturnRefOfCopy(hash));
+
+  return res;
+}
+
 struct MockTransactionBatch : public shared_model::interface::TransactionBatch {
   MOCK_CONST_METHOD0(
       transactions,
@@ -95,7 +113,7 @@ struct MockTransactionBatch : public shared_model::interface::TransactionBatch {
 
 /**
  * Creates mock batch with provided hash
- * @param hash -- const ref to hash to be returned by the batch
+ * @param hash -- const ref to reduced hash to be returned by the batch
  * @return shared_ptr for batch
  */
 auto createMockBatchWithHash(
@@ -106,6 +124,28 @@ auto createMockBatchWithHash(
   auto res = std::make_shared<NiceMock<MockTransactionBatch>>();
 
   ON_CALL(*res, reducedHash()).WillByDefault(ReturnRefOfCopy(hash));
+
+  return res;
+}
+
+/**
+ * Creates mock batch with provided transactions
+ * @param txs -- const ref to hash to be returned by the batch
+ * @return shared_ptr for batch
+ */
+auto createMockBatchWithTransactions(
+    const shared_model::interface::types::SharedTxsCollectionType &txs) {
+  using ::testing::NiceMock;
+  using ::testing::ReturnRefOfCopy;
+
+  auto res = std::make_shared<NiceMock<MockTransactionBatch>>();
+
+  ON_CALL(*res, transactions()).WillByDefault(ReturnRefOfCopy(txs));
+
+  ON_CALL(*res, reducedHash())
+      .WillByDefault(ReturnRefOfCopy(shared_model::crypto::Hash::fromHexString(
+          shared_model::crypto::DefaultCryptoAlgorithmType::generateSeed()
+              .hex())));
 
   return res;
 }

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -7,7 +7,6 @@
 #define IROHA_SHARED_MODEL_INTERFACE_MOCKS_HPP
 
 #include <gmock/gmock.h>
-#include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/public_key.hpp"
 #include "cryptography/signed.hpp"
 #include "interfaces/commands/command.hpp"
@@ -134,7 +133,8 @@ auto createMockBatchWithHash(
  * @return shared_ptr for batch
  */
 auto createMockBatchWithTransactions(
-    const shared_model::interface::types::SharedTxsCollectionType &txs) {
+    const shared_model::interface::types::SharedTxsCollectionType &txs,
+    std::string hash) {
   using ::testing::NiceMock;
   using ::testing::ReturnRefOfCopy;
 
@@ -143,9 +143,7 @@ auto createMockBatchWithTransactions(
   ON_CALL(*res, transactions()).WillByDefault(ReturnRefOfCopy(txs));
 
   ON_CALL(*res, reducedHash())
-      .WillByDefault(ReturnRefOfCopy(shared_model::crypto::Hash::fromHexString(
-          shared_model::crypto::DefaultCryptoAlgorithmType::generateSeed()
-              .hex())));
+      .WillByDefault(ReturnRefOfCopy(shared_model::crypto::Hash{hash}));
 
   return res;
 }

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -129,7 +129,8 @@ auto createMockBatchWithHash(
 
 /**
  * Creates mock batch with provided transactions
- * @param txs -- const ref to hash to be returned by the batch
+ * @param txs -- list of transactions in the batch
+ * @param hash -- const ref to hash to be returned by the batch
  * @return shared_ptr for batch
  */
 auto createMockBatchWithTransactions(


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Previously uncommitted transactions cache was removing by reduced hash of transaction batch. However block event emitted to ordering gate returns hashes of transactions. So the fix removes batches from the cache by transaction's hash. So, if any batch in transaction cache contains transaction with given transaction hash, then entire batch with that transaction is removed from the cache

### Benefits

No more duplication warnings

### Possible Drawbacks 

None

### Usage Examples or Tests

on_demand_cache_test with remove function was updated
