### PR TITLE
Add libc++ to docker build image

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -18,6 +18,7 @@ RUN set -e; \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test; \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
     echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main' >> /etc/apt/sources.list; \
+    echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main' >> /etc/apt/sources.list; \
     apt-get update
 
 RUN set -e; \
@@ -37,6 +38,14 @@ RUN set -e; \
         curl file gdb gdbserver ccache \
         gcovr cppcheck doxygen rsync graphviz graphviz-dev unzip vim zip; \
     apt-get -y clean
+
+# compiler clang-7 and libc++ only on x86_64, for debug purpose
+RUN set -e; \
+    if [ `uname -m` = "x86_64" ]; then \
+      apt-get -y --no-install-recommends install \
+        clang-7 lldb-7 lld-7 libc++-7-dev libc++abi-7-dev; \
+      apt-get -y clean; \
+    fi
 
 # install cmake 3.11.4
 RUN set -e; \


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
It is not trivial to install libc++6-dev on ubuntu 16.04,
The another solution was proposed:  Install  clang-7 (it has libc++7-dev in llvm.org )

### Benefits
One more compiler to test and build 

### Possible Drawbacks 
`clang-7` may update some library  that used in `clang-6.0`

### Usage Examples or Tests *[optional]*


### Alternate Designs *[optional]*

