### PR TITLE
Fix Status Stream Performance Degradation

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -96,7 +96,8 @@ namespace torii {
                     shared_model::interface::StatelessFailedTxResponse,
                     shared_model::interface::StatefulFailedTxResponse,
                     shared_model::interface::CommittedTxResponse,
-                    shared_model::interface::MstExpiredResponse>::value;
+                    shared_model::interface::MstExpiredResponse,
+                    shared_model::interface::RejectTxResponse>::value;
 
   rxcpp::observable<
       std::shared_ptr<shared_model::interface::TransactionResponse>>


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

In some cases, the transaction status stream may not end in 10 seconds even if a final status (e.g. "committed") was already reported.


#### Details

That might happen when there are no transactions committed in the network and the delay between consensus rounds was increased up to 5 seconds.
The status stream gets forced to end in the case when tx status is not updated during two consensus rounds.

### Benefits

Clients that expect immediate stream end after a final tx status receiving would not suffer from redundant delay.

### Possible Drawbacks 

The solution is not elegant enough, because we do a kind of synchronization on a local variable. 
There is no data race because we do the processing in the same thread.

### Usage Examples or Tests

The gist is a repro script - https://gist.github.com/igor-egorov/e07d803b3ef9f17eee48804713140c04

In normal mode, the script will end less than in 20 seconds.

In degraded mode, the script would not finish even in a minute.

### Alternate Designs

Probably, `take_until(status_bus.last())` can be applied somehow.
That approach will avoid the usage of custom synchronization variables.
Unfortunately, take_until prevents the execution of subscribed lambdas when the source stream has ended by the moment of intended processing.