### PR TITLE
Fix fuzzing build

### DIFF
--- a/test/fuzzing/retrieve_blocks_fuzz.cpp
+++ b/test/fuzzing/retrieve_blocks_fuzz.cpp
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "block_loader_fixture.hpp"
+#include "fuzzing/block_loader_fixture.hpp"
+
 #include "module/vendor/grpc_mocks.hpp"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
@@ -16,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
   iroha::network::proto::BlocksRequest request;
   if (protobuf_mutator::libfuzzer::LoadProtoInput(true, data, size, &request)) {
     grpc::ServerContext context;
-    testing::MockServerWriter serverWriter;
+    iroha::MockServerWriter<iroha::protocol::Block> serverWriter;
     fixture.block_loader_service_->retrieveBlocks(
         &context,
         &request,

--- a/test/fuzzing/status_fuzz.cpp
+++ b/test/fuzzing/status_fuzz.cpp
@@ -5,15 +5,16 @@
 
 #include "torii/impl/command_service_transport_grpc.hpp"
 
-#include <gtest/gtest.h>
 #include <memory>
+
+#include <gtest/gtest.h>
+#include <libfuzzer/libfuzzer_macro.h>
 #include "ametsuchi/tx_cache_response.hpp"
 #include "backend/protobuf/proto_transport_factory.hpp"
 #include "backend/protobuf/proto_tx_status_factory.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
-#include "libfuzzer/libfuzzer_macro.h"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
@@ -24,7 +25,6 @@
 #include "validators/default_validator.hpp"
 #include "validators/protobuf/proto_transaction_validator.hpp"
 
-using namespace std::chrono_literals;
 using testing::_;
 using testing::Return;
 
@@ -36,6 +36,7 @@ struct CommandFixture {
   std::shared_ptr<iroha::network::MockPeerCommunicationService> pcs_;
   std::shared_ptr<iroha::MockMstProcessor> mst_processor_;
   std::shared_ptr<iroha::ametsuchi::MockBlockQuery> bq_;
+  std::shared_ptr<iroha::network::MockConsensusGate> consensus_gate_;
 
   rxcpp::subjects::subject<iroha::network::OrderingEvent> prop_notifier_;
   rxcpp::subjects::subject<iroha::simulator::VerifiedProposalCreatorEvent>
@@ -45,6 +46,7 @@ struct CommandFixture {
   rxcpp::subjects::subject<iroha::DataType> mst_notifier_;
   rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
       mst_state_notifier_;
+  rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_notifier_;
 
   CommandFixture() {
     spdlog::set_level(spdlog::level::err);
@@ -96,6 +98,10 @@ struct CommandFixture {
         transaction_batch_factory = std::make_shared<
             shared_model::interface::TransactionBatchFactoryImpl>();
 
+    consensus_gate_ = std::make_shared<iroha::network::MockConsensusGate>();
+    ON_CALL(*consensus_gate_, onOutcome())
+        .WillByDefault(Return(consensus_notifier_.get_observable()));
+
     storage_ = std::make_shared<iroha::ametsuchi::MockStorage>();
     bq_ = std::make_shared<iroha::ametsuchi::MockBlockQuery>();
     EXPECT_CALL(*storage_, getBlockQuery()).WillRepeatedly(Return(bq_));
@@ -104,12 +110,12 @@ struct CommandFixture {
     service_transport_ = std::make_shared<torii::CommandServiceTransportGrpc>(
         service_,
         status_bus,
-        15s,
-        15s,
         status_factory,
         transaction_factory,
         batch_parser,
-        transaction_batch_factory);
+        transaction_batch_factory,
+        consensus_gate_,
+        2);
   }
 };
 


### PR DESCRIPTION
### Description of the Change
Fix fuzzing build
- `MockServerWriter` usages were refactored according to changes in https://github.com/hyperledger/iroha/pull/1853
- `CommandServiceTransportGrpc` constructor calls were refactored according to changes in https://github.com/hyperledger/iroha/pull/1980

### Benefits
Fuzzing builds and works

### Possible Drawbacks 
None

### Alternate Designs 
Build fuzzing in CI
