### PR TITLE
Fix clang build warnings

### DIFF
--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -191,8 +191,7 @@ namespace iroha {
       // reject_counter and local_counter are local mutable variables of lambda
       auto delay = [reject_counter = kCounter,
                     local_counter = kCounter,
-                    &time_generator,
-                    kMaxLocalCounter](const auto &commit) mutable {
+                    &time_generator](const auto &commit) mutable {
         using iroha::synchronizer::SynchronizationOutcomeType;
         if (commit.sync_outcome == SynchronizationOutcomeType::kReject
             or commit.sync_outcome == SynchronizationOutcomeType::kNothing) {

--- a/schema/mst.proto
+++ b/schema/mst.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 package iroha.network.transport;
 
 import "transaction.proto";
-import "primitive.proto";
 import "google/protobuf/empty.proto";
 
 message MstState {

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -63,7 +63,8 @@ namespace {
       "id@" + domain_id;
   const shared_model::interface::types::AccountIdType another_account_id =
       "id@" + another_domain_id;
-  const shared_model::interface::types::AccountIdType account_id2 = "id2@" + domain_id;
+  const shared_model::interface::types::AccountIdType account_id2 =
+      "id2@" + domain_id;
 }  // namespace
 
 namespace iroha {
@@ -560,8 +561,7 @@ namespace iroha {
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
           std::move(result), [](const auto &cast_resp) {
-            ASSERT_EQ(cast_resp.accountAssets()[0].accountId(),
-                      account_id2);
+            ASSERT_EQ(cast_resp.accountAssets()[0].accountId(), account_id2);
             ASSERT_EQ(cast_resp.accountAssets()[0].assetId(), asset_id);
           });
     }
@@ -580,8 +580,7 @@ namespace iroha {
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
           std::move(result), [](const auto &cast_resp) {
-            ASSERT_EQ(cast_resp.accountAssets()[0].accountId(),
-                      account_id2);
+            ASSERT_EQ(cast_resp.accountAssets()[0].accountId(), account_id2);
             ASSERT_EQ(cast_resp.accountAssets()[0].assetId(), asset_id);
           });
     }
@@ -1183,7 +1182,7 @@ namespace iroha {
     };
 
     struct GetAccountTxPaginationImpl {
-      static std::initializer_list<permissions::Role> getUserPermissions() {
+      static shared_model::interface::RolePermissionSet getUserPermissions() {
         return {permissions::Role::kSetDetail, permissions::Role::kGetMyAccTxs};
       }
 
@@ -1227,7 +1226,7 @@ namespace iroha {
     }
 
     struct GetAccountAssetTxPaginationImpl {
-      static std::initializer_list<permissions::Role> getUserPermissions() {
+      static shared_model::interface::RolePermissionSet getUserPermissions() {
         return {permissions::Role::kReceive,
                 permissions::Role::kGetMyAccAstTxs};
       }
@@ -1322,8 +1321,7 @@ namespace iroha {
           std::move(result), [](const auto &cast_resp) {
             ASSERT_EQ(cast_resp.transactions().size(), 2);
             for (const auto &tx : cast_resp.transactions()) {
-              EXPECT_EQ(account_id2, tx.creatorAccountId())
-                  << tx.toString();
+              EXPECT_EQ(account_id2, tx.creatorAccountId()) << tx.toString();
             }
           });
     }
@@ -1347,8 +1345,7 @@ namespace iroha {
           std::move(result), [](const auto &cast_resp) {
             ASSERT_EQ(cast_resp.transactions().size(), 2);
             for (const auto &tx : cast_resp.transactions()) {
-              EXPECT_EQ(account_id2, tx.creatorAccountId())
-                  << tx.toString();
+              EXPECT_EQ(account_id2, tx.creatorAccountId()) << tx.toString();
             }
           });
     }
@@ -1590,11 +1587,11 @@ namespace iroha {
 
       commitBlocks();
 
-      auto query = TestQueryBuilder()
-                       .creatorAccountId(account_id)
-                       .getAccountAssetTransactions(
-                               account_id2, asset_id, kTxPageSize)
-                       .build();
+      auto query =
+          TestQueryBuilder()
+              .creatorAccountId(account_id)
+              .getAccountAssetTransactions(account_id2, asset_id, kTxPageSize)
+              .build();
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::TransactionsPageResponse>(
           std::move(result), [this](const auto &cast_resp) {
@@ -1615,11 +1612,11 @@ namespace iroha {
 
       commitBlocks();
 
-      auto query = TestQueryBuilder()
-                       .creatorAccountId(account_id)
-                       .getAccountAssetTransactions(
-                               account_id2, asset_id, kTxPageSize)
-                       .build();
+      auto query =
+          TestQueryBuilder()
+              .creatorAccountId(account_id)
+              .getAccountAssetTransactions(account_id2, asset_id, kTxPageSize)
+              .build();
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::TransactionsPageResponse>(
           std::move(result), [this](const auto &cast_resp) {


### PR DESCRIPTION

### Description of the Change
Fix some compilation warnings for mainstream clang (tested with 7.0 on MacOS)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Code clean. Also warnings in postgres_query_executor_test result in compilation error due to -WError option.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Some warnings are still present, in old model and in soci. Not worth to deal with them at the moment. Also to build a system test you still have to update boost to 1.69.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

