### PR TITLE
Make genesis block error message more user friendly

### DIFF
--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -215,10 +215,12 @@ int main(int argc, char *argv[]) {
       [](const auto &) { return true; },
       [](iroha::expected::Error<std::string> &) { return false; });
 
-  if (not blocks_exist) {  // may happen only in case of bug or zero disk space
+  if (not blocks_exist) {
     log->error(
-        "You should have never seen this message. There are no blocks in the "
-        "ledger.  Unable to start. Try to specify --genesis_block and "
+        "Unable to start the ledger. There are no blocks in the ledger. Please "
+        "ensure that you are not trying to start the newer version of "
+        "the ledger over incompatible version of the storage or there is "
+        "enough disk space. Try to specify --genesis_block and "
         "--overwrite_ledger parameters at the same time.");
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Make genesis block error message more user friendly. 
Users were seeing "impossible" message in case of incompatibility of blockstore and ledger versions.

### Benefits

No more scary messages.

### Possible Drawbacks 

None ?
