### PR TITLE
ITF fake peer: applying new aliasing rules

### DIFF
--- a/test/framework/integration_framework/fake_peer/behaviour/behaviour.hpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/behaviour.hpp
@@ -25,7 +25,6 @@ namespace integration_framework {
 
     class Behaviour {
      public:
-
       virtual ~Behaviour();
 
       /// Enable the behaviour for the given peer
@@ -35,16 +34,19 @@ namespace integration_framework {
       void absolve();
 
       /// This method gets subscribed on Fake Peer's MST messages.
-      virtual void processMstMessage(MstMessagePtr message) = 0;
+      virtual void processMstMessage(std::shared_ptr<MstMessage> message) = 0;
 
       /// This method gets subscribed on Fake Peer's YAC messages.
-      virtual void processYacMessage(YacMessagePtr message) = 0;
+      virtual void processYacMessage(
+          std::shared_ptr<const YacMessage> message) = 0;
 
       /// This method gets subscribed on Fake Peer's OS messages.
-      virtual void processOsBatch(OsBatchPtr batch) = 0;
+      virtual void processOsBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> batch) = 0;
 
       /// This method gets subscribed on Fake Peer's OG messages.
-      virtual void processOgProposal(OgProposalPtr proposal) = 0;
+      virtual void processOgProposal(
+          std::shared_ptr<shared_model::interface::Proposal> proposal) = 0;
 
       /// This method handles block requests for Fake Peer's.
       virtual LoaderBlockRequestResult processLoaderBlockRequest(

--- a/test/framework/integration_framework/fake_peer/behaviour/empty.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/empty.cpp
@@ -8,10 +8,14 @@
 namespace integration_framework {
   namespace fake_peer {
 
-    void EmptyBehaviour::processMstMessage(MstMessagePtr message) {}
-    void EmptyBehaviour::processYacMessage(YacMessagePtr message) {}
-    void EmptyBehaviour::processOsBatch(OsBatchPtr batch) {}
-    void EmptyBehaviour::processOgProposal(OgProposalPtr proposal) {}
+    void EmptyBehaviour::processMstMessage(
+        std::shared_ptr<MstMessage> message) {}
+    void EmptyBehaviour::processYacMessage(
+        std::shared_ptr<const YacMessage> message) {}
+    void EmptyBehaviour::processOsBatch(
+        std::shared_ptr<shared_model::interface::TransactionBatch> batch) {}
+    void EmptyBehaviour::processOgProposal(
+        std::shared_ptr<shared_model::interface::Proposal> proposal) {}
     LoaderBlockRequestResult EmptyBehaviour::processLoaderBlockRequest(
         LoaderBlockRequest request) {
       return {};

--- a/test/framework/integration_framework/fake_peer/behaviour/empty.hpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/empty.hpp
@@ -20,10 +20,14 @@ namespace integration_framework {
      public:
       virtual ~EmptyBehaviour() = default;
 
-      void processMstMessage(MstMessagePtr message) override;
-      void processYacMessage(YacMessagePtr message) override;
-      void processOsBatch(OsBatchPtr batch) override;
-      void processOgProposal(OgProposalPtr proposal) override;
+      void processMstMessage(std::shared_ptr<MstMessage> message) override;
+      void processYacMessage(
+          std::shared_ptr<const YacMessage> message) override;
+      void processOsBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> batch)
+          override;
+      void processOgProposal(
+          std::shared_ptr<shared_model::interface::Proposal> proposal) override;
       LoaderBlockRequestResult processLoaderBlockRequest(
           LoaderBlockRequest request) override;
       LoaderBlocksRequestResult processLoaderBlocksRequest(

--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -28,7 +28,8 @@ namespace integration_framework {
               std::make_unique<shared_model::proto::ProtoProposalFactory<
                   shared_model::validation::DefaultProposalValidator>>()) {}
 
-    void HonestBehaviour::processYacMessage(YacMessagePtr message) {
+    void HonestBehaviour::processYacMessage(
+        std::shared_ptr<const YacMessage> message) {
       getFakePeer().voteForTheSame(message);
     }
 
@@ -63,7 +64,7 @@ namespace integration_framework {
         return {};
       }
       BlockStorage::HeightType current_height = request;
-      BlockStorage::BlockPtr block;
+      std::shared_ptr<const shared_model::proto::Block> block;
       LoaderBlocksRequestResult blocks;
       while ((block = block_storage->getBlockByHeight(current_height++))
              != nullptr) {

--- a/test/framework/integration_framework/fake_peer/behaviour/honest.hpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.hpp
@@ -18,7 +18,8 @@ namespace integration_framework {
       HonestBehaviour();
       virtual ~HonestBehaviour() = default;
 
-      void processYacMessage(YacMessagePtr message) override;
+      void processYacMessage(
+          std::shared_ptr<const YacMessage> message) override;
       LoaderBlockRequestResult processLoaderBlockRequest(
           LoaderBlockRequest request) override;
       LoaderBlocksRequestResult processLoaderBlocksRequest(

--- a/test/framework/integration_framework/fake_peer/block_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.cpp
@@ -40,7 +40,8 @@ namespace integration_framework {
           blocks_by_hash_(std::move(other.blocks_by_hash_)),
           log_(logger::log("Fake peer block storage")) {}
 
-    void BlockStorage::storeBlock(const BlockPtr &block) {
+    void BlockStorage::storeBlock(
+        const std::shared_ptr<const shared_model::proto::Block> &block) {
       std::lock_guard<std::shared_timed_mutex> lock(block_maps_mutex_);
       if (emplaceCheckingOverwrite(blocks_by_height_, block->height(), block)) {
         log_->warn("Overwriting block with height {}.", block->height());
@@ -50,8 +51,8 @@ namespace integration_framework {
       }
     }
 
-    BlockStorage::BlockPtr BlockStorage::getBlockByHeight(
-        BlockStorage::HeightType height) const {
+    std::shared_ptr<const shared_model::proto::Block>
+    BlockStorage::getBlockByHeight(BlockStorage::HeightType height) const {
       std::shared_lock<std::shared_timed_mutex> lock(block_maps_mutex_);
       const auto found = blocks_by_height_.find(height);
       if (found == blocks_by_height_.end()) {
@@ -62,8 +63,8 @@ namespace integration_framework {
       return found->second;
     }
 
-    BlockStorage::BlockPtr BlockStorage::getBlockByHash(
-        const BlockStorage::HashType &hash) const {
+    std::shared_ptr<const shared_model::proto::Block>
+    BlockStorage::getBlockByHash(const BlockStorage::HashType &hash) const {
       std::shared_lock<std::shared_timed_mutex> lock(block_maps_mutex_);
       const auto found = blocks_by_hash_.find(hash);
       if (found == blocks_by_hash_.end()) {
@@ -74,7 +75,8 @@ namespace integration_framework {
       return found->second;
     }
 
-    BlockStorage::BlockPtr BlockStorage::getTopBlock() const {
+    std::shared_ptr<const shared_model::proto::Block>
+    BlockStorage::getTopBlock() const {
       std::shared_lock<std::shared_timed_mutex> lock(block_maps_mutex_);
       if (blocks_by_height_.empty()) {
         log_->info("Requested top block, but the block storage is empty.");

--- a/test/framework/integration_framework/fake_peer/block_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/block_storage.hpp
@@ -27,7 +27,6 @@ namespace integration_framework {
 
     class BlockStorage final {
      public:
-      using BlockPtr = std::shared_ptr<const shared_model::proto::Block>;
       using HeightType = shared_model::interface::types::HeightType;
       using HashType = shared_model::crypto::Hash;
 
@@ -37,15 +36,23 @@ namespace integration_framework {
       BlockStorage operator=(const BlockStorage &) = delete;
       BlockStorage operator=(BlockStorage &&) = delete;
 
-      void storeBlock(const BlockPtr &block);
+      void storeBlock(
+          const std::shared_ptr<const shared_model::proto::Block> &block);
 
-      BlockPtr getBlockByHeight(HeightType height) const;
-      BlockPtr getBlockByHash(const HashType &hash) const;
-      BlockPtr getTopBlock() const;
+      std::shared_ptr<const shared_model::proto::Block> getBlockByHeight(
+          HeightType height) const;
+      std::shared_ptr<const shared_model::proto::Block> getBlockByHash(
+          const HashType &hash) const;
+      std::shared_ptr<const shared_model::proto::Block> getTopBlock() const;
 
      private:
-      std::unordered_map<HeightType, BlockPtr> blocks_by_height_;
-      std::unordered_map<HashType, BlockPtr, HashType::Hasher> blocks_by_hash_;
+      std::unordered_map<HeightType,
+                         std::shared_ptr<const shared_model::proto::Block>>
+          blocks_by_height_;
+      std::unordered_map<HashType,
+                         std::shared_ptr<const shared_model::proto::Block>,
+                         HashType::Hasher>
+          blocks_by_hash_;
       mutable std::shared_timed_mutex block_maps_mutex_;
 
       logger::Logger log_;

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -183,7 +183,7 @@ namespace integration_framework {
 
     boost::optional<ProposalStorage &> FakePeer::getProposalStorage() const {
       if (proposal_storage_) {
-       return *proposal_storage_;
+        return *proposal_storage_;
       }
       return boost::none;
     }
@@ -224,19 +224,24 @@ namespace integration_framework {
       return *keypair_;
     }
 
-    rxcpp::observable<MstMessagePtr> FakePeer::getMstStatesObservable() {
+    rxcpp::observable<std::shared_ptr<MstMessage>>
+    FakePeer::getMstStatesObservable() {
       return mst_network_notifier_->getObservable();
     }
 
-    rxcpp::observable<YacMessagePtr> FakePeer::getYacStatesObservable() {
+    rxcpp::observable<std::shared_ptr<const YacMessage>>
+    FakePeer::getYacStatesObservable() {
       return yac_network_notifier_->getObservable();
     }
 
-    rxcpp::observable<OsBatchPtr> FakePeer::getOsBatchesObservable() {
+    rxcpp::observable<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+    FakePeer::getOsBatchesObservable() {
       return os_network_notifier_->getObservable();
     }
 
-    rxcpp::observable<OgProposalPtr> FakePeer::getOgProposalsObservable() {
+    rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
+    FakePeer::getOgProposalsObservable() {
       return og_network_notifier_->getObservable();
     }
 
@@ -300,7 +305,8 @@ namespace integration_framework {
       yac_transport_->sendState(*real_peer_, state);
     }
 
-    void FakePeer::voteForTheSame(const YacMessagePtr &incoming_votes) {
+    void FakePeer::voteForTheSame(
+        const std::shared_ptr<const YacMessage> &incoming_votes) {
       using iroha::consensus::yac::VoteMessage;
       log_->debug("Got a YAC state message with {} votes.",
                   incoming_votes->size());
@@ -350,8 +356,10 @@ namespace integration_framework {
                                                         request);
     }
 
-    void FakePeer::sendBatchesForRound(iroha::consensus::Round round,
-                                       std::vector<OsBatchPtr> batches) {
+    void FakePeer::sendBatchesForRound(
+        iroha::consensus::Round round,
+        std::vector<std::shared_ptr<shared_model::interface::TransactionBatch>>
+            batches) {
       auto client = iroha::network::createClient<
           iroha::ordering::proto::OnDemandOrdering>(real_peer_->address());
       grpc::ClientContext context;

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -103,16 +103,20 @@ namespace integration_framework {
       const shared_model::crypto::Keypair &getKeypair() const;
 
       /// Get the observable of MST states received by this peer.
-      rxcpp::observable<MstMessagePtr> getMstStatesObservable();
+      rxcpp::observable<std::shared_ptr<MstMessage>> getMstStatesObservable();
 
       /// Get the observable of YAC states received by this peer.
-      rxcpp::observable<YacMessagePtr> getYacStatesObservable();
+      rxcpp::observable<std::shared_ptr<const YacMessage>>
+      getYacStatesObservable();
 
       /// Get the observable of OS batches received by this peer.
-      rxcpp::observable<OsBatchPtr> getOsBatchesObservable();
+      rxcpp::observable<
+          std::shared_ptr<shared_model::interface::TransactionBatch>>
+      getOsBatchesObservable();
 
       /// Get the observable of OG proposals received by this peer.
-      rxcpp::observable<OgProposalPtr> getOgProposalsObservable();
+      rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
+      getOgProposalsObservable();
 
       /// Get the observable of block requests received by this peer.
       rxcpp::observable<LoaderBlockRequest> getLoaderBlockRequestObservable();
@@ -133,7 +137,8 @@ namespace integration_framework {
        *
        * @param incoming_votes - the votes to take as the base.
        */
-      void voteForTheSame(const YacMessagePtr &incoming_votes);
+      void voteForTheSame(
+          const std::shared_ptr<const YacMessage> &incoming_votes);
 
       /**
        * Make a signature of the provided hash.
@@ -157,15 +162,20 @@ namespace integration_framework {
       void sendProposal(
           std::unique_ptr<shared_model::interface::Proposal> proposal);
 
-      void sendBatch(const OsBatchPtr &batch);
+      void sendBatch(
+          const std::shared_ptr<shared_model::interface::TransactionBatch>
+              &batch);
 
       bool sendBlockRequest(const LoaderBlockRequest &request);
 
       size_t sendBlocksRequest(const LoaderBlocksRequest &request);
 
       /// Send the real peer the provided batches for the provided round.
-      void sendBatchesForRound(iroha::consensus::Round round,
-                               std::vector<OsBatchPtr> batches);
+      void sendBatchesForRound(
+          iroha::consensus::Round round,
+          std::vector<
+              std::shared_ptr<shared_model::interface::TransactionBatch>>
+              batches);
 
       /**
        * Request the real peer's on demand ordering service a proposal for the

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
@@ -15,7 +15,8 @@ namespace integration_framework {
           std::make_shared<MstMessage>(from, new_state));
     }
 
-    rxcpp::observable<MstMessagePtr> MstNetworkNotifier::getObservable() {
+    rxcpp::observable<std::shared_ptr<MstMessage>>
+    MstNetworkNotifier::getObservable() {
       return mst_subject_.get_observable();
     }
 

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
@@ -21,10 +21,10 @@ namespace integration_framework {
       void onNewState(const shared_model::crypto::PublicKey &from,
                       const iroha::MstState &new_state) override;
 
-      rxcpp::observable<MstMessagePtr> getObservable();
+      rxcpp::observable<std::shared_ptr<MstMessage>> getObservable();
 
      private:
-      rxcpp::subjects::subject<MstMessagePtr> mst_subject_;
+      rxcpp::subjects::subject<std::shared_ptr<MstMessage>> mst_subject_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -12,42 +12,43 @@
 namespace integration_framework {
   namespace fake_peer {
 
-      OnDemandOsNetworkNotifier::OnDemandOsNetworkNotifier(
-          const std::shared_ptr<FakePeer> &fake_peer)
-          : fake_peer_wptr_(fake_peer) {}
+    OnDemandOsNetworkNotifier::OnDemandOsNetworkNotifier(
+        const std::shared_ptr<FakePeer> &fake_peer)
+        : fake_peer_wptr_(fake_peer) {}
 
-      void OnDemandOsNetworkNotifier::onBatches(Round round,
-                                                CollectionType batches) {
-        batches_subject_.get_subscriber().on_next(
-            std::make_shared<BatchesForRound>(round, batches));
-      }
+    void OnDemandOsNetworkNotifier::onBatches(iroha::consensus::Round round,
+                                              CollectionType batches) {
+      batches_subject_.get_subscriber().on_next(
+          std::make_shared<BatchesForRound>(round, batches));
+    }
 
-      boost::optional<OnDemandOsNetworkNotifier::ProposalType>
-      OnDemandOsNetworkNotifier::onRequestProposal(Round round) {
-        rounds_subject_.get_subscriber().on_next(round);
-        auto fake_peer = fake_peer_wptr_.lock();
-        BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
-        const auto behaviour = fake_peer->getBehaviour();
-        if (behaviour) {
-          auto opt_proposal = behaviour->processOrderingProposalRequest(round);
-          if (opt_proposal) {
-            return std::unique_ptr<shared_model::interface::Proposal>(
-                std::make_unique<shared_model::proto::Proposal>(
-                    (*opt_proposal)->getTransport()));
-          }
+    boost::optional<OnDemandOsNetworkNotifier::ProposalType>
+    OnDemandOsNetworkNotifier::onRequestProposal(
+        iroha::consensus::Round round) {
+      rounds_subject_.get_subscriber().on_next(round);
+      auto fake_peer = fake_peer_wptr_.lock();
+      BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
+      const auto behaviour = fake_peer->getBehaviour();
+      if (behaviour) {
+        auto opt_proposal = behaviour->processOrderingProposalRequest(round);
+        if (opt_proposal) {
+          return std::unique_ptr<shared_model::interface::Proposal>(
+              std::make_unique<shared_model::proto::Proposal>(
+                  (*opt_proposal)->getTransport()));
         }
-        return {};
       }
+      return {};
+    }
 
-      rxcpp::observable<OnDemandOsNetworkNotifier::Round>
-      OnDemandOsNetworkNotifier::getProposalRequestsObservable() {
-        return rounds_subject_.get_observable();
-      }
+    rxcpp::observable<iroha::consensus::Round>
+    OnDemandOsNetworkNotifier::getProposalRequestsObservable() {
+      return rounds_subject_.get_observable();
+    }
 
-      rxcpp::observable<std::shared_ptr<BatchesForRound>>
-      OnDemandOsNetworkNotifier::getBatchesObservable() {
-        return batches_subject_.get_observable();
-      }
+    rxcpp::observable<std::shared_ptr<BatchesForRound>>
+    OnDemandOsNetworkNotifier::getBatchesObservable() {
+      return batches_subject_.get_observable();
+    }
 
   }  // namespace fake_peer
 }  // namespace integration_framework

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -19,22 +19,23 @@ namespace integration_framework {
     class OnDemandOsNetworkNotifier final
         : public iroha::ordering::transport::OdOsNotification {
      public:
-      using Round = iroha::consensus::Round;
-
       OnDemandOsNetworkNotifier(const std::shared_ptr<FakePeer> &fake_peer);
 
-      virtual void onBatches(Round round, CollectionType batches);
+      virtual void onBatches(iroha::consensus::Round round,
+                             CollectionType batches);
 
-      virtual boost::optional<ProposalType> onRequestProposal(Round round);
+      virtual boost::optional<ProposalType> onRequestProposal(
+          iroha::consensus::Round round);
 
-      rxcpp::observable<Round> getProposalRequestsObservable();
+      rxcpp::observable<iroha::consensus::Round>
+      getProposalRequestsObservable();
 
       rxcpp::observable<std::shared_ptr<BatchesForRound>>
       getBatchesObservable();
 
      private:
       std::weak_ptr<FakePeer> fake_peer_wptr_;
-      rxcpp::subjects::subject<Round> rounds_subject_;
+      rxcpp::subjects::subject<iroha::consensus::Round> rounds_subject_;
       rxcpp::subjects::subject<std::shared_ptr<BatchesForRound>>
           batches_subject_;
     };

--- a/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.cpp
@@ -10,11 +10,13 @@
 namespace integration_framework {
   namespace fake_peer {
 
-    void OgNetworkNotifier::onProposal(OgProposalPtr proposal) {
+    void OgNetworkNotifier::onProposal(
+        std::shared_ptr<shared_model::interface::Proposal> proposal) {
       proposals_subject_.get_subscriber().on_next(std::move(proposal));
     }
 
-    rxcpp::observable<OgProposalPtr> OgNetworkNotifier::getObservable() {
+    rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
+    OgNetworkNotifier::getObservable() {
       return proposals_subject_.get_observable();
     }
 

--- a/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.hpp
@@ -18,12 +18,16 @@ namespace integration_framework {
     class OgNetworkNotifier final
         : public iroha::network::OrderingGateNotification {
      public:
-      void onProposal(OgProposalPtr proposal) override;
+      void onProposal(
+          std::shared_ptr<shared_model::interface::Proposal> proposal) override;
 
-      rxcpp::observable<OgProposalPtr> getObservable();
+      rxcpp::observable<std::shared_ptr<shared_model::interface::Proposal>>
+      getObservable();
 
      private:
-      rxcpp::subjects::subject<OgProposalPtr> proposals_subject_;
+      rxcpp::subjects::subject<
+          std::shared_ptr<shared_model::interface::Proposal>>
+          proposals_subject_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.cpp
@@ -17,7 +17,9 @@ namespace integration_framework {
       batches_subject_.get_subscriber().on_next(std::move(batch_ptr));
     }
 
-    rxcpp::observable<OsBatchPtr> OsNetworkNotifier::getObservable() {
+    rxcpp::observable<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+    OsNetworkNotifier::getObservable() {
       return batches_subject_.get_observable();
     }
 

--- a/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.hpp
@@ -20,10 +20,14 @@ namespace integration_framework {
       void onBatch(std::unique_ptr<shared_model::interface::TransactionBatch>
                        batch) override;
 
-      rxcpp::observable<OsBatchPtr> getObservable();
+      rxcpp::observable<
+          std::shared_ptr<shared_model::interface::TransactionBatch>>
+      getObservable();
 
      private:
-      rxcpp::subjects::subject<OsBatchPtr> batches_subject_;
+      rxcpp::subjects::subject<
+          std::shared_ptr<shared_model::interface::TransactionBatch>>
+          batches_subject_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/network/yac_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/yac_network_notifier.cpp
@@ -17,7 +17,8 @@ namespace integration_framework {
       votes_subject_.get_subscriber().on_next(state_ptr);
     }
 
-    rxcpp::observable<YacMessagePtr> YacNetworkNotifier::getObservable() {
+    rxcpp::observable<std::shared_ptr<const YacMessage>>
+    YacNetworkNotifier::getObservable() {
       return votes_subject_.get_observable();
     }
 

--- a/test/framework/integration_framework/fake_peer/network/yac_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/yac_network_notifier.hpp
@@ -22,10 +22,11 @@ namespace integration_framework {
 
       void onState(StateMessage state) override;
 
-      rxcpp::observable<YacMessagePtr> getObservable();
+      rxcpp::observable<std::shared_ptr<const YacMessage>> getObservable();
 
      private:
-      rxcpp::subjects::subject<YacMessagePtr> votes_subject_;
+      rxcpp::subjects::subject<std::shared_ptr<const YacMessage>>
+          votes_subject_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -77,12 +77,7 @@ namespace integration_framework {
     struct BatchesForRound;
     struct MstMessage;
 
-    using MstMessagePtr = std::shared_ptr<MstMessage>;
-    using YacMessagePtr =
-        std::shared_ptr<const std::vector<iroha::consensus::yac::VoteMessage>>;
-    using OgProposalPtr = std::shared_ptr<shared_model::interface::Proposal>;
-    using OsBatchPtr =
-        std::shared_ptr<shared_model::interface::TransactionBatch>;
+    using YacMessage = std::vector<iroha::consensus::yac::VoteMessage>;
     using LoaderBlockRequest = std::shared_ptr<shared_model::crypto::Hash>;
     using LoaderBlocksRequest = shared_model::interface::types::HeightType;
     using LoaderBlockRequestResult =

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -340,7 +340,8 @@ TEST_F(FakePeerExampleFixture,
         : tx_hash_(tx_hash),
           got_proposal_from_main_peer_(got_proposal_from_main_peer) {}
 
-    void processYacMessage(fake_peer::YacMessagePtr message) override {
+    void processYacMessage(
+        std::shared_ptr<const fake_peer::YacMessage> message) override {
       const auto proposal_from_main_peer = getFakePeer().sendProposalRequest(
           message->front().hash.vote_round, kProposalWaitingTime);
       if (proposal_from_main_peer


### PR DESCRIPTION
### Description of the Change

During the review of the fake peers trunk, there arose an issue regarding using aliases. Together with @lebdron, @muratovv and @luckychess we came to a consensus of not hiding top-level type modifiers like `const`, `&`, `*` and smart pointers behind aliases, and also not to alias a type with no templates. The only exception is using an alias as a business logic type.

### Benefits

Standardized approach to using aliases.

### Possible Drawbacks 

As for me, the code has got less readable due to a lot of long and nested types being exposed distract from the higher-level picture.
