### PR TITLE
Refactored ITF fake peer initialization

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -25,6 +25,7 @@
 #include "cryptography/default_hash_provider.hpp"
 #include "datetime/time.hpp"
 #include "framework/common_constants.hpp"
+#include "framework/integration_framework/fake_peer/behaviour/honest.hpp"
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 #include "framework/integration_framework/iroha_instance.hpp"
 #include "framework/integration_framework/port_guard.hpp"
@@ -148,6 +149,17 @@ namespace integration_framework {
     fake_peer->initialize();
     fake_peers_.emplace_back(fake_peer);
     return fake_peer;
+  }
+
+  std::vector<std::shared_ptr<fake_peer::FakePeer>>
+  IntegrationTestFramework::addInitialPeers(size_t amount) {
+    std::vector<std::shared_ptr<fake_peer::FakePeer>> fake_peers;
+    std::generate_n(std::back_inserter(fake_peers), amount, [this] {
+      auto fake_peer = addInitialPeer({});
+      fake_peer->setBehaviour(std::make_shared<fake_peer::HonestBehaviour>());
+      return fake_peer;
+    });
+    return fake_peers;
   }
 
   shared_model::proto::Block IntegrationTestFramework::defaultBlock(

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -132,36 +132,22 @@ namespace integration_framework {
     }
   }
 
