### PR TITLE
Add CHECK_TXS macro to acceptance fixture. Reduce code duplication

### DIFF
--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -47,7 +47,7 @@ namespace {
 
 #define CHECK_MST_PENDING BASE_CHECK_RESPONSE(MstPendingResponse)
 
-#define CHECK_TXS(i) \
+#define CHECK_TXS_QUANTITY(i) \
   [](const auto &resp) { ASSERT_EQ(resp->transactions().size(), i); }
 }  // namespace
 

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -45,6 +45,9 @@ namespace {
 #define CHECK_COMMITTED BASE_CHECK_RESPONSE(CommittedTxResponse)
 
 #define CHECK_MST_PENDING BASE_CHECK_RESPONSE(MstPendingResponse)
+
+#define CHECK_TXS(i) \
+  [](const auto &resp) { ASSERT_EQ(resp->transactions().size(), i); }
 }  // namespace
 
 /**

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -6,10 +6,11 @@
 #ifndef IROHA_ACCEPTANCE_FIXTURE_HPP
 #define IROHA_ACCEPTANCE_FIXTURE_HPP
 
-#include <gtest/gtest.h>
 #include <functional>
 #include <string>
 #include <vector>
+
+#include <gtest/gtest.h>
 #include "cryptography/keypair.hpp"
 #include "framework/common_constants.hpp"
 #include "interfaces/permissions.hpp"

--- a/test/integration/acceptance/add_signatory_test.cpp
+++ b/test/integration/acceptance/add_signatory_test.cpp
@@ -46,11 +46,11 @@ class AddSignatory : public AcceptanceFixture {
 TEST_F(AddSignatory, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendQuery(
           complete(baseQry().creatorAccountId(kAdminId).getSignatories(kUserId),
                    kAdminKeypair),
@@ -80,11 +80,11 @@ TEST_F(AddSignatory, NoPermission) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser({interface::permissions::Role::kReceive}),
-                   CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+                   CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -102,16 +102,16 @@ TEST_F(AddSignatory, GrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kAddMySignatory}),
-          CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().grantPermission(
               kUser2Id, interface::permissions::Grantable::kAddMySignatory)),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTxAwait(complete(baseTx().creatorAccountId(kUser2Id).addSignatory(
                                 kUserId, kUser2Keypair.publicKey()),
                             kUser2Keypair),
-                   CHECK_TXS(1));
+                   CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -127,12 +127,12 @@ TEST_F(AddSignatory, NonGrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kAddMySignatory}),
-          CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().creatorAccountId(kUser2Id).addSignatory(
                            kUserId, kUser2Keypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -144,11 +144,11 @@ TEST_F(AddSignatory, NonGrantedPermission) {
 TEST_F(AddSignatory, NonExistentUser) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().addSignatory("inexistent@" + kDomain,
                                              kUserKeypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -160,7 +160,7 @@ TEST_F(AddSignatory, NonExistentUser) {
 TEST_F(AddSignatory, InvalidKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().addSignatory(kUserId,
                                              shared_model::crypto::PublicKey(
                                                  std::string(1337, 'a'))),
@@ -177,10 +177,10 @@ TEST_F(AddSignatory, InvalidKey) {
 TEST_F(AddSignatory, NonExistedKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(
           baseTx().addSignatory(
               kUserId, shared_model::crypto::PublicKey(std::string(32, 'a'))),
           kUser2Keypair))
-      .checkVerifiedProposal(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0));
 }

--- a/test/integration/acceptance/add_signatory_test.cpp
+++ b/test/integration/acceptance/add_signatory_test.cpp
@@ -36,9 +36,6 @@ class AddSignatory : public AcceptanceFixture {
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
 };
 
-#define CHECK_BLOCK(i) \
-  [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
-
 /**
  * C224 Add existing public key of other user
  * @given some user with CanAddSignatory permission and a second user
@@ -49,11 +46,11 @@ class AddSignatory : public AcceptanceFixture {
 TEST_F(AddSignatory, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendQuery(
           complete(baseQry().creatorAccountId(kAdminId).getSignatories(kUserId),
                    kAdminKeypair),
@@ -83,11 +80,11 @@ TEST_F(AddSignatory, NoPermission) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser({interface::permissions::Role::kReceive}),
-                   CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+                   CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTx(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0));
 }
 
 /**
@@ -105,16 +102,16 @@ TEST_F(AddSignatory, GrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kAddMySignatory}),
-          CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+          CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().grantPermission(
               kUser2Id, interface::permissions::Grantable::kAddMySignatory)),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTxAwait(complete(baseTx().creatorAccountId(kUser2Id).addSignatory(
                                 kUserId, kUser2Keypair.publicKey()),
                             kUser2Keypair),
-                   CHECK_BLOCK(1));
+                   CHECK_TXS(1));
 }
 
 /**
@@ -130,12 +127,12 @@ TEST_F(AddSignatory, NonGrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kAddMySignatory}),
-          CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+          CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().creatorAccountId(kUser2Id).addSignatory(
                            kUserId, kUser2Keypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0));
 }
 
 /**
@@ -147,11 +144,11 @@ TEST_F(AddSignatory, NonGrantedPermission) {
 TEST_F(AddSignatory, NonExistentUser) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().addSignatory("inexistent@" + kDomain,
                                              kUserKeypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0));
 }
 
 /**
@@ -163,7 +160,7 @@ TEST_F(AddSignatory, NonExistentUser) {
 TEST_F(AddSignatory, InvalidKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().addSignatory(kUserId,
                                              shared_model::crypto::PublicKey(
                                                  std::string(1337, 'a'))),
@@ -180,10 +177,10 @@ TEST_F(AddSignatory, InvalidKey) {
 TEST_F(AddSignatory, NonExistedKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(
           baseTx().addSignatory(
               kUserId, shared_model::crypto::PublicKey(std::string(32, 'a'))),
           kUser2Keypair))
-      .checkVerifiedProposal(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0));
 }

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -176,11 +176,11 @@ TEST_F(CreateAccount, PrivelegeElevation) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(second_domain_tx, CHECK_TXS(1))
-      .sendTxAwait(makeUserWithPerms(), CHECK_TXS(1))
+      .sendTxAwait(second_domain_tx, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeUserWithPerms(), CHECK_TXS_QUANTITY(1))
       .sendTx(create_elevated_user)
       .skipProposal()
-      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
       .checkBlock([&rejected_hash](const auto &block) {
         const auto rejected_hashes = block->rejected_transactions_hashes();
         ASSERT_THAT(rejected_hashes, ::testing::Contains(rejected_hash));

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -11,7 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-
 class CreateAccount : public AcceptanceFixture {
  public:
   auto makeUserWithPerms(const interface::RolePermissionSet &perms = {

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -11,10 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-// TODO igor-egorov, 2018-12-27, IR-148, move all check macroses to
-// acceptance_fixture.hpp
-#define check(i) \
-  [](const auto &resp) { ASSERT_EQ(resp->transactions().size(), i); }
 
 class CreateAccount : public AcceptanceFixture {
  public:
@@ -181,11 +177,11 @@ TEST_F(CreateAccount, PrivelegeElevation) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(second_domain_tx, check(1))
-      .sendTxAwait(makeUserWithPerms(), check(1))
+      .sendTxAwait(second_domain_tx, CHECK_TXS(1))
+      .sendTxAwait(makeUserWithPerms(), CHECK_TXS(1))
       .sendTx(create_elevated_user)
       .skipProposal()
-      .checkVerifiedProposal(check(0))
+      .checkVerifiedProposal(CHECK_TXS(0))
       .checkBlock([&rejected_hash](const auto &block) {
         const auto rejected_hashes = block->rejected_transactions_hashes();
         ASSERT_THAT(rejected_hashes, ::testing::Contains(rejected_hash));

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -17,8 +17,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-#define CHECK_BLOCK(i) \
-  [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
 
 class GetAccount : public AcceptanceFixture {
  public:
@@ -45,7 +43,7 @@ class GetAccount : public AcceptanceFixture {
       const interface::RolePermissionSet &perms = {
           interface::permissions::Role::kGetMyAccount}) {
     itf.setInitialState(kAdminKeypair)
-        .sendTxAwait(makeUserWithPerms(perms), CHECK_BLOCK(1));
+        .sendTxAwait(makeUserWithPerms(perms), CHECK_TXS(1));
     return itf;
   }
 
@@ -224,7 +222,7 @@ TEST_F(GetAccount, WithGetAllPermission) {
 TEST_F(GetAccount, NoPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({})
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -238,7 +236,7 @@ TEST_F(GetAccount, NoPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetMyAccount})
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -253,7 +251,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetDomainAccounts})
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kDomain, kUser2Id, kRole2));
 }
@@ -266,7 +264,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetAllAccounts})
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kDomain, kUser2Id, kRole2));
 }
@@ -279,7 +277,7 @@ TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
 TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -293,7 +291,7 @@ TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetMyAccount})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -307,7 +305,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetDomainAccounts})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -323,7 +321,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetAllPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetAllAccounts})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kNewDomain, kUser2Id, kRole2));
 }

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -11,7 +11,6 @@
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/account_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
-#include "interfaces/query_responses/account_response.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
@@ -42,7 +41,7 @@ class GetAccount : public AcceptanceFixture {
       const interface::RolePermissionSet &perms = {
           interface::permissions::Role::kGetMyAccount}) {
     itf.setInitialState(kAdminKeypair)
-        .sendTxAwait(makeUserWithPerms(perms), CHECK_TXS(1));
+        .sendTxAwait(makeUserWithPerms(perms), CHECK_TXS_QUANTITY(1));
     return itf;
   }
 
@@ -221,7 +220,7 @@ TEST_F(GetAccount, WithGetAllPermission) {
 TEST_F(GetAccount, NoPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({})
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -235,7 +234,7 @@ TEST_F(GetAccount, NoPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetMyAccount})
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -250,7 +249,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetDomainAccounts})
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kDomain, kUser2Id, kRole2));
 }
@@ -263,7 +262,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
 TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
   const std::string kUser2Id = kUser2 + "@" + kDomain;
   prepareState({interface::permissions::Role::kGetAllAccounts})
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kDomain, kUser2Id, kRole2));
 }
@@ -276,7 +275,7 @@ TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
 TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -290,7 +289,7 @@ TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetMyAccount})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -304,7 +303,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetDomainAccounts})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkQueryErrorResponse<
                      shared_model::interface::StatefulFailedErrorResponse>());
@@ -320,7 +319,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
 TEST_F(GetAccount, WithGetAllPermissionOtherAccountInterdomain) {
   const std::string kUser2Id = kUser2 + "@" + kNewDomain;
   prepareState({interface::permissions::Role::kGetAllAccounts})
-      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondInterdomainUser(), CHECK_TXS_QUANTITY(1))
       .sendQuery(makeQuery(kUser2Id),
                  checkValidAccount(kNewDomain, kUser2Id, kRole2));
 }

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -17,7 +17,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-
 class GetAccount : public AcceptanceFixture {
  public:
   GetAccount() : itf(1) {}

--- a/test/integration/acceptance/remove_signatory_test.cpp
+++ b/test/integration/acceptance/remove_signatory_test.cpp
@@ -35,9 +35,6 @@ class RemoveSignatory : public AcceptanceFixture {
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
 };
 
-#define CHECK_BLOCK(i) \
-  [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
-
 /**
  * C264 Remove signatory from own account
  * C267 Remove signatory more than once
@@ -50,18 +47,18 @@ class RemoveSignatory : public AcceptanceFixture {
 TEST_F(RemoveSignatory, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTxAwait(complete(baseTx().removeSignatory(
                        kUserId, kUser2Keypair.publicKey())),
-                   CHECK_BLOCK(1))
+                   CHECK_TXS(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -74,16 +71,16 @@ TEST_F(RemoveSignatory, Basic) {
 TEST_F(RemoveSignatory, NoPermission) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser({}), CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser({}), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -99,20 +96,20 @@ TEST_F(RemoveSignatory, GrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kRemoveMySignatory}),
-          CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+          CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().grantPermission(
               kUser2Id, interface::permissions::Grantable::kRemoveMySignatory)),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTxAwait(complete(baseTx().creatorAccountId(kUser2Id).removeSignatory(
                                 kUserId, kUser2Keypair.publicKey()),
                             kUser2Keypair),
-                   CHECK_BLOCK(1));
+                   CHECK_TXS(1));
 }
 
 /**
@@ -127,17 +124,17 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kRemoveMySignatory}),
-          CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+          CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTx(complete(baseTx().creatorAccountId(kUser2Id).removeSignatory(
                            kUserId, kUser2Keypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -148,12 +145,12 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
 TEST_F(RemoveSignatory, NonExistentUser) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().removeSignatory("inexistent@" + kDomain,
                                                 kUserKeypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -165,7 +162,7 @@ TEST_F(RemoveSignatory, NonExistentUser) {
 TEST_F(RemoveSignatory, InvalidKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().removeSignatory(
                   kUserId,
                   shared_model::crypto::PublicKey(std::string(1337, 'a')))),
@@ -181,11 +178,11 @@ TEST_F(RemoveSignatory, InvalidKey) {
 TEST_F(RemoveSignatory, NonExistedKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       .sendTx(complete(baseTx().removeSignatory(
           kUserId, shared_model::crypto::PublicKey(std::string(32, 'a')))))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -201,18 +198,18 @@ TEST_F(RemoveSignatory, NonExistedKey) {
 TEST_F(RemoveSignatory, DISABLED_SignatoriesLesserThanQuorum) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_BLOCK(1))
-      .sendTxAwait(makeSecondUser(), CHECK_BLOCK(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTxAwait(
           complete(
               baseTx().creatorAccountId(kAdminId).setAccountQuorum(kUserId, 2),
               kAdminKeypair),
-          CHECK_BLOCK(1))
+          CHECK_TXS(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_BLOCK(0))
-      .checkBlock(CHECK_BLOCK(0));
+      .checkVerifiedProposal(CHECK_TXS(0))
+      .checkBlock(CHECK_TXS(0));
 }

--- a/test/integration/acceptance/remove_signatory_test.cpp
+++ b/test/integration/acceptance/remove_signatory_test.cpp
@@ -47,18 +47,18 @@ class RemoveSignatory : public AcceptanceFixture {
 TEST_F(RemoveSignatory, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTxAwait(complete(baseTx().removeSignatory(
                        kUserId, kUser2Keypair.publicKey())),
-                   CHECK_TXS(1))
+                   CHECK_TXS_QUANTITY(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -71,16 +71,16 @@ TEST_F(RemoveSignatory, Basic) {
 TEST_F(RemoveSignatory, NoPermission) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser({}), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser({}), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -96,20 +96,20 @@ TEST_F(RemoveSignatory, GrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kRemoveMySignatory}),
-          CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().grantPermission(
               kUser2Id, interface::permissions::Grantable::kRemoveMySignatory)),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTxAwait(complete(baseTx().creatorAccountId(kUser2Id).removeSignatory(
                                 kUserId, kUser2Keypair.publicKey()),
                             kUser2Keypair),
-                   CHECK_TXS(1));
+                   CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -124,17 +124,17 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
       .setInitialState(kAdminKeypair)
       .sendTxAwait(
           makeFirstUser({interface::permissions::Role::kRemoveMySignatory}),
-          CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey()),
                    kUserKeypair),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().creatorAccountId(kUser2Id).removeSignatory(
                            kUserId, kUser2Keypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -145,12 +145,12 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
 TEST_F(RemoveSignatory, NonExistentUser) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().removeSignatory("inexistent@" + kDomain,
                                                 kUserKeypair.publicKey()),
                        kUser2Keypair))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -162,7 +162,7 @@ TEST_F(RemoveSignatory, NonExistentUser) {
 TEST_F(RemoveSignatory, InvalidKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().removeSignatory(
                   kUserId,
                   shared_model::crypto::PublicKey(std::string(1337, 'a')))),
@@ -178,11 +178,11 @@ TEST_F(RemoveSignatory, InvalidKey) {
 TEST_F(RemoveSignatory, NonExistedKey) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().removeSignatory(
           kUserId, shared_model::crypto::PublicKey(std::string(32, 'a')))))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -198,18 +198,18 @@ TEST_F(RemoveSignatory, NonExistedKey) {
 TEST_F(RemoveSignatory, DISABLED_SignatoriesLesserThanQuorum) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(baseTx().addSignatory(kUserId, kUser2Keypair.publicKey())),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTxAwait(
           complete(
               baseTx().creatorAccountId(kAdminId).setAccountQuorum(kUserId, 2),
               kAdminKeypair),
-          CHECK_TXS(1))
+          CHECK_TXS_QUANTITY(1))
       .sendTx(complete(
           baseTx().removeSignatory(kUserId, kUser2Keypair.publicKey())))
-      .checkVerifiedProposal(CHECK_TXS(0))
-      .checkBlock(CHECK_TXS(0));
+      .checkVerifiedProposal(CHECK_TXS_QUANTITY(0))
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }

--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -26,7 +26,7 @@ class ReplayFixture : public AcceptanceFixture {
                      .addAssetQuantity(kAssetId, "10000.0"),
                  kAdminKeypair);
     itf.setInitialState(kAdminKeypair)
-        .sendTxAwait(create_user_tx, CHECK_TXS(1));
+        .sendTxAwait(create_user_tx, CHECK_TXS_QUANTITY(1));
   }
 
   IntegrationTestFramework itf;
@@ -45,8 +45,8 @@ TEST_F(ReplayFixture, OrderingGateReplay) {
       baseTx(kAdminId).transferAsset(kAdminId, kUserId, kAssetId, "", "1.0"),
       kAdminKeypair);
 
-  itf.sendTxAwait(transfer_tx, CHECK_TXS(1));  // should be committed
-  itf.sendTx(transfer_tx);                     // should not
+  itf.sendTxAwait(transfer_tx, CHECK_TXS_QUANTITY(1));  // should be committed
+  itf.sendTx(transfer_tx);                              // should not
   EXPECT_THROW(itf.skipProposal(),
                std::runtime_error);  // missed proposal should be thrown here
   // TODO 2019-01-09 igor-egorov IR-152

--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -11,7 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-#define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
 
 class ReplayFixture : public AcceptanceFixture {
  public:
@@ -23,13 +22,13 @@ class ReplayFixture : public AcceptanceFixture {
                      .createAccount(kUser, kDomain, kUserKeypair.publicKey())
                      .addAssetQuantity(kAssetId, "10000.0"),
                  kAdminKeypair);
-    itf.setInitialState(kAdminKeypair).sendTxAwait(create_user_tx, check(1));
+    itf.setInitialState(kAdminKeypair).sendTxAwait(create_user_tx, CHECK_TXS(1));
   }
 
   IntegrationTestFramework itf;
 };
 
-// TODO igor-egorov, 07 Nov 2018, enable the test, IR-1773 & IR-1838
+// TODO igor-egorov, 07 Nov 2018, enable the test, IR-151
 /**
  * Basic case of transaction replay attack
  * @given an initialized ITF and a transaction
@@ -41,6 +40,6 @@ TEST_F(ReplayFixture, DISABLED_BasicTxReplay) {
       baseTx(kAdminId).transferAsset(kAdminId, kUserId, kAssetId, "", "1.0"),
       kAdminKeypair);
 
-  itf.sendTxAwait(transfer_tx, check(1));  // should be committed
-  itf.sendTxAwait(transfer_tx, check(0));  // should not
+  itf.sendTxAwait(transfer_tx, CHECK_TXS(1));  // should be committed
+  itf.sendTxAwait(transfer_tx, CHECK_TXS(0));  // should not
 }

--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -11,7 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-
 class ReplayFixture : public AcceptanceFixture {
  public:
   ReplayFixture() : itf(1) {}
@@ -22,7 +21,8 @@ class ReplayFixture : public AcceptanceFixture {
                      .createAccount(kUser, kDomain, kUserKeypair.publicKey())
                      .addAssetQuantity(kAssetId, "10000.0"),
                  kAdminKeypair);
-    itf.setInitialState(kAdminKeypair).sendTxAwait(create_user_tx, CHECK_TXS(1));
+    itf.setInitialState(kAdminKeypair)
+        .sendTxAwait(create_user_tx, CHECK_TXS(1));
   }
 
   IntegrationTestFramework itf;

--- a/test/integration/acceptance/replay_test.cpp
+++ b/test/integration/acceptance/replay_test.cpp
@@ -6,19 +6,23 @@
 #include <gtest/gtest.h>
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
+#include "interfaces/permissions.hpp"
 
 using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
+using namespace shared_model::interface::permissions;
 
 class ReplayFixture : public AcceptanceFixture {
  public:
-  ReplayFixture() : itf(1) {}
+  ReplayFixture() : itf(1), kReceiverRole("receiver") {}
 
   void SetUp() override {
     auto create_user_tx =
         complete(baseTx(kAdminId)
                      .createAccount(kUser, kDomain, kUserKeypair.publicKey())
+                     .createRole(kReceiverRole, {Role::kReceive})
+                     .appendRole(kUserId, kReceiverRole)
                      .addAssetQuantity(kAssetId, "10000.0"),
                  kAdminKeypair);
     itf.setInitialState(kAdminKeypair)
@@ -26,20 +30,35 @@ class ReplayFixture : public AcceptanceFixture {
   }
 
   IntegrationTestFramework itf;
+  const interface::types::RoleIdType kReceiverRole;
 };
 
-// TODO igor-egorov, 07 Nov 2018, enable the test, IR-151
 /**
- * Basic case of transaction replay attack
+ * Basic case of transaction replay attack.
+ * OG/OS should not pass replayed transaction
  * @given an initialized ITF and a transaction
  * @when the transaction is sent to ITF twice
  * @then the second submission should be rejected
  */
