### PR TITLE
Comments on reworking integration tests

### DIFF
--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -22,7 +22,7 @@ class AddAssetQuantity : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 17.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given some user with can_add_asset_qty permission
@@ -41,7 +41,7 @@ TEST_F(AddAssetQuantity, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a  integration test
+ * TODO mboldyrev 17.01.2019 IR-203 convert to an integration test
  *
  * @given some user without can_add_asset_qty permission
  * @when execute tx with AddAssetQuantity command
@@ -63,7 +63,7 @@ TEST_F(AddAssetQuantity, NoPermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ * TODO mboldyrev 17.01.2019 IR-203 convert to a field validator unit test
  *
  * @given pair of users with all required permissions
  * @when execute tx with AddAssetQuantity command with negative amount
@@ -82,7 +82,7 @@ TEST_F(AddAssetQuantity, NegativeAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * TODO mboldyrev 17.01.2019 IR-203 seems can be removed (covered by field
  * validator test and the above test)
  *
  * @given pair of users with all required permissions
@@ -102,7 +102,7 @@ TEST_F(AddAssetQuantity, ZeroAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 17.01.2019 IR-203 remove, covered by
  * postgres_executor_test AddAccountAssetTest.Uint256Overflow
  *
  * @given pair of users with all required permissions
@@ -135,7 +135,7 @@ TEST_F(AddAssetQuantity, Uint256DestOverflow) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 17.01.2019 IR-203 remove, covered by
  * postgres_executor_test AddAccountAssetTest.InvalidAsset
  *
  * @given some user with all required permissions

--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -22,6 +22,9 @@ class AddAssetQuantity : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given some user with can_add_asset_qty permission
  * @when execute tx with AddAssetQuantity command
  * @then there is the tx in proposal
@@ -38,6 +41,8 @@ TEST_F(AddAssetQuantity, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a  integration test
+ *
  * @given some user without can_add_asset_qty permission
  * @when execute tx with AddAssetQuantity command
  * @then verified proposal is empty
@@ -58,6 +63,8 @@ TEST_F(AddAssetQuantity, NoPermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with AddAssetQuantity command with negative amount
  * @then the tx hasn't passed stateless validation
@@ -75,6 +82,9 @@ TEST_F(AddAssetQuantity, NegativeAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * validator test and the above test)
+ *
  * @given pair of users with all required permissions
  * @when execute tx with AddAssetQuantity command with zero amount
  * @then the tx hasn't passed stateless validation
@@ -92,6 +102,9 @@ TEST_F(AddAssetQuantity, ZeroAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test AddAccountAssetTest.Uint256Overflow
+ *
  * @given pair of users with all required permissions
  * @when execute two txes with AddAssetQuantity command with amount more than a
  * uint256 max half
@@ -122,6 +135,9 @@ TEST_F(AddAssetQuantity, Uint256DestOverflow) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test AddAccountAssetTest.InvalidAsset
+ *
  * @given some user with all required permissions
  * @when execute tx with AddAssetQuantity command with nonexistent asset
  * @then verified proposal is empty

--- a/test/integration/acceptance/add_signatory_test.cpp
+++ b/test/integration/acceptance/add_signatory_test.cpp
@@ -37,6 +37,9 @@ class AddSignatory : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * C224 Add existing public key of other user
  * @given some user with CanAddSignatory permission and a second user
  * @when execute tx with AddSignatory where the first is a creator and the
@@ -70,6 +73,9 @@ TEST_F(AddSignatory, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test AddSignatory.NoPerms
+ *
  * C228 AddSignatory without such permissions
  * @given some user without CanAddSignatory permission and a second user
  * @when execute tx with AddSignatory where the first is a creator and the
@@ -88,6 +94,9 @@ TEST_F(AddSignatory, NoPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test AddSignatory.ValidGrantablePerms
+ *
  * C225 Add signatory to other user
  * C227 Add signatory to an account, which granted permission to add it, and add
  *      the same public key
@@ -115,6 +124,8 @@ TEST_F(AddSignatory, GrantedPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ *
  * C226 Add signatory to account, which isn't granted such permission
  * @given some user with CanAddMySignatory permission and a second user without
           granted CanAddMySignatory
@@ -136,6 +147,8 @@ TEST_F(AddSignatory, NonGrantedPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ *
  * C222 Add signatory to non-existing account ID
  * @given some user with CanAddMySignatory permission
  * @when execute tx with AddSignatory with inexistent user
@@ -152,9 +165,11 @@ TEST_F(AddSignatory, NonExistentUser) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * C223 Add invalid public key
  * @given some user with CanAddMySignatory permission
- * @when execute tx with AddSignatory with inexistent public key
+ * @when execute tx with AddSignatory with incorrectly formed public key
  * @then the tx is stateless invalid
  */
 TEST_F(AddSignatory, InvalidKey) {
@@ -169,9 +184,11 @@ TEST_F(AddSignatory, InvalidKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ *
  * @given some user with CanAddMySignatory permission
- * @when execute tx with AddSignatory with a valid key which isn't associated
- *       with any user
+ * @when execute tx with AddSignatory with a correctly formed key which isn't
+ * associated with any user
  * @then there is no tx in proposal
  */
 TEST_F(AddSignatory, NonExistedKey) {

--- a/test/integration/acceptance/add_signatory_test.cpp
+++ b/test/integration/acceptance/add_signatory_test.cpp
@@ -37,7 +37,7 @@ class AddSignatory : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * C224 Add existing public key of other user
@@ -73,7 +73,7 @@ TEST_F(AddSignatory, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-204 remove, covered by
  * postgres_executor_test AddSignatory.NoPerms
  *
  * C228 AddSignatory without such permissions
@@ -94,7 +94,7 @@ TEST_F(AddSignatory, NoPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-204 remove, covered by
  * postgres_executor_test AddSignatory.ValidGrantablePerms
  *
  * C225 Add signatory to other user
@@ -124,7 +124,7 @@ TEST_F(AddSignatory, GrantedPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-204 convert to a SFV integration test
  *
  * C226 Add signatory to account, which isn't granted such permission
  * @given some user with CanAddMySignatory permission and a second user without
@@ -147,7 +147,7 @@ TEST_F(AddSignatory, NonGrantedPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-204 convert to a SFV integration test
  *
  * C222 Add signatory to non-existing account ID
  * @given some user with CanAddMySignatory permission
@@ -165,7 +165,7 @@ TEST_F(AddSignatory, NonExistentUser) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-204 remove, covered by field validator test
  *
  * C223 Add invalid public key
  * @given some user with CanAddMySignatory permission
@@ -184,7 +184,7 @@ TEST_F(AddSignatory, InvalidKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-204 convert to a SFV integration test
  *
  * @given some user with CanAddMySignatory permission
  * @when execute tx with AddSignatory with a correctly formed key which isn't

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -24,6 +24,9 @@ class CreateAccount : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given some user with can_create_account permission
  * @when execute tx with CreateAccount command
  * @then there is the tx in proposal
@@ -41,6 +44,9 @@ TEST_F(CreateAccount, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NoPerms
+ *
  * @given some user without can_create_account permission
  * @when execute tx with CreateAccount command
  * @then verified proposal is empty
@@ -62,6 +68,9 @@ TEST_F(CreateAccount, NoPermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NoDomain
+ *
  * @given some user with can_create_account permission
  * @when execute tx with CreateAccount command with nonexistent domain
  * @then verified proposal is empty
@@ -84,6 +93,9 @@ TEST_F(CreateAccount, NoDomain) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NameExists
+ *
  * @given some user with can_create_account permission
  * @when execute tx with CreateAccount command with already existing username
  * @then verified proposal is empty
@@ -106,6 +118,9 @@ TEST_F(CreateAccount, ExistingName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * validator test)
+ *
  * @given some user with can_create_account permission
  * @when execute tx with CreateAccount command with maximum available length
  * @then there is the tx in proposal
@@ -123,8 +138,11 @@ TEST_F(CreateAccount, MaxLenName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * validator test)
+ *
  * @given some user with can_create_account permission
- * @when execute tx with CreateAccount command with too long length
+ * @when execute tx with CreateAccount command with too long account length
  * @then the tx hasn't passed stateless validation
  *       (aka skipProposal throws)
  */
@@ -140,6 +158,9 @@ TEST_F(CreateAccount, TooLongName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * validator test and the above test)
+ *
  * @given some user with can_create_account permission
  * @when execute tx with CreateAccount command with empty user name
  * @then the tx hasn't passed stateless validation

--- a/test/integration/acceptance/create_account_test.cpp
+++ b/test/integration/acceptance/create_account_test.cpp
@@ -24,7 +24,7 @@ class CreateAccount : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given some user with can_create_account permission
@@ -44,7 +44,7 @@ TEST_F(CreateAccount, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-205 remove, covered by
  * postgres_executor_test CreateAccount.NoPerms
  *
  * @given some user without can_create_account permission
@@ -68,7 +68,7 @@ TEST_F(CreateAccount, NoPermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-205 remove, covered by
  * postgres_executor_test CreateAccount.NoDomain
  *
  * @given some user with can_create_account permission
@@ -93,7 +93,7 @@ TEST_F(CreateAccount, NoDomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-205 remove, covered by
  * postgres_executor_test CreateAccount.NameExists
  *
  * @given some user with can_create_account permission
@@ -118,7 +118,7 @@ TEST_F(CreateAccount, ExistingName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * TODO mboldyrev 18.01.2019 IR-205 seems can be removed (covered by field
  * validator test)
  *
  * @given some user with can_create_account permission
@@ -138,7 +138,7 @@ TEST_F(CreateAccount, MaxLenName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * TODO mboldyrev 18.01.2019 IR-205 seems can be removed (covered by field
  * validator test)
  *
  * @given some user with can_create_account permission
@@ -158,7 +158,7 @@ TEST_F(CreateAccount, TooLongName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * TODO mboldyrev 18.01.2019 IR-205 seems can be removed (covered by field
  * validator test and the above test)
  *
  * @given some user with can_create_account permission

--- a/test/integration/acceptance/create_asset_test.cpp
+++ b/test/integration/acceptance/create_asset_test.cpp
@@ -29,15 +29,15 @@ class CreateAssetFixture : public AcceptanceFixture {
 /*
  * With the current implementation of crateAsset method of TransactionBuilder
  * that is not possible to create tests for the following cases:
- * C237 Create asset with a negative precision
- *   because the current implementation of TransactionBuilder does not
- *   allow to pass negative value on a type level.
  * C238 Create asset with overflow of precision data type
  *   because the current implementation of TransactionBuilder does not
  *   allow to pass oversized value on a type level.
  */
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given some user with can_create_asset permission
  * @when the user tries to create an asset
  * @then asset is successfully created
@@ -66,6 +66,9 @@ TEST_F(CreateAssetFixture, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV unit test (this one has more
+ * test cases than its duplicate field validator test)
+ *
  * C235 Create asset with an empty name
  * C236 Create asset with boundary values per name validation
  * @given some user with can_create_asset permission
@@ -86,6 +89,9 @@ TEST_F(CreateAssetFixture, IllegalCharactersInName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NameNotUnique
+ *
  * C234 Create asset with an existing id (name)
  * @given a user with can_create_asset permission
  * @when the user tries to create asset that already exists
@@ -111,6 +117,8 @@ TEST_F(CreateAssetFixture, ExistingName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ *
  * C234a Create asset with an existing id (name) but different precision
  * @given a user with can_create_asset permission
  * @when the user tries to create asset that already exists but with different
@@ -138,6 +146,9 @@ TEST_F(CreateAssetFixture, ExistingNameDifferentPrecision) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NoPerms
+ *
  * C239 CreateAsset without such permissions
  * @given a user without can_create_asset permission
  * @when the user tries to create asset
@@ -163,6 +174,9 @@ TEST_F(CreateAssetFixture, WithoutPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateAccount.NoDomain
+ *
  * @given a user with can_create_asset permission
  * @when the user tries to create asset in valid but non existing domain
  * @then stateful validation will be failed
@@ -188,6 +202,9 @@ TEST_F(CreateAssetFixture, ValidNonExistingDomain) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV unit test (this one has more
+ * test cases than its duplicate field validator test)
+ *
  * @given a user with can_create_asset permission
  * @when the user tries to create an asset in a domain with illegal characters
  * @then stateless validation failed

--- a/test/integration/acceptance/create_asset_test.cpp
+++ b/test/integration/acceptance/create_asset_test.cpp
@@ -35,7 +35,7 @@ class CreateAssetFixture : public AcceptanceFixture {
  */
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given some user with can_create_asset permission
@@ -66,7 +66,7 @@ TEST_F(CreateAssetFixture, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV unit test (this one has more
+ * TODO mboldyrev 18.01.2019 IR-206 convert to a SLV unit test (this one has more
  * test cases than its duplicate field validator test)
  *
  * C235 Create asset with an empty name
@@ -89,7 +89,7 @@ TEST_F(CreateAssetFixture, IllegalCharactersInName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-206 remove, covered by
  * postgres_executor_test CreateAccount.NameNotUnique
  *
  * C234 Create asset with an existing id (name)
@@ -117,7 +117,7 @@ TEST_F(CreateAssetFixture, ExistingName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-206 convert to a SFV integration test
  *
  * C234a Create asset with an existing id (name) but different precision
  * @given a user with can_create_asset permission
@@ -146,7 +146,7 @@ TEST_F(CreateAssetFixture, ExistingNameDifferentPrecision) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-206 remove, covered by
  * postgres_executor_test CreateAccount.NoPerms
  *
  * C239 CreateAsset without such permissions
@@ -174,7 +174,7 @@ TEST_F(CreateAssetFixture, WithoutPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-206 remove, covered by
  * postgres_executor_test CreateAccount.NoDomain
  *
  * @given a user with can_create_asset permission
@@ -202,7 +202,7 @@ TEST_F(CreateAssetFixture, ValidNonExistingDomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV unit test (this one has more
+ * TODO mboldyrev 18.01.2019 IR-206 convert to a SLV unit test (this one has more
  * test cases than its duplicate field validator test)
  *
  * @given a user with can_create_asset permission

--- a/test/integration/acceptance/create_domain_test.cpp
+++ b/test/integration/acceptance/create_domain_test.cpp
@@ -22,7 +22,7 @@ class CreateDomain : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given some user with can_create_domain permission
@@ -41,7 +41,7 @@ TEST_F(CreateDomain, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by
  * postgres_executor_test CreateDomain.NoPerms
  *
  * @given some user without can_create_domain permission
@@ -64,7 +64,7 @@ TEST_F(CreateDomain, NoPermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by
  * postgres_executor_test CreateDomain.NoDefaultRole
  *
  * @given some user with can_create_domain permission
@@ -88,7 +88,7 @@ TEST_F(CreateDomain, NoRole) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by
  * postgres_executor_test CreateDomain.NameNotUnique
  *
  * @given some user with can_create_domain permission
@@ -111,7 +111,7 @@ TEST_F(CreateDomain, ExistingName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by field validator test
  *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with maximum available length
@@ -135,7 +135,7 @@ TEST_F(CreateDomain, MaxLenName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by field validator test
  *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with too long length
@@ -153,7 +153,7 @@ TEST_F(CreateDomain, TooLongName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by field validator test
  *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with empty domain name
@@ -172,7 +172,7 @@ TEST_F(CreateDomain, EmptyName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-207 remove, covered by field validator test
  *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with empty role name

--- a/test/integration/acceptance/create_domain_test.cpp
+++ b/test/integration/acceptance/create_domain_test.cpp
@@ -22,6 +22,9 @@ class CreateDomain : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command
  * @then there is the tx in proposal
@@ -38,6 +41,9 @@ TEST_F(CreateDomain, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateDomain.NoPerms
+ *
  * @given some user without can_create_domain permission
  * @when execute tx with CreateDomain command
  * @then verified proposal is empty
@@ -58,6 +64,9 @@ TEST_F(CreateDomain, NoPermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateDomain.NoDefaultRole
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with nonexistent role
  * @then verified proposal is empty
@@ -79,6 +88,9 @@ TEST_F(CreateDomain, NoRole) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test CreateDomain.NameNotUnique
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with already existing domain
  * @then verified proposal is empty
@@ -99,6 +111,8 @@ TEST_F(CreateDomain, ExistingName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with maximum available length
  * @then there is the tx in proposal
@@ -121,6 +135,8 @@ TEST_F(CreateDomain, MaxLenName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with too long length
  * @then the tx hasn't passed stateless validation
@@ -137,6 +153,8 @@ TEST_F(CreateDomain, TooLongName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with empty domain name
  * @then the tx hasn't passed stateless validation
@@ -154,6 +172,8 @@ TEST_F(CreateDomain, EmptyName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_domain permission
  * @when execute tx with CreateDomain command with empty role name
  * @then the tx hasn't passed stateless validation

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -37,6 +37,9 @@ class CreateRole : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command
  * @then there is the tx in proposal
@@ -56,6 +59,8 @@ TEST_F(CreateRole, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? SFV covered by CreateRole.NoPerms
+ *
  * @given some user without can_create_role permission
  * @when execute tx with CreateRole command
  * @then there is an empty verified proposal
@@ -76,6 +81,8 @@ TEST_F(CreateRole, HaveNoPerms) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with empty role
  * @then the tx hasn't passed stateless validation
@@ -93,6 +100,8 @@ TEST_F(CreateRole, EmptyRole) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with empty permission
  * @then the tx hasn't passed stateless validation
@@ -111,6 +120,8 @@ TEST_F(CreateRole, EmptyPerms) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with too long role name
  * @then the tx hasn't passed stateless validation
@@ -129,6 +140,8 @@ TEST_F(CreateRole, LongRoleName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with maximal role name size
  * @then the tx is comitted
@@ -146,6 +159,8 @@ TEST_F(CreateRole, MaxLenRoleName) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * TODO 15/05/2018 andrei: IR-1267 fix builders setting default value for
  * nonexisting permissions
  * @given some user with can_create_role permission
@@ -165,6 +180,8 @@ TEST_F(CreateRole, DISABLED_NonexistentPerm) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? SFV covered by CreateRole.NameNotUnique
+ *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with existing role name
  * @then there is an empty verified proposal

--- a/test/integration/acceptance/create_role_test.cpp
+++ b/test/integration/acceptance/create_role_test.cpp
@@ -37,7 +37,7 @@ class CreateRole : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given some user with can_create_role permission
@@ -59,7 +59,7 @@ TEST_F(CreateRole, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? SFV covered by CreateRole.NoPerms
+ * TODO mboldyrev 18.01.2019 IR-208 remove, SFV covered by CreateRole.NoPerms
  *
  * @given some user without can_create_role permission
  * @when execute tx with CreateRole command
@@ -81,7 +81,7 @@ TEST_F(CreateRole, HaveNoPerms) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-208 remove, covered by field validator test
  *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with empty role
@@ -100,7 +100,7 @@ TEST_F(CreateRole, EmptyRole) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-208 remove, covered by field validator test
  *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with empty permission
@@ -120,7 +120,7 @@ TEST_F(CreateRole, EmptyPerms) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-208 remove, covered by field validator test
  *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with too long role name
@@ -140,7 +140,7 @@ TEST_F(CreateRole, LongRoleName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-208 remove, covered by field validator test
  *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with maximal role name size
@@ -159,7 +159,7 @@ TEST_F(CreateRole, MaxLenRoleName) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-208 remove, covered by field validator test
  *
  * TODO 15/05/2018 andrei: IR-1267 fix builders setting default value for
  * nonexisting permissions
@@ -180,7 +180,7 @@ TEST_F(CreateRole, DISABLED_NonexistentPerm) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? SFV covered by CreateRole.NameNotUnique
+ * TODO mboldyrev 18.01.2019 IR-208 remove, SFV covered by CreateRole.NameNotUnique
  *
  * @given some user with can_create_role permission
  * @when execute tx with CreateRole command with existing role name

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -13,7 +13,7 @@ static constexpr shared_model::interface::types::TransactionsNumberType
     kTxPageSize(10);
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-209 remove, covered by field validator test
  *
  * C346 Pass an empty asset id
  * @given a user with kGetAllAccAstTxs permission
@@ -30,7 +30,7 @@ TEST_F(AccountAssetTxsFixture, ReadEmptyAssetHavingAllTxsPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-209 convert to a SFV integration test
  * (no such test in postgres_query_executor_test)
  *
  * C347 Pass a non existing asset id
@@ -52,7 +52,7 @@ TEST_F(AccountAssetTxsFixture,
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-209 convert to a SFV integration test
  * (no such test in postgres_query_executor_test)
  *
  * @given a user with kGetAllAccAstTxs permission
@@ -75,7 +75,7 @@ TEST_F(AccountAssetTxsFixture, DISABLED_OwnTxsIncludingAddAssetQuantity) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-209 convert to a SFV integration test
  * (no such test in postgres_query_executor_test)
  *
  * @given a user with kGetAllAccAstTxs permission

--- a/test/integration/acceptance/get_account_asset_txs_test.cpp
+++ b/test/integration/acceptance/get_account_asset_txs_test.cpp
@@ -13,6 +13,8 @@ static constexpr shared_model::interface::types::TransactionsNumberType
     kTxPageSize(10);
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * C346 Pass an empty asset id
  * @given a user with kGetAllAccAstTxs permission
  * @when the user tries to retrieve a list of own asset transactions specifying
@@ -28,6 +30,9 @@ TEST_F(AccountAssetTxsFixture, ReadEmptyAssetHavingAllTxsPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (no such test in postgres_query_executor_test)
+ *
  * C347 Pass a non existing asset id
  * @given a user with kGetAllAccAstTxs permission
  * @when the user tries tor retrieve a list of own asset transactions specifying
@@ -47,6 +52,9 @@ TEST_F(AccountAssetTxsFixture,
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (no such test in postgres_query_executor_test)
+ *
  * @given a user with kGetAllAccAstTxs permission
  * @when the user tries to retrieve a list of own asset transactions, which
  * contain a transaction with addAssetQuantity command
@@ -67,6 +75,9 @@ TEST_F(AccountAssetTxsFixture, DISABLED_OwnTxsIncludingAddAssetQuantity) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (no such test in postgres_query_executor_test)
+ *
  * @given a user with kGetAllAccAstTxs permission
  * @when the user tries to retrieve a list of own asset transactions, which
  * contain a transaction with subtractAssetQuantity command

--- a/test/integration/acceptance/get_account_assets_test.cpp
+++ b/test/integration/acceptance/get_account_assets_test.cpp
@@ -27,7 +27,7 @@ auto getAccountAssetsQuantityChecker(int quantity) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-210 convert to a SFV integration test
  * (no such test in postgres_query_executor_test)
  *
  * @given a user with all required permissions

--- a/test/integration/acceptance/get_account_assets_test.cpp
+++ b/test/integration/acceptance/get_account_assets_test.cpp
@@ -27,6 +27,9 @@ auto getAccountAssetsQuantityChecker(int quantity) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (no such test in postgres_query_executor_test)
+ *
  * @given a user with all required permissions
  * @when GetAccountAssets is queried on the user with no assets
  * @then there is an AccountAssetResponse reporting no asset presence

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -141,7 +141,7 @@ class GetAccount : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by field validator test
  *
  * C321 Pass an empty account id
  * @given a user with all required permissions
@@ -156,7 +156,7 @@ TEST_F(GetAccount, EmptyAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by
  * postgres_query_executor_test GetAccountExecutorTest.InvalidNoAccount
  *
  * C320 Get an non-existing account
@@ -173,7 +173,7 @@ TEST_F(GetAccount, NonexistentAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -190,7 +190,7 @@ TEST_F(GetAccount, NoPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by
  * postgres_query_executor_test GetAccountExecutorTest.ValidMyAccount
  *
  * C322 Get my account with a CanGetMyAccount permission
@@ -203,7 +203,7 @@ TEST_F(GetAccount, WithGetMyPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -218,7 +218,7 @@ TEST_F(GetAccount, WithGetDomainPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -233,7 +233,7 @@ TEST_F(GetAccount, WithGetAllPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -251,7 +251,7 @@ TEST_F(GetAccount, NoPermissionOtherAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -269,7 +269,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by
  * postgres_query_executor_test GetAccountExecutorTest.ValidMyAccount
  *
  * C318 Get an account from the domain having CanGetDomainAccounts
@@ -286,7 +286,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by
  * postgres_query_executor_test GetAccountExecutorTest.ValidDomainAccount
  *
  * @given a user with GetAllAccounts permission and a user in the same domain
@@ -302,7 +302,7 @@ TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -320,7 +320,7 @@ TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *
@@ -338,7 +338,7 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-211 remove, covered by
  * postgres_query_executor_test GetAccountExecutorTest.InvalidDifferentDomain
  *
  * @given a user with rermissions to get domain accounts and a user in other
@@ -356,7 +356,7 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-211 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -141,6 +141,8 @@ class GetAccount : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * C321 Pass an empty account id
  * @given a user with all required permissions
  * @when GetAccount is queried on the empty account name
@@ -154,6 +156,9 @@ TEST_F(GetAccount, EmptyAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAccountExecutorTest.InvalidNoAccount
+ *
  * C320 Get an non-existing account
  * @given a user with all required permissions
  * @when GetAccount is queried on the user
@@ -168,6 +173,10 @@ TEST_F(GetAccount, NonexistentAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * C315 Get my account without a CanGetMyAccount permission
  * @given a user without any query-related permission
  * @when GetAccount is queried on the user
@@ -181,6 +190,9 @@ TEST_F(GetAccount, NoPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAccountExecutorTest.ValidMyAccount
+ *
  * C322 Get my account with a CanGetMyAccount permission
  * @given a user with GetMyAccount permission
  * @when GetAccount is queried on the user
@@ -191,6 +203,10 @@ TEST_F(GetAccount, WithGetMyPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * C316 Get my account with only CanGetDomainAccounts permission
  * @given a user with GetDomainAccounts permission
  * @when GetAccount is queried on the user
@@ -202,6 +218,10 @@ TEST_F(GetAccount, WithGetDomainPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * C317 Get my account with only CanGetAllAccounts permission
  * @given a user with GetAllAccounts permission
  * @when GetAccount is queried on the user
@@ -213,6 +233,10 @@ TEST_F(GetAccount, WithGetAllPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * @given a user without any permission and a user in the same domain
  * @when GetAccount is queried on the second user
  * @then query is stateful invalid response
@@ -227,6 +251,10 @@ TEST_F(GetAccount, NoPermissionOtherAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * @given a user with GetMyAccount permission and a user in the same domain
  * @when GetAccount is queried on the second user
  * @then query is stateful invalid response
@@ -241,6 +269,9 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAccountExecutorTest.ValidMyAccount
+ *
  * C318 Get an account from the domain having CanGetDomainAccounts
  * @given a user with GetDomainAccounts permission and a user in the same domain
  * @when GetAccount is queried on the second user
@@ -255,6 +286,9 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAccountExecutorTest.ValidDomainAccount
+ *
  * @given a user with GetAllAccounts permission and a user in the same domain
  * @when GetAccount is queried on the second user
  * @then there is a valid AccountResponse
@@ -268,7 +302,11 @@ TEST_F(GetAccount, WithGetAllPermissionOtherAccount) {
 }
 
 /**
- * @given a user with all required permissions and a user in other domain
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
+ * @given a user with no related permissions and a user in other domain
  * @when GetAccount is queried on the second user
  * @then query is stateful invalid response
  */
@@ -282,7 +320,11 @@ TEST_F(GetAccount, NoPermissionOtherAccountInterdomain) {
 }
 
 /**
- * @given a user with all required permissions and a user in other domain
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
+ * @given a user with permission to get own account and a user in other domain
  * @when GetAccount is queried on the second user
  * @then query is stateful invalid response
  */
@@ -296,7 +338,11 @@ TEST_F(GetAccount, WithGetMyPermissionOtherAccountInterdomain) {
 }
 
 /**
- * @given a user with all required permissions and a user in other domain
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAccountExecutorTest.InvalidDifferentDomain
+ *
+ * @given a user with rermissions to get domain accounts and a user in other
+ * domain
  * @when GetAccount is queried on the second user
  * @then query is stateful invalid response
  */
@@ -310,6 +356,10 @@ TEST_F(GetAccount, WithGetDomainPermissionOtherAccountInterdomain) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * C319 Get an account from another domain in the system having
  * CanGetAllAccounts
  * @given a user with all required permissions and a user in other domain

--- a/test/integration/acceptance/get_asset_info_test.cpp
+++ b/test/integration/acceptance/get_asset_info_test.cpp
@@ -97,6 +97,9 @@ class GetAssetInfo : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * C363 Get asset info with CanReadAssets permission
  * @given a user with GetMyAccount permission
  * @when GetAssetInfo is queried on the user
@@ -108,6 +111,9 @@ TEST_F(GetAssetInfo, DISABLED_Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * validator test)
+ *
  * C365 Pass an empty asset id
  * @given a user with all required permissions
  * @when GetAssetInfo is queried on the empty asset name
@@ -121,6 +127,9 @@ TEST_F(GetAssetInfo, EmptyAsset) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAssetInfoExecutorTest.InvalidNoAsset
+ *
  * C366 Pass a non-existing asset id
  * @given a user with all required permissions
  * @when GetAssetInfo is queried on the user
@@ -133,6 +142,10 @@ TEST_F(GetAssetInfo, NonexistentAsset) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetAssetInfoExecutorTest.Invalid
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * C364 Get asset info without CanReadAssets permission
  * @given a user without any query-related permission
  * @when GetAssetInfo is queried on the user

--- a/test/integration/acceptance/get_asset_info_test.cpp
+++ b/test/integration/acceptance/get_asset_info_test.cpp
@@ -97,7 +97,7 @@ class GetAssetInfo : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * C363 Get asset info with CanReadAssets permission
@@ -111,7 +111,7 @@ TEST_F(GetAssetInfo, DISABLED_Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 seems can be removed (covered by field
+ * TODO mboldyrev 18.01.2019 IR-212 seems can be removed (covered by field
  * validator test)
  *
  * C365 Pass an empty asset id
@@ -127,7 +127,7 @@ TEST_F(GetAssetInfo, EmptyAsset) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-212 remove, covered by
  * postgres_query_executor_test GetAssetInfoExecutorTest.InvalidNoAsset
  *
  * C366 Pass a non-existing asset id
@@ -142,7 +142,7 @@ TEST_F(GetAssetInfo, NonexistentAsset) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-212 remove, covered by
  * postgres_query_executor_test GetAssetInfoExecutorTest.Invalid
  * seems we should move the common_query_permissions_test to SFV integration
  *

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -16,7 +16,7 @@ using namespace shared_model;
 using namespace common_constants;
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * C369 Get role permissions by user with allowed GetRoles permission
@@ -43,7 +43,7 @@ TEST_F(AcceptanceFixture, CanGetRolePermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-213 remove, covered by
  * postgres_query_executor_test GetRolePermsExecutorTest.Invalid
  *
  * C370 Get role permissions without allowed GetRoles permission

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -16,6 +16,9 @@ using namespace shared_model;
 using namespace common_constants;
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * C369 Get role permissions by user with allowed GetRoles permission
  * @given a user with kGetRoles permission
  * @when the user send query with getRolePermissions request
@@ -40,6 +43,9 @@ TEST_F(AcceptanceFixture, CanGetRolePermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetRolePermsExecutorTest.Invalid
+ *
  * C370 Get role permissions without allowed GetRoles permission
  * @given a user without kGetRoles permission
  * @when the user send query with getRolePermissions request

--- a/test/integration/acceptance/get_roles_test.cpp
+++ b/test/integration/acceptance/get_roles_test.cpp
@@ -17,6 +17,9 @@ using namespace shared_model;
 using namespace common_constants;
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ *
  * @given a user with CanGetRoles permission
  * @when execute query with getRoles command
  * @then the query returns list of roles
@@ -47,6 +50,9 @@ TEST_F(AcceptanceFixture, CanGetRoles) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetRolesExecutorTest.Invalid
+ *
  * @given a user without CanGetRoles permission
  * @when execute query with getRoles command
  * @then there is no way to to get roles due to user hasn't permissions enough

--- a/test/integration/acceptance/get_roles_test.cpp
+++ b/test/integration/acceptance/get_roles_test.cpp
@@ -17,7 +17,7 @@ using namespace shared_model;
 using namespace common_constants;
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  *
  * @given a user with CanGetRoles permission
@@ -50,7 +50,7 @@ TEST_F(AcceptanceFixture, CanGetRoles) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-214 remove, covered by
  * postgres_query_executor_test GetRolesExecutorTest.Invalid
  *
  * @given a user without CanGetRoles permission

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -54,6 +54,10 @@ class GetTransactions : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * convert to a common SFV permissions integration test
+ *
  * @given some user without can_get_{my,all}_txs permissions
  * @when query GetTransactions of existing transaction of the user
  * @then stateful validation fail returned
@@ -79,6 +83,10 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidAllAccounts
+ * convert to a common SFV permissions integration test
+ *
  * @given some user with only can_get_all_txs permission
  * @when query GetTransactions of existing transaction of the user
  * @then receive TransactionsResponse with the transaction hash
@@ -107,6 +115,10 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidMyAccount
+ * convert to a common SFV permissions integration test
+ *
  * @given some user with only can_get_my_txs permission
  * @when query GetTransactions of existing transaction of the user
  * @then receive TransactionsResponse with the transaction hash
@@ -135,6 +147,9 @@ TEST_F(GetTransactions, HaveGetMyTx) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * query_processor_test QueryProcessorTest.QueryProcessorWithWrongKey
+ *
  * @given some user with only can_get_my_txs permission
  * @when query GetTransactions of existing transaction of the user, but with
  * invalid signatures
@@ -170,6 +185,9 @@ TEST_F(GetTransactions, InvalidSignatures) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ *
  * @given some user with only can_get_my_txs permission
  * @when query GetTransactions with nonexistent hash
  * @then Stateful invalid query response
@@ -199,6 +217,10 @@ TEST_F(GetTransactions, NonexistentHash) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_query_executor_test)
+ * seems we should move the common_query_permissions_test to SFV integration
+ *
  * @given some user with can_get_my_txs
  * @when query GetTransactions of existing transaction of the other user
  * @then TransactionsResponse with no transactions

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -54,7 +54,7 @@ class GetTransactions : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-215 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * convert to a common SFV permissions integration test
  *
@@ -83,7 +83,7 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-215 remove, covered by
  * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidAllAccounts
  * convert to a common SFV permissions integration test
  *
@@ -115,7 +115,7 @@ TEST_F(GetTransactions, HaveGetAllTx) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-215 remove, covered by
  * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidMyAccount
  * convert to a common SFV permissions integration test
  *
@@ -147,7 +147,7 @@ TEST_F(GetTransactions, HaveGetMyTx) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-215 remove, covered by
  * query_processor_test QueryProcessorTest.QueryProcessorWithWrongKey
  *
  * @given some user with only can_get_my_txs permission
@@ -185,7 +185,7 @@ TEST_F(GetTransactions, InvalidSignatures) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-215 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  *
  * @given some user with only can_get_my_txs permission
@@ -217,7 +217,7 @@ TEST_F(GetTransactions, NonexistentHash) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-215 convert to a SFV integration test
  * (not covered by postgres_query_executor_test)
  * seems we should move the common_query_permissions_test to SFV integration
  *

--- a/test/integration/acceptance/grant_permission_test.cpp
+++ b/test/integration/acceptance/grant_permission_test.cpp
@@ -13,7 +13,7 @@ using namespace shared_model::interface::permissions;
 using namespace common_constants;
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-216 remove, covered by
  * postgres_executor_test GrantPermissions.NoAccount
  *
  * C256 Grant permission to a non-existing account
@@ -41,7 +41,7 @@ TEST_F(GrantablePermissionsFixture, GrantToInexistingAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * TODO mboldyrev 18.01.2019 IR-216 transform to command executor storage
  * integration test
  * the part with queries is covered by permission SFV integration tests
  *
@@ -81,7 +81,7 @@ TEST_F(GrantablePermissionsFixture, GrantAddSignatoryPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * TODO mboldyrev 18.01.2019 IR-216 transform to command executor storage
  * integration test
  * the part with queries is covered by permission SFV integration tests
  *
@@ -139,7 +139,7 @@ TEST_F(GrantablePermissionsFixture, GrantRemoveSignatoryPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-216 remove, covered by
  * postgres_executor_test GrantPermissions.Valid
  * and permission tests
  *
@@ -192,7 +192,7 @@ TEST_F(GrantablePermissionsFixture, GrantSetQuorumPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * TODO mboldyrev 18.01.2019 IR-216 transform to command executor storage
  * integration test
  * the part with queries is covered by permission SFV integration tests
  *
@@ -230,7 +230,7 @@ TEST_F(GrantablePermissionsFixture, GrantSetAccountDetailPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * TODO mboldyrev 18.01.2019 IR-216 transform to command executor storage
  * integration test
  * the part with queries is covered by permission SFV integration tests
  *
@@ -276,7 +276,7 @@ TEST_F(GrantablePermissionsFixture, GrantTransferPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-216 remove, covered by
  * postgres_executor_test GrantPermissions.NoPerms
  * the part with queries is covered by permission SFV integration tests
  *
@@ -301,7 +301,7 @@ TEST_F(GrantablePermissionsFixture, GrantWithoutGrantPermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * TODO mboldyrev 18.01.2019 IR-216 transform to command executor storage
  * integration test
  *
  * C263 GrantPermission more than once

--- a/test/integration/acceptance/grant_permission_test.cpp
+++ b/test/integration/acceptance/grant_permission_test.cpp
@@ -13,6 +13,9 @@ using namespace shared_model::interface::permissions;
 using namespace common_constants;
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test GrantPermissions.NoAccount
+ *
  * C256 Grant permission to a non-existing account
  * @given an account with rights to grant rights to other accounts
  * @when the account grants rights to non-existing account
@@ -38,6 +41,10 @@ TEST_F(GrantablePermissionsFixture, GrantToInexistingAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * integration test
+ * the part with queries is covered by permission SFV integration tests
+ *
  * C257 Grant add signatory permission
  * @given an account with rights to grant rights to other accounts
  * AND the account grants add signatory rights to an existing account
@@ -74,6 +81,10 @@ TEST_F(GrantablePermissionsFixture, GrantAddSignatoryPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * integration test
+ * the part with queries is covered by permission SFV integration tests
+ *
  * C258 Grant remove signatory permission
  * @given an account with rights to grant rights to other accounts
  * AND the account grants add and remove signatory rights to an existing account
@@ -128,6 +139,10 @@ TEST_F(GrantablePermissionsFixture, GrantRemoveSignatoryPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test GrantPermissions.Valid
+ * and permission tests
+ *
  * C259 Grant set quorum permission
  * @given an account with rights to grant rights to other accounts
  * AND the account grants add signatory rights
@@ -177,6 +192,10 @@ TEST_F(GrantablePermissionsFixture, GrantSetQuorumPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * integration test
+ * the part with queries is covered by permission SFV integration tests
+ *
  * C260 Grant set account detail permission
  * @given an account with rights to grant rights to other accounts
  * AND the account grants set account detail permission to a permittee
@@ -211,6 +230,10 @@ TEST_F(GrantablePermissionsFixture, GrantSetAccountDetailPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * integration test
+ * the part with queries is covered by permission SFV integration tests
+ *
  * C261 Grant transfer permission
  * @given an account with rights to grant transfer of his/her assets
  * AND the account can receive assets
@@ -253,6 +276,10 @@ TEST_F(GrantablePermissionsFixture, GrantTransferPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test GrantPermissions.NoPerms
+ * the part with queries is covered by permission SFV integration tests
+ *
  * C262 GrantPermission without such permissions
  * @given an account !without! rights to grant rights to other accounts
  * @when the account grants rights to an existing account
@@ -274,6 +301,9 @@ TEST_F(GrantablePermissionsFixture, GrantWithoutGrantPermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 transform to command executor storage
+ * integration test
+ *
  * C263 GrantPermission more than once
  * @given an account with rights to grant rights to other accounts
  * AND an account that have already granted a permission to a permittee

--- a/test/integration/acceptance/invalid_fields_test.cpp
+++ b/test/integration/acceptance/invalid_fields_test.cpp
@@ -15,6 +15,8 @@ using namespace common_constants;
 class InvalidField : public AcceptanceFixture {};
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given tx with CreateAccount command and invalid signature size
  * @when send it
  * @then Torii returns stateless fail
@@ -31,6 +33,8 @@ TEST_F(InvalidField, Signature) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given tx with CreateAccount command and invalid pub key size
  * @when send it
  * @then Torii returns stateless fail

--- a/test/integration/acceptance/invalid_fields_test.cpp
+++ b/test/integration/acceptance/invalid_fields_test.cpp
@@ -15,7 +15,7 @@ using namespace common_constants;
 class InvalidField : public AcceptanceFixture {};
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-217 remove, covered by field validator test
  *
  * @given tx with CreateAccount command and invalid signature size
  * @when send it
@@ -33,7 +33,7 @@ TEST_F(InvalidField, Signature) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-217 remove, covered by field validator test
  *
  * @given tx with CreateAccount command and invalid pub key size
  * @when send it

--- a/test/integration/acceptance/queries_acceptance_test.cpp
+++ b/test/integration/acceptance/queries_acceptance_test.cpp
@@ -62,6 +62,9 @@ class QueriesAcceptanceTest : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (possibly including torii query processor)
+ *
  * @given query with a non-existent creator_account_id
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateful validation
@@ -74,6 +77,8 @@ TEST_F(QueriesAcceptanceTest, NonExistentCreatorId) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with an 1 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query returns list of roles
@@ -88,6 +93,8 @@ TEST_F(QueriesAcceptanceTest, OneHourOldTime) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with more than 24 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -105,6 +112,8 @@ TEST_F(QueriesAcceptanceTest, More24HourOldTime) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with less than 24 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query returns list of roles
@@ -120,6 +129,8 @@ TEST_F(QueriesAcceptanceTest, Less24HourOldTime) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with less than 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query returns list of roles
@@ -135,6 +146,8 @@ TEST_F(QueriesAcceptanceTest, LessFiveMinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query returns list of roles
@@ -149,6 +162,8 @@ TEST_F(QueriesAcceptanceTest, FiveMinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with more than 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -166,6 +181,8 @@ TEST_F(QueriesAcceptanceTest, MoreFiveMinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with 10 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -182,6 +199,10 @@ TEST_F(QueriesAcceptanceTest, TenMinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains invalid signature but valid public
  * key
  * @when execute any correct query with kGetRoles permissions
@@ -200,6 +221,10 @@ TEST_F(QueriesAcceptanceTest, InvalidSignValidPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains valid signature but invalid public
  * key
  * @when execute any correct query with kGetRoles permissions
@@ -218,6 +243,9 @@ TEST_F(QueriesAcceptanceTest, ValidSignInvalidPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * query_processor_test QueryProcessorTest.QueryProcessorWithWrongKey
+ *
  * @given query with Keypair which contains invalid signature and invalid public
  * key
  * @when execute any correct query with kGetRoles permissions
@@ -236,6 +264,10 @@ TEST_F(QueriesAcceptanceTest, FullyInvalidKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains empty signature and valid public key
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -252,6 +284,8 @@ TEST_F(QueriesAcceptanceTest, EmptySignValidPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given query with Keypair which contains valid signature and empty public key
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -268,6 +302,10 @@ TEST_F(QueriesAcceptanceTest, ValidSignEmptyPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains empty signature and empty public key
  * @when execute any correct query with kGetRoles permissions
  * @then the query should not pass stateless validation
@@ -285,6 +323,10 @@ TEST_F(QueriesAcceptanceTest, FullyEmptyPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains invalid signature and empty public
  * key
  * @when execute any correct query with kGetRoles permissions
@@ -307,6 +349,10 @@ TEST_F(QueriesAcceptanceTest, InvalidSignEmptyPubKeypair) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * including SignableModelValidator or even whole torii::QueryService
+ * and the crypto provider
+ *
  * @given query with Keypair which contains empty signature and invalid public
  * key
  * @when execute any correct query with kGetRoles permissions

--- a/test/integration/acceptance/queries_acceptance_test.cpp
+++ b/test/integration/acceptance/queries_acceptance_test.cpp
@@ -62,7 +62,7 @@ class QueriesAcceptanceTest : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a SFV integration test
  * (possibly including torii query processor)
  *
  * @given query with a non-existent creator_account_id
@@ -77,7 +77,7 @@ TEST_F(QueriesAcceptanceTest, NonExistentCreatorId) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with an 1 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -93,7 +93,7 @@ TEST_F(QueriesAcceptanceTest, OneHourOldTime) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with more than 24 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -112,7 +112,7 @@ TEST_F(QueriesAcceptanceTest, More24HourOldTime) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with less than 24 hour old UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -129,7 +129,7 @@ TEST_F(QueriesAcceptanceTest, Less24HourOldTime) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with less than 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -146,7 +146,7 @@ TEST_F(QueriesAcceptanceTest, LessFiveMinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -162,7 +162,7 @@ TEST_F(QueriesAcceptanceTest, FiveMinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with more than 5 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -181,7 +181,7 @@ TEST_F(QueriesAcceptanceTest, MoreFiveMinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with 10 minutes from future UNIX time
  * @when execute any correct query with kGetRoles permissions
@@ -199,7 +199,7 @@ TEST_F(QueriesAcceptanceTest, TenMinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a crypto provider unit test
  * Note a similar test: AcceptanceTest.TransactionInvalidPublicKey
  *
  * @given query with Keypair which contains invalid signature but valid public
@@ -220,7 +220,7 @@ TEST_F(QueriesAcceptanceTest, InvalidSignValidPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains valid signature but invalid public
  * key
@@ -240,7 +240,7 @@ TEST_F(QueriesAcceptanceTest, ValidSignInvalidPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a SFV integration test
  *
  * @given query with Keypair which contains invalid signature and invalid public
  * key
@@ -260,7 +260,7 @@ TEST_F(QueriesAcceptanceTest, FullyInvalidKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a crypto provider unit test
  * Note a similar test: AcceptanceTest.EmptySignatures
  *
  * @given query with Keypair which contains empty signature and valid public key
@@ -279,7 +279,7 @@ TEST_F(QueriesAcceptanceTest, EmptySignValidPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-218 remove, covered by field validator test
  *
  * @given query with Keypair which contains valid signature and empty public key
  * @when execute any correct query with kGetRoles permissions
@@ -297,7 +297,7 @@ TEST_F(QueriesAcceptanceTest, ValidSignEmptyPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains empty signature and empty public key
  * @when execute any correct query with kGetRoles permissions
@@ -316,7 +316,7 @@ TEST_F(QueriesAcceptanceTest, FullyEmptyPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains invalid signature and empty public
  * key
@@ -340,7 +340,7 @@ TEST_F(QueriesAcceptanceTest, InvalidSignEmptyPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-218 convert to a SFV integration test
  * including SignableModelValidator or even whole torii::QueryService
  * and the crypto provider, that verifies that a transaction failing the
  * crypto provider check is rejected.

--- a/test/integration/acceptance/queries_acceptance_test.cpp
+++ b/test/integration/acceptance/queries_acceptance_test.cpp
@@ -199,9 +199,8 @@ TEST_F(QueriesAcceptanceTest, TenMinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
- * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * Note a similar test: AcceptanceTest.TransactionInvalidPublicKey
  *
  * @given query with Keypair which contains invalid signature but valid public
  * key
@@ -221,9 +220,7 @@ TEST_F(QueriesAcceptanceTest, InvalidSignValidPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
- * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains valid signature but invalid public
  * key
@@ -243,8 +240,7 @@ TEST_F(QueriesAcceptanceTest, ValidSignInvalidPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
- * query_processor_test QueryProcessorTest.QueryProcessorWithWrongKey
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
  *
  * @given query with Keypair which contains invalid signature and invalid public
  * key
@@ -264,9 +260,8 @@ TEST_F(QueriesAcceptanceTest, FullyInvalidKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
- * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * Note a similar test: AcceptanceTest.EmptySignatures
  *
  * @given query with Keypair which contains empty signature and valid public key
  * @when execute any correct query with kGetRoles permissions
@@ -302,9 +297,7 @@ TEST_F(QueriesAcceptanceTest, ValidSignEmptyPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
- * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains empty signature and empty public key
  * @when execute any correct query with kGetRoles permissions
@@ -323,9 +316,7 @@ TEST_F(QueriesAcceptanceTest, FullyEmptyPubKeypair) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
- * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
  *
  * @given query with Keypair which contains invalid signature and empty public
  * key
@@ -351,7 +342,9 @@ TEST_F(QueriesAcceptanceTest, InvalidSignEmptyPubKeypair) {
 /**
  * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
  * including SignableModelValidator or even whole torii::QueryService
- * and the crypto provider
+ * and the crypto provider, that verifies that a transaction failing the
+ * crypto provider check is rejected.
+ *
  *
  * @given query with Keypair which contains empty signature and invalid public
  * key

--- a/test/integration/acceptance/query_permission_common_tests.cpp
+++ b/test/integration/acceptance/query_permission_common_tests.cpp
@@ -20,7 +20,7 @@ using QueryPermissionTestingTypes =
 TYPED_TEST_CASE(QueryPermissionFixture, QueryPermissionTestingTypes);
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-219 remove, covered by field validator test
  *
  * Get data from a non-existing account
  * @given a user with permission to read all accounts
@@ -41,7 +41,7 @@ TYPED_TEST(QueryPermissionFixture,
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-219 remove, covered by field validator test
  *
  * Pass an empty account id
  * @given a user with permission to read all accounts
@@ -60,7 +60,7 @@ TYPED_TEST(QueryPermissionFixture, ReadEmptyAccountHavingPermissionForAll) {
 }
 
 /*
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-219 convert to a SFV integration test
  *
  * Below are test cases that check different combinations of permission modes
  * (1 - no permissions,   2 - can_get_my_*,

--- a/test/integration/acceptance/query_permission_common_tests.cpp
+++ b/test/integration/acceptance/query_permission_common_tests.cpp
@@ -20,6 +20,8 @@ using QueryPermissionTestingTypes =
 TYPED_TEST_CASE(QueryPermissionFixture, QueryPermissionTestingTypes);
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * Get data from a non-existing account
  * @given a user with permission to read all accounts
  * @when tries to retrieve data from a non-existing
@@ -39,6 +41,8 @@ TYPED_TEST(QueryPermissionFixture,
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * Pass an empty account id
  * @given a user with permission to read all accounts
  * @when the user tries to retrieve data from an account with empty id
@@ -56,6 +60,8 @@ TYPED_TEST(QueryPermissionFixture, ReadEmptyAccountHavingPermissionForAll) {
 }
 
 /*
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ *
  * Below are test cases that check different combinations of permission modes
  * (1 - no permissions,   2 - can_get_my_*,
  *  3 - can_get_domain_*, 4 - can_get_all_*)

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -49,6 +49,10 @@ class QueryAcceptanceTest : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidMyAccount
+ * seems we should move common query permissions tests to SFV integration
+ *
  * @given some user with only can_get_my_txs permission
  * @when query GetTransactions of existing transaction of the user in parallel
  * @then receive TransactionsResponse with the transaction hash

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -49,7 +49,7 @@ class QueryAcceptanceTest : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-220 remove, covered by
  * postgres_query_executor_test GetTransactionsHashExecutorTest.ValidMyAccount
  * seems we should move common query permissions tests to SFV integration
  *

--- a/test/integration/acceptance/remove_signatory_test.cpp
+++ b/test/integration/acceptance/remove_signatory_test.cpp
@@ -36,7 +36,7 @@ class RemoveSignatory : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  * the second part of the test is covered by
  * postgres_executor_test RemoveSignatory.NoSuchSignatory
@@ -67,7 +67,7 @@ TEST_F(RemoveSignatory, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.NoPerms
  *
  * C263 RemoveSignatory without such permissions
@@ -92,7 +92,7 @@ TEST_F(RemoveSignatory, NoPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.ValidGrantablePerm
  *
  * C265 Remove signatory from granted account
@@ -124,7 +124,7 @@ TEST_F(RemoveSignatory, GrantedPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.NoPerms
  *
  * @given first user with CanRemoveMySignatory permission and second without it
@@ -152,7 +152,7 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.NoAccount
  *
  * @given some user with CanRemoveSignatory permission
@@ -171,7 +171,7 @@ TEST_F(RemoveSignatory, NonExistentUser) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by field validator test
  *
  * C266 Remove signatory with an incorrectly formed public key
  * @given some user with CanRemoveSignatory permission
@@ -189,7 +189,7 @@ TEST_F(RemoveSignatory, InvalidKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.NoSuchSignatory
  *
  * @given some user with CanRemoveSignatory permission
@@ -208,7 +208,7 @@ TEST_F(RemoveSignatory, NonExistedKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-221 remove, covered by
  * postgres_executor_test RemoveSignatory.SignatoriesLessThanQuorum
  *
  * C268 Remove signatory so that account may have less signatories than the

--- a/test/integration/acceptance/remove_signatory_test.cpp
+++ b/test/integration/acceptance/remove_signatory_test.cpp
@@ -36,6 +36,11 @@ class RemoveSignatory : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ * the second part of the test is covered by
+ * postgres_executor_test RemoveSignatory.NoSuchSignatory
+ *
  * C264 Remove signatory from own account
  * C267 Remove signatory more than once
  * @given some user with CanRemoveSignatory permission and its signatory
@@ -62,6 +67,9 @@ TEST_F(RemoveSignatory, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.NoPerms
+ *
  * C263 RemoveSignatory without such permissions
  * @given some user without CanRemoveSignatory permission and its signatory
  * @when execute tx with RemoveSignatory where the first is a creator and the
@@ -84,6 +92,9 @@ TEST_F(RemoveSignatory, NoPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.ValidGrantablePerm
+ *
  * C265 Remove signatory from granted account
  * @given some user with CanRemoveMySignatory permission and its signatory with
  *        granted CanRemoveMySignatory
@@ -113,10 +124,13 @@ TEST_F(RemoveSignatory, GrantedPermission) {
 }
 
 /**
- * @given some user with CanRemoveMySignatory permission and its signatory
- *        without granted CanRemoveMySignatory
- * @when execute tx with RemoveSignatory where the second is a creator and the
- *       second's key is removed as a signatory
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.NoPerms
+ *
+ * @given first user with CanRemoveMySignatory permission and second without it
+ *        second user's key is added to first user's signatories
+ * @when second user executes RemoveSignatory to remove his key from the first
+ *       user's signatories
  * @then there is no tx in proposal
  */
 TEST_F(RemoveSignatory, NonGrantedPermission) {
@@ -138,6 +152,9 @@ TEST_F(RemoveSignatory, NonGrantedPermission) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.NoAccount
+ *
  * @given some user with CanRemoveSignatory permission
  * @when execute tx with RemoveSignatory with inexistent user
  * @then there is no tx in proposal
@@ -154,7 +171,9 @@ TEST_F(RemoveSignatory, NonExistentUser) {
 }
 
 /**
- * C266 Remove signatory with an invalid public key
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
+ * C266 Remove signatory with an incorrectly formed public key
  * @given some user with CanRemoveSignatory permission
  * @when execute tx with RemoveSignatory with invalid public key
  * @then the tx is stateless invalid
@@ -170,6 +189,9 @@ TEST_F(RemoveSignatory, InvalidKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.NoSuchSignatory
+ *
  * @given some user with CanRemoveSignatory permission
  * @when execute tx with RemoveSignatory with a key which isn't associated with
  *       any user
@@ -186,6 +208,9 @@ TEST_F(RemoveSignatory, NonExistedKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RemoveSignatory.SignatoriesLessThanQuorum
+ *
  * C268 Remove signatory so that account may have less signatories than the
  *      quorum
  * @given some user with CanRemoveSignatory permission, which account quorum is

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -15,7 +15,7 @@ using namespace shared_model::interface::permissions;
 using namespace common_constants;
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  * also covered by postgres_executor_test RevokePermission.Valid
  *
@@ -48,7 +48,7 @@ TEST_F(GrantablePermissionsFixture, RevokeFromNonExistingAccount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-222 convert to a SFV integration test
  * (no such test in postgres_executor_test)
  *
  * C271 Revoke permission more than once
@@ -89,7 +89,7 @@ TEST_F(GrantablePermissionsFixture, RevokeTwice) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-222 remove, covered by
  * postgres_executor_test RevokePermission.NoPerms
  *
  * Revoke without permission
@@ -322,7 +322,7 @@ namespace grantables {
   TYPED_TEST_CASE(GrantRevokeFixture, GrantablePermissionsTypes);
 
   /**
-   * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+   * TODO mboldyrev 18.01.2019 IR-222 convert to a SFV integration test
    *
    * The test iterates over helper types (GrantablePermissionsTypes).
    * That helper types contain information about required Grantable and Role

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -15,6 +15,10 @@ using namespace shared_model::interface::permissions;
 using namespace common_constants;
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ * also covered by postgres_executor_test RevokePermission.Valid
+ *
  * C269 Revoke permission from a non-existing account
  * @given ITF instance and only one account with can_grant permission
  * @when the account tries to revoke grantable permission from non-existing
@@ -44,6 +48,9 @@ TEST_F(GrantablePermissionsFixture, RevokeFromNonExistingAccount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (no such test in postgres_executor_test)
+ *
  * C271 Revoke permission more than once
  * @given ITF instance, two accounts, the first account has granted a permission
  * to the second
@@ -82,6 +89,9 @@ TEST_F(GrantablePermissionsFixture, RevokeTwice) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test RevokePermission.NoPerms
+ *
  * Revoke without permission
  * @given ITF instance, three accounts:
  *  - first account does not have any permissions
@@ -312,6 +322,8 @@ namespace grantables {
   TYPED_TEST_CASE(GrantRevokeFixture, GrantablePermissionsTypes);
 
   /**
+   * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+   *
    * The test iterates over helper types (GrantablePermissionsTypes).
    * That helper types contain information about required Grantable and Role
    * permissions for the test.

--- a/test/integration/acceptance/set_account_detail_test.cpp
+++ b/test/integration/acceptance/set_account_detail_test.cpp
@@ -49,7 +49,7 @@ class SetAccountDetail : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by
  * postgres_executor_test SetAccountDetail.Valid
  *
  * C274
@@ -69,7 +69,7 @@ TEST_F(SetAccountDetail, Self) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by
  * postgres_executor_test SetAccountDetail.NoAccount
  *
  * C273
@@ -90,7 +90,7 @@ TEST_F(SetAccountDetail, NonExistentUser) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by
  * postgres_executor_test SetAccountDetail.NoPerms
  *
  * C280
@@ -120,7 +120,7 @@ TEST_F(SetAccountDetail, WithoutNoPerm) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by
  * postgres_executor_test SetAccountDetail.ValidRolePerm
  *
  * @given a pair of users and first one with can_set_detail perm
@@ -145,7 +145,7 @@ TEST_F(SetAccountDetail, WithPerm) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by
  * postgres_executor_test SetAccountDetail.ValidGrantablePerm
  *
  * C275
@@ -185,7 +185,7 @@ TEST_F(SetAccountDetail, WithGrantablePerm) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ * TODO mboldyrev 18.01.2019 IR-223 convert to a field validator unit test
  *
  * C276
  * @given a user with required permission
@@ -205,7 +205,7 @@ TEST_F(SetAccountDetail, BigPossibleKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by field validator test
  *
  * C277
  * @given a user with required permission
@@ -224,7 +224,7 @@ TEST_F(SetAccountDetail, EmptyKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-223 remove, covered by field validator test
  *
  * C278
  * @given a user with required permission
@@ -244,7 +244,7 @@ TEST_F(SetAccountDetail, EmptyValue) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert the part with key to a field
+ * TODO mboldyrev 18.01.2019 IR-223 convert the part with key to a field
  * validator unit test; the part with value is covered by field validator test
  *
  * C279

--- a/test/integration/acceptance/set_account_detail_test.cpp
+++ b/test/integration/acceptance/set_account_detail_test.cpp
@@ -49,6 +49,9 @@ class SetAccountDetail : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetAccountDetail.Valid
+ *
  * C274
  * @given a user without can_set_detail permission
  * @when execute tx with SetAccountDetail command aimed to the user
@@ -66,6 +69,9 @@ TEST_F(SetAccountDetail, Self) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetAccountDetail.NoAccount
+ *
  * C273
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with inexistent user
@@ -84,6 +90,9 @@ TEST_F(SetAccountDetail, NonExistentUser) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetAccountDetail.NoPerms
+ *
  * C280
  * @given a pair of users and first one without permissions
  * @when the first one tries to use SetAccountDetail on the second
@@ -111,6 +120,9 @@ TEST_F(SetAccountDetail, WithoutNoPerm) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetAccountDetail.ValidRolePerm
+ *
  * @given a pair of users and first one with can_set_detail perm
  * @when the first one tries to use SetAccountDetail on the second
  * @then there is the tx in block
@@ -133,6 +145,9 @@ TEST_F(SetAccountDetail, WithPerm) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetAccountDetail.ValidGrantablePerm
+ *
  * C275
  * @given a pair of users
  *        @and second has been granted can_set_my_detail from the first
@@ -170,6 +185,8 @@ TEST_F(SetAccountDetail, WithGrantablePerm) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ *
  * C276
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with max key
@@ -188,6 +205,8 @@ TEST_F(SetAccountDetail, BigPossibleKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * C277
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with empty key
@@ -205,6 +224,8 @@ TEST_F(SetAccountDetail, EmptyKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * C278
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with empty value
@@ -223,6 +244,9 @@ TEST_F(SetAccountDetail, EmptyValue) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert the part with key to a field
+ * validator unit test; the part with value is covered by field validator test
+ *
  * C279
  * @given a user with required permission
  * @when execute tx with SetAccountDetail command with huge both key and value

--- a/test/integration/acceptance/set_account_quorum_test.cpp
+++ b/test/integration/acceptance/set_account_quorum_test.cpp
@@ -27,7 +27,7 @@ class QuorumFixture : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  * also covered by postgres_executor_test SetQuorum.Valid
  *
@@ -43,7 +43,7 @@ TEST_F(QuorumFixture, CanRaiseQuorum) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-224 remove, covered by
  * postgres_executor_test SetQuorum.LessSignatoriesThanNewQuorum
  *
  * @given a user with two signatories linked
@@ -60,7 +60,7 @@ TEST_F(QuorumFixture, CannotRaiseQuorumMoreThanSignatures) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-224 remove, covered by
  * postgres_executor_test SetQuorum.Valid
  *
  * @given a user with two signatories linked
@@ -84,7 +84,7 @@ TEST_F(QuorumFixture, CanLowerQuorum) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ * TODO mboldyrev 18.01.2019 IR-224 convert to a field validator unit test
  *
  * @given a user with two signatories linked
  * @when the user tries to set zero quorum

--- a/test/integration/acceptance/set_account_quorum_test.cpp
+++ b/test/integration/acceptance/set_account_quorum_test.cpp
@@ -27,6 +27,10 @@ class QuorumFixture : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ * also covered by postgres_executor_test SetQuorum.Valid
+ *
  * @given a user with two signatories linked
  * @when the user tries to set own quorum equal two
  * @then the transaction is committed
@@ -39,6 +43,9 @@ TEST_F(QuorumFixture, CanRaiseQuorum) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetQuorum.LessSignatoriesThanNewQuorum
+ *
  * @given a user with two signatories linked
  * @when the user tries to set own quorum more (3) than amount of signatories
  * (2)
@@ -53,6 +60,9 @@ TEST_F(QuorumFixture, CannotRaiseQuorumMoreThanSignatures) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SetQuorum.Valid
+ *
  * @given a user with two signatories linked
  * @when the user tries to increase quorum and then to lower again
  * @then all the transactions are committed
@@ -74,6 +84,8 @@ TEST_F(QuorumFixture, CanLowerQuorum) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ *
  * @given a user with two signatories linked
  * @when the user tries to set zero quorum
  * @then the transaction did not pass stateless validation

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -38,6 +38,10 @@ class SubtractAssetQuantity : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ * also covered by postgres_executor_test SubtractAccountAssetTest.Valid
+ *
  * @given some user with all required permissions
  * @when execute tx with SubtractAssetQuantity command with max available amount
  * @then there is the tx in proposal
@@ -58,6 +62,9 @@ TEST_F(SubtractAssetQuantity, Everything) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SubtractAccountAssetTest.NotEnoughAsset
+ *
  * @given some user with all required permissions
  * @when execute tx with SubtractAssetQuantity command with amount more than
  * user has
@@ -83,9 +90,12 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SubtractAccountAssetTest.NoPerms
+ *
  * @given some user without can_subtract_asset_qty permission
- * @when execute tx with SubtractAssetQuantity command
-there is an empty verified proposal
+ * @when execute tx with SubtractAssetQuantity command there is an empty
+ * verified proposal
  */
 TEST_F(SubtractAssetQuantity, NoPermissions) {
   IntegrationTestFramework(1)
@@ -107,6 +117,8 @@ TEST_F(SubtractAssetQuantity, NoPermissions) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with SubtractAssetQuantity command with negative amount
  * @then the tx hasn't passed stateless validation
@@ -124,6 +136,8 @@ TEST_F(SubtractAssetQuantity, NegativeAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with SubtractAssetQuantity command with zero amount
  * @then the tx hasn't passed stateless validation
@@ -141,6 +155,9 @@ TEST_F(SubtractAssetQuantity, ZeroAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test SubtractAccountAssetTest.NoAsset
+ *
  * @given some user with all required permissions
  * @when execute tx with SubtractAssetQuantity command with nonexistent asset
  * @then there is an empty verified proposal

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -38,7 +38,7 @@ class SubtractAssetQuantity : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  * also covered by postgres_executor_test SubtractAccountAssetTest.Valid
  *
@@ -62,7 +62,7 @@ TEST_F(SubtractAssetQuantity, Everything) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-225 remove, covered by
  * postgres_executor_test SubtractAccountAssetTest.NotEnoughAsset
  *
  * @given some user with all required permissions
@@ -90,7 +90,7 @@ TEST_F(SubtractAssetQuantity, Overdraft) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-225 remove, covered by
  * postgres_executor_test SubtractAccountAssetTest.NoPerms
  *
  * @given some user without can_subtract_asset_qty permission
@@ -117,7 +117,7 @@ TEST_F(SubtractAssetQuantity, NoPermissions) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-225 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
  * @when execute tx with SubtractAssetQuantity command with negative amount
@@ -136,7 +136,7 @@ TEST_F(SubtractAssetQuantity, NegativeAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-225 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
  * @when execute tx with SubtractAssetQuantity command with zero amount
@@ -155,7 +155,7 @@ TEST_F(SubtractAssetQuantity, ZeroAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-225 remove, covered by
  * postgres_executor_test SubtractAccountAssetTest.NoAsset
  *
  * @given some user with all required permissions

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -72,7 +72,7 @@ class TransferAsset : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * TODO mboldyrev 18.01.2019 IR-228 "Basic" tests should be replaced with a
  * common acceptance test
  * also covered by postgres_executor_test TransferAccountAssetTest.Valid
  *
@@ -90,7 +90,7 @@ TEST_F(TransferAsset, Basic) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by
  * postgres_executor_test TransferAccountAssetTest.NoPerms
  *
  * @given pair of users
@@ -112,7 +112,7 @@ TEST_F(TransferAsset, WithoutCanTransfer) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-226 convert to a SFV integration test
  * (not covered by postgres_executor_test)
  *
  * @given pair of users
@@ -136,7 +136,7 @@ TEST_F(TransferAsset, WithoutCanReceive) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by
  * postgres_executor_test TransferAccountAssetTest.NoAccount
  *
  * @given some user with all required permissions
@@ -158,7 +158,7 @@ TEST_F(TransferAsset, NonexistentDest) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by
  * postgres_executor_test TransferAccountAssetTest.NoAsset
  *
  * @given pair of users with all required permissions
@@ -181,7 +181,7 @@ TEST_F(TransferAsset, NonexistentAsset) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ * TODO mboldyrev 18.01.2019 IR-226 convert to a field validator unit test
  *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with negative amount
@@ -198,7 +198,7 @@ TEST_F(TransferAsset, NegativeAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with zero amount
@@ -215,7 +215,7 @@ TEST_F(TransferAsset, ZeroAmount) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with empty-str description
@@ -233,7 +233,7 @@ TEST_F(TransferAsset, EmptyDesc) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with very long description
@@ -253,7 +253,7 @@ TEST_F(TransferAsset, LongDesc) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by
  * postgres_executor_test TransferAccountAssetTest.Overdraft
  *
  * @given pair of users with all required permissions
@@ -274,7 +274,7 @@ TEST_F(TransferAsset, MoreThanHas) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by
  * postgres_executor_test TransferAccountAssetTest.OverflowDestination
  *
  * @given pair of users with all required permissions, and tx sender's balance
@@ -306,7 +306,7 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a TransactionValidator unit test
+ * TODO mboldyrev 18.01.2019 IR-226 convert to a TransactionValidator unit test
  *
  * @given some user with all required permissions
  * @when execute tx with TransferAsset command where the source and destination
@@ -325,7 +325,7 @@ TEST_F(TransferAsset, SourceIsDest) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * TODO mboldyrev 18.01.2019 IR-226 convert to a SFV integration test
  * (not covered by postgres_executor_test)
  *
  * @given some user with all required permission
@@ -361,7 +361,7 @@ TEST_F(TransferAsset, InterDomain) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-226 remove, covered by field validator test
  *
  * @given a pair of users with all required permissions
  *        AND asset with big precision

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -306,7 +306,7 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a TransactionValidator unit test
  *
  * @given some user with all required permissions
  * @when execute tx with TransferAsset command where the source and destination

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -72,6 +72,10 @@ class TransferAsset : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 "Basic" tests should be replaced with a
+ * common acceptance test
+ * also covered by postgres_executor_test TransferAccountAssetTest.Valid
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command
  * @then there is the tx in proposal
@@ -86,6 +90,9 @@ TEST_F(TransferAsset, Basic) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test TransferAccountAssetTest.NoPerms
+ *
  * @given pair of users
  *        AND the first user without can_transfer permission
  * @when execute tx with TransferAsset command
@@ -105,6 +112,9 @@ TEST_F(TransferAsset, WithoutCanTransfer) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_executor_test)
+ *
  * @given pair of users
  *        AND the second user without can_receive permission
  * @when execute tx with TransferAsset command
@@ -126,6 +136,9 @@ TEST_F(TransferAsset, WithoutCanReceive) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test TransferAccountAssetTest.NoAccount
+ *
  * @given some user with all required permissions
  * @when execute tx with TransferAsset command to nonexistent destination
  * @then there is an empty verified proposal
@@ -145,6 +158,9 @@ TEST_F(TransferAsset, NonexistentDest) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test TransferAccountAssetTest.NoAsset
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with nonexistent asset
  * @then there is an empty verified proposal
@@ -165,6 +181,8 @@ TEST_F(TransferAsset, NonexistentAsset) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a field validator unit test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with negative amount
  * @then the tx hasn't passed stateless validation
@@ -180,6 +198,8 @@ TEST_F(TransferAsset, NegativeAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with zero amount
  * @then the tx hasn't passed stateless validation
@@ -195,6 +215,8 @@ TEST_F(TransferAsset, ZeroAmount) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with empty-str description
  * @then it passed to the proposal
@@ -211,6 +233,8 @@ TEST_F(TransferAsset, EmptyDesc) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with very long description
  * @then the tx hasn't passed stateless validation
@@ -229,6 +253,9 @@ TEST_F(TransferAsset, LongDesc) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test TransferAccountAssetTest.Overdraft
+ *
  * @given pair of users with all required permissions
  * @when execute tx with TransferAsset command with amount more, than user has
  * @then there is an empty verified proposal
@@ -247,6 +274,9 @@ TEST_F(TransferAsset, MoreThanHas) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by
+ * postgres_executor_test TransferAccountAssetTest.OverflowDestination
+ *
  * @given pair of users with all required permissions, and tx sender's balance
  * is replenished if required
  * @when execute two txes with TransferAsset command with amount more than a
@@ -276,6 +306,8 @@ TEST_F(TransferAsset, Uint256DestOverflow) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
+ *
  * @given some user with all required permissions
  * @when execute tx with TransferAsset command where the source and destination
  * accounts are the same
@@ -293,6 +325,9 @@ TEST_F(TransferAsset, SourceIsDest) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SFV integration test
+ * (not covered by postgres_executor_test)
+ *
  * @given some user with all required permission
  * @when execute tx with TransferAsset command where the destination user's
  * domain differ from the source user one
@@ -326,6 +361,8 @@ TEST_F(TransferAsset, InterDomain) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given a pair of users with all required permissions
  *        AND asset with big precision
  * @when asset is added and then TransferAsset is called

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -37,6 +37,10 @@ class AcceptanceTest : public AcceptanceFixture {
 };
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a separate status test
+ * and a SFV integration test of non existing tx creator account
+ * (seems not covered in postgres_executor_test or transaction_processor_test)
+ *
  * @given non existent user
  * @when sending  transaction to the ledger
  * @then receive ENOUGH_SIGNATURES_COLLECTED status
@@ -56,6 +60,8 @@ TEST_F(AcceptanceTest, NonExistentCreatorAccountId) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an 1 hour old UNIX time
  * @then receive ENOUGH_SIGNATURES_COLLECTED status
@@ -74,6 +80,8 @@ TEST_F(AcceptanceTest, Transaction1HourOld) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an less than 24 hour old UNIX time
  * @then receive ENOUGH_SIGNATURES_COLLECTED status
@@ -92,6 +100,8 @@ TEST_F(AcceptanceTest, DISABLED_TransactionLess24HourOld) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an more than 24 hour old UNIX time
  * @then receive STATELESS_VALIDATION_FAILED status
@@ -106,6 +116,8 @@ TEST_F(AcceptanceTest, TransactionMore24HourOld) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an less that 5 minutes from future UNIX time
  * @then receive ENOUGH_SIGNATURES_COLLECTED status
@@ -124,6 +136,8 @@ TEST_F(AcceptanceTest, Transaction5MinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an 10 minutes from future UNIX time
  * @then receive STATELESS_VALIDATION_FAILED status
@@ -138,6 +152,8 @@ TEST_F(AcceptanceTest, Transaction10MinutesFromFuture) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ *
  * @given some user
  * @when sending transactions with an empty public Key
  * @then receive STATELESS_VALIDATION_FAILED status
@@ -155,6 +171,10 @@ TEST_F(AcceptanceTest, TransactionEmptyPubKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
+ * including SignableModelValidator or even whole
+ * torii::CommandServiceTransportGrpc and the crypto provider
+ *
  * @given some user
  * @when sending transactions with an empty signedBlob
  * @then receive STATELESS_VALIDATION_FAILED status
@@ -169,8 +189,12 @@ TEST_F(AcceptanceTest, TransactionEmptySignedblob) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
+ * including SignableModelValidator or even whole
+ * torii::CommandServiceTransportGrpc and the crypto provider
+ *
  * @given some user
- * @when sending transactions with Invalid PublicKey
+ * @when sending transactions with correctly formed invalid PublicKey
  * @then receive STATELESS_VALIDATION_FAILED status
  */
 TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
@@ -189,6 +213,10 @@ TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
+ * including SignableModelValidator or even whole
+ * torii::CommandServiceTransportGrpc and the crypto provider
+ *
  * @given some user
  * @when sending transactions with Invalid SignedBlock
  * @then receive STATELESS_VALIDATION_FAILED status
@@ -211,6 +239,8 @@ TEST_F(AcceptanceTest, TransactionInvalidSignedBlob) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a separate status test
+ *
  * @given some user
  * @when sending transactions with valid signature
  * @then receive ENOUGH_SIGNATURES_COLLECTED status
@@ -227,6 +257,8 @@ TEST_F(AcceptanceTest, TransactionValidSignedBlob) {
 }
 
 /**
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a SignableModelValidator test
+ *
  * @given some user
  * @when sending transaction without any signature
  * @then the response is STATELESS_VALIDATION_FAILED

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -37,7 +37,7 @@ class AcceptanceTest : public AcceptanceFixture {
 };
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a separate status test
+ * TODO mboldyrev 18.01.2019 IR-227 convert to a separate status test
  * and a SFV integration test of non existing tx creator account
  * (seems not covered in postgres_executor_test or transaction_processor_test)
  *
@@ -60,7 +60,7 @@ TEST_F(AcceptanceTest, NonExistentCreatorAccountId) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an 1 hour old UNIX time
@@ -80,7 +80,7 @@ TEST_F(AcceptanceTest, Transaction1HourOld) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an less than 24 hour old UNIX time
@@ -100,7 +100,7 @@ TEST_F(AcceptanceTest, DISABLED_TransactionLess24HourOld) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an more than 24 hour old UNIX time
@@ -116,7 +116,7 @@ TEST_F(AcceptanceTest, TransactionMore24HourOld) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an less that 5 minutes from future UNIX time
@@ -136,7 +136,7 @@ TEST_F(AcceptanceTest, Transaction5MinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an 10 minutes from future UNIX time
@@ -152,7 +152,7 @@ TEST_F(AcceptanceTest, Transaction10MinutesFromFuture) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? covered by field validator test
+ * TODO mboldyrev 18.01.2019 IR-227 remove, covered by field validator test
  *
  * @given some user
  * @when sending transactions with an empty public Key
@@ -171,7 +171,7 @@ TEST_F(AcceptanceTest, TransactionEmptyPubKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test.
+ * TODO mboldyrev 18.01.2019 IR-227 convert to a crypto provider unit test.
  * Also make a single SVL integration test including SignableModelValidator or
  * even whole torii::CommandServiceTransportGrpc and the crypto provider
  *
@@ -189,7 +189,7 @@ TEST_F(AcceptanceTest, TransactionEmptySignedblob) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-227 convert to a crypto provider unit test
  *
  * @given some user
  * @when sending transactions with correctly formed invalid PublicKey
@@ -211,7 +211,7 @@ TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
+ * TODO mboldyrev 18.01.2019 IR-227 convert to a crypto provider unit test
  *
  * @given some user
  * @when sending transactions with Invalid SignedBlock
@@ -235,7 +235,7 @@ TEST_F(AcceptanceTest, TransactionInvalidSignedBlob) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 remove? successful case covered by
+ * TODO mboldyrev 18.01.2019 IR-227 remove, successful case covered by
  * higher-level tests
  *
  * @given some user
@@ -254,7 +254,7 @@ TEST_F(AcceptanceTest, TransactionValidSignedBlob) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SignableModelValidator test
+ * TODO mboldyrev 18.01.2019 IR-227 convert to a SignableModelValidator test
  *
  * @given some user
  * @when sending transaction without any signature

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -171,9 +171,9 @@ TEST_F(AcceptanceTest, TransactionEmptyPubKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
- * including SignableModelValidator or even whole
- * torii::CommandServiceTransportGrpc and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test.
+ * Also make a single SVL integration test including SignableModelValidator or
+ * even whole torii::CommandServiceTransportGrpc and the crypto provider
  *
  * @given some user
  * @when sending transactions with an empty signedBlob
@@ -189,9 +189,7 @@ TEST_F(AcceptanceTest, TransactionEmptySignedblob) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
- * including SignableModelValidator or even whole
- * torii::CommandServiceTransportGrpc and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
  *
  * @given some user
  * @when sending transactions with correctly formed invalid PublicKey
@@ -213,9 +211,7 @@ TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a SLV integration test
- * including SignableModelValidator or even whole
- * torii::CommandServiceTransportGrpc and the crypto provider
+ * TODO mboldyrev 05.12.2018 IR-56 convert to a crypto provider unit test
  *
  * @given some user
  * @when sending transactions with Invalid SignedBlock
@@ -239,7 +235,8 @@ TEST_F(AcceptanceTest, TransactionInvalidSignedBlob) {
 }
 
 /**
- * TODO mboldyrev 05.12.2018 IR-56 convert to a separate status test
+ * TODO mboldyrev 05.12.2018 IR-56 remove? successful case covered by
+ * higher-level tests
  *
  * @given some user
  * @when sending transactions with valid signature


### PR DESCRIPTION
### Description of the Change

This change adds comments to some integration tests that suggest rewriting or removing them.

### Benefits

It will help us to reach consensus and rework these tests in the future.

### Possible Drawbacks 

If we misinterpret some test scopes, we may unintentionally cause lowering the test coverage.

### Usage Examples or Tests *[optional]*

Read the tests, read the comments, agree silently or argue noticeably.

### Alternate Designs *[optional]*

Design new test coverage from scratch.
