### PR TITLE
ITF: fake peer on demand OS usage example

### DIFF
--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -24,6 +24,7 @@ namespace integration_framework {
 
       boost::optional<OnDemandOsNetworkNotifier::ProposalType>
       OnDemandOsNetworkNotifier::onRequestProposal(Round round) {
+        rounds_subject_.get_subscriber().on_next(round);
         auto fake_peer = fake_peer_wptr_.lock();
         BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
         const auto behaviour = fake_peer->getBehaviour();


### PR DESCRIPTION
### Description of the Change

A test example for new on-demand-os functionality in ITF Fake Peers.

### Benefits

A test example and a proof of work.

### Usage Examples or Tests *[optional]*

Please see `fake_peer_example_test`.