### PR TITLE
Add round check to consensus gate, fix ordering gate round

### DIFF
--- a/irohad/consensus/round.hpp
+++ b/irohad/consensus/round.hpp
@@ -10,6 +10,8 @@
 #include <cstdint>
 #include <string>
 
+#include <boost/operators.hpp>
+
 namespace iroha {
   namespace consensus {
 
@@ -26,7 +28,7 @@ namespace iroha {
     /**
      * Type of proposal round
      */
-    struct Round {
+    struct Round : public boost::less_than_comparable<Round> {
       BlockRoundType block_round;
       RejectRoundType reject_round;
 

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "consensus/yac/yac.hpp"
@@ -108,13 +96,16 @@ namespace iroha {
           return;
         }
 
-        log_->info("Vote for round ({}, {}), hash ({}, {})",
+        const auto &current_leader = cluster_order_.currentLeader();
+
+        log_->info("Vote for round ({}, {}), hash ({}, {}) to peer {}",
                    vote.hash.vote_round.block_round,
                    vote.hash.vote_round.reject_round,
                    vote.hash.vote_hashes.proposal_hash,
-                   vote.hash.vote_hashes.block_hash);
+                   vote.hash.vote_hashes.block_hash,
+                   current_leader.toString());
 
-        network_->sendState(cluster_order_.currentLeader(), {vote});
+        network_->sendState(current_leader, {vote});
         cluster_order_.switchToNext();
         if (cluster_order_.hasNext()) {
           timer_->invokeAfterDelay([this, vote] { this->votingStep(vote); });

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -98,12 +98,11 @@ namespace iroha {
 
         const auto &current_leader = cluster_order_.currentLeader();
 
-        log_->info("Vote for round ({}, {}), hash ({}, {}) to peer {}",
-                   vote.hash.vote_round.block_round,
-                   vote.hash.vote_round.reject_round,
+        log_->info("Vote for round {}, hash ({}, {}) to peer {}",
+                   vote.hash.vote_round,
                    vote.hash.vote_hashes.proposal_hash,
                    vote.hash.vote_hashes.block_hash,
-                   current_leader.toString());
+                   current_leader);
 
         network_->sendState(current_leader, {vote});
         cluster_order_.switchToNext();

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -33,12 +33,24 @@ namespace iroha {
             hash_provider_(std::move(hash_provider)),
             block_creator_(std::move(block_creator)),
             consensus_result_cache_(std::move(consensus_result_cache)),
-            log_(logger::log("YacGate")) {
+            log_(logger::log("YacGate")),
+            current_hash_() {
         block_creator_->onBlock().subscribe(
             [this](const auto &event) { this->vote(event); });
       }
 
       void YacGateImpl::vote(const simulator::BlockCreatorEvent &event) {
+        if (not(current_hash_.vote_round < event.round)) {
+          log_->info(
+              "Current round [{}, {}] is greater or equal than vote round [{}, "
+              "{}], skipped",
+              current_hash_.vote_round.block_round,
+              current_hash_.vote_round.reject_round,
+              event.round.block_round,
+              event.round.reject_round);
+          return;
+        }
+
         current_hash_ = hash_provider_->makeHash(event);
 
         if (not event.round_data) {
@@ -85,12 +97,18 @@ namespace iroha {
       rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleCommit(
           const CommitMessage &msg) {
         const auto hash = getHash(msg.votes).value();
-        if (hash.vote_hashes.proposal_hash.empty()) {
-          // if consensus agreed on nothing for commit
-          log_->info("Consensus skipped round, voted for nothing");
-          return rxcpp::observable<>::just<GateObject>(
-              AgreementOnNone{current_hash_.vote_round});
-        } else if (hash == current_hash_) {
+        if (hash.vote_round < current_hash_.vote_round) {
+          log_->info(
+              "Current round [{}, {}] is greater than commit round [{}, {}], "
+              "skipped",
+              current_hash_.vote_round.block_round,
+              current_hash_.vote_round.reject_round,
+              hash.vote_round.block_round,
+              hash.vote_round.reject_round);
+          return rxcpp::observable<>::empty<GateObject>();
+        }
+
+        if (hash == current_hash_ and current_block_) {
           // if node has voted for the committed block
           // append signatures of other nodes
           this->copySignatures(msg);
@@ -101,7 +119,19 @@ namespace iroha {
           return rxcpp::observable<>::just<GateObject>(
               PairValid{block, current_hash_.vote_round});
         }
+
+        current_hash_ = hash;
+
+        if (hash.vote_hashes.proposal_hash.empty()) {
+          // if consensus agreed on nothing for commit
+          log_->info("Consensus skipped round, voted for nothing");
+          current_block_ = boost::none;
+          return rxcpp::observable<>::just<GateObject>(
+              AgreementOnNone{current_hash_.vote_round});
+        }
+
         log_->info("Voted for another block, waiting for sync");
+        current_block_ = boost::none;
         auto public_keys = boost::copy_range<
             shared_model::interface::types::PublicKeyCollectionType>(
             msg.votes | boost::adaptors::transformed([](auto &vote) {
@@ -116,8 +146,26 @@ namespace iroha {
 
       rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleReject(
           const RejectMessage &msg) {
-        const auto hash = getHash(msg.votes);
-        if (not hash) {
+        const auto hash = getHash(msg.votes).value();
+        if (hash.vote_round < current_hash_.vote_round) {
+          log_->info(
+              "Current round [{}, {}] is greater than reject round [{}, {}], "
+              "skipped",
+              current_hash_.vote_round.block_round,
+              current_hash_.vote_round.reject_round,
+              hash.vote_round.block_round,
+              hash.vote_round.reject_round);
+          return rxcpp::observable<>::empty<GateObject>();
+        }
+
+        auto has_same_proposals =
+            std::all_of(std::next(msg.votes.begin()),
+                        msg.votes.end(),
+                        [first = msg.votes.begin()](const auto &current) {
+                          return first->hash.vote_hashes.proposal_hash
+                              == current.hash.vote_hashes.proposal_hash;
+                        });
+        if (not has_same_proposals) {
           log_->info("Proposal reject since all hashes are different");
           return rxcpp::observable<>::just<GateObject>(
               ProposalReject{current_hash_.vote_round});

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -40,14 +40,12 @@ namespace iroha {
       }
 
       void YacGateImpl::vote(const simulator::BlockCreatorEvent &event) {
-        if (not(current_hash_.vote_round < event.round)) {
+        if (current_hash_.vote_round >= event.round) {
           log_->info(
-              "Current round [{}, {}] is greater or equal than vote round [{}, "
-              "{}], skipped",
-              current_hash_.vote_round.block_round,
-              current_hash_.vote_round.reject_round,
-              event.round.block_round,
-              event.round.reject_round);
+              "Current round {} is greater than or equal to vote round {}, "
+              "skipped",
+              current_hash_.vote_round,
+              event.round);
           return;
         }
 
@@ -99,12 +97,9 @@ namespace iroha {
         const auto hash = getHash(msg.votes).value();
         if (hash.vote_round < current_hash_.vote_round) {
           log_->info(
-              "Current round [{}, {}] is greater than commit round [{}, {}], "
-              "skipped",
-              current_hash_.vote_round.block_round,
-              current_hash_.vote_round.reject_round,
-              hash.vote_round.block_round,
-              hash.vote_round.reject_round);
+              "Current round {} is greater than commit round {}, skipped",
+              current_hash_.vote_round,
+              hash.vote_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
 
@@ -149,12 +144,9 @@ namespace iroha {
         const auto hash = getHash(msg.votes).value();
         if (hash.vote_round < current_hash_.vote_round) {
           log_->info(
-              "Current round [{}, {}] is greater than reject round [{}, {}], "
-              "skipped",
-              current_hash_.vote_round.block_round,
-              current_hash_.vote_round.reject_round,
-              hash.vote_round.block_round,
-              hash.vote_round.reject_round);
+              "Current round {} is greater than reject round {}, skipped",
+              current_hash_.vote_round,
+              hash.vote_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
 

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -28,10 +28,9 @@ namespace iroha {
           votes_.push_back(msg);
 
           log_->info(
-              "Vote with rounds ({}, {}) and hashes ({}, {}) inserted, votes "
-              "in storage [{}/{}]",
-              msg.hash.vote_round.block_round,
-              msg.hash.vote_round.reject_round,
+              "Vote with round {} and hashes ({}, {}) inserted, votes in "
+              "storage [{}/{}]",
+              msg.hash.vote_round,
               msg.hash.vote_hashes.proposal_hash,
               msg.hash.vote_hashes.block_hash,
               votes_.size(),

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "consensus/yac/storage/yac_block_storage.hpp"
@@ -39,13 +27,15 @@ namespace iroha {
         if (validScheme(msg) and uniqueVote(msg)) {
           votes_.push_back(msg);
 
-          log_->info("Vote with rounds ({}, {}) and hashes ({}, {}) inserted",
-                     msg.hash.vote_round.block_round,
-                     msg.hash.vote_round.reject_round,
-                     msg.hash.vote_hashes.proposal_hash,
-                     msg.hash.vote_hashes.block_hash);
           log_->info(
-              "Votes in storage [{}/{}]", votes_.size(), peers_in_round_);
+              "Vote with rounds ({}, {}) and hashes ({}, {}) inserted, votes "
+              "in storage [{}/{}]",
+              msg.hash.vote_round.block_round,
+              msg.hash.vote_round.reject_round,
+              msg.hash.vote_hashes.proposal_hash,
+              msg.hash.vote_hashes.block_hash,
+              votes_.size(),
+              peers_in_round_);
         }
         return getState();
       }

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -101,7 +101,7 @@ namespace iroha {
 
           // generate permutation of peers list from corresponding round
           // hash
-          auto generate_permutation = [&](auto &&round) {
+          auto generate_permutation = [&](auto round) {
             auto &hash = std::get<round()>(current_hashes);
             log_->debug("Using hash: {}", hash.toString());
             auto &permutation = permutations_[round()];
@@ -119,7 +119,7 @@ namespace iroha {
           generate_permutation(RoundTypeConstant<kNextRound>{});
           generate_permutation(RoundTypeConstant<kRoundAfterNext>{});
         };
-        auto on_nothing = [this, &current_round](const auto &) {
+        auto on_nothing = [&current_round](const auto &) {
           current_round = ordering::nextRejectRound(current_round);
         };
 

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -93,7 +93,7 @@ namespace iroha {
           current_round = ordering::nextCommitRound(current_round);
 
           // retrieve peer list from database
-          // TODO andrei 08.11.2018 IR-1853 Refactor PeerQuery without
+          // TODO lebdron 08.11.2018 IR-1853 Refactor PeerQuery without
           // database access and optional
           peer_query_factory->createPeerQuery() | [](auto &&query) {
             return query->getLedgerPeers();
@@ -101,7 +101,7 @@ namespace iroha {
 
           // generate permutation of peers list from corresponding round
           // hash
-          auto generate_permutation = [&](auto round) {
+          auto generate_permutation = [&](auto &&round) {
             auto &hash = std::get<round()>(current_hashes);
             log_->debug("Using hash: {}", hash.toString());
             auto &permutation = permutations_[round()];

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -132,9 +132,8 @@ namespace iroha {
           // with number of peers
           auto &peer =
               current_peers_[permutation[reject_round % permutation.size()]];
-          log_->debug("For round [block={}, reject={}, ], using OS on peer: {}",
-                      current_round.block_round,
-                      reject_round,
+          log_->debug("For round {}, using OS on peer: {}",
+                      consensus::Round{current_round.block_round, reject_round},
                       peer->toString());
           return peer;
         };

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -84,51 +84,56 @@ namespace iroha {
         auto &latest_commit = std::get<0>(latest_data);
         auto &current_hashes = std::get<1>(latest_data);
 
-        auto on_blocks =
-            [this, peer_query_factory, current_hashes](const auto &commit) {
-              current_reject_round_ = ordering::kFirstRejectRound;
+        consensus::Round current_round = latest_commit.round;
 
-              // retrieve peer list from database
-              // TODO andrei 08.11.2018 IR-1853 Refactor PeerQuery without
-              // database access and optional
-              peer_query_factory->createPeerQuery() | [](auto &&query) {
-                return query->getLedgerPeers();
-              } | [this](auto &&peers) { current_peers_ = std::move(peers); };
+        auto on_blocks = [this,
+                          peer_query_factory,
+                          current_hashes,
+                          &current_round](const auto &commit) {
+          current_round = ordering::nextCommitRound(current_round);
 
-              // generate permutation of peers list from corresponding round
-              // hash
-              auto generate_permutation = [&](auto round) {
-                auto &hash = std::get<round()>(current_hashes);
-                log_->debug("Using hash: {}", hash.toString());
-                auto &permutation = permutations_[round()];
+          // retrieve peer list from database
+          // TODO andrei 08.11.2018 IR-1853 Refactor PeerQuery without
+          // database access and optional
+          peer_query_factory->createPeerQuery() | [](auto &&query) {
+            return query->getLedgerPeers();
+          } | [this](auto &&peers) { current_peers_ = std::move(peers); };
 
-                std::seed_seq seed(hash.blob().begin(), hash.blob().end());
-                gen_.seed(seed);
+          // generate permutation of peers list from corresponding round
+          // hash
+          auto generate_permutation = [&](auto round) {
+            auto &hash = std::get<round()>(current_hashes);
+            log_->debug("Using hash: {}", hash.toString());
+            auto &permutation = permutations_[round()];
 
-                permutation.resize(current_peers_.size());
-                std::iota(permutation.begin(), permutation.end(), 0);
+            std::seed_seq seed(hash.blob().begin(), hash.blob().end());
+            gen_.seed(seed);
 
-                std::shuffle(permutation.begin(), permutation.end(), gen_);
-              };
+            permutation.resize(current_peers_.size());
+            std::iota(permutation.begin(), permutation.end(), 0);
 
-              generate_permutation(RoundTypeConstant<kCurrentRound>{});
-              generate_permutation(RoundTypeConstant<kNextRound>{});
-              generate_permutation(RoundTypeConstant<kRoundAfterNext>{});
-            };
-        auto on_nothing = [this](const auto &) { current_reject_round_++; };
+            std::shuffle(permutation.begin(), permutation.end(), gen_);
+          };
+
+          generate_permutation(RoundTypeConstant<kCurrentRound>{});
+          generate_permutation(RoundTypeConstant<kNextRound>{});
+          generate_permutation(RoundTypeConstant<kRoundAfterNext>{});
+        };
+        auto on_nothing = [this, &current_round](const auto &) {
+          current_round = ordering::nextRejectRound(current_round);
+        };
 
         matchEvent(latest_commit, on_blocks, on_nothing);
 
-        const auto current_block_round = latest_commit.round.block_round + 1;
-        auto getOsPeer = [this, &current_block_round](auto block_round_advance,
-                                                      auto reject_round) {
+        auto getOsPeer = [this, &current_round](auto block_round_advance,
+                                                auto reject_round) {
           auto &permutation = permutations_[block_round_advance];
           // since reject round can be greater than number of peers, wrap it
           // with number of peers
           auto &peer =
               current_peers_[permutation[reject_round % permutation.size()]];
           log_->debug("For round [block={}, reject={}, ], using OS on peer: {}",
-                      current_block_round + block_round_advance,
+                      current_round.block_round,
                       reject_round,
                       peer->toString());
           return peer;
@@ -151,15 +156,15 @@ namespace iroha {
          * o, round 0 - kIssuer
          */
         peers.peers.at(OnDemandConnectionManager::kCurrentRoundRejectConsumer) =
-            getOsPeer(
-                kCurrentRound,
-                ordering::currentRejectRoundConsumer(current_reject_round_));
+            getOsPeer(kCurrentRound,
+                      ordering::currentRejectRoundConsumer(
+                          current_round.reject_round));
         peers.peers.at(OnDemandConnectionManager::kNextRoundRejectConsumer) =
             getOsPeer(kNextRound, ordering::kNextRejectRoundConsumer);
         peers.peers.at(OnDemandConnectionManager::kNextRoundCommitConsumer) =
             getOsPeer(kRoundAfterNext, ordering::kNextCommitRoundConsumer);
         peers.peers.at(OnDemandConnectionManager::kIssuer) =
-            getOsPeer(kCurrentRound, current_reject_round_);
+            getOsPeer(kCurrentRound, current_round.reject_round);
         return peers;
       };
 
@@ -228,12 +233,13 @@ namespace iroha {
                               rejected.end(),
                               std::inserter(hashes, hashes.end()));
                   });
-              return ordering::OnDemandOrderingGate::BlockEvent{commit.round,
-                                                                hashes};
+              return ordering::OnDemandOrderingGate::BlockEvent{
+                  ordering::nextCommitRound(commit.round), hashes};
             },
-            [](const auto &)
+            [](const auto &nothing)
                 -> ordering::OnDemandOrderingGate::BlockRoundEventType {
-              return ordering::OnDemandOrderingGate::EmptyEvent{};
+              return ordering::OnDemandOrderingGate::EmptyEvent{
+                  ordering::nextRejectRound(nothing.round)};
             });
       };
 

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -127,8 +127,6 @@ namespace iroha {
      private:
       logger::Logger log_ = logger::log("OnDemandOrderingInit");
 
-      /// reject round set from latest commit chain size
-      consensus::RejectRoundType current_reject_round_ = 1;
       std::vector<std::shared_ptr<shared_model::interface::Peer>>
           current_peers_;
 

--- a/irohad/ordering/impl/on_demand_common.cpp
+++ b/irohad/ordering/impl/on_demand_common.cpp
@@ -21,5 +21,13 @@ namespace iroha {
     const consensus::RejectRoundType kNextCommitRoundConsumer =
         kFirstRejectRound;
 
+    consensus::Round nextCommitRound(consensus::Round round) {
+      return {round.block_round + 1, kFirstRejectRound};
+    }
+
+    consensus::Round nextRejectRound(consensus::Round round) {
+      return {round.block_round, round.reject_round + 1};
+    }
+
   }  // namespace ordering
 }  // namespace iroha

--- a/irohad/ordering/impl/on_demand_common.cpp
+++ b/irohad/ordering/impl/on_demand_common.cpp
@@ -21,11 +21,11 @@ namespace iroha {
     const consensus::RejectRoundType kNextCommitRoundConsumer =
         kFirstRejectRound;
 
-    consensus::Round nextCommitRound(consensus::Round round) {
+    consensus::Round nextCommitRound(const consensus::Round &round) {
       return {round.block_round + 1, kFirstRejectRound};
     }
 
-    consensus::Round nextRejectRound(consensus::Round round) {
+    consensus::Round nextRejectRound(const consensus::Round &round) {
       return {round.block_round, round.reject_round + 1};
     }
 

--- a/irohad/ordering/impl/on_demand_common.hpp
+++ b/irohad/ordering/impl/on_demand_common.hpp
@@ -20,9 +20,9 @@ namespace iroha {
 
     extern const consensus::RejectRoundType kNextCommitRoundConsumer;
 
-    consensus::Round nextCommitRound(consensus::Round round);
+    consensus::Round nextCommitRound(const consensus::Round &round);
 
-    consensus::Round nextRejectRound(consensus::Round round);
+    consensus::Round nextRejectRound(const consensus::Round &round);
 
   }  // namespace ordering
 }  // namespace iroha

--- a/irohad/ordering/impl/on_demand_common.hpp
+++ b/irohad/ordering/impl/on_demand_common.hpp
@@ -20,6 +20,10 @@ namespace iroha {
 
     extern const consensus::RejectRoundType kNextCommitRoundConsumer;
 
+    consensus::Round nextCommitRound(consensus::Round round);
+
+    consensus::Round nextRejectRound(consensus::Round round);
+
   }  // namespace ordering
 }  // namespace iroha
 

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -35,15 +35,13 @@ OnDemandOrderingGate::OnDemandOrderingGate(
                          log_->debug("BlockEvent. round [{}, {}]",
                                      block_event.round.block_round,
                                      block_event.round.reject_round);
-                         current_round_ = {block_event.round.block_round + 1,
-                                           kFirstRejectRound};
+                         current_round_ = block_event.round;
                          cache_->remove(block_event.hashes);
                        },
-                       [this](const EmptyEvent &empty) {
+                       [this](const EmptyEvent &empty_event) {
                          // no blocks committed, increment reject round
                          log_->debug("EmptyEvent");
-                         current_round_ = {current_round_.block_round,
-                                           current_round_.reject_round + 1};
+                         current_round_ = empty_event.round;
                        });
         log_->debug("Current round: [{}, {}]",
                     current_round_.block_round,

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -43,7 +43,9 @@ namespace iroha {
       /**
        * Represents no storage modification. Reject round increment
        */
-      struct EmptyEvent {};
+      struct EmptyEvent {
+        consensus::Round round;
+      };
 
       using BlockRoundEventType = boost::variant<BlockEvent, EmptyEvent>;
 

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -36,7 +36,9 @@ namespace iroha {
        * Represents storage modification. Proposal round increment
        */
       struct BlockEvent {
+        /// next round number
         consensus::Round round;
+        /// hashes of processed transactions
         cache::OrderingGateCache::HashesSetType hashes;
       };
 
@@ -44,6 +46,7 @@ namespace iroha {
        * Represents no storage modification. Reject round increment
        */
       struct EmptyEvent {
+        /// next round number
         consensus::Round round;
       };
 

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -18,6 +18,7 @@ auto operator<<(StreamType &os, const T &object)
   return os << object.toString();
 }
 
+#include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
 namespace logger {

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -10,9 +10,6 @@
 #include <numeric>  // for std::accumulate
 #include <string>
 
-#include <spdlog/fmt/ostr.h>
-#include <spdlog/spdlog.h>
-
 /// Allows to log objects, which have toString() method without calling it, e.g.
 /// log.info("{}", myObject)
 template <typename StreamType, typename T>
@@ -20,6 +17,8 @@ auto operator<<(StreamType &os, const T &object)
     -> decltype(os << object.toString()) {
   return os << object.toString();
 }
+
+#include <spdlog/spdlog.h>
 
 namespace logger {
 

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -77,6 +77,9 @@ class YacGateTest : public ::testing::Test {
     block_creator = std::make_shared<MockBlockCreator>();
     block_cache = std::make_shared<ConsensusResultCache>();
 
+    ON_CALL(*hash_gate, onOutcome())
+        .WillByDefault(Return(outcome_notifier.get_observable()));
+
     ON_CALL(*block_creator, onBlock())
         .WillByDefault(Return(block_notifier.get_observable()));
 
@@ -121,9 +124,6 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(expected_hash, _)).Times(1);
 
-  EXPECT_CALL(*hash_gate, onOutcome())
-      .WillOnce(Return(outcome_notifier.get_observable()));
-
   // generate order of peers
   EXPECT_CALL(*peer_orderer, getOrdering(_))
       .WillOnce(Return(ClusterOrdering::create({mk_peer("fake_node")})));
@@ -163,8 +163,6 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(_, _)).Times(0);
 
-  EXPECT_CALL(*hash_gate, onOutcome()).Times(0);
-
   // generate order of peers
   EXPECT_CALL(*peer_orderer, getOrdering(_)).WillOnce(Return(boost::none));
 
@@ -188,7 +186,7 @@ TEST_F(YacGateTest, AgreementOnNone) {
 
   ASSERT_EQ(block_cache->get(), nullptr);
 
-  gate->vote({boost::none, {}});
+  gate->vote({boost::none, round});
 
   ASSERT_EQ(block_cache->get(), nullptr);
 }
@@ -225,10 +223,6 @@ TEST_F(YacGateTest, DifferentCommit) {
   commit_message = CommitMessage({message});
   expected_commit = commit_message;
 
-  // yac
-  EXPECT_CALL(*hash_gate, onOutcome())
-      .WillOnce(Return(outcome_notifier.get_observable()));
-
   // convert yac hash to model hash
   EXPECT_CALL(*hash_provider, toModelHash(message.hash))
       .WillOnce(Return(actual_hash));
@@ -250,6 +244,107 @@ TEST_F(YacGateTest, DifferentCommit) {
   });
 
   outcome_notifier.get_subscriber().on_next(expected_commit);
+
+  ASSERT_TRUE(gate_wrapper.validate());
+}
+
+/**
+ * @given yac gate with current round initialized
+ * @when vote for older round is called
+ * @then vote is ignored
+ */
+TEST_F(YacGateTest, OlderVote) {
+  // generate order of peers
+  ON_CALL(*peer_orderer, getOrdering(_))
+      .WillByDefault(Return(ClusterOrdering::create({mk_peer("fake_node")})));
+
+  // make hash from block
+  ON_CALL(*hash_provider, makeHash(_)).WillByDefault(Return(expected_hash));
+
+  block_notifier.get_subscriber().on_next(
+      BlockCreatorEvent{RoundData{expected_proposal, expected_block}, round});
+
+  EXPECT_CALL(*hash_gate, vote(expected_hash, _)).Times(0);
+
+  EXPECT_CALL(*peer_orderer, getOrdering(_)).Times(0);
+
+  EXPECT_CALL(*hash_provider, makeHash(_)).Times(0);
+
+  block_notifier.get_subscriber().on_next(BlockCreatorEvent{
+      boost::none, {round.block_round - 1, round.reject_round}});
+}
+
+/**
+ * @given yac gate with current round initialized
+ * @when commit for older round is received
+ * @then commit is ignored
+ */
+TEST_F(YacGateTest, OlderCommit) {
+  // generate order of peers
+  ON_CALL(*peer_orderer, getOrdering(_))
+      .WillByDefault(Return(ClusterOrdering::create({mk_peer("fake_node")})));
+
+  // make hash from block
+  ON_CALL(*hash_provider, makeHash(_)).WillByDefault(Return(expected_hash));
+
+  block_notifier.get_subscriber().on_next(
+      BlockCreatorEvent{RoundData{expected_proposal, expected_block}, round});
+
+  auto signature = std::make_shared<MockSignature>();
+  EXPECT_CALL(*signature, publicKey())
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey")));
+
+  VoteMessage message{YacHash({round.block_round - 1, round.reject_round},
+                              "actual_proposal",
+                              "actual_block"),
+                      signature};
+  Answer commit{CommitMessage({message})};
+
+  auto gate_wrapper = make_test_subscriber<CallExact>(gate->onOutcome(), 0);
+  gate_wrapper.subscribe();
+
+  outcome_notifier.get_subscriber().on_next(commit);
+
+  ASSERT_TRUE(gate_wrapper.validate());
+}
+
+/**
+ * @given yac gate with current round initialized
+ * @when reject for older round is received
+ * @then reject is ignored
+ */
+TEST_F(YacGateTest, OlderReject) {
+  // generate order of peers
+  ON_CALL(*peer_orderer, getOrdering(_))
+      .WillByDefault(Return(ClusterOrdering::create({mk_peer("fake_node")})));
+
+  // make hash from block
+  ON_CALL(*hash_provider, makeHash(_)).WillByDefault(Return(expected_hash));
+
+  block_notifier.get_subscriber().on_next(
+      BlockCreatorEvent{RoundData{expected_proposal, expected_block}, round});
+
+  auto signature1 = std::make_shared<MockSignature>(),
+       signature2 = std::make_shared<MockSignature>();
+  EXPECT_CALL(*signature1, publicKey())
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey1")));
+  EXPECT_CALL(*signature2, publicKey())
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey2")));
+
+  VoteMessage message1{YacHash({round.block_round - 1, round.reject_round},
+                               "actual_proposal1",
+                               "actual_block1"),
+                       signature1},
+      message2{YacHash({round.block_round - 1, round.reject_round},
+                       "actual_proposal2",
+                       "actual_block2"),
+               signature2};
+  Answer reject{RejectMessage({message1, message2})};
+
+  auto gate_wrapper = make_test_subscriber<CallExact>(gate->onOutcome(), 0);
+  gate_wrapper.subscribe();
+
+  outcome_notifier.get_subscriber().on_next(reject);
 
   ASSERT_TRUE(gate_wrapper.validate());
 }

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -62,7 +62,8 @@ class OnDemandOrderingGateTest : public ::testing::Test {
 
   std::shared_ptr<cache::MockOrderingGateCache> cache;
 
-  const consensus::Round initial_round = {2, kFirstRejectRound};
+  const consensus::Round initial_round = {1, kFirstRejectRound},
+                         round = {2, kFirstRejectRound};
 };
 
 /**
@@ -88,9 +89,6 @@ TEST_F(OnDemandOrderingGateTest, propagateBatch) {
  * @then new proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, BlockEvent) {
-  consensus::Round event_round{3, kFirstRejectRound},
-      round{4, kFirstRejectRound};
-
   auto mproposal = std::make_unique<MockProposal>();
   auto proposal = mproposal.get();
   boost::optional<OdOsNotification::ProposalType> oproposal(
@@ -119,8 +117,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
     ASSERT_EQ(factory_proposal, getProposalUnsafe(val).get());
   });
 
-  rounds.get_subscriber().on_next(
-      OnDemandOrderingGate::BlockEvent{event_round, {}});
+  rounds.get_subscriber().on_next(OnDemandOrderingGate::BlockEvent{round, {}});
 
   ASSERT_TRUE(gate_wrapper.validate());
 }
@@ -132,9 +129,6 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
  * @then new proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
-  consensus::Round round{initial_round.block_round,
-                         initial_round.reject_round + 1};
-
   auto mproposal = std::make_unique<MockProposal>();
   auto proposal = mproposal.get();
   boost::optional<OdOsNotification::ProposalType> oproposal(
@@ -163,7 +157,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
     ASSERT_EQ(factory_proposal, getProposalUnsafe(val).get());
   });
 
-  rounds.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent{});
+  rounds.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent{round});
 
   ASSERT_TRUE(gate_wrapper.validate());
 }
@@ -175,9 +169,6 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
  * @then new empty proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
-  consensus::Round event_round{3, kFirstRejectRound},
-      round{4, kFirstRejectRound};
-
   boost::optional<OdOsNotification::ProposalType> proposal;
 
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
@@ -188,8 +179,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) { ASSERT_FALSE(val.proposal); });
 
-  rounds.get_subscriber().on_next(
-      OnDemandOrderingGate::BlockEvent{event_round, {}});
+  rounds.get_subscriber().on_next(OnDemandOrderingGate::BlockEvent{round, {}});
 
   ASSERT_TRUE(gate_wrapper.validate());
 }
@@ -201,9 +191,6 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
  * @then new empty proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
-  consensus::Round round{initial_round.block_round,
-                         initial_round.reject_round + 1};
-
   boost::optional<OdOsNotification::ProposalType> proposal;
 
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
@@ -214,7 +201,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) { ASSERT_FALSE(val.proposal); });
 
-  rounds.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent{});
+  rounds.get_subscriber().on_next(OnDemandOrderingGate::EmptyEvent{round});
 
   ASSERT_TRUE(gate_wrapper.validate());
 }
@@ -226,9 +213,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
  * this transaction
  */
 TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
-  OnDemandOrderingGate::BlockEvent event = {initial_round, {}};
-  consensus::Round round{initial_round.block_round + 1,
-                         initial_round.reject_round};
+  OnDemandOrderingGate::BlockEvent event = {round, {}};
 
   // initialize mock transaction
   auto tx1 = std::make_shared<NiceMock<MockTransaction>>();
@@ -281,9 +266,6 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
  * @then batch1 and batch2 are propagated to network
  */
 TEST_F(OnDemandOrderingGateTest, SendBatchesFromTheCache) {
-  consensus::Round round{initial_round.block_round + 1,
-                         initial_round.reject_round};
-
   // prepare hashes for mock batches
   shared_model::interface::types::HashType hash1("hash1");
   shared_model::interface::types::HashType hash2("hash2");
@@ -302,8 +284,7 @@ TEST_F(OnDemandOrderingGateTest, SendBatchesFromTheCache) {
               onBatches(round, UnorderedElementsAreArray(collection)))
       .Times(1);
 
-  rounds.get_subscriber().on_next(
-      OnDemandOrderingGate::BlockEvent{initial_round, {}});
+  rounds.get_subscriber().on_next(OnDemandOrderingGate::BlockEvent{round, {}});
 }
 
 /**
@@ -324,5 +305,5 @@ TEST_F(OnDemandOrderingGateTest, BatchesRemoveFromCache) {
   EXPECT_CALL(*cache, remove(UnorderedElementsAre(hash1, hash2))).Times(1);
 
   rounds.get_subscriber().on_next(
-      OnDemandOrderingGate::BlockEvent{initial_round, {hash1, hash2}});
+      OnDemandOrderingGate::BlockEvent{round, {hash1, hash2}});
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
- Ordering gate was generating incorrect reject rounds based on initial stored value. Now it uses the value from observable
- Yac gate was accepting votes and consensus results for old rounds. Now it ignores them
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Predictable pipeline behavior
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None?
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
YacGateTest.OlderVote, YacGateTest.OlderCommit, YacGateTest.OlderReject
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
