### PR TITLE
Fix Query & Tx signer in iroha-cli

### DIFF
--- a/iroha-cli/interactive/impl/interactive_status_cli.cpp
+++ b/iroha-cli/interactive/impl/interactive_status_cli.cpp
@@ -22,10 +22,18 @@ namespace iroha_cli {
              "Transaction has not passed stateful validation."},
             {iroha::protocol::TxStatus::STATEFUL_VALIDATION_SUCCESS,
              "Transaction has successfully passed stateful validation."},
+            {iroha::protocol::TxStatus::REJECTED,
+             "Transaction has been rejected."},
             {iroha::protocol::TxStatus::COMMITTED,
              "Transaction was successfully committed."},
+            {iroha::protocol::TxStatus::MST_EXPIRED,
+             "Transaction has not collected enough signatures in time."},
             {iroha::protocol::TxStatus::NOT_RECEIVED,
-             "Transaction was not found in the system."}};
+             "Transaction was not found in the system."},
+            {iroha::protocol::TxStatus::MST_PENDING,
+             "Transaction has not collected quorum of signatures."},
+            {iroha::protocol::TxStatus::ENOUGH_SIGNATURES_COLLECTED,
+             "Transaction has collected all signatures."}};
 
     InteractiveStatusCli::InteractiveStatusCli(
         const std::string &default_peer_ip, int default_port)
