### PR TITLE
Fix hexstringToBytestring method

### DIFF
--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -80,12 +80,16 @@ namespace iroha {
     std::string result(str.size() / 2, 0);
     for (size_t i = 0; i < result.length(); ++i) {
       std::string byte = str.substr(i * 2, 2);
+      size_t pos = 0;  // processed characters count
       try {
         result.at(i) =
-            static_cast<std::string::value_type>(std::stoul(byte, nullptr, 16));
+            static_cast<std::string::value_type>(std::stoul(byte, &pos, 16));
       } catch (const std::invalid_argument &) {
         return boost::none;
       } catch (const std::out_of_range &) {
+        return boost::none;
+      }
+      if (pos != byte.size()) {
         return boost::none;
       }
     }

--- a/test/module/libs/converter/string_converter_test.cpp
+++ b/test/module/libs/converter/string_converter_test.cpp
@@ -21,6 +21,16 @@ TEST(StringConverterTest, ConvertHexToBinary) {
 }
 
 /**
+ * @given invalid hex string
+ * @when string is converted to binary string
+ * @then boost::none is returned
+ */
+TEST(StringConverterTest, InvalidHexToBinary) {
+  std::string invalid_hex = "au";
+  ASSERT_FALSE(hexstringToBytestring(invalid_hex));
+}
+
+/**
  * @given binary string
  * @when binary string was converted to hex string
  * @then converted string match the result we are expected


### PR DESCRIPTION
### Description of the Change
Fix hexstringToBytestring method ignoring the failure to parse the whole byte.
Parsing "au" would result in failure instead of value "10".

### Benefits
More correct behavior of the method

### Possible Drawbacks 
None

### Usage Examples or Tests
StringConverterTest.InvalidHexToBinary

