### PR TITLE
New logger integration to irohad: part 2

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(application
     )
 target_link_libraries(application
     logger
+    logger_manager
     yac
     yac_transport
     server_runner
@@ -63,10 +64,14 @@ target_link_libraries(irohad
     keys_manager
     common
     iroha_conf_loader
+    logger
+    logger_manager
     )
 
 add_library(iroha_conf_loader iroha_conf_loader.cpp)
-target_link_libraries(iroha_conf_loader iroha_conf_literals)
+target_link_libraries(iroha_conf_loader
+  iroha_conf_literals
+  logger_manager)
 
 add_library(iroha_conf_literals iroha_conf_literals.cpp)
 target_include_directories(iroha_conf_literals PUBLIC ${fmt_INCLUDE_DIR})

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -70,8 +70,9 @@ target_link_libraries(irohad
 
 add_library(iroha_conf_loader iroha_conf_loader.cpp)
 target_link_libraries(iroha_conf_loader
-  iroha_conf_literals
-  logger_manager)
+    iroha_conf_literals
+    logger_manager
+)
 
 add_library(iroha_conf_literals iroha_conf_literals.cpp)
 target_include_directories(iroha_conf_literals PUBLIC ${fmt_INCLUDE_DIR})

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -19,6 +19,8 @@
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
 #include "interfaces/permission_to_string.hpp"
+#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_processor_impl.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy_stub.hpp"
@@ -58,6 +60,7 @@ Irohad::Irohad(const std::string &block_store_dir,
                std::chrono::milliseconds proposal_delay,
                std::chrono::milliseconds vote_delay,
                const shared_model::crypto::Keypair &keypair,
+               logger::LoggerManagerTreePtr logger_manager,
                const boost::optional<GossipPropagationStrategyParams>
                    &opt_mst_gossip_params)
     : block_store_dir_(block_store_dir),
@@ -70,8 +73,11 @@ Irohad::Irohad(const std::string &block_store_dir,
       vote_delay_(vote_delay),
       is_mst_supported_(opt_mst_gossip_params),
       opt_mst_gossip_params_(opt_mst_gossip_params),
+      ordering_init(logger_manager->getLogger()),
+      log_manager_(std::move(logger_manager)),
+      validators_log_manager_(log_manager_->getChild("Validators")),
+      log_(log_manager_->getLogger()),
       keypair(keypair) {
-  log_ = logger::log("IROHAD");
   log_->info("created");
   // Initializing storage at this point in order to insert genesis block before
   // initialization of iroha daemon
@@ -130,7 +136,8 @@ void Irohad::initStorage() {
                                            pg_conn_,
                                            common_objects_factory_,
                                            std::move(block_converter),
-                                           perm_converter);
+                                           perm_converter,
+                                           log_manager_->getChild("Storage"));
   storageResult.match(
       [&](expected::Value<std::shared_ptr<ametsuchi::StorageImpl>> &_storage) {
         storage = _storage.value;
@@ -172,10 +179,13 @@ void Irohad::initBatchParser() {
 void Irohad::initValidators() {
   auto factory = std::make_unique<shared_model::proto::ProtoProposalFactory<
       shared_model::validation::DefaultProposalValidator>>();
-  stateful_validator =
-      std::make_shared<StatefulValidatorImpl>(std::move(factory), batch_parser);
+  stateful_validator = std::make_shared<StatefulValidatorImpl>(
+      std::move(factory),
+      batch_parser,
+      validators_log_manager_->getChild("Stateful")->getLogger());
   chain_validator = std::make_shared<ChainValidatorImpl>(
-      std::make_shared<consensus::yac::SupermajorityCheckerImpl>());
+      std::make_shared<consensus::yac::SupermajorityCheckerImpl>(),
+      validators_log_manager_->getChild("Chain")->getLogger());
 
   log_->info("[Init] => validators");
 }
@@ -185,7 +195,8 @@ void Irohad::initValidators() {
  */
 void Irohad::initNetworkClient() {
   async_call_ =
-      std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>();
+      std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>(
+          log_manager_->getChild("AsyncNetworkClient")->getLogger());
 }
 
 void Irohad::initFactories() {
@@ -292,18 +303,20 @@ void Irohad::initOrderingGate() {
     return std::chrono::seconds(reject_counter);
   };
 
-  ordering_gate = ordering_init.initOrderingGate(max_proposal_size_,
-                                                 proposal_delay_,
-                                                 std::move(hashes),
-                                                 storage,
-                                                 transaction_factory,
-                                                 batch_parser,
-                                                 transaction_batch_factory_,
-                                                 async_call_,
-                                                 std::move(factory),
-                                                 persistent_cache,
-                                                 {blocks.back()->height(), 1},
-                                                 delay);
+  ordering_gate =
+      ordering_init.initOrderingGate(max_proposal_size_,
+                                     proposal_delay_,
+                                     std::move(hashes),
+                                     storage,
+                                     transaction_factory,
+                                     batch_parser,
+                                     transaction_batch_factory_,
+                                     async_call_,
+                                     std::move(factory),
+                                     persistent_cache,
+                                     {blocks.back()->height(), 1},
+                                     delay,
+                                     log_manager_->getChild("Ordering"));
   log_->info("[Init] => init ordering gate - [{}]",
              logger::logBool(ordering_gate));
 }
@@ -322,12 +335,14 @@ void Irohad::initSimulator() {
       std::make_unique<
           shared_model::validation::DefaultUnsignedBlockValidator>(),
       std::make_unique<shared_model::validation::ProtoBlockValidator>());
-  simulator = std::make_shared<Simulator>(ordering_gate,
-                                          stateful_validator,
-                                          storage,
-                                          storage,
-                                          crypto_signer_,
-                                          std::move(block_factory));
+  simulator = std::make_shared<Simulator>(
+      ordering_gate,
+      stateful_validator,
+      storage,
+      storage,
+      crypto_signer_,
+      std::move(block_factory),
+      validators_log_manager_->getChild("Simulator")->getLogger());
 
   log_->info("[Init] => init simulator");
 }
@@ -346,7 +361,10 @@ void Irohad::initConsensusCache() {
  */
 void Irohad::initBlockLoader() {
   block_loader =
-      loader_init.initBlockLoader(storage, storage, consensus_result_cache_);
+      loader_init.initBlockLoader(storage,
+                                  storage,
+                                  consensus_result_cache_,
+                                  log_manager_->getChild("BlockLoader"));
 
   log_->info("[Init] => block loader");
 }
@@ -355,14 +373,16 @@ void Irohad::initBlockLoader() {
  * Initializing consensus gate
  */
 void Irohad::initConsensusGate() {
-  consensus_gate = yac_init.initConsensusGate(storage,
-                                              simulator,
-                                              block_loader,
-                                              keypair,
-                                              consensus_result_cache_,
-                                              vote_delay_,
-                                              async_call_,
-                                              common_objects_factory_);
+  consensus_gate =
+      yac_init.initConsensusGate(storage,
+                                 simulator,
+                                 block_loader,
+                                 keypair,
+                                 consensus_result_cache_,
+                                 vote_delay_,
+                                 async_call_,
+                                 common_objects_factory_,
+                                 log_manager_->getChild("Consensus"));
 
   log_->info("[Init] => consensus gate");
 }
@@ -372,7 +392,12 @@ void Irohad::initConsensusGate() {
  */
 void Irohad::initSynchronizer() {
   synchronizer = std::make_shared<SynchronizerImpl>(
-      consensus_gate, chain_validator, storage, storage, block_loader);
+      consensus_gate,
+      chain_validator,
+      storage,
+      storage,
+      block_loader,
+      log_manager_->getChild("Synchronizer")->getLogger());
 
   log_->info("[Init] => synchronizer");
 }
@@ -382,7 +407,10 @@ void Irohad::initSynchronizer() {
  */
 void Irohad::initPeerCommunicationService() {
   pcs = std::make_shared<PeerCommunicationServiceImpl>(
-      ordering_gate, synchronizer, simulator);
+      ordering_gate,
+      synchronizer,
+      simulator,
+      log_manager_->getChild("PeerCommunicationService")->getLogger());
 
   pcs->onProposal().subscribe([this](const auto &) {
     log_->info("~~~~~~~~~| PROPOSAL ^_^ |~~~~~~~~~ ");
@@ -414,8 +442,14 @@ void Irohad::initStatusBus() {
 }
 
 void Irohad::initMstProcessor() {
+  auto mst_logger_manager =
+      log_manager_->getChild("MultiSignatureTransactions");
+  auto mst_state_logger = mst_logger_manager->getChild("State")->getLogger();
   auto mst_completer = std::make_shared<DefaultCompleter>();
-  auto mst_storage = std::make_shared<MstStorageStateImpl>(mst_completer);
+  auto mst_storage = std::make_shared<MstStorageStateImpl>(
+      mst_completer,
+      mst_state_logger,
+      mst_logger_manager->getChild("Storage")->getLogger());
   std::shared_ptr<iroha::PropagationStrategy> mst_propagation;
   if (is_mst_supported_) {
     mst_transport = std::make_shared<iroha::network::MstTransportGrpc>(
@@ -424,7 +458,9 @@ void Irohad::initMstProcessor() {
         batch_parser,
         transaction_batch_factory_,
         persistent_cache,
-        keypair.publicKey());
+        keypair.publicKey(),
+        std::move(mst_state_logger),
+        mst_logger_manager->getChild("Transport")->getLogger());
     mst_propagation = std::make_shared<GossipPropagationStrategy>(
         storage, rxcpp::observe_on_new_thread(), *opt_mst_gossip_params_);
   } else {
@@ -434,7 +470,11 @@ void Irohad::initMstProcessor() {
 
   auto mst_time = std::make_shared<MstTimeProviderImpl>();
   auto fair_mst_processor = std::make_shared<FairMstProcessor>(
-      mst_transport, mst_storage, mst_propagation, mst_time);
+      mst_transport,
+      mst_storage,
+      mst_propagation,
+      mst_time,
+      mst_logger_manager->getChild("Processor")->getLogger());
   mst_processor = fair_mst_processor;
   mst_transport->subscribe(fair_mst_processor);
   log_->info("[Init] => MST processor");
@@ -452,12 +492,21 @@ void Irohad::initPendingTxsStorage() {
  * Initializing transaction command service
  */
 void Irohad::initTransactionCommandService() {
+  auto command_service_log_manager = log_manager_->getChild("CommandService");
   auto status_factory =
       std::make_shared<shared_model::proto::ProtoTxStatusFactory>();
   auto tx_processor = std::make_shared<TransactionProcessorImpl>(
-      pcs, mst_processor, status_bus_, status_factory);
+      pcs,
+      mst_processor,
+      status_bus_,
+      status_factory,
+      command_service_log_manager->getChild("Processor")->getLogger());
   command_service = std::make_shared<::torii::CommandServiceImpl>(
-      tx_processor, storage, status_bus_, status_factory);
+      tx_processor,
+      storage,
+      status_bus_,
+      status_factory,
+      command_service_log_manager->getLogger());
   command_service_transport =
       std::make_shared<::torii::CommandServiceTransportGrpc>(
           command_service,
@@ -467,7 +516,8 @@ void Irohad::initTransactionCommandService() {
           batch_parser,
           transaction_batch_factory_,
           consensus_gate,
-          2);
+          2,
+          command_service_log_manager->getChild("Transport")->getLogger());
 
   log_->info("[Init] => command service");
 }
@@ -476,11 +526,16 @@ void Irohad::initTransactionCommandService() {
  * Initializing query command service
  */
 void Irohad::initQueryService() {
+  auto query_service_log_manager = log_manager_->getChild("QueryService");
   auto query_processor = std::make_shared<QueryProcessorImpl>(
-      storage, storage, pending_txs_storage_, query_response_factory_);
+      storage,
+      storage,
+      pending_txs_storage_,
+      query_response_factory_,
+      query_service_log_manager->getChild("Processor")->getLogger());
 
-  query_service =
-      std::make_shared<::torii::QueryService>(query_processor, query_factory);
+  query_service = std::make_shared<::torii::QueryService>(
+      query_processor, query_factory, query_service_log_manager->getLogger());
 
   log_->info("[Init] => query service");
 }
@@ -498,13 +553,15 @@ Irohad::RunResult Irohad::run() {
 
   // Initializing torii server
   torii_server = std::make_unique<ServerRunner>(
-      listen_ip_ + ":" + std::to_string(torii_port_), false);
+      listen_ip_ + ":" + std::to_string(torii_port_),
+      log_manager_->getChild("ToriiServerRunner")->getLogger(),
+      false);
 
   // Initializing internal server
   internal_server = std::make_unique<ServerRunner>(
       listen_ip_ + ":" + std::to_string(internal_port_),
-      false,
-      logger::log("InternalServerRunner"));
+      log_manager_->getChild("InternalServerRunner")->getLogger(),
+      false);
 
   // Run torii server
   return (torii_server->append(command_service_transport)

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -75,7 +75,6 @@ Irohad::Irohad(const std::string &block_store_dir,
       opt_mst_gossip_params_(opt_mst_gossip_params),
       ordering_init(logger_manager->getLogger()),
       log_manager_(std::move(logger_manager)),
-      validators_log_manager_(log_manager_->getChild("Validators")),
       log_(log_manager_->getLogger()),
       keypair(keypair) {
   log_->info("created");
@@ -179,13 +178,14 @@ void Irohad::initBatchParser() {
 void Irohad::initValidators() {
   auto factory = std::make_unique<shared_model::proto::ProtoProposalFactory<
       shared_model::validation::DefaultProposalValidator>>();
+  auto validators_log_manager = log_manager_->getChild("Validators");
   stateful_validator = std::make_shared<StatefulValidatorImpl>(
       std::move(factory),
       batch_parser,
-      validators_log_manager_->getChild("Stateful")->getLogger());
+      validators_log_manager->getChild("Stateful")->getLogger());
   chain_validator = std::make_shared<ChainValidatorImpl>(
       std::make_shared<consensus::yac::SupermajorityCheckerImpl>(),
-      validators_log_manager_->getChild("Chain")->getLogger());
+      validators_log_manager->getChild("Chain")->getLogger());
 
   log_->info("[Init] => validators");
 }
@@ -342,7 +342,7 @@ void Irohad::initSimulator() {
       storage,
       crypto_signer_,
       std::move(block_factory),
-      validators_log_manager_->getChild("Simulator")->getLogger());
+      log_manager_->getChild("Simulator")->getLogger());
 
   log_->info("[Init] => init simulator");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -263,8 +263,6 @@ class Irohad {
   std::shared_ptr<iroha::network::MstTransport> mst_transport;
 
   logger::LoggerManagerTreePtr log_manager_;  ///< application root log manager
-  logger::LoggerManagerTreePtr
-      validators_log_manager_;  ///< log manager for validators subsystem
 
   logger::LoggerPtr log_;  ///< log for local messages
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -262,7 +262,11 @@ class Irohad {
 
   std::shared_ptr<iroha::network::MstTransport> mst_transport;
 
-  logger::LoggerPtr log_;
+  logger::LoggerManagerTreePtr log_manager_;  ///< application root log manager
+  logger::LoggerManagerTreePtr
+      validators_log_manager_;  ///< log manager for validators subsystem
+
+  logger::LoggerPtr log_;  ///< log for local messages
 
  public:
   std::shared_ptr<iroha::ametsuchi::Storage> storage;

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "main/impl/block_loader_init.hpp"
+
+#include "logger/logger_manager.hpp"
 #include "validators/default_validator.hpp"
 #include "validators/protobuf/proto_block_validator.hpp"
 
@@ -13,26 +15,33 @@ using namespace iroha::network;
 
 auto BlockLoaderInit::createService(
     std::shared_ptr<BlockQueryFactory> block_query_factory,
-    std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache) {
+    std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache,
+    const logger::LoggerManagerTreePtr &loader_log_manager) {
   return std::make_shared<BlockLoaderService>(
-      std::move(block_query_factory), std::move(consensus_result_cache));
+      std::move(block_query_factory),
+      std::move(consensus_result_cache),
+      loader_log_manager->getChild("Network")->getLogger());
 }
 
 auto BlockLoaderInit::createLoader(
-    std::shared_ptr<PeerQueryFactory> peer_query_factory) {
+    std::shared_ptr<PeerQueryFactory> peer_query_factory,
+    logger::LoggerPtr loader_log) {
   shared_model::proto::ProtoBlockFactory factory(
       std::make_unique<shared_model::validation::DefaultSignedBlockValidator>(),
       std::make_unique<shared_model::validation::ProtoBlockValidator>());
-  return std::make_shared<BlockLoaderImpl>(std::move(peer_query_factory),
-                                           std::move(factory));
+  return std::make_shared<BlockLoaderImpl>(
+      std::move(peer_query_factory), std::move(factory), std::move(loader_log));
 }
 
 std::shared_ptr<BlockLoader> BlockLoaderInit::initBlockLoader(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     std::shared_ptr<BlockQueryFactory> block_query_factory,
-    std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache) {
+    std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache,
+    logger::LoggerManagerTreePtr loader_log_manager) {
   service = createService(std::move(block_query_factory),
-                          std::move(consensus_result_cache));
-  loader = createLoader(std::move(peer_query_factory));
+                          std::move(consensus_result_cache),
+                          loader_log_manager);
+  loader = createLoader(std::move(peer_query_factory),
+                        loader_log_manager->getLogger());
   return loader;
 }

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<BlockLoader> BlockLoaderInit::initBlockLoader(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     std::shared_ptr<BlockQueryFactory> block_query_factory,
     std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache,
-    logger::LoggerManagerTreePtr loader_log_manager) {
+    const logger::LoggerManagerTreePtr &loader_log_manager) {
   service = createService(std::move(block_query_factory),
                           std::move(consensus_result_cache),
                           loader_log_manager);

--- a/irohad/main/impl/block_loader_init.hpp
+++ b/irohad/main/impl/block_loader_init.hpp
@@ -8,6 +8,8 @@
 
 #include "ametsuchi/block_query_factory.hpp"
 #include "consensus/consensus_block_cache.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 #include "network/impl/block_loader_impl.hpp"
 #include "network/impl/block_loader_service.hpp"
 
@@ -22,20 +24,24 @@ namespace iroha {
        * Create block loader service with given storage
        * @param block_query_factory - factory to block query component
        * @param block_cache used to retrieve last block put by consensus
+       * @param loader_log - the log of the loader subsystem
        * @return initialized service
        */
       auto createService(
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
-          std::shared_ptr<consensus::ConsensusResultCache> block_cache);
+          std::shared_ptr<consensus::ConsensusResultCache> block_cache,
+          const logger::LoggerManagerTreePtr &loader_log_manager);
 
       /**
        * Create block loader for loading blocks from given peer factory by top
        * block
        * @param peer_query_factory - factory for peer query component creation
+       * @param loader_log - the log of the loader subsystem
        * @return initialized loader
        */
       auto createLoader(
-          std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory);
+          std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
+          logger::LoggerPtr loader_log);
 
      public:
       /**
@@ -43,12 +49,14 @@ namespace iroha {
        * @param peer_query_factory - factory to peer query component
        * @param block_query_factory - factory to block query component
        * @param block_cache used to retrieve last block put by consensus
+       * @param loader_log - the log of the loader subsystem
        * @return initialized service
        */
       std::shared_ptr<BlockLoader> initBlockLoader(
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
-          std::shared_ptr<consensus::ConsensusResultCache> block_cache);
+          std::shared_ptr<consensus::ConsensusResultCache> block_cache,
+          logger::LoggerManagerTreePtr loader_log_manager);
 
       std::shared_ptr<BlockLoaderImpl> loader;
       std::shared_ptr<BlockLoaderService> service;

--- a/irohad/main/impl/block_loader_init.hpp
+++ b/irohad/main/impl/block_loader_init.hpp
@@ -56,7 +56,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<consensus::ConsensusResultCache> block_cache,
-          logger::LoggerManagerTreePtr loader_log_manager);
+          const logger::LoggerManagerTreePtr &loader_log_manager);
 
       std::shared_ptr<BlockLoaderImpl> loader;
       std::shared_ptr<BlockLoaderService> service;

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -19,8 +19,6 @@
 #define IROHA_CONSENSUS_INIT_HPP
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "ametsuchi/peer_query_factory.hpp"
 #include "consensus/consensus_block_cache.hpp"
@@ -33,6 +31,7 @@
 #include "consensus/yac/yac_peer_orderer.hpp"
 #include "cryptography/keypair.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
+#include "logger/logger_manager_fwd.hpp"
 #include "network/block_loader.hpp"
 #include "simulator/block_creator.hpp"
 
@@ -47,8 +46,10 @@ namespace iroha {
         auto createPeerOrderer(
             std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory);
 
-        auto createNetwork(std::shared_ptr<iroha::network::AsyncGrpcClient<
-                               google::protobuf::Empty>> async_call);
+        auto createNetwork(
+            std::shared_ptr<iroha::network::AsyncGrpcClient<
+                google::protobuf::Empty>> async_call,
+            const logger::LoggerManagerTreePtr &consensus_log_manager);
 
         auto createCryptoProvider(
             const shared_model::crypto::Keypair &keypair,
@@ -67,7 +68,8 @@ namespace iroha {
                 iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
             std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-                common_objects_factory);
+                common_objects_factory,
+            const logger::LoggerManagerTreePtr &consensus_log_manager);
 
        public:
         std::shared_ptr<YacGate> initConsensusGate(
@@ -81,7 +83,8 @@ namespace iroha {
                 iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
             std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-                common_objects_factory);
+                common_objects_factory,
+            const logger::LoggerManagerTreePtr &consensus_log_manager);
 
         std::shared_ptr<NetworkImpl> consensus_network;
       };

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -11,6 +11,8 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "logger/logger.hpp"
+#include "logger/logger_manager.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 #include "ordering/impl/on_demand_connection_manager.hpp"
 #include "ordering/impl/on_demand_ordering_gate.hpp"
@@ -41,14 +43,19 @@ namespace {
 namespace iroha {
   namespace network {
 
+    OnDemandOrderingInit::OnDemandOrderingInit(logger::LoggerPtr log)
+        : log_(std::move(log)) {}
+
     auto OnDemandOrderingInit::createNotificationFactory(
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call,
-        std::chrono::milliseconds delay) {
+        std::chrono::milliseconds delay,
+        const logger::LoggerManagerTreePtr &ordering_log_manager) {
       return std::make_shared<ordering::transport::OnDemandOsClientGrpcFactory>(
           std::move(async_call),
           [] { return std::chrono::system_clock::now(); },
-          delay);
+          delay,
+          ordering_log_manager->getChild("NetworkClient")->getLogger());
     }
 
     auto OnDemandOrderingInit::createConnectionManager(
@@ -56,7 +63,8 @@ namespace iroha {
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call,
         std::chrono::milliseconds delay,
-        std::vector<shared_model::interface::types::HashType> initial_hashes) {
+        std::vector<shared_model::interface::types::HashType> initial_hashes,
+        const logger::LoggerManagerTreePtr &ordering_log_manager) {
       // since top block will be the first in notifier observable, hashes of
       // two previous blocks are prepended
       const size_t kBeforePreviousTop = 0, kPreviousTop = 1;
@@ -174,7 +182,10 @@ namespace iroha {
                        .map(map_peers);
 
       return std::make_shared<ordering::OnDemandConnectionManager>(
-          createNotificationFactory(std::move(async_call), delay), peers);
+          createNotificationFactory(
+              std::move(async_call), delay, ordering_log_manager),
+          peers,
+          ordering_log_manager->getChild("ConnectionManager")->getLogger());
     }
 
     auto OnDemandOrderingInit::createGate(
@@ -186,8 +197,8 @@ namespace iroha {
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
         consensus::Round initial_round,
         std::function<std::chrono::seconds(
-            const synchronizer::SynchronizationEvent &)> delay_func) {
-
+            const synchronizer::SynchronizationEvent &)> delay_func,
+        const logger::LoggerManagerTreePtr &ordering_log_manager) {
       auto map = [](auto commit) {
         return matchEvent(
             commit,
@@ -230,16 +241,21 @@ namespace iroha {
           std::move(cache),
           std::move(proposal_factory),
           std::move(tx_cache),
-          initial_round);
+          initial_round,
+          ordering_log_manager->getChild("Gate")->getLogger());
     }
 
     auto OnDemandOrderingInit::createService(
         size_t max_size,
         std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
             proposal_factory,
-        std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache) {
+        std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        const logger::LoggerManagerTreePtr &ordering_log_manager) {
       return std::make_shared<ordering::OnDemandOrderingServiceImpl>(
-          max_size, std::move(proposal_factory), std::move(tx_cache));
+          max_size,
+          std::move(proposal_factory),
+          std::move(tx_cache),
+          ordering_log_manager->getChild("Service")->getLogger());
     }
 
     OnDemandOrderingInit::~OnDemandOrderingInit() {
@@ -266,24 +282,29 @@ namespace iroha {
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
         consensus::Round initial_round,
         std::function<std::chrono::seconds(
-            const synchronizer::SynchronizationEvent &)> delay_func) {
-      auto ordering_service =
-          createService(max_size, proposal_factory, tx_cache);
+            const synchronizer::SynchronizationEvent &)> delay_func,
+        logger::LoggerManagerTreePtr ordering_log_manager) {
+      auto ordering_service = createService(
+          max_size, proposal_factory, tx_cache, ordering_log_manager);
       service = std::make_shared<ordering::transport::OnDemandOsServerGrpc>(
           ordering_service,
           std::move(transaction_factory),
           std::move(batch_parser),
-          std::move(transaction_batch_factory));
+          std::move(transaction_batch_factory),
+          ordering_log_manager->getChild("Server")->getLogger());
+      auto conn_mgr = createConnectionManager(std::move(peer_query_factory),
+                                              std::move(async_call),
+                                              delay,
+                                              std::move(initial_hashes),
+                                              ordering_log_manager);
       return createGate(ordering_service,
-                        createConnectionManager(std::move(peer_query_factory),
-                                                std::move(async_call),
-                                                delay,
-                                                std::move(initial_hashes)),
+                        std::move(conn_mgr),
                         std::make_shared<ordering::cache::OnDemandCache>(),
                         std::move(proposal_factory),
                         std::move(tx_cache),
                         initial_round,
-                        std::move(delay_func));
+                        std::move(delay_func),
+                        ordering_log_manager);
     }
 
   }  // namespace network

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -11,7 +11,8 @@
 #include "ametsuchi/peer_query_factory.hpp"
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
+#include "logger/logger_manager_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_gate.hpp"
 #include "network/peer_communication_service.hpp"
@@ -36,7 +37,8 @@ namespace iroha {
       auto createNotificationFactory(
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
-          std::chrono::milliseconds delay);
+          std::chrono::milliseconds delay,
+          const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       /**
        * Creates connection manager which redirects requests to appropriate
@@ -48,7 +50,8 @@ namespace iroha {
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
           std::chrono::milliseconds delay,
-          std::vector<shared_model::interface::types::HashType> initial_hashes);
+          std::vector<shared_model::interface::types::HashType> initial_hashes,
+          const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       /**
        * Creates on-demand ordering gate. \see initOrderingGate for parameters
@@ -63,7 +66,8 @@ namespace iroha {
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round,
           std::function<std::chrono::seconds(
-              const synchronizer::SynchronizationEvent &)> delay_func);
+              const synchronizer::SynchronizationEvent &)> delay_func,
+          const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       /**
        * Creates on-demand ordering service. \see initOrderingGate for
@@ -73,9 +77,15 @@ namespace iroha {
           size_t max_size,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
-          std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache);
+          std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          const logger::LoggerManagerTreePtr &ordering_log_manager);
 
      public:
+
+      /// Constructor.
+      /// @param log - the logger to use for internal messages.
+      OnDemandOrderingInit(logger::LoggerPtr log);
+
       ~OnDemandOrderingInit();
 
       /**
@@ -120,7 +130,8 @@ namespace iroha {
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round,
           std::function<std::chrono::seconds(
-              const synchronizer::SynchronizationEvent &)> delay_func);
+              const synchronizer::SynchronizationEvent &)> delay_func,
+          logger::LoggerManagerTreePtr ordering_log_manager);
 
       /// gRPC service for ordering service
       std::shared_ptr<ordering::proto::OnDemandOrdering::Service> service;
@@ -131,7 +142,7 @@ namespace iroha {
           notifier;
 
      private:
-      logger::Logger log_ = logger::log("OnDemandOrderingInit");
+      logger::LoggerPtr log_;
 
       std::vector<std::shared_ptr<shared_model::interface::Peer>>
           current_peers_;

--- a/irohad/main/impl/ordering_init.hpp
+++ b/irohad/main/impl/ordering_init.hpp
@@ -9,7 +9,7 @@
 #include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/os_persistent_state_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "ordering/impl/ordering_gate_impl.hpp"
 #include "ordering/impl/ordering_gate_transport_grpc.hpp"
 #include "ordering/impl/ordering_service_transport_grpc.hpp"
@@ -59,6 +59,8 @@ namespace iroha {
               persistent_state);
 
      public:
+      OrderingInit(logger::LoggerPtr log);
+
       /**
        * Initialization of ordering gate(client) and ordering service (service)
        * @param peer_query_factory - factory to get peer list
@@ -82,7 +84,8 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call);
+              async_call,
+          logger::LoggerPtr gate_log);
 
       std::shared_ptr<ordering::SinglePeerOrderingService> ordering_service;
       std::shared_ptr<iroha::network::OrderingGate> ordering_gate;
@@ -92,7 +95,7 @@ namespace iroha {
           ordering_service_transport;
 
      protected:
-      logger::Logger log_ = logger::log("OrderingInit");
+      logger::LoggerPtr log_;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/main/impl/raw_block_loader.cpp
+++ b/irohad/main/impl/raw_block_loader.cpp
@@ -10,6 +10,7 @@
 #include "backend/protobuf/block.hpp"
 #include "common/bind.hpp"
 #include "converters/protobuf/json_proto_converter.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace main {
@@ -17,7 +18,8 @@ namespace iroha {
     using shared_model::converters::protobuf::jsonToProto;
     using shared_model::interface::Block;
 
-    BlockLoader::BlockLoader(logger::Logger log) : log_(std::move(log)) {}
+    BlockLoader::BlockLoader(logger::LoggerPtr log)
+        : log_(std::move(log)) {}
 
     boost::optional<std::shared_ptr<Block>> BlockLoader::parseBlock(
         const std::string &data) {

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -11,6 +11,7 @@
 #include <grpc++/grpc++.h>
 #include "common/result.hpp"
 #include "crypto/keys_manager_impl.hpp"
+#include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
 #include "main/application.hpp"
 #include "main/iroha_conf_literals.hpp"
@@ -130,7 +131,8 @@ int main(int argc, char *argv[]) {
   log->info("config initialized");
 
   // Reading public and private key files
-  iroha::KeysManagerImpl keysManager(FLAGS_keypair_name);
+  iroha::KeysManagerImpl keysManager(
+      FLAGS_keypair_name, log_manager->getChild("KeysManager")->getLogger());
   auto keypair = keysManager.loadKeys();
   // Check if both keys are read properly
   if (not keypair) {
@@ -194,7 +196,8 @@ int main(int argc, char *argv[]) {
           "Passed genesis block will be ignored without --overwrite_ledger "
           "flag. Restoring existing state.");
     } else {
-      iroha::main::BlockLoader loader;
+      iroha::main::BlockLoader loader(
+          log_manager->getChild("GenesisBlockLoader")->getLogger());
       auto file = loader.loadFile(FLAGS_genesis_block);
       auto block = loader.parseBlock(file.value());
 

--- a/irohad/main/raw_block_loader.hpp
+++ b/irohad/main/raw_block_loader.hpp
@@ -11,7 +11,7 @@
 
 #include <boost/optional.hpp>
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -29,7 +29,7 @@ namespace iroha {
      */
     class BlockLoader {
      public:
-      explicit BlockLoader(logger::Logger log = logger::log("BlockLoader"));
+      explicit BlockLoader(logger::LoggerPtr log);
 
       /**
        * Parse block from file
@@ -47,7 +47,7 @@ namespace iroha {
       boost::optional<std::string> loadFile(const std::string &path);
 
      private:
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
   }  // namespace main

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -6,12 +6,13 @@
 #include "main/server_runner.hpp"
 
 #include <boost/format.hpp>
+#include "logger/logger.hpp"
 
 const auto kPortBindError = "Cannot bind server to address %s";
 
 ServerRunner::ServerRunner(const std::string &address,
-                           bool reuse,
-                           logger::Logger log)
+                           logger::LoggerPtr log,
+                           bool reuse)
     : log_(std::move(log)), serverAddress_(address), reuse_(reuse) {}
 
 ServerRunner &ServerRunner::append(std::shared_ptr<grpc::Service> service) {

--- a/irohad/main/server_runner.hpp
+++ b/irohad/main/server_runner.hpp
@@ -9,7 +9,7 @@
 #include <grpc++/grpc++.h>
 #include <grpc++/impl/codegen/service_type.h>
 #include "common/result.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 /**
  * Class runs Torii server for handling queries and commands.
@@ -19,12 +19,12 @@ class ServerRunner {
   /**
    * Constructor. Initialize a new instance of ServerRunner class.
    * @param address - the address the server will be bind to in URI form
-   * @param reuse - allow multiple sockets to bind to the same port
    * @param log to print progress to
+   * @param reuse - allow multiple sockets to bind to the same port
    */
   explicit ServerRunner(const std::string &address,
-                        bool reuse = true,
-                        logger::Logger log = logger::log("ServerRunner"));
+                        logger::LoggerPtr log,
+                        bool reuse = true);
 
   /**
    * Adds a new grpc service to be run.
@@ -55,7 +55,7 @@ class ServerRunner {
   void shutdown(const std::chrono::system_clock::time_point &deadline);
 
  private:
-  logger::Logger log_;
+  logger::LoggerPtr log_;
 
   std::unique_ptr<grpc::Server> serverInstance_;
   std::mutex waitForServer_;


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

### Description of the Change

This is a part of new logger integration to irohad. As the complete integration patch is too big for a single PR (+743 -462), it is split in three parts (#2050, #2051, #2052) according to the source code directory structure. This PR includes changes made to `irohad/main`. You can use the unified patch 496b2e9d0 (which was exactly equal to these three PRs put together when they were opened) to build Irohad with the new logger.

### Benefits

One more step towards the new logger.