### PR TITLE
Fix GetAccountTransactions and GetAccountAssetTransactions behaviour

### DIFF
--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -227,7 +227,7 @@ namespace iroha {
                   query_range, perms...);
             });
       } catch (const std::exception &e) {
-        return logAndReturnErrorResponse(
+        return this->logAndReturnErrorResponse(
             QueryErrorType::kStatefulFailed, e.what(), 1);
       }
     }
@@ -441,7 +441,7 @@ namespace iroha {
               // parameters were wrong
               if (auto query_incorrect =
                       std::forward<QueryChecker>(qry_checker)(q)) {
-                return logAndReturnErrorResponse(
+                return this->logAndReturnErrorResponse(
                     QueryErrorType::kStatefulFailed,
                     query_incorrect.error_message_,
                     query_incorrect.error_code_);

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -443,8 +443,8 @@ namespace iroha {
                       std::forward<QueryChecker>(qry_checker)(q)) {
                 return this->logAndReturnErrorResponse(
                     QueryErrorType::kStatefulFailed,
-                    query_incorrect.error_message_,
-                    query_incorrect.error_code_);
+                    query_incorrect.error_message,
+                    query_incorrect.error_code);
               }
             }
 
@@ -599,7 +599,7 @@ namespace iroha {
       };
 
       auto check_query = [this](const auto &q) {
-        if (existsInDb<int>("account", "account_id", "quorum", q.accountId())) {
+        if (this->existsInDb<int>("account", "account_id", "quorum", q.accountId())) {
           return QueryFallbackCheckResult{};
         }
         return QueryFallbackCheckResult{
@@ -709,12 +709,12 @@ namespace iroha {
       };
 
       auto check_query = [this](const auto &q) {
-        if (not existsInDb<int>(
+        if (not this->existsInDb<int>(
                 "account", "account_id", "quorum", q.accountId())) {
           return QueryFallbackCheckResult{
               5, "no account with such id found: " + q.accountId()};
         }
-        if (not existsInDb<int>(
+        if (not this->existsInDb<int>(
                 "asset", "asset_id", "precision", q.assetId())) {
           return QueryFallbackCheckResult{
               6, "no asset with such id found: " + q.assetId()};

--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -166,6 +166,25 @@ namespace iroha {
           QueryApplier applier,
           Permissions... perms);
 
+      /**
+       * Check if entry with such key exists in the database
+       * @tparam ReturnValueType - type of the value to be returned in the
+       * underlying query
+       * @param table_name - name of the table to be checked
+       * @param key_name - name of the table attritute, against which the search
+       * is performed
+       * @param selected_value_name - name of the value, which is to be returned
+       * from the search (attribute with such name is to exist)
+       * @param actual value of the key attribute
+       * @return true, if entry with such value of the key attribute exists,
+       * false otherwise
+       */
+      template <typename ReturnValueType>
+      bool existsInDb(const std::string &table_name,
+                      const std::string &key_name,
+                      const std::string &value_name,
+                      const std::string &value) const;
+
       struct QueryFallbackCheckResult {
         QueryFallbackCheckResult() = default;
         QueryFallbackCheckResult(size_t error_code, std::string &&error_message)

--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -146,8 +146,8 @@ namespace iroha {
        * Execute query which returns list of transactions
        * uses pagination
        * @param query - query object
-       * @param qry_checker - fallback checker of the query, needed in some
-       * unclear cases
+       * @param qry_checker - fallback checker of the query, needed if paging
+       * hash is not specified and 0 transaction are returned as a query result
        * @param related_txs - SQL query which returns transaction relevant
        * to this query
        * @param applier - function which accepts SQL
@@ -171,13 +171,15 @@ namespace iroha {
        * @tparam ReturnValueType - type of the value to be returned in the
        * underlying query
        * @param table_name - name of the table to be checked
-       * @param key_name - name of the table attritute, against which the search
+       * @param key_name - name of the table attribute, against which the search
        * is performed
-       * @param selected_value_name - name of the value, which is to be returned
+       * @param value_name - name of the value, which is to be returned
        * from the search (attribute with such name is to exist)
-       * @param actual value of the key attribute
+       * @param value - actual value of the key attribute
        * @return true, if entry with such value of the key attribute exists,
        * false otherwise
+       *
+       * @throws if check query finishes with an exception
        */
       template <typename ReturnValueType>
       bool existsInDb(const std::string &table_name,
@@ -187,17 +189,23 @@ namespace iroha {
 
       struct QueryFallbackCheckResult {
         QueryFallbackCheckResult() = default;
-        QueryFallbackCheckResult(size_t error_code, std::string &&error_message)
-            : contains_error_{true},
-              error_code_{error_code},
-              error_message_{std::move(error_message)} {}
+        QueryFallbackCheckResult(
+            shared_model::interface::ErrorQueryResponse::ErrorCodeType
+                error_code,
+            shared_model::interface::ErrorQueryResponse::ErrorMessageType
+                &&error_message)
+            : contains_error{true},
+              error_code{error_code},
+              error_message{std::move(error_message)} {}
 
         explicit operator bool() const {
-          return contains_error_;
+          return contains_error;
         }
-        bool contains_error_ = false;
-        size_t error_code_ = 0;
-        std::string error_message_ = "";
+        bool contains_error = false;
+        shared_model::interface::ErrorQueryResponse::ErrorCodeType error_code =
+            0;
+        shared_model::interface::ErrorQueryResponse::ErrorMessageType
+            error_message = "";
       };
 
       soci::session &sql_;

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -213,6 +213,10 @@ namespace iroha {
           ErrorCodeType kNoPermissions = 2;
       static constexpr shared_model::interface::ErrorQueryResponse::
           ErrorCodeType kInvalidPagination = 4;
+      static constexpr shared_model::interface::ErrorQueryResponse::
+          ErrorCodeType kInvalidAccountId = 5;
+      static constexpr shared_model::interface::ErrorQueryResponse::
+          ErrorCodeType kInvalidAssetId = 6;
 
       void createDefaultAccount() {
         execute(*mock_command_factory->constructCreateAccount(
@@ -1312,12 +1316,12 @@ namespace iroha {
     }
 
     /**
-     * @given initialized storage, permission
+     * @given initialized storage, all permissions
      * @when get account transactions of non existing account
      * @then Return empty account transactions
      */
-    TEST_F(GetAccountTransactionsExecutorTest, DISABLED_InvalidNoAccount) {
-      addPerms({shared_model::interface::permissions::Role::kGetAllAccTxs});
+    TEST_F(GetAccountTransactionsExecutorTest, InvalidNoAccount) {
+      addAllPerms();
 
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
@@ -1325,7 +1329,7 @@ namespace iroha {
                        .build();
       auto result = executeQuery(query);
       checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
-          std::move(result), kNoStatefulError);
+          std::move(result), kInvalidAccountId);
     }
 
     // ------------------------/ tx pagination tests \----------------------- //
@@ -1582,11 +1586,48 @@ namespace iroha {
 
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
-                       .getAccountTransactions(another_account_id, kTxPageSize)
+                       .getAccountAssetTransactions(
+                           another_account_id, asset_id, kTxPageSize)
                        .build();
       auto result = executeQuery(query);
       checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
           std::move(result), kNoPermissions);
+    }
+
+    /**
+     * @given initialized storage
+     * @when get account asset transactions of non-existing user
+     * @then corresponding error is returned
+     */
+    TEST_F(GetAccountAssetTransactionsExecutorTest, InvalidAccountId) {
+      addAllPerms();
+
+      auto query = TestQueryBuilder()
+                       .creatorAccountId(account_id)
+                       .getAccountAssetTransactions(
+                           "doge@noaccount", asset_id, kTxPageSize)
+                       .build();
+      auto result = executeQuery(query);
+      checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
+          std::move(result), kInvalidAccountId);
+    }
+
+    /**
+     * @given initialized storage
+     * @when get account asset transactions of non-existing asset
+     * @then corresponding error is returned
+     */
+    TEST_F(GetAccountAssetTransactionsExecutorTest, InvalidAssetId) {
+      addAllPerms();
+
+      auto query =
+          TestQueryBuilder()
+              .creatorAccountId(account_id)
+              .getAccountAssetTransactions(account_id, "doge#coin", kTxPageSize)
+              .build();
+      auto result = executeQuery(query);
+      checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
+          std::move(result), kInvalidAssetId);
     }
 
     /**

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -1318,7 +1318,7 @@ namespace iroha {
     /**
      * @given initialized storage, all permissions
      * @when get account transactions of non existing account
-     * @then Return empty account transactions
+     * @then return error
      */
     TEST_F(GetAccountTransactionsExecutorTest, InvalidNoAccount) {
       addAllPerms();
@@ -1595,7 +1595,7 @@ namespace iroha {
     }
 
     /**
-     * @given initialized storage
+     * @given initialized storage, all permissions
      * @when get account asset transactions of non-existing user
      * @then corresponding error is returned
      */
@@ -1613,7 +1613,7 @@ namespace iroha {
     }
 
     /**
-     * @given initialized storage
+     * @given initialized storage, all permissions
      * @when get account asset transactions of non-existing asset
      * @then corresponding error is returned
      */


### PR DESCRIPTION
[IR-136](https://jira.hyperledger.org/browse/IR-136)


### Description of the Change

Those queries behaved incorrect in case invalid account_id or asset_id was supplied, leading to a success, but empty result in such a case. This PR adds a "fallback" check, which can deduce it and return a correct stateful error.

### Benefits

Correct behaviour of the queries.

### Possible Drawbacks 

Another DB check, which is though executed only in one specific case and does not touch success or another error ones.