### PR TITLE
Fix saving rejected txs hashes for failed atomic batches

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -363,7 +363,8 @@ void Irohad::initConsensusGate() {
                                               vote_delay_,
                                               async_call_,
                                               common_objects_factory_);
-  consensus_gate->onOutcome().subscribe(gate_object.get_subscriber());
+  consensus_gate->onOutcome().subscribe(
+      consensus_gate_objects.get_subscriber());
   log_->info("[Init] => consensus gate");
 }
 
@@ -466,8 +467,10 @@ void Irohad::initTransactionCommandService() {
           transaction_factory,
           batch_parser,
           transaction_batch_factory_,
-          gate_object.get_observable(),
-          2);
+          consensus_gate_objects.get_observable().map([](const auto &) {
+            return torii::CommandServiceTransportGrpc::ConsensusGateEvent{};
+          }),
+          2);  // TODO 18.01.2019 igor-egorov, make it configurable IR-230
 
   log_->info("[Init] => command service");
 }

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -468,7 +468,7 @@ void Irohad::initTransactionCommandService() {
           batch_parser,
           transaction_batch_factory_,
           consensus_gate_objects.get_observable().map([](const auto &) {
-            return torii::CommandServiceTransportGrpc::ConsensusGateEvent{};
+            return ::torii::CommandServiceTransportGrpc::ConsensusGateEvent{};
           }),
           2);  // TODO 18.01.2019 igor-egorov, make it configurable IR-230
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -363,7 +363,7 @@ void Irohad::initConsensusGate() {
                                               vote_delay_,
                                               async_call_,
                                               common_objects_factory_);
-
+  consensus_gate->onOutcome().subscribe(gate_object.get_subscriber());
   log_->info("[Init] => consensus gate");
 }
 
