### PR TITLE
Consensus consistency model read from config

### DIFF
--- a/example/config.sample
+++ b/example/config.sample
@@ -6,6 +6,7 @@
   "max_proposal_size" : 10,
   "proposal_delay" : 5000,
   "vote_delay" : 5000,
-  "mst_enable" : false
+  "mst_enable" : false,
+  "consistency_model": "BFT"
 }
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -44,10 +44,6 @@ using namespace iroha::consensus::yac;
 
 using namespace std::chrono_literals;
 
-/// Consensus consistency model type.
-static constexpr iroha::consensus::yac::ConsistencyModel
-    kConsensusConsistencyModel = iroha::consensus::yac::ConsistencyModel::kBft;
-
 /**
  * Configuring iroha daemon
  */
@@ -60,6 +56,7 @@ Irohad::Irohad(const std::string &block_store_dir,
                std::chrono::milliseconds proposal_delay,
                std::chrono::milliseconds vote_delay,
                const shared_model::crypto::Keypair &keypair,
+               const iroha::consensus::yac::ConsistencyModel consistency_model,
                const boost::optional<GossipPropagationStrategyParams>
                    &opt_mst_gossip_params)
     : block_store_dir_(block_store_dir),
@@ -72,7 +69,8 @@ Irohad::Irohad(const std::string &block_store_dir,
       vote_delay_(vote_delay),
       is_mst_supported_(opt_mst_gossip_params),
       opt_mst_gossip_params_(opt_mst_gossip_params),
-      keypair(keypair) {
+      keypair(keypair),
+      consistency_model_(consistency_model) {
   log_ = logger::log("IROHAD");
   log_->info("created");
   // Initializing storage at this point in order to insert genesis block before
@@ -185,7 +183,7 @@ void Irohad::initValidators() {
   stateful_validator =
       std::make_shared<StatefulValidatorImpl>(std::move(factory), batch_parser);
   chain_validator = std::make_shared<ChainValidatorImpl>(
-      getSupermajorityChecker(kConsensusConsistencyModel));
+      getSupermajorityChecker(consistency_model_));
 
   log_->info("[Init] => validators");
 }
@@ -317,7 +315,7 @@ void Irohad::initConsensusGate() {
                                               vote_delay_,
                                               async_call_,
                                               common_objects_factory_,
-                                              kConsensusConsistencyModel);
+                                              consistency_model_);
 
   log_->info("[Init] => consensus gate");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/impl/storage_impl.hpp"
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "consensus/consensus_block_cache.hpp"
+#include "consensus/yac/consistency_model.hpp"
 #include "cryptography/crypto_provider/crypto_model_signer.hpp"
 #include "cryptography/keypair.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
@@ -65,6 +66,7 @@ class Irohad {
    * @param proposal_delay - maximum waiting time util emitting new proposal
    * @param vote_delay - waiting time before sending vote to next peer
    * @param keypair - public and private keys for crypto signer
+   * @param consistency_model - the type of consistency model to use (CFT, BFT)
    * @param opt_mst_gossip_params - parameters for Gossip MST propagation
    * (optional). If not provided, disables mst processing support
    *
@@ -79,6 +81,7 @@ class Irohad {
          std::chrono::milliseconds proposal_delay,
          std::chrono::milliseconds vote_delay,
          const shared_model::crypto::Keypair &keypair,
+         const iroha::consensus::yac::ConsistencyModel consistency_model,
          const boost::optional<iroha::GossipPropagationStrategyParams>
              &opt_mst_gossip_params = boost::none);
 
@@ -270,6 +273,7 @@ class Irohad {
   std::shared_ptr<iroha::ametsuchi::Storage> storage;
 
   shared_model::crypto::Keypair keypair;
+  const iroha::consensus::yac::ConsistencyModel consistency_model_;
   grpc::ServerBuilder builder;
 };
 

--- a/irohad/main/assert_config.hpp
+++ b/irohad/main/assert_config.hpp
@@ -21,6 +21,9 @@
 #include <stdexcept>
 #include <string>
 
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/any_range.hpp>
+
 namespace assert_config {
   /**
    * error message helpers that are used in json validation.
@@ -32,6 +35,16 @@ namespace assert_config {
   inline std::string type_error(std::string const &value,
                                 std::string const &type) {
     return "'" + value + "' is not " + type;
+  }
+
+  inline std::string value_error(
+      std::string const &value,
+      const boost::any_range<std::string,
+                             boost::forward_traversal_tag,
+                             const std::string &,
+                             std::ptrdiff_t> permitted_values) {
+    return "`" + value + "' is not one of `"
+        + boost::algorithm::join(permitted_values, "', `") + "'";
   }
 
   inline std::string parse_error(std::string const &path) {

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -130,18 +130,20 @@ int main(int argc, char *argv[]) {
   }
 
   // Configuring iroha daemon
-  Irohad irohad(config[mbr::BlockStorePath].GetString(),
-                config[mbr::PgOpt].GetString(),
-                kListenIp,  // TODO(mboldyrev) 17/10/2018: add a parameter in
-                            // config file and/or command-line arguments?
-                config[mbr::ToriiPort].GetUint(),
-                config[mbr::InternalPort].GetUint(),
-                config[mbr::MaxProposalSize].GetUint(),
-                std::chrono::milliseconds(config[mbr::ProposalDelay].GetUint()),
-                std::chrono::milliseconds(config[mbr::VoteDelay].GetUint()),
-                *keypair,
-                boost::make_optional(config[mbr::MstSupport].GetBool(),
-                                     iroha::GossipPropagationStrategyParams{}));
+  Irohad irohad(
+      config[mbr::BlockStorePath].GetString(),
+      config[mbr::PgOpt].GetString(),
+      kListenIp,  // TODO(mboldyrev) 17/10/2018: add a parameter in
+                  // config file and/or command-line arguments?
+      config[mbr::ToriiPort].GetUint(),
+      config[mbr::InternalPort].GetUint(),
+      config[mbr::MaxProposalSize].GetUint(),
+      std::chrono::milliseconds(config[mbr::ProposalDelay].GetUint()),
+      std::chrono::milliseconds(config[mbr::VoteDelay].GetUint()),
+      *keypair,
+      kConsistencyModels.at(config[mbr::ConsistencyModelKey].GetString()),
+      boost::make_optional(config[mbr::MstSupport].GetBool(),
+                           iroha::GossipPropagationStrategyParams{}));
 
   // Check if iroha daemon storage was successfully initialized
   if (not irohad.storage) {

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -20,6 +20,7 @@
 #include "builders/protobuf/transaction.hpp"
 #include "builders/protobuf/transaction_sequence_builder.hpp"
 #include "common/files.hpp"
+#include "consensus/yac/consistency_model.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
@@ -67,6 +68,9 @@ namespace {
   std::string kLocalHost = "127.0.0.1";
   constexpr size_t kDefaultToriiPort = 11501;
   constexpr size_t kDefaultInternalPort = 50541;
+  /// Consensus consistency model type.
+  constexpr iroha::consensus::yac::ConsistencyModel kConsensusConsistencyModel =
+      iroha::consensus::yac::ConsistencyModel::kBft;
 }  // namespace
 
 namespace integration_framework {
@@ -83,12 +87,14 @@ namespace integration_framework {
       : port_guard_(std::make_unique<PortGuard>()),
         torii_port_(port_guard_->getPort(kDefaultToriiPort)),
         internal_port_(port_guard_->getPort(kDefaultInternalPort)),
-        iroha_instance_(std::make_shared<IrohaInstance>(mst_support,
-                                                        block_store_path,
-                                                        kLocalHost,
-                                                        torii_port_,
-                                                        internal_port_,
-                                                        dbname)),
+        iroha_instance_(
+            std::make_shared<IrohaInstance>(mst_support,
+                                            block_store_path,
+                                            kLocalHost,
+                                            torii_port_,
+                                            internal_port_,
+                                            kConsensusConsistencyModel,
+                                            dbname)),
         command_client_(kLocalHost, torii_port_),
         query_client_(kLocalHost, torii_port_),
         async_call_(std::make_shared<AsyncCall>()),

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -26,12 +26,14 @@ using namespace std::chrono_literals;
 
 namespace integration_framework {
 
-  IrohaInstance::IrohaInstance(bool mst_support,
-                               const std::string &block_store_path,
-                               const std::string &listen_ip,
-                               size_t torii_port,
-                               size_t internal_port,
-                               const boost::optional<std::string> &dbname)
+  IrohaInstance::IrohaInstance(
+      bool mst_support,
+      const std::string &block_store_path,
+      const std::string &listen_ip,
+      size_t torii_port,
+      size_t internal_port,
+      const iroha::consensus::yac::ConsistencyModel consistency_model,
+      const boost::optional<std::string> &dbname)
       : block_store_dir_(block_store_path),
         pg_conn_(getPostgreCredsOrDefault(dbname)),
         listen_ip_(listen_ip),
@@ -42,6 +44,7 @@ namespace integration_framework {
         proposal_delay_(1h),
         // not required due to solo consensus
         vote_delay_(0ms),
+        consistency_model_(consistency_model),
         opt_mst_gossip_params_(boost::make_optional(
             mst_support, iroha::GossipPropagationStrategyParams{})) {}
 
@@ -79,6 +82,7 @@ namespace integration_framework {
                                              proposal_delay_,
                                              vote_delay_,
                                              key_pair,
+                                             consistency_model_,
                                              opt_mst_gossip_params_);
   }
 

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 #include "ametsuchi/impl/postgres_options.hpp"
+#include "consensus/yac/consistency_model.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy_params.hpp"
 
 namespace shared_model {
@@ -47,14 +48,17 @@ namespace integration_framework {
      * @param listen_ip - ip address for opening ports (internal & torii)
      * @param torii_port - port to bind Torii service to
      * @param internal_port - port for internal irohad communication
+     * @param consistency_model - the type of consistency model (CFT, BFT)
      * @param dbname is a name of postgres database
      */
-    IrohaInstance(bool mst_support,
-                  const std::string &block_store_path,
-                  const std::string &listen_ip,
-                  size_t torii_port,
-                  size_t internal_port,
-                  const boost::optional<std::string> &dbname = boost::none);
+    IrohaInstance(
+        bool mst_support,
+        const std::string &block_store_path,
+        const std::string &listen_ip,
+        size_t torii_port,
+        size_t internal_port,
+        const iroha::consensus::yac::ConsistencyModel consistency_model,
+        const boost::optional<std::string> &dbname = boost::none);
 
     void makeGenesis(const shared_model::interface::Block &block);
 
@@ -82,6 +86,7 @@ namespace integration_framework {
     const size_t internal_port_;
     const std::chrono::milliseconds proposal_delay_;
     const std::chrono::milliseconds vote_delay_;
+    const iroha::consensus::yac::ConsistencyModel consistency_model_;
     boost::optional<iroha::GossipPropagationStrategyParams>
         opt_mst_gossip_params_;
 

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -36,6 +36,7 @@ namespace integration_framework {
                std::chrono::milliseconds proposal_delay,
                std::chrono::milliseconds vote_delay,
                const shared_model::crypto::Keypair &keypair,
+               const iroha::consensus::yac::ConsistencyModel consistency_model,
                const boost::optional<iroha::GossipPropagationStrategyParams>
                    &opt_mst_gossip_params = boost::none)
         : Irohad(block_store_dir,
@@ -47,6 +48,7 @@ namespace integration_framework {
                  proposal_delay,
                  vote_delay,
                  keypair,
+                 consistency_model,
                  opt_mst_gossip_params) {}
 
     auto &getCommandService() {

--- a/test/system/irohad_test_data/config.sample
+++ b/test/system/irohad_test_data/config.sample
@@ -6,6 +6,7 @@
   "max_proposal_size" : 10,
   "proposal_delay" : 5000,
   "vote_delay" : 5000,
-  "mst_enable" : false
+  "mst_enable" : false,
+  "consistency_model": "BFT"
 }
 


### PR DESCRIPTION
### Description of the Change

New key named `"consistency_model"` of string type is added to the irohad JSON config. Its allowed values are strings `"BFT"` and `"CFT"`.

### Benefits

Startup-time consensus consistency configuration.

### Usage example

In `example/config.sample`:
```
"consistency_model": "BFT"
```
