### PR TITLE
Fix proposal validation and prevent resending of incomplete batches

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -31,7 +31,9 @@
 #include "torii/impl/status_bus_impl.hpp"
 #include "validators/default_validator.hpp"
 #include "validators/field_validator.hpp"
+#include "validators/proposal_validator.hpp"
 #include "validators/protobuf/proto_block_validator.hpp"
+#include "validators/protobuf/proto_proposal_validator.hpp"
 #include "validators/protobuf/proto_query_validator.hpp"
 #include "validators/protobuf/proto_transaction_validator.hpp"
 
@@ -189,6 +191,26 @@ void Irohad::initNetworkClient() {
 }
 
 void Irohad::initFactories() {
+  // proposal factory
+  std::shared_ptr<
+      shared_model::validation::AbstractValidator<iroha::protocol::Transaction>>
+      proto_transaction_validator = std::make_shared<
+          shared_model::validation::ProtoTransactionValidator>();
+  std::unique_ptr<shared_model::validation::AbstractValidator<
+      shared_model::interface::Proposal>>
+      proposal_validator = std::make_unique<
+          shared_model::validation::DefaultProposalValidator>();
+  std::unique_ptr<
+      shared_model::validation::AbstractValidator<iroha::protocol::Proposal>>
+      proto_proposal_validator =
+          std::make_unique<shared_model::validation::ProtoProposalValidator>(
+              proto_transaction_validator);
+  proposal_factory =
+      std::make_shared<shared_model::proto::ProtoTransportFactory<
+          shared_model::interface::Proposal,
+          shared_model::proto::Proposal>>(std::move(proposal_validator),
+                                          std::move(proto_proposal_validator));
+
   // transaction factories
   transaction_batch_factory_ =
       std::make_shared<shared_model::interface::TransactionBatchFactoryImpl>();
@@ -198,10 +220,6 @@ void Irohad::initFactories() {
       transaction_validator =
           std::make_unique<shared_model::validation::
                                DefaultOptionalSignedTransactionValidator>();
-  std::unique_ptr<
-      shared_model::validation::AbstractValidator<iroha::protocol::Transaction>>
-      proto_transaction_validator = std::make_unique<
-          shared_model::validation::ProtoTransactionValidator>();
   transaction_factory =
       std::make_shared<shared_model::proto::ProtoTransportFactory<
           shared_model::interface::Transaction,
@@ -301,6 +319,7 @@ void Irohad::initOrderingGate() {
                                                  transaction_batch_factory_,
                                                  async_call_,
                                                  std::move(factory),
+                                                 proposal_factory,
                                                  persistent_cache,
                                                  {blocks.back()->height(), 1},
                                                  delay);

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -195,6 +195,12 @@ class Irohad {
   // persistent cache
   std::shared_ptr<iroha::ametsuchi::TxPresenceCache> persistent_cache;
 
+  // proposal factory
+  std::shared_ptr<shared_model::interface::AbstractTransportFactory<
+      shared_model::interface::Proposal,
+      iroha::protocol::Proposal>>
+      proposal_factory;
+
   // ordering gate
   std::shared_ptr<iroha::network::OrderingGate> ordering_gate;
 

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -28,6 +28,12 @@ namespace iroha {
      * Encapsulates initialization logic for on-demand ordering gate and service
      */
     class OnDemandOrderingInit {
+     public:
+      using TransportFactoryType =
+          shared_model::interface::AbstractTransportFactory<
+              shared_model::interface::Proposal,
+              iroha::protocol::Proposal>;
+
      private:
       /**
        * Creates notification factory for individual connections to peers with
@@ -36,6 +42,7 @@ namespace iroha {
       auto createNotificationFactory(
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay);
 
       /**
@@ -47,6 +54,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay,
           std::vector<shared_model::interface::types::HashType> initial_hashes);
 
@@ -117,6 +125,7 @@ namespace iroha {
               async_call,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round,
           std::function<std::chrono::seconds(

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -19,12 +19,14 @@ OnDemandOsClientGrpc::OnDemandOsClientGrpc(
     std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub,
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call,
+    std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<TimepointType()> time_provider,
     std::chrono::milliseconds proposal_request_timeout,
     logger::Logger log)
     : log_(std::move(log)),
       stub_(std::move(stub)),
       async_call_(std::move(async_call)),
+      proposal_factory_(std::move(proposal_factory)),
       time_provider_(std::move(time_provider)),
       proposal_request_timeout_(proposal_request_timeout) {}
 
@@ -64,16 +66,28 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   if (not response.has_proposal()) {
     return boost::none;
   }
-  return ProposalType{std::make_unique<shared_model::proto::Proposal>(
-      std::move(response.proposal()))};
+  return proposal_factory_->build(response.proposal())
+      .match(
+          [&](iroha::expected::Value<
+              std::unique_ptr<shared_model::interface::Proposal>> &v)
+              -> boost::optional<OdOsNotification::ProposalType> {
+            return ProposalType{std::move(v).value};
+          },
+          [this](iroha::expected::Error<TransportFactoryType::Error> &error)
+              -> boost::optional<OdOsNotification::ProposalType> {
+            log_->info(error.error.error);  // error
+            return {};
+          });
 }
 
 OnDemandOsClientGrpcFactory::OnDemandOsClientGrpcFactory(
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call,
+    std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
     OnDemandOsClientGrpc::TimeoutType proposal_request_timeout)
     : async_call_(std::move(async_call)),
+      proposal_factory_(std::move(proposal_factory)),
       time_provider_(time_provider),
       proposal_request_timeout_(proposal_request_timeout) {}
 
@@ -82,6 +96,7 @@ std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
   return std::make_unique<OnDemandOsClientGrpc>(
       network::createClient<proto::OnDemandOrdering>(to.address()),
       async_call_,
+      proposal_factory_,
       time_provider_,
       proposal_request_timeout_,
       logger::log("OnDemandOsClientGrpc"));

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -8,6 +8,7 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "ordering.grpc.pb.h"
 
@@ -20,6 +21,10 @@ namespace iroha {
        */
       class OnDemandOsClientGrpc : public OdOsNotification {
        public:
+        using TransportFactoryType =
+            shared_model::interface::AbstractTransportFactory<
+                shared_model::interface::Proposal,
+                iroha::protocol::Proposal>;
         using TimepointType = std::chrono::system_clock::time_point;
         using TimeoutType = std::chrono::milliseconds;
 
@@ -31,6 +36,7 @@ namespace iroha {
             std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub,
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
+            std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
             logger::Logger log = logger::log("OnDemandOsClientGrpc"));
@@ -45,15 +51,18 @@ namespace iroha {
         std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub_;
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
+        std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
       };
 
       class OnDemandOsClientGrpcFactory : public OdOsNotificationFactory {
        public:
+        using TransportFactoryType = OnDemandOsClientGrpc::TransportFactoryType;
         OnDemandOsClientGrpcFactory(
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
+            std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
             OnDemandOsClientGrpc::TimeoutType proposal_request_timeout);
 
@@ -69,6 +78,7 @@ namespace iroha {
        private:
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
+        std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
       };

--- a/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.cpp
@@ -5,106 +5,20 @@
 
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
 
-#include <boost/range/combine.hpp>
-
-#include "interfaces/iroha_internal/batch_meta.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
 #include "interfaces/transaction.hpp"
 #include "validators/answer.hpp"
-
-namespace {
-  enum class BatchCheckResult {
-    kOk,
-    kNoBatchMeta,
-    kIncorrectBatchMetaSize,
-    kIncorrectHashes
-  };
-  /**
-   * Check that all transactions from the collection are mentioned in batch_meta
-   * and are positioned correctly
-   * @param transactions to be checked
-   * @return enum, reporting about success result or containing a found error
-   */
-  BatchCheckResult batchIsWellFormed(
-      const shared_model::interface::types::SharedTxsCollectionType
-          &transactions) {
-    auto batch_meta_opt = transactions[0]->batchMeta();
-    if (not batch_meta_opt and transactions.size() == 1) {
-      // batch is created from one tx - there is no batch_meta in valid case
-      return BatchCheckResult::kOk;
-    }
-    if (not batch_meta_opt) {
-      // in all other cases batch_meta must present
-      return BatchCheckResult::kNoBatchMeta;
-    }
-
-    const auto &batch_hashes = batch_meta_opt->get()->reducedHashes();
-    if (batch_hashes.size() != transactions.size()) {
-      return BatchCheckResult::kIncorrectBatchMetaSize;
-    }
-
-    auto metas_and_txs = boost::combine(batch_hashes, transactions);
-    auto hashes_are_correct =
-        std::all_of(boost::begin(metas_and_txs),
-                    boost::end(metas_and_txs),
-                    [](const auto &meta_and_tx) {
-                      shared_model::interface::types::HashType batch_hash;
-                      std::shared_ptr<shared_model::interface::Transaction> tx;
-                      boost::tie(batch_hash, tx) = meta_and_tx;
-                      return batch_hash == tx->reducedHash();
-                    });
-    if (not hashes_are_correct) {
-      return BatchCheckResult::kIncorrectHashes;
-    }
-
-    return BatchCheckResult::kOk;
-  }
-}  // namespace
 
 namespace shared_model {
   namespace interface {
     TransactionBatchFactoryImpl::FactoryImplResult
     TransactionBatchFactoryImpl::createTransactionBatch(
         const types::SharedTxsCollectionType &transactions) const {
-      std::string reason_name = "Transaction batch factory: ";
-      validation::ReasonsGroupType batch_reason;
-      batch_reason.first = reason_name;
-
-      bool has_at_least_one_signature = std::any_of(
-          transactions.begin(), transactions.end(), [](const auto tx) {
-            return not boost::empty(tx->signatures());
-          });
-      if (not has_at_least_one_signature) {
-        batch_reason.second.emplace_back(
-            "Transaction batch should contain at least one signature");
-      }
-
-      switch (batchIsWellFormed(transactions)) {
-        case BatchCheckResult::kOk:
-          break;
-        case BatchCheckResult::kNoBatchMeta:
-          batch_reason.second.emplace_back(
-              "There is no batch meta in provided transactions");
-          break;
-        case BatchCheckResult::kIncorrectBatchMetaSize:
-          batch_reason.second.emplace_back(
-              "Sizes of batch_meta and provided transactions are different");
-          break;
-        case BatchCheckResult::kIncorrectHashes:
-          batch_reason.second.emplace_back(
-              "Hashes of provided transactions and ones in batch_meta are "
-              "different");
-          break;
-      }
-
-      if (not batch_reason.second.empty()) {
-        validation::Answer answer;
-        answer.addReason(std::move(batch_reason));
-        return iroha::expected::makeError(answer.reason());
-      }
-
       std::unique_ptr<TransactionBatch> batch_ptr =
           std::make_unique<TransactionBatchImpl>(transactions);
+      if (auto answer = batch_validator_.validate(*batch_ptr)) {
+        return iroha::expected::makeError(answer.reason());
+      }
       return iroha::expected::makeValue(std::move(batch_ptr));
     }
 

--- a/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.hpp
@@ -7,6 +7,7 @@
 #define IROHA_TRANSACTION_BATCH_FACTORY_IMPL_HPP
 
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
+#include "validators/transaction_batch_validator.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -21,6 +22,9 @@ namespace shared_model {
 
       FactoryImplResult createTransactionBatch(
           std::shared_ptr<Transaction> transaction) const override;
+
+     private:
+      validation::BatchValidator batch_validator_;
     };
 
   }  // namespace interface

--- a/shared_model/validators/CMakeLists.txt
+++ b/shared_model/validators/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(shared_model_stateless_validation
         protobuf/proto_block_validator.cpp
         protobuf/proto_query_validator.cpp
         protobuf/proto_transaction_validator.cpp
+        protobuf/proto_proposal_validator.cpp
+        transaction_batch_validator.cpp
         )
 
 target_link_libraries(shared_model_stateless_validation

--- a/shared_model/validators/proposal_validator.hpp
+++ b/shared_model/validators/proposal_validator.hpp
@@ -11,6 +11,7 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
+#include "validators/abstract_validator.hpp"
 #include "validators/answer.hpp"
 #include "validators/container_validator.hpp"
 
@@ -26,7 +27,8 @@ namespace shared_model {
     class ProposalValidator
         : public ContainerValidator<interface::Proposal,
                                     FieldValidator,
-                                    TransactionsCollectionValidator> {
+                                    TransactionsCollectionValidator>,
+          public AbstractValidator<interface::Proposal> {
      public:
       using ContainerValidator<
           interface::Proposal,

--- a/shared_model/validators/protobuf/proto_proposal_validator.cpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "validators/protobuf/proto_proposal_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    ProtoProposalValidator::ProtoProposalValidator(
+        ProtoValidatorType transaction_validator)
+        : transaction_validator_(std::move(transaction_validator)) {}
+
+    Answer ProtoProposalValidator::validate(
+        const iroha::protocol::Proposal &proposal) const {
+      Answer answer;
+      std::string tx_reason_name = "Protobuf Proposal";
+      ReasonsGroupType reason{tx_reason_name, GroupedReasons()};
+
+      for (const auto &tx : proposal.transactions()) {
+        if (auto tx_answer = transaction_validator_->validate(tx)) {
+          reason.second.emplace_back(tx_answer.reason());
+          break;
+        }
+      }
+
+      if (not reason.second.empty()) {
+        answer.addReason(std::move(reason));
+      }
+
+      return answer;
+    }
+
+  }  // namespace validation
+}  // namespace shared_model

--- a/shared_model/validators/protobuf/proto_proposal_validator.hpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.hpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef IROHA_PROTO_PROPOSAL_VALIDATOR_HPP
+#define IROHA_PROTO_PROPOSAL_VALIDATOR_HPP
+
+#include "proposal.pb.h"
+#include "validators/abstract_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+    class ProtoProposalValidator
+        : public AbstractValidator<iroha::protocol::Proposal> {
+     public:
+      using ProtoValidatorType =
+          std::shared_ptr<shared_model::validation::AbstractValidator<
+              typename iroha::protocol::Transaction>>;
+
+      ProtoProposalValidator(ProtoValidatorType transaction_validator);
+
+      Answer validate(const iroha::protocol::Proposal &proposal) const override;
+
+     private:
+      ProtoValidatorType transaction_validator_;
+    };
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_PROTO_PROPOSAL_VALIDATOR_HPP

--- a/shared_model/validators/transaction_batch_validator.cpp
+++ b/shared_model/validators/transaction_batch_validator.cpp
@@ -1,0 +1,111 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "validators/transaction_batch_validator.hpp"
+
+#include <boost/range/adaptor/indirected.hpp>
+#include <boost/range/combine.hpp>
+#include "interfaces/iroha_internal/batch_meta.hpp"
+#include "interfaces/transaction.hpp"
+
+namespace {
+  enum class BatchCheckResult {
+    kOk,
+    kNoBatchMeta,
+    kIncorrectBatchMetaSize,
+    kIncorrectHashes
+  };
+  /**
+   * Check that all transactions from the collection are mentioned in batch_meta
+   * and are positioned correctly
+   * @param transactions to be checked
+   * @return enum, reporting about success result or containing a found error
+   */
+  BatchCheckResult batchIsWellFormed(
+      const shared_model::interface::types::TransactionsForwardCollectionType
+          &transactions) {
+    auto batch_meta_opt = transactions.begin()->batchMeta();
+    if (not batch_meta_opt and boost::size(transactions) == 1) {
+      // batch is created from one tx - there is no batch_meta in valid case
+      return BatchCheckResult::kOk;
+    }
+    if (not batch_meta_opt) {
+      // in all other cases batch_meta must present
+      return BatchCheckResult::kNoBatchMeta;
+    }
+
+    const auto &batch_hashes = batch_meta_opt->get()->reducedHashes();
+    if (batch_hashes.size() != boost::size(transactions)) {
+      return BatchCheckResult::kIncorrectBatchMetaSize;
+    }
+
+    auto metas_and_txs = boost::combine(batch_hashes, transactions);
+    auto hashes_are_correct =
+        std::all_of(boost::begin(metas_and_txs),
+                    boost::end(metas_and_txs),
+                    [](const auto &meta_and_tx) {
+                      return boost::get<0>(meta_and_tx)
+                          == boost::get<1>(meta_and_tx).reducedHash();
+                    });
+    if (not hashes_are_correct) {
+      return BatchCheckResult::kIncorrectHashes;
+    }
+
+    return BatchCheckResult::kOk;
+  }
+}  // namespace
+
+namespace shared_model {
+  namespace validation {
+
+    Answer BatchValidator::validate(
+        const interface::TransactionBatch &batch) const {
+      auto transactions = batch.transactions();
+      return validate(transactions | boost::adaptors::indirected);
+    }
+
+    Answer BatchValidator::validate(
+        interface::types::TransactionsForwardCollectionType transactions)
+        const {
+      std::string reason_name = "Transaction batch factory: ";
+      validation::ReasonsGroupType batch_reason;
+      batch_reason.first = reason_name;
+
+      bool has_at_least_one_signature = std::any_of(
+          transactions.begin(), transactions.end(), [](const auto &tx) {
+            return not boost::empty(tx.signatures());
+          });
+      if (not has_at_least_one_signature) {
+        batch_reason.second.emplace_back(
+            "Transaction batch should contain at least one signature");
+      }
+
+      switch (batchIsWellFormed(transactions)) {
+        case BatchCheckResult::kOk:
+          break;
+        case BatchCheckResult::kNoBatchMeta:
+          batch_reason.second.emplace_back(
+              "There is no batch meta in provided transactions");
+          break;
+        case BatchCheckResult::kIncorrectBatchMetaSize:
+          batch_reason.second.emplace_back(
+              "Sizes of batch_meta and provided transactions are different");
+          break;
+        case BatchCheckResult::kIncorrectHashes:
+          batch_reason.second.emplace_back(
+              "Hashes of provided transactions and ones in batch_meta are "
+              "different");
+          break;
+      }
+
+      validation::Answer answer;
+      if (not batch_reason.second.empty()) {
+        answer.addReason(std::move(batch_reason));
+      }
+      return answer;
+    }
+
+  }  // namespace validation
+}  // namespace shared_model

--- a/shared_model/validators/transaction_batch_validator.hpp
+++ b/shared_model/validators/transaction_batch_validator.hpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef IROHA_TRANSACTION_BATCH_VALIDATOR_HPP
+#define IROHA_TRANSACTION_BATCH_VALIDATOR_HPP
+
+#include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "validators/abstract_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    class BatchValidator
+        : public AbstractValidator<interface::TransactionBatch> {
+     public:
+      Answer validate(const interface::TransactionBatch &batch) const override;
+
+      Answer validate(interface::types::TransactionsForwardCollectionType
+                          transactions) const;
+    };
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_TRANSACTION_BATCH_VALIDATOR_HPP

--- a/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
+++ b/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
@@ -10,9 +10,11 @@
 #include <boost/format.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
+#include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
 #include "validators/default_validator.hpp"
 #include "validators/field_validator.hpp"
 #include "validators/signable_validator.hpp"
+#include "validators/transaction_batch_validator.hpp"
 #include "validators/transaction_validator.hpp"
 #include "validators/transactions_collection/batch_order_validator.hpp"
 
@@ -54,6 +56,17 @@ namespace shared_model {
               (boost::format("Tx %s : %s") % tx.hash().hex() % answer.reason())
                   .str();
           reason.second.push_back(message);
+        }
+      }
+
+      interface::TransactionBatchParserImpl batch_parser;
+      BatchValidator batch_validator;
+
+      auto batches = batch_parser.parseBatches(transactions);
+      for (auto &batch : batches) {
+        if (auto answer = batch_validator.validate(batch)) {
+          reason.second.emplace_back(answer.reason());
+          break;
         }
       }
 

--- a/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
@@ -6,10 +6,13 @@
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
 
 #include <gtest/gtest.h>
+#include "backend/protobuf/proposal.hpp"
+#include "backend/protobuf/proto_transport_factory.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "framework/mock_stream.h"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
+#include "module/shared_model/validators/validators.hpp"
 #include "ordering_mock.grpc.pb.h"
 
 using namespace iroha;
@@ -23,14 +26,37 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 
-struct OnDemandOsClientGrpcTest : public ::testing::Test {
+class OnDemandOsClientGrpcTest : public ::testing::Test {
+ public:
+  using ProtoProposalTransportFactory =
+      shared_model::proto::ProtoTransportFactory<
+          shared_model::interface::Proposal,
+          shared_model::proto::Proposal>;
+  using ProposalTransportFactory =
+      shared_model::interface::AbstractTransportFactory<
+          shared_model::interface::Proposal,
+          shared_model::proto::Proposal::TransportType>;
+  using MockProposalValidator = shared_model::validation::MockValidator<
+      shared_model::interface::Proposal>;
+  using MockProtoProposalValidator =
+      shared_model::validation::MockValidator<iroha::protocol::Proposal>;
+
   void SetUp() override {
     auto ustub = std::make_unique<proto::MockOnDemandOrderingStub>();
     stub = ustub.get();
     async_call =
         std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>();
-    client = std::make_shared<OnDemandOsClientGrpc>(
-        std::move(ustub), async_call, [&] { return timepoint; }, timeout);
+    auto validator = std::make_unique<MockProposalValidator>();
+    proposal_validator = validator.get();
+    auto proto_validator = std::make_unique<MockProtoProposalValidator>();
+    proto_proposal_validator = proto_validator.get();
+    proposal_factory = std::make_shared<ProtoProposalTransportFactory>(
+        std::move(validator), std::move(proto_validator));
+    client = std::make_shared<OnDemandOsClientGrpc>(std::move(ustub),
+                                                    async_call,
+                                                    proposal_factory,
+                                                    [&] { return timepoint; },
+                                                    timeout);
   }
 
   proto::MockOnDemandOrderingStub *stub;
@@ -39,6 +65,10 @@ struct OnDemandOsClientGrpcTest : public ::testing::Test {
   std::chrono::milliseconds timeout{1};
   std::shared_ptr<OnDemandOsClientGrpc> client;
   consensus::Round round{1, 2};
+
+  MockProposalValidator *proposal_validator;
+  MockProtoProposalValidator *proto_proposal_validator;
+  std::shared_ptr<ProposalTransportFactory> proposal_factory;
 };
 
 /**

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -66,3 +66,12 @@ target_link_libraries(proto_block_validator_test
     shared_model_proto_backend
     shared_model_stateless_validation
     )
+
+addtest(proposal_validator_test
+    proposal_validator_test.cpp
+    )
+target_link_libraries(proposal_validator_test
+    shared_model_proto_backend
+    shared_model_interfaces_factories
+    shared_model_stateless_validation
+    )

--- a/test/module/shared_model/validators/proposal_validator_test.cpp
+++ b/test/module/shared_model/validators/proposal_validator_test.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "module/shared_model/validators/validators_fixture.hpp"
+
+#include <gtest/gtest.h>
+
+#include "framework/batch_helper.hpp"
+#include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/default_validator.hpp"
+
+using namespace shared_model::validation;
+
+class ProposalValidatorTest : public ValidatorsTest {
+ public:
+  using BatchTypeAndCreatorPair =
+      std::pair<shared_model::interface::types::BatchType, std::string>;
+
+  DefaultProposalValidator validator_;
+};
+
+/**
+ * @given a proposal with a transaction
+ * @when transaction's batch meta contains info about two transactions
+ * @then such proposal should be rejected
+ */
+TEST_F(ProposalValidatorTest, IncompleteBatch) {
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      std::vector<BatchTypeAndCreatorPair>{
+          BatchTypeAndCreatorPair{
+              shared_model::interface::types::BatchType::ATOMIC, "a@domain"},
+          BatchTypeAndCreatorPair{
+              shared_model::interface::types::BatchType::ATOMIC, "b@domain"}});
+  std::vector<shared_model::proto::Transaction> proto_txs;
+  proto_txs.push_back(*std::move(
+      std::static_pointer_cast<shared_model::proto::Transaction>(txs[0])));
+  auto proposal = std::make_shared<shared_model::proto::Proposal>(
+      TestProposalBuilder()
+          .height(1)
+          .createdTime(txs[0]->createdTime())
+          .transactions(proto_txs)
+          .build());
+
+  auto answer = validator_.validate(*proposal);
+  ASSERT_TRUE(answer);
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

This pr will be a part of RC2 hotfix release.
The #2033 should be merged before this pr. Then this pr has to be rebased to master.

### Description of the Change

Create standalone batch validator.
Add and integrate proto proposal validator.
Prevent resend/reprocessing of "partially valid" * atomic batches.
Add test.

\* I mean that some transaction has failed stateful validation within an atomic batch.

### Benefits

Fixed batches processing behavior.

### Possible Drawbacks 

To be discovered.

### Usage Examples or Tests

```
on_demand_os_client_grpc_test
proposal_validator_test
```


Many thanks to @lebdron! 