@@ -466,7 +466,7 @@ void Irohad::initTransactionCommandService() {
           transaction_factory,
           batch_parser,
           transaction_batch_factory_,
-          consensus_gate,
+          gate_object.get_observable(),
           2);
 
   log_->info("[Init] => command service");

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -210,6 +210,7 @@ class Irohad {
 
   // consensus gate
   std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
+  rxcpp::subjects::subject<iroha::consensus::GateObject> gate_object;
 
   // synchronizer
   std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -210,7 +210,7 @@ class Irohad {
 
   // consensus gate
   std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
-  rxcpp::subjects::subject<iroha::consensus::GateObject> gate_object;
+  rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_gate_objects;
 
   // synchronizer
   std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -23,237 +23,235 @@
 
 namespace torii {
 
-    CommandServiceTransportGrpc::CommandServiceTransportGrpc(
-        std::shared_ptr<CommandService> command_service,
-        std::shared_ptr<iroha::torii::StatusBus> status_bus,
-        std::shared_ptr<shared_model::interface::TxStatusFactory>
-            status_factory,
-        std::shared_ptr<TransportFactoryType> transaction_factory,
-        std::shared_ptr<shared_model::interface::TransactionBatchParser>
-            batch_parser,
-        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-            transaction_batch_factory,
-        rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
-        int maximum_rounds_without_update,
-        logger::Logger log)
-        : command_service_(std::move(command_service)),
-          status_bus_(std::move(status_bus)),
-          status_factory_(std::move(status_factory)),
-          transaction_factory_(std::move(transaction_factory)),
-          batch_parser_(std::move(batch_parser)),
-          batch_factory_(std::move(transaction_batch_factory)),
-          log_(std::move(log)),
-          consensus_gate_objects_(std::move(consensus_gate_objects)),
-          maximum_rounds_without_update_(maximum_rounds_without_update) {}
+  CommandServiceTransportGrpc::CommandServiceTransportGrpc(
+      std::shared_ptr<CommandService> command_service,
+      std::shared_ptr<iroha::torii::StatusBus> status_bus,
+      std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory,
+      std::shared_ptr<TransportFactoryType> transaction_factory,
+      std::shared_ptr<shared_model::interface::TransactionBatchParser>
+          batch_parser,
+      std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+          transaction_batch_factory,
+      rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
+      int maximum_rounds_without_update,
+      logger::Logger log)
+      : command_service_(std::move(command_service)),
+        status_bus_(std::move(status_bus)),
+        status_factory_(std::move(status_factory)),
+        transaction_factory_(std::move(transaction_factory)),
+        batch_parser_(std::move(batch_parser)),
+        batch_factory_(std::move(transaction_batch_factory)),
+        log_(std::move(log)),
+        consensus_gate_objects_(std::move(consensus_gate_objects)),
+        maximum_rounds_without_update_(maximum_rounds_without_update) {}
 
-    grpc::Status CommandServiceTransportGrpc::Torii(
-        grpc::ServerContext *context,
-        const iroha::protocol::Transaction *request,
-        google::protobuf::Empty *response) {
-      iroha::protocol::TxList single_tx_list;
-      *single_tx_list.add_transactions() = *request;
-      return ListTorii(context, &single_tx_list, response);
-    }
+  grpc::Status CommandServiceTransportGrpc::Torii(
+      grpc::ServerContext *context,
+      const iroha::protocol::Transaction *request,
+      google::protobuf::Empty *response) {
+    iroha::protocol::TxList single_tx_list;
+    *single_tx_list.add_transactions() = *request;
+    return ListTorii(context, &single_tx_list, response);
+  }
 
-    namespace {
-      /**
-       * Form an error message, which is to be shared between all transactions,
-       * if there are several of them, or individual message, if there's only
-       * one
-       * @param tx_hashes is non empty hash list to form error message from
-       * @param error of those tx(s)
-       * @return message
-       */
-      std::string formErrorMessage(
-          const std::vector<shared_model::crypto::Hash> &tx_hashes,
-          const std::string &error) {
-        if (tx_hashes.size() == 1) {
-          return (boost::format("Stateless invalid tx, error: %s, hash: %s")
-                  % error % tx_hashes[0].hex())
-              .str();
-        }
-
-        std::string folded_hashes =
-            std::accumulate(std::next(tx_hashes.begin()),
-                            tx_hashes.end(),
-                            tx_hashes[0].hex(),
-                            [](auto &&acc, const auto &h) -> std::string {
-                              return acc + ", " + h.hex();
-                            });
-
-        return (boost::format(
-                    "Stateless invalid tx in transaction sequence, error: %s\n"
-                    "Hash list: [%s]")
-                % error % folded_hashes)
+  namespace {
+    /**
+     * Form an error message, which is to be shared between all transactions,
+     * if there are several of them, or individual message, if there's only
+     * one
+     * @param tx_hashes is non empty hash list to form error message from
+     * @param error of those tx(s)
+     * @return message
+     */
+    std::string formErrorMessage(
+        const std::vector<shared_model::crypto::Hash> &tx_hashes,
+        const std::string &error) {
+      if (tx_hashes.size() == 1) {
+        return (boost::format("Stateless invalid tx, error: %s, hash: %s")
+                % error % tx_hashes[0].hex())
             .str();
       }
-    }  // namespace
 
-    shared_model::interface::types::SharedTxsCollectionType
-    CommandServiceTransportGrpc::deserializeTransactions(
-        const iroha::protocol::TxList *request) {
-      shared_model::interface::types::SharedTxsCollectionType tx_collection;
-      for (const auto &tx : request->transactions()) {
-        transaction_factory_->build(tx).match(
-            [&tx_collection](
-                iroha::expected::Value<
-                    std::unique_ptr<shared_model::interface::Transaction>> &v) {
-              tx_collection.emplace_back(std::move(v).value);
-            },
-            [this](iroha::expected::Error<TransportFactoryType::Error> &error) {
-              status_bus_->publish(status_factory_->makeStatelessFail(
-                  error.error.hash,
-                  shared_model::interface::TxStatusFactory::TransactionError{
-                      error.error.error, 0, 0}));
-            });
-      }
-      return tx_collection;
+      std::string folded_hashes =
+          std::accumulate(std::next(tx_hashes.begin()),
+                          tx_hashes.end(),
+                          tx_hashes[0].hex(),
+                          [](auto &&acc, const auto &h) -> std::string {
+                            return acc + ", " + h.hex();
+                          });
+
+      return (boost::format(
+                  "Stateless invalid tx in transaction sequence, error: %s\n"
+                  "Hash list: [%s]")
+              % error % folded_hashes)
+          .str();
+    }
+  }  // namespace
+
+  shared_model::interface::types::SharedTxsCollectionType
+  CommandServiceTransportGrpc::deserializeTransactions(
+      const iroha::protocol::TxList *request) {
+    shared_model::interface::types::SharedTxsCollectionType tx_collection;
+    for (const auto &tx : request->transactions()) {
+      transaction_factory_->build(tx).match(
+          [&tx_collection](
+              iroha::expected::Value<
+                  std::unique_ptr<shared_model::interface::Transaction>> &v) {
+            tx_collection.emplace_back(std::move(v).value);
+          },
+          [this](iroha::expected::Error<TransportFactoryType::Error> &error) {
+            status_bus_->publish(status_factory_->makeStatelessFail(
+                error.error.hash,
+                shared_model::interface::TxStatusFactory::TransactionError{
+                    error.error.error, 0, 0}));
+          });
+    }
+    return tx_collection;
+  }
+
+  grpc::Status CommandServiceTransportGrpc::ListTorii(
+      grpc::ServerContext *context,
+      const iroha::protocol::TxList *request,
+      google::protobuf::Empty *response) {
+    auto transactions = deserializeTransactions(request);
+
+    auto batches = batch_parser_->parseBatches(transactions);
+
+    for (auto &batch : batches) {
+      batch_factory_->createTransactionBatch(batch).match(
+          [&](iroha::expected::Value<std::unique_ptr<
+                  shared_model::interface::TransactionBatch>> &value) {
+            this->command_service_->handleTransactionBatch(
+                std::move(value).value);
+          },
+          [&](iroha::expected::Error<std::string> &error) {
+            std::vector<shared_model::crypto::Hash> hashes;
+
+            std::transform(batch.begin(),
+                           batch.end(),
+                           std::back_inserter(hashes),
+                           [](const auto &tx) { return tx->hash(); });
+
+            auto error_msg = formErrorMessage(hashes, error.error);
+            // set error response for each transaction in a batch candidate
+            std::for_each(
+                hashes.begin(), hashes.end(), [this, &error_msg](auto &hash) {
+                  status_bus_->publish(status_factory_->makeStatelessFail(
+                      hash,
+                      shared_model::interface::TxStatusFactory::
+                          TransactionError{error_msg, 0, 0}));
+                });
+          });
     }
 
-    grpc::Status CommandServiceTransportGrpc::ListTorii(
-        grpc::ServerContext *context,
-        const iroha::protocol::TxList *request,
-        google::protobuf::Empty *response) {
-      auto transactions = deserializeTransactions(request);
+    return grpc::Status::OK;
+  }
 
-      auto batches = batch_parser_->parseBatches(transactions);
+  grpc::Status CommandServiceTransportGrpc::Status(
+      grpc::ServerContext *context,
+      const iroha::protocol::TxStatusRequest *request,
+      iroha::protocol::ToriiResponse *response) {
+    *response =
+        std::static_pointer_cast<shared_model::proto::TransactionResponse>(
+            command_service_->getStatus(
+                shared_model::crypto::Hash::fromHexString(request->tx_hash())))
+            ->getTransport();
+    return grpc::Status::OK;
+  }
 
-      for (auto &batch : batches) {
-        batch_factory_->createTransactionBatch(batch).match(
-            [&](iroha::expected::Value<std::unique_ptr<
-                    shared_model::interface::TransactionBatch>> &value) {
-              this->command_service_->handleTransactionBatch(
-                  std::move(value).value);
-            },
-            [&](iroha::expected::Error<std::string> &error) {
-              std::vector<shared_model::crypto::Hash> hashes;
-
-              std::transform(batch.begin(),
-                             batch.end(),
-                             std::back_inserter(hashes),
-                             [](const auto &tx) { return tx->hash(); });
-
-              auto error_msg = formErrorMessage(hashes, error.error);
-              // set error response for each transaction in a batch candidate
-              std::for_each(
-                  hashes.begin(), hashes.end(), [this, &error_msg](auto &hash) {
-                    status_bus_->publish(status_factory_->makeStatelessFail(
-                        hash,
-                        shared_model::interface::TxStatusFactory::
-                            TransactionError{error_msg, 0, 0}));
-                  });
-            });
+  namespace {
+    void handleEvents(rxcpp::composite_subscription &subscription,
+                      rxcpp::schedulers::run_loop &run_loop) {
+      while (subscription.is_subscribed() or not run_loop.empty()) {
+        run_loop.dispatch();
       }
-
-      return grpc::Status::OK;
     }
+  }  // namespace
 
-    grpc::Status CommandServiceTransportGrpc::Status(
-        grpc::ServerContext *context,
-        const iroha::protocol::TxStatusRequest *request,
-        iroha::protocol::ToriiResponse *response) {
-      *response =
-          std::static_pointer_cast<shared_model::proto::TransactionResponse>(
-              command_service_->getStatus(
-                  shared_model::crypto::Hash::fromHexString(
-                      request->tx_hash())))
+  grpc::Status CommandServiceTransportGrpc::StatusStream(
+      grpc::ServerContext *context,
+      const iroha::protocol::TxStatusRequest *request,
+      grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer) {
+    rxcpp::schedulers::run_loop rl;
+
+    auto current_thread =
+        rxcpp::observe_on_one_worker(rxcpp::schedulers::make_run_loop(rl));
+
+    rxcpp::composite_subscription subscription;
+
+    auto hash = shared_model::crypto::Hash::fromHexString(request->tx_hash());
+
+    auto client_id_format = boost::format("Peer: '%s', %s");
+    std::string client_id =
+        (client_id_format % context->peer() % hash.toString()).str();
+
+    auto consensus_gate_observable =
+        consensus_gate_objects_
+            // via scan we do type erasure here
+            .scan(0, [](int seed, const auto &) { return ++seed; })
+            // a dummy start_with lets us don't wait for the consensus event
+            // on further combine_latest
+            .start_with(0);
+
+    boost::optional<iroha::protocol::TxStatus> last_tx_status;
+    auto rounds_counter{0};
+    command_service_
+        ->getStatusStream(hash)
+        // convert to transport objects
+        .map([&](auto response) {
+          log_->info("mapped {}, {}", *response, client_id);
+          return std::static_pointer_cast<
+                     shared_model::proto::TransactionResponse>(response)
               ->getTransport();
-      return grpc::Status::OK;
-    }
+        })
+        .combine_latest(consensus_gate_observable)
+        // complete the observable if client is disconnected or too many
+        // rounds have passed without tx status change
+        .take_while([=, &rounds_counter, &last_tx_status](const auto &tuple) {
+          auto is_cancelled = context->IsCancelled();
+          if (is_cancelled) {
+            log_->debug("client unsubscribed, {}", client_id);
+          }
+          // we increment round counter when the same status arrived again.
+          auto status = std::get<0>(tuple).tx_status();
+          if (last_tx_status and (status == *last_tx_status)) {
+            ++rounds_counter;
+          } else {
+            rounds_counter = 0;
+          }
+          // we stop the stream when round counter is greater than allowed.
+          if (rounds_counter >= maximum_rounds_without_update_) {
+            return false;
+          }
 
-    namespace {
-      void handleEvents(rxcpp::composite_subscription &subscription,
-                        rxcpp::schedulers::run_loop &run_loop) {
-        while (subscription.is_subscribed() or not run_loop.empty()) {
-          run_loop.dispatch();
-        }
-      }
-    }  // namespace
+          return not is_cancelled;
+        })
+        .filter([&last_tx_status](const auto &tuple) {
+          auto status = std::get<0>(tuple).tx_status();
+          // we allow further processing in case of any new status
+          // (including the first one)
+          auto result = not last_tx_status or (*last_tx_status != status);
+          last_tx_status = status;
+          return result;
+        })
+        .subscribe(subscription,
+                   [this, &response_writer, &client_id](const auto &tuple) {
+                     auto response = std::get<0>(tuple);
+                     if (response_writer->Write(response)) {
+                       log_->debug("status written, {}", client_id);
+                     }
+                   },
+                   [&](std::exception_ptr ep) {
+                     log_->error("something bad happened, client_id {}",
+                                 client_id);
+                   },
+                   [&] { log_->debug("stream done, {}", client_id); });
 
-    grpc::Status CommandServiceTransportGrpc::StatusStream(
-        grpc::ServerContext *context,
-        const iroha::protocol::TxStatusRequest *request,
-        grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer) {
-      rxcpp::schedulers::run_loop rl;
+    // run loop while subscription is active or there are pending events in
+    // the queue
+    handleEvents(subscription, rl);
 
-      auto current_thread =
-          rxcpp::observe_on_one_worker(rxcpp::schedulers::make_run_loop(rl));
-
-      rxcpp::composite_subscription subscription;
-
-      auto hash = shared_model::crypto::Hash::fromHexString(request->tx_hash());
-
-      auto client_id_format = boost::format("Peer: '%s', %s");
-      std::string client_id =
-          (client_id_format % context->peer() % hash.toString()).str();
-
-      auto consensus_gate_observable =
-          consensus_gate_objects_
-              // via scan we do type erasure here
-              .scan(0, [](int seed, const auto &) { return ++seed; })
-              // a dummy start_with lets us don't wait for the consensus event
-              // on further combine_latest
-              .start_with(0);
-
-      boost::optional<iroha::protocol::TxStatus> last_tx_status;
-      auto rounds_counter{0};
-      command_service_
-          ->getStatusStream(hash)
-          // convert to transport objects
-          .map([&](auto response) {
-            log_->info("mapped {}, {}", *response, client_id);
-            return std::static_pointer_cast<
-                       shared_model::proto::TransactionResponse>(response)
-                ->getTransport();
-          })
-          .combine_latest(consensus_gate_observable)
-          // complete the observable if client is disconnected or too many
-          // rounds have passed without tx status change
-          .take_while([=, &rounds_counter, &last_tx_status](const auto &tuple) {
-            auto is_cancelled = context->IsCancelled();
-            if (is_cancelled) {
-              log_->debug("client unsubscribed, {}", client_id);
-            }
-            // we increment round counter when the same status arrived again.
-            auto status = std::get<0>(tuple).tx_status();
-            if (last_tx_status and (status == *last_tx_status)) {
-              ++rounds_counter;
-            } else {
-              rounds_counter = 0;
-            }
-            // we stop the stream when round counter is greater than allowed.
-            if (rounds_counter >= maximum_rounds_without_update_) {
-              return false;
-            }
-
-            return not is_cancelled;
-          })
-          .filter([&last_tx_status](const auto &tuple) {
-            auto status = std::get<0>(tuple).tx_status();
-            // we allow further processing in case of any new status
-            // (including the first one)
-            auto result = not last_tx_status or (*last_tx_status != status);
-            last_tx_status = status;
-            return result;
-          })
-          .subscribe(subscription,
-                     [this, &response_writer, &client_id](const auto &tuple) {
-                       auto response = std::get<0>(tuple);
-                       if (response_writer->Write(response)) {
-                         log_->debug("status written, {}", client_id);
-                       }
-                     },
-                     [&](std::exception_ptr ep) {
-                       log_->error("something bad happened, client_id {}",
-                                   client_id);
-                     },
-                     [&] { log_->debug("stream done, {}", client_id); });
-
-      // run loop while subscription is active or there are pending events in
-      // the queue
-      handleEvents(subscription, rl);
-
-      log_->debug("status stream done, {}", client_id);
-      return grpc::Status::OK;
-    }
-  }  // namespace torii
+    log_->debug("status stream done, {}", client_id);
+    return grpc::Status::OK;
+  }
+}  // namespace torii

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -187,11 +187,9 @@ namespace torii {
 
     auto consensus_gate_observable =
         consensus_gate_objects_
-            // via scan we do type erasure here
-            .scan(0, [](int seed, const auto &) { return ++seed; })
             // a dummy start_with lets us don't wait for the consensus event
             // on further combine_latest
-            .start_with(0);
+            .start_with(ConsensusGateEvent{});
 
     boost::optional<iroha::protocol::TxStatus> last_tx_status;
     auto rounds_counter{0};

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -14,240 +14,246 @@
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
-#include "common/timeout.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
 #include "interfaces/transaction.hpp"
-#include "network/consensus_gate.hpp"
 #include "torii/status_bus.hpp"
 
 namespace torii {
 
-  CommandServiceTransportGrpc::CommandServiceTransportGrpc(
-      std::shared_ptr<CommandService> command_service,
-      std::shared_ptr<iroha::torii::StatusBus> status_bus,
-      std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory,
-      std::shared_ptr<TransportFactoryType> transaction_factory,
-      std::shared_ptr<shared_model::interface::TransactionBatchParser>
-          batch_parser,
-      std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-          transaction_batch_factory,
-      rxcpp::observable<iroha::consensus::GateObject> gate_object,
-      int maximum_rounds_without_update,
-      logger::Logger log)
-      : command_service_(std::move(command_service)),
-        status_bus_(std::move(status_bus)),
-        status_factory_(std::move(status_factory)),
-        transaction_factory_(std::move(transaction_factory)),
-        batch_parser_(std::move(batch_parser)),
-        batch_factory_(std::move(transaction_batch_factory)),
-        log_(std::move(log)),
-        gate_object_(std::move(gate_object)),
-        maximum_rounds_without_update_(maximum_rounds_without_update) {}
+    CommandServiceTransportGrpc::CommandServiceTransportGrpc(
+        std::shared_ptr<CommandService> command_service,
+        std::shared_ptr<iroha::torii::StatusBus> status_bus,
+        std::shared_ptr<shared_model::interface::TxStatusFactory>
+            status_factory,
+        std::shared_ptr<TransportFactoryType> transaction_factory,
+        std::shared_ptr<shared_model::interface::TransactionBatchParser>
+            batch_parser,
+        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+            transaction_batch_factory,
+        rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
+        int maximum_rounds_without_update,
+        logger::Logger log)
+        : command_service_(std::move(command_service)),
+          status_bus_(std::move(status_bus)),
+          status_factory_(std::move(status_factory)),
+          transaction_factory_(std::move(transaction_factory)),
+          batch_parser_(std::move(batch_parser)),
+          batch_factory_(std::move(transaction_batch_factory)),
+          log_(std::move(log)),
+          consensus_gate_objects_(std::move(consensus_gate_objects)),
+          maximum_rounds_without_update_(maximum_rounds_without_update) {}
 
-  grpc::Status CommandServiceTransportGrpc::Torii(
-      grpc::ServerContext *context,
-      const iroha::protocol::Transaction *request,
-      google::protobuf::Empty *response) {
-    iroha::protocol::TxList single_tx_list;
-    *single_tx_list.add_transactions() = *request;
-    return ListTorii(context, &single_tx_list, response);
-  }
+    grpc::Status CommandServiceTransportGrpc::Torii(
+        grpc::ServerContext *context,
+        const iroha::protocol::Transaction *request,
+        google::protobuf::Empty *response) {
+      iroha::protocol::TxList single_tx_list;
+      *single_tx_list.add_transactions() = *request;
+      return ListTorii(context, &single_tx_list, response);
+    }
 
-  namespace {
-    /**
-     * Form an error message, which is to be shared between all transactions, if
-     * there are several of them, or individual message, if there's only one
-     * @param tx_hashes is non empty hash list to form error message from
-     * @param error of those tx(s)
-     * @return message
-     */
-    std::string formErrorMessage(
-        const std::vector<shared_model::crypto::Hash> &tx_hashes,
-        const std::string &error) {
-      if (tx_hashes.size() == 1) {
-        return (boost::format("Stateless invalid tx, error: %s, hash: %s")
-                % error % tx_hashes[0].hex())
+    namespace {
+      /**
+       * Form an error message, which is to be shared between all transactions,
+       * if there are several of them, or individual message, if there's only
+       * one
+       * @param tx_hashes is non empty hash list to form error message from
+       * @param error of those tx(s)
+       * @return message
+       */
+      std::string formErrorMessage(
+          const std::vector<shared_model::crypto::Hash> &tx_hashes,
+          const std::string &error) {
+        if (tx_hashes.size() == 1) {
+          return (boost::format("Stateless invalid tx, error: %s, hash: %s")
+                  % error % tx_hashes[0].hex())
+              .str();
+        }
+
+        std::string folded_hashes =
+            std::accumulate(std::next(tx_hashes.begin()),
+                            tx_hashes.end(),
+                            tx_hashes[0].hex(),
+                            [](auto &&acc, const auto &h) -> std::string {
+                              return acc + ", " + h.hex();
+                            });
+
+        return (boost::format(
+                    "Stateless invalid tx in transaction sequence, error: %s\n"
+                    "Hash list: [%s]")
+                % error % folded_hashes)
             .str();
       }
+    }  // namespace
 
-      std::string folded_hashes =
-          std::accumulate(std::next(tx_hashes.begin()),
-                          tx_hashes.end(),
-                          tx_hashes[0].hex(),
-                          [](auto &&acc, const auto &h) -> std::string {
-                            return acc + ", " + h.hex();
-                          });
-
-      return (boost::format(
-                  "Stateless invalid tx in transaction sequence, error: %s\n"
-                  "Hash list: [%s]")
-              % error % folded_hashes)
-          .str();
-    }
-  }  // namespace
-
-  shared_model::interface::types::SharedTxsCollectionType
-  CommandServiceTransportGrpc::deserializeTransactions(
-      const iroha::protocol::TxList *request) {
-    shared_model::interface::types::SharedTxsCollectionType tx_collection;
-    for (const auto &tx : request->transactions()) {
-      transaction_factory_->build(tx).match(
-          [&tx_collection](
-              iroha::expected::Value<
-                  std::unique_ptr<shared_model::interface::Transaction>> &v) {
-            tx_collection.emplace_back(std::move(v).value);
-          },
-          [this](iroha::expected::Error<TransportFactoryType::Error> &error) {
-            status_bus_->publish(status_factory_->makeStatelessFail(
-                error.error.hash,
-                shared_model::interface::TxStatusFactory::TransactionError{
-                    error.error.error, 0, 0}));
-          });
-    }
-    return tx_collection;
-  }
-
-  grpc::Status CommandServiceTransportGrpc::ListTorii(
-      grpc::ServerContext *context,
-      const iroha::protocol::TxList *request,
-      google::protobuf::Empty *response) {
-    auto transactions = deserializeTransactions(request);
-
-    auto batches = batch_parser_->parseBatches(transactions);
-
-    for (auto &batch : batches) {
-      batch_factory_->createTransactionBatch(batch).match(
-          [&](iroha::expected::Value<std::unique_ptr<
-                  shared_model::interface::TransactionBatch>> &value) {
-            this->command_service_->handleTransactionBatch(
-                std::move(value).value);
-          },
-          [&](iroha::expected::Error<std::string> &error) {
-            std::vector<shared_model::crypto::Hash> hashes;
-
-            std::transform(batch.begin(),
-                           batch.end(),
-                           std::back_inserter(hashes),
-                           [](const auto &tx) { return tx->hash(); });
-
-            auto error_msg = formErrorMessage(hashes, error.error);
-            // set error response for each transaction in a batch candidate
-            std::for_each(
-                hashes.begin(), hashes.end(), [this, &error_msg](auto &hash) {
-                  status_bus_->publish(status_factory_->makeStatelessFail(
-                      hash,
-                      shared_model::interface::TxStatusFactory::
-                          TransactionError{error_msg, 0, 0}));
-                });
-          });
-    }
-
-    return grpc::Status::OK;
-  }
-
-  grpc::Status CommandServiceTransportGrpc::Status(
-      grpc::ServerContext *context,
-      const iroha::protocol::TxStatusRequest *request,
-      iroha::protocol::ToriiResponse *response) {
-    *response =
-        std::static_pointer_cast<shared_model::proto::TransactionResponse>(
-            command_service_->getStatus(
-                shared_model::crypto::Hash::fromHexString(request->tx_hash())))
-            ->getTransport();
-    return grpc::Status::OK;
-  }
-
-  namespace {
-    void handleEvents(rxcpp::composite_subscription &subscription,
-                      rxcpp::schedulers::run_loop &run_loop) {
-      while (subscription.is_subscribed() or not run_loop.empty()) {
-        run_loop.dispatch();
+    shared_model::interface::types::SharedTxsCollectionType
+    CommandServiceTransportGrpc::deserializeTransactions(
+        const iroha::protocol::TxList *request) {
+      shared_model::interface::types::SharedTxsCollectionType tx_collection;
+      for (const auto &tx : request->transactions()) {
+        transaction_factory_->build(tx).match(
+            [&tx_collection](
+                iroha::expected::Value<
+                    std::unique_ptr<shared_model::interface::Transaction>> &v) {
+              tx_collection.emplace_back(std::move(v).value);
+            },
+            [this](iroha::expected::Error<TransportFactoryType::Error> &error) {
+              status_bus_->publish(status_factory_->makeStatelessFail(
+                  error.error.hash,
+                  shared_model::interface::TxStatusFactory::TransactionError{
+                      error.error.error, 0, 0}));
+            });
       }
+      return tx_collection;
     }
-  }  // namespace
 
-  grpc::Status CommandServiceTransportGrpc::StatusStream(
-      grpc::ServerContext *context,
-      const iroha::protocol::TxStatusRequest *request,
-      grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer) {
-    rxcpp::schedulers::run_loop rl;
+    grpc::Status CommandServiceTransportGrpc::ListTorii(
+        grpc::ServerContext *context,
+        const iroha::protocol::TxList *request,
+        google::protobuf::Empty *response) {
+      auto transactions = deserializeTransactions(request);
 
-    auto current_thread =
-        rxcpp::observe_on_one_worker(rxcpp::schedulers::make_run_loop(rl));
+      auto batches = batch_parser_->parseBatches(transactions);
 
-    rxcpp::composite_subscription subscription;
+      for (auto &batch : batches) {
+        batch_factory_->createTransactionBatch(batch).match(
+            [&](iroha::expected::Value<std::unique_ptr<
+                    shared_model::interface::TransactionBatch>> &value) {
+              this->command_service_->handleTransactionBatch(
+                  std::move(value).value);
+            },
+            [&](iroha::expected::Error<std::string> &error) {
+              std::vector<shared_model::crypto::Hash> hashes;
 
-    auto hash = shared_model::crypto::Hash::fromHexString(request->tx_hash());
+              std::transform(batch.begin(),
+                             batch.end(),
+                             std::back_inserter(hashes),
+                             [](const auto &tx) { return tx->hash(); });
 
-    auto client_id_format = boost::format("Peer: '%s', %s");
-    std::string client_id =
-        (client_id_format % context->peer() % hash.toString()).str();
-    
-    auto consensus_gate_observable =
-        gate_object_.scan(0, [](int seed, const auto &) { return ++seed; })
-            .start_with(0);
+              auto error_msg = formErrorMessage(hashes, error.error);
+              // set error response for each transaction in a batch candidate
+              std::for_each(
+                  hashes.begin(), hashes.end(), [this, &error_msg](auto &hash) {
+                    status_bus_->publish(status_factory_->makeStatelessFail(
+                        hash,
+                        shared_model::interface::TxStatusFactory::
+                            TransactionError{error_msg, 0, 0}));
+                  });
+            });
+      }
 
-    boost::optional<iroha::protocol::TxStatus> last_tx_status;
-    auto rounds_counter{0};
-    command_service_
-        ->getStatusStream(hash)
-        // convert to transport objects
-        .map([&](auto response) {
-          log_->info("mapped {}, {}", *response, client_id);
-          return std::static_pointer_cast<
-                     shared_model::proto::TransactionResponse>(response)
+      return grpc::Status::OK;
+    }
+
+    grpc::Status CommandServiceTransportGrpc::Status(
+        grpc::ServerContext *context,
+        const iroha::protocol::TxStatusRequest *request,
+        iroha::protocol::ToriiResponse *response) {
+      *response =
+          std::static_pointer_cast<shared_model::proto::TransactionResponse>(
+              command_service_->getStatus(
+                  shared_model::crypto::Hash::fromHexString(
+                      request->tx_hash())))
               ->getTransport();
-        })
-        .combine_latest(consensus_gate_observable)
-        // complete the observable if client is disconnected
-        .take_while([=, &rounds_counter, &last_tx_status](const auto &tuple) {
-          auto is_cancelled = context->IsCancelled();
-          if (is_cancelled) {
-            log_->debug("client unsubscribed, {}", client_id);
-          }
-          // we increment round counter when the same status arrived again.
-          auto status = std::get<0>(tuple).tx_status();
-          if (last_tx_status and (status == *last_tx_status)) {
-            ++rounds_counter;
-          } else {
-            rounds_counter = 0;
-          }
-          // we stop the stream when round counter is greater than allowed.
-          if (rounds_counter >= maximum_rounds_without_update_) {
-            return false;
-          }
+      return grpc::Status::OK;
+    }
 
-          return not is_cancelled;
-        })
-        .filter([&last_tx_status](const auto &tuple) {
-          auto status = std::get<0>(tuple).tx_status();
-          // we allow further processing in case of any new status
-          // (including the first one)
-          auto result = not last_tx_status or (*last_tx_status != status);
-          last_tx_status = status;
-          return result;
-        })
-        .subscribe(subscription,
-                   [this, &response_writer, &client_id](const auto &tuple) {
-                     auto response = std::get<0>(tuple);
-                     if (response_writer->Write(response)) {
-                       log_->debug("status written, {}", client_id);
-                     }
-                   },
-                   [&](std::exception_ptr ep) {
-                     log_->error("something bad happened, client_id {}",
-                                 client_id);
-                   },
-                   [&] { log_->debug("stream done, {}", client_id); });
+    namespace {
+      void handleEvents(rxcpp::composite_subscription &subscription,
+                        rxcpp::schedulers::run_loop &run_loop) {
+        while (subscription.is_subscribed() or not run_loop.empty()) {
+          run_loop.dispatch();
+        }
+      }
+    }  // namespace
 
-    // run loop while subscription is active or there are pending events in
-    // the queue
-    handleEvents(subscription, rl);
+    grpc::Status CommandServiceTransportGrpc::StatusStream(
+        grpc::ServerContext *context,
+        const iroha::protocol::TxStatusRequest *request,
+        grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer) {
+      rxcpp::schedulers::run_loop rl;
 
-    log_->debug("status stream done, {}", client_id);
-    return grpc::Status::OK;
-  }
-}  // namespace torii
+      auto current_thread =
+          rxcpp::observe_on_one_worker(rxcpp::schedulers::make_run_loop(rl));
+
+      rxcpp::composite_subscription subscription;
+
+      auto hash = shared_model::crypto::Hash::fromHexString(request->tx_hash());
+
+      auto client_id_format = boost::format("Peer: '%s', %s");
+      std::string client_id =
+          (client_id_format % context->peer() % hash.toString()).str();
+
+      auto consensus_gate_observable =
+          consensus_gate_objects_
+              // via scan we do type erasure here
+              .scan(0, [](int seed, const auto &) { return ++seed; })
+              // a dummy start_with lets us don't wait for the consensus event
+              // on further combine_latest
+              .start_with(0);
+
+      boost::optional<iroha::protocol::TxStatus> last_tx_status;
+      auto rounds_counter{0};
+      command_service_
+          ->getStatusStream(hash)
+          // convert to transport objects
+          .map([&](auto response) {
+            log_->info("mapped {}, {}", *response, client_id);
+            return std::static_pointer_cast<
+                       shared_model::proto::TransactionResponse>(response)
+                ->getTransport();
+          })
+          .combine_latest(consensus_gate_observable)
+          // complete the observable if client is disconnected or too many
+          // rounds have passed without tx status change
+          .take_while([=, &rounds_counter, &last_tx_status](const auto &tuple) {
+            auto is_cancelled = context->IsCancelled();
+            if (is_cancelled) {
+              log_->debug("client unsubscribed, {}", client_id);
+            }
+            // we increment round counter when the same status arrived again.
+            auto status = std::get<0>(tuple).tx_status();
+            if (last_tx_status and (status == *last_tx_status)) {
+              ++rounds_counter;
+            } else {
+              rounds_counter = 0;
+            }
+            // we stop the stream when round counter is greater than allowed.
+            if (rounds_counter >= maximum_rounds_without_update_) {
+              return false;
+            }
+
+            return not is_cancelled;
+          })
+          .filter([&last_tx_status](const auto &tuple) {
+            auto status = std::get<0>(tuple).tx_status();
+            // we allow further processing in case of any new status
+            // (including the first one)
+            auto result = not last_tx_status or (*last_tx_status != status);
+            last_tx_status = status;
+            return result;
+          })
+          .subscribe(subscription,
+                     [this, &response_writer, &client_id](const auto &tuple) {
+                       auto response = std::get<0>(tuple);
+                       if (response_writer->Write(response)) {
+                         log_->debug("status written, {}", client_id);
+                       }
+                     },
+                     [&](std::exception_ptr ep) {
+                       log_->error("something bad happened, client_id {}",
+                                   client_id);
+                     },
+                     [&] { log_->debug("stream done, {}", client_id); });
+
+      // run loop while subscription is active or there are pending events in
+      // the queue
+      handleEvents(subscription, rl);
+
+      log_->debug("status stream done, {}", client_id);
+      return grpc::Status::OK;
+    }
+  }  // namespace torii

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -8,13 +8,12 @@
 
 #include "torii/command_service.hpp"
 
+#include "consensus/gate_object.hpp"
 #include "endpoint.grpc.pb.h"
 #include "endpoint.pb.h"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "logger/logger.hpp"
-
-#include "consensus/gate_object.hpp" // todo
 
 namespace iroha {
   namespace torii {
@@ -30,11 +29,6 @@ namespace shared_model {
   }  // namespace interface
 }  // namespace shared_model
 
-namespace iroha {
-  namespace network {
-    class ConsensusGate;
-  }
-}  // namespace iroha
 
 namespace torii {
   class CommandServiceTransportGrpc
@@ -45,101 +39,105 @@ namespace torii {
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
 
-    /**
-     * Creates a new instance of CommandServiceTransportGrpc
-     * @param command_service - to delegate logic work
-     * @param status_bus is a common notifier for tx statuses
-     * @param status_factory - factory of statuses
-     * @param transaction_factory - factory of transactions
-     * @param batch_parser - parses of batches
-     * @param transaction_batch_factory - factory of batches
-     * @param initial_timeout - streaming timeout when tx is not received
-     * @param nonfinal_timeout - streaming timeout when tx is being processed
-     * @param log to print progress
-     */
-    CommandServiceTransportGrpc(
-        std::shared_ptr<CommandService> command_service,
-        std::shared_ptr<iroha::torii::StatusBus> status_bus,
-        std::shared_ptr<shared_model::interface::TxStatusFactory>
-            status_factory,
-        std::shared_ptr<TransportFactoryType> transaction_factory,
-        std::shared_ptr<shared_model::interface::TransactionBatchParser>
-            batch_parser,
-        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-            transaction_batch_factory,
-        rxcpp::observable<iroha::consensus::GateObject> gate_object,
-        int maximum_rounds_without_update,
-        logger::Logger log = logger::log("CommandServiceTransportGrpc"));
+      struct ConsensusGateEvent {};
 
-    /**
-     * Torii call via grpc
-     * @param context - call context (see grpc docs for details)
-     * @param request - transaction received
-     * @param response - no actual response (grpc stub for empty answer)
-     * @return status
-     */
-    grpc::Status Torii(grpc::ServerContext *context,
-                       const iroha::protocol::Transaction *request,
-                       google::protobuf::Empty *response) override;
+      /**
+       * Creates a new instance of CommandServiceTransportGrpc
+       * @param command_service - to delegate logic work
+       * @param status_bus is a common notifier for tx statuses
+       * @param status_factory - factory of statuses
+       * @param transaction_factory - factory of transactions
+       * @param batch_parser - parses of batches
+       * @param transaction_batch_factory - factory of batches of transactions
+       * @param consensus_gate_objects - events from consensus gate
+       * @param maximum_rounds_without_update - defines how long tx status
+       * stream is kept alive when no new tx statuses appear
+       * @param log to print progress
+       */
+      CommandServiceTransportGrpc(
+          std::shared_ptr<CommandService> command_service,
+          std::shared_ptr<iroha::torii::StatusBus> status_bus,
+          std::shared_ptr<shared_model::interface::TxStatusFactory>
+              status_factory,
+          std::shared_ptr<TransportFactoryType> transaction_factory,
+          std::shared_ptr<shared_model::interface::TransactionBatchParser>
+              batch_parser,
+          std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+              transaction_batch_factory,
+          rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
+          int maximum_rounds_without_update,
+          logger::Logger log = logger::log("CommandServiceTransportGrpc"));
 
-    /**
-     * Torii call for transactions list via grpc
-     * @param context - call context (see grpc docs for details)
-     * @param request - list of transactions received
-     * @param response - no actual response (grpc stub for empty answer)
-     * @return status
-     */
-    grpc::Status ListTorii(grpc::ServerContext *context,
-                           const iroha::protocol::TxList *request,
-                           google::protobuf::Empty *response) override;
+      /**
+       * Torii call via grpc
+       * @param context - call context (see grpc docs for details)
+       * @param request - transaction received
+       * @param response - no actual response (grpc stub for empty answer)
+       * @return status
+       */
+      grpc::Status Torii(grpc::ServerContext *context,
+                         const iroha::protocol::Transaction *request,
+                         google::protobuf::Empty *response) override;
 
-    /**
-     * Status call via grpc
-     * @param context - call context
-     * @param request - TxStatusRequest object which identifies transaction
-     * uniquely
-     * @param response - ToriiResponse which contains a current state of
-     * requested transaction
-     * @return status
-     */
-    grpc::Status Status(grpc::ServerContext *context,
-                        const iroha::protocol::TxStatusRequest *request,
-                        iroha::protocol::ToriiResponse *response) override;
+      /**
+       * Torii call for transactions list via grpc
+       * @param context - call context (see grpc docs for details)
+       * @param request - list of transactions received
+       * @param response - no actual response (grpc stub for empty answer)
+       * @return status
+       */
+      grpc::Status ListTorii(grpc::ServerContext *context,
+                             const iroha::protocol::TxList *request,
+                             google::protobuf::Empty *response) override;
 
-    /**
-     * StatusStream call via grpc
-     * @param context - call context
-     * @param request - TxStatusRequest object which identifies transaction
-     * uniquely
-     * @param response_writer - grpc::ServerWriter which can repeatedly send
-     * transaction statuses back to the client
-     * @return status
-     */
-    grpc::Status StatusStream(grpc::ServerContext *context,
-                              const iroha::protocol::TxStatusRequest *request,
-                              grpc::ServerWriter<iroha::protocol::ToriiResponse>
-                                  *response_writer) override;
+      /**
+       * Status call via grpc
+       * @param context - call context
+       * @param request - TxStatusRequest object which identifies transaction
+       * uniquely
+       * @param response - ToriiResponse which contains a current state of
+       * requested transaction
+       * @return status
+       */
+      grpc::Status Status(grpc::ServerContext *context,
+                          const iroha::protocol::TxStatusRequest *request,
+                          iroha::protocol::ToriiResponse *response) override;
 
-   private:
-    /**
-     * Flat map transport transactions to shared model
-     */
-    shared_model::interface::types::SharedTxsCollectionType
-    deserializeTransactions(const iroha::protocol::TxList *request);
+      /**
+       * StatusStream call via grpc
+       * @param context - call context
+       * @param request - TxStatusRequest object which identifies transaction
+       * uniquely
+       * @param response_writer - grpc::ServerWriter which can repeatedly send
+       * transaction statuses back to the client
+       * @return status
+       */
+      grpc::Status StatusStream(
+          grpc::ServerContext *context,
+          const iroha::protocol::TxStatusRequest *request,
+          grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer)
+          override;
 
-    std::shared_ptr<CommandService> command_service_;
-    std::shared_ptr<iroha::torii::StatusBus> status_bus_;
-    std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
-    std::shared_ptr<TransportFactoryType> transaction_factory_;
-    std::shared_ptr<shared_model::interface::TransactionBatchParser>
-        batch_parser_;
-    std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-        batch_factory_;
-    logger::Logger log_;
+     private:
+      /**
+       * Flat map transport transactions to shared model
+       */
+      shared_model::interface::types::SharedTxsCollectionType
+      deserializeTransactions(const iroha::protocol::TxList *request);
 
-    rxcpp::observable<iroha::consensus::GateObject> gate_object_;
-    const int maximum_rounds_without_update_;
-  };
-}  // namespace torii
+      std::shared_ptr<CommandService> command_service_;
+      std::shared_ptr<iroha::torii::StatusBus> status_bus_;
+      std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
+      std::shared_ptr<TransportFactoryType> transaction_factory_;
+      std::shared_ptr<shared_model::interface::TransactionBatchParser>
+          batch_parser_;
+      std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+          batch_factory_;
+      logger::Logger log_;
+
+      rxcpp::observable<ConsensusGateEvent> consensus_gate_objects_;
+      const int maximum_rounds_without_update_;
+    };
+  }  // namespace torii
 
 #endif  // TORII_COMMAND_SERVICE_TRANSPORT_GRPC_HPP

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -14,6 +14,8 @@
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "logger/logger.hpp"
 
+#include "consensus/gate_object.hpp" // todo
+
 namespace iroha {
   namespace torii {
     class StatusBus;
@@ -65,7 +67,7 @@ namespace torii {
             batch_parser,
         std::shared_ptr<shared_model::interface::TransactionBatchFactory>
             transaction_batch_factory,
-        std::shared_ptr<iroha::network::ConsensusGate> consensus_gate,
+        rxcpp::observable<iroha::consensus::GateObject> gate_object,
         int maximum_rounds_without_update,
         logger::Logger log = logger::log("CommandServiceTransportGrpc"));
 
@@ -135,7 +137,7 @@ namespace torii {
         batch_factory_;
     logger::Logger log_;
 
-    std::shared_ptr<iroha::network::ConsensusGate> consensus_gate_;
+    rxcpp::observable<iroha::consensus::GateObject> gate_object_;
     const int maximum_rounds_without_update_;
   };
 }  // namespace torii

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -8,7 +8,6 @@
 
 #include "torii/command_service.hpp"
 
-#include "consensus/gate_object.hpp"
 #include "endpoint.grpc.pb.h"
 #include "endpoint.pb.h"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -29,7 +29,6 @@ namespace shared_model {
   }  // namespace interface
 }  // namespace shared_model
 
-
 namespace torii {
   class CommandServiceTransportGrpc
       : public iroha::protocol::CommandService_v1::Service {
@@ -39,105 +38,104 @@ namespace torii {
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
 
-      struct ConsensusGateEvent {};
+    struct ConsensusGateEvent {};
 
-      /**
-       * Creates a new instance of CommandServiceTransportGrpc
-       * @param command_service - to delegate logic work
-       * @param status_bus is a common notifier for tx statuses
-       * @param status_factory - factory of statuses
-       * @param transaction_factory - factory of transactions
-       * @param batch_parser - parses of batches
-       * @param transaction_batch_factory - factory of batches of transactions
-       * @param consensus_gate_objects - events from consensus gate
-       * @param maximum_rounds_without_update - defines how long tx status
-       * stream is kept alive when no new tx statuses appear
-       * @param log to print progress
-       */
-      CommandServiceTransportGrpc(
-          std::shared_ptr<CommandService> command_service,
-          std::shared_ptr<iroha::torii::StatusBus> status_bus,
-          std::shared_ptr<shared_model::interface::TxStatusFactory>
-              status_factory,
-          std::shared_ptr<TransportFactoryType> transaction_factory,
-          std::shared_ptr<shared_model::interface::TransactionBatchParser>
-              batch_parser,
-          std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-              transaction_batch_factory,
-          rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
-          int maximum_rounds_without_update,
-          logger::Logger log = logger::log("CommandServiceTransportGrpc"));
+    /**
+     * Creates a new instance of CommandServiceTransportGrpc
+     * @param command_service - to delegate logic work
+     * @param status_bus is a common notifier for tx statuses
+     * @param status_factory - factory of statuses
+     * @param transaction_factory - factory of transactions
+     * @param batch_parser - parses of batches
+     * @param transaction_batch_factory - factory of batches of transactions
+     * @param consensus_gate_objects - events from consensus gate
+     * @param maximum_rounds_without_update - defines how long tx status
+     * stream is kept alive when no new tx statuses appear
+     * @param log to print progress
+     */
+    CommandServiceTransportGrpc(
+        std::shared_ptr<CommandService> command_service,
+        std::shared_ptr<iroha::torii::StatusBus> status_bus,
+        std::shared_ptr<shared_model::interface::TxStatusFactory>
+            status_factory,
+        std::shared_ptr<TransportFactoryType> transaction_factory,
+        std::shared_ptr<shared_model::interface::TransactionBatchParser>
+            batch_parser,
+        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+            transaction_batch_factory,
+        rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
+        int maximum_rounds_without_update,
+        logger::Logger log = logger::log("CommandServiceTransportGrpc"));
 
-      /**
-       * Torii call via grpc
-       * @param context - call context (see grpc docs for details)
-       * @param request - transaction received
-       * @param response - no actual response (grpc stub for empty answer)
-       * @return status
-       */
-      grpc::Status Torii(grpc::ServerContext *context,
-                         const iroha::protocol::Transaction *request,
-                         google::protobuf::Empty *response) override;
+    /**
+     * Torii call via grpc
+     * @param context - call context (see grpc docs for details)
+     * @param request - transaction received
+     * @param response - no actual response (grpc stub for empty answer)
+     * @return status
+     */
+    grpc::Status Torii(grpc::ServerContext *context,
+                       const iroha::protocol::Transaction *request,
+                       google::protobuf::Empty *response) override;
 
-      /**
-       * Torii call for transactions list via grpc
-       * @param context - call context (see grpc docs for details)
-       * @param request - list of transactions received
-       * @param response - no actual response (grpc stub for empty answer)
-       * @return status
-       */
-      grpc::Status ListTorii(grpc::ServerContext *context,
-                             const iroha::protocol::TxList *request,
-                             google::protobuf::Empty *response) override;
+    /**
+     * Torii call for transactions list via grpc
+     * @param context - call context (see grpc docs for details)
+     * @param request - list of transactions received
+     * @param response - no actual response (grpc stub for empty answer)
+     * @return status
+     */
+    grpc::Status ListTorii(grpc::ServerContext *context,
+                           const iroha::protocol::TxList *request,
+                           google::protobuf::Empty *response) override;
 
-      /**
-       * Status call via grpc
-       * @param context - call context
-       * @param request - TxStatusRequest object which identifies transaction
-       * uniquely
-       * @param response - ToriiResponse which contains a current state of
-       * requested transaction
-       * @return status
-       */
-      grpc::Status Status(grpc::ServerContext *context,
-                          const iroha::protocol::TxStatusRequest *request,
-                          iroha::protocol::ToriiResponse *response) override;
+    /**
+     * Status call via grpc
+     * @param context - call context
+     * @param request - TxStatusRequest object which identifies transaction
+     * uniquely
+     * @param response - ToriiResponse which contains a current state of
+     * requested transaction
+     * @return status
+     */
+    grpc::Status Status(grpc::ServerContext *context,
+                        const iroha::protocol::TxStatusRequest *request,
+                        iroha::protocol::ToriiResponse *response) override;
 
-      /**
-       * StatusStream call via grpc
-       * @param context - call context
-       * @param request - TxStatusRequest object which identifies transaction
-       * uniquely
-       * @param response_writer - grpc::ServerWriter which can repeatedly send
-       * transaction statuses back to the client
-       * @return status
-       */
-      grpc::Status StatusStream(
-          grpc::ServerContext *context,
-          const iroha::protocol::TxStatusRequest *request,
-          grpc::ServerWriter<iroha::protocol::ToriiResponse> *response_writer)
-          override;
+    /**
+     * StatusStream call via grpc
+     * @param context - call context
+     * @param request - TxStatusRequest object which identifies transaction
+     * uniquely
+     * @param response_writer - grpc::ServerWriter which can repeatedly send
+     * transaction statuses back to the client
+     * @return status
+     */
+    grpc::Status StatusStream(grpc::ServerContext *context,
+                              const iroha::protocol::TxStatusRequest *request,
+                              grpc::ServerWriter<iroha::protocol::ToriiResponse>
+                                  *response_writer) override;
 
-     private:
-      /**
-       * Flat map transport transactions to shared model
-       */
-      shared_model::interface::types::SharedTxsCollectionType
-      deserializeTransactions(const iroha::protocol::TxList *request);
+   private:
+    /**
+     * Flat map transport transactions to shared model
+     */
+    shared_model::interface::types::SharedTxsCollectionType
+    deserializeTransactions(const iroha::protocol::TxList *request);
 
-      std::shared_ptr<CommandService> command_service_;
-      std::shared_ptr<iroha::torii::StatusBus> status_bus_;
-      std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
-      std::shared_ptr<TransportFactoryType> transaction_factory_;
-      std::shared_ptr<shared_model::interface::TransactionBatchParser>
-          batch_parser_;
-      std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-          batch_factory_;
-      logger::Logger log_;
+    std::shared_ptr<CommandService> command_service_;
+    std::shared_ptr<iroha::torii::StatusBus> status_bus_;
+    std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
+    std::shared_ptr<TransportFactoryType> transaction_factory_;
+    std::shared_ptr<shared_model::interface::TransactionBatchParser>
+        batch_parser_;
+    std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+        batch_factory_;
+    logger::Logger log_;
 
-      rxcpp::observable<ConsensusGateEvent> consensus_gate_objects_;
-      const int maximum_rounds_without_update_;
-    };
-  }  // namespace torii
+    rxcpp::observable<ConsensusGateEvent> consensus_gate_objects_;
+    const int maximum_rounds_without_update_;
+  };
+}  // namespace torii
 
 #endif  // TORII_COMMAND_SERVICE_TRANSPORT_GRPC_HPP

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -82,10 +82,12 @@ namespace iroha {
                 transactions_errors_log.emplace_back(
                     validation::TransactionError{
                         tx.hash(),
+                        // TODO igor-egorov 22.01.2019 IR-245 add a separate
+                        // error code for failed batch case
                         validation::CommandError{
                             "",
                             1,  // internal error code
-                            "The other transaction failed the batch",
+                            "Another transaction failed the batch",
                             true,
                             std::numeric_limits<size_t>::max()}});
               }

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -75,6 +75,21 @@ namespace iroha {
             // batch is successful; release savepoint
             validation_result = true;
             savepoint->release();
+          } else {
+            auto failed_tx_hash = transactions_errors_log.back().tx_hash;
+            for (const auto &tx : batch) {
+              if (tx.hash() != failed_tx_hash) {
+                transactions_errors_log.emplace_back(
+                    validation::TransactionError{
+                        tx.hash(),
+                        validation::CommandError{
+                            "",
+                            1,  // internal error code
+                            "The other transaction failed the batch",
+                            true,
+                            std::numeric_limits<size_t>::max()}});
+              }
+            }
           }
 
           validation_results.insert(

--- a/test/module/irohad/torii/torii_transport_command_test.cpp
+++ b/test/module/irohad/torii/torii_transport_command_test.cpp
@@ -78,7 +78,7 @@ class CommandServiceTransportGrpcTest : public testing::Test {
     status_bus = std::make_shared<MockStatusBus>();
     command_service = std::make_shared<MockCommandService>();
 
-    transport_grpc = std::make_shared<CommandServiceTransportGrpc>(
+    transport_grpc = std::make_shared<torii::CommandServiceTransportGrpc>(
         command_service,
         status_bus,
         status_factory,
@@ -102,9 +102,11 @@ class CommandServiceTransportGrpcTest : public testing::Test {
   std::shared_ptr<MockCommandService> command_service;
   std::shared_ptr<torii::CommandServiceTransportGrpc> transport_grpc;
 
-  rxcpp::subjects::subject<CommandServiceTransportGrpc::ConsensusGateEvent>
+  rxcpp::subjects::subject<
+      torii::CommandServiceTransportGrpc::ConsensusGateEvent>
       consensus_gate_objects;
-  std::vector<CommandServiceTransportGrpc::ConsensusGateEvent> gate_objects{2};
+  std::vector<torii::CommandServiceTransportGrpc::ConsensusGateEvent>
+      gate_objects{2};
 
   const size_t kHashLength = 32;
   const size_t kTimes = 5;

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -316,11 +316,21 @@ TEST_F(Validator, Batches) {
   ASSERT_EQ(
       verified_proposal_and_errors->verified_proposal->transactions().size(),
       5);
-  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(), 1);
-  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
-                ->error.error_code,
-            sample_error_code);
-  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
-                ->error.error_extra,
-            sample_error_extra);
+  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(), 2);
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[0].error.error_code,
+      sample_error_code);
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[0].error.error_extra,
+      sample_error_extra);
+  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions[0].tx_hash,
+            txs[3].hash());
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[1].error.error_code,
+      1);
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[1].error.error_extra,
+      "The other transaction failed the batch");
+  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions[1].tx_hash,
+            txs[4].hash());
 }

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -316,7 +316,8 @@ TEST_F(Validator, Batches) {
   ASSERT_EQ(
       verified_proposal_and_errors->verified_proposal->transactions().size(),
       5);
-  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(), 2);
+  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(),
+            failed_atomic_batch.size());
   EXPECT_EQ(
       verified_proposal_and_errors->rejected_transactions[0].error.error_code,
       sample_error_code);
@@ -330,7 +331,7 @@ TEST_F(Validator, Batches) {
       1);
   EXPECT_EQ(
       verified_proposal_and_errors->rejected_transactions[1].error.error_extra,
-      "The other transaction failed the batch");
+      "Another transaction failed the batch");
   EXPECT_EQ(verified_proposal_and_errors->rejected_transactions[1].tx_hash,
             txs[4].hash());
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

This pr will be a part of RC2 hotfix release.
The #2033 should be merged before this pr. Then this pr has to be rebased to master.

### Description of the Change

When an atomic batch arrived with one stateful valid and one stateful invalid transaction, only one tx's hash was saved to block as rejected (stateful invalid).
The second tx (stateful valid) was not saved as rejected too.

### Benefits

Correct operating.

### Possible Drawbacks

The area for improvements is initialization of fail reason for valid transactions which are within the same atomic batch as a tranasction that did not pass stateful validation. 

### Usage Examples or Tests

```
stateful_validator_test
```