### PR TITLE
Python sha3 dependency to docker

### DIFF
--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -277,10 +277,8 @@ RUN set -e; \
 
 # python bindings dependencies
 RUN set -e; \
-    pip install grpcio_tools; \
-    pip3 install grpcio_tools; \
-    pip install pysha3; \
-    pip3 install pysha3
+    pip install grpcio_tools pysha3; \
+    pip3 install grpcio_tools pysha3;
 
 # install lcov
 RUN set -e; \

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -278,7 +278,9 @@ RUN set -e; \
 # python bindings dependencies
 RUN set -e; \
     pip install grpcio_tools; \
-    pip3 install grpcio_tools
+    pip3 install grpcio_tools; \
+    pip install pysha3; \
+    pip3 install pysha3
 
 # install lcov
 RUN set -e; \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -272,10 +272,8 @@ RUN set -e; \
 
 # python bindings dependencies
 RUN set -e; \
-    pip install grpcio_tools; \
-    pip3 install grpcio_tools; \
-    pip install pysha3; \
-    pip3 install pysha3
+    pip install grpcio_tools pysha3; \
+    pip3 install grpcio_tools pysha3;
 
 # install lcov
 RUN set -e; \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -273,7 +273,9 @@ RUN set -e; \
 # python bindings dependencies
 RUN set -e; \
     pip install grpcio_tools; \
-    pip3 install grpcio_tools
+    pip3 install grpcio_tools; \
+    pip install pysha3; \
+    pip3 install pysha3
 
 # install lcov
 RUN set -e; \


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

@bakhtin, @kogeler, please add the dependency to the mac CI environment.

### Description of the Change

Iroha crypto requires sha3_512 algo.
Python that is older than 3.6 does not have its built-in support.
Additional dependency solves the problem.


### Benefits

Python 3.x where x < 6 is supported
BTF will be enabled on CI.