-TEST_F(ReplayFixture, DISABLED_BasicTxReplay) {
+TEST_F(ReplayFixture, OrderingGateReplay) {
   auto transfer_tx = complete(
       baseTx(kAdminId).transferAsset(kAdminId, kUserId, kAssetId, "", "1.0"),
       kAdminKeypair);
 
   itf.sendTxAwait(transfer_tx, CHECK_TXS(1));  // should be committed
-  itf.sendTxAwait(transfer_tx, CHECK_TXS(0));  // should not
+  itf.sendTx(transfer_tx);                     // should not
+  EXPECT_THROW(itf.skipProposal(),
+               std::runtime_error);  // missed proposal should be thrown here
+  // TODO 2019-01-09 igor-egorov IR-152
+  // redo without exception handling. Need to make ITF able to handle
+  // "none" answer from ordering service when there is no proposal
+}
+
+/**
+ * @given ITF with hacked OS that provides the same proposal twice
+ * @when YAC accepts the proposal twice
+ * @then a transaction from proposal would not be committed twice
+ */
+TEST_F(ReplayFixture, DISABLED_ConsensusReplay) {
+  // TODO 2019-01-09 igor-egorov IR-153
 }

--- a/test/integration/acceptance/set_account_quorum_test.cpp
+++ b/test/integration/acceptance/set_account_quorum_test.cpp
@@ -11,7 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-
 class QuorumFixture : public AcceptanceFixture {
  public:
   QuorumFixture() : itf(1) {}
@@ -20,7 +19,8 @@ class QuorumFixture : public AcceptanceFixture {
     auto add_public_key_tx = complete(
         baseTx(kAdminId).addSignatory(kAdminId, kUserKeypair.publicKey()),
         kAdminKeypair);
-    itf.setInitialState(kAdminKeypair).sendTxAwait(add_public_key_tx, CHECK_TXS(1));
+    itf.setInitialState(kAdminKeypair)
+        .sendTxAwait(add_public_key_tx, CHECK_TXS(1));
   }
 
   IntegrationTestFramework itf;

--- a/test/integration/acceptance/set_account_quorum_test.cpp
+++ b/test/integration/acceptance/set_account_quorum_test.cpp
@@ -11,7 +11,6 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-#define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
 
 class QuorumFixture : public AcceptanceFixture {
  public:
@@ -21,7 +20,7 @@ class QuorumFixture : public AcceptanceFixture {
     auto add_public_key_tx = complete(
         baseTx(kAdminId).addSignatory(kAdminId, kUserKeypair.publicKey()),
         kAdminKeypair);
-    itf.setInitialState(kAdminKeypair).sendTxAwait(add_public_key_tx, check(1));
+    itf.setInitialState(kAdminKeypair).sendTxAwait(add_public_key_tx, CHECK_TXS(1));
   }
 
   IntegrationTestFramework itf;
@@ -36,7 +35,7 @@ TEST_F(QuorumFixture, CanRaiseQuorum) {
   const auto new_quorum = 2;
   auto raise_quorum_tx = complete(
       baseTx(kAdminId).setAccountQuorum(kAdminId, new_quorum), kAdminKeypair);
-  itf.sendTxAwait(raise_quorum_tx, check(1));
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(1));
 }
 
 /**
@@ -49,7 +48,7 @@ TEST_F(QuorumFixture, CannotRaiseQuorumMoreThanSignatures) {
   const auto new_quorum = 3;
   auto raise_quorum_tx = complete(
       baseTx(kAdminId).setAccountQuorum(kAdminId, new_quorum), kAdminKeypair);
-  itf.sendTxAwait(raise_quorum_tx, check(0))
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(0))
       .getTxStatus(raise_quorum_tx.hash(), CHECK_STATEFUL_INVALID);
 }
 
@@ -70,8 +69,8 @@ TEST_F(QuorumFixture, CanLowerQuorum) {
                              .signAndAddSignature(kAdminKeypair)
                              .signAndAddSignature(kUserKeypair)
                              .finish();
-  itf.sendTxAwait(raise_quorum_tx, check(1));
-  itf.sendTxAwait(lower_quorum_tx, check(1));
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(1));
+  itf.sendTxAwait(lower_quorum_tx, CHECK_TXS(1));
 }
 
 /**

--- a/test/integration/acceptance/set_account_quorum_test.cpp
+++ b/test/integration/acceptance/set_account_quorum_test.cpp
@@ -20,7 +20,7 @@ class QuorumFixture : public AcceptanceFixture {
         baseTx(kAdminId).addSignatory(kAdminId, kUserKeypair.publicKey()),
         kAdminKeypair);
     itf.setInitialState(kAdminKeypair)
-        .sendTxAwait(add_public_key_tx, CHECK_TXS(1));
+        .sendTxAwait(add_public_key_tx, CHECK_TXS_QUANTITY(1));
   }
 
   IntegrationTestFramework itf;
@@ -35,7 +35,7 @@ TEST_F(QuorumFixture, CanRaiseQuorum) {
   const auto new_quorum = 2;
   auto raise_quorum_tx = complete(
       baseTx(kAdminId).setAccountQuorum(kAdminId, new_quorum), kAdminKeypair);
-  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(1));
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -48,7 +48,7 @@ TEST_F(QuorumFixture, CannotRaiseQuorumMoreThanSignatures) {
   const auto new_quorum = 3;
   auto raise_quorum_tx = complete(
       baseTx(kAdminId).setAccountQuorum(kAdminId, new_quorum), kAdminKeypair);
-  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(0))
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS_QUANTITY(0))
       .getTxStatus(raise_quorum_tx.hash(), CHECK_STATEFUL_INVALID);
 }
 
@@ -69,8 +69,8 @@ TEST_F(QuorumFixture, CanLowerQuorum) {
                              .signAndAddSignature(kAdminKeypair)
                              .signAndAddSignature(kUserKeypair)
                              .finish();
-  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS(1));
-  itf.sendTxAwait(lower_quorum_tx, CHECK_TXS(1));
+  itf.sendTxAwait(raise_quorum_tx, CHECK_TXS_QUANTITY(1));
+  itf.sendTxAwait(lower_quorum_tx, CHECK_TXS_QUANTITY(1));
 }
 
 /**

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -5,12 +5,12 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
-#include "acceptance_fixture.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
@@ -71,8 +71,6 @@ class TransferAsset : public AcceptanceFixture {
       crypto::DefaultCryptoAlgorithmType::generateKeypair();
 };
 
-#define check(i) [](auto &block) { ASSERT_EQ(block->transactions().size(), i); }
-
 /**
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command
@@ -81,10 +79,10 @@ class TransferAsset : public AcceptanceFixture {
 TEST_F(TransferAsset, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
-      .sendTxAwait(makeTransfer(), check(1));
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeTransfer(), CHECK_TXS(1));
 }
 
 /**
@@ -96,14 +94,14 @@ TEST_F(TransferAsset, Basic) {
 TEST_F(TransferAsset, WithoutCanTransfer) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser({}), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser({}), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(makeTransfer())
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -115,16 +113,16 @@ TEST_F(TransferAsset, WithoutCanTransfer) {
 TEST_F(TransferAsset, WithoutCanReceive) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
       // TODO(@l4l) 23/06/18: remove permission with IR-1367
       .sendTxAwait(makeSecondUser({interface::permissions::Role::kAddPeer}),
-                   check(1))
-      .sendTxAwait(addAssets(), check(1))
+                   CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(makeTransfer())
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -136,14 +134,14 @@ TEST_F(TransferAsset, NonexistentDest) {
   std::string nonexistent = "inexist@test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(complete(baseTx().transferAsset(
           kUserId, nonexistent, kAssetId, kDesc, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -155,15 +153,15 @@ TEST_F(TransferAsset, NonexistentAsset) {
   std::string nonexistent = "inexist#test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(complete(baseTx().transferAsset(
           kUserId, kUser2Id, nonexistent, kDesc, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -175,9 +173,9 @@ TEST_F(TransferAsset, NonexistentAsset) {
 TEST_F(TransferAsset, NegativeAmount) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(makeTransfer("-1.0"), CHECK_STATELESS_INVALID);
 }
 
@@ -190,9 +188,9 @@ TEST_F(TransferAsset, NegativeAmount) {
 TEST_F(TransferAsset, ZeroAmount) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(makeTransfer("0.0"), CHECK_STATELESS_INVALID);
 }
 
@@ -204,12 +202,12 @@ TEST_F(TransferAsset, ZeroAmount) {
 TEST_F(TransferAsset, EmptyDesc) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTxAwait(complete(baseTx().transferAsset(
                        kUserId, kUser2Id, kAssetId, "", kAmount)),
-                   check(1));
+                   CHECK_TXS(1));
 }
 
 /**
@@ -221,9 +219,9 @@ TEST_F(TransferAsset, EmptyDesc) {
 TEST_F(TransferAsset, LongDesc) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(
           complete(baseTx().transferAsset(
               kUserId, kUser2Id, kAssetId, std::string(100000, 'a'), kAmount)),
@@ -238,14 +236,14 @@ TEST_F(TransferAsset, LongDesc) {
 TEST_F(TransferAsset, MoreThanHas) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets("50.0"), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets("50.0"), CHECK_TXS(1))
       .sendTx(makeTransfer("100.0"))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -262,19 +260,19 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
       "19966.0";  // 2**255 - 2
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(addAssets(uint256_halfmax), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS(1))
       // Send first half of the maximum
-      .sendTxAwait(makeTransfer(uint256_halfmax), check(1))
+      .sendTxAwait(makeTransfer(uint256_halfmax), CHECK_TXS(1))
       // Restore self balance
-      .sendTxAwait(addAssets(uint256_halfmax), check(1))
+      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS(1))
       // Send second half of the maximum
       .sendTx(makeTransfer(uint256_halfmax))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(check(0));
+      .checkBlock(CHECK_TXS(0));
 }
 
 /**
@@ -287,8 +285,8 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
 TEST_F(TransferAsset, SourceIsDest) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(addAssets(), check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(addAssets(), CHECK_TXS(1))
       .sendTx(complete(baseTx().transferAsset(
                   kUserId, kUserId, kAssetId, kDesc, kAmount)),
               CHECK_STATELESS_INVALID);
@@ -321,10 +319,10 @@ TEST_F(TransferAsset, InterDomain) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(make_second_user, check(1))
-      .sendTxAwait(add_assets, check(1))
-      .sendTxAwait(make_transfer, check(1));
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(make_second_user, CHECK_TXS(1))
+      .sendTxAwait(add_assets, CHECK_TXS(1))
+      .sendTxAwait(make_transfer, CHECK_TXS(1));
 }
 
 /**
@@ -375,11 +373,11 @@ TEST_F(TransferAsset, BigPrecision) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), check(1))
-      .sendTxAwait(makeSecondUser(), check(1))
-      .sendTxAwait(create_asset, check(1))
-      .sendTxAwait(add_assets, check(1))
-      .sendTxAwait(make_transfer, check(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
+      .sendTxAwait(create_asset, CHECK_TXS(1))
+      .sendTxAwait(add_assets, CHECK_TXS(1))
+      .sendTxAwait(make_transfer, CHECK_TXS(1))
       .sendQuery(make_query(kUserId), check_balance(kUserId, kLeft))
       .sendQuery(make_query(kUser2Id), check_balance(kUser2Id, kForTransfer));
 }

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -79,10 +79,10 @@ class TransferAsset : public AcceptanceFixture {
 TEST_F(TransferAsset, Basic) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
-      .sendTxAwait(makeTransfer(), CHECK_TXS(1));
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeTransfer(), CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -94,14 +94,14 @@ TEST_F(TransferAsset, Basic) {
 TEST_F(TransferAsset, WithoutCanTransfer) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser({}), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser({}), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(makeTransfer())
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -113,16 +113,16 @@ TEST_F(TransferAsset, WithoutCanTransfer) {
 TEST_F(TransferAsset, WithoutCanReceive) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       // TODO(@l4l) 23/06/18: remove permission with IR-1367
       .sendTxAwait(makeSecondUser({interface::permissions::Role::kAddPeer}),
-                   CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+                   CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(makeTransfer())
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -134,14 +134,14 @@ TEST_F(TransferAsset, NonexistentDest) {
   std::string nonexistent = "inexist@test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().transferAsset(
           kUserId, nonexistent, kAssetId, kDesc, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -153,15 +153,15 @@ TEST_F(TransferAsset, NonexistentAsset) {
   std::string nonexistent = "inexist#test";
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().transferAsset(
           kUserId, kUser2Id, nonexistent, kDesc, kAmount)))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -173,9 +173,9 @@ TEST_F(TransferAsset, NonexistentAsset) {
 TEST_F(TransferAsset, NegativeAmount) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(makeTransfer("-1.0"), CHECK_STATELESS_INVALID);
 }
 
@@ -188,9 +188,9 @@ TEST_F(TransferAsset, NegativeAmount) {
 TEST_F(TransferAsset, ZeroAmount) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(makeTransfer("0.0"), CHECK_STATELESS_INVALID);
 }
 
@@ -202,12 +202,12 @@ TEST_F(TransferAsset, ZeroAmount) {
 TEST_F(TransferAsset, EmptyDesc) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(complete(baseTx().transferAsset(
                        kUserId, kUser2Id, kAssetId, "", kAmount)),
-                   CHECK_TXS(1));
+                   CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -219,9 +219,9 @@ TEST_F(TransferAsset, EmptyDesc) {
 TEST_F(TransferAsset, LongDesc) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(
           complete(baseTx().transferAsset(
               kUserId, kUser2Id, kAssetId, std::string(100000, 'a'), kAmount)),
@@ -236,14 +236,14 @@ TEST_F(TransferAsset, LongDesc) {
 TEST_F(TransferAsset, MoreThanHas) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets("50.0"), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets("50.0"), CHECK_TXS_QUANTITY(1))
       .sendTx(makeTransfer("100.0"))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -260,19 +260,19 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
       "19966.0";  // 2**255 - 2
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS_QUANTITY(1))
       // Send first half of the maximum
-      .sendTxAwait(makeTransfer(uint256_halfmax), CHECK_TXS(1))
+      .sendTxAwait(makeTransfer(uint256_halfmax), CHECK_TXS_QUANTITY(1))
       // Restore self balance
-      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS(1))
+      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS_QUANTITY(1))
       // Send second half of the maximum
       .sendTx(makeTransfer(uint256_halfmax))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })
-      .checkBlock(CHECK_TXS(0));
+      .checkBlock(CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -285,8 +285,8 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
 TEST_F(TransferAsset, SourceIsDest) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(addAssets(), CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
       .sendTx(complete(baseTx().transferAsset(
                   kUserId, kUserId, kAssetId, kDesc, kAmount)),
               CHECK_STATELESS_INVALID);
@@ -319,10 +319,10 @@ TEST_F(TransferAsset, InterDomain) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(make_second_user, CHECK_TXS(1))
-      .sendTxAwait(add_assets, CHECK_TXS(1))
-      .sendTxAwait(make_transfer, CHECK_TXS(1));
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(make_second_user, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(add_assets, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(make_transfer, CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -373,11 +373,11 @@ TEST_F(TransferAsset, BigPrecision) {
 
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS(1))
-      .sendTxAwait(create_asset, CHECK_TXS(1))
-      .sendTxAwait(add_assets, CHECK_TXS(1))
-      .sendTxAwait(make_transfer, CHECK_TXS(1))
+      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(create_asset, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(add_assets, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(make_transfer, CHECK_TXS_QUANTITY(1))
       .sendQuery(make_query(kUserId), check_balance(kUserId, kLeft))
       .sendQuery(make_query(kUser2Id), check_balance(kUser2Id, kForTransfer));
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The same macro for checking transactions quantity in response was defined in several places.
Now it is defined in acceptance fixture header.


### Benefits

Reduced code duplication.


### Possible Drawbacks 

Still a macro, but we have agreed to use it for the purpose.


### Usage Examples or Tests

```
add_signatory_test
create_account_test
get_account_test
remove_signatory_test
set_account_quorum_test
transfer_asset_test
```
