### PR TITLE
Make command client testable

### DIFF
--- a/iroha-cli/client.cpp
+++ b/iroha-cli/client.cpp
@@ -11,11 +11,15 @@
 #include "model/converters/json_transaction_factory.hpp"
 #include "model/converters/pb_query_factory.hpp"
 #include "model/converters/pb_transaction_factory.hpp"
+#include "network/impl/grpc_channel_builder.hpp"
 
 namespace iroha_cli {
 
   CliClient::CliClient(std::string target_ip, int port)
-      : command_client_(target_ip, port), query_client_(target_ip, port) {}
+      : command_client_(
+            iroha::network::createClient<iroha::protocol::CommandService_v1>(
+                target_ip + ":" + std::to_string(port))),
+        query_client_(target_ip, port) {}
 
   CliClient::Response<CliClient::TxStatus> CliClient::sendTx(
       const shared_model::interface::Transaction &tx) {

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -20,9 +20,9 @@ namespace torii {
    */
   class CommandSyncClient {
    public:
-    CommandSyncClient(const std::string &ip,
-                      size_t port,
-                      logger::Logger log = logger::log("CommandSyncClient"));
+    CommandSyncClient(
+        std::unique_ptr<iroha::protocol::CommandService_v1::StubInterface> stub,
+        logger::Logger log = logger::log("CommandSyncClient"));
 
     /**
      * requests tx to a torii server and returns response (blocking, sync)
@@ -57,7 +57,7 @@ namespace torii {
         std::vector<iroha::protocol::ToriiResponse> &response) const;
 
    private:
-    std::unique_ptr<iroha::protocol::CommandService_v1::Stub> stub_;
+    std::unique_ptr<iroha::protocol::CommandService_v1::StubInterface> stub_;
     logger::Logger log_;
   };
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -39,6 +39,7 @@
 #include "module/shared_model/validators/always_valid_validators.hpp"
 #include "multi_sig_transactions/transport/mst_transport_grpc.hpp"
 #include "network/impl/async_grpc_client.hpp"
+#include "network/impl/grpc_channel_builder.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 using namespace shared_model::crypto;
@@ -89,7 +90,9 @@ namespace integration_framework {
                                                         torii_port_,
                                                         internal_port_,
                                                         dbname)),
-        command_client_(kLocalHost, torii_port_),
+        command_client_(
+            iroha::network::createClient<iroha::protocol::CommandService_v1>(
+                kLocalHost + ":" + std::to_string(torii_port_))),
         query_client_(kLocalHost, torii_port_),
         async_call_(std::make_shared<AsyncCall>()),
         proposal_waiting(proposal_waiting),

--- a/test/module/irohad/torii/command_sync_client_test.cpp
+++ b/test/module/irohad/torii/command_sync_client_test.cpp
@@ -8,6 +8,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "endpoint_mock.grpc.pb.h"
+#include "framework/mock_stream.h"
 #include "main/server_runner.hpp"
 #include "module/irohad/torii/torii_mocks.hpp"
 
@@ -18,19 +19,16 @@ using testing::Return;
 class CommandSyncClientTest : public testing::Test {
  public:
   void SetUp() override {
-    runner = std::make_unique<ServerRunner>(ip + ":0");
-    server = std::make_shared<iroha::torii::MockCommandServiceTransport>();
-    runner->append(server).run().match(
-        [this](iroha::expected::Value<int> port) { this->port = port.value; },
-        [](iroha::expected::Error<std::string> err) { FAIL() << err.error; });
+    auto ustub = std::make_unique<iroha::protocol::MockCommandService_v1Stub>();
+    stub = ustub.get();
+    client = std::make_shared<torii::CommandSyncClient>(std::move(ustub));
   }
 
-  std::unique_ptr<ServerRunner> runner;
-  std::shared_ptr<iroha::torii::MockCommandServiceTransport> server;
+  iroha::protocol::MockCommandService_v1Stub *stub;
+  std::shared_ptr<torii::CommandSyncClient> client;
 
-  const std::string ip = "127.0.0.1";
   const size_t kHashLength = 32;
-  int port;
+  const std::string kTxHash = std::string(kHashLength, '1');
 };
 
 /**
@@ -39,13 +37,18 @@ class CommandSyncClientTest : public testing::Test {
  * @then the same method of the server is called and client successfully return
  */
 TEST_F(CommandSyncClientTest, Status) {
-  iroha::protocol::TxStatusRequest tx_request;
-  tx_request.set_tx_hash(std::string(kHashLength, '1'));
-  iroha::protocol::ToriiResponse toriiResponse;
-
-  torii::CommandSyncClient client(ip, port);
-  EXPECT_CALL(*server, Status(_, _, _)).WillOnce(Return(grpc::Status::OK));
-  auto stat = client.Status(tx_request, toriiResponse);
+  iroha::protocol::TxStatusRequest tx_request, intermediary_tx_request;
+  tx_request.set_tx_hash(kTxHash);
+  iroha::protocol::ToriiResponse torii_response, intermediary_response;
+  intermediary_response.set_tx_hash(kTxHash);
+  EXPECT_CALL(*stub, Status(_, _, _))
+      .WillOnce(
+          ::testing::DoAll(::testing::SaveArg<1>(&intermediary_tx_request),
+                           ::testing::SetArgPointee<2>(intermediary_response),
+                           Return(::grpc::Status::OK)));
+  auto stat = client->Status(tx_request, torii_response);
+  ASSERT_EQ(kTxHash, intermediary_tx_request.tx_hash());
+  ASSERT_EQ(kTxHash, torii_response.tx_hash());
   ASSERT_TRUE(stat.ok());
 }
 
@@ -55,10 +58,15 @@ TEST_F(CommandSyncClientTest, Status) {
  * @then the same method of the server is called and client successfully return
  */
 TEST_F(CommandSyncClientTest, Torii) {
-  iroha::protocol::Transaction tx;
-  EXPECT_CALL(*server, Torii(_, _, _)).WillOnce(Return(grpc::Status()));
-  torii::CommandSyncClient client(ip, port);
-  auto stat = client.Torii(tx);
+  iroha::protocol::Transaction tx, intermediary_tx;
+  tx.mutable_payload()->mutable_reduced_payload()->set_creator_account_id(
+      kTxHash);
+  EXPECT_CALL(*stub, Torii(_, _, _))
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&intermediary_tx),
+                                 ::testing::Return(::grpc::Status::OK)));
+  auto stat = client->Torii(tx);
+  ASSERT_EQ(kTxHash,
+            intermediary_tx.payload().reduced_payload().creator_account_id());
   ASSERT_TRUE(stat.ok());
 }
 
@@ -68,10 +76,20 @@ TEST_F(CommandSyncClientTest, Torii) {
  * @then the same method of the server is called and client successfully return
  */
 TEST_F(CommandSyncClientTest, ListTorii) {
-  iroha::protocol::TxList tx;
-  EXPECT_CALL(*server, ListTorii(_, _, _)).WillOnce(Return(grpc::Status()));
-  torii::CommandSyncClient client(ip, port);
-  auto stat = client.ListTorii(tx);
+  iroha::protocol::TxList tx_list, intermediary_tx_list;
+  tx_list.add_transactions()
+      ->mutable_payload()
+      ->mutable_reduced_payload()
+      ->set_creator_account_id(kTxHash);
+  EXPECT_CALL(*stub, ListTorii(_, _, _))
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&intermediary_tx_list),
+                                 ::testing::Return(::grpc::Status::OK)));
+  auto stat = client->ListTorii(tx_list);
+  ASSERT_EQ(kTxHash,
+            intermediary_tx_list.transactions()[0]
+                .payload()
+                .reduced_payload()
+                .creator_account_id());
   ASSERT_TRUE(stat.ok());
 }
 