-  std::future<std::shared_ptr<FakePeer>>
-  IntegrationTestFramework::addInitialPeer(
+  std::shared_ptr<FakePeer> IntegrationTestFramework::addInitialPeer(
       const boost::optional<Keypair> &key) {
-    fake_peers_promises_.emplace_back(std::promise<std::shared_ptr<FakePeer>>(),
-                                      key);
-    return fake_peers_promises_.back().first.get_future();
-  }
-
-  void IntegrationTestFramework::makeFakePeers() {
-    if (fake_peers_promises_.size() == 0) {
-      return;
-    }
-    log_->info("creating fake iroha peers");
-    assert(this_peer_ && "this_peer_ is needed for fake peers initialization, "
-        "but not set");
-    for (auto &promise_and_key : fake_peers_promises_) {
-      auto fake_peer =
-          std::make_shared<FakePeer>(kLocalHost,
-                                     port_guard_->getPort(kDefaultInternalPort),
-                                     promise_and_key.second,
-                                     this_peer_,
-                                     common_objects_factory_,
-                                     transaction_factory_,
-                                     batch_parser_,
-                                     transaction_batch_factory_,
-                                     tx_presence_cache_);
-      fake_peer->initialize();
-      fake_peers_.emplace_back(fake_peer);
-      promise_and_key.first.set_value(fake_peer);
-    }
+    BOOST_ASSERT_MSG(this_peer_, "Need to set the ITF peer key first!");
+    auto fake_peer =
+        std::make_shared<FakePeer>(kLocalHost,
+                                   port_guard_->getPort(kDefaultInternalPort),
+                                   key,
+                                   this_peer_,
+                                   common_objects_factory_,
+                                   transaction_factory_,
+                                   batch_parser_,
+                                   transaction_batch_factory_,
+                                   tx_presence_cache_);
+    fake_peer->initialize();
+    fake_peers_.emplace_back(fake_peer);
+    return fake_peer;
   }
 
   shared_model::proto::Block IntegrationTestFramework::defaultBlock(
@@ -205,11 +191,21 @@ namespace integration_framework {
     return genesis_block;
   }
 
+  shared_model::proto::Block IntegrationTestFramework::defaultBlock() const {
+    BOOST_ASSERT_MSG(my_key_, "Need to set the ITF peer key first!");
+    return defaultBlock(*my_key_);
+  }
+
+  IntegrationTestFramework &IntegrationTestFramework::setGenesisBlock(
+      const shared_model::interface::Block &block) {
+    iroha_instance_->makeGenesis(block);
+    return *this;
+  }
+
   IntegrationTestFramework &IntegrationTestFramework::setInitialState(
       const Keypair &keypair) {
     initPipeline(keypair);
-    iroha_instance_->makeGenesis(
-        IntegrationTestFramework::defaultBlock(keypair));
+    setGenesisBlock(defaultBlock(keypair));
     log_->info("added genesis block");
     subscribeQueuesAndRun();
     return *this;
@@ -226,7 +222,7 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::setInitialState(
       const Keypair &keypair, const shared_model::interface::Block &block) {
     initPipeline(keypair);
-    iroha_instance_->makeGenesis(block);
+    setGenesisBlock(block);
     log_->info("added genesis block");
     subscribeQueuesAndRun();
     return *this;
@@ -243,28 +239,15 @@ namespace integration_framework {
   void IntegrationTestFramework::initPipeline(
       const shared_model::crypto::Keypair &keypair) {
     log_->info("init state");
-    // peer initialization
-    common_objects_factory_
-        ->createPeer(kLocalHost + ":" + std::to_string(internal_port_),
-                     keypair.publicKey())
-        .match(
-            [this](iroha::expected::Result<
-                   std::unique_ptr<shared_model::interface::Peer>,
-                   std::string>::ValueType &result) {
-              this->this_peer_ = std::move(result.value);
-            },
-            [](const iroha::expected::Result<
-                std::unique_ptr<shared_model::interface::Peer>,
-                std::string>::ErrorType &error) {
-              BOOST_THROW_EXCEPTION(std::runtime_error(
-                  "Failed to create peer object for current irohad instance. "
-                  + error.error));
-            });
-
+    my_key_ = keypair;
+    this_peer_ = framework::expected::val(
+                     common_objects_factory_->createPeer(
+                         kLocalHost + ":" + std::to_string(internal_port_),
+                         keypair.publicKey()))
+                     .value()
+                     .value;
     iroha_instance_->initPipeline(keypair, maximum_proposal_size_);
     log_->info("created pipeline");
-
-    makeFakePeers();
   }
 
   void IntegrationTestFramework::subscribeQueuesAndRun() {

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -134,7 +134,7 @@ namespace integration_framework {
 
   std::shared_ptr<FakePeer> IntegrationTestFramework::addInitialPeer(
       const boost::optional<Keypair> &key) {
-    BOOST_ASSERT_MSG(this_peer_, "Need to set the ITF peer key first!");
+    BOOST_ASSERT_MSG(this_peer_, "Need to initialize the ITF peer first!");
     auto fake_peer =
         std::make_shared<FakePeer>(kLocalHost,
                                    port_guard_->getPort(kDefaultInternalPort),

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -107,7 +107,7 @@ namespace integration_framework {
 
     ~IntegrationTestFramework();
 
-    std::future<std::shared_ptr<fake_peer::FakePeer>> addInitialPeer(
+    std::shared_ptr<fake_peer::FakePeer> addInitialPeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
 
     /**
@@ -122,6 +122,13 @@ namespace integration_framework {
      */
     shared_model::proto::Block defaultBlock(
         const shared_model::crypto::Keypair &key) const;
+
+    /// Construct default genesis block using the my_key_ key.
+    shared_model::proto::Block defaultBlock() const;
+
+    /// Set the provided genesis block.
+    IntegrationTestFramework &setGenesisBlock(
+        const shared_model::interface::Block &block);
 
     /**
      * Initialize Iroha instance with default genesis block and provided signing
@@ -369,6 +376,12 @@ namespace integration_framework {
     /// Get the controlled Iroha instance.
     const std::shared_ptr<IrohaInstance> &getIrohaInstance() const;
 
+    /// Set the ITF peer keypair and initialize irohad pipeline.
+    void initPipeline(const shared_model::crypto::Keypair &keypair);
+
+    /// Start the ITF.
+    void subscribeQueuesAndRun();
+
    protected:
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 
@@ -406,9 +419,6 @@ namespace integration_framework {
 
     std::shared_ptr<AsyncCall> async_call_;
 
-    void initPipeline(const shared_model::crypto::Keypair &keypair);
-    void subscribeQueuesAndRun();
-
     // config area
 
     /// maximum time of waiting before appearing next proposal
@@ -439,11 +449,10 @@ namespace integration_framework {
     std::shared_ptr<iroha::network::OrderingServiceTransport> os_transport_;
     std::shared_ptr<iroha::ordering::OrderingGateTransportGrpc> og_transport_;
 
+    boost::optional<shared_model::crypto::Keypair> my_key_;
     std::shared_ptr<shared_model::interface::Peer> this_peer_;
 
    private:
-    void makeFakePeers();
-
     logger::Logger log_ = logger::log("IntegrationTestFramework");
     std::mutex queue_mu;
     std::condition_variable queue_cond;

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -107,8 +107,14 @@ namespace integration_framework {
 
     ~IntegrationTestFramework();
 
+    /// Add a fake peer with given key.
     std::shared_ptr<fake_peer::FakePeer> addInitialPeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
+
+    /// Add the given amount of fake peers with generated default keys and
+    /// "honest" behaviours.
+    std::vector<std::shared_ptr<fake_peer::FakePeer>> addInitialPeers(
+        size_t amount);
 
     /**
      * Construct default genesis block.

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -43,11 +43,7 @@ class FakePeerExampleFixture : public AcceptanceFixture {
     itf_->initPipeline(kAdminKeypair);
 
     // make the fake peers with honest behaviour
-    std::generate_n(std::back_inserter(fake_peers_), num_fake_peers, [this] {
-      FakePeerPtr fake_peer = this->itf_->addInitialPeer({});
-      fake_peer->setBehaviour(std::make_shared<fake_peer::HonestBehaviour>());
-      return fake_peer;
-    });
+    fake_peers_ = itf_->addInitialPeers(num_fake_peers);
 
     itf_->setGenesisBlock(itf_->defaultBlock()).subscribeQueuesAndRun();
 

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -40,29 +40,25 @@ class FakePeerExampleFixture : public AcceptanceFixture {
    */
   IntegrationTestFramework &prepareState(size_t num_fake_peers) {
     // request the fake peers construction
-    std::vector<std::future<FakePeerPtr>> fake_peers_futures;
-    std::generate_n(std::back_inserter(fake_peers_futures),
-                    num_fake_peers,
-                    [this] { return itf_->addInitialPeer({}); });
+    itf_->initPipeline(kAdminKeypair);
 
-    itf_->setInitialState(kAdminKeypair);
-
-    auto permissions =
-        interface::RolePermissionSet({Role::kReceive, Role::kTransfer});
-
-    // get the constructed fake peers & set honest behaviour
-    for (auto &fake_peer_future : fake_peers_futures) {
-      assert(fake_peer_future.valid() && "fake peer must be ready");
-      FakePeerPtr fake_peer = fake_peer_future.get();
+    // make the fake peers with honest behaviour
+    std::generate_n(std::back_inserter(fake_peers_), num_fake_peers, [this] {
+      FakePeerPtr fake_peer = this->itf_->addInitialPeer({});
       fake_peer->setBehaviour(std::make_shared<fake_peer::HonestBehaviour>());
-      fake_peers_.emplace_back(std::move(fake_peer));
-    }
+      return fake_peer;
+    });
+
+    itf_->setGenesisBlock(itf_->defaultBlock()).subscribeQueuesAndRun();
 
     // inside prepareState we can use lambda for such assert, since
     // prepare transactions are not going to fail
     auto block_with_tx = [](auto &block) {
       ASSERT_EQ(block->transactions().size(), 1);
     };
+
+    auto permissions =
+        interface::RolePermissionSet({Role::kReceive, Role::kTransfer});
 
     return itf_->sendTxAwait(makeUserWithPerms(permissions), block_with_tx)
         .sendTxAwait(


### PR DESCRIPTION
### Description of the Change

I stumbled upon a race condition when the ITF was run and started sending out votes but the Fake Peers were not yet assigned a proper behaviour to react to them. Overcoming that seems impossible without separating genesis block generation from ITF starting to different external interface functions. While doing that I could also rework the interface of Fake Peers addition to the ITF without `future`s, because we now can initialize ITF main peer's key without starting ITF and assigning the genesis block.

### Benefits

Easier and more granular Fake Peer initialization.

### Possible Drawbacks 

Two ITF functions got exposed. One of them `initPipeline` may be not very clear for the users that do not know the guts of the ITF, but I kept it as is, because some existing code relies on it.  

### Usage Examples or Tests *[optional]*

Please see `fake_peer_example_test`.

### Alternate Designs *[optional]*

Providing an optional behaviour when requesting a fake peer, keeping the ugly design with `future`s.
