### PR TITLE
Feature/iroha tests coredump

### DIFF
--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -25,7 +25,7 @@ def doDebugBuild(coverageEnabled=false) {
 
   // for saving coredumps
   sh "sudo echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
-  sh "sudo ulimit -c unlimited"
+  sh "sudo bash -c 'ulimit -c unlimited'"
 
   sh "docker network create ${env.IROHA_NETWORK}"
   def iC = dPullOrBuild.dockerPullOrUpdate("${platform}-develop-build",

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -24,8 +24,8 @@ def doDebugBuild(coverageEnabled=false) {
   }
 
   // for saving coredumps
-  sh "sudo echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
-  sh "sudo bash -c 'ulimit -c unlimited'"
+  sh "echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
+  sh "bash -c 'ulimit -c unlimited'"
 
   sh "docker network create ${env.IROHA_NETWORK}"
   def iC = dPullOrBuild.dockerPullOrUpdate("${platform}-develop-build",

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -22,6 +22,8 @@ def doDebugBuild(coverageEnabled=false) {
   if (env.NODE_NAME.contains('arm7')) {
     parallelism = 1
   }
+  sh "sudo echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
+  sh "sudo ulimit -c unlimited"
 
   sh "docker network create ${env.IROHA_NETWORK}"
   def iC = dPullOrBuild.dockerPullOrUpdate("${platform}-develop-build",

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -22,6 +22,8 @@ def doDebugBuild(coverageEnabled=false) {
   if (env.NODE_NAME.contains('arm7')) {
     parallelism = 1
   }
+
+  // for saving coredumps
   sh "sudo echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
   sh "sudo ulimit -c unlimited"
 

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -26,7 +26,6 @@ def doDebugBuild(coverageEnabled=false) {
   // enable coredumps collecting
   if (params.coredump) {
     sh "echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
-    sh "echo \$0"
     sh "ulimit -c unlimited"
   }
 

--- a/.jenkinsci/debug-build.groovy
+++ b/.jenkinsci/debug-build.groovy
@@ -23,9 +23,12 @@ def doDebugBuild(coverageEnabled=false) {
     parallelism = 1
   }
 
-  // for saving coredumps
-  sh "echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
-  sh "bash -c 'ulimit -c unlimited'"
+  // enable coredumps collecting
+  if (params.coredump) {
+    sh "echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
+    sh "echo \$0"
+    sh "ulimit -c unlimited"
+  }
 
   sh "docker network create ${env.IROHA_NETWORK}"
   def iC = dPullOrBuild.dockerPullOrUpdate("${platform}-develop-build",

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -6,7 +6,8 @@ def linuxPostStep() {
       def dumpsFileName = sprintf('coredumps-%1$s.zip',
         [GIT_COMMIT.substring(0,8)])
 
-      sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
+      // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
+      sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} \{\} \\;")
 
       withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
         artifactServers.each {

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -4,7 +4,7 @@ def linuxPostStep() {
       // handling coredumps (if tests crashed)
       def currentPath = sh(script: "pwd", returnStdout: true).trim()
       def dumpsFileName = sprintf('coredumps-%1$s.zip',
-        [commit.substring(0,8)])
+        [GIT_COMMIT.substring(0,8)])
 
       sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
 

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -7,7 +7,7 @@ def linuxPostStep() {
         [GIT_COMMIT.substring(0,8)])
 
       // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
-      sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} \{\} \\;")
+      sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} {} \\;")
 
       withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
         artifactServers.each {

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -3,16 +3,14 @@ def linuxPostStep() {
     try {
       // handling coredumps (if tests crashed)
       def currentPath = sh(script: "pwd", returnStdout: true).trim()
-      def dumpsFileName = sprintf('coredumps-%1$s.zip',
+      def dumpsFileName = sprintf('coredumps-%1$s.tar',
         [GIT_COMMIT.substring(0,8)])
 
       // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
       sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} {} \\;")
 
       withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
-        artifactServers.each {
-          sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://${it}/repository/artifacts/iroha/coredumps/${dumpsFileName}")
-        }
+        sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
       }
       if (currentBuild.currentResult == "SUCCESS" && GIT_LOCAL_BRANCH ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -8,7 +8,7 @@ def linuxPostStep() {
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find . -type f -name '*.coredump'-exec tar -cjvf ${dumpsFileName} {} \\;")
+        sh(script: "find . -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -1,16 +1,19 @@
 def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
-      // handling coredumps (if tests crashed)
-      def currentPath = sh(script: "pwd", returnStdout: true).trim()
-      def dumpsFileName = sprintf('coredumps-%1$s.tar',
-        [GIT_COMMIT.substring(0,8)])
+      if (currentBuild.currentResult != "SUCCESS") {
+        // handling coredumps (if tests crashed)
+        def currentPath = sh(script: "pwd", returnStdout: true).trim()
+        def dumpsFileName = sprintf('coredumps-%1$s.tar',
+          [GIT_COMMIT.substring(0,8)])
 
-      // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
-      sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} {} \\;")
+        // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
+        sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} {} \\;")
 
-      withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
-        sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
+        withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
+          sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
+        }
+        echo "Build failed! See core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
       }
       if (currentBuild.currentResult == "SUCCESS" && GIT_LOCAL_BRANCH ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -8,7 +8,7 @@ def linuxPostStep() {
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find ${$WORKSPACE} -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\+ \\;")
+        sh(script: "find ${WORKSPACE} -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\+ \\;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -11,11 +11,12 @@ def linuxPostStep() {
 
         // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
         sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvfj ${dumpsFileName} {} \\;")
-
-        withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
-          sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
+        if( fileExists(dumpsFileName)) {
+          withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
+            sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
+          }
+          echo "Build is not SUCCESS! See core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
         }
-        echo "Build is not SUCCESS! See core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
       }
       if (currentBuild.currentResult == "SUCCESS" && GIT_LOCAL_BRANCH ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -1,6 +1,18 @@
 def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
+      // handling coredumps (if tests crashed)
+      def currentPath = sh(script: "pwd", returnStdout: true).trim()
+      def dumpsFileName = sprintf('coredumps-%1$s.zip',
+        [commit.substring(0,8)])
+
+      sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
+
+      withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
+        artifactServers.each {
+          sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://${it}/repository/artifacts/iroha/coredumps/${dumpsFileName}")
+        }
+      }
       if (currentBuild.currentResult == "SUCCESS" && GIT_LOCAL_BRANCH ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"
         def commit = env.GIT_COMMIT

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -8,7 +8,7 @@ def linuxPostStep() {
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find ${$WORKSPACE} -type f -name '*.coredump' -exec tar -rvfj ${dumpsFileName} {} \\;")
+        sh(script: "find ${$WORKSPACE} -type f -name '*.coredump' -exec tar -rvfj ${dumpsFileName} {} \\+ \\;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -8,7 +8,7 @@ def linuxPostStep() {
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find . -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\;")
+        sh(script: "find . -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\+;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -1,6 +1,8 @@
 def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
+      // stop write core dumps
+      sh "bash -c 'ulimit -c 0'"
       if (currentBuild.currentResult != "SUCCESS") {
         // handling coredumps (if tests crashed)
         def currentPath = sh(script: "pwd", returnStdout: true).trim()
@@ -8,12 +10,12 @@ def linuxPostStep() {
           [GIT_COMMIT.substring(0,8)])
 
         // sh(script: "find ${currentPath} -type f -name '*.coredump' | zip -j ${dumpsFileName} -@")
-        sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvf ${dumpsFileName} {} \\;")
+        sh(script: "find ${currentPath} -type f -name '*.coredump' -exec tar -rvfj ${dumpsFileName} {} \\;")
 
         withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
           sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
         }
-        echo "Build failed! See core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
+        echo "Build is not SUCCESS! See core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
       }
       if (currentBuild.currentResult == "SUCCESS" && GIT_LOCAL_BRANCH ==~ /(master|develop)/) {
         def artifacts = load ".jenkinsci/artifacts.groovy"

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -8,7 +8,7 @@ def linuxPostStep() {
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find ${$WORKSPACE} -type f -name '*.coredump' -exec tar -rvfj ${dumpsFileName} {} \\+ \\;")
+        sh(script: "find ${$WORKSPACE} -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\+ \\;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -3,12 +3,12 @@ def linuxPostStep() {
     try {
       // stop write core dumps
       sh "ulimit -c 0"
+      // handling coredumps (if tests crashed)
       if (currentBuild.currentResult != "SUCCESS" && params.coredump) {
-        // handling coredumps (if tests crashed)
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
           [GIT_COMMIT.substring(0,8)])
 
-        sh(script: "find ${WORKSPACE} -type f -name '*.coredump' -exec tar -cjvf ${dumpsFileName} {} \\+ \\;")
+        sh(script: "find . -type f -name '*.coredump'-exec tar -cjvf ${dumpsFileName} {} \\;")
         if( fileExists(dumpsFileName)) {
           withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
             sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")

--- a/.jenkinsci/linux-post-step.groovy
+++ b/.jenkinsci/linux-post-step.groovy
@@ -2,7 +2,7 @@ def linuxPostStep() {
   timeout(time: 600, unit: "SECONDS") {
     try {
       // stop write core dumps
-      sh "bash -c 'ulimit -c 0'"
+      sh "ulimit -c 0"
       if (currentBuild.currentResult != "SUCCESS" && params.coredump) {
         // handling coredumps (if tests crashed)
         def dumpsFileName = sprintf('coredumps-%1$s.bzip2',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ properties([parameters([
   booleanParam(defaultValue: true, description: 'Build docs', name: 'Doxygen'),
   booleanParam(defaultValue: true, description: 'Sanitize address;leak', name: 'sanitize'),
   booleanParam(defaultValue: false, description: 'Build fuzzing, but do not run tests', name: 'fuzzing'),
+  booleanParam(defaultValue: true, description: 'Collect coredumps', name: 'coredump'),
   string(defaultValue: '8', description: 'Expect ~3GB memory consumtion per CPU core', name: 'PARALLELISM')])])
 
 

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -24,7 +24,7 @@ using namespace framework::test_subscriber;
 static size_t num_peers = 1, my_num = 0;
 
 auto mk_local_peer(uint64_t num) {
-  auto address = "0.0.0.0:--" + std::to_string(num);
+  auto address = "0.0.0.0:" + std::to_string(num);
   return iroha::consensus::yac::mk_peer(address);
 }
 
@@ -62,7 +62,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
   uint64_t delay = 3 * 1000;
   std::shared_ptr<Yac> yac;
 
-  static const size_t port = 505410;
+  static const size_t port = 50541;
 
   ConsensusSunnyDayTest() : my_peer(mk_local_peer(port + my_num)) {
     for (decltype(num_peers) i = 0; i < num_peers; ++i) {

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -24,7 +24,7 @@ using namespace framework::test_subscriber;
 static size_t num_peers = 1, my_num = 0;
 
 auto mk_local_peer(uint64_t num) {
-  auto address = "0.0.0.0:" + std::to_string(num);
+  auto address = "0.0.0.0:--" + std::to_string(num);
   return iroha::consensus::yac::mk_peer(address);
 }
 
@@ -62,7 +62,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
   uint64_t delay = 3 * 1000;
   std::shared_ptr<Yac> yac;
 
-  static const size_t port = 50541;
+  static const size_t port = 505410;
 
   ConsensusSunnyDayTest() : my_peer(mk_local_peer(port + my_num)) {
     for (decltype(num_peers) i = 0; i < num_peers; ++i) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR allows to archive and upload all core dumps to nexus server
All files will be stored at [/artifacts/iroha/coredumps/](https://nexus.iroha.tech/#browse/browse:artifacts:iroha%2Fcoredumps)
[Example file](https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/coredumps-959fb10e.tar)
Task: [DOPS-198](https://soramitsu.atlassian.net/browse/DOPS-198)
### Benefits

Easy debug for failed tests

### Possible Drawbacks 

`ulimit -c unlimited` settings doesn't restrict size of core dump. In theory, it might be too large

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
