### PR TITLE
Fix MST pending storage

### DIFF
--- a/irohad/multi_sig_transactions/impl/mst_processor.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor.cpp
@@ -25,4 +25,9 @@ namespace iroha {
   rxcpp::observable<DataType> MstProcessor::onExpiredBatches() const {
     return this->onExpiredBatchesImpl();
   }
+
+  bool MstProcessor::batchInStorage(const DataType &batch) const {
+    return this->batchInStorageImpl(batch);
+  }
+
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -84,11 +84,14 @@ namespace iroha {
     }
   }
 
+  bool FairMstProcessor::batchInStorageImpl(const DataType &batch) const {
+    return storage_->batchInStorage(batch);
+  }
+
   // -------------------| MstTransportNotification override |-------------------
 
-  void FairMstProcessor::onNewState(
-      const shared_model::crypto::PublicKey &from,
-      ConstRefState new_state) {
+  void FairMstProcessor::onNewState(const shared_model::crypto::PublicKey &from,
+                                    ConstRefState new_state) {
     log_->info("Applying new state");
     auto current_time = time_provider_->getCurrentTime();
 

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -43,6 +43,13 @@ namespace iroha {
     void propagateBatch(const DataType &batch);
 
     /**
+     * Check, if passed batch is in pending storage
+     * @param batch to be checked
+     * @return true, if batch is already in pending storage, false otherwise
+     */
+    bool batchInStorage(const DataType &batch) const;
+
+    /**
      * Prove updating of state for handling status of signing
      */
     rxcpp::observable<std::shared_ptr<MstState>> onStateUpdate() const;
@@ -90,6 +97,11 @@ namespace iroha {
      */
     virtual auto onExpiredBatchesImpl() const
         -> decltype(onExpiredBatches()) = 0;
+
+    /**
+     * @see batchInStorage method
+     */
+    virtual bool batchInStorageImpl(const DataType &batch) const = 0;
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -61,6 +61,8 @@ namespace iroha {
 
     auto onExpiredBatchesImpl() const -> decltype(onExpiredBatches()) override;
 
+    bool batchInStorageImpl(const DataType &batch) const override;
+
     // ------------------| MstTransportNotification override |------------------
 
     void onNewState(const shared_model::crypto::PublicKey &from,

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -171,4 +171,8 @@ namespace iroha {
     index_.push(rhs_batch);
   }
 
+  bool MstState::contains(const DataType &element) const {
+    return internal_state_.find(element) != internal_state_.end();
+  }
+
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -128,6 +128,13 @@ namespace iroha {
      */
     MstState eraseByTime(const TimeType &time);
 
+    /**
+     * Check, if this MST state contains that element
+     * @param element to be checked
+     * @return true, if state contains the element, false otherwise
+     */
+    bool contains(const DataType &element) const;
+
    private:
     // --------------------------| private api |------------------------------
 

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
@@ -40,4 +40,8 @@ namespace iroha {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return whatsNewImpl(new_state);
   }
+
+  bool MstStorage::batchInStorage(const DataType &batch) const {
+    return batchInStorageImpl(batch);
+  }
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -59,4 +59,8 @@ namespace iroha {
     return new_state - own_state_;
   }
 
+  bool MstStorageStateImpl::batchInStorageImpl(const DataType &batch) const {
+    return own_state_.contains(batch);
+  }
+
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/storage/mst_storage.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage.hpp
@@ -19,6 +19,7 @@
 #define IROHA_MST_STORAGE_HPP
 
 #include <mutex>
+
 #include "cryptography/public_key.hpp"
 #include "logger/logger.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
@@ -79,6 +80,13 @@ namespace iroha {
      */
     MstState whatsNew(ConstRefState new_state) const;
 
+    /**
+     * Check, if passed batch is in the storage
+     * @param batch to be checked
+     * @return true, if batch is already in the storage, false otherwise
+     */
+    bool batchInStorage(const DataType &batch) const;
+
     virtual ~MstStorage() = default;
 
    protected:
@@ -108,6 +116,8 @@ namespace iroha {
 
     virtual auto whatsNewImpl(ConstRefState new_state) const
         -> decltype(whatsNew(new_state)) = 0;
+
+    virtual bool batchInStorageImpl(const DataType &batch) const = 0;
 
     // -------------------------------| fields |--------------------------------
 

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -57,6 +57,8 @@ namespace iroha {
     auto whatsNewImpl(ConstRefState new_state) const
         -> decltype(whatsNew(new_state)) override;
 
+    bool batchInStorageImpl(const DataType &batch) const override;
+
    private:
     // ---------------------------| private fields |----------------------------
 

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -134,7 +134,8 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::TransactionBatch>
             transaction_batch) const {
       log_->info("handle batch");
-      if (transaction_batch->hasAllSignatures()) {
+      if (transaction_batch->hasAllSignatures()
+          and not mst_processor_->batchInStorage(transaction_batch)) {
         log_->info("propagating batch to PCS");
         this->publishEnoughSignaturesStatus(transaction_batch->transactions());
         pcs_->propagate_batch(transaction_batch);

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -231,15 +231,12 @@ TEST_F(MstPipelineTest, GetPendingTxsNoSignedTxs) {
 }
 
 /**
- * Disabled because fully signed transaction doesn't go through MST and pending
- * transaction remains in query response IR-1329
  * @given a ledger with mst user (quorum=3) created
  * @when the user sends a transaction with only one signature, then sends the
  * transaction with all three signatures
  * @then there should be no pending transactions
  */
-TEST_F(MstPipelineTest, DISABLED_ReplayViaFullySignedTransaction) {
-  // TODO igor-egorov, 2018-09-25, IR-1329, enable the test
+TEST_F(MstPipelineTest, ReplayViaFullySignedTransaction) {
   auto &mst_itf = prepareMstItf();
   auto pending_tx =
       baseTx().setAccountDetail(kUserId, "age", "10").quorum(kSignatories + 1);

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -57,6 +57,7 @@ namespace iroha {
                        rxcpp::observable<std::shared_ptr<MstState>>());
     MOCK_CONST_METHOD0(onPreparedBatchesImpl, rxcpp::observable<DataType>());
     MOCK_CONST_METHOD0(onExpiredBatchesImpl, rxcpp::observable<DataType>());
+    MOCK_CONST_METHOD1(batchInStorageImpl, bool(const DataType &));
   };
 }  // namespace iroha
 #endif  // IROHA_MST_MOCKS_HPP

--- a/test/module/irohad/multi_sig_transactions/state_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/state_test.cpp
@@ -53,23 +53,31 @@ TEST(StateTest, UpdateExistingState) {
 }
 
 /**
- * @given empty state @and two batches
- * @when inserting first batch and not the second
- * @then "contains" method shows presence of the first batch @and absence of the
- * second one
+ * @given empty state @and a batch
+ * @when inserting the batch
+ * @then "contains" method shows presence of the batch
  */
-TEST(StateTest, ContainsMethodWorkCorrectly) {
+TEST(StateTest, ContainsMethodFindsInsertedBatch) {
   auto state = MstState::empty();
 
   auto first_signature = makeSignature("1", "pub_key_1");
-  auto first_batch = makeTestBatch(txBuilder(1, iroha::time::now()));
-  auto tx = addSignatures(first_batch, 0, first_signature);
+  auto batch = makeTestBatch(txBuilder(1, iroha::time::now()));
+  auto tx = addSignatures(batch, 0, first_signature);
   state += tx;
 
-  auto second_batch = makeTestBatch(txBuilder(1, iroha::time::now()));
+  EXPECT_TRUE(state.contains(batch));
+}
 
-  ASSERT_TRUE(state.contains(first_batch));
-  ASSERT_FALSE(state.contains(second_batch));
+/**
+ * @given empty state @and a distinct batch
+ * @when checking that batch's presence in the state
+ * @then "contains" method shows absence of the batch
+ */
+TEST(StateTest, ContainsMethodDoesNotFindNonInsertedBatch) {
+  auto state = MstState::empty();
+  auto batch = makeTestBatch(txBuilder(1, iroha::time::now()));
+
+  EXPECT_FALSE(state.contains(batch));
 }
 
 /**

--- a/test/module/irohad/multi_sig_transactions/state_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/state_test.cpp
@@ -53,11 +53,31 @@ TEST(StateTest, UpdateExistingState) {
 }
 
 /**
+ * @given empty state @and two batches
+ * @when inserting first batch and not the second
+ * @then "contains" method shows presence of the first batch @and absence of the
+ * second one
+ */
+TEST(StateTest, ContainsMethodWorkCorrectly) {
+  auto state = MstState::empty();
+
+  auto first_signature = makeSignature("1", "pub_key_1");
+  auto first_batch = makeTestBatch(txBuilder(1, iroha::time::now()));
+  auto tx = addSignatures(first_batch, 0, first_signature);
+  state += tx;
+
+  auto second_batch = makeTestBatch(txBuilder(1, iroha::time::now()));
+
+  ASSERT_TRUE(state.contains(first_batch));
+  ASSERT_FALSE(state.contains(second_batch));
+}
+
+/**
  * @given empty state
  * @when  insert batch with same signatures two times
  * @then  checks that the state contains only one signature
  */
-TEST(StateTest, UpdateStateWhenTransacionsSame) {
+TEST(StateTest, UpdateStateWhenTransactionsSame) {
   log_->info("Create empty state => insert two equal transaction");
 
   auto state = MstState::empty();

--- a/test/module/irohad/multi_sig_transactions/storage_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/storage_test.cpp
@@ -98,3 +98,17 @@ TEST_F(StorageTest, StorageWhenCreate) {
                 .getBatches()
                 .size());
 }
+
+/**
+ * @given storage with three batches @and one another batch
+ * @when checking, if one of the three batches @and another one belongs to the
+ * storage
+ * @then one of the batches belongs to the state, while the last one does not
+ */
+TEST_F(StorageTest, StorageFindsBatch) {
+  auto batch_in_state = makeTestBatch(txBuilder(1, creation_time));
+  auto distinct_batch = makeTestBatch(txBuilder(4, creation_time));
+
+  ASSERT_TRUE(storage->batchInStorage(batch_in_state));
+  ASSERT_FALSE(storage->batchInStorage(distinct_batch));
+}

--- a/test/module/irohad/multi_sig_transactions/storage_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/storage_test.cpp
@@ -100,15 +100,26 @@ TEST_F(StorageTest, StorageWhenCreate) {
 }
 
 /**
- * @given storage with three batches @and one another batch
- * @when checking, if one of the three batches @and another one belongs to the
- * storage
- * @then one of the batches belongs to the state, while the last one does not
+ * @given storage with three batches
+ * @when checking, if those batches belong to the storage
+ * @then storage reports, that those batches are in it
  */
-TEST_F(StorageTest, StorageFindsBatch) {
-  auto batch_in_state = makeTestBatch(txBuilder(1, creation_time));
-  auto distinct_batch = makeTestBatch(txBuilder(4, creation_time));
+TEST_F(StorageTest, StorageFindsExistingBatch) {
+  auto batch1 = makeTestBatch(txBuilder(1, creation_time));
+  auto batch2 = makeTestBatch(txBuilder(2, creation_time));
+  auto batch3 = makeTestBatch(txBuilder(3, creation_time));
 
-  ASSERT_TRUE(storage->batchInStorage(batch_in_state));
-  ASSERT_FALSE(storage->batchInStorage(distinct_batch));
+  EXPECT_TRUE(storage->batchInStorage(batch1));
+  EXPECT_TRUE(storage->batchInStorage(batch2));
+  EXPECT_TRUE(storage->batchInStorage(batch3));
+}
+
+/**
+ * @given storage with three batches @and one another batch not in the storage
+ * @when checking, if the last batch belongs to the storage
+ * @then storage reports, that this batch is not in it
+ */
+TEST_F(StorageTest, StorageDoesNotFindNonExistingBatch) {
+  auto distinct_batch = makeTestBatch(txBuilder(4, creation_time));
+  EXPECT_FALSE(storage->batchInStorage(distinct_batch));
 }


### PR DESCRIPTION
### Description of the Change

Previously, if batch was pending, and the same batch with **all** signatures comes, it went straight to the PCS. Because of that, the pending one was not removed and in theory could be replayed. Now, the system checks, if the arrived batch does already exist in MST storage, even if it has all signatures.

### Benefits

No more replays possible, and pending storage gets cleaned.

### Possible Drawbacks 

Overhead for unordered_set's `find`.