### PR TITLE
Fix memory leaks on irohad shutdown

### DIFF
--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -265,6 +265,10 @@ namespace iroha {
           max_size, std::move(proposal_factory), std::move(tx_cache));
     }
 
+    OnDemandOrderingInit::~OnDemandOrderingInit() {
+      notifier.get_subscriber().unsubscribe();
+    }
+
     std::shared_ptr<iroha::network::OrderingGate>
     OnDemandOrderingInit::initOrderingGate(
         size_t max_size,

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -74,6 +74,8 @@ namespace iroha {
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache);
 
      public:
+      ~OnDemandOrderingInit();
+
       /**
        * Initializes on-demand ordering gate and ordering sevice components
        *

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -32,6 +32,10 @@ OnDemandConnectionManager::OnDemandConnectionManager(
   initializeConnections(initial_peers);
 }
 
+OnDemandConnectionManager::~OnDemandConnectionManager() {
+  subscription_.unsubscribe();
+}
+
 void OnDemandConnectionManager::onBatches(consensus::Round round,
                                           CollectionType batches) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -58,6 +58,8 @@ namespace iroha {
           rxcpp::observable<CurrentPeers> peers,
           CurrentPeers initial_peers);
 
+      ~OnDemandConnectionManager() override;
+
       void onBatches(consensus::Round round, CollectionType batches) override;
 
       boost::optional<ProposalType> onRequestProposal(

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -72,6 +72,10 @@ OnDemandOrderingGate::OnDemandOrderingGate(
       tx_cache_(std::move(tx_cache)),
       current_round_(initial_round) {}
 
+OnDemandOrderingGate::~OnDemandOrderingGate() {
+  events_subscription_.unsubscribe();
+}
+
 void OnDemandOrderingGate::propagateBatch(
     std::shared_ptr<shared_model::interface::TransactionBatch> batch) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -64,6 +64,8 @@ namespace iroha {
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round);
 
+      ~OnDemandOrderingGate() override;
+
       void propagateBatch(
           std::shared_ptr<shared_model::interface::TransactionBatch> batch)
           override;


### PR DESCRIPTION

### Description of the Change
Pull request fixes couple of memory leaks on irohad shutdown by calling unsubscribe() in destructors of several classes.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Clean output of leak sanitizer, Irohad destructor is called now.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


