### PR TITLE
Fix build of multi language docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,9 @@ with open('common.yaml', 'r') as stream:
 with open('locale.yaml', 'r') as stream:    
     locale = yaml.load(stream)
     language = locale.get('language')
-    locale_dirs = locale.get('locale_dirs')
+    if locale.get('locale_dirs'):
+        print("Setting locale dir to " + locale.get('locale_dirs'))
+        locale_dirs = [(locale.get('locale_dirs'))]
 
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Recently I introduced YAML files in docs config here: #1954. Now guess what? 
When you try to run build of docs in Japanese or Dutch here is what you got:

```
Running Sphinx v1.8.2
loading translations [ja]... done
making output directory...
WARNING: The config value `locale_dirs' has type `str', defaults to `list'.
```

This warning actually is an error — as the docs cannot be built in target language. This had to be merged, otherwise people cannot see localized_docs.

### Benefits

Contributors would be able to see docs in their language.

### Possible Drawbacks 

None

### Usage Examples or Tests *[optional]*

Go to https://github.com/soramitsu/localized_docs, follow README.md and try to build Japanese docs in folder docs/ja. You won't see any Japanese text.
Now if you update .gitmodule file with this branch (fix/docs-build) you will see this is a solution.