### PR TITLE
Fix/itf fake peer block storage safety

### DIFF
--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -51,7 +51,7 @@ namespace integration_framework {
             request->toString());
         return {};
       }
-      return *std::static_pointer_cast<shared_model::proto::Block>(block);
+      return block;
     }
 
     LoaderBlocksRequestResult HonestBehaviour::processLoaderBlocksRequest(
@@ -67,7 +67,7 @@ namespace integration_framework {
       LoaderBlocksRequestResult blocks;
       while ((block = block_storage->getBlockByHeight(current_height++))
              != nullptr) {
-        blocks.emplace_back(*block);
+        blocks.emplace_back(block);
       }
       return blocks;
     }

--- a/test/framework/integration_framework/fake_peer/block_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.cpp
@@ -30,6 +30,16 @@ namespace integration_framework {
     BlockStorage::BlockStorage()
         : log_(logger::log("Fake peer block storage")) {}
 
+    BlockStorage::BlockStorage(const BlockStorage &other)
+        : blocks_by_height_(other.blocks_by_height_),
+          blocks_by_hash_(other.blocks_by_hash_),
+          log_(logger::log("Fake peer block storage")) {}
+
+    BlockStorage::BlockStorage(BlockStorage &&other)
+        : blocks_by_height_(std::move(other.blocks_by_height_)),
+          blocks_by_hash_(std::move(other.blocks_by_hash_)),
+          log_(logger::log("Fake peer block storage")) {}
+
     void BlockStorage::storeBlock(const BlockPtr &block) {
       boost::lock_guard<boost::shared_mutex> lock(block_maps_mutex_);
       if (emplaceCheckingOverwrite(blocks_by_height_, block->height(), block)) {

--- a/test/framework/integration_framework/fake_peer/block_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.cpp
@@ -8,6 +8,8 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/max_element.hpp>
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/shared_lock_guard.hpp>
 #include "backend/protobuf/block.hpp"
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 
@@ -25,23 +27,26 @@ static bool emplaceCheckingOverwrite(MapType &map,
 namespace integration_framework {
   namespace fake_peer {
 
+    BlockStorage::BlockStorage()
+        : log_(logger::log("Fake peer block storage")) {}
+
     void BlockStorage::storeBlock(const BlockPtr &block) {
+      boost::lock_guard<boost::shared_mutex> lock(block_maps_mutex_);
       if (emplaceCheckingOverwrite(blocks_by_height_, block->height(), block)) {
-        getLogger()->warn("Overwriting block with height {}.", block->height());
+        log_->warn("Overwriting block with height {}.", block->height());
       }
       if (emplaceCheckingOverwrite(blocks_by_hash_, block->hash(), block)) {
-        getLogger()->warn("Overwriting block with hash {}.",
-                          block->hash().toString());
+        log_->warn("Overwriting block with hash {}.", block->hash().toString());
       }
     }
 
     BlockStorage::BlockPtr BlockStorage::getBlockByHeight(
         BlockStorage::HeightType height) const {
+      boost::shared_lock_guard<boost::shared_mutex> lock(block_maps_mutex_);
       const auto found = blocks_by_height_.find(height);
       if (found == blocks_by_height_.end()) {
-        getLogger()->info(
-            "Requested block with height {} not found in block storage.",
-            height);
+        log_->info("Requested block with height {} not found in block storage.",
+                   height);
         return {};
       }
       return found->second;
@@ -49,71 +54,24 @@ namespace integration_framework {
 
     BlockStorage::BlockPtr BlockStorage::getBlockByHash(
         const BlockStorage::HashType &hash) const {
+      boost::shared_lock_guard<boost::shared_mutex> lock(block_maps_mutex_);
       const auto found = blocks_by_hash_.find(hash);
       if (found == blocks_by_hash_.end()) {
-        getLogger()->info(
-            "Requested block with hash {} not found in block storage.",
-            hash.toString());
+        log_->info("Requested block with hash {} not found in block storage.",
+                   hash.toString());
         return {};
       }
       return found->second;
     }
 
     BlockStorage::BlockPtr BlockStorage::getTopBlock() const {
+      boost::shared_lock_guard<boost::shared_mutex> lock(block_maps_mutex_);
       if (blocks_by_height_.empty()) {
-        getLogger()->info(
-            "Requested top block, but the block storage is empty.");
+        log_->info("Requested top block, but the block storage is empty.");
         return {};
       }
       return blocks_by_height_.at(*boost::range::max_element(
           blocks_by_height_ | boost::adaptors::map_keys));
-    }
-
-    void BlockStorage::claimUsingPeer(const std::shared_ptr<FakePeer> &peer) {
-      auto found = std::find_if(
-          using_peers_.begin(), using_peers_.end(), [&peer](const auto &wptr) {
-            return wptr.lock() == peer;
-          });
-      if (found != using_peers_.end()) {
-        getLogger()->warn(
-            "Requested adding of a using fake peer ({}) "
-            "that was already added before.",
-            peer->getAddress());
-        return;
-      }
-      using_peers_.emplace_back(peer);
-    }
-
-    void BlockStorage::claimNotUsingPeer(
-        const std::shared_ptr<FakePeer> &peer) {
-      auto found = std::find_if(
-          using_peers_.begin(), using_peers_.end(), [&peer](const auto &wptr) {
-            return wptr.lock() == peer;
-          });
-      if (found == using_peers_.end()) {
-        getLogger()->warn(
-            "Requested removal of a using fake peer "
-            "without previously registering it.");
-        return;
-      }
-      using_peers_.erase(found);
-    }
-
-    logger::Logger BlockStorage::getLogger() const {
-      std::vector<std::string> addresses_of_users;
-      auto it = using_peers_.begin();
-      while (it != using_peers_.end()) {
-        auto peer = it->lock();
-        if (not peer) {
-          it = using_peers_.erase(it);
-        } else {
-          addresses_of_users.emplace_back(peer->getAddress());
-          ++it;
-        }
-      }
-      return logger::log("Fake peer block storage used by ["
-                         + boost::algorithm::join(addresses_of_users, ", ")
-                         + "]");
     }
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/block_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.hpp
@@ -6,6 +6,7 @@
 #ifndef INTEGRATION_FRAMEWORK_FAKE_PEER_BLOCK_STORAGE_HPP_
 #define INTEGRATION_FRAMEWORK_FAKE_PEER_BLOCK_STORAGE_HPP_
 
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -45,7 +46,7 @@ namespace integration_framework {
      private:
       std::unordered_map<HeightType, BlockPtr> blocks_by_height_;
       std::unordered_map<HashType, BlockPtr, HashType::Hasher> blocks_by_hash_;
-      mutable boost::shared_mutex block_maps_mutex_;
+      mutable std::shared_timed_mutex block_maps_mutex_;
 
       logger::Logger log_;
     };

--- a/test/framework/integration_framework/fake_peer/block_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.hpp
@@ -31,6 +31,10 @@ namespace integration_framework {
       using HashType = shared_model::crypto::Hash;
 
       BlockStorage();
+      BlockStorage(const BlockStorage &);
+      BlockStorage(BlockStorage &&);
+      BlockStorage operator=(const BlockStorage &) = delete;
+      BlockStorage operator=(BlockStorage &&) = delete;
 
       void storeBlock(const BlockPtr &block);
 

--- a/test/framework/integration_framework/fake_peer/block_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.hpp
@@ -25,7 +25,7 @@ namespace integration_framework {
 
     class BlockStorage final {
      public:
-      using BlockPtr = std::shared_ptr<shared_model::proto::Block>;
+      using BlockPtr = std::shared_ptr<const shared_model::proto::Block>;
       using HeightType = shared_model::interface::types::HeightType;
       using HashType = shared_model::crypto::Hash;
 

--- a/test/framework/integration_framework/fake_peer/block_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <boost/thread/shared_mutex.hpp>
 #include "cryptography/hash.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "logger/logger.hpp"
@@ -29,29 +30,20 @@ namespace integration_framework {
       using HeightType = shared_model::interface::types::HeightType;
       using HashType = shared_model::crypto::Hash;
 
+      BlockStorage();
+
       void storeBlock(const BlockPtr &block);
 
       BlockPtr getBlockByHeight(HeightType height) const;
       BlockPtr getBlockByHash(const HashType &hash) const;
       BlockPtr getTopBlock() const;
 
-      // Claim that a fake peer uses this storage. Used for logging.
-      void claimUsingPeer(const std::shared_ptr<FakePeer> &peer);
-
-      // claim that a fake peer is not using this storage any more.
-      void claimNotUsingPeer(const std::shared_ptr<FakePeer> &peer);
-
      private:
-      logger::Logger getLogger() const;
-
       std::unordered_map<HeightType, BlockPtr> blocks_by_height_;
       std::unordered_map<HashType, BlockPtr, HashType::Hasher> blocks_by_hash_;
+      mutable boost::shared_mutex block_maps_mutex_;
 
-      /// The collection of peers claiming to use this block storage.
-      // Vector is used (although a kind of set would fit better) because
-      // weak pointers seem unsuitable for any comparison, as the shared_ptr
-      // they refer to may change.
-      mutable std::vector<std::weak_ptr<FakePeer>> using_peers_;
+      logger::Logger log_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -148,19 +148,12 @@ namespace integration_framework {
     FakePeer &FakePeer::setBlockStorage(
         const std::shared_ptr<BlockStorage> &block_storage) {
       ensureInitialized();
-      if (block_storage_) {
-        block_storage_->claimNotUsingPeer(shared_from_this());
-      }
       block_storage_ = block_storage;
-      block_storage_->claimUsingPeer(shared_from_this());
       return *this;
     }
 
     FakePeer &FakePeer::removeBlockStorage() {
       ensureInitialized();
-      if (block_storage_) {
-        block_storage_->claimNotUsingPeer(shared_from_this());
-      }
       block_storage_.reset();
       return *this;
     }

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.cpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.cpp
@@ -81,11 +81,11 @@ namespace integration_framework {
         return ::grpc::Status(::grpc::StatusCode::INTERNAL,
                               "Fake Peer has no behaviour set!");
       }
-      auto block = behaviour->processLoaderBlockRequest(hash);
-      if (!block) {
+      auto opt_block = behaviour->processLoaderBlockRequest(hash);
+      if (!opt_block) {
         return ::grpc::Status(::grpc::StatusCode::NOT_FOUND, "Block not found");
       }
-      *response->mutable_block_v1() = block->getTransport();
+      *response->mutable_block_v1() = (*opt_block)->getTransport();
       return ::grpc::Status::OK;
     }
 
@@ -104,7 +104,7 @@ namespace integration_framework {
       auto blocks = behaviour->processLoaderBlocksRequest(height);
       for (auto &block : blocks) {
         iroha::protocol::Block proto_block;
-        *proto_block.mutable_block_v1() = block.get().getTransport();
+        *proto_block.mutable_block_v1() = block->getTransport();
         writer->Write(proto_block);
       }
       return ::grpc::Status::OK;

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -86,9 +86,9 @@ namespace integration_framework {
     using LoaderBlockRequest = std::shared_ptr<shared_model::crypto::Hash>;
     using LoaderBlocksRequest = shared_model::interface::types::HeightType;
     using LoaderBlockRequestResult =
-        boost::optional<const shared_model::proto::Block &>;
+        boost::optional<std::shared_ptr<const shared_model::proto::Block>>;
     using LoaderBlocksRequestResult =
-        std::vector<std::reference_wrapper<const shared_model::proto::Block>>;
+        std::vector<std::shared_ptr<const shared_model::proto::Block>>;
     using OrderingProposalRequest = iroha::consensus::Round;
     using OrderingProposalRequestResult =
         boost::optional<shared_model::proto::Proposal &>;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This change makes the Block Storage of ITF Fake Peers thread-safe. It is necessary due to the shared usage of these objects.

Also, the logging of using peers is removed from block storage, as it introduced too much complexity and was not thread-safe.

### Benefits

<!-- What benefits will be realized by the code change? -->

Bug fixed.

### Possible Drawbacks 

Synchronization slows down execution.