### PR TITLE
New logger implementation part 1: main classes

### DIFF
--- a/libs/logger/CMakeLists.txt
+++ b/libs/logger/CMakeLists.txt
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(logger STATIC logger.cpp)
+add_library(logger logger.cpp)
 target_link_libraries(logger
     spdlog
 )
 
-add_library(logger_manager STATIC logger_manager.cpp)
+add_library(logger_manager logger_manager.cpp)
 target_link_libraries(logger_manager
     logger
 )

--- a/libs/logger/CMakeLists.txt
+++ b/libs/logger/CMakeLists.txt
@@ -7,3 +7,8 @@ add_library(logger STATIC logger.cpp)
 target_link_libraries(logger
     spdlog
 )
+
+add_library(logger_manager STATIC logger_manager.cpp)
+target_link_libraries(logger_manager
+    logger
+)

--- a/libs/logger/CMakeLists.txt
+++ b/libs/logger/CMakeLists.txt
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(logger logger.cpp)
+add_library(logger
+  logger.cpp
+  logger_spdlog.cpp)
 target_link_libraries(logger
     spdlog
 )

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -11,7 +11,6 @@
 #include <spdlog/spdlog.h>
 
 static const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F][%L] %n: %v)";
-static const std::string kTagHierarchySeparator = "/";
 
 namespace logger {
 
@@ -37,81 +36,17 @@ namespace logger {
     return kDefaultPattern;
   }
 
-  LoggerConfigTreeNode::LoggerConfigTreeNode(std::string tag,
-                                             LoggerConfig config)
-      : tag_(std::move(tag)), config_(std::move(config)){};
-
-  LoggerConfigTreeNodePtr LoggerConfigTreeNode::addChild(
-      std::string tag,
-      boost::optional<LogLevel> log_level,
-      boost::optional<LogPatterns> patterns) {
-    LoggerConfig child_config{
-        log_level.value_or(config_.log_level),
-        patterns ? LogPatterns{std::move(*patterns)} : config_.patterns};
-    auto child =
-        std::make_shared<LoggerConfigTreeNode>(tag, std::move(child_config));
-    auto map_elem = std::make_pair<const std::string, LoggerConfigTreeNodePtr>(
-        std::move(tag), std::move(child));
-    return children_.emplace(std::move(map_elem)).first->second;
-  }
-
-  const std::string &LoggerConfigTreeNode::getTag() const {
-    return tag_;
-  }
-
-  const LoggerConfig &LoggerConfigTreeNode::getConfig() const {
-    return config_;
-  }
-
-  boost::optional<LoggerConfigTreeNodePtr> LoggerConfigTreeNode::getChild(
-      const std::string &tag) {
-    const auto it = children_.find(tag);
-    if (it == children_.end()) {
-      return boost::none;
-    }
-    return it->second;
-  }
-
-  boost::optional<ConstLoggerConfigTreeNodePtr> LoggerConfigTreeNode::getChild(
-      const std::string &tag) const {
-    const auto it = children_.find(tag);
-    if (it == children_.end()) {
-      return boost::none;
-    }
-    return std::static_pointer_cast<const LoggerConfigTreeNode>(it->second);
-  }
-
   class Logger::Impl {
    public:
     virtual ~Impl() = default;
 
-    /// Constructor.
-    ///
-    /// @param tag - the tag of constructed logger
-    /// @param tree - the logger tree configuration
-    /// @param spdlog_logger - the spdlog logger to use
-    Impl(std::string tag, ConstLoggerConfigTreeNodePtr tree)
+    /// @param tag - the tag for logging (aka logger name)
+    /// @param config - logger configuration
+    Impl(std::string tag, ConstLoggerConfigPtr config)
         : tag_(std::move(tag)),
-          tree_(std::move(tree)),
+          config_(std::move(config)),
           logger_(spdlog::stdout_color_mt(tag)) {
       setupLogger();
-    }
-
-    LoggerPtr getChild(std::string tag) {
-      std::lock_guard<std::mutex> lock(children_mutex_);
-      const auto child_it = children_.find(tag);
-      if (child_it != children_.end()) {
-        return child_it->second;
-      }
-      // if a node for this child is not found in the tree config, create a
-      // new standalone logger using this logger's settings
-      auto child_config = tree_->getChild(tag).value_or(
-          std::make_shared<LoggerConfigTreeNode>(tag, tree_->getConfig()));
-      Logger new_child(tag_ + kTagHierarchySeparator + tag,
-                       std::move(child_config));
-      return children_
-          .emplace(std::make_pair(tag, std::make_shared<Logger>(new_child)))
-          .first->second;
     }
 
    private:
@@ -123,37 +58,23 @@ namespace logger {
                            {LogLevel::kWarn, spdlog::level::warn},
                            {LogLevel::kError, spdlog::level::err},
                            {LogLevel::kCritical, spdlog::level::critical}};
-      const auto it = kSpdLogLevels.find(tree_->getConfig().log_level);
+      const auto it = kSpdLogLevels.find(config_->log_level);
       BOOST_ASSERT_MSG(it != kSpdLogLevels.end(), "Unknown log level!");
       logger_->set_level(it == kSpdLogLevels.end()
                              ? kSpdLogLevels.at(kDefaultLogLevel)
                              : it->second);
-      logger_->set_pattern(
-          kDefaultLogPatterns.getPattern(tree_->getConfig().log_level));
+      logger_->set_pattern(kDefaultLogPatterns.getPattern(config_->log_level));
     }
 
     // --- Fields accessible by logger::Logger ---
    public:
     const std::string tag_;
-    const ConstLoggerConfigTreeNodePtr tree_;
+    const ConstLoggerConfigPtr config_;
     const std::shared_ptr<spdlog::logger> logger_;
-
-    // --- Internal use fields ---
-   private:
-    std::unordered_map<std::string, LoggerPtr> children_;
-    std::mutex children_mutex_;
   };
 
-  Logger::Logger(ConstLoggerConfigTreeNodePtr tree_config)
-      : impl_(std::make_shared<Impl>(tree_config->getTag(), tree_config)) {}
-
-  Logger::Logger(std::string tag, LoggerConfig config)
-      : impl_(std::make_shared<Impl>(
-            tag,
-            std::make_shared<LoggerConfigTreeNode>(tag, std::move(config)))) {}
-
-  Logger::Logger(std::string tag, ConstLoggerConfigTreeNodePtr tree_config)
-      : impl_(std::make_shared<Impl>(std::move(tag), std::move(tree_config))) {}
+  Logger::Logger(std::string tag, ConstLoggerConfigPtr config)
+      : impl_(std::make_shared<Impl>(tag, std::move(config))) {}
 
   Logger::Logger(const Logger &other) : impl_(other.impl_) {}
 
