### PR TITLE
Build system tests with sanitizer

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -5,12 +5,16 @@ def doDebugBuild(coverageEnabled=false) {
   def manifest = load ".jenkinsci/docker-manifest.groovy"
   def pCommit = load ".jenkinsci/previous-commit.groovy"
   def parallelism = params.PARALLELISM
+  def sanitizeEnabled = params.sanitize
   def platform = sh(script: 'uname -m', returnStdout: true).trim()
   def previousCommit = pCommit.previousCommitOrCurrent()
   // params are always null unless job is started
   // this is the case for the FIRST build only.
   // So just set this to same value as default.
   // This is a known bug. See https://issues.jenkins-ci.org/browse/JENKINS-41929
+  if (sanitizeEnabled == null){
+    sanitizeEnabled = true
+  }
   if (!parallelism) {
     parallelism = 4
   }
@@ -62,7 +66,10 @@ def doDebugBuild(coverageEnabled=false) {
     def scmVars = checkout scm
     def cmakeOptions = ""
     if ( coverageEnabled ) {
-      cmakeOptions = " -DCOVERAGE=ON "
+      cmakeOptions += " -DCOVERAGE=ON "
+    }
+    if ( sanitizeEnabled ){
+      cmakeOptions += " -DSANITIZE='address;leak' "
     }
     env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
     env.IROHA_HOME = "/opt/iroha"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ properties([parameters([
   choice(choices: 'Release\nDebug', description: 'Android bindings build type', name: 'ABBuildType'),
   choice(choices: 'arm64-v8a\narmeabi-v7a\narmeabi\nx86_64\nx86', description: 'Android bindings platform', name: 'ABPlatform'),
   booleanParam(defaultValue: true, description: 'Build docs', name: 'Doxygen'),
+  booleanParam(defaultValue: true, description: 'Sanitize address;leak', name: 'sanitize'),
   string(defaultValue: '8', description: 'Expect ~3GB memory consumtion per CPU core', name: 'PARALLELISM')])])
 
 

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -15,3 +15,10 @@ target_link_libraries(irohad_test
 add_dependencies(irohad_test irohad)
 add_definitions(-DPATHIROHAD="${PROJECT_BINARY_DIR}/bin")
 add_definitions(-DPATHTESTDATA="${CMAKE_CURRENT_SOURCE_DIR}/irohad_test_data")
+
+if (SANITIZE)
+    target_link_libraries(irohad_test asan)
+    foreach(el ${SANITIZE})
+        target_compile_options(irohad_test PRIVATE  -fsanitize=${el})
+    endforeach(el)
+endif ()


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Build system tests target with sanitizer by using  `-fsanitize=address -fsanitize=leak`.

The `address and leak` sanitize is enough for most cases. But you may select any sanitize and building locally. Just add parameter `-DSANITIZE` , ex: `cmake [...] -DSANITIZE='address;leak'`
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Test will fail if some leaks is found
<!-- What benefits will be realized by the code change? -->
### Possible Drawbacks 
If enable it for all binary, test time and build time may increase  
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
```
/opt/iroha# cmake  -DTESTING=ON  -H.  -Bbuild -DCMAKE_BUILD_TYPE=Debug   -DSANITIZE='address;leak'
/opt/iroha# cmake --build build -- -j4
/opt/iroha# cd build; ctest --output-on-failure --no-compress-output -R '(system)' -T Test
Cannot find file: /opt/iroha/build/DartConfiguration.tcl
   Site: 
   Build name: (empty)
Cannot find file: /opt/iroha/build/DartConfiguration.tcl
Test project /opt/iroha/build
    Start 161: system_irohad_test
1/1 Test #161: system_irohad_test ...............   Passed   37.49 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =  37.51 sec
```
Currently we do not have any leaks in system test 

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
 We can enable sanitizer for all binary:
To do it  add  this snippet in middle of `./CMakeLists.txt` (line ~50)
```
foreach(SAN_OPT ${SANITIZE})
  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SAN_OPT}")
endforeach(SAN_OPT)
```
then run :
```
/opt/iroha# cmake  -DTESTING=ON  -H.  -Bbuild -DCMAKE_BUILD_TYPE=Debug   -DSANITIZE='address;leak'
/opt/iroha# cmake --build build -- -j4
/opt/iroha# cd build; ctest --output-on-failure --no-compress-output -R '(module)' -T Test
Cannot find file: /opt/iroha/build/DartConfiguration.tcl
   Site: 
   Build name: (empty)
Cannot find file: /opt/iroha/build/DartConfiguration.tcl
Test project /opt/iroha/build
        Start   1: module_client_test
  1/123 Test   #1: module_client_test ................................***Failed    0.37 sec
Running main() from gtest_main.cc
[==========] Running 8 tests from 1 test case.
.....
[==========] 8 tests from 1 test case ran. (40 ms total)
[  PASSED  ] 8 tests.

=================================================================
==30737==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 704 byte(s) in 8 object(s) allocated from:
    #0 0x7fa59669e592 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x99592)
    #1 0x428c2d in rxcpp::schedulers::detail::action_queue::ensure(std::shared_ptr<rxcpp::schedulers::worker_interface>) /usr/local/include/rxcpp/schedulers/rx-currentthread.hpp:97
    #2 0x429a60 in rxcpp::schedulers::new_thread::new_worker::new_worker(rxcpp::composite_subscription, std::function<std::thread (std::function<void ()>)>&)::{lambda()#2}::operator()() const (/opt/iroha/build/test_bin/client_test+0x429a60)
 .....

```

#### Jenkins
In Jenkins build we can send sanitize list  instead of true/false. But sanitize list have to be carefully prepared and chosen wisely. 

