### PR TITLE
Fix thread safe issue in status streaming

### DIFF
--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -185,7 +185,7 @@ namespace torii {
 
     auto hash = shared_model::crypto::Hash(request->tx_hash());
 
-    static auto client_id_format = boost::format("Peer: '%s', %s");
+    auto client_id_format = boost::format("Peer: '%s', %s");
     std::string client_id =
         (client_id_format % context->peer() % hash.toString()).str();
 


### PR DESCRIPTION
### Description of the Change
Pull request replaces static local variable in to a generic local one in status streaming handler to prevent races on it (actually, initialisation by itself is safe but % operator is not).

### Benefits
Clients can now perform streaming status requests without unknown status issue (IR-76).

### Possible Drawbacks 
None.

### Usage Examples or Tests 
Correctness of fix was tested with help of thread sanitizer. Also instance of irohad is now able to survive under load of 4 clients bombarding it with transactions and streaming status requests on it for at least 30 minutes.