@@ -131,7 +139,7 @@ namespace iroha_cli {
       iroha::protocol::ToriiResponse answer;
       if (iroha::hexstringToBytestring(txHash_)) {
         answer = CliClient(address.value().first, address.value().second)
-                     .getTxStatus(*iroha::hexstringToBytestring(txHash_))
+                     .getTxStatus(txHash_)
                      .answer;
         status = answer.tx_status();
       }

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -154,8 +154,8 @@ namespace iroha {
         meta->set_query_counter(query->query_counter);
         // Set signatures
         auto sig = pb_query.mutable_signature();
-        sig->set_signature(query->signature.signature.to_string());
-        sig->set_public_key(query->signature.pubkey.to_string());
+        sig->set_signature(query->signature.signature.to_hexstring());
+        sig->set_public_key(query->signature.pubkey.to_hexstring());
       }
 
       boost::optional<protocol::Query> PbQueryFactory::serialize(

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -136,8 +136,8 @@ namespace iroha {
         const auto &pb_sign = pb_query.signature();
 
         Signature sign{};
-        sign.pubkey = pubkey_t::from_string(pb_sign.public_key());
-        sign.signature = sig_t::from_string(pb_sign.signature());
+        sign.pubkey = pubkey_t::from_hexstring(pb_sign.public_key());
+        sign.signature = sig_t::from_hexstring(pb_sign.signature());
 
         val->query_counter = pl.meta().query_counter();
         val->signature = sign;

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -106,7 +106,7 @@ namespace iroha {
                              pb_cast.tx_hashes().end(),
                              std::back_inserter(query.tx_hashes),
                              [](auto tx_hash) {
-                               return iroha::hash256_t::from_string(tx_hash);
+                               return iroha::hash256_t::from_hexstring(tx_hash);
                              });
               val = std::make_shared<GetTransactions>(query);
               break;
@@ -240,7 +240,7 @@ namespace iroha {
                       tmp->tx_hashes.end(),
                       [&pb_query_mut](auto tx_hash) {
                         auto adder = pb_query_mut->add_tx_hashes();
-                        *adder = tx_hash.to_string();
+                        *adder = tx_hash.to_hexstring();
                       });
         return pb_query;
       }

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -29,8 +29,8 @@ namespace iroha {
 
         for (const auto &sig_obj : tx.signatures) {
           auto proto_signature = pbtx.add_signatures();
-          proto_signature->set_public_key(sig_obj.pubkey.to_string());
-          proto_signature->set_signature(sig_obj.signature.to_string());
+          proto_signature->set_public_key(sig_obj.pubkey.to_hexstring());
+          proto_signature->set_signature(sig_obj.signature.to_hexstring());
         }
         return pbtx;
       }

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -47,8 +47,8 @@ namespace iroha {
 
         for (const auto &pb_sig : pb_tx.signatures()) {
           model::Signature sig{};
-          sig.pubkey = pubkey_t::from_string(pb_sig.public_key());
-          sig.signature = sig_t::from_string(pb_sig.signature());
+          sig.pubkey = pubkey_t::from_hexstring(pb_sig.public_key());
+          sig.signature = sig_t::from_hexstring(pb_sig.signature());
           tx.signatures.push_back(sig);
         }
 

--- a/libs/common/blob.hpp
+++ b/libs/common/blob.hpp
@@ -12,6 +12,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "common/hexutils.hpp"
+
 namespace iroha {
   using BadFormatException = std::invalid_argument;
   using byte_t = uint8_t;
@@ -94,6 +96,17 @@ namespace iroha {
       std::copy(data.begin(), data.end(), b.begin());
 
       return b;
+    }
+
+    static blob_t<size_> from_hexstring(const std::string &hex) {
+      auto bytes = iroha::hexstringToBytestring(hex);
+      if (not bytes) {
+        throw BadFormatException(
+            "Provided data (" + hex
+            + ") is not a valid hex value for blob of size ("
+            + std::to_string(size_) + ").");
+      }
+      return from_string(*bytes);
     }
   };
 }  // namespace iroha

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -7,8 +7,6 @@
 #define IROHA_BYTEUTILS_H
 
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -16,6 +14,7 @@
 
 #include "common/bind.hpp"
 #include "common/blob.hpp"
+#include "common/hexutils.hpp"
 
 namespace iroha {
   /**
@@ -50,46 +49,6 @@ namespace iroha {
     blob_t<size> array;
     std::copy(string.begin(), string.end(), array.begin());
     return array;
-  }
-
-  /**
-   * Convert string of raw bytes to printable hex string
-   * @param str - raw bytes string to convert
-   * @return - converted hex string
-   */
-  inline std::string bytestringToHexstring(const std::string &str) {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (const auto &c : str) {
-      ss << std::setw(2) << (static_cast<int>(c) & 0xff);
-    }
-    return ss.str();
-  }
-
-  /**
-   * Convert printable hex string to string of raw bytes
-   * @param str - hex string to convert
-   * @return - raw bytes converted string or boost::noneif provided string
-   * was not a correct hex string
-   */
-  inline boost::optional<std::string> hexstringToBytestring(
-      const std::string &str) {
-    if (str.empty() or str.size() % 2 != 0) {
-      return boost::none;
-    }
-    std::string result(str.size() / 2, 0);
-    for (size_t i = 0; i < result.length(); ++i) {
-      std::string byte = str.substr(i * 2, 2);
-      try {
-        result.at(i) =
-            static_cast<std::string::value_type>(std::stoul(byte, nullptr, 16));
-      } catch (const std::invalid_argument &) {
-        return boost::none;
-      } catch (const std::out_of_range &) {
-        return boost::none;
-      }
-    }
-    return result;
   }
 
   /**

--- a/libs/common/hexutils.hpp
+++ b/libs/common/hexutils.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef IROHA_HEXUTILS_HPP
+#define IROHA_HEXUTILS_HPP
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace iroha {
+
+  /**
+   * Convert string of raw bytes to printable hex string
+   * @param str - raw bytes string to convert
+   * @return - converted hex string
+   */
+  inline std::string bytestringToHexstring(const std::string &str) {
+    std::stringstream ss;
+    ss << std::hex << std::setfill('0');
+    for (const auto &c : str) {
+      ss << std::setw(2) << (static_cast<int>(c) & 0xff);
+    }
+    return ss.str();
+  }
+
+  /**
+   * Convert printable hex string to string of raw bytes
+   * @param str - hex string to convert
+   * @return - raw bytes converted string or boost::noneif provided string
+   * was not a correct hex string
+   */
+  inline boost::optional<std::string> hexstringToBytestring(
+      const std::string &str) {
+    if (str.empty() or str.size() % 2 != 0) {
+      return boost::none;
+    }
+    std::string result(str.size() / 2, 0);
+    for (size_t i = 0; i < result.length(); ++i) {
+      std::string byte = str.substr(i * 2, 2);
+      try {
+        result.at(i) =
+            static_cast<std::string::value_type>(std::stoul(byte, nullptr, 16));
+      } catch (const std::invalid_argument &) {
+        return boost::none;
+      } catch (const std::out_of_range &) {
+        return boost::none;
+      }
+    }
+    return result;
+  }
+
+}  // namespace iroha
+
+#endif  // IROHA_HEXUTILS_HPP


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Now iroha-cli can send transactions and queries with valid signatures.

### Benefits

Working iroha-cli.

### Possible Drawbacks 

To be discovered.

### Usage Examples or Tests

1. run irohad
2. run iroha-cli
3. send some transaction to iroha (e.g. create asset tx)
