### PR TITLE
New logger integration to irohad: part 3

### DIFF
--- a/irohad/model/converters/impl/json_block_factory.cpp
+++ b/irohad/model/converters/impl/json_block_factory.cpp
@@ -11,7 +11,7 @@ namespace iroha {
   namespace model {
     namespace converters {
 
-      JsonBlockFactory::JsonBlockFactory(logger::Logger log)
+      JsonBlockFactory::JsonBlockFactory(logger::LoggerPtr log)
           : log_{std::move(log)} {}
 
       Document JsonBlockFactory::serialize(const Block &block) {

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -5,6 +5,7 @@
 
 #include "model/converters/pb_query_factory.hpp"
 
+#include "logger/logger.hpp"
 #include "model/common.hpp"
 #include "model/queries/get_account.hpp"
 #include "model/queries/get_account_assets.hpp"

--- a/irohad/model/converters/json_block_factory.hpp
+++ b/irohad/model/converters/json_block_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_JSON_BLOCK_FACTORY_HPP
 #define IROHA_JSON_BLOCK_FACTORY_HPP
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "model/block.hpp"
 #include "model/converters/json_transaction_factory.hpp"
 
@@ -16,15 +16,14 @@ namespace iroha {
 
       class JsonBlockFactory {
        public:
-        explicit JsonBlockFactory(
-            logger::Logger log = logger::log("JsonBlockFactory"));
+        explicit JsonBlockFactory(logger::LoggerPtr log);
         rapidjson::Document serialize(const Block &block);
 
         boost::optional<Block> deserialize(const rapidjson::Document &document);
 
        private:
         JsonTransactionFactory factory_;
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
 
     }  // namespace converters

--- a/irohad/model/converters/pb_query_factory.hpp
+++ b/irohad/model/converters/pb_query_factory.hpp
@@ -7,7 +7,7 @@
 
 #include <typeindex>
 #include <unordered_map>
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "model/common.hpp"
 #include "model/query.hpp"
 #include "queries.pb.h"
@@ -37,8 +37,7 @@ namespace iroha {
         boost::optional<protocol::Query> serialize(
             std::shared_ptr<const model::Query> query) const;
 
-        explicit PbQueryFactory(
-            logger::Logger log = logger::log("PbQueryFactory"));
+        explicit PbQueryFactory(logger::LoggerPtr log);
 
        private:
         // Query serializer:
@@ -75,7 +74,7 @@ namespace iroha {
             std::shared_ptr<const Query>) const;
         std::unordered_map<std::type_index, Serializer> serializers_;
 
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
 
     }  // namespace converters

--- a/irohad/model/sha3_hash.cpp
+++ b/irohad/model/sha3_hash.cpp
@@ -12,7 +12,11 @@ namespace iroha {
   // TODO: 24.01.2018 @victordrobny: remove factories IR-850
   const static model::converters::PbTransactionFactory tx_factory;
   const static model::converters::PbBlockFactory block_factory;
-  const static model::converters::PbQueryFactory query_factory;
+  // TODO 10.01.2019 mboldyrev: initialize query_factory logger using config
+  const static model::converters::PbQueryFactory query_factory(
+      logger::Logger("QueryFactory",
+                     logger::LoggerConfig{logger::kDefaultLogLevel,
+                                          logger::kDefaultLogPatterns}));
 
   hash256_t hash(const model::Transaction &tx) {
     auto &&pb_dat = tx_factory.serialize(tx);

--- a/irohad/multi_sig_transactions/impl/mst_processor.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor.cpp
@@ -7,7 +7,8 @@
 
 namespace iroha {
 
-  MstProcessor::MstProcessor(logger::Logger log) : log_(std::move(log)) {}
+  MstProcessor::MstProcessor(logger::LoggerPtr log)
+      : log_(std::move(log)) {}
 
   void MstProcessor::propagateBatch(const DataType &batch) {
     this->propagateBatchImpl(batch);

--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -5,6 +5,7 @@
 
 #include <utility>
 
+#include "logger/logger.hpp"
 #include "multi_sig_transactions/mst_processor_impl.hpp"
 
 namespace iroha {
@@ -13,14 +14,16 @@ namespace iroha {
       std::shared_ptr<iroha::network::MstTransport> transport,
       std::shared_ptr<MstStorage> storage,
       std::shared_ptr<PropagationStrategy> strategy,
-      std::shared_ptr<MstTimeProvider> time_provider)
-      : MstProcessor(logger::log("FairMstProcessor")),
+      std::shared_ptr<MstTimeProvider> time_provider,
+      logger::LoggerPtr log)
+      : MstProcessor(log),  // use the same logger in base class
         transport_(std::move(transport)),
         storage_(std::move(storage)),
         strategy_(std::move(strategy)),
         time_provider_(std::move(time_provider)),
         propagation_subscriber_(strategy_->emitter().subscribe(
-            [this](auto data) { this->onPropagate(data); })) {}
+            [this](auto data) { this->onPropagate(data); })),
+        log_(std::move(log)) {}
 
   FairMstProcessor::~FairMstProcessor() {
     propagation_subscriber_.unsubscribe();

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <rxcpp/rx.hpp>
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
 
@@ -56,9 +56,9 @@ namespace iroha {
     virtual ~MstProcessor() = default;
 
    protected:
-    explicit MstProcessor(logger::Logger log = logger::log("MstProcessor"));
+    explicit MstProcessor(logger::LoggerPtr log);
 
-    logger::Logger log_;
+    logger::LoggerPtr log_;
 
    private:
     // ------------------------| inheritance interface |------------------------

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 #include "cryptography/public_key.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
@@ -33,7 +33,8 @@ namespace iroha {
     FairMstProcessor(std::shared_ptr<iroha::network::MstTransport> transport,
                      std::shared_ptr<MstStorage> storage,
                      std::shared_ptr<PropagationStrategy> strategy,
-                     std::shared_ptr<MstTimeProvider> time_provider);
+                     std::shared_ptr<MstTimeProvider> time_provider,
+                     logger::LoggerPtr log);
 
     ~FairMstProcessor();
 
@@ -107,6 +108,8 @@ namespace iroha {
     /// use for tracking the propagation subscription
 
     rxcpp::composite_subscription propagation_subscriber_;
+
+    logger::LoggerPtr log_;
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -12,6 +12,7 @@
 #include "common/set.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
 
@@ -35,22 +36,23 @@ namespace iroha {
 
   // ------------------------------| public api |-------------------------------
 
-  MstState MstState::empty(const CompleterType &completer) {
-    return MstState(completer);
+  MstState MstState::empty(logger::LoggerPtr log,
+                           const CompleterType &completer) {
+    return MstState(completer, std::move(log));
   }
 
   StateUpdateResult MstState::operator+=(const DataType &rhs) {
     auto state_update = StateUpdateResult{
-        std::make_shared<MstState>(MstState::empty(completer_)),
-        std::make_shared<MstState>(MstState::empty(completer_))};
+        std::make_shared<MstState>(MstState::empty(log_, completer_)),
+        std::make_shared<MstState>(MstState::empty(log_, completer_))};
     insertOne(state_update, rhs);
     return state_update;
   }
 
   StateUpdateResult MstState::operator+=(const MstState &rhs) {
     auto state_update = StateUpdateResult{
-        std::make_shared<MstState>(MstState::empty(completer_)),
-        std::make_shared<MstState>(MstState::empty(completer_))};
+        std::make_shared<MstState>(MstState::empty(log_, completer_)),
+        std::make_shared<MstState>(MstState::empty(log_, completer_))};
     for (auto &&rhs_tx : rhs.internal_state_) {
       insertOne(state_update, rhs_tx);
     }
@@ -59,7 +61,8 @@ namespace iroha {
 
   MstState MstState::operator-(const MstState &rhs) const {
     return MstState(this->completer_,
-                    set_difference(this->internal_state_, rhs.internal_state_));
+                    set_difference(this->internal_state_, rhs.internal_state_),
+                    log_);
   }
 
   bool MstState::operator==(const MstState &rhs) const {
@@ -81,7 +84,7 @@ namespace iroha {
   }
 
   MstState MstState::eraseByTime(const TimeType &time) {
-    MstState out = MstState::empty(completer_);
+    MstState out = MstState::empty(log_, completer_);
     while (not index_.empty() and (*completer_)(index_.top(), time)) {
       auto iter = internal_state_.find(index_.top());
 
@@ -125,12 +128,12 @@ namespace iroha {
     return inserted_new_signatures;
   }
 
-  MstState::MstState(const CompleterType &completer, logger::Logger log)
+  MstState::MstState(const CompleterType &completer, logger::LoggerPtr log)
       : MstState(completer, InternalStateType{}, std::move(log)) {}
 
   MstState::MstState(const CompleterType &completer,
                      const InternalStateType &transactions,
-                     logger::Logger log)
+                     logger::LoggerPtr log)
       : completer_(completer),
         internal_state_(transactions.begin(), transactions.end()),
         index_(transactions.begin(), transactions.end()),

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -10,7 +10,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/hash.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 
@@ -71,10 +71,12 @@ namespace iroha {
 
     /**
      * Create empty state
+     * @param log - the logger to use in the new object
      * @param completer - strategy for determine completed and expired batches
      * @return empty mst state
      */
     static MstState empty(
+        logger::LoggerPtr log,
         const CompleterType &completer = std::make_shared<DefaultCompleter>());
 
     /**
@@ -154,12 +156,11 @@ namespace iroha {
     using IndexType =
         std::priority_queue<DataType, std::vector<DataType>, Less>;
 
-    explicit MstState(const CompleterType &completer,
-                      logger::Logger log = logger::log("MstState"));
+    MstState(const CompleterType &completer, logger::LoggerPtr log);
 
     MstState(const CompleterType &completer,
              const InternalStateType &transactions,
-             logger::Logger log = logger::log("MstState"));
+             logger::LoggerPtr log);
 
     /**
      * Insert batch in own state and push it in out_completed_state or
@@ -183,7 +184,7 @@ namespace iroha {
 
     IndexType index_;
 
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
@@ -8,7 +8,7 @@
 #include "multi_sig_transactions/storage/mst_storage.hpp"
 
 namespace iroha {
-  MstStorage::MstStorage(logger::Logger log) : log_{std::move(log)} {}
+  MstStorage::MstStorage(logger::LoggerPtr log) : log_{std::move(log)} {}
 
   StateUpdateResult MstStorage::apply(
       const shared_model::crypto::PublicKey &target_peer_key,

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -12,17 +12,22 @@ namespace iroha {
       const shared_model::crypto::PublicKey &target_peer_key) {
     auto target_state_iter = peer_states_.find(target_peer_key);
     if (target_state_iter == peer_states_.end()) {
-      return peer_states_.insert({target_peer_key, MstState::empty(completer_)})
+      return peer_states_
+          .insert(
+              {target_peer_key, MstState::empty(mst_state_logger_, completer_)})
           .first;
     }
     return target_state_iter;
   }
   // -----------------------------| interface API |-----------------------------
 
-  MstStorageStateImpl::MstStorageStateImpl(const CompleterType &completer)
-      : MstStorage(),
+  MstStorageStateImpl::MstStorageStateImpl(const CompleterType &completer,
+                                           logger::LoggerPtr mst_state_logger,
+                                           logger::LoggerPtr log)
+      : MstStorage(log),
         completer_(completer),
-        own_state_(MstState::empty(completer_)) {}
+        own_state_(MstState::empty(mst_state_logger, completer_)),
+        mst_state_logger_(std::move(mst_state_logger)) {}
 
   auto MstStorageStateImpl::applyImpl(
       const shared_model::crypto::PublicKey &target_peer_key,

--- a/irohad/multi_sig_transactions/storage/mst_storage.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage.hpp
@@ -9,7 +9,7 @@
 #include <mutex>
 
 #include "cryptography/public_key.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
 
@@ -83,7 +83,7 @@ namespace iroha {
     /**
      * Constructor provide initialization of protected fields, such as logger.
      */
-    explicit MstStorage(logger::Logger log = logger::log("MstStorage"));
+    explicit MstStorage(logger::LoggerPtr log);
 
    private:
     virtual auto applyImpl(
@@ -112,7 +112,7 @@ namespace iroha {
     mutable std::mutex mutex_;
 
    protected:
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 }  // namespace iroha
 #endif  // IROHA_MST_STORAGE_HPP

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -26,9 +26,9 @@ namespace iroha {
 
    public:
     // ----------------------------| interface API |----------------------------
-    explicit MstStorageStateImpl(const CompleterType &completer,
-                                 logger::LoggerPtr mst_state_logger,
-                                 logger::LoggerPtr log);
+    MstStorageStateImpl(const CompleterType &completer,
+                        logger::LoggerPtr mst_state_logger,
+                        logger::LoggerPtr log);
 
     auto applyImpl(const shared_model::crypto::PublicKey &target_peer_key,
                    const MstState &new_state)

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -7,6 +7,7 @@
 #define IROHA_MST_STORAGE_IMPL_HPP
 
 #include <unordered_map>
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/hash.hpp"
 #include "multi_sig_transactions/storage/mst_storage.hpp"
 
@@ -25,7 +26,9 @@ namespace iroha {
 
    public:
     // ----------------------------| interface API |----------------------------
-    explicit MstStorageStateImpl(const CompleterType &completer);
+    explicit MstStorageStateImpl(const CompleterType &completer,
+                                 logger::LoggerPtr mst_state_logger,
+                                 logger::LoggerPtr log);
 
     auto applyImpl(const shared_model::crypto::PublicKey &target_peer_key,
                    const MstState &new_state)
@@ -56,6 +59,9 @@ namespace iroha {
                        iroha::model::BlobHasher>
         peer_states_;
     MstState own_state_;
+
+    logger::LoggerPtr mst_state_logger_;  ///< Logger for created MstState
+                                          ///< objects.
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -13,6 +13,7 @@
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
+#include "logger/logger.hpp"
 #include "validators/field_validator.hpp"
 
 using namespace iroha::network;
@@ -32,13 +33,17 @@ MstTransportGrpc::MstTransportGrpc(
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory,
     std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache,
-    shared_model::crypto::PublicKey my_key)
+    shared_model::crypto::PublicKey my_key,
+    logger::LoggerPtr mst_state_logger,
+    logger::LoggerPtr log)
     : async_call_(std::move(async_call)),
       transaction_factory_(std::move(transaction_factory)),
       batch_parser_(std::move(batch_parser)),
       batch_factory_(std::move(transaction_batch_factory)),
       tx_presence_cache_(std::move(tx_presence_cache)),
-      my_key_(shared_model::crypto::toBinaryString(my_key)) {}
+      my_key_(shared_model::crypto::toBinaryString(my_key)),
+      mst_state_logger_(std::move(mst_state_logger)),
+      log_(std::move(log)) {}
 
 shared_model::interface::types::SharedTxsCollectionType
 MstTransportGrpc::deserializeTransactions(const transport::MstState *request) {
@@ -55,10 +60,9 @@ MstTransportGrpc::deserializeTransactions(const transport::MstState *request) {
               },
               [&](const iroha::expected::Error<TransportFactoryType::Error>
                       &error) {
-                async_call_->log_->info(
-                    "Transaction deserialization failed: hash {}, {}",
-                    error.error.hash,
-                    error.error.error);
+                log_->info("Transaction deserialization failed: hash {}, {}",
+                           error.error.hash,
+                           error.error.error);
                 return false;
               });
         })
@@ -74,13 +78,13 @@ grpc::Status MstTransportGrpc::SendState(
     ::grpc::ServerContext *context,
     const ::iroha::network::transport::MstState *request,
     ::google::protobuf::Empty *response) {
-  async_call_->log_->info("MstState Received");
+  log_->info("MstState Received");
 
   auto transactions = deserializeTransactions(request);
 
   auto batches = batch_parser_->parseBatches(transactions);
 
-  MstState new_state = MstState::empty();
+  MstState new_state = MstState::empty(mst_state_logger_);
 
   for (auto &batch : batches) {
     batch_factory_->createTransactionBatch(batch).match(
@@ -89,8 +93,8 @@ grpc::Status MstTransportGrpc::SendState(
           auto cache_presence = tx_presence_cache_->check(*value.value);
           if (not cache_presence) {
             // TODO andrei 30.11.18 IR-51 Handle database error
-            async_call_->log_->warn(
-                "Check tx presence database error. Batch: {}", *value.value);
+            log_->warn("Check tx presence database error. Batch: {}",
+                       *value.value);
             return;
           }
           auto is_replay = std::any_of(
@@ -109,26 +113,23 @@ grpc::Status MstTransportGrpc::SendState(
           }
         },
         [&](iroha::expected::Error<std::string> &error) {
-          async_call_->log_->warn("Batch deserialization failed: {}",
-                                  error.error);
+          log_->warn("Batch deserialization failed: {}", error.error);
         });
   }
 
-  async_call_->log_->info("batches in MstState: {}",
-                          new_state.getBatches().size());
+  log_->info("batches in MstState: {}", new_state.getBatches().size());
 
   shared_model::crypto::PublicKey source_key(request->source_peer_key());
   auto key_invalid_reason =
       shared_model::validation::validatePubkey(source_key);
   if (key_invalid_reason) {
-    async_call_->log_->info(
-        "Dropping received MST State due to invalid public key: {}",
-        *key_invalid_reason);
+    log_->info("Dropping received MST State due to invalid public key: {}",
+               *key_invalid_reason);
     return grpc::Status::OK;
   }
 
   if (new_state.isEmpty()) {
-    async_call_->log_->info(
+    log_->info(
         "All transactions from received MST state have been processed already, "
         "nothing to propagate to MST processor");
     return grpc::Status::OK;
@@ -138,7 +139,7 @@ grpc::Status MstTransportGrpc::SendState(
     subscriber->onNewState(
       source_key,
       std::move(new_state));} else {
-    async_call_->log_->warn("No subscriber for MST SendState event is set");
+    log_->warn("No subscriber for MST SendState event is set");
   }
 
   return grpc::Status::OK;
@@ -151,7 +152,7 @@ void MstTransportGrpc::subscribe(
 
 void MstTransportGrpc::sendState(const shared_model::interface::Peer &to,
                                  ConstRefState providing_state) {
-  async_call_->log_->info("Propagate MstState to peer {}", to.address());
+  log_->info("Propagate MstState to peer {}", to.address());
   sendStateAsyncImpl(to, providing_state, my_key_, *async_call_);
 }
 

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -14,7 +14,7 @@
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 
 namespace iroha {
@@ -41,7 +41,9 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory,
           std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache,
-          shared_model::crypto::PublicKey my_key);
+          shared_model::crypto::PublicKey my_key,
+          logger::LoggerPtr mst_state_logger,
+          logger::LoggerPtr log);
 
       /**
        * Server part of grpc SendState method call
@@ -79,6 +81,10 @@ namespace iroha {
       std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache_;
       /// source peer key for MST propogation messages
       const std::string my_key_;
+
+      logger::LoggerPtr mst_state_logger_;  ///< Logger for created MstState
+                                            ///< objects.
+      logger::LoggerPtr log_;               ///< Logger for local use.
     };
 
     void sendStateAsync(const shared_model::interface::Peer &to,

--- a/irohad/network/impl/async_grpc_client.hpp
+++ b/irohad/network/impl/async_grpc_client.hpp
@@ -23,8 +23,7 @@ namespace iroha {
     template <typename Response>
     class AsyncGrpcClient {
      public:
-      explicit AsyncGrpcClient(
-          logger::Logger log = logger::log("AsyncGrpcClient"))
+      explicit AsyncGrpcClient(logger::LoggerPtr log)
           : thread_(&AsyncGrpcClient::asyncCompleteRpc, this),
             log_(std::move(log)) {}
 
@@ -52,7 +51,6 @@ namespace iroha {
 
       grpc::CompletionQueue cq_;
       std::thread thread_;
-      logger::Logger log_;
 
       /**
        * State and data information of gRPC call
@@ -79,6 +77,9 @@ namespace iroha {
         call->response_reader = lambda(&call->context, &cq_);
         call->response_reader->Finish(&call->reply, &call->status, call);
       }
+
+     private:
+      logger::LoggerPtr log_;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -11,6 +11,7 @@
 #include "builders/protobuf/transport_builder.hpp"
 #include "common/bind.hpp"
 #include "interfaces/common_objects/peer.hpp"
+#include "logger/logger.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 
 using namespace iroha::ametsuchi;
@@ -27,7 +28,7 @@ namespace {
 BlockLoaderImpl::BlockLoaderImpl(
     std::shared_ptr<PeerQueryFactory> peer_query_factory,
     shared_model::proto::ProtoBlockFactory factory,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : peer_query_factory_(std::move(peer_query_factory)),
       block_factory_(std::move(factory)),
       log_(std::move(log)) {}

--- a/irohad/network/impl/block_loader_impl.hpp
+++ b/irohad/network/impl/block_loader_impl.hpp
@@ -13,7 +13,7 @@
 #include "ametsuchi/peer_query_factory.hpp"
 #include "backend/protobuf/proto_block_factory.hpp"
 #include "loader.grpc.pb.h"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace network {
@@ -22,7 +22,7 @@ namespace iroha {
       BlockLoaderImpl(
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           shared_model::proto::ProtoBlockFactory factory,
-          logger::Logger log = logger::log("BlockLoaderImpl"));
+          logger::LoggerPtr log);
 
       rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
       retrieveBlocks(
@@ -57,7 +57,7 @@ namespace iroha {
       std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory_;
       shared_model::proto::ProtoBlockFactory block_factory_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -4,8 +4,10 @@
  */
 
 #include "network/impl/block_loader_service.hpp"
+
 #include "backend/protobuf/block.hpp"
 #include "common/bind.hpp"
+#include "logger/logger.hpp"
 
 using namespace iroha;
 using namespace iroha::ametsuchi;
@@ -15,7 +17,7 @@ BlockLoaderService::BlockLoaderService(
     std::shared_ptr<BlockQueryFactory> block_query_factory,
     std::shared_ptr<iroha::consensus::ConsensusResultCache>
         consensus_result_cache,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : block_query_factory_(std::move(block_query_factory)),
       consensus_result_cache_(std::move(consensus_result_cache)),
       log_(std::move(log)) {}

--- a/irohad/network/impl/block_loader_service.hpp
+++ b/irohad/network/impl/block_loader_service.hpp
@@ -9,7 +9,7 @@
 #include "ametsuchi/block_query_factory.hpp"
 #include "consensus/consensus_block_cache.hpp"
 #include "loader.grpc.pb.h"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace network {
@@ -19,7 +19,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<iroha::consensus::ConsensusResultCache>
               consensus_result_cache,
-          logger::Logger log = logger::log("BlockLoaderService"));
+          logger::LoggerPtr log);
 
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,
@@ -34,7 +34,7 @@ namespace iroha {
       std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory_;
       std::shared_ptr<iroha::consensus::ConsensusResultCache>
           consensus_result_cache_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -6,6 +6,7 @@
 #include "network/impl/peer_communication_service_impl.hpp"
 
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "logger/logger.hpp"
 #include "network/ordering_gate.hpp"
 #include "simulator/verified_proposal_creator.hpp"
 #include "synchronizer/synchronizer.hpp"
@@ -17,7 +18,7 @@ namespace iroha {
         std::shared_ptr<synchronizer::Synchronizer> synchronizer,
         std::shared_ptr<iroha::simulator::VerifiedProposalCreator>
             proposal_creator,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : ordering_gate_(std::move(ordering_gate)),
           synchronizer_(std::move(synchronizer)),
           proposal_creator_(std::move(proposal_creator)),

--- a/irohad/network/impl/peer_communication_service_impl.hpp
+++ b/irohad/network/impl/peer_communication_service_impl.hpp
@@ -8,7 +8,7 @@
 
 #include "network/peer_communication_service.hpp"
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace simulator {
@@ -28,7 +28,7 @@ namespace iroha {
           std::shared_ptr<OrderingGate> ordering_gate,
           std::shared_ptr<synchronizer::Synchronizer> synchronizer,
           std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator,
-          logger::Logger log = logger::log("PCS"));
+          logger::LoggerPtr log);
 
       void propagate_batch(
           std::shared_ptr<shared_model::interface::TransactionBatch> batch)
@@ -46,7 +46,7 @@ namespace iroha {
       std::shared_ptr<OrderingGate> ordering_gate_;
       std::shared_ptr<synchronizer::Synchronizer> synchronizer_;
       std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/range/combine.hpp>
 #include "interfaces/iroha_internal/proposal.hpp"
+#include "logger/logger.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 
 using namespace iroha;
@@ -15,7 +16,7 @@ using namespace iroha::ordering;
 OnDemandConnectionManager::OnDemandConnectionManager(
     std::shared_ptr<transport::OdOsNotificationFactory> factory,
     rxcpp::observable<CurrentPeers> peers,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : log_(std::move(log)),
       factory_(std::move(factory)),
       subscription_(peers.subscribe([this](const auto &peers) {
@@ -29,7 +30,7 @@ OnDemandConnectionManager::OnDemandConnectionManager(
     std::shared_ptr<transport::OdOsNotificationFactory> factory,
     rxcpp::observable<CurrentPeers> peers,
     CurrentPeers initial_peers,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : OnDemandConnectionManager(std::move(factory), peers, std::move(log)) {
   // using start_with(initial_peers) results in deadlock
   initializeConnections(initial_peers);

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -11,7 +11,7 @@
 #include <shared_mutex>
 
 #include <rxcpp/rx.hpp>
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ordering {
@@ -52,13 +52,13 @@ namespace iroha {
       OnDemandConnectionManager(
           std::shared_ptr<transport::OdOsNotificationFactory> factory,
           rxcpp::observable<CurrentPeers> peers,
-          logger::Logger log = logger::log("OnDemandConnectionManager"));
+          logger::LoggerPtr log);
 
       OnDemandConnectionManager(
           std::shared_ptr<transport::OdOsNotificationFactory> factory,
           rxcpp::observable<CurrentPeers> peers,
           CurrentPeers initial_peers,
-          logger::Logger log = logger::log("OnDemandConnectionManager"));
+          logger::LoggerPtr log);
 
       ~OnDemandConnectionManager() override;
 
@@ -82,7 +82,7 @@ namespace iroha {
        */
       void initializeConnections(const CurrentPeers &peers);
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
       std::shared_ptr<transport::OdOsNotificationFactory> factory_;
       rxcpp::composite_subscription subscription_;
 

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -9,6 +9,7 @@
 #include <boost/range/empty.hpp>
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "common/visitor.hpp"
+#include "logger/logger.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 
 using namespace iroha;
@@ -22,7 +23,7 @@ OnDemandOrderingGate::OnDemandOrderingGate(
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory> factory,
     std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
     consensus::Round initial_round,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : log_(std::move(log)),
       ordering_service_(std::move(ordering_service)),
       network_client_(std::move(network_client)),

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -15,7 +15,7 @@
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp"
 #include "ordering/on_demand_ordering_service.hpp"
 
@@ -63,7 +63,7 @@ namespace iroha {
               factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round,
-          logger::Logger log = logger::log("OnDemandOrderingGate"));
+          logger::LoggerPtr log);
 
       ~OnDemandOrderingGate() override;
 
@@ -91,7 +91,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<shared_model::interface::Proposal>>
       removeReplays(shared_model::interface::Proposal &&proposal) const;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
       std::shared_ptr<OnDemandOrderingService> ordering_service_;
       std::shared_ptr<transport::OdOsNotification> network_client_;
       rxcpp::composite_subscription events_subscription_;

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -19,6 +19,7 @@
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
+#include "logger/logger.hpp"
 
 using namespace iroha;
 using namespace iroha::ordering;
@@ -28,9 +29,9 @@ OnDemandOrderingServiceImpl::OnDemandOrderingServiceImpl(
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
         proposal_factory,
     std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+    logger::LoggerPtr log,
     size_t number_of_proposals,
-    const consensus::Round &initial_round,
-    logger::Logger log)
+    const consensus::Round &initial_round)
     : transaction_limit_(transaction_limit),
       number_of_proposals_(number_of_proposals),
       proposal_factory_(std::move(proposal_factory)),

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -14,7 +14,7 @@
 
 #include <tbb/concurrent_queue.h>
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 
 namespace iroha {
@@ -30,20 +30,20 @@ namespace iroha {
        * proposal
        * @param proposal_factory - used to generate proposals
        * @param tx_cache - cache of transactions
+       * @param log to print progress
        * @param number_of_proposals - number of stored proposals, older will be
        * removed. Default value is 3
        * @param initial_round - first round of agreement.
        * Default value is {2, kFirstRejectRound} since genesis block height is 1
-       * @param log to print progress
        */
       OnDemandOrderingServiceImpl(
           size_t transaction_limit,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          logger::LoggerPtr log,
           size_t number_of_proposals = 3,
-          const consensus::Round &initial_round = {2, kFirstRejectRound},
-          logger::Logger log = logger::log("OnDemandOrderingServiceImpl"));
+          const consensus::Round &initial_round = {2, kFirstRejectRound});
 
       // --------------------- | OnDemandOrderingService |_---------------------
 
@@ -129,7 +129,7 @@ namespace iroha {
       /**
        * Logger instance
        */
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ordering
 }  // namespace iroha

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -9,6 +9,7 @@
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "logger/logger.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 
 using namespace iroha;
@@ -21,7 +22,7 @@ OnDemandOsClientGrpc::OnDemandOsClientGrpc(
         async_call,
     std::function<TimepointType()> time_provider,
     std::chrono::milliseconds proposal_request_timeout,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : log_(std::move(log)),
       stub_(std::move(stub)),
       async_call_(std::move(async_call)),
@@ -72,10 +73,12 @@ OnDemandOsClientGrpcFactory::OnDemandOsClientGrpcFactory(
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call,
     std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
-    OnDemandOsClientGrpc::TimeoutType proposal_request_timeout)
+    OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
+    logger::LoggerPtr client_log)
     : async_call_(std::move(async_call)),
       time_provider_(time_provider),
-      proposal_request_timeout_(proposal_request_timeout) {}
+      proposal_request_timeout_(proposal_request_timeout),
+      client_log_(std::move(client_log)) {}
 
 std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
     const shared_model::interface::Peer &to) {
@@ -84,5 +87,5 @@ std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
       async_call_,
       time_provider_,
       proposal_request_timeout_,
-      logger::log("OnDemandOsClientGrpc"));
+      client_log_);
 }

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -8,6 +8,7 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "ordering.grpc.pb.h"
 
@@ -33,7 +34,7 @@ namespace iroha {
                 async_call,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
-            logger::Logger log = logger::log("OnDemandOsClientGrpc"));
+            logger::LoggerPtr log);
 
         void onBatches(consensus::Round round, CollectionType batches) override;
 
@@ -41,7 +42,7 @@ namespace iroha {
             consensus::Round round) override;
 
        private:
-        logger::Logger log_;
+        logger::LoggerPtr log_;
         std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub_;
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
@@ -55,7 +56,8 @@ namespace iroha {
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
-            OnDemandOsClientGrpc::TimeoutType proposal_request_timeout);
+            OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
+            logger::LoggerPtr client_log);
 
         /**
          * Create connection with insecure gRPC channel defined by
@@ -71,6 +73,7 @@ namespace iroha {
             async_call_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
+        logger::LoggerPtr client_log_;
       };
 
     }  // namespace transport

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -12,6 +12,7 @@
 #include "backend/protobuf/proposal.hpp"
 #include "common/bind.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "logger/logger.hpp"
 
 using namespace iroha::ordering;
 using namespace iroha::ordering::transport;
@@ -23,7 +24,7 @@ OnDemandOsServerGrpc::OnDemandOsServerGrpc(
         batch_parser,
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory,
-    logger::Logger log)
+    logger::LoggerPtr log)
     : ordering_service_(ordering_service),
       transaction_factory_(std::move(transaction_factory)),
       batch_parser_(std::move(batch_parser)),

--- a/irohad/ordering/impl/on_demand_os_server_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.hpp
@@ -11,7 +11,7 @@
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "ordering.grpc.pb.h"
 
 namespace iroha {
@@ -35,7 +35,7 @@ namespace iroha {
                 batch_parser,
             std::shared_ptr<shared_model::interface::TransactionBatchFactory>
                 transaction_batch_factory,
-            logger::Logger log = logger::log("OnDemandOsServerGrpc"));
+            logger::LoggerPtr log);
 
         grpc::Status SendBatches(::grpc::ServerContext *context,
                                  const proto::BatchesRequest *request,
@@ -61,7 +61,7 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::TransactionBatchFactory>
             batch_factory_;
 
-        logger::Logger log_;
+        logger::LoggerPtr log_;
       };
 
     }  // namespace transport

--- a/irohad/ordering/impl/ordering_gate_impl.cpp
+++ b/irohad/ordering/impl/ordering_gate_impl.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "logger/logger.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 
 namespace iroha {
@@ -26,7 +27,7 @@ namespace iroha {
         std::shared_ptr<iroha::network::OrderingGateTransport> transport,
         shared_model::interface::types::HeightType initial_height,
         bool run_async,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : transport_(std::move(transport)),
           last_block_height_(initial_height),
           log_(std::move(log)),

--- a/irohad/ordering/impl/ordering_gate_impl.hpp
+++ b/irohad/ordering/impl/ordering_gate_impl.hpp
@@ -13,7 +13,7 @@
 #include <tbb/concurrent_priority_queue.h>
 
 #include "interfaces/common_objects/types.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_gate_transport.hpp"
 
@@ -54,8 +54,8 @@ namespace iroha {
       OrderingGateImpl(
           std::shared_ptr<iroha::network::OrderingGateTransport> transport,
           shared_model::interface::types::HeightType initial_height,
-          bool run_async = true,
-          logger::Logger log = logger::log("OrderingGate"));
+          bool run_async,
+          logger::LoggerPtr log);
 
       void propagateBatch(
           std::shared_ptr<shared_model::interface::TransactionBatch> batch)
@@ -105,7 +105,7 @@ namespace iroha {
       /// subscription of pcs::on_commit
       rxcpp::composite_subscription pcs_subscriber_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
 
       bool run_async_;
     };

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.cpp
@@ -8,6 +8,7 @@
 #include "backend/protobuf/transaction.hpp"
 #include "endpoint.pb.h"
 #include "interfaces/common_objects/types.hpp"
+#include "logger/logger.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 
 using namespace iroha;
@@ -17,23 +18,23 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
     ::grpc::ServerContext *context,
     const iroha::protocol::Proposal *request,
     ::google::protobuf::Empty *response) {
-  async_call_->log_->info("receive proposal");
+  log_->info("receive proposal");
 
   auto proposal_res = factory_->createProposal(*request);
   proposal_res.match(
       [this](iroha::expected::Value<
              std::unique_ptr<shared_model::interface::Proposal>> &v) {
-        async_call_->log_->info("transactions in proposal: {}",
+        log_->info("transactions in proposal: {}",
                                 v.value->transactions().size());
 
         if (not subscriber_.expired()) {
           subscriber_.lock()->onProposal(std::move(v.value));
         } else {
-          async_call_->log_->error("(onProposal) No subscriber");
+          log_->error("(onProposal) No subscriber");
         }
       },
       [this](const iroha::expected::Error<std::string> &e) {
-        async_call_->log_->error("Received invalid proposal: {}", e.error);
+        log_->error("Received invalid proposal: {}", e.error);
       });
 
   return grpc::Status::OK;
@@ -42,16 +43,18 @@ grpc::Status OrderingGateTransportGrpc::onProposal(
 OrderingGateTransportGrpc::OrderingGateTransportGrpc(
     const std::string &server_address,
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call)
+        async_call,
+    logger::LoggerPtr log)
     : client_(network::createClient<proto::OrderingServiceTransportGrpc>(
           server_address)),
       async_call_(std::move(async_call)),
       factory_(std::make_unique<shared_model::proto::ProtoProposalFactory<
-                   shared_model::validation::DefaultProposalValidator>>()) {}
+                   shared_model::validation::DefaultProposalValidator>>()),
+      log_(std::move(log)) {}
 
 void OrderingGateTransportGrpc::propagateBatch(
     std::shared_ptr<shared_model::interface::TransactionBatch> batch) {
-  async_call_->log_->info("Propagate transaction batch (on transport)");
+  log_->info("Propagate transaction batch (on transport)");
 
   iroha::protocol::TxList batch_transport;
   for (const auto tx : batch->transactions()) {
@@ -66,6 +69,6 @@ void OrderingGateTransportGrpc::propagateBatch(
 
 void OrderingGateTransportGrpc::subscribe(
     std::shared_ptr<iroha::network::OrderingGateNotification> subscriber) {
-  async_call_->log_->info("Subscribe");
+  log_->info("Subscribe");
   subscriber_ = subscriber;
 }

--- a/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_gate_transport_grpc.hpp
@@ -10,7 +10,7 @@
 #include "backend/protobuf/proto_proposal_factory.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_gate_transport.hpp"
 #include "ordering.grpc.pb.h"
@@ -25,7 +25,8 @@ namespace iroha {
       OrderingGateTransportGrpc(
           const std::string &server_address,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call);
+              async_call,
+          logger::LoggerPtr log);
 
       grpc::Status onProposal(::grpc::ServerContext *context,
                               const protocol::Proposal *request,

--- a/irohad/ordering/impl/ordering_service_transport_grpc.hpp
+++ b/irohad/ordering/impl/ordering_service_transport_grpc.hpp
@@ -8,7 +8,7 @@
 #include <google/protobuf/empty.pb.h>
 
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "network/ordering_service_transport.hpp"
 #include "ordering.grpc.pb.h"
@@ -25,7 +25,8 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call);
+              async_call,
+          logger::LoggerPtr log);
       void subscribe(
           std::shared_ptr<iroha::network::OrderingServiceNotification>
               subscriber) override;

--- a/irohad/ordering/impl/single_peer_ordering_service.cpp
+++ b/irohad/ordering/impl/single_peer_ordering_service.cpp
@@ -15,6 +15,7 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
+#include "logger/logger.hpp"
 #include "network/ordering_service_transport.hpp"
 
 namespace iroha {
@@ -27,7 +28,7 @@ namespace iroha {
         std::shared_ptr<ametsuchi::OsPersistentStateFactory> persistent_state,
         std::unique_ptr<shared_model::interface::ProposalFactory> factory,
         bool is_async,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : peer_query_factory_(peer_query_factory),
           max_size_(max_size),
           current_size_(0),

--- a/irohad/ordering/impl/single_peer_ordering_service.hpp
+++ b/irohad/ordering/impl/single_peer_ordering_service.hpp
@@ -15,7 +15,7 @@
 #include "ametsuchi/os_persistent_state_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "interfaces/iroha_internal/proposal_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/ordering_service.hpp"
 #include "ordering.grpc.pb.h"
 
@@ -56,8 +56,8 @@ namespace iroha {
           std::shared_ptr<network::OrderingServiceTransport> transport,
           std::shared_ptr<ametsuchi::OsPersistentStateFactory> persistent_state,
           std::unique_ptr<shared_model::interface::ProposalFactory> factory,
-          bool is_async = true,
-          logger::Logger log = logger::log("OrderingServiceImpl"));
+          bool is_async,
+          logger::LoggerPtr log);
 
       /**
        * Process transaction(s) received from network
@@ -136,7 +136,7 @@ namespace iroha {
        */
       size_t proposal_height_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace ordering
 }  // namespace iroha

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -9,6 +9,7 @@
 #include "common/bind.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace simulator {
@@ -22,7 +23,7 @@ namespace iroha {
             crypto_signer,
         std::unique_ptr<shared_model::interface::UnsafeBlockFactory>
             block_factory,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : validator_(std::move(statefulValidator)),
           ametsuchi_factory_(std::move(factory)),
           block_query_factory_(block_query_factory),

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -12,7 +12,7 @@
 #include "ametsuchi/temporary_factory.hpp"
 #include "cryptography/crypto_provider/crypto_model_signer.hpp"
 #include "interfaces/iroha_internal/unsafe_block_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/ordering_gate.hpp"
 #include "simulator/block_creator.hpp"
 #include "simulator/verified_proposal_creator.hpp"
@@ -32,7 +32,7 @@ namespace iroha {
               crypto_signer,
           std::unique_ptr<shared_model::interface::UnsafeBlockFactory>
               block_factory,
-          logger::Logger log = logger::log("Simulator"));
+          logger::LoggerPtr log);
 
       ~Simulator() override;
 
@@ -64,7 +64,7 @@ namespace iroha {
       std::unique_ptr<shared_model::interface::UnsafeBlockFactory>
           block_factory_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
 
       // last block
       std::shared_ptr<shared_model::interface::Block> last_block;

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -11,6 +11,7 @@
 #include "ametsuchi/mutable_storage.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace synchronizer {
@@ -21,7 +22,7 @@ namespace iroha {
         std::shared_ptr<ametsuchi::MutableFactory> mutable_factory,
         std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
         std::shared_ptr<network::BlockLoader> block_loader,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : validator_(std::move(validator)),
           mutable_factory_(std::move(mutable_factory)),
           block_query_factory_(std::move(block_query_factory)),

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -9,7 +9,7 @@
 #include "synchronizer/synchronizer.hpp"
 
 #include "ametsuchi/mutable_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "network/block_loader.hpp"
 #include "network/consensus_gate.hpp"
 #include "validation/chain_validator.hpp"
@@ -30,7 +30,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::MutableFactory> mutable_factory,
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<network::BlockLoader> block_loader,
-          logger::Logger log = logger::log("Synchronizer"));
+          logger::LoggerPtr log);
 
       ~SynchronizerImpl() override;
 
@@ -66,7 +66,7 @@ namespace iroha {
       rxcpp::subjects::subject<SynchronizationEvent> notifier_;
       rxcpp::composite_subscription subscription_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
   }  // namespace synchronizer

--- a/irohad/torii/command_client.hpp
+++ b/irohad/torii/command_client.hpp
@@ -11,7 +11,7 @@
 #include <memory>
 #include <thread>
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace torii {
 
@@ -22,7 +22,7 @@ namespace torii {
    public:
     CommandSyncClient(const std::string &ip,
                       size_t port,
-                      logger::Logger log = logger::log("CommandSyncClient"));
+                      logger::LoggerPtr log);
 
     /**
      * requests tx to a torii server and returns response (blocking, sync)
@@ -58,7 +58,7 @@ namespace torii {
 
    private:
     std::unique_ptr<iroha::protocol::CommandService_v1::Stub> stub_;
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 
 }  // namespace torii

--- a/irohad/torii/impl/command_client.cpp
+++ b/irohad/torii/impl/command_client.cpp
@@ -8,6 +8,7 @@
 #include <grpc++/grpc++.h>
 
 #include "common/byteutils.hpp"
+#include "logger/logger.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 #include "torii/command_client.hpp"
 #include "transaction.pb.h"
@@ -19,7 +20,7 @@ namespace torii {
 
   CommandSyncClient::CommandSyncClient(const std::string &ip,
                                        size_t port,
-                                       logger::Logger log)
+                                       logger::LoggerPtr log)
       : stub_(iroha::network::createClient<iroha::protocol::CommandService_v1>(
             ip + ":" + std::to_string(port))),
         log_(std::move(log)) {}

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -12,6 +12,7 @@
 #include "common/is_any.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "logger/logger.hpp"
 
 namespace torii {
 
@@ -20,7 +21,7 @@ namespace torii {
       std::shared_ptr<iroha::ametsuchi::Storage> storage,
       std::shared_ptr<iroha::torii::StatusBus> status_bus,
       std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory,
-      logger::Logger log)
+      logger::LoggerPtr log)
       : tx_processor_(std::move(tx_processor)),
         storage_(std::move(storage)),
         status_bus_(std::move(status_bus)),

--- a/irohad/torii/impl/command_service_impl.hpp
+++ b/irohad/torii/impl/command_service_impl.hpp
@@ -12,7 +12,7 @@
 #include "cache/cache.hpp"
 #include "cryptography/hash.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "torii/processor/transaction_processor.hpp"
 #include "torii/status_bus.hpp"
 
@@ -35,7 +35,7 @@ namespace torii {
         std::shared_ptr<iroha::torii::StatusBus> status_bus,
         std::shared_ptr<shared_model::interface::TxStatusFactory>
             status_factory,
-        logger::Logger log = logger::log("CommandServiceImpl"));
+        logger::LoggerPtr log);
 
     /**
      * Disable copying in any way to prevent potential issues with common
@@ -93,7 +93,7 @@ namespace torii {
     std::shared_ptr<CacheType> cache_;
     std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
 
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 
 }  // namespace torii

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -19,6 +19,7 @@
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
 #include "interfaces/transaction.hpp"
+#include "logger/logger.hpp"
 #include "network/consensus_gate.hpp"
 #include "torii/status_bus.hpp"
 
@@ -35,7 +36,7 @@ namespace torii {
           transaction_batch_factory,
       std::shared_ptr<iroha::network::ConsensusGate> consensus_gate,
       int maximum_rounds_without_update,
-      logger::Logger log)
+      logger::LoggerPtr log)
       : command_service_(std::move(command_service)),
         status_bus_(std::move(status_bus)),
         status_factory_(std::move(status_factory)),

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -12,7 +12,7 @@
 #include "endpoint.pb.h"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace torii {
@@ -67,7 +67,7 @@ namespace torii {
             transaction_batch_factory,
         std::shared_ptr<iroha::network::ConsensusGate> consensus_gate,
         int maximum_rounds_without_update,
-        logger::Logger log = logger::log("CommandServiceTransportGrpc"));
+        logger::LoggerPtr log);
 
     /**
      * Torii call via grpc
@@ -133,7 +133,7 @@ namespace torii {
         batch_parser_;
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         batch_factory_;
-    logger::Logger log_;
+    logger::LoggerPtr log_;
 
     std::shared_ptr<iroha::network::ConsensusGate> consensus_gate_;
     const int maximum_rounds_without_update_;

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -9,6 +9,7 @@
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
+#include "logger/logger.hpp"
 #include "validators/default_validator.hpp"
 
 namespace torii {
@@ -16,7 +17,7 @@ namespace torii {
   QueryService::QueryService(
       std::shared_ptr<iroha::torii::QueryProcessor> query_processor,
       std::shared_ptr<QueryFactoryType> query_factory,
-      logger::Logger log)
+      logger::LoggerPtr log)
       : query_processor_{std::move(query_processor)},
         query_factory_{std::move(query_factory)},
         log_{std::move(log)} {}

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -13,6 +13,7 @@
 #include "interfaces/queries/query.hpp"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "interfaces/query_responses/query_response.hpp"
+#include "logger/logger.hpp"
 #include "validation/utils.hpp"
 
 namespace iroha {
@@ -24,7 +25,7 @@ namespace iroha {
         std::shared_ptr<iroha::PendingTransactionStorage> pending_transactions,
         std::shared_ptr<shared_model::interface::QueryResponseFactory>
             response_factory,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : storage_{std::move(storage)},
           qry_exec_{std::move(qry_exec)},
           pending_transactions_{std::move(pending_transactions)},

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
+#include "logger/logger.hpp"
 #include "validation/stateful_validator_common.hpp"
 
 namespace iroha {
@@ -48,7 +49,7 @@ namespace iroha {
         std::shared_ptr<iroha::torii::StatusBus> status_bus,
         std::shared_ptr<shared_model::interface::TxStatusFactory>
             status_factory,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : pcs_(std::move(pcs)),
           mst_processor_(std::move(mst_processor)),
           status_bus_(std::move(status_bus)),

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -8,7 +8,7 @@
 
 #include "ametsuchi/storage.hpp"
 #include "interfaces/iroha_internal/query_response_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "torii/processor/query_processor.hpp"
 
 namespace iroha {
@@ -26,7 +26,7 @@ namespace iroha {
               pending_transactions,
           std::shared_ptr<shared_model::interface::QueryResponseFactory>
               response_factory,
-          logger::Logger log = logger::log("QueryProcessorImpl"));
+          logger::LoggerPtr log);
 
       /**
        * Checks if query has needed signatures
@@ -54,7 +54,7 @@ namespace iroha {
       std::shared_ptr<shared_model::interface::QueryResponseFactory>
           response_factory_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
   }  // namespace torii

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -14,7 +14,7 @@
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
 #include "interfaces/transaction_responses/tx_response.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "network/peer_communication_service.hpp"
 #include "torii/status_bus.hpp"
@@ -36,7 +36,7 @@ namespace iroha {
           std::shared_ptr<iroha::torii::StatusBus> status_bus,
           std::shared_ptr<shared_model::interface::TxStatusFactory>
               status_factory,
-          logger::Logger log = logger::log("TxProcessor"));
+          logger::LoggerPtr log);
 
       void batchHandle(
           std::shared_ptr<shared_model::interface::TransactionBatch>
@@ -62,7 +62,7 @@ namespace iroha {
       // creates transaction status
       std::shared_ptr<shared_model::interface::TxStatusFactory> status_factory_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
 
       /// prevents from emitting new tx statuses from different threads
       /// in parallel

--- a/irohad/torii/query_service.hpp
+++ b/irohad/torii/query_service.hpp
@@ -17,7 +17,7 @@
 #include "cache/cache.hpp"
 #include "torii/processor/query_processor.hpp"
 
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -40,7 +40,7 @@ namespace torii {
 
     QueryService(std::shared_ptr<iroha::torii::QueryProcessor> query_processor,
                  std::shared_ptr<QueryFactoryType> query_factory,
-                 logger::Logger log = logger::log("Query Service"));
+                 logger::LoggerPtr log);
 
     QueryService(const QueryService &) = delete;
     QueryService &operator=(const QueryService &) = delete;
@@ -72,7 +72,7 @@ namespace torii {
                         shared_model::crypto::Hash::Hasher>
         cache_;
 
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 
 }  // namespace torii

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -11,14 +11,16 @@
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace validation {
     ChainValidatorImpl::ChainValidatorImpl(
         std::shared_ptr<consensus::yac::SupermajorityChecker>
             supermajority_checker,
-        logger::Logger log)
-        : supermajority_checker_(supermajority_checker), log_(std::move(log)) {}
+        logger::LoggerPtr log)
+        : supermajority_checker_(supermajority_checker),
+          log_(std::move(log)) {}
 
     bool ChainValidatorImpl::validateAndApply(
         rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -11,7 +11,7 @@
 #include <memory>
 
 #include "interfaces/common_objects/types.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -34,10 +34,9 @@ namespace iroha {
   namespace validation {
     class ChainValidatorImpl : public ChainValidator {
      public:
-      explicit ChainValidatorImpl(
-          std::shared_ptr<consensus::yac::SupermajorityChecker>
-              supermajority_checker,
-          logger::Logger log = logger::log("ChainValidator"));
+      ChainValidatorImpl(std::shared_ptr<consensus::yac::SupermajorityChecker>
+                             supermajority_checker,
+                         logger::LoggerPtr log);
 
       bool validateAndApply(
           rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
@@ -71,7 +70,7 @@ namespace iroha {
       std::shared_ptr<consensus::yac::SupermajorityChecker>
           supermajority_checker_;
 
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
   }  // namespace validation
 }  // namespace iroha

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -14,6 +14,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/batch_meta.hpp"
+#include "logger/logger.hpp"
 #include "validation/utils.hpp"
 
 namespace iroha {
@@ -54,7 +55,7 @@ namespace iroha {
         const shared_model::interface::types::TransactionsCollectionType &txs,
         ametsuchi::TemporaryWsv &temporary_wsv,
         validation::TransactionsErrors &transactions_errors_log,
-        const logger::Logger &log,
+        const logger::LoggerPtr & /*log*/,
         const shared_model::interface::TransactionBatchParser &batch_parser) {
       std::vector<bool> validation_results;
       validation_results.reserve(boost::size(txs));
@@ -100,7 +101,7 @@ namespace iroha {
         std::unique_ptr<shared_model::interface::UnsafeProposalFactory> factory,
         std::shared_ptr<shared_model::interface::TransactionBatchParser>
             batch_parser,
-        logger::Logger log)
+        logger::LoggerPtr log)
         : factory_(std::move(factory)),
           batch_parser_(std::move(batch_parser)),
           log_(std::move(log)) {}

--- a/irohad/validation/impl/stateful_validator_impl.hpp
+++ b/irohad/validation/impl/stateful_validator_impl.hpp
@@ -10,7 +10,7 @@
 
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace validation {
@@ -25,7 +25,7 @@ namespace iroha {
               factory,
           std::shared_ptr<shared_model::interface::TransactionBatchParser>
               batch_parser,
-          logger::Logger log = logger::log("SFV"));
+          logger::LoggerPtr log);
 
       std::unique_ptr<validation::VerifiedProposalAndErrors> validate(
           const shared_model::interface::Proposal &proposal,
@@ -35,7 +35,7 @@ namespace iroha {
       std::unique_ptr<shared_model::interface::UnsafeProposalFactory> factory_;
       std::shared_ptr<shared_model::interface::TransactionBatchParser>
           batch_parser_;
-      logger::Logger log_;
+      logger::LoggerPtr log_;
     };
 
   }  // namespace validation

--- a/libs/common/files.cpp
+++ b/libs/common/files.cpp
@@ -10,31 +10,31 @@
 #include <boost/filesystem.hpp>
 #include "logger/logger.hpp"
 
-void iroha::remove_dir_contents(const std::string &dump_dir) {
-  auto log = logger::log("common::remove_all");
+void iroha::remove_dir_contents(const std::string &dir,
+                                const logger::LoggerPtr &log) {
   boost::system::error_code error_code;
 
-  bool exists = boost::filesystem::exists(dump_dir, error_code);
+  bool exists = boost::filesystem::exists(dir, error_code);
   if (error_code != boost::system::errc::success) {
     log->error(error_code.message());
     return;
   }
   if (not exists) {
-    log->error("Directory does not exist {}", dump_dir);
+    log->error("Directory does not exist {}", dir);
     return;
   }
 
-  bool is_dir = boost::filesystem::is_directory(dump_dir, error_code);
+  bool is_dir = boost::filesystem::is_directory(dir, error_code);
   if (error_code != boost::system::errc::success) {
     log->error(error_code.message());
     return;
   }
   if (not is_dir) {
-    log->error("{} is not a directory", dump_dir);
+    log->error("{} is not a directory", dir);
     return;
   }
 
-  for (auto entry : boost::filesystem::directory_iterator(dump_dir)) {
+  for (auto entry : boost::filesystem::directory_iterator(dir)) {
     boost::filesystem::remove_all(entry.path(), error_code);
     if (error_code != boost::system::errc::success)
       log->error(error_code.message());

--- a/libs/common/files.hpp
+++ b/libs/common/files.hpp
@@ -21,7 +21,7 @@ namespace iroha {
    * @param dir - target folder
    * @param log - a log for local messages
    */
-  void remove_dir_contents(const std::string &dump_dir,
+  void remove_dir_contents(const std::string &dir,
                            const logger::LoggerPtr &log);
 }  // namespace iroha
 #endif  // IROHA_FILES_HPP

--- a/libs/common/files.hpp
+++ b/libs/common/files.hpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "logger/logger_fwd.hpp"
+
 /**
  * This source file contains common methods related to files
  */
@@ -16,8 +18,10 @@ namespace iroha {
   /**
    * Remove all files and directories inside a folder.
    * Keeps the target folder.
-   * @param dump_dir - target folder
+   * @param dir - target folder
+   * @param log - a log for local messages
    */
-  void remove_dir_contents(const std::string &dump_dir);
+  void remove_dir_contents(const std::string &dump_dir,
+                           const logger::LoggerPtr &log);
 }  // namespace iroha
 #endif  // IROHA_FILES_HPP

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -45,7 +45,7 @@ namespace iroha {
   KeysManagerImpl::KeysManagerImpl(
       const std::string &account_id,
       const boost::filesystem::path &path_to_keypair,
-      logger::Logger log)
+      logger::LoggerPtr log)
       : path_to_keypair_(path_to_keypair),
         account_id_(account_id),
         log_(std::move(log)) {}
@@ -56,7 +56,7 @@ namespace iroha {
    * account_id.
    */
   KeysManagerImpl::KeysManagerImpl(const std::string account_id,
-                                   logger::Logger log)
+                                   logger::LoggerPtr log)
       : KeysManagerImpl(account_id, "", std::move(log)) {}
 
   bool KeysManagerImpl::validate(const Keypair &keypair) const {

--- a/libs/crypto/keys_manager_impl.hpp
+++ b/libs/crypto/keys_manager_impl.hpp
@@ -11,7 +11,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 #include "cryptography/keypair.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
 
@@ -26,15 +26,14 @@ namespace iroha {
      */
     KeysManagerImpl(const std::string &account_id,
                     const boost::filesystem::path &path_to_keypair,
-                    logger::Logger log = logger::log("KeysManagerImpl"));
+                    logger::LoggerPtr log);
 
     /**
      * Initialize key manager for a specific account
      * @param account_id - fully qualified account id, e.g. admin@test
      * @param log to print progress
      */
-    KeysManagerImpl(const std::string account_id,
-                    logger::Logger log = logger::log("KeysManagerImpl"));
+    KeysManagerImpl(const std::string account_id, logger::LoggerPtr log);
 
     bool createKeys() override;
 
@@ -74,7 +73,7 @@ namespace iroha {
 
     boost::filesystem::path path_to_keypair_;
     std::string account_id_;
-    logger::Logger log_;
+    logger::LoggerPtr log_;
   };
 }  // namespace iroha
 #endif  // IROHA_KEYS_MANAGER_IMPL_HPP

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -19,6 +19,9 @@ namespace logger {
   LoggerManagerTree::LoggerManagerTree(ConstLoggerConfigPtr config)
       : config_(std::move(config)){};
 
+  LoggerManagerTree::LoggerManagerTree(LoggerConfig config)
+      : config_(std::make_shared<const LoggerConfig>(std::move(config))){};
+
   LoggerManagerTree::LoggerManagerTree(std::string full_tag,
                                        std::string node_tag,
                                        ConstLoggerConfigPtr config)

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -26,6 +26,8 @@ namespace logger {
    public:
     LoggerManagerTree(ConstLoggerConfigPtr config);
 
+    LoggerManagerTree(LoggerConfig config);
+
     /**
      * Register a child configuration. The new child's configuration parameters
      * are taken from the parent optionally overrided by the arguments. Thread

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -24,9 +24,9 @@ namespace logger {
    */
   class LoggerManagerTree {
    public:
-    LoggerManagerTree(ConstLoggerConfigPtr config);
+    explicit LoggerManagerTree(ConstLoggerConfigPtr config);
 
-    LoggerManagerTree(LoggerConfig config);
+    explicit LoggerManagerTree(LoggerConfig config);
 
     /**
      * Register a child configuration. The new child's configuration parameters

--- a/shared_model/backend/protobuf/commands/impl/proto_command.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_command.cpp
@@ -66,8 +66,6 @@ namespace shared_model {
       }()};
 
       CommandVariantType ivariant_{variant_};
-
-      logger::Logger log_{logger::log("ProtoCommand")};
     };
 
     Command::Command(Command &&o) noexcept = default;
@@ -83,12 +81,8 @@ namespace shared_model {
     }
 
     Command *Command::clone() const {
-      logError("tried to clone a proto command, which is uncloneable");
-      std::terminate();
-    }
-
-    void Command::logError(const std::string &message) const {
-      impl_->log_->error(message);
+      throw std::runtime_error(
+          "tried to clone a proto command, which is uncloneable");
     }
 
   }  // namespace proto


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

### Description of the Change

This is a part of new logger integration to irohad. As the complete integration patch is too big for a single PR (+743 -462), it is split in three parts (#2050, #2051, #2052) according to the source code directory structure. This PR includes changes made outside `irohad/{ametsuchi,consensus,main}`. You can use the unified patch 496b2e9d0 (which was exactly equal to these three PRs put together when they were opened) to build Irohad with the new logger.

### Benefits

One more step towards the new logger.