### PR TITLE
Fix GetTransactions query behaviour

### DIFF
--- a/docs/source/api/queries.rst
+++ b/docs/source/api/queries.rst
@@ -122,6 +122,7 @@ Purpose
 -------
 
 GetTransactions is used for retrieving information about transactions, based on their hashes.
+.. note:: This query is valid if and only if all the requested hashes are correct: corresponding transactions exist, and the user has a permission to retrieve them
 
 Request Schema
 --------------

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -191,11 +191,11 @@ namespace iroha {
               typename PermissionTuple,
               typename QueryExecutor,
               typename ResponseCreator,
-              typename ErrResponse>
+              typename PermissionsErrResponse>
     QueryExecutorResult PostgresQueryExecutorVisitor::executeQuery(
         QueryExecutor &&query_executor,
         ResponseCreator &&response_creator,
-        ErrResponse &&err_response) {
+        PermissionsErrResponse &&perms_err_response) {
       using T = concat<QueryTuple, PermissionTuple>;
       try {
         soci::rowset<T> st = std::forward<QueryExecutor>(query_executor)();
@@ -203,7 +203,8 @@ namespace iroha {
 
         return apply(
             viewPermissions<PermissionTuple>(range.front()),
-            [this, range, &response_creator, &err_response](auto... perms) {
+            [this, range, &response_creator, &perms_err_response](
+                auto... perms) {
               bool temp[] = {not perms...};
               if (std::all_of(std::begin(temp), std::end(temp), [](auto b) {
                     return b;
@@ -212,7 +213,7 @@ namespace iroha {
                 // with a named constant
                 return this->logAndReturnErrorResponse(
                     QueryErrorType::kStatefulFailed,
-                    std::forward<ErrResponse>(err_response)(),
+                    std::forward<PermissionsErrResponse>(perms_err_response)(),
                     2);
               }
               auto query_range = range
@@ -619,6 +620,14 @@ namespace iroha {
             return (sql_.prepare << cmd, soci::use(creator_id_, "account_id"));
           },
           [&](auto range, auto &my_perm, auto &all_perm) {
+            if (boost::size(range) != q.transactionHashes().size()) {
+              // at least one of the hashes in the query was invalid -
+              // nonexistent or permissions were lacked
+              return logAndReturnErrorResponse(
+                  QueryErrorType::kStatefulFailed,
+                  "At least one of the supplied hashes is incorrect",
+                  4);
+            }
             std::map<uint64_t, std::unordered_set<std::string>> index;
             boost::for_each(range, [&index](auto t) {
               apply(t, [&index](auto &height, auto &hash) {

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -623,7 +623,7 @@ namespace iroha {
             if (boost::size(range) != q.transactionHashes().size()) {
               // at least one of the hashes in the query was invalid -
               // nonexistent or permissions were lacked
-              return logAndReturnErrorResponse(
+              return this->logAndReturnErrorResponse(
                   QueryErrorType::kStatefulFailed,
                   "At least one of the supplied hashes is incorrect",
                   4);

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -621,8 +621,10 @@ namespace iroha {
           },
           [&](auto range, auto &my_perm, auto &all_perm) {
             if (boost::size(range) != q.transactionHashes().size()) {
+              // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 4
+              // with a named constant
               // at least one of the hashes in the query was invalid -
-              // nonexistent or permissions were lacked
+              // nonexistent or permissions were missed
               return this->logAndReturnErrorResponse(
                   QueryErrorType::kStatefulFailed,
                   "At least one of the supplied hashes is incorrect",

--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -114,21 +114,23 @@ namespace iroha {
        * @tparam PermissionTuple - permissions, needed for the query
        * @tparam QueryExecutor - type of function, which executes the query
        * @tparam ResponseCreator - type of function, which creates response of
-       * the query
-       * @tparam ErrResponse - type of function, which creates error response
+       * the query, successful or error one
+       * @tparam PermissionsErrResponse - type of function, which creates error
+       * response in case something wrong with permissions
        * @param query_executor - function, executing query
        * @param response_creator - function, creating query response
-       * @param err_response - function, creating error response
+       * @param perms_err_response - function, creating error response
        * @return query response created as a result of query execution
        */
       template <typename QueryTuple,
                 typename PermissionTuple,
                 typename QueryExecutor,
                 typename ResponseCreator,
-                typename ErrResponse>
-      QueryExecutorResult executeQuery(QueryExecutor &&query_executor,
-                                       ResponseCreator &&response_creator,
-                                       ErrResponse &&err_response);
+                typename PermissionsErrResponse>
+      QueryExecutorResult executeQuery(
+          QueryExecutor &&query_executor,
+          ResponseCreator &&response_creator,
+          PermissionsErrResponse &&perms_err_response);
 
       /**
        * Create a query error response and log it

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -172,15 +172,17 @@ TEST_F(GetTransactions, InvalidSignatures) {
 /**
  * @given some user with only can_get_my_txs permission
  * @when query GetTransactions with nonexistent hash
- * @then TransactionsResponse with no transactions
+ * @then Stateful invalid query response
  */
 TEST_F(GetTransactions, NonexistentHash) {
   auto check = [](auto &status) {
     ASSERT_NO_THROW({
       const auto &resp =
-          boost::get<const shared_model::interface::TransactionsResponse &>(
+          boost::get<const shared_model::interface::ErrorQueryResponse &>(
               status.get());
-      ASSERT_EQ(resp.transactions().size(), 0);
+      ASSERT_EQ(resp.errorCode(), 4);
+      boost::get<const shared_model::interface::StatefulFailedErrorResponse &>(
+          resp.get());
     });
   };
 

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -180,6 +180,8 @@ TEST_F(GetTransactions, NonexistentHash) {
       const auto &resp =
           boost::get<const shared_model::interface::ErrorQueryResponse &>(
               status.get());
+      // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 4
+      // with a named constant
       ASSERT_EQ(resp.errorCode(), 4);
       boost::get<const shared_model::interface::StatefulFailedErrorResponse &>(
           resp.get());

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -1472,7 +1472,7 @@ namespace iroha {
      * @when get transactions with two valid @and one invalid hashes in query
      * @then error is returned
      */
-    TEST_F(GetTransactionsHashExecutorTest, InvalidBadHash) {
+    TEST_F(GetTransactionsHashExecutorTest, BadHash) {
       addPerms({shared_model::interface::permissions::Role::kGetAllTxs});
 
       commitBlocks();
@@ -1487,6 +1487,8 @@ namespace iroha {
                        .getTransactions(hashes)
                        .build();
       auto result = executeQuery(query);
+      // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 4
+      // with a named constant
       checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
           std::move(result), 4);
     }

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -1477,7 +1477,7 @@ namespace iroha {
 
       commitBlocks();
 
-      std::vector<decltype(hash3)> hashes;
+      std::vector<decltype(hash1)> hashes;
       hashes.push_back(hash1);
       hashes.emplace_back("AbsolutelyInvalidHash");
       hashes.push_back(hash2);


### PR DESCRIPTION
[IR-135](https://jira.hyperledger.org/browse/IR-135)

### Description of the Change

GetTransactions query returned list of only those transactions, which hashes were correct and the user had a permission to view them. This behaviour was considered incorrect, so now this query is going to return a stateful error, if at least one of the hashes does not meet the described requirement.

### Benefits

Correct behaviour of the query.

### Possible Drawbacks 

Less usability?