### PR TITLE
New logger integration to irohad: part 1

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(ametsuchi
 
 target_link_libraries(ametsuchi
     logger
+    logger_manager
     rxcpp
     libs_files
     common

--- a/irohad/ametsuchi/impl/flat_file/flat_file.hpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.hpp
@@ -11,7 +11,7 @@
 #include <atomic>
 #include <memory>
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -48,10 +48,11 @@ namespace iroha {
       /**
        * Create storage in paths
        * @param path - target path for creating
+       * @param log - logger
        * @return created storage
        */
       static boost::optional<std::unique_ptr<FlatFile>> create(
-          const std::string &path);
+          const std::string &path, logger::LoggerPtr log);
 
       bool add(Identifier id, const Bytes &blob) override;
 
@@ -66,10 +67,11 @@ namespace iroha {
        * If some block in the middle is missing all blocks following it are
        * deleted
        * @param dump_dir - folder of storage
+       * @param log - log for local messages
        * @return - last available identifier
        */
       static boost::optional<Identifier> check_consistency(
-          const std::string &dump_dir);
+          const std::string &dump_dir, logger::LoggerPtr log);
 
       void dropAll() override;
 
@@ -94,7 +96,7 @@ namespace iroha {
       FlatFile(Identifier last_id,
                const std::string &path,
                FlatFile::private_tag,
-               logger::Logger log = logger::log("FlatFile"));
+               logger::LoggerPtr log);
 
      private:
       // ----------| private fields |----------
@@ -109,7 +111,7 @@ namespace iroha {
        */
       const std::string dump_dir_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
 
      public:
       ~FlatFile() = default;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -13,6 +13,8 @@
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "interfaces/commands/command.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
+#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -21,15 +23,19 @@ namespace iroha {
         std::shared_ptr<PostgresCommandExecutor> cmd_executor,
         std::unique_ptr<soci::session> sql,
         std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
-        logger::Logger log)
+        logger::LoggerManagerTreePtr log_manager)
         : top_hash_(top_hash),
           sql_(std::move(sql)),
-          peer_query_(std::make_unique<PeerQueryWsv>(
-              std::make_shared<PostgresWsvQuery>(*sql_, std::move(factory)))),
-          block_index_(std::make_unique<PostgresBlockIndex>(*sql_)),
+          peer_query_(
+              std::make_unique<PeerQueryWsv>(std::make_shared<PostgresWsvQuery>(
+                  *sql_,
+                  std::move(factory),
+                  log_manager->getChild("WsvQuery")->getLogger()))),
+          block_index_(std::make_unique<PostgresBlockIndex>(
+              *sql_, log_manager->getChild("PostgresBlockIndex")->getLogger())),
           command_executor_(std::move(cmd_executor)),
           committed(false),
-          log_(std::move(log)) {
+          log_(log_manager->getLogger()) {
       *sql_ << "BEGIN";
     }
 

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -13,7 +13,8 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -30,7 +31,7 @@ namespace iroha {
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
               factory,
-          logger::Logger log = logger::log("MutableStorage"));
+          logger::LoggerManagerTreePtr log_manager);
 
       bool apply(const shared_model::interface::Block &block) override;
 
@@ -69,7 +70,7 @@ namespace iroha {
 
       bool committed;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -12,6 +12,7 @@
 #include "interfaces/commands/command_variant.hpp"
 #include "interfaces/commands/transfer_asset.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger.hpp"
 
 namespace {
   // Return transfer asset if command contains it
@@ -119,7 +120,7 @@ namespace {
 namespace iroha {
   namespace ametsuchi {
     PostgresBlockIndex::PostgresBlockIndex(soci::session &sql,
-                                           logger::Logger log)
+                                           logger::LoggerPtr log)
         : sql_(sql), log_(std::move(log)) {}
 
     void PostgresBlockIndex::index(

--- a/irohad/ametsuchi/impl/postgres_block_index.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.hpp
@@ -11,15 +11,13 @@
 #include "ametsuchi/impl/block_index.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
 #include "interfaces/transaction.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
     class PostgresBlockIndex : public BlockIndex {
      public:
-      PostgresBlockIndex(
-          soci::session &sql,
-          logger::Logger log = logger::log("PostgresBlockIndex"));
+      PostgresBlockIndex(soci::session &sql, logger::LoggerPtr log);
 
       /**
        * Create several indices for block. Namely:
@@ -38,7 +36,7 @@ namespace iroha {
 
      private:
       soci::session &sql_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -11,6 +11,7 @@
 
 #include "ametsuchi/impl/soci_utils.hpp"
 #include "common/byteutils.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -19,7 +20,7 @@ namespace iroha {
         KeyValueStorage &file_store,
         std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
             converter,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : sql_(sql),
           block_store_(file_store),
           converter_(std::move(converter)),
@@ -30,7 +31,7 @@ namespace iroha {
         KeyValueStorage &file_store,
         std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
             converter,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : psql_(std::move(sql)),
           sql_(*psql_),
           block_store_(file_store),

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -12,7 +12,7 @@
 #include <boost/optional.hpp>
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include "interfaces/iroha_internal/block_json_deserializer.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -29,14 +29,14 @@ namespace iroha {
           KeyValueStorage &file_store,
           std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
               converter,
-          logger::Logger log = logger::log("PostgresBlockQuery"));
+          logger::LoggerPtr log);
 
       PostgresBlockQuery(
           std::unique_ptr<soci::session> sql,
           KeyValueStorage &file_store,
           std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
               converter,
-          logger::Logger log = logger::log("PostgresBlockQuery"));
+          logger::LoggerPtr log);
 
       std::vector<wBlock> getBlocks(
           shared_model::interface::types::HeightType height,
@@ -71,7 +71,7 @@ namespace iroha {
       std::shared_ptr<shared_model::interface::BlockJsonDeserializer>
           converter_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_ordering_service_persistent_state.cpp
+++ b/irohad/ametsuchi/impl/postgres_ordering_service_persistent_state.cpp
@@ -8,6 +8,7 @@
 #include <soci/postgresql/soci-postgresql.h>
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -25,7 +26,7 @@ namespace iroha {
     expected::Result<std::shared_ptr<PostgresOrderingServicePersistentState>,
                      std::string>
     PostgresOrderingServicePersistentState::create(
-        const std::string &postgres_options) {
+        const std::string &postgres_options, logger::LoggerPtr log) {
       std::unique_ptr<soci::session> sql;
       try {
         sql =
@@ -41,13 +42,13 @@ namespace iroha {
           storage;
       storage = expected::makeValue(
           std::make_shared<PostgresOrderingServicePersistentState>(
-              std::move(sql)));
+              std::move(sql), std::move(log)));
       return storage;
     }
 
     PostgresOrderingServicePersistentState::
         PostgresOrderingServicePersistentState(
-            std::unique_ptr<soci::session> sql, logger::Logger log)
+            std::unique_ptr<soci::session> sql, logger::LoggerPtr log)
         : sql_(std::move(sql)), log_(std::move(log)) {}
 
     bool PostgresOrderingServicePersistentState::initStorage() {

--- a/irohad/ametsuchi/impl/postgres_ordering_service_persistent_state.hpp
+++ b/irohad/ametsuchi/impl/postgres_ordering_service_persistent_state.hpp
@@ -10,7 +10,7 @@
 
 #include <soci/soci.h>
 #include "common/result.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -25,21 +25,20 @@ namespace iroha {
       /**
        * Create the instance of PostgresOrderingServicePersistentState
        * @param postgres_options postgres connection string
+       * @param log - the logger to use in the new object
        * @return new instace of PostgresOrderingServicePersistentState
        */
       static expected::Result<
           std::shared_ptr<PostgresOrderingServicePersistentState>,
           std::string>
-      create(const std::string &postgres_options);
+      create(const std::string &postgres_options, logger::LoggerPtr log);
 
       /**
        * @param sql - pointer to soci session
        * @param log to print progress
        */
-      PostgresOrderingServicePersistentState(
-          std::unique_ptr<soci::session> sql,
-          logger::Logger log =
-              logger::log("PostgresOrderingServicePersistentState"));
+      PostgresOrderingServicePersistentState(std::unique_ptr<soci::session> sql,
+                                             logger::LoggerPtr log);
 
       /**
        * Initialize storage.
@@ -75,7 +74,7 @@ namespace iroha {
      private:
       std::unique_ptr<soci::session> sql_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
 
       bool execute_(std::string query);
     };

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -33,6 +33,8 @@
 #include "interfaces/queries/get_transactions.hpp"
 #include "interfaces/queries/query.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
+#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 
 using namespace shared_model::interface::permissions;
 
@@ -242,7 +244,7 @@ namespace iroha {
             response_factory,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
-        logger::Logger log)
+        logger::LoggerManagerTreePtr log_manager)
         : sql_(std::move(sql)),
           block_store_(block_store),
           pending_txs_storage_(std::move(pending_txs_storage)),
@@ -251,9 +253,10 @@ namespace iroha {
                    pending_txs_storage_,
                    std::move(converter),
                    response_factory,
-                   perm_converter),
+                   perm_converter,
+                   log_manager->getChild("Visitor")->getLogger()),
           query_response_factory_{std::move(response_factory)},
-          log_(std::move(log)) {}
+          log_(log_manager->getLogger()) {}
 
     QueryExecutorResult PostgresQueryExecutor::validateAndExecute(
         const shared_model::interface::Query &query) {
@@ -288,7 +291,7 @@ namespace iroha {
             response_factory,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : sql_(sql),
           block_store_(block_store),
           pending_txs_storage_(std::move(pending_txs_storage)),

--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -33,7 +33,8 @@
 #include "interfaces/queries/blocks_query.hpp"
 #include "interfaces/queries/query.hpp"
 #include "interfaces/query_responses/query_response.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -58,7 +59,7 @@ namespace iroha {
               response_factory,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
-          logger::Logger log = logger::log("PostgresQueryExecutorVisitor"));
+          logger::LoggerPtr log);
 
       void setCreatorId(
           const shared_model::interface::types::AccountIdType &creator_id);
@@ -221,7 +222,7 @@ namespace iroha {
           query_response_factory_;
       std::shared_ptr<shared_model::interface::PermissionToString>
           perm_converter_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
     class PostgresQueryExecutor : public QueryExecutor {
@@ -236,7 +237,7 @@ namespace iroha {
               response_factory,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
-          logger::Logger log = logger::log("PostgresQueryExecutor"));
+          logger::LoggerManagerTreePtr log_manager);
 
       QueryExecutorResult validateAndExecute(
           const shared_model::interface::Query &query) override;
@@ -250,7 +251,7 @@ namespace iroha {
       PostgresQueryExecutorVisitor visitor_;
       std::shared_ptr<shared_model::interface::QueryResponseFactory>
           query_response_factory_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -10,6 +10,7 @@
 #include "backend/protobuf/permissions.hpp"
 #include "common/result.hpp"
 #include "cryptography/public_key.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -29,13 +30,13 @@ namespace iroha {
     PostgresWsvQuery::PostgresWsvQuery(
         soci::session &sql,
         std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : sql_(sql), factory_(factory), log_(std::move(log)) {}
 
     PostgresWsvQuery::PostgresWsvQuery(
         std::unique_ptr<soci::session> sql,
         std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : psql_(std::move(sql)),
           sql_(*psql_),
           factory_(factory),

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -11,7 +11,7 @@
 #include <soci/soci.h>
 
 #include "interfaces/common_objects/common_objects_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -21,13 +21,13 @@ namespace iroha {
           soci::session &sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
               factory,
-          logger::Logger log = logger::log("PostgresWsvQuery"));
+          logger::LoggerPtr log);
 
       PostgresWsvQuery(
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
               factory,
-          logger::Logger log = logger::log("PostgresWsvQuery"));
+          logger::LoggerPtr log);
 
       boost::optional<std::vector<shared_model::interface::types::RoleIdType>>
       getAccountRoles(const shared_model::interface::types::AccountIdType
@@ -107,7 +107,7 @@ namespace iroha {
       std::unique_ptr<soci::session> psql_;
       soci::session &sql_;
       std::shared_ptr<shared_model::interface::CommonObjectsFactory> factory_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -20,7 +20,8 @@
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "interfaces/iroha_internal/block_json_converter.hpp"
 #include "interfaces/permission_to_string.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -40,7 +41,7 @@ namespace iroha {
           const std::string &options_str_without_dbname);
 
       static expected::Result<ConnectionContext, std::string> initConnections(
-          std::string block_store_dir);
+          std::string block_store_dir, logger::LoggerPtr log);
 
       static expected::Result<std::shared_ptr<soci::connection_pool>,
                               std::string>
@@ -56,6 +57,7 @@ namespace iroha {
               converter,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
+          logger::LoggerManagerTreePtr log_manager,
           size_t pool_size = 10);
 
       expected::Result<std::unique_ptr<TemporaryWsv>, std::string>
@@ -128,7 +130,7 @@ namespace iroha {
                       perm_converter,
                   size_t pool_size,
                   bool enable_prepared_blocks,
-                  logger::Logger log = logger::log("StorageImpl"));
+                  logger::LoggerManagerTreePtr log_manager);
 
       /**
        * Folder with raw blocks
@@ -163,7 +165,8 @@ namespace iroha {
       std::shared_ptr<shared_model::interface::PermissionToString>
           perm_converter_;
 
-      logger::Logger log_;
+      logger::LoggerManagerTreePtr log_manager_;
+      logger::LoggerPtr log_;
 
       mutable std::shared_timed_mutex drop_mutex;
 

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -11,7 +11,8 @@
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -28,7 +29,8 @@ namespace iroha {
      public:
       struct SavepointWrapperImpl : public TemporaryWsv::SavepointWrapper {
         SavepointWrapperImpl(const TemporaryWsvImpl &wsv,
-                             std::string savepoint_name);
+                             std::string savepoint_name,
+                             logger::LoggerPtr log);
 
         void release() override;
 
@@ -38,7 +40,7 @@ namespace iroha {
         soci::session &sql_;
         std::string savepoint_name_;
         bool is_released_;
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
 
       TemporaryWsvImpl(
@@ -47,7 +49,7 @@ namespace iroha {
               factory,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
-          logger::Logger log = logger::log("TemporaryWSV"));
+          logger::LoggerManagerTreePtr log_manager);
 
       expected::Result<void, validation::CommandError> apply(
           const shared_model::interface::Transaction &transaction) override;
@@ -68,7 +70,8 @@ namespace iroha {
       std::unique_ptr<soci::session> sql_;
       std::unique_ptr<CommandExecutor> command_executor_;
 
-      logger::Logger log_;
+      logger::LoggerManagerTreePtr log_manager_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/consensus/yac/CMakeLists.txt
+++ b/irohad/consensus/yac/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(yac
     common
     rxcpp
     logger
+    logger_manager
     hash
     consensus_round
     gate_object

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -16,6 +16,7 @@
 #include "cryptography/public_key.hpp"
 #include "cryptography/signed.hpp"
 #include "interfaces/common_objects/peer.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -42,7 +43,7 @@ namespace iroha {
           std::shared_ptr<YacCryptoProvider> crypto,
           std::shared_ptr<Timer> timer,
           ClusterOrdering order,
-          logger::Logger log) {
+          logger::LoggerPtr log) {
         return std::make_shared<Yac>(
             vote_storage, network, crypto, timer, order, std::move(log));
       }
@@ -52,7 +53,7 @@ namespace iroha {
                std::shared_ptr<YacCryptoProvider> crypto,
                std::shared_ptr<Timer> timer,
                ClusterOrdering order,
-               logger::Logger log)
+               logger::LoggerPtr log)
           : vote_storage_(std::move(vote_storage)),
             network_(std::move(network)),
             crypto_(std::move(crypto)),

--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
@@ -52,8 +52,6 @@ namespace iroha {
                   vote.signature = std::move(sig.value);
                 },
                 [](iroha::expected::Error<std::string> &reason) {
-                  logger::log("YacCryptoProvider::getVote")
-                      ->error("Cannot build vote signature: {}", reason.error);
                 });
 
         return vote;

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -15,6 +15,7 @@
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger.hpp"
 #include "simulator/block_creator.hpp"
 
 namespace iroha {
@@ -28,7 +29,7 @@ namespace iroha {
           std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<consensus::ConsensusResultCache>
               consensus_result_cache,
-          logger::Logger log)
+          logger::LoggerPtr log)
           : hash_gate_(std::move(hash_gate)),
             orderer_(std::move(orderer)),
             hash_provider_(std::move(hash_provider)),

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -12,7 +12,7 @@
 
 #include "consensus/consensus_block_cache.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
 
@@ -38,7 +38,7 @@ namespace iroha {
                     std::shared_ptr<simulator::BlockCreator> block_creator,
                     std::shared_ptr<consensus::ConsensusResultCache>
                         consensus_result_cache,
-                    logger::Logger log = logger::log("YacGate"));
+                    logger::LoggerPtr log);
         void vote(const simulator::BlockCreatorEvent &event) override;
 
         rxcpp::observable<GateObject> onOutcome() override;
@@ -61,7 +61,7 @@ namespace iroha {
         std::shared_ptr<consensus::ConsensusResultCache>
             consensus_result_cache_;
 
-        logger::Logger log_;
+        logger::LoggerPtr log_;
 
         boost::optional<std::shared_ptr<shared_model::interface::Block>>
             current_block_;

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -5,7 +5,7 @@
 
 #include "consensus/yac/storage/yac_block_storage.hpp"
 
-using namespace logger;
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -16,12 +16,12 @@ namespace iroha {
       YacBlockStorage::YacBlockStorage(
           YacHash hash,
           PeersNumberType peers_in_round,
+          logger::LoggerPtr log,
           std::shared_ptr<SupermajorityChecker> supermajority_checker)
           : storage_key_(std::move(hash)),
             peers_in_round_(peers_in_round),
-            supermajority_checker_(std::move(supermajority_checker)) {
-        log_ = log("YacBlockStorage");
-      }
+            supermajority_checker_(std::move(supermajority_checker)),
+            log_(std::move(log)) {}
 
       boost::optional<Answer> YacBlockStorage::insert(VoteMessage msg) {
         if (validScheme(msg) and uniqueVote(msg)) {

--- a/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
@@ -5,7 +5,8 @@
 
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 
-using namespace logger;
+#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -32,6 +33,7 @@ namespace iroha {
                     store_hash.vote_hashes.proposal_hash,
                     store_hash.vote_hashes.block_hash),
             peers_in_round_,
+            log_manager_->getChild("BlockStorage")->getLogger(),
             supermajority_checker_);
       }
 
@@ -40,13 +42,14 @@ namespace iroha {
       YacProposalStorage::YacProposalStorage(
           Round store_round,
           PeersNumberType peers_in_round,
+          logger::LoggerManagerTreePtr log_manager,
           std::shared_ptr<SupermajorityChecker> supermajority_checker)
           : current_state_(boost::none),
             storage_key_(store_round),
             peers_in_round_(peers_in_round),
-            supermajority_checker_(supermajority_checker) {
-        log_ = log("ProposalStorage");
-      }
+            supermajority_checker_(supermajority_checker),
+            log_manager_(std::move(log_manager)),
+            log_(log_manager_->getLogger()) {}
 
       boost::optional<Answer> YacProposalStorage::insert(VoteMessage msg) {
         if (shouldInsert(msg)) {

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
+#include "logger/logger_manager.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -46,10 +47,14 @@ namespace iroha {
             proposal_storages_.end(),
             msg.hash.vote_round,
             peers_in_round,
+            log_manager_->getChild("ProposalStorage"),
             std::make_shared<SupermajorityCheckerImpl>());
       }
 
       // --------| public api |--------
+
+      YacVoteStorage::YacVoteStorage(logger::LoggerManagerTreePtr log_manager)
+          : log_manager_(std::move(log_manager)) {}
 
       boost::optional<Answer> YacVoteStorage::store(
           std::vector<VoteMessage> state, PeersNumberType peers_in_round) {

--- a/irohad/consensus/yac/storage/yac_block_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_block_storage.hpp
@@ -26,7 +26,7 @@
 #include "consensus/yac/messages.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "consensus/yac/yac_types.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -47,6 +47,7 @@ namespace iroha {
         YacBlockStorage(
             YacHash hash,
             PeersNumberType peers_in_round,
+            logger::LoggerPtr log,
             std::shared_ptr<SupermajorityChecker> supermajority_checker =
                 std::make_shared<SupermajorityCheckerImpl>());
 
@@ -130,7 +131,7 @@ namespace iroha {
         /**
          * Storage logger
          */
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/storage/yac_proposal_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_proposal_storage.hpp
@@ -15,7 +15,8 @@
 #include "consensus/yac/storage/yac_block_storage.hpp"
 #include "consensus/yac/storage/yac_common.hpp"
 #include "consensus/yac/yac_types.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -45,6 +46,7 @@ namespace iroha {
         YacProposalStorage(
             Round store_round,
             PeersNumberType peers_in_round,
+            logger::LoggerManagerTreePtr log_manager,
             std::shared_ptr<SupermajorityChecker> supermajority_checker =
                 std::make_shared<SupermajorityCheckerImpl>());
 
@@ -134,9 +136,14 @@ namespace iroha {
         std::shared_ptr<SupermajorityChecker> supermajority_checker_;
 
         /**
+         * Storage logger manager
+         */
+        logger::LoggerManagerTreePtr log_manager_;
+
+        /**
          * Storage logger
          */
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -27,6 +27,7 @@
 #include "consensus/yac/storage/storage_result.hpp"  // for Answer
 #include "consensus/yac/storage/yac_common.hpp"      // for ProposalHash
 #include "consensus/yac/yac_types.hpp"
+#include "logger/logger_manager_fwd.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -93,6 +94,8 @@ namespace iroha {
        public:
         // --------| public api |--------
 
+        YacVoteStorage(logger::LoggerManagerTreePtr log_manager);
+
         /**
          * Insert votes in storage
          * @param state - current message with votes
@@ -143,6 +146,8 @@ namespace iroha {
          */
         std::unordered_map<Round, ProposalState, RoundTypeHasher>
             processing_state_;
+
+        logger::LoggerManagerTreePtr log_manager_;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -14,7 +14,7 @@
 
 #include "consensus/yac/messages.hpp"
 #include "interfaces/common_objects/types.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 
 namespace iroha {
@@ -33,7 +33,9 @@ namespace iroha {
        public:
         explicit NetworkImpl(
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call);
+                async_call,
+            logger::LoggerPtr log);
+
         void subscribe(
             std::shared_ptr<YacNetworkNotifications> handler) override;
 
@@ -75,6 +77,8 @@ namespace iroha {
          */
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
+
+        logger::LoggerPtr log_;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/transport/yac_pb_converters.hpp
+++ b/irohad/consensus/yac/transport/yac_pb_converters.hpp
@@ -88,7 +88,7 @@ namespace iroha {
         }
 
         static boost::optional<VoteMessage> deserializeVote(
-            const proto::Vote &pb_vote) {
+            const proto::Vote &pb_vote, logger::LoggerPtr log) {
           static shared_model::proto::ProtoCommonObjectsFactory<
               shared_model::validation::FieldValidator>
               factory_;
@@ -105,8 +105,7 @@ namespace iroha {
                             std::unique_ptr<shared_model::interface::Signature>>
                                 &sig) { val = std::move(sig.value); },
                         [&](iroha::expected::Error<std::string> &reason) {
-                          logger::log("YacPbConverter::deserializeVote")
-                              ->error(msg, reason.error);
+                          log->error(msg, reason.error);
                         });
               };
 

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -16,7 +16,7 @@
 #include "consensus/yac/storage/yac_vote_storage.hpp"  // for VoteStorage
 #include "consensus/yac/transport/yac_network_interface.hpp"  // for YacNetworkNotifications
 #include "consensus/yac/yac_gate.hpp"                         // for HashGate
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -37,14 +37,14 @@ namespace iroha {
             std::shared_ptr<YacCryptoProvider> crypto,
             std::shared_ptr<Timer> timer,
             ClusterOrdering order,
-            logger::Logger log = logger::log("YAC"));
+            logger::LoggerPtr log);
 
         Yac(YacVoteStorage vote_storage,
             std::shared_ptr<YacNetwork> network,
             std::shared_ptr<YacCryptoProvider> crypto,
             std::shared_ptr<Timer> timer,
             ClusterOrdering order,
-            logger::Logger log = logger::log("YAC"));
+            logger::LoggerPtr log);
 
         // ------|Hash gate|------
 
@@ -98,7 +98,7 @@ namespace iroha {
         ClusterOrdering cluster_order_;
 
         // ------|Logger|------
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
     }  // namespace yac
   }    // namespace consensus


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

### Description of the Change

This is a part of new logger integration to irohad. As the complete integration patch is too big for a single PR (+743 -462), it is split in three parts (#2050, #2051, #2052) according to the source code directory structure. This PR includes changes made to `irohad/{ametsuchi,consensus}`. You can use the unified patch 496b2e9d0 (which was exactly equal to these three PRs put together when they were opened) to build Irohad with the new logger.

### Benefits

One more step towards the new logger.