### PR TITLE
Hotfix for segfault and atomic batches

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -363,7 +363,8 @@ void Irohad::initConsensusGate() {
                                               vote_delay_,
                                               async_call_,
                                               common_objects_factory_);
-
+  consensus_gate->onOutcome().subscribe(
+      consensus_gate_objects.get_subscriber());
   log_->info("[Init] => consensus gate");
 }
 
@@ -466,8 +467,10 @@ void Irohad::initTransactionCommandService() {
           transaction_factory,
           batch_parser,
           transaction_batch_factory_,
-          consensus_gate,
-          2);
+          consensus_gate_objects.get_observable().map([](const auto &) {
+            return ::torii::CommandServiceTransportGrpc::ConsensusGateEvent{};
+          }),
+          2);  // TODO 18.01.2019 igor-egorov, make it configurable IR-230
 
   log_->info("[Init] => command service");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -195,6 +195,12 @@ class Irohad {
   // persistent cache
   std::shared_ptr<iroha::ametsuchi::TxPresenceCache> persistent_cache;
 
+  // proposal factory
+  std::shared_ptr<shared_model::interface::AbstractTransportFactory<
+      shared_model::interface::Proposal,
+      iroha::protocol::Proposal>>
+      proposal_factory;
+
   // ordering gate
   std::shared_ptr<iroha::network::OrderingGate> ordering_gate;
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -210,6 +210,7 @@ class Irohad {
 
   // consensus gate
   std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
+  rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_gate_objects;
 
   // synchronizer
   std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -28,6 +28,12 @@ namespace iroha {
      * Encapsulates initialization logic for on-demand ordering gate and service
      */
     class OnDemandOrderingInit {
+     public:
+      using TransportFactoryType =
+          shared_model::interface::AbstractTransportFactory<
+              shared_model::interface::Proposal,
+              iroha::protocol::Proposal>;
+
      private:
       /**
        * Creates notification factory for individual connections to peers with
@@ -36,6 +42,7 @@ namespace iroha {
       auto createNotificationFactory(
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay);
 
       /**
@@ -47,6 +54,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay,
           std::vector<shared_model::interface::types::HashType> initial_hashes);
 
@@ -117,6 +125,7 @@ namespace iroha {
               async_call,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
+          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           consensus::Round initial_round,
           std::function<std::chrono::seconds(

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -19,12 +19,14 @@ OnDemandOsClientGrpc::OnDemandOsClientGrpc(
     std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub,
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call,
+    std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<TimepointType()> time_provider,
     std::chrono::milliseconds proposal_request_timeout,
     logger::Logger log)
     : log_(std::move(log)),
       stub_(std::move(stub)),
       async_call_(std::move(async_call)),
+      proposal_factory_(std::move(proposal_factory)),
       time_provider_(std::move(time_provider)),
       proposal_request_timeout_(proposal_request_timeout) {}
 
@@ -64,16 +66,28 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   if (not response.has_proposal()) {
     return boost::none;
   }
-  return ProposalType{std::make_unique<shared_model::proto::Proposal>(
-      std::move(response.proposal()))};
+  return proposal_factory_->build(response.proposal())
+      .match(
+          [&](iroha::expected::Value<
+              std::unique_ptr<shared_model::interface::Proposal>> &v)
+              -> boost::optional<OdOsNotification::ProposalType> {
+            return ProposalType{std::move(v).value};
+          },
+          [this](iroha::expected::Error<TransportFactoryType::Error> &error)
+              -> boost::optional<OdOsNotification::ProposalType> {
+            log_->info(error.error.error);  // error
+            return {};
+          });
 }
 
 OnDemandOsClientGrpcFactory::OnDemandOsClientGrpcFactory(
     std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call,
+    std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
     OnDemandOsClientGrpc::TimeoutType proposal_request_timeout)
     : async_call_(std::move(async_call)),
+      proposal_factory_(std::move(proposal_factory)),
       time_provider_(time_provider),
       proposal_request_timeout_(proposal_request_timeout) {}
 
@@ -82,6 +96,7 @@ std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
   return std::make_unique<OnDemandOsClientGrpc>(
       network::createClient<proto::OnDemandOrdering>(to.address()),
       async_call_,
+      proposal_factory_,
       time_provider_,
       proposal_request_timeout_,
       logger::log("OnDemandOsClientGrpc"));

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -8,6 +8,7 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "network/impl/async_grpc_client.hpp"
 #include "ordering.grpc.pb.h"
 
@@ -20,6 +21,10 @@ namespace iroha {
        */
       class OnDemandOsClientGrpc : public OdOsNotification {
        public:
+        using TransportFactoryType =
+            shared_model::interface::AbstractTransportFactory<
+                shared_model::interface::Proposal,
+                iroha::protocol::Proposal>;
         using TimepointType = std::chrono::system_clock::time_point;
         using TimeoutType = std::chrono::milliseconds;
 
@@ -31,6 +36,7 @@ namespace iroha {
             std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub,
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
+            std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
             logger::Logger log = logger::log("OnDemandOsClientGrpc"));
@@ -45,15 +51,18 @@ namespace iroha {
         std::unique_ptr<proto::OnDemandOrdering::StubInterface> stub_;
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
+        std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
       };
 
       class OnDemandOsClientGrpcFactory : public OdOsNotificationFactory {
        public:
+        using TransportFactoryType = OnDemandOsClientGrpc::TransportFactoryType;
         OnDemandOsClientGrpcFactory(
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
                 async_call,
+            std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
             OnDemandOsClientGrpc::TimeoutType proposal_request_timeout);
 
@@ -69,6 +78,7 @@ namespace iroha {
        private:
         std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
             async_call_;
+        std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
       };

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -112,8 +112,9 @@ namespace torii {
         // prepend initial status
         .start_with(initial_status)
         // select statuses with requested hash
-        .filter(
-            [&](auto response) { return response->transactionHash() == hash; })
+        .filter([hash](auto response) {
+          return response->transactionHash() == hash;
+        })
         // successfully complete the observable if final status is received.
         // final status is included in the observable
         .template lift<ResponsePtrType>([](rxcpp::subscriber<ResponsePtrType>

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -193,6 +193,7 @@ namespace torii {
 
     boost::optional<iroha::protocol::TxStatus> last_tx_status;
     auto rounds_counter{0};
+    std::mutex stream_write_mutex;
     command_service_
         ->getStatusStream(hash)
         // convert to transport objects
@@ -206,40 +207,43 @@ namespace torii {
         .map([](const auto &tuple) { return std::get<0>(tuple); })
         // complete the observable if client is disconnected or too many
         // rounds have passed without tx status change
-        .take_while(
-            [=, &rounds_counter, &last_tx_status](const auto &response) {
-              auto is_cancelled = context->IsCancelled();
-              if (is_cancelled) {
-                log_->debug("client unsubscribed, {}", client_id);
-              }
-              // we increment round counter when the same status arrived again.
-              auto status = response.tx_status();
-              if (last_tx_status and (status == *last_tx_status)) {
-                ++rounds_counter;
-              } else {
-                rounds_counter = 0;
-              }
-              // we stop the stream when round counter is greater than allowed.
-              if (rounds_counter >= maximum_rounds_without_update_) {
-                return false;
-              }
+        .take_while([=, &rounds_counter, &last_tx_status, &stream_write_mutex](
+                        const auto &response) {
+          // TODO [IR-249] akvinikym 23.01.19: remove the mutex after
+          // ensuring only one thread can be here
+          std::lock_guard<std::mutex> lg{stream_write_mutex};
 
-              return not is_cancelled;
-            })
-        .filter([&last_tx_status](const auto &response) {
+          if (context->IsCancelled()) {
+            log_->debug("client unsubscribed, {}", client_id);
+            return false;
+          }
+
+          // increment round counter when the same status arrived again.
           auto status = response.tx_status();
-          // we allow further processing in case of any new status
-          // (including the first one)
-          auto result = not last_tx_status or (*last_tx_status != status);
+          auto status_is_same = last_tx_status and (status == *last_tx_status);
+          if (status_is_same) {
+            ++rounds_counter;
+            if (rounds_counter >= maximum_rounds_without_update_) {
+              // we stop the stream when round counter is greater than allowed.
+              return false;
+            }
+            // omit the received status, but do not stop the stream
+            return true;
+          }
+          rounds_counter = 0;
           last_tx_status = status;
-          return result;
+
+          // write a new status to the stream
+          if (not response_writer->Write(response)) {
+            log_->error("write to stream has failed to client {}", client_id);
+            return false;
+          }
+
+          log_->debug("status written, {}", client_id);
+          return true;
         })
         .subscribe(subscription,
-                   [this, &response_writer, &client_id](const auto &response) {
-                     if (response_writer->Write(response)) {
-                       log_->debug("status written, {}", client_id);
-                     }
-                   },
+                   [](const auto &) {},
                    [&](std::exception_ptr ep) {
                      log_->error("something bad happened, client_id {}",
                                  client_id);
@@ -252,5 +256,5 @@ namespace torii {
 
     log_->debug("status stream done, {}", client_id);
     return grpc::Status::OK;
-  }
+  }  // namespace torii
 }  // namespace torii

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -28,12 +28,6 @@ namespace shared_model {
   }  // namespace interface
 }  // namespace shared_model
 
-namespace iroha {
-  namespace network {
-    class ConsensusGate;
-  }
-}  // namespace iroha
-
 namespace torii {
   class CommandServiceTransportGrpc
       : public iroha::protocol::CommandService_v1::Service {
@@ -43,6 +37,8 @@ namespace torii {
             shared_model::interface::Transaction,
             iroha::protocol::Transaction>;
 
+    struct ConsensusGateEvent {};
+
     /**
      * Creates a new instance of CommandServiceTransportGrpc
      * @param command_service - to delegate logic work
@@ -50,9 +46,10 @@ namespace torii {
      * @param status_factory - factory of statuses
      * @param transaction_factory - factory of transactions
      * @param batch_parser - parses of batches
-     * @param transaction_batch_factory - factory of batches
-     * @param initial_timeout - streaming timeout when tx is not received
-     * @param nonfinal_timeout - streaming timeout when tx is being processed
+     * @param transaction_batch_factory - factory of batches of transactions
+     * @param consensus_gate_objects - events from consensus gate
+     * @param maximum_rounds_without_update - defines how long tx status
+     * stream is kept alive when no new tx statuses appear
      * @param log to print progress
      */
     CommandServiceTransportGrpc(
@@ -65,7 +62,7 @@ namespace torii {
             batch_parser,
         std::shared_ptr<shared_model::interface::TransactionBatchFactory>
             transaction_batch_factory,
-        std::shared_ptr<iroha::network::ConsensusGate> consensus_gate,
+        rxcpp::observable<ConsensusGateEvent> consensus_gate_objects,
         int maximum_rounds_without_update,
         logger::Logger log = logger::log("CommandServiceTransportGrpc"));
 
@@ -135,7 +132,7 @@ namespace torii {
         batch_factory_;
     logger::Logger log_;
 
-    std::shared_ptr<iroha::network::ConsensusGate> consensus_gate_;
+    rxcpp::observable<ConsensusGateEvent> consensus_gate_objects_;
     const int maximum_rounds_without_update_;
   };
 }  // namespace torii

--- a/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.cpp
@@ -5,106 +5,20 @@
 
 #include "interfaces/iroha_internal/transaction_batch_factory_impl.hpp"
 
-#include <boost/range/combine.hpp>
-
-#include "interfaces/iroha_internal/batch_meta.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
 #include "interfaces/transaction.hpp"
 #include "validators/answer.hpp"
-
-namespace {
-  enum class BatchCheckResult {
-    kOk,
-    kNoBatchMeta,
-    kIncorrectBatchMetaSize,
-    kIncorrectHashes
-  };
-  /**
-   * Check that all transactions from the collection are mentioned in batch_meta
-   * and are positioned correctly
-   * @param transactions to be checked
-   * @return enum, reporting about success result or containing a found error
-   */
-  BatchCheckResult batchIsWellFormed(
-      const shared_model::interface::types::SharedTxsCollectionType
-          &transactions) {
-    auto batch_meta_opt = transactions[0]->batchMeta();
-    if (not batch_meta_opt and transactions.size() == 1) {
-      // batch is created from one tx - there is no batch_meta in valid case
-      return BatchCheckResult::kOk;
-    }
-    if (not batch_meta_opt) {
-      // in all other cases batch_meta must present
-      return BatchCheckResult::kNoBatchMeta;
-    }
-
-    const auto &batch_hashes = batch_meta_opt->get()->reducedHashes();
-    if (batch_hashes.size() != transactions.size()) {
-      return BatchCheckResult::kIncorrectBatchMetaSize;
-    }
-
-    auto metas_and_txs = boost::combine(batch_hashes, transactions);
-    auto hashes_are_correct =
-        std::all_of(boost::begin(metas_and_txs),
-                    boost::end(metas_and_txs),
-                    [](const auto &meta_and_tx) {
-                      shared_model::interface::types::HashType batch_hash;
-                      std::shared_ptr<shared_model::interface::Transaction> tx;
-                      boost::tie(batch_hash, tx) = meta_and_tx;
-                      return batch_hash == tx->reducedHash();
-                    });
-    if (not hashes_are_correct) {
-      return BatchCheckResult::kIncorrectHashes;
-    }
-
-    return BatchCheckResult::kOk;
-  }
-}  // namespace
 
 namespace shared_model {
   namespace interface {
     TransactionBatchFactoryImpl::FactoryImplResult
     TransactionBatchFactoryImpl::createTransactionBatch(
         const types::SharedTxsCollectionType &transactions) const {
-      std::string reason_name = "Transaction batch factory: ";
-      validation::ReasonsGroupType batch_reason;
-      batch_reason.first = reason_name;
-
-      bool has_at_least_one_signature = std::any_of(
-          transactions.begin(), transactions.end(), [](const auto tx) {
-            return not boost::empty(tx->signatures());
-          });
-      if (not has_at_least_one_signature) {
-        batch_reason.second.emplace_back(
-            "Transaction batch should contain at least one signature");
-      }
-
-      switch (batchIsWellFormed(transactions)) {
-        case BatchCheckResult::kOk:
-          break;
-        case BatchCheckResult::kNoBatchMeta:
-          batch_reason.second.emplace_back(
-              "There is no batch meta in provided transactions");
-          break;
-        case BatchCheckResult::kIncorrectBatchMetaSize:
-          batch_reason.second.emplace_back(
-              "Sizes of batch_meta and provided transactions are different");
-          break;
-        case BatchCheckResult::kIncorrectHashes:
-          batch_reason.second.emplace_back(
-              "Hashes of provided transactions and ones in batch_meta are "
-              "different");
-          break;
-      }
-
-      if (not batch_reason.second.empty()) {
-        validation::Answer answer;
-        answer.addReason(std::move(batch_reason));
-        return iroha::expected::makeError(answer.reason());
-      }
-
       std::unique_ptr<TransactionBatch> batch_ptr =
           std::make_unique<TransactionBatchImpl>(transactions);
+      if (auto answer = batch_validator_.validate(*batch_ptr)) {
+        return iroha::expected::makeError(answer.reason());
+      }
       return iroha::expected::makeValue(std::move(batch_ptr));
     }
 

--- a/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_factory_impl.hpp
@@ -7,6 +7,7 @@
 #define IROHA_TRANSACTION_BATCH_FACTORY_IMPL_HPP
 
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
+#include "validators/transaction_batch_validator.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -21,6 +22,9 @@ namespace shared_model {
 
       FactoryImplResult createTransactionBatch(
           std::shared_ptr<Transaction> transaction) const override;
+
+     private:
+      validation::BatchValidator batch_validator_;
     };
 
   }  // namespace interface

--- a/shared_model/validators/CMakeLists.txt
+++ b/shared_model/validators/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(shared_model_stateless_validation
         protobuf/proto_block_validator.cpp
         protobuf/proto_query_validator.cpp
         protobuf/proto_transaction_validator.cpp
+        protobuf/proto_proposal_validator.cpp
+        transaction_batch_validator.cpp
         )
 
 target_link_libraries(shared_model_stateless_validation

--- a/shared_model/validators/proposal_validator.hpp
+++ b/shared_model/validators/proposal_validator.hpp
@@ -11,6 +11,7 @@
 #include "datetime/time.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
+#include "validators/abstract_validator.hpp"
 #include "validators/answer.hpp"
 #include "validators/container_validator.hpp"
 
@@ -26,7 +27,8 @@ namespace shared_model {
     class ProposalValidator
         : public ContainerValidator<interface::Proposal,
                                     FieldValidator,
-                                    TransactionsCollectionValidator> {
+                                    TransactionsCollectionValidator>,
+          public AbstractValidator<interface::Proposal> {
      public:
       using ContainerValidator<
           interface::Proposal,

--- a/shared_model/validators/protobuf/proto_proposal_validator.cpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "validators/protobuf/proto_proposal_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    ProtoProposalValidator::ProtoProposalValidator(
+        ProtoValidatorType transaction_validator)
+        : transaction_validator_(std::move(transaction_validator)) {}
+
+    Answer ProtoProposalValidator::validate(
+        const iroha::protocol::Proposal &proposal) const {
+      Answer answer;
+      std::string tx_reason_name = "Protobuf Proposal";
+      ReasonsGroupType reason{tx_reason_name, GroupedReasons()};
+
+      for (const auto &tx : proposal.transactions()) {
+        if (auto tx_answer = transaction_validator_->validate(tx)) {
+          reason.second.emplace_back(tx_answer.reason());
+        }
+      }
+
+      if (not reason.second.empty()) {
+        answer.addReason(std::move(reason));
+      }
+
+      return answer;
+    }
+
+  }  // namespace validation
+}  // namespace shared_model

--- a/shared_model/validators/protobuf/proto_proposal_validator.hpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.hpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef IROHA_PROTO_PROPOSAL_VALIDATOR_HPP
+#define IROHA_PROTO_PROPOSAL_VALIDATOR_HPP
+
+#include "proposal.pb.h"
+#include "validators/abstract_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+    class ProtoProposalValidator
+        : public AbstractValidator<iroha::protocol::Proposal> {
+     public:
+      using ProtoValidatorType =
+          std::shared_ptr<shared_model::validation::AbstractValidator<
+              typename iroha::protocol::Transaction>>;
+
+      ProtoProposalValidator(ProtoValidatorType transaction_validator);
+
+      Answer validate(const iroha::protocol::Proposal &proposal) const override;
+
+     private:
+      ProtoValidatorType transaction_validator_;
+    };
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_PROTO_PROPOSAL_VALIDATOR_HPP

--- a/shared_model/validators/transaction_batch_validator.cpp
+++ b/shared_model/validators/transaction_batch_validator.cpp
@@ -1,0 +1,114 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "validators/transaction_batch_validator.hpp"
+
+#include <boost/range/adaptor/indirected.hpp>
+#include "interfaces/iroha_internal/batch_meta.hpp"
+#include "interfaces/transaction.hpp"
+
+namespace {
+  enum class BatchCheckResult {
+    kOk,
+    kNoBatchMeta,
+    kIncorrectBatchMetaSize,
+    kIncorrectHashes
+  };
+  /**
+   * Check that all transactions from the collection are mentioned in batch_meta
+   * and are positioned correctly
+   * @param transactions to be checked
+   * @return enum, reporting about success result or containing a found error
+   */
+  BatchCheckResult batchIsWellFormed(
+      const shared_model::interface::types::TransactionsForwardCollectionType
+          &transactions) {
+    // equality of transactions batchMeta is checked during batch parsing
+    auto batch_meta_opt = transactions.begin()->batchMeta();
+    const auto transactions_quantity = boost::size(transactions);
+    if (not batch_meta_opt and transactions_quantity == 1) {
+      // batch is created from one tx - there is no batch_meta in valid case
+      return BatchCheckResult::kOk;
+    }
+    if (not batch_meta_opt) {
+      // in all other cases batch_meta must present
+      return BatchCheckResult::kNoBatchMeta;
+    }
+
+    const auto &batch_hashes = batch_meta_opt->get()->reducedHashes();
+    if (batch_hashes.size() != transactions_quantity) {
+      return BatchCheckResult::kIncorrectBatchMetaSize;
+    }
+
+    auto hashes_are_correct =
+        std::equal(boost::begin(batch_hashes),
+                   boost::end(batch_hashes),
+                   boost::begin(transactions),
+                   boost::end(transactions),
+                   [](const auto &tx_reduced_hash, const auto &tx) {
+                     return tx_reduced_hash == tx.reducedHash();
+                   });
+    if (not hashes_are_correct) {
+      return BatchCheckResult::kIncorrectHashes;
+    }
+
+    return BatchCheckResult::kOk;
+  }
+}  // namespace
+
+namespace shared_model {
+  namespace validation {
+
+    Answer BatchValidator::validate(
+        const interface::TransactionBatch &batch) const {
+      auto transactions = batch.transactions();
+      return validate(transactions | boost::adaptors::indirected);
+    }
+
+    Answer BatchValidator::validate(
+        interface::types::TransactionsForwardCollectionType transactions)
+        const {
+      std::string reason_name = "Transaction batch factory: ";
+      validation::ReasonsGroupType batch_reason;
+      batch_reason.first = reason_name;
+
+      bool has_at_least_one_signature = std::any_of(
+          transactions.begin(), transactions.end(), [](const auto &tx) {
+            return not boost::empty(tx.signatures());
+          });
+      if (not has_at_least_one_signature) {
+        batch_reason.second.emplace_back(
+            "Transaction batch should contain at least one signature");
+        // no stronger check for signatures is required here
+        // here we are checking only batch logic, not transaction-related
+      }
+
+      switch (batchIsWellFormed(transactions)) {
+        case BatchCheckResult::kOk:
+          break;
+        case BatchCheckResult::kNoBatchMeta:
+          batch_reason.second.emplace_back(
+              "There is no batch meta in provided transactions");
+          break;
+        case BatchCheckResult::kIncorrectBatchMetaSize:
+          batch_reason.second.emplace_back(
+              "Sizes of batch_meta and provided transactions are different");
+          break;
+        case BatchCheckResult::kIncorrectHashes:
+          batch_reason.second.emplace_back(
+              "Hashes of provided transactions and ones in batch_meta are "
+              "different");
+          break;
+      }
+
+      validation::Answer answer;
+      if (not batch_reason.second.empty()) {
+        answer.addReason(std::move(batch_reason));
+      }
+      return answer;
+    }
+
+  }  // namespace validation
+}  // namespace shared_model

--- a/shared_model/validators/transaction_batch_validator.hpp
+++ b/shared_model/validators/transaction_batch_validator.hpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef IROHA_TRANSACTION_BATCH_VALIDATOR_HPP
+#define IROHA_TRANSACTION_BATCH_VALIDATOR_HPP
+
+#include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "validators/abstract_validator.hpp"
+
+namespace shared_model {
+  namespace validation {
+
+    class BatchValidator
+        : public AbstractValidator<interface::TransactionBatch> {
+     public:
+      Answer validate(const interface::TransactionBatch &batch) const override;
+
+      Answer validate(interface::types::TransactionsForwardCollectionType
+                          transactions) const;
+    };
+  }  // namespace validation
+}  // namespace shared_model
+
+#endif  // IROHA_TRANSACTION_BATCH_VALIDATOR_HPP

--- a/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
+++ b/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
@@ -10,9 +10,11 @@
 #include <boost/format.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
+#include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
 #include "validators/default_validator.hpp"
 #include "validators/field_validator.hpp"
 #include "validators/signable_validator.hpp"
+#include "validators/transaction_batch_validator.hpp"
 #include "validators/transaction_validator.hpp"
 #include "validators/transactions_collection/batch_order_validator.hpp"
 
@@ -54,6 +56,16 @@ namespace shared_model {
               (boost::format("Tx %s : %s") % tx.hash().hex() % answer.reason())
                   .str();
           reason.second.push_back(message);
+        }
+      }
+
+      interface::TransactionBatchParserImpl batch_parser;
+      BatchValidator batch_validator;
+
+      auto batches = batch_parser.parseBatches(transactions);
+      for (auto &batch : batches) {
+        if (auto answer = batch_validator.validate(batch)) {
+          reason.second.emplace_back(answer.reason());
         }
       }
 

--- a/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
@@ -6,10 +6,13 @@
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
 
 #include <gtest/gtest.h>
+#include "backend/protobuf/proposal.hpp"
+#include "backend/protobuf/proto_transport_factory.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "framework/mock_stream.h"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
+#include "module/shared_model/validators/validators.hpp"
 #include "ordering_mock.grpc.pb.h"
 
 using namespace iroha;
@@ -23,14 +26,37 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 
-struct OnDemandOsClientGrpcTest : public ::testing::Test {
+class OnDemandOsClientGrpcTest : public ::testing::Test {
+ public:
+  using ProtoProposalTransportFactory =
+      shared_model::proto::ProtoTransportFactory<
+          shared_model::interface::Proposal,
+          shared_model::proto::Proposal>;
+  using ProposalTransportFactory =
+      shared_model::interface::AbstractTransportFactory<
+          shared_model::interface::Proposal,
+          shared_model::proto::Proposal::TransportType>;
+  using MockProposalValidator = shared_model::validation::MockValidator<
+      shared_model::interface::Proposal>;
+  using MockProtoProposalValidator =
+      shared_model::validation::MockValidator<iroha::protocol::Proposal>;
+
   void SetUp() override {
     auto ustub = std::make_unique<proto::MockOnDemandOrderingStub>();
     stub = ustub.get();
     async_call =
         std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>();
-    client = std::make_shared<OnDemandOsClientGrpc>(
-        std::move(ustub), async_call, [&] { return timepoint; }, timeout);
+    auto validator = std::make_unique<MockProposalValidator>();
+    proposal_validator = validator.get();
+    auto proto_validator = std::make_unique<MockProtoProposalValidator>();
+    proto_proposal_validator = proto_validator.get();
+    proposal_factory = std::make_shared<ProtoProposalTransportFactory>(
+        std::move(validator), std::move(proto_validator));
+    client = std::make_shared<OnDemandOsClientGrpc>(std::move(ustub),
+                                                    async_call,
+                                                    proposal_factory,
+                                                    [&] { return timepoint; },
+                                                    timeout);
   }
 
   proto::MockOnDemandOrderingStub *stub;
@@ -39,6 +65,10 @@ struct OnDemandOsClientGrpcTest : public ::testing::Test {
   std::chrono::milliseconds timeout{1};
   std::shared_ptr<OnDemandOsClientGrpc> client;
   consensus::Round round{1, 2};
+
+  MockProposalValidator *proposal_validator;
+  MockProtoProposalValidator *proto_proposal_validator;
+  std::shared_ptr<ProposalTransportFactory> proposal_factory;
 };
 
 /**

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 
+#include "cryptography/hash.hpp"
 #include "endpoint.grpc.pb.h"
 #include "endpoint.pb.h"
 #include "interfaces/query_responses/block_query_response.hpp"
@@ -72,7 +73,7 @@ namespace iroha {
           getStatusStream,
           rxcpp::observable<
               std::shared_ptr<shared_model::interface::TransactionResponse>>(
-              const shared_model::crypto::Hash &hash));
+              const shared_model::crypto::Hash &));
     };
 
   }  // namespace torii

--- a/test/module/irohad/torii/torii_transport_command_test.cpp
+++ b/test/module/irohad/torii/torii_transport_command_test.cpp
@@ -35,9 +35,6 @@ using ::testing::Property;
 using ::testing::Return;
 using ::testing::StrEq;
 
-using iroha::consensus::BlockReject;
-using iroha::consensus::GateObject;
-
 using namespace iroha::ametsuchi;
 using namespace iroha::torii;
 using namespace std::chrono_literals;
@@ -73,11 +70,6 @@ class CommandServiceTransportGrpcTest : public testing::Test {
     batch_parser =
         std::make_shared<shared_model::interface::TransactionBatchParserImpl>();
     batch_factory = std::make_shared<MockTransactionBatchFactory>();
-
-    mock_consensus_gate = std::make_shared<iroha::network::MockConsensusGate>();
-    ON_CALL(*mock_consensus_gate, onOutcome())
-        .WillByDefault(
-            Return(rxcpp::observable<>::empty<iroha::consensus::GateObject>()));
   }
 
   void SetUp() override {
@@ -93,8 +85,8 @@ class CommandServiceTransportGrpcTest : public testing::Test {
         transaction_factory,
         batch_parser,
         batch_factory,
-        mock_consensus_gate,
-        2);
+        rxcpp::observable<>::iterate(gate_objects),
+        gate_objects.size());
   }
 
   std::shared_ptr<MockStatusBus> status_bus;
@@ -110,7 +102,11 @@ class CommandServiceTransportGrpcTest : public testing::Test {
   std::shared_ptr<MockCommandService> command_service;
   std::shared_ptr<torii::CommandServiceTransportGrpc> transport_grpc;
 
-  std::shared_ptr<iroha::network::MockConsensusGate> mock_consensus_gate;
+  rxcpp::subjects::subject<
+      torii::CommandServiceTransportGrpc::ConsensusGateEvent>
+      consensus_gate_objects;
+  std::vector<torii::CommandServiceTransportGrpc::ConsensusGateEvent>
+      gate_objects{2};
 
   const size_t kHashLength = 32;
   const size_t kTimes = 5;
@@ -284,10 +280,6 @@ TEST_F(CommandServiceTransportGrpcTest, StatusStreamOnNotReceived) {
                              StrEq(hash.hex())),
                     _))
       .WillOnce(Return(true));
-
-  std::vector<GateObject> gate_objects{BlockReject{}, BlockReject{}};
-  EXPECT_CALL(*mock_consensus_gate, onOutcome())
-      .WillOnce(Return(rxcpp::observable<>::iterate(gate_objects)));
 
   ASSERT_TRUE(transport_grpc
                   ->StatusStream(

--- a/test/module/irohad/validation/stateful_validator_test.cpp
+++ b/test/module/irohad/validation/stateful_validator_test.cpp
@@ -316,11 +316,22 @@ TEST_F(Validator, Batches) {
   ASSERT_EQ(
       verified_proposal_and_errors->verified_proposal->transactions().size(),
       5);
-  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(), 1);
-  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
-                ->error.error_code,
-            sample_error_code);
-  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions.begin()
-                ->error.error_extra,
-            sample_error_extra);
+  ASSERT_EQ(verified_proposal_and_errors->rejected_transactions.size(),
+            failed_atomic_batch.size());
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[0].error.error_code,
+      sample_error_code);
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[0].error.error_extra,
+      sample_error_extra);
+  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions[0].tx_hash,
+            txs[3].hash());
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[1].error.error_code,
+      1);
+  EXPECT_EQ(
+      verified_proposal_and_errors->rejected_transactions[1].error.error_extra,
+      "Another transaction failed the batch");
+  EXPECT_EQ(verified_proposal_and_errors->rejected_transactions[1].tx_hash,
+            txs[4].hash());
 }

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -66,3 +66,12 @@ target_link_libraries(proto_block_validator_test
     shared_model_proto_backend
     shared_model_stateless_validation
     )
+
+addtest(proposal_validator_test
+    proposal_validator_test.cpp
+    )
+target_link_libraries(proposal_validator_test
+    shared_model_proto_backend
+    shared_model_interfaces_factories
+    shared_model_stateless_validation
+    )

--- a/test/module/shared_model/validators/proposal_validator_test.cpp
+++ b/test/module/shared_model/validators/proposal_validator_test.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "module/shared_model/validators/validators_fixture.hpp"
+
+#include <gtest/gtest.h>
+
+#include "framework/batch_helper.hpp"
+#include "module/shared_model/builders/protobuf/test_proposal_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "validators/default_validator.hpp"
+
+using namespace shared_model::validation;
+
+class ProposalValidatorTest : public ValidatorsTest {
+ public:
+  using BatchTypeAndCreatorPair =
+      std::pair<shared_model::interface::types::BatchType, std::string>;
+
+  DefaultProposalValidator validator_;
+};
+
+/**
+ * @given a proposal with a transaction
+ * @when transaction's batch meta contains info about two transactions
+ * @then such proposal should be rejected
+ */
+TEST_F(ProposalValidatorTest, IncompleteBatch) {
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      std::vector<BatchTypeAndCreatorPair>{
+          BatchTypeAndCreatorPair{
+              shared_model::interface::types::BatchType::ATOMIC, "a@domain"},
+          BatchTypeAndCreatorPair{
+              shared_model::interface::types::BatchType::ATOMIC, "b@domain"}});
+  std::vector<shared_model::proto::Transaction> proto_txs;
+  proto_txs.push_back(*std::move(
+      std::static_pointer_cast<shared_model::proto::Transaction>(txs[0])));
+  auto proposal = std::make_shared<shared_model::proto::Proposal>(
+      TestProposalBuilder()
+          .height(1)
+          .createdTime(txs[0]->createdTime())
+          .transactions(proto_txs)
+          .build());
+
+  auto answer = validator_.validate(*proposal);
+  ASSERT_TRUE(answer);
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change


Fix tx status streaming (#2033)

1. Consensus events now are delivered to all subscribers (TransportCommandService and Synchronizer)
2. Fixed non-graceful shutdown of tx status stream.

The first issue may lead to hang of client application in case when no events were emitted in the network.


Fix saving rejected txs hashes for failed atomic batches (#2043)

When an atomic batch arrived with one stateful valid and one stateful invalid transaction, only one tx's hash was saved to block as rejected (stateful invalid).
The second tx (stateful valid) was not saved as rejected too.


Fix proposal validation and prevent resending of incomplete batches (#2044)

Create standalone batch validator.
Add and integrate proto proposal validator.
Prevent resend/reprocessing of "partially valid" atomic batches
(some transaction has failed stateful validation 
within an atomic batch).
Add test.


Fix segfault in StatusStream (#2053) 


### Benefits

Core functionality is fixed

### Possible Drawbacks 

ƪ(˘⌣˘)ʃ

### Usage Examples or Tests

```
torii_transport_command_test
stateful_validator_test
on_demand_os_client_grpc_test
proposal_validator_test
```
