### PR TITLE
Refactor: libacceptance_fixture detached from ITF lib

### DIFF
--- a/shared_model/utils/query_error_response_visitor.hpp
+++ b/shared_model/utils/query_error_response_visitor.hpp
@@ -7,6 +7,7 @@
 #define IROHA_QUERY_ERROR_RESPONSE_VISITOR_HPP
 
 #include <boost/variant.hpp>
+#include "common/visitor.hpp"
 #include "interfaces/query_responses/error_query_response.hpp"
 
 namespace shared_model {

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -14,12 +14,12 @@ add_library(integration_framework
     integration_framework/fake_peer/fake_peer.cpp
     integration_framework/fake_peer/yac_network_notifier.cpp
     integration_framework/port_guard.cpp
-    common_constants.cpp
     )
 target_link_libraries(integration_framework
     application
     integration_framework_config_helper
     command_client
+    common_test_constants
     query_client
     ordering_gate_common
     yac_transport
@@ -27,6 +27,8 @@ target_link_libraries(integration_framework
     server_runner
     mst_transport
     )
+
+add_library(common_test_constants common_constants.cpp)
 
 target_include_directories(integration_framework PUBLIC ${PROJECT_SOURCE_DIR}/test)
 

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -16,31 +16,37 @@ add_library(grantable_permissions_fixture
     )
 target_link_libraries(grantable_permissions_fixture
     acceptance_fixture
+    integration_framework
     )
 
 addtest(add_asset_qty_test add_asset_qty_test.cpp)
 target_link_libraries(add_asset_qty_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(create_account_test create_account_test.cpp)
 target_link_libraries(create_account_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(create_domain_test create_domain_test.cpp)
 target_link_libraries(create_domain_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(create_role_test create_role_test.cpp)
 target_link_libraries(create_role_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_transactions_test get_transactions_test.cpp)
 target_link_libraries(get_transactions_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(grant_permission_test grant_permission_test.cpp)
@@ -56,31 +62,37 @@ target_link_libraries(revoke_permission_test
 addtest(invalid_fields_test invalid_fields_test.cpp)
 target_link_libraries(invalid_fields_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(query_test query_test.cpp)
 target_link_libraries(query_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(subtract_asset_qty_test subtract_asset_qty_test.cpp)
 target_link_libraries(subtract_asset_qty_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(transfer_asset_test transfer_asset_test.cpp)
 target_link_libraries(transfer_asset_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(tx_acceptance_test tx_acceptance_test.cpp)
 target_link_libraries(tx_acceptance_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(tx_heavy_data tx_heavy_data.cpp)
 target_link_libraries(tx_heavy_data
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_account_assets_test
@@ -90,26 +102,31 @@ query_permission_test_base.cpp"
     )
 target_link_libraries(get_account_assets_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(set_account_detail_test set_account_detail_test.cpp)
 target_link_libraries(set_account_detail_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_roles_test get_roles_test.cpp)
 target_link_libraries(get_roles_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(queries_acceptance_test queries_acceptance_test.cpp)
 target_link_libraries(queries_acceptance_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(create_asset_test create_asset_test.cpp)
 target_link_libraries(create_asset_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_account_asset_txs_test
@@ -119,6 +136,7 @@ query_permission_test_base.cpp"
     )
 target_link_libraries(get_account_asset_txs_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(query_permissions_common_test
@@ -132,6 +150,7 @@ query_permission_test_signatories.cpp"
     )
 target_link_libraries(query_permissions_common_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_account_test
@@ -139,6 +158,7 @@ addtest(get_account_test
     )
 target_link_libraries(get_account_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(add_signatory_test
@@ -146,6 +166,7 @@ addtest(add_signatory_test
     )
 target_link_libraries(add_signatory_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(remove_signatory_test
@@ -153,6 +174,7 @@ addtest(remove_signatory_test
     )
 target_link_libraries(remove_signatory_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_asset_info_test
@@ -160,6 +182,7 @@ addtest(get_asset_info_test
     )
 target_link_libraries(get_asset_info_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(get_role_permissions_test
@@ -167,6 +190,7 @@ addtest(get_role_permissions_test
     )
 target_link_libraries(get_role_permissions_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(replay_test
@@ -174,6 +198,7 @@ addtest(replay_test
     )
 target_link_libraries(replay_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(basic_mst_state_propagation_test
@@ -181,6 +206,7 @@ addtest(basic_mst_state_propagation_test
     )
 target_link_libraries(basic_mst_state_propagation_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(set_account_quorum_test
@@ -188,4 +214,5 @@ addtest(set_account_quorum_test
     )
 target_link_libraries(set_account_quorum_test
     acceptance_fixture
+    integration_framework
     )

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(acceptance_fixture acceptance_fixture.cpp)
 target_link_libraries(acceptance_fixture
     gtest::gtest
     gmock::gmock
-    integration_framework
     shared_model_proto_builders
     )
 

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(acceptance_fixture acceptance_fixture.cpp)
 target_link_libraries(acceptance_fixture
     gtest::gtest
     gmock::gmock
+    common_test_constants
     shared_model_proto_builders
     )
 

--- a/test/integration/acceptance/acceptance_fixture.cpp
+++ b/test/integration/acceptance/acceptance_fixture.cpp
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "datetime/time.hpp"
-#include "framework/integration_framework/integration_test_framework.hpp"
 #include "utils/query_error_response_visitor.hpp"
 
 using namespace common_constants;

--- a/test/integration/pipeline/CMakeLists.txt
+++ b/test/integration/pipeline/CMakeLists.txt
@@ -6,14 +6,17 @@
 addtest(pipeline_test pipeline_test.cpp)
 target_link_libraries(pipeline_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(batch_pipeline_test batch_pipeline_test.cpp)
 target_link_libraries(batch_pipeline_test
     acceptance_fixture
+    integration_framework
     )
 
 addtest(multisig_tx_pipeline_test multisig_tx_pipeline_test.cpp)
 target_link_libraries(multisig_tx_pipeline_test
     acceptance_fixture
+    integration_framework
     )


### PR DESCRIPTION
### Description of the Change

Before this change `libintegration_framework` was linked to `libacceptance_fixture`, despite of it being not necessary. In this change they are decoupled, so that the executables may use `libacceptance_fixture` without `libintegration_framework`. Many tests relied on this implicit linkage, which is made explicit here.

### Benefits

Removed an unnecessary dependency. Expected faster compilation and smaller executable size where the first lib is used without the second.