### PR TITLE
Add fuzzing build process to nightly Iroha builds

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -6,12 +6,14 @@ def doDebugBuild(coverageEnabled=false) {
   def pCommit = load ".jenkinsci/previous-commit.groovy"
   def parallelism = params.PARALLELISM
   def sanitizeEnabled = params.sanitize
+  def fuzzingEnabled = params.fuzzing
   def platform = sh(script: 'uname -m', returnStdout: true).trim()
   def previousCommit = pCommit.previousCommitOrCurrent()
   // params are always null unless job is started
   // this is the case for the FIRST build only.
   // So just set this to same value as default.
   // This is a known bug. See https://issues.jenkins-ci.org/browse/JENKINS-41929
+  echo "fuzzingEnabled=${fuzzingEnabled}"
   if (sanitizeEnabled == null){
     sanitizeEnabled = true
   }
@@ -71,6 +73,9 @@ def doDebugBuild(coverageEnabled=false) {
     if ( sanitizeEnabled ){
       cmakeOptions += " -DSANITIZE='address;leak' "
     }
+    if ( fuzzingEnabled ){
+      cmakeOptions += " -DFUZZING=ON "
+    }
     env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
     env.IROHA_HOME = "/opt/iroha"
     env.IROHA_BUILD = "${env.IROHA_HOME}/build"
@@ -95,12 +100,15 @@ def doDebugBuild(coverageEnabled=false) {
     if ( coverageEnabled ) {
       sh "cmake --build build --target coverage.init.info"
     }
-    sh "cd build; ctest --output-on-failure --no-compress-output -T Test || true"
-    sh 'python .jenkinsci/helpers/platform_tag.py "Linux \$(uname -m)" \$(ls build/Testing/*/Test.xml)'
-    // Mark build as UNSTABLE if there are any failed tests (threshold <100%)
-    xunit testTimeMargin: '3000', thresholdMode: 2, thresholds: [passed(unstableThreshold: '100')], \
-      tools: [CTest(deleteOutputFiles: true, failIfNotNew: false, \
-      pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+    //If fuzzing Enabled do not run tests, they never stop
+    if ( !fuzzingEnabled ){
+      sh "cd build; ctest --output-on-failure --no-compress-output -T Test || true"
+      sh 'python .jenkinsci/helpers/platform_tag.py "Linux \$(uname -m)" \$(ls build/Testing/*/Test.xml)'
+      // Mark build as UNSTABLE if there are any failed tests (threshold <100%)
+      xunit testTimeMargin: '3000', thresholdMode: 2, thresholds: [passed(unstableThreshold: '100')], \
+        tools: [CTest(deleteOutputFiles: true, failIfNotNew: false, \
+        pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+    }
     if ( coverageEnabled ) {
       sh "cmake --build build --target cppcheck"
       // Sonar

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -73,7 +73,7 @@ def doDebugBuild(coverageEnabled=false) {
       cmakeOptions += " -DSANITIZE='address;leak' "
     }
     if ( fuzzingEnabled ){
-      cmakeOptions += " -DCMAKE_CC_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DFUZZING=ON "
+      cmakeOptions += " -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DFUZZING=ON "
     }
     env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
     env.IROHA_HOME = "/opt/iroha"

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -13,7 +13,6 @@ def doDebugBuild(coverageEnabled=false) {
   // this is the case for the FIRST build only.
   // So just set this to same value as default.
   // This is a known bug. See https://issues.jenkins-ci.org/browse/JENKINS-41929
-  echo "fuzzingEnabled=${fuzzingEnabled}"
   if (sanitizeEnabled == null){
     sanitizeEnabled = true
   }
@@ -74,7 +73,7 @@ def doDebugBuild(coverageEnabled=false) {
       cmakeOptions += " -DSANITIZE='address;leak' "
     }
     if ( fuzzingEnabled ){
-      cmakeOptions += " -DFUZZING=ON "
+      cmakeOptions += " -DCMAKE_CC_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DFUZZING=ON "
     }
     env.IROHA_VERSION = "0x${scmVars.GIT_COMMIT}"
     env.IROHA_HOME = "/opt/iroha"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ properties([parameters([
   choice(choices: 'arm64-v8a\narmeabi-v7a\narmeabi\nx86_64\nx86', description: 'Android bindings platform', name: 'ABPlatform'),
   booleanParam(defaultValue: true, description: 'Build docs', name: 'Doxygen'),
   booleanParam(defaultValue: true, description: 'Sanitize address;leak', name: 'sanitize'),
+  booleanParam(defaultValue: false, description: 'Build fuzzing, but do not run tests', name: 'fuzzing'),
   string(defaultValue: '8', description: 'Expect ~3GB memory consumtion per CPU core', name: 'PARALLELISM')])])
 
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Add fuzzing build process to nightly Iroha builds
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
increase stability of fuzzing target
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Currently it is not possible run tests if fuzzing is enabled, tests newer stops
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