@@ -197,11 +118,7 @@ namespace logger {
   }
 
   bool Logger::shouldLog(Level level) const {
-    return impl_->tree_->getConfig().log_level <= level;
-  }
-
-  LoggerPtr Logger::getChild(std::string tag) {
-    return impl_->getChild(tag);
+    return impl_->config_->log_level <= level;
   }
 
   std::string boolRepr(bool value) {

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -206,12 +206,14 @@ namespace logger {
 
   Logger::Logger(Logger &&other) : impl_(std::move(other.impl_)) {}
 
-  Logger &operator=(const Logger &other) {
+  Logger &Logger::operator=(const Logger &other) {
     impl_ = other.impl_;
+    return *this;
   }
 
-  Logger &operator=(Logger &&other) {
+  Logger &Logger::operator=(Logger &&other) {
     impl_ = std::move(other.impl_);
+    return *this;
   }
 
   Logger::~Logger() = default;

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -10,7 +10,7 @@
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
-static const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F] %n %v)";
+static const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F][%L] %n: %v)";
 static const std::string kTagHierarchySeparator = "/";
 
 namespace logger {
@@ -19,7 +19,7 @@ namespace logger {
   const LogPatterns kDefaultLogPatterns = ([] {
     LogPatterns p;
     p.setPattern(LogLevel::kTrace,
-                 R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%l] %n %v)");
+                 R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%L] %n: %v)");
     p.setPattern(LogLevel::kInfo, kDefaultPattern);
     return p;
   })();

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -5,40 +5,248 @@
 
 #include "logger/logger.hpp"
 
