### PR TITLE
Commands Mocks Factory

### DIFF
--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(commands_mocks_factory
     shared_model_interfaces
     shared_model_proto_backend
     logger
+    gtest::main
     gmock::main
     )

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -36,4 +36,5 @@ add_library(commands_mocks_factory
 target_link_libraries(commands_mocks_factory
     shared_model_interfaces
     logger
+    gmock::main
     )

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -29,3 +29,11 @@ target_link_libraries(interface_test
     shared_model_default_builders
     logger
     )
+
+add_library(commands_mocks_factory
+    mock_objects_factories/mock_command_factory.cpp
+    )
+target_link_libraries(commands_mocks_factory
+    shared_model_interfaces
+    logger
+    )

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(commands_mocks_factory
     )
 target_link_libraries(commands_mocks_factory
     shared_model_interfaces
+    shared_model_proto_backend
     logger
     gmock::main
     )

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -96,6 +96,7 @@ namespace shared_model {
         : public shared_model::interface::GrantPermission {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
+      MOCK_CONST_METHOD0(toString, std::string());
       MOCK_CONST_METHOD0(clone, MockGrantPermission *());
     };
 
@@ -110,6 +111,7 @@ namespace shared_model {
         : public shared_model::interface::RevokePermission {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
+      MOCK_CONST_METHOD0(toString, std::string());
       MOCK_CONST_METHOD0(clone, MockRevokePermission *());
     };
 

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -1,0 +1,148 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_COMMAND_MOCKS_HPP
+#define IROHA_COMMAND_MOCKS_HPP
+
+#include <gmock/gmock.h>
+#include <boost/variant.hpp>
+#include "cryptography/public_key.hpp"
+#include "interfaces/commands/add_asset_quantity.hpp"
+#include "interfaces/commands/add_peer.hpp"
+#include "interfaces/commands/add_signatory.hpp"
+#include "interfaces/commands/append_role.hpp"
+#include "interfaces/commands/command.hpp"
+#include "interfaces/commands/create_account.hpp"
+#include "interfaces/commands/create_asset.hpp"
+#include "interfaces/commands/create_domain.hpp"
+#include "interfaces/commands/create_role.hpp"
+#include "interfaces/commands/detach_role.hpp"
+#include "interfaces/commands/grant_permission.hpp"
+#include "interfaces/commands/remove_signatory.hpp"
+#include "interfaces/commands/revoke_permission.hpp"
+#include "interfaces/commands/set_account_detail.hpp"
+#include "interfaces/commands/set_quorum.hpp"
+#include "interfaces/commands/subtract_asset_quantity.hpp"
+#include "interfaces/commands/transfer_asset.hpp"
+#include "logger/logger.hpp"
+
+namespace shared_model {
+  namespace interface {
+    struct MockCommand : public shared_model::interface::Command {
+      MOCK_CONST_METHOD0(get, const Command::CommandVariantType &());
+      MOCK_CONST_METHOD0(clone, Command *());
+    };
+
+    struct MockAddAssetQuantity
+        : public shared_model::interface::AddAssetQuantity {
+      MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
+      MOCK_CONST_METHOD0(amount, const Amount &());
+      MOCK_CONST_METHOD0(clone, AddAssetQuantity *());
+    };
+
+    struct MockAddPeer : public shared_model::interface::AddPeer {
+      MOCK_CONST_METHOD0(peer, const Peer &());
+      MOCK_CONST_METHOD0(clone, MockAddPeer *());
+    };
+
+    struct MockAddSignatory : public shared_model::interface::AddSignatory {
+      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(clone, MockAddSignatory *());
+    };
+
+    struct MockAppendRole : public shared_model::interface::AppendRole {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
+      MOCK_CONST_METHOD0(clone, MockAppendRole *());
+    };
+
+    struct MockCreateAccount : public shared_model::interface::CreateAccount {
+      MOCK_CONST_METHOD0(accountName, const types::AccountNameType &());
+      MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
+      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(clone, MockCreateAccount *());
+    };
+
+    struct MockCreateAsset : public shared_model::interface::CreateAsset {
+      MOCK_CONST_METHOD0(assetName, const types::AssetNameType &());
+      MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
+      MOCK_CONST_METHOD0(precision, const PrecisionType &());
+      MOCK_CONST_METHOD0(clone, MockCreateAsset *());
+    };
+
+    struct MockCreateDomain : public shared_model::interface::CreateDomain {
+      MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
+      MOCK_CONST_METHOD0(userDefaultRole, const types::RoleIdType &());
+      MOCK_CONST_METHOD0(clone, MockCreateDomain *());
+    };
+
+    struct MockCreateRole : public shared_model::interface::CreateRole {
+      MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
+      MOCK_CONST_METHOD0(rolePermissions, const RolePermissionSet &());
+      MOCK_CONST_METHOD0(toString, std::string());
+      MOCK_CONST_METHOD0(clone, MockCreateRole *());
+    };
+
+    struct MockDetachRole : public shared_model::interface::DetachRole {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
+      MOCK_CONST_METHOD0(clone, MockDetachRole *());
+    };
+
+    struct MockGrantPermission
+        : public shared_model::interface::GrantPermission {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
+      MOCK_CONST_METHOD0(clone, MockGrantPermission *());
+    };
+
+    struct MockRemoveSignatory
+        : public shared_model::interface::RemoveSignatory {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(clone, MockRemoveSignatory *());
+    };
+
+    struct MockRevokePermission
+        : public shared_model::interface::RevokePermission {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
+      MOCK_CONST_METHOD0(clone, MockRevokePermission *());
+    };
+
+    struct MockSetAccountDetail
+        : public shared_model::interface::SetAccountDetail {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(key, const types::AccountDetailKeyType &());
+      MOCK_CONST_METHOD0(value, const types::AccountDetailValueType &());
+      MOCK_CONST_METHOD0(clone, MockSetAccountDetail *());
+    };
+
+    struct MockSetQuorum : public shared_model::interface::SetQuorum {
+      MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(newQuorum, types::QuorumType());
+      MOCK_CONST_METHOD0(clone, MockSetQuorum *());
+    };
+
+    struct MockSubtractAssetQuantity
+        : public shared_model::interface::SubtractAssetQuantity {
+      MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
+      MOCK_CONST_METHOD0(amount, const Amount &());
+      MOCK_CONST_METHOD0(clone, MockSubtractAssetQuantity *());
+    };
+
+    struct MockTransferAsset : public shared_model::interface::TransferAsset {
+      MOCK_CONST_METHOD0(srcAccountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(destAccountId, const types::AccountIdType &());
+      MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
+      MOCK_CONST_METHOD0(amount, const Amount &());
+      MOCK_CONST_METHOD0(description, const types::DescriptionType &());
+      MOCK_CONST_METHOD0(clone, MockTransferAsset *());
+    };
+  }  // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_COMMAND_MOCKS_HPP

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -28,6 +28,8 @@
 #include "interfaces/commands/transfer_asset.hpp"
 #include "logger/logger.hpp"
 
+using testing::Return;
+
 namespace shared_model {
   namespace interface {
     struct MockCommand : public shared_model::interface::Command {
@@ -80,6 +82,10 @@ namespace shared_model {
     };
 
     struct MockCreateRole : public shared_model::interface::CreateRole {
+      MockCreateRole() {
+        ON_CALL(*this, toString()).WillByDefault(Return("MockCreateRole"));
+      }
+
       MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
       MOCK_CONST_METHOD0(rolePermissions, const RolePermissionSet &());
       MOCK_CONST_METHOD0(toString, std::string());
@@ -94,6 +100,11 @@ namespace shared_model {
 
     struct MockGrantPermission
         : public shared_model::interface::GrantPermission {
+      MockGrantPermission() {
+        ON_CALL(*this, toString())
+            .WillByDefault(Return("MockGrantPermissions"));
+      }
+
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
       MOCK_CONST_METHOD0(toString, std::string());
@@ -109,6 +120,11 @@ namespace shared_model {
 
     struct MockRevokePermission
         : public shared_model::interface::RevokePermission {
+      MockRevokePermission() {
+        ON_CALL(*this, toString())
+            .WillByDefault(Return("MockRevokePermission"));
+      }
+
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
       MOCK_CONST_METHOD0(toString, std::string());

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -6,6 +6,7 @@
 #include "module/shared_model/mock_objects_factories/mock_command_factory.hpp"
 
 using ::testing::Return;
+using ::testing::ReturnRef;
 using ::testing::ReturnRefOfCopy;
 
 namespace shared_model {
@@ -37,7 +38,7 @@ namespace shared_model {
       return createFactoryResult<MockAddPeer>(
           [&peer](FactoryResult<MockAddPeer> specific_cmd_mock) {
             EXPECT_CALL(*specific_cmd_mock, peer())
-                .WillRepeatedly(ReturnRefOfCopy(peer));
+                .WillRepeatedly(ReturnRef(peer));
             return specific_cmd_mock;
           });
     }

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -1,0 +1,276 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "module/shared_model/mock_objects_factories/mock_command_factory.hpp"
+
+using ::testing::Return;
+using ::testing::ReturnRefOfCopy;
+
+namespace shared_model {
+  namespace interface {
+    template <typename CommandType, typename ExpectsCallable>
+    MockCommandFactory::FactoryResult<CommandType>
+    MockCommandFactory::createFactoryResult(
+        ExpectsCallable expects_callable) const {
+      auto specific_cmd_mock = std::make_unique<CommandType>();
+      return expects_callable(std::move(specific_cmd_mock));
+    }
+
+    MockCommandFactory::FactoryResult<MockAddAssetQuantity>
+    MockCommandFactory::constructAddAssetQuantity(
+        const types::AssetIdType &asset_id, const Amount &asset_amount) const {
+      return createFactoryResult<MockAddAssetQuantity>(
+          [&asset_id, &asset_amount](
+              FactoryResult<MockAddAssetQuantity> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, assetId())
+                .WillRepeatedly(ReturnRefOfCopy(asset_id));
+            EXPECT_CALL(*specific_cmd_mock, amount())
+                .WillRepeatedly(ReturnRefOfCopy(asset_amount));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockAddPeer>
+    MockCommandFactory::constructAddPeer(const Peer &peer) const {
+      return createFactoryResult<MockAddPeer>(
+          [&peer](FactoryResult<MockAddPeer> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, peer())
+                .WillRepeatedly(ReturnRefOfCopy(peer));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockAddSignatory>
+    MockCommandFactory::constructAddSignatory(
+        const types::PubkeyType &pubkey,
+        const types::AccountIdType &account_id) const {
+      return createFactoryResult<MockAddSignatory>(
+          [&pubkey,
+           &account_id](FactoryResult<MockAddSignatory> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, pubkey())
+                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockAppendRole>
+    MockCommandFactory::constructAppendRole(
+        const types::AccountIdType &account_id,
+        const types::RoleIdType &role_name) const {
+      return createFactoryResult<MockAppendRole>(
+          [&account_id,
+           &role_name](FactoryResult<MockAppendRole> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, roleName())
+                .WillRepeatedly(ReturnRefOfCopy(role_name));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockCreateAccount>
+    MockCommandFactory::constructCreateAccount(
+        const types::AccountNameType &account_name,
+        const types::DomainIdType &domain_id,
+        const types::PubkeyType &pubkey) const {
+      return createFactoryResult<MockCreateAccount>(
+          [&account_name, &domain_id, &pubkey](
+              FactoryResult<MockCreateAccount> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountName())
+                .WillRepeatedly(ReturnRefOfCopy(account_name));
+            EXPECT_CALL(*specific_cmd_mock, domainId())
+                .WillRepeatedly(ReturnRefOfCopy(domain_id));
+            EXPECT_CALL(*specific_cmd_mock, pubkey())
+                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockCreateAsset>
+    MockCommandFactory::constructCreateAsset(
+        const types::AssetNameType &asset_name,
+        const types::DomainIdType &domain_id,
+        const types::PrecisionType &precision) const {
+      return createFactoryResult<MockCreateAsset>(
+          [&asset_name, &domain_id, &precision](
+              FactoryResult<MockCreateAsset> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, assetName())
+                .WillRepeatedly(ReturnRefOfCopy(asset_name));
+            EXPECT_CALL(*specific_cmd_mock, domainId())
+                .WillRepeatedly(ReturnRefOfCopy(domain_id));
+            EXPECT_CALL(*specific_cmd_mock, precision())
+                .WillRepeatedly(ReturnRefOfCopy(precision));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockCreateDomain>
+    MockCommandFactory::constructCreateDomain(
+        const types::DomainIdType &domain_id,
+        const types::RoleIdType &role_id) const {
+      return createFactoryResult<MockCreateDomain>(
+          [&domain_id,
+           &role_id](FactoryResult<MockCreateDomain> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, domainId())
+                .WillRepeatedly(ReturnRefOfCopy(domain_id));
+            EXPECT_CALL(*specific_cmd_mock, userDefaultRole())
+                .WillRepeatedly(ReturnRefOfCopy(role_id));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockCreateRole>
+    MockCommandFactory::constructCreateRole(
+        const types::RoleIdType &role_id,
+        const RolePermissionSet &role_permissions) const {
+      return createFactoryResult<MockCreateRole>(
+          [&role_id,
+           &role_permissions](FactoryResult<MockCreateRole> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, roleName())
+                .WillRepeatedly(ReturnRefOfCopy(role_id));
+            EXPECT_CALL(*specific_cmd_mock, rolePermissions())
+                .WillRepeatedly(ReturnRefOfCopy(role_permissions));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockDetachRole>
+    MockCommandFactory::constructDetachRole(
+        const types::AccountIdType &account_id,
+        const types::RoleIdType &role_id) const {
+      return createFactoryResult<MockDetachRole>(
+          [&account_id,
+           &role_id](FactoryResult<MockDetachRole> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, roleName())
+                .WillRepeatedly(ReturnRefOfCopy(role_id));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockGrantPermission>
+    MockCommandFactory::constructGrantPermission(
+        const types::AccountIdType &account_id,
+        permissions::Grantable permission) const {
+      return createFactoryResult<MockGrantPermission>(
+          [&account_id,
+           permission](FactoryResult<MockGrantPermission> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, permissionName())
+                .WillRepeatedly(Return(permission));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockRemoveSignatory>
+    MockCommandFactory::constructRemoveSignatory(
+        const types::AccountIdType &account_id,
+        const types::PubkeyType &pubkey) const {
+      return createFactoryResult<MockRemoveSignatory>(
+          [&account_id,
+           &pubkey](FactoryResult<MockRemoveSignatory> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, pubkey())
+                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockRevokePermission>
+    MockCommandFactory::constructRevokePermission(
+        const types::AccountIdType &account_id,
+        permissions::Grantable permission) const {
+      return createFactoryResult<MockRevokePermission>(
+          [&account_id,
+           permission](FactoryResult<MockRevokePermission> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, permissionName())
+                .WillRepeatedly(Return(permission));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockSetAccountDetail>
+    MockCommandFactory::constructSetAccountDetail(
+        const types::AccountIdType &account_id,
+        const types::AccountDetailKeyType &cmd_key,
+        const types::AccountDetailValueType &cmd_value) const {
+      return createFactoryResult<MockSetAccountDetail>(
+          [&account_id, &cmd_key, &cmd_value](
+              FactoryResult<MockSetAccountDetail> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, key())
+                .WillRepeatedly(ReturnRefOfCopy(cmd_key));
+            EXPECT_CALL(*specific_cmd_mock, value())
+                .WillRepeatedly(ReturnRefOfCopy(cmd_value));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockSetQuorum>
+    MockCommandFactory::constructSetQuorum(
+        const types::AccountIdType &account_id,
+        types::QuorumType quorum) const {
+      return createFactoryResult<MockSetQuorum>(
+          [&account_id,
+           quorum](FactoryResult<MockSetQuorum> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, accountId())
+                .WillRepeatedly(ReturnRefOfCopy(account_id));
+            EXPECT_CALL(*specific_cmd_mock, newQuorum())
+                .WillRepeatedly(Return(quorum));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockSubtractAssetQuantity>
+    MockCommandFactory::constructSubtractAssetQuantity(
+        const types::AssetIdType &asset_id, const Amount &cmd_amount) const {
+      return createFactoryResult<MockSubtractAssetQuantity>(
+          [&asset_id, &cmd_amount](
+              FactoryResult<MockSubtractAssetQuantity> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, assetId())
+                .WillRepeatedly(ReturnRefOfCopy(asset_id));
+            EXPECT_CALL(*specific_cmd_mock, amount())
+                .WillRepeatedly(ReturnRefOfCopy(cmd_amount));
+            return specific_cmd_mock;
+          });
+    }
+
+    MockCommandFactory::FactoryResult<MockTransferAsset>
+    MockCommandFactory::constructTransferAsset(
+        const types::AccountIdType &src_account_id,
+        const types::AccountIdType &dest_account_id,
+        const types::AssetIdType &asset_id,
+        const Amount &cmd_amount,
+        const types::DescriptionType &cmd_description) const {
+      return createFactoryResult<MockTransferAsset>(
+          [&src_account_id,
+           &dest_account_id,
+           &asset_id,
+           &cmd_amount,
+           &cmd_description](
+              FactoryResult<MockTransferAsset> specific_cmd_mock) {
+            EXPECT_CALL(*specific_cmd_mock, srcAccountId())
+                .WillRepeatedly(ReturnRefOfCopy(src_account_id));
+            EXPECT_CALL(*specific_cmd_mock, destAccountId())
+                .WillRepeatedly(ReturnRefOfCopy(dest_account_id));
+            EXPECT_CALL(*specific_cmd_mock, assetId())
+                .WillRepeatedly(ReturnRefOfCopy(asset_id));
+            EXPECT_CALL(*specific_cmd_mock, amount())
+                .WillRepeatedly(ReturnRefOfCopy(cmd_amount));
+            EXPECT_CALL(*specific_cmd_mock, description())
+                .WillRepeatedly(ReturnRefOfCopy(cmd_description));
+            return specific_cmd_mock;
+          });
+    }
+  }  // namespace interface
+}  // namespace shared_model

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "module/shared_model/mock_objects_factories/mock_command_factory.hpp"
+#include "backend/protobuf/permissions.hpp"
+#include "utils/string_builder.hpp"
 
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -135,6 +137,15 @@ namespace shared_model {
                 .WillRepeatedly(ReturnRefOfCopy(role_id));
             EXPECT_CALL(*specific_cmd_mock, rolePermissions())
                 .WillRepeatedly(ReturnRefOfCopy(role_permissions));
+            EXPECT_CALL(*specific_cmd_mock, toString())
+                .WillRepeatedly(Return(
+                    detail::PrettyStringBuilder()
+                        .init("CreateRole")
+                        .append("role_name", role_id)
+                        .appendAll(shared_model::proto::permissions::toString(
+                                       role_permissions),
+                                   [](auto p) { return p; })
+                        .finalize()));
             return specific_cmd_mock;
           });
     }
@@ -165,6 +176,15 @@ namespace shared_model {
                 .WillRepeatedly(ReturnRefOfCopy(account_id));
             EXPECT_CALL(*specific_cmd_mock, permissionName())
                 .WillRepeatedly(Return(permission));
+            EXPECT_CALL(*specific_cmd_mock, toString())
+                .WillRepeatedly(Return(
+                    detail::PrettyStringBuilder()
+                        .init("GrantPermission")
+                        .append("account_id", account_id)
+                        .append("permission",
+                                shared_model::proto::permissions::toString(
+                                    permission))
+                        .finalize()));
             return specific_cmd_mock;
           });
     }
@@ -195,6 +215,15 @@ namespace shared_model {
                 .WillRepeatedly(ReturnRefOfCopy(account_id));
             EXPECT_CALL(*specific_cmd_mock, permissionName())
                 .WillRepeatedly(Return(permission));
+            EXPECT_CALL(*specific_cmd_mock, toString())
+                .WillRepeatedly(Return(
+                    detail::PrettyStringBuilder()
+                        .init("RevokePermission")
+                        .append("account_id", account_id)
+                        .append("permission",
+                                shared_model::proto::permissions::toString(
+                                    permission))
+                        .finalize()));
             return specific_cmd_mock;
           });
     }

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
@@ -1,0 +1,201 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_MOCK_COMMAND_FACTORY_HPP
+#define IROHA_MOCK_COMMAND_FACTORY_HPP
+
+#include "module/shared_model/command_mocks.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class MockCommandFactory {
+      template <typename T>
+      using FactoryResult = std::unique_ptr<T>;
+
+     public:
+      /**
+       * Construct a mocked AddAssetQuantity
+       * @param asset_id to be in that command
+       * @param asset_amount to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockAddAssetQuantity> constructAddAssetQuantity(
+          const types::AssetIdType &asset_id, const Amount &asset_amount) const;
+
+      /**
+       * Construct a mocked AddPeer
+       * @param peer to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockAddPeer> constructAddPeer(const Peer &peer) const;
+
+      /**
+       * Construct a mocked AddSignatory
+       * @param pubkey to be in that command
+       * @param account_id to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockAddSignatory> constructAddSignatory(
+          const types::PubkeyType &pubkey,
+          const types::AccountIdType &account_id) const;
+
+      /**
+       * Construct a mocked AppendRole
+       * @param account_id to be in that command
+       * @param role_name to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockAppendRole> constructAppendRole(
+          const types::AccountIdType &account_id,
+          const types::RoleIdType &role_name) const;
+
+      /**
+       * Construct a mocked CreateAccount
+       * @param account_name to be in that command
+       * @param domain_id to be in that command
+       * @param pubkey to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockCreateAccount> constructCreateAccount(
+          const types::AccountNameType &account_name,
+          const types::DomainIdType &domain_id,
+          const types::PubkeyType &pubkey) const;
+
+      /**
+       * Construct a mocked CreateAsset
+       * @param asset_name to be in that command
+       * @param domain_id to be in that command
+       * @param precision to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockCreateAsset> constructCreateAsset(
+          const types::AssetNameType &asset_name,
+          const types::DomainIdType &domain_id,
+          const types::PrecisionType &precision) const;
+
+      /**
+       * Construct a mocked CreateDomain
+       * @param domain_id to be in that command
+       * @param role_id to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockCreateDomain> constructCreateDomain(
+          const types::DomainIdType &domain_id,
+          const types::RoleIdType &role_id) const;
+
+      /**
+       * Construct a mocked CreateRole
+       * @param role_id to be in that command
+       * @param role_permissions to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockCreateRole> constructCreateRole(
+          const types::RoleIdType &role_id,
+          const RolePermissionSet &role_permissions) const;
+
+      /**
+       * Construct a mocked DetachRole
+       * @param account_id to be in that command
+       * @param role_id to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockDetachRole> constructDetachRole(
+          const types::AccountIdType &account_id,
+          const types::RoleIdType &role_id) const;
+
+      /**
+       * Construct a mocked GrantPermission
+       * @param account_id to be in that command
+       * @param permission to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockGrantPermission> constructGrantPermission(
+          const types::AccountIdType &account_id,
+          permissions::Grantable permission) const;
+
+      /**
+       * Construct a mocked RemoveSignatory
+       * @param account_id to be in that command
+       * @param pubkey to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockRemoveSignatory> constructRemoveSignatory(
+          const types::AccountIdType &account_id,
+          const types::PubkeyType &pubkey) const;
+
+      /**
+       * Construct a mocked RevokePermission
+       * @param account_id to be in that command
+       * @param permission to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockRevokePermission> constructRevokePermission(
+          const types::AccountIdType &account_id,
+          permissions::Grantable permission) const;
+
+      /**
+       * Construct a mocked SetAccountDetail
+       * @param account_id to be in that command
+       * @param key to be in that command
+       * @param value to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockSetAccountDetail> constructSetAccountDetail(
+          const types::AccountIdType &account_id,
+          const types::AccountDetailKeyType &key,
+          const types::AccountDetailValueType &value) const;
+
+      /**
+       * Construct a mocked SetQuorum
+       * @param account_id to be in that command
+       * @param quorum to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockSetQuorum> constructSetQuorum(
+          const types::AccountIdType &account_id,
+          types::QuorumType quorum) const;
+
+      /**
+       * Construct a mocked SubtractAssetQuantity
+       * @param asset_id to be in that command
+       * @param amount to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockSubtractAssetQuantity> constructSubtractAssetQuantity(
+          const types::AssetIdType &asset_id, const Amount &amount) const;
+
+      /**
+       * Construct a mocked TransferAsset
+       * @param src_account_id to be in that command
+       * @param dest_account_id to be in that command
+       * @param asset_id to be in that command
+       * @param amount to be in that command
+       * @param description to be in that command
+       * @return pointer to the created command
+       */
+      FactoryResult<MockTransferAsset> constructTransferAsset(
+          const types::AccountIdType &src_account_id,
+          const types::AccountIdType &dest_account_id,
+          const types::AssetIdType &asset_id,
+          const Amount &amount,
+          const types::DescriptionType &description) const;
+
+     private:
+      /**
+       * Actually create a pointer to the mocked command
+       * @tparam CommandType - type of the command to be mocked
+       * @tparam ExpectsCallable - type of callable, which contains necessary
+       * EXPECT-s statements
+       * @param callable - that callable
+       * @return pointer to the mocked command
+       */
+      template <typename CommandType, typename ExpectsCallable>
+      FactoryResult<CommandType> createFactoryResult(
+          ExpectsCallable callable) const;
+    };
+  }  // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_MOCK_COMMAND_FACTORY_HPP


### PR DESCRIPTION
### Description of the Change

This PR introduces mocks for commands and a factory, which creates those mocks, so that it will be possible to use them in places, where the actual commands are not needed, such as both ExecutorTest-s.

### Benefits

Less dependencies in future.

### Possible Drawbacks 

None.