@@ -81,20 +99,25 @@ TEST_F(CommandSyncClientTest, ListTorii) {
  * @then the same method of the server is called and client successfully return
  */
 TEST_F(CommandSyncClientTest, StatusStream) {
-  iroha::protocol::TxStatusRequest tx;
+  iroha::protocol::TxStatusRequest tx, intermediary_tx;
   iroha::protocol::ToriiResponse resp;
-  resp.set_tx_hash(std::string(kHashLength, '1'));
+  auto hash = std::string(kHashLength, '1');
+  tx.set_tx_hash(hash);
+  resp.set_tx_hash(hash);
   std::vector<iroha::protocol::ToriiResponse> responses;
-  EXPECT_CALL(*server, StatusStream(_, _, _))
-      .WillOnce(Invoke([&](auto,
-                           auto,
-                           grpc::ServerWriter<iroha::protocol::ToriiResponse>
-                               *response_writer) {
-        response_writer->Write(resp);
-        return grpc::Status();
-      }));
-  torii::CommandSyncClient client(ip, port);
-  client.StatusStream(tx, responses);
+  auto reader = std::make_unique<
+      grpc::testing::MockClientReader<::iroha::protocol::ToriiResponse>>();
+
+  EXPECT_CALL(*reader, Read(_))
+      .WillOnce(DoAll(::testing::SetArgPointee<0>(resp), Return(true)))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*reader, Finish()).WillOnce(Return(::grpc::Status::OK));
+
+  EXPECT_CALL(*stub, StatusStreamRaw(_, _))
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&intermediary_tx),
+                                 Return(reader.release())));
+  client->StatusStream(tx, responses);
+  ASSERT_EQ(intermediary_tx.tx_hash(), resp.tx_hash());
   ASSERT_EQ(responses.size(), 1);
   ASSERT_EQ(responses[0].tx_hash(), resp.tx_hash());
 }

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -21,6 +21,7 @@
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/roles_response.hpp"
 #include "main/iroha_conf_loader.hpp"
+#include "network/impl/grpc_channel_builder.hpp"
 #include "torii/command_client.hpp"
 #include "torii/query_client.hpp"
 
@@ -146,7 +147,9 @@ class IrohadTest : public AcceptanceFixture {
         complete(baseTx(kAdminId).setAccountQuorum(kAdminId, 1), key_pair);
     tx_request.set_tx_hash(tx.hash().hex());
 
-    torii::CommandSyncClient client(kAddress, kPort);
+    torii::CommandSyncClient client(
+        iroha::network::createClient<iroha::protocol::CommandService_v1>(
+            kAddress + ":" + std::to_string(kPort)));
     client.Torii(tx.getTransport());
 
     auto resub_counter(resubscribe_attempts);


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

No need to create true server for tests.

### Benefits

More precise tests. Improved testability.

### Possible Drawbacks 

🤷‍♂️

### Usage Examples or Tests

```
command_sync_client_test
build of iroha-cli
```

thanks to @lebdron 