+#include <mutex>
+
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
+
+static const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F] %n %v)";
+static const std::string kTagHierarchySeparator = "/";
+
 namespace logger {
-  const std::string end = "\033[0m";
 
-  static void setGlobalPattern(spdlog::logger &logger) {
-    logger.set_pattern("[%Y-%m-%d %H:%M:%S.%F] %n %v");
+  const LogLevel kDefaultLogLevel = LogLevel::kInfo;
+  const LogPatterns kDefaultLogPatterns = ([] {
+    LogPatterns p;
+    p.setPattern(LogLevel::kTrace,
+                 R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%l] %n %v)");
+    p.setPattern(LogLevel::kInfo, kDefaultPattern);
+    return p;
+  })();
+
+  void LogPatterns::setPattern(LogLevel level, std::string pattern) {
+    patterns_[level] = pattern;
   }
 
-  static void setDebugPattern(spdlog::logger &logger) {
-    logger.set_pattern("[%Y-%m-%d %H:%M:%S.%F][th:%t][%l] %n %v");
-  }
-
-  static std::shared_ptr<spdlog::logger> createLogger(const std::string &tag,
-                                                      bool debug_mode = true) {
-    auto logger = spdlog::stdout_color_mt(tag);
-    if (debug_mode) {
-      setDebugPattern(*logger);
-    } else {
-      setGlobalPattern(*logger);
+  std::string LogPatterns::getPattern(LogLevel level) const {
+    for (auto it = patterns_.rbegin(); it != patterns_.rend(); ++it) {
+      if (it->first <= level) {
+        return it->second;
+      }
     }
-    return logger;
+    return kDefaultPattern;
   }
 
-  Logger log(const std::string &tag) {
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> lock(mutex);
-    auto logger = spdlog::get(tag);
-    if (logger == nullptr) {
-      logger = createLogger(tag);
+  LoggerConfigTreeNode::LoggerConfigTreeNode(std::string tag,
+                                             LoggerConfig config)
+      : tag_(std::move(tag)), config_(std::move(config)){};
+
+  void LoggerConfigTreeNode::addChild(std::string tag,
+                                      boost::optional<LogLevel> log_level,
+                                      boost::optional<LogPatterns> patterns) {
+    children_[tag] = std::make_shared<LoggerConfigTreeNode>(
+        tag,
+        LoggerConfig{
+            log_level.value_or(config_.log_level),
+            patterns ? LogPatterns{std::move(*patterns)} : config_.patterns});
+  }
+
+  const std::string &LoggerConfigTreeNode::getTag() const {
+    return tag_;
+  }
+
+  const LoggerConfig &LoggerConfigTreeNode::getConfig() const {
+    return config_;
+  }
+
+  boost::optional<std::shared_ptr<LoggerConfigTreeNode>>
+  LoggerConfigTreeNode::getChild(const std::string &tag) const {
+    const auto it = children_.find(tag);
+    if (it == children_.end()) {
+      return boost::none;
     }
-    return logger;
+    return it->second;
   }
 
-  Logger testLog(const std::string &tag) {
-    return log(tag);
+  class Logger::Impl {
+   public:
+    virtual ~Impl() = default;
+
+    /// Constructor.
+    ///
+    /// @param tag - the tag of constructed logger
+    /// @param tree - the logger tree configuration
+    /// @param spdlog_logger - the spdlog logger to use
+    Impl(std::string tag,
+         std::shared_ptr<const LoggerConfigTreeNode> tree,
+         std::shared_ptr<spdlog::logger> spdlog_logger)
+        : tag_(std::move(tag)),
+          tree_(std::move(tree)),
+          logger_(std::move(spdlog_logger)) {
+      setupLogger();
+    }
+
+    virtual LoggerPtr getChild(std::string tag, LoggerThreadSafety ts) = 0;
+
+   protected:
+    LoggerPtr getChildSingleTread(std::string tag, LoggerThreadSafety ts) {
+      std::string child_full_tag = tag_ + kTagHierarchySeparator + tag;
+      auto &children_by_tag = children_[tag];
+      const auto child_it = children_by_tag.find(ts);
+      if (child_it != children_by_tag.end()) {
+        return child_it->second;
+      }
+      // if a node for this child is not found in the tree config, create a
+      // new standalone logger using this logger's settings
+      auto child_config = tree_->getChild(tag).value_or(
+          std::make_shared<LoggerConfigTreeNode>(tag, tree_->getConfig()));
+      Logger new_child(
+          tag_ + kTagHierarchySeparator + tag, std::move(child_config), ts);
+      return children_by_tag
+          .emplace(std::make_pair(ts, std::make_shared<Logger>(new_child)))
+          .first->second;
+    }
+
+   private:
+    void setupLogger() {
+      static const std::map<LogLevel, const spdlog::level::level_enum>
+          kSpdLogLevels = {{LogLevel::kTrace, spdlog::level::trace},
+                           {LogLevel::kDebug, spdlog::level::debug},
+                           {LogLevel::kInfo, spdlog::level::info},
+                           {LogLevel::kWarn, spdlog::level::warn},
+                           {LogLevel::kError, spdlog::level::err},
+                           {LogLevel::kCritical, spdlog::level::critical}};
+      const auto it = kSpdLogLevels.find(tree_->getConfig().log_level);
+      BOOST_ASSERT_MSG(it != kSpdLogLevels.end(), "Unknown log level!");
+      logger_->set_level(it == kSpdLogLevels.end()
+                             ? kSpdLogLevels.at(kDefaultLogLevel)
+                             : it->second);
+      logger_->set_pattern(
+          kDefaultLogPatterns.getPattern(tree_->getConfig().log_level));
+    }
+
+    // --- Fields accessible by logger::Logger ---
+   public:
+    const std::string tag_;
+    const std::shared_ptr<const LoggerConfigTreeNode> tree_;
+    const std::shared_ptr<spdlog::logger> logger_;
+
+    // --- Internal use fields ---
+   private:
+    std::unordered_map<std::string, std::map<LoggerThreadSafety, LoggerPtr>>
+        children_;
+  };
+
+  class LoggerImplSingleThread : public Logger::Impl {
+   public:
+    template <typename... Types>
+    LoggerImplSingleThread(std::string tag, Types &&... args)
+        : Logger::Impl(
+              tag, std::forward<Types>(args)..., spdlog::stdout_color_st(tag)) {
+    }
+
+    virtual ~LoggerImplSingleThread() = default;
+
+    LoggerPtr getChild(std::string tag, LoggerThreadSafety ts) {
+      return getChildSingleTread(tag, ts);
+    }
+  };
+
+  class LoggerImplMultiThread : public Logger::Impl {
+   public:
+    template <typename... Types>
+    LoggerImplMultiThread(std::string tag, Types &&... args)
+        : Logger::Impl(
+              tag, std::forward<Types>(args)..., spdlog::stdout_color_mt(tag)) {
+    }
+
+    virtual ~LoggerImplMultiThread() = default;
+
+    LoggerPtr getChild(std::string tag, LoggerThreadSafety ts) {
+      std::lock_guard<std::mutex> lock(children_mutex);
+      return getChildSingleTread(tag, ts);
+    }
+
+   private:
+    std::mutex children_mutex;
+  };
+
+  static std::unique_ptr<Logger::Impl> makeLoggerImpl(
+      std::string tag,
+      std::shared_ptr<const LoggerConfigTreeNode> tree_config,
+      LoggerThreadSafety ts) {
+    switch (ts) {
+      case LoggerThreadSafety::kSingleThread:
+        return std::make_unique<LoggerImplSingleThread>(std::move(tag),
+                                                        std::move(tree_config));
+      case LoggerThreadSafety::kMultiThread:
+        return std::make_unique<LoggerImplMultiThread>(std::move(tag),
+                                                       std::move(tree_config));
+      default:
+        BOOST_THROW_EXCEPTION(std::runtime_error("Unknown logger type!"));
+    }
+  }
+
+  Logger::Logger(std::shared_ptr<const LoggerConfigTreeNode> tree_config,
+                 LoggerThreadSafety ts)
+      : impl_(makeLoggerImpl(tree_config->getTag(), tree_config, ts)) {}
+
+  Logger::Logger(std::string tag, LoggerConfig config, LoggerThreadSafety ts)
+      : impl_(makeLoggerImpl(
+            tag,
+            std::make_shared<LoggerConfigTreeNode>(tag, std::move(config)),
+            ts)) {}
+
+  Logger::Logger(std::string tag,
+                 std::shared_ptr<const LoggerConfigTreeNode> tree_config,
+                 LoggerThreadSafety ts)
+      : impl_(makeLoggerImpl(std::move(tag), std::move(tree_config), ts)) {}
+
+  Logger::Logger(const Logger &other) : impl_(other.impl_) {}
+
+  Logger::Logger(Logger &&other) : impl_(std::move(other.impl_)) {}
+
+  Logger &operator=(const Logger &other) {
+    impl_ = other.impl_;
+  }
+
+  Logger &operator=(Logger &&other) {
+    impl_ = std::move(other.impl_);
+  }
+
+  Logger::~Logger() = default;
+
+  void Logger::logInternal(Level level, const std::string &s) const {
+    switch (level) {
+      case LogLevel::kTrace:
+        impl_->logger_->trace(s);
+        break;
+      case LogLevel::kDebug:
+        impl_->logger_->debug(s);
+        break;
+      case LogLevel::kInfo:
+        impl_->logger_->info(s);
+        break;
+      case LogLevel::kWarn:
+        impl_->logger_->warn(s);
+        break;
+      case LogLevel::kError:
+        impl_->logger_->error(s);
+        break;
+      case LogLevel::kCritical:
+        impl_->logger_->critical(s);
+        break;
+      default:
+        BOOST_THROW_EXCEPTION(std::runtime_error("Unknown log level!"));
+    }
+  }
+
+  bool Logger::shouldLog(Level level) const {
+    return impl_->tree_->getConfig().log_level <= level;
+  }
+
+  LoggerPtr Logger::getChild(std::string tag, LoggerThreadSafety ts) {
+    return impl_->getChild(tag, ts);
   }
 
   std::string boolRepr(bool value) {

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -5,124 +5,12 @@
 
 #include "logger/logger.hpp"
 
-#include <mutex>
-
-#include <spdlog/fmt/ostr.h>
-#include <spdlog/spdlog.h>
-
-static const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F][%L] %n: %v)";
-
 namespace logger {
 
   const LogLevel kDefaultLogLevel = LogLevel::kInfo;
-  const LogPatterns kDefaultLogPatterns = ([] {
-    LogPatterns p;
-    p.setPattern(LogLevel::kTrace,
-                 R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%L] %n: %v)");
-    p.setPattern(LogLevel::kInfo, kDefaultPattern);
-    return p;
-  })();
-
-  void LogPatterns::setPattern(LogLevel level, std::string pattern) {
-    patterns_[level] = pattern;
-  }
-
-  std::string LogPatterns::getPattern(LogLevel level) const {
-    for (auto it = patterns_.rbegin(); it != patterns_.rend(); ++it) {
-      if (it->first <= level) {
-        return it->second;
-      }
-    }
-    return kDefaultPattern;
-  }
-
-  class Logger::Impl {
-   public:
-    virtual ~Impl() = default;
-
-    /// @param tag - the tag for logging (aka logger name)
-    /// @param config - logger configuration
-    Impl(std::string tag, ConstLoggerConfigPtr config)
-        : tag_(std::move(tag)),
-          config_(std::move(config)),
-          logger_(spdlog::stdout_color_mt(tag)) {
-      setupLogger();
-    }
-
-   private:
-    void setupLogger() {
-      static const std::map<LogLevel, const spdlog::level::level_enum>
-          kSpdLogLevels = {{LogLevel::kTrace, spdlog::level::trace},
-                           {LogLevel::kDebug, spdlog::level::debug},
-                           {LogLevel::kInfo, spdlog::level::info},
-                           {LogLevel::kWarn, spdlog::level::warn},
-                           {LogLevel::kError, spdlog::level::err},
-                           {LogLevel::kCritical, spdlog::level::critical}};
-      const auto it = kSpdLogLevels.find(config_->log_level);
-      BOOST_ASSERT_MSG(it != kSpdLogLevels.end(), "Unknown log level!");
-      logger_->set_level(it == kSpdLogLevels.end()
-                             ? kSpdLogLevels.at(kDefaultLogLevel)
-                             : it->second);
-      logger_->set_pattern(kDefaultLogPatterns.getPattern(config_->log_level));
-    }
-
-    // --- Fields accessible by logger::Logger ---
-   public:
-    const std::string tag_;
-    const ConstLoggerConfigPtr config_;
-    const std::shared_ptr<spdlog::logger> logger_;
-  };
-
-  Logger::Logger(std::string tag, ConstLoggerConfigPtr config)
-      : impl_(std::make_shared<Impl>(tag, std::move(config))) {}
-
-  Logger::Logger(const Logger &other) : impl_(other.impl_) {}
-
-  Logger::Logger(Logger &&other) : impl_(std::move(other.impl_)) {}
-
-  Logger &Logger::operator=(const Logger &other) {
-    impl_ = other.impl_;
-    return *this;
-  }
-
-  Logger &Logger::operator=(Logger &&other) {
-    impl_ = std::move(other.impl_);
-    return *this;
-  }
-
-  Logger::~Logger() = default;
-
-  void Logger::logInternal(Level level, const std::string &s) const {
-    switch (level) {
-      case LogLevel::kTrace:
-        impl_->logger_->trace(s);
-        break;
-      case LogLevel::kDebug:
-        impl_->logger_->debug(s);
-        break;
-      case LogLevel::kInfo:
-        impl_->logger_->info(s);
-        break;
-      case LogLevel::kWarn:
-        impl_->logger_->warn(s);
-        break;
-      case LogLevel::kError:
-        impl_->logger_->error(s);
-        break;
-      case LogLevel::kCritical:
-        impl_->logger_->critical(s);
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::runtime_error("Unknown log level!"));
-    }
-  }
-
-  bool Logger::shouldLog(Level level) const {
-    return impl_->config_->log_level <= level;
-  }
 
   std::string boolRepr(bool value) {
     return value ? "true" : "false";
   }
 
-}  // namespace logger
+}

--- a/libs/logger/logger.cpp
+++ b/libs/logger/logger.cpp
@@ -8,24 +8,6 @@
 namespace logger {
   const std::string end = "\033[0m";
 
-  std::string red(const std::string &string) {
-    const std::string red_start = "\033[31m";
-    return red_start + string + end;
-  }
-
-  std::string yellow(const std::string &string) {
-    const std::string yellow_start = "\033[33m";
-    return yellow_start + string + end;
-  }
-
-  std::string output(const std::string &string) {
-    return yellow("---> " + string);
-  }
-
-  std::string input(const std::string &string) {
-    return red("<--- " + string);
-  }
-
   static void setGlobalPattern(spdlog::logger &logger) {
     logger.set_pattern("[%Y-%m-%d %H:%M:%S.%F] %n %v");
   }

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -207,7 +207,7 @@ namespace logger {
      bool shouldLog(Level level) const;
 
      friend class Logger::Impl;
-     const std::shared_ptr<Impl> impl_;
+     std::shared_ptr<Impl> impl_;
   };
 
   /**

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -3,15 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef IROHA_SPDLOG_LOGGER_LOGGER_HPP
-#define IROHA_SPDLOG_LOGGER_LOGGER_HPP
+#ifndef IROHA_LOGGER_LOGGER_HPP
+#define IROHA_LOGGER_LOGGER_HPP
 
-#include <map>
 #include <memory>
 #include <numeric>  // for std::accumulate
 #include <string>
-
-#include <boost/optional.hpp>
 
 /// Allows to log objects, which have toString() method without calling it, e.g.
 /// log.info("{}", myObject)
@@ -87,7 +84,7 @@ namespace logger {
        }
      }
 
-    private:
+    protected:
      virtual void logInternal(Level level, const std::string &s) const = 0;
 
      /// Whether the configured logging level is at least as verbose as the
@@ -158,4 +155,4 @@ namespace logger {
 
 }  // namespace logger
 
-#endif
+#endif  // IROHA_LOGGER_LOGGER_HPP

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -40,9 +40,11 @@ namespace logger {
     /// Set a logging pattern for the given level.
     void setPattern(LogLevel level, std::string pattern);
 
-    /// Get the logging pattern for the given level. If not set, get the
-    /// next present more verbose level pattern, if any, or the default
-    /// pattern.
+    /**
+     * Get the logging pattern for the given level. If not set, get the
+     * next present more verbose level pattern, if any, or the default
+     * pattern.
+     */
     std::string getPattern(LogLevel level) const;
 
    private:

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -25,13 +25,6 @@ namespace logger {
 
   using Logger = std::shared_ptr<spdlog::logger>;
 
-  std::string red(const std::string &string);
-
-  std::string yellow(const std::string &string);
-
-  std::string output(const std::string &string);
-
-  std::string input(const std::string &string);
 
   /**
    * Provide logger object

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -49,7 +49,7 @@ namespace logger {
     std::map<LogLevel, std::string> patterns_;
   };
 
-  // TODO mboldyrev 29.12.2018 Add sink options (console, file, syslog, etc)
+  // TODO mboldyrev 29.12.2018 IR-188 Add sink options (console, file, syslog)
   struct LoggerConfig {
     LogLevel log_level;
     LogPatterns patterns;

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -24,38 +24,11 @@ auto operator<<(StreamType &os, const T &object)
 namespace logger {
 
   class Logger;
-  class LogPatterns;
-  class LoggerConfig;
   enum class LogLevel;
 
   using LoggerPtr = std::shared_ptr<Logger>;
-  using ConstLoggerConfigPtr = std::shared_ptr<const LoggerConfig>;
 
   extern const LogLevel kDefaultLogLevel;
-  extern const LogPatterns kDefaultLogPatterns;
-
-  /// Patterns for logging depending on the log level.
-  class LogPatterns {
-   public:
-    /// Set a logging pattern for the given level.
-    void setPattern(LogLevel level, std::string pattern);
-
-    /**
-     * Get the logging pattern for the given level. If not set, get the
-     * next present more verbose level pattern, if any, or the default
-     * pattern.
-     */
-    std::string getPattern(LogLevel level) const;
-
-   private:
-    std::map<LogLevel, std::string> patterns_;
-  };
-
-  // TODO mboldyrev 29.12.2018 IR-188 Add sink options (console, file, syslog)
-  struct LoggerConfig {
-    LogLevel log_level;
-    LogPatterns patterns;
-  };
 
   /// Log levels
   enum class LogLevel {
@@ -71,20 +44,7 @@ namespace logger {
     public:
      using Level = LogLevel;
 
-     // --- Constructors and assignment (aka the big 5) ---
-
-     /**
-      * @param tag - the tag for logging (aka logger name)
-      * @param config - logger configuration
-      */
-     Logger(std::string tag, ConstLoggerConfigPtr config);
-
-     Logger(const Logger &other);
-     Logger(Logger &&other);
-     Logger &operator=(const Logger &other);
-     Logger &operator=(Logger &&other);
-
-     virtual ~Logger();
+     virtual ~Logger() = default;
 
      // --- Logging functions ---
 
@@ -128,16 +88,11 @@ namespace logger {
      }
 
     private:
-
-     void logInternal(Level level, const std::string &s) const;
+     virtual void logInternal(Level level, const std::string &s) const = 0;
 
      /// Whether the configured logging level is at least as verbose as the
      /// one given in parameter.
-     bool shouldLog(Level level) const;
-
-     class Impl;
-     friend class Impl;
-     std::shared_ptr<Impl> impl_;
+     virtual bool shouldLog(Level level) const = 0;
   };
 
   /**

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -25,10 +25,14 @@ auto operator<<(StreamType &os, const T &object)
 namespace logger {
 
   class Logger;
+  class LoggerConfigTreeNode;
   class LogPatterns;
   enum class LogLevel;
 
   using LoggerPtr = std::shared_ptr<Logger>;
+  using LoggerConfigTreeNodePtr = std::shared_ptr<LoggerConfigTreeNode>;
+  using ConstLoggerConfigTreeNodePtr =
+      std::shared_ptr<const LoggerConfigTreeNode>;
 
   extern const LogLevel kDefaultLogLevel;
   extern const LogPatterns kDefaultLogPatterns;
@@ -67,9 +71,9 @@ namespace logger {
      * @param log_level - override the log level for the new child
      * @param patterns - override the patterns
      */
-    void addChild(std::string tag,
-                  boost::optional<LogLevel> log_level,
-                  boost::optional<LogPatterns> patterns);
+    LoggerConfigTreeNodePtr addChild(std::string tag,
+                                     boost::optional<LogLevel> log_level,
+                                     boost::optional<LogPatterns> patterns);
 
     /// Get tag.
     const std::string &getTag() const;
@@ -77,15 +81,18 @@ namespace logger {
     /// Get config.
     const LoggerConfig &getConfig() const;
 
-    /// Get child config by tag, if present.
-    boost::optional<std::shared_ptr<LoggerConfigTreeNode>> getChild(
+    /// Get non-const child config by tag, if present.
+    boost::optional<LoggerConfigTreeNodePtr> getChild(
+        const std::string &tag);
+
+    /// Get const child config by tag, if present.
+    boost::optional<ConstLoggerConfigTreeNodePtr> getChild(
         const std::string &tag) const;
 
    private:
     const std::string tag_;
     const LoggerConfig config_;
-    std::unordered_map<std::string, std::shared_ptr<LoggerConfigTreeNode>>
-        children_;
+    std::unordered_map<std::string, LoggerConfigTreeNodePtr> children_;
   };
 
   /// Log levels
@@ -115,8 +122,7 @@ namespace logger {
       * @param tree_config - the logger config tree
       * @param ts - thread safety of the created logger
       */
-     Logger(std::shared_ptr<const LoggerConfigTreeNode> tree_config,
-            LoggerThreadSafety ts);
+     Logger(ConstLoggerConfigTreeNodePtr tree_config, LoggerThreadSafety ts);
 
      /**
       * Create a standalone logger without tree config.
@@ -197,7 +203,7 @@ namespace logger {
       * @param ts - thread safety of the created logger
       */
      Logger(std::string tag,
-            std::shared_ptr<const LoggerConfigTreeNode> tree_config,
+            ConstLoggerConfigTreeNodePtr tree_config,
             LoggerThreadSafety ts);
 
      void logInternal(Level level, const std::string &s) const;

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -105,12 +105,6 @@ namespace logger {
     kCritical,
   };
 
-  /// Logger thread safety
-  enum class LoggerThreadSafety {
-    kSingleThread,
-    kMultiThread,
-  };
-
   class Logger {
     public:
      using Level = LogLevel;
@@ -120,17 +114,15 @@ namespace logger {
      /**
       * Create a logger corresponding to the root of the given tree config.
       * @param tree_config - the logger config tree
-      * @param ts - thread safety of the created logger
       */
-     Logger(ConstLoggerConfigTreeNodePtr tree_config, LoggerThreadSafety ts);
+     Logger(ConstLoggerConfigTreeNodePtr tree_config);
 
      /**
       * Create a standalone logger without tree config.
       * @param tag - the tag for logging (aka logger name)
       * @param config - logger configuration
-      * @param ts - thread safety of the created logger
       */
-     Logger(std::string tag, LoggerConfig config, LoggerThreadSafety ts);
+     Logger(std::string tag, LoggerConfig config);
 
      Logger(const Logger &other);
      Logger(Logger &&other);
@@ -187,12 +179,8 @@ namespace logger {
       * for the same child twice will yield the same object.
       *
       * @param tag - the tag of the child logger
-      * @param ts - thread safety of the child logger
       */
-     LoggerPtr getChild(std::string tag, LoggerThreadSafety ts);
-
-     // Public impl is needed to allow inheritance from Impl.
-     class Impl;
+     LoggerPtr getChild(std::string tag);
 
     private:
 
@@ -200,11 +188,8 @@ namespace logger {
       * Create a child logger corresponding to the root of the tree config.
       * @param tag - the tag for logging (aka logger name)
       * @param tree_config - the logger config tree
-      * @param ts - thread safety of the created logger
       */
-     Logger(std::string tag,
-            ConstLoggerConfigTreeNodePtr tree_config,
-            LoggerThreadSafety ts);
+     Logger(std::string tag, ConstLoggerConfigTreeNodePtr tree_config);
 
      void logInternal(Level level, const std::string &s) const;
 
@@ -212,7 +197,8 @@ namespace logger {
      /// one given in parameter.
      bool shouldLog(Level level) const;
 
-     friend class Logger::Impl;
+     class Impl;
+     friend class Impl;
      std::shared_ptr<Impl> impl_;
   };
 

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -7,8 +7,6 @@
 
 #include <atomic>
 
-#include "logger/logger_spdlog.hpp"
-
 static const std::string kTagHierarchySeparator = "/";
 
 static inline std::string joinTags(const std::string &parent,
@@ -34,7 +32,7 @@ namespace logger {
       boost::optional<LogPatterns> patterns) {
     LoggerConfig child_config{
         log_level.value_or(config_->log_level),
-        patterns ? LogPatterns{std::move(*patterns)} : config_->patterns};
+        patterns ? LogPatterns{*std::move(patterns)} : config_->patterns};
     // Operator new is employed due to private visibility of used constructor.
     LoggerManagerTreePtr child(new LoggerManagerTree(
         joinTags(full_tag_, tag),

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "logger/logger_manager.hpp"
+
+#include <atomic>
+
+static const std::string kTagHierarchySeparator = "/";
+
+static inline std::string joinTags(const std::string &parent,
+                                   const std::string &child) {
+  return parent.empty() ? child : parent + kTagHierarchySeparator + child;
+}
+
+namespace logger {
+
+  LoggerManagerTree::LoggerManagerTree(ConstLoggerConfigPtr config)
+      : config_(std::move(config)){};
+
+  LoggerManagerTree::LoggerManagerTree(std::string full_tag,
+                                       std::string node_tag,
+                                       ConstLoggerConfigPtr config)
+      : node_tag_(std::move(node_tag)),
+        full_tag_(std::move(full_tag)),
+        config_(std::move(config)){};
+
+  LoggerManagerTreePtr LoggerManagerTree::registerChild(
+      std::string tag,
+      boost::optional<LogLevel> log_level,
+      boost::optional<LogPatterns> patterns) {
+    LoggerConfig child_config{
+        log_level.value_or(config_->log_level),
+        patterns ? LogPatterns{std::move(*patterns)} : config_->patterns};
+    // Operator new is employed due to private visibility of used constructor.
+    LoggerManagerTreePtr child(new LoggerManagerTree(
+        joinTags(full_tag_, tag),
+        tag,
+        std::make_shared<const LoggerConfig>(std::move(child_config))));
+    auto map_elem = std::make_pair<const std::string, LoggerManagerTreePtr>(
+        std::move(tag), std::move(child));
+    std::lock_guard<std::mutex> lock(children_mutex_);
+    return children_.emplace(std::move(map_elem)).first->second;
+  }
+
+  LoggerPtr LoggerManagerTree::getLogger() {
+    LoggerPtr logger =
+        std::atomic_load_explicit(&logger_, std::memory_order_acquire);
+    if (not logger) {
+      auto new_logger = std::make_shared<Logger>(full_tag_, config_);
+      while (not logger) {
+        if (std::atomic_compare_exchange_weak_explicit(
+                &logger_,
+                &logger,
+                new_logger,
+                std::memory_order_release,
+                std::memory_order_acquire)) {
+          return new_logger;
+        }
+      }
+    }
+    return logger;
+  }
+
+  LoggerManagerTreePtr LoggerManagerTree::getChild(const std::string &tag) {
+    std::lock_guard<std::mutex> lock(children_mutex_);
+    const auto child_it = children_.find(tag);
+    if (child_it != children_.end()) {
+      return child_it->second;
+    }
+    // If a node for this child is not found in the tree config, create a
+    // new standalone logger using this logger's settings.
+    LoggerManagerTreePtr new_child(
+        new LoggerManagerTree(joinTags(full_tag_, tag), tag, config_));
+    return children_.emplace(std::make_pair(tag, std::move(new_child)))
+        .first->second;
+  }
+
+}  // namespace logger

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -7,6 +7,8 @@
 
 #include <atomic>
 
+#include "logger/logger_spdlog.hpp"
+
 static const std::string kTagHierarchySeparator = "/";
 
 static inline std::string joinTags(const std::string &parent,
@@ -48,7 +50,7 @@ namespace logger {
     LoggerPtr logger =
         std::atomic_load_explicit(&logger_, std::memory_order_acquire);
     if (not logger) {
-      auto new_logger = std::make_shared<Logger>(full_tag_, config_);
+      LoggerPtr new_logger = std::make_shared<LoggerSpdlog>(full_tag_, config_);
       while (not logger) {
         if (std::atomic_compare_exchange_weak_explicit(
                 &logger_,

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -20,13 +20,18 @@ namespace logger {
 
   using LoggerManagerTreePtr = std::shared_ptr<LoggerManagerTree>;
 
+  /**
+   * A node of logger managers tree. It stores the configuration needed to
+   * create a logger corresponding to this node and its children. Thread safe.
+   */
   class LoggerManagerTree {
    public:
     LoggerManagerTree(ConstLoggerConfigPtr config);
 
     /**
      * Register a child configuration. The new child's cnofiguartion parameters
-     * are taken from the parent optionally overrided by the arguments.
+     * are taken from the parent optionally overrided by the arguments. Thread
+     * safe.
      *
      * @param tag - the child's tag, without any parents' frefixes
      * @param log_level - override the log level for the new child
@@ -36,10 +41,10 @@ namespace logger {
                                        boost::optional<LogLevel> log_level,
                                        boost::optional<LogPatterns> patterns);
 
-    /// Get this node's logger.
+    /// Get this node's logger. Thread safe.
     LoggerPtr getLogger();
 
-    /// Get non-const child config by tag, if present.
+    /// Get non-const child config by tag, if present. Thread safe.
     LoggerManagerTreePtr getChild(const std::string &tag);
 
    private:

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -29,11 +29,11 @@ namespace logger {
     LoggerManagerTree(ConstLoggerConfigPtr config);
 
     /**
-     * Register a child configuration. The new child's cnofiguartion parameters
+     * Register a child configuration. The new child's configuration parameters
      * are taken from the parent optionally overrided by the arguments. Thread
      * safe.
      *
-     * @param tag - the child's tag, without any parents' frefixes
+     * @param tag - the child's tag, without any parents' prefixes
      * @param log_level - override the log level for the new child
      * @param patterns - override the patterns
      */
@@ -44,7 +44,7 @@ namespace logger {
     /// Get this node's logger. Thread safe.
     LoggerPtr getLogger();
 
-    /// Get non-const child config by tag, if present. Thread safe.
+    /// Get non-const child node by tag, if present. Thread safe.
     LoggerManagerTreePtr getChild(const std::string &tag);
 
    private:

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SPDLOG_LOGGER_MANAGER_HPP
+#define IROHA_SPDLOG_LOGGER_MANAGER_HPP
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include <boost/optional.hpp>
+#include "logger/logger.hpp"
+
+namespace logger {
+
+  class LoggerManagerTree;
+
+  using LoggerManagerTreePtr = std::shared_ptr<LoggerManagerTree>;
+
+  class LoggerManagerTree {
+   public:
+    LoggerManagerTree(ConstLoggerConfigPtr config);
+
+    /**
+     * Register a child configuration. The new child's cnofiguartion parameters
+     * are taken from the parent optionally overrided by the arguments.
+     *
+     * @param tag - the child's tag, without any parents' frefixes
+     * @param log_level - override the log level for the new child
+     * @param patterns - override the patterns
+     */
+    LoggerManagerTreePtr registerChild(std::string tag,
+                                       boost::optional<LogLevel> log_level,
+                                       boost::optional<LogPatterns> patterns);
+
+    /// Get this node's logger.
+    LoggerPtr getLogger();
+
+    /// Get non-const child config by tag, if present.
+    LoggerManagerTreePtr getChild(const std::string &tag);
+
+   private:
+    LoggerManagerTree(std::string full_tag,
+                      std::string node_tag,
+                      ConstLoggerConfigPtr config);
+
+    const std::string node_tag_;
+    const std::string full_tag_;
+    const ConstLoggerConfigPtr config_;
+    std::shared_ptr<Logger> logger_;
+    std::unordered_map<std::string, LoggerManagerTreePtr> children_;
+    std::mutex children_mutex_;
+  };
+
+}  // namespace logger
+
+#endif  // IROHA_SPDLOG_LOGGER_MANAGER_HPP

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -12,7 +12,7 @@
 #include <unordered_map>
 
 #include <boost/optional.hpp>
-#include "logger/logger.hpp"
+#include "logger/logger_spdlog.hpp"
 
 namespace logger {
 

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -1,0 +1,92 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "logger/logger_spdlog.hpp"
+
+#include <mutex>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+static const std::string kDefaultPattern =
+    R"([%Y-%m-%d %H:%M:%S.%F] [%L] [%n]: %v)";
+
+namespace logger {
+
+  const LogPatterns kDefaultLogPatterns = ([] {
+    LogPatterns p;
+    p.setPattern(LogLevel::kTrace,
+                 R"([%Y-%m-%d %H:%M:%S.%F] [th:%t] [%5l] [%n]: %v)");
+    p.setPattern(LogLevel::kInfo, kDefaultPattern);
+    return p;
+  })();
+
+  void LogPatterns::setPattern(LogLevel level, std::string pattern) {
+    patterns_[level] = pattern;
+  }
+
+  std::string LogPatterns::getPattern(LogLevel level) const {
+    for (auto it = patterns_.rbegin(); it != patterns_.rend(); ++it) {
+      if (it->first <= level) {
+        return it->second;
+      }
+    }
+    return kDefaultPattern;
+  }
+
+  LoggerSpdlog::LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config)
+      : tag_(tag),
+        config_(std::move(config)),
+        logger_(spdlog::stdout_color_mt(tag)) {
+    setupLogger();
+  }
+
+        LoggerSpdlog::~LoggerSpdlog() = default;
+
+  void LoggerSpdlog::setupLogger() {
+    static const std::map<LogLevel, const spdlog::level::level_enum>
+        kSpdLogLevels = {{LogLevel::kTrace, spdlog::level::trace},
+                         {LogLevel::kDebug, spdlog::level::debug},
+                         {LogLevel::kInfo, spdlog::level::info},
+                         {LogLevel::kWarn, spdlog::level::warn},
+                         {LogLevel::kError, spdlog::level::err},
+                         {LogLevel::kCritical, spdlog::level::critical}};
+    const auto it = kSpdLogLevels.find(config_->log_level);
+    BOOST_ASSERT_MSG(it != kSpdLogLevels.end(), "Unknown log level!");
+    logger_->set_level(it == kSpdLogLevels.end()
+                           ? kSpdLogLevels.at(kDefaultLogLevel)
+                           : it->second);
+    logger_->set_pattern(config_->patterns.getPattern(config_->log_level));
+  }
+
+  void LoggerSpdlog::logInternal(Level level, const std::string &s) const {
+    switch (level) {
+      case LogLevel::kTrace:
+        logger_->trace(s);
+        break;
+      case LogLevel::kDebug:
+        logger_->debug(s);
+        break;
+      case LogLevel::kInfo:
+        logger_->info(s);
+        break;
+      case LogLevel::kWarn:
+        logger_->warn(s);
+        break;
+      case LogLevel::kError:
+        logger_->error(s);
+        break;
+      case LogLevel::kCritical:
+        logger_->critical(s);
+        break;
+      default:
+        BOOST_THROW_EXCEPTION(std::runtime_error("Unknown log level!"));
+    }
+  }
+
+  bool LoggerSpdlog::shouldLog(Level level) const {
+    return config_->log_level <= level;
+  }
+}  // namespace logger

--- a/libs/logger/logger_spdlog.hpp
+++ b/libs/logger/logger_spdlog.hpp
@@ -12,8 +12,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/optional.hpp>
-
 namespace spdlog {
   class logger;
 }
@@ -52,56 +50,11 @@ namespace logger {
 
   class LoggerSpdlog : public Logger {
    public:
-    using Level = LogLevel;
-
     /**
      * @param tag - the tag for logging (aka logger name)
      * @param config - logger configuration
      */
     LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config);
-
-    virtual ~LoggerSpdlog();
-
-    // --- Logging functions ---
-
-    template <typename... Args>
-    void trace(const std::string &format, const Args &... args) const {
-      log(LogLevel::kTrace, format, args...);
-    }
-
-    template <typename... Args>
-    void debug(const std::string &format, const Args &... args) const {
-      log(LogLevel::kDebug, format, args...);
-    }
-
-    template <typename... Args>
-    void info(const std::string &format, const Args &... args) const {
-      log(LogLevel::kInfo, format, args...);
-    }
-
-    template <typename... Args>
-    void warn(const std::string &format, const Args &... args) const {
-      log(LogLevel::kWarn, format, args...);
-    }
-
-    template <typename... Args>
-    void error(const std::string &format, const Args &... args) const {
-      log(LogLevel::kError, format, args...);
-    }
-
-    template <typename... Args>
-    void critical(const std::string &format, const Args &... args) const {
-      log(LogLevel::kCritical, format, args...);
-    }
-
-    template <typename... Args>
-    void log(Level level,
-             const std::string &format,
-             const Args &... args) const {
-      if (shouldLog(level)) {
-        logInternal(level, format);  // TODO perform the actual formatting here
-      }
-    }
 
    private:
     void logInternal(Level level, const std::string &s) const override;
@@ -120,4 +73,4 @@ namespace logger {
 
 }  // namespace logger
 
-#endif
+#endif  // IROHA_LOGGER_SPDLOG_HPP

--- a/libs/logger/logger_spdlog.hpp
+++ b/libs/logger/logger_spdlog.hpp
@@ -1,0 +1,123 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_LOGGER_SPDLOG_HPP
+#define IROHA_LOGGER_SPDLOG_HPP
+
+#include "logger/logger.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace spdlog {
+  class logger;
+}
+
+namespace logger {
+
+  class LogPatterns;
+  struct LoggerConfig;
+
+  using ConstLoggerConfigPtr = std::shared_ptr<const LoggerConfig>;
+
+  extern const LogPatterns kDefaultLogPatterns;
+
+  /// Patterns for logging depending on the log level.
+  class LogPatterns {
+   public:
+    /// Set a logging pattern for the given level.
+    void setPattern(LogLevel level, std::string pattern);
+
+    /**
+     * Get the logging pattern for the given level. If not set, get the
+     * next present more verbose level pattern, if any, or the default
+     * pattern.
+     */
+    std::string getPattern(LogLevel level) const;
+
+   private:
+    std::map<LogLevel, std::string> patterns_;
+  };
+
+  // TODO mboldyrev 29.12.2018 IR-188 Add sink options (console, file, syslog)
+  struct LoggerConfig {
+    LogLevel log_level;
+    LogPatterns patterns;
+  };
+
+  class LoggerSpdlog : public Logger {
+   public:
+    using Level = LogLevel;
+
+    /**
+     * @param tag - the tag for logging (aka logger name)
+     * @param config - logger configuration
+     */
+    LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config);
+
+    virtual ~LoggerSpdlog();
+
+    // --- Logging functions ---
+
+    template <typename... Args>
+    void trace(const std::string &format, const Args &... args) const {
+      log(LogLevel::kTrace, format, args...);
+    }
+
+    template <typename... Args>
+    void debug(const std::string &format, const Args &... args) const {
+      log(LogLevel::kDebug, format, args...);
+    }
+
+    template <typename... Args>
+    void info(const std::string &format, const Args &... args) const {
+      log(LogLevel::kInfo, format, args...);
+    }
+
+    template <typename... Args>
+    void warn(const std::string &format, const Args &... args) const {
+      log(LogLevel::kWarn, format, args...);
+    }
+
+    template <typename... Args>
+    void error(const std::string &format, const Args &... args) const {
+      log(LogLevel::kError, format, args...);
+    }
+
+    template <typename... Args>
+    void critical(const std::string &format, const Args &... args) const {
+      log(LogLevel::kCritical, format, args...);
+    }
+
+    template <typename... Args>
+    void log(Level level,
+             const std::string &format,
+             const Args &... args) const {
+      if (shouldLog(level)) {
+        logInternal(level, format);  // TODO perform the actual formatting here
+      }
+    }
+
+   private:
+    void logInternal(Level level, const std::string &s) const override;
+
+    /// Whether the configured logging level is at least as verbose as the
+    /// one given in parameter.
+    bool shouldLog(Level level) const override;
+
+    /// Set Spdlog logger level and pattern.
+    void setupLogger();
+
+    const std::string tag_;
+    const ConstLoggerConfigPtr config_;
+    const std::shared_ptr<spdlog::logger> logger_;
+  };
+
+}  // namespace logger
+
+#endif

--- a/test/module/irohad/logger/CMakeLists.txt
+++ b/test/module/irohad/logger/CMakeLists.txt
@@ -8,5 +8,6 @@
 AddTest(logger_test logger_test.cpp)
 target_link_libraries(logger_test
     logger
+    logger_manager
     )
 

--- a/test/module/irohad/logger/logger_test.cpp
+++ b/test/module/irohad/logger/logger_test.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 #include <gtest/gtest.h>
 
 #include <vector>
@@ -11,11 +11,12 @@
 TEST(LoggerTest, basicStandaloneLoggerTest) {
   logger::LoggerConfig config;
   config.log_level = logger::LogLevel::kInfo;
-  auto one_logger = logger::Logger(
-      "standalone_logger", config, logger::LoggerThreadSafety::kSingleThread);
-  one_logger.trace("testing a standalone logger: trace");
-  one_logger.info("testing a standalone logger: info");
-  one_logger.error("testing a standalone logger: error");
+  logger::LoggerManagerTree manager(
+      std::make_unique<const logger::LoggerConfig>(std::move(config)));
+  auto a_logger = manager.getChild("test info logger")->getLogger();
+  a_logger->trace("testing a standalone logger: trace");
+  a_logger->info("testing a standalone logger: info");
+  a_logger->error("testing a standalone logger: error");
 }
 
 TEST(LoggerTest, boolReprTest) {

--- a/test/module/irohad/logger/logger_test.cpp
+++ b/test/module/irohad/logger/logger_test.cpp
@@ -15,10 +15,6 @@ TEST(LoggerTest, getLoggerTest) {
   auto another_logger = logger::log("another_logger");
   another_logger->warn("another logger");
   another_logger->info("temporal output {}, {}", 123, "string param");
-  another_logger->info(logger::red("color output"));
-  another_logger->info(
-      logger::yellow("color args output {} // note: require char *").c_str(),
-      "=^._.^=");
 }
 
 TEST(LoggerTest, boolReprTest) {

--- a/test/module/irohad/logger/logger_test.cpp
+++ b/test/module/irohad/logger/logger_test.cpp
@@ -8,13 +8,14 @@
 
 #include <vector>
 
-TEST(LoggerTest, getLoggerTest) {
-  auto one_logger = logger::log("one_logger");
-  one_logger->info("one logger");
-
-  auto another_logger = logger::log("another_logger");
-  another_logger->warn("another logger");
-  another_logger->info("temporal output {}, {}", 123, "string param");
+TEST(LoggerTest, basicStandaloneLoggerTest) {
+  logger::LoggerConfig config;
+  config.log_level = logger::LogLevel::kInfo;
+  auto one_logger = logger::Logger(
+      "standalone_logger", config, logger::LoggerThreadSafety::kSingleThread);
+  one_logger.trace("testing a standalone logger: trace");
+  one_logger.info("testing a standalone logger: info");
+  one_logger.error("testing a standalone logger: error");
 }
 
 TEST(LoggerTest, boolReprTest) {


### PR DESCRIPTION

[IR-97](https://jira.hyperledger.org/browse/IR-97), [IR-99](https://jira.hyperledger.org/browse/IR-99), [IR-140](https://jira.hyperledger.org/browse/IR-140)

### Description of the Change

Main classes of a new logger implementation that ...

### Benefits

... supports tree config structure and hides spdlog library.

### Usage Examples

Loggers can be created with and without a tree config. Project components should pass children of their loggers to their sub-components. Child loggers get the settings from their parents, optionally overridden if a tree config was used.

Please note that this is the first step towards the working new logger, and the project is not yet using it, so it is not expected to compile successfully.