### PR TITLE
Fixed thread safety in ITF Fake Peer proposal storage

### DIFF
--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -83,13 +83,13 @@ namespace integration_framework {
             request.toString());
         return boost::none;
       }
-      auto proposal = proposal_storage->getProposal(request);
+      auto opt_proposal = proposal_storage->getProposal(request);
       getLogger()->debug(
           "Got an OnDemandOrderingService.GetProposal call for round {}, "
           "{} returning a proposal.",
           request.toString(),
-          proposal ? "" : "NOT");
-      return proposal;
+          opt_proposal ? "" : "NOT");
+      return opt_proposal;
     }
 
     void HonestBehaviour::processOrderingBatches(
@@ -125,7 +125,7 @@ namespace integration_framework {
       std::vector<shared_model::proto::Transaction> txs;
       auto opt_proposal = proposal_storage->getProposal(round);
       if (opt_proposal) {
-        for (const auto &tx : opt_proposal->getTransport().transactions()) {
+        for (const auto &tx : (*opt_proposal)->getTransport().transactions()) {
           txs.emplace_back(tx);
         }
       }

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -29,11 +29,11 @@ namespace integration_framework {
         BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
         const auto behaviour = fake_peer->getBehaviour();
         if (behaviour) {
-          auto proposal = behaviour->processOrderingProposalRequest(round);
-          if (proposal) {
+          auto opt_proposal = behaviour->processOrderingProposalRequest(round);
+          if (opt_proposal) {
             return std::unique_ptr<shared_model::interface::Proposal>(
                 std::make_unique<shared_model::proto::Proposal>(
-                    proposal->getTransport()));
+                    (*opt_proposal)->getTransport()));
           }
         }
         return {};

--- a/test/framework/integration_framework/fake_peer/proposal_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.cpp
@@ -5,8 +5,7 @@
 
 #include "framework/integration_framework/fake_peer/proposal_storage.hpp"
 
-#include <boost/thread/lock_guard.hpp>
-#include <boost/thread/shared_lock_guard.hpp>
+#include <mutex>
 
 namespace integration_framework {
   namespace fake_peer {
@@ -16,7 +15,7 @@ namespace integration_framework {
 
     OrderingProposalRequestResult ProposalStorage::getProposal(
         const Round &round) const {
-      boost::shared_lock_guard<boost::shared_mutex> lock(proposals_map_mutex_);
+      std::shared_lock<std::shared_timed_mutex> lock(proposals_map_mutex_);
       auto it = proposals_map_.find(round);
       if (it != proposals_map_.end()) {
         if (it->second) {
@@ -30,7 +29,7 @@ namespace integration_framework {
 
     ProposalStorage &ProposalStorage::storeProposal(
         const Round &round, std::shared_ptr<Proposal> proposal) {
-      boost::lock_guard<boost::shared_mutex> lock(proposals_map_mutex_);
+      std::lock_guard<std::shared_timed_mutex> lock(proposals_map_mutex_);
       const auto it = proposals_map_.find(round);
       if (it == proposals_map_.end()) {
         proposals_map_.emplace(round, proposal);

--- a/test/framework/integration_framework/fake_peer/proposal_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.cpp
@@ -13,6 +13,7 @@ namespace integration_framework {
 
     OrderingProposalRequestResult ProposalStorage::getProposal(
         const Round &round) const {
+      boost::shared_lock<boost::shared_mutex> lock(proposals_map_mutex_);
       auto it = proposals_map_.find(round);
       if (it != proposals_map_.end()) {
         if (it->second) {
@@ -26,18 +27,13 @@ namespace integration_framework {
 
     ProposalStorage &ProposalStorage::storeProposal(
         const Round &round, std::shared_ptr<Proposal> proposal) {
+      boost::unique_lock<boost::shared_mutex> lock(proposals_map_mutex_);
       const auto it = proposals_map_.find(round);
       if (it == proposals_map_.end()) {
         proposals_map_.emplace(round, proposal);
       } else {
         it->second = proposal;
       }
-      return *this;
-    }
-
-    ProposalStorage &ProposalStorage::setDefaultProvider(
-        DefaultProvider default_provider) {
-      default_provider_ = default_provider;
       return *this;
     }
 

--- a/test/framework/integration_framework/fake_peer/proposal_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.cpp
@@ -20,7 +20,7 @@ namespace integration_framework {
       auto it = proposals_map_.find(round);
       if (it != proposals_map_.end()) {
         if (it->second) {
-          return *it->second;
+          return it->second;
         } else {
           return boost::none;
         }

--- a/test/framework/integration_framework/fake_peer/proposal_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.cpp
@@ -5,6 +5,9 @@
 
 #include "framework/integration_framework/fake_peer/proposal_storage.hpp"
 
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/shared_lock_guard.hpp>
+
 namespace integration_framework {
   namespace fake_peer {
 
@@ -13,7 +16,7 @@ namespace integration_framework {
 
     OrderingProposalRequestResult ProposalStorage::getProposal(
         const Round &round) const {
-      boost::shared_lock<boost::shared_mutex> lock(proposals_map_mutex_);
+      boost::shared_lock_guard<boost::shared_mutex> lock(proposals_map_mutex_);
       auto it = proposals_map_.find(round);
       if (it != proposals_map_.end()) {
         if (it->second) {
@@ -27,7 +30,7 @@ namespace integration_framework {
 
     ProposalStorage &ProposalStorage::storeProposal(
         const Round &round, std::shared_ptr<Proposal> proposal) {
-      boost::unique_lock<boost::shared_mutex> lock(proposals_map_mutex_);
+      boost::lock_guard<boost::shared_mutex> lock(proposals_map_mutex_);
       const auto it = proposals_map_.find(round);
       if (it == proposals_map_.end()) {
         proposals_map_.emplace(round, proposal);

--- a/test/framework/integration_framework/fake_peer/proposal_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.hpp
@@ -7,8 +7,8 @@
 #define INTEGRATION_FRAMEWORK_FAKE_PEER_PROPOSAL_STORAGE_HPP_
 
 #include <map>
+#include <shared_mutex>
 
-#include <boost/thread/shared_mutex.hpp>
 #include "backend/protobuf/proposal.hpp"
 #include "consensus/round.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"
@@ -34,7 +34,7 @@ namespace integration_framework {
      private:
       DefaultProvider default_provider_;
       std::map<Round, std::shared_ptr<const Proposal>> proposals_map_;
-      mutable boost::shared_mutex proposals_map_mutex_;
+      mutable std::shared_timed_mutex proposals_map_mutex_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/proposal_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.hpp
@@ -8,6 +8,7 @@
 
 #include <map>
 
+#include <boost/thread/shared_mutex.hpp>
 #include "backend/protobuf/proposal.hpp"
 #include "consensus/round.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"
@@ -30,11 +31,10 @@ namespace integration_framework {
       ProposalStorage &storeProposal(const Round &round,
                                      std::shared_ptr<Proposal> proposal);
 
-      ProposalStorage &setDefaultProvider(DefaultProvider default_provider);
-
      private:
       DefaultProvider default_provider_;
-      std::map<Round, std::shared_ptr<Proposal>> proposals_map_;
+      std::map<Round, std::shared_ptr<const Proposal>> proposals_map_;
+      mutable boost::shared_mutex proposals_map_mutex_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -91,7 +91,7 @@ namespace integration_framework {
         std::vector<std::reference_wrapper<const shared_model::proto::Block>>;
     using OrderingProposalRequest = iroha::consensus::Round;
     using OrderingProposalRequestResult =
-        boost::optional<shared_model::proto::Proposal &>;
+        boost::optional<const shared_model::proto::Proposal &>;
 
   }  // namespace fake_peer
 }  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -91,7 +91,7 @@ namespace integration_framework {
         std::vector<std::reference_wrapper<const shared_model::proto::Block>>;
     using OrderingProposalRequest = iroha::consensus::Round;
     using OrderingProposalRequestResult =
-        boost::optional<const shared_model::proto::Proposal &>;
+        boost::optional<std::shared_ptr<const shared_model::proto::Proposal>>;
 
   }  // namespace fake_peer
 }  // namespace integration_framework


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This change makes the Proposal Storage of ITF Fake Peers thread-safe. It is necessary due to the shared usage of these objects.

### Benefits

<!-- What benefits will be realized by the code change? -->

Bug fixed.

### Possible Drawbacks 

Synchronization slows down execution.