### PR TITLE
Storage: fixed drop deadlock

### DIFF
--- a/irohad/ametsuchi/impl/peer_query_wsv.cpp
+++ b/irohad/ametsuchi/impl/peer_query_wsv.cpp
@@ -17,12 +17,7 @@ namespace iroha {
 
     boost::optional<std::vector<PeerQuery::wPeer>>
     PeerQueryWsv::getLedgerPeers() {
-      auto peers = wsv_->getPeers();
-      if (peers) {
-        return boost::make_optional(peers.value());
-      } else {
-        return boost::none;
-      }
+      return wsv_->getPeers();
     }
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -406,10 +406,7 @@ namespace iroha {
       try {
         *(storage->sql_) << "COMMIT";
         storage->committed = true;
-        return PeerQueryWsv(std::make_shared<PostgresWsvQuery>(*(storage->sql_),
-                                                               factory_))
-                   .getLedgerPeers()
-            |
+        return PostgresWsvQuery(*(storage->sql_), factory_).getPeers() |
             [](auto &&peers) {
               return boost::optional<std::unique_ptr<LedgerState>>(
                   std::make_unique<LedgerState>(
@@ -446,9 +443,8 @@ namespace iroha {
         PostgresBlockIndex block_index(sql);
         block_index.index(block);
         block_is_prepared = false;
-        return PeerQueryWsv(std::make_shared<PostgresWsvQuery>(sql, factory_))
-                       .getLedgerPeers()
-                   | [this, &block](auto &&peers)
+        return PostgresWsvQuery(sql, factory_).getPeers() |
+                   [this, &block](auto &&peers)
                    -> boost::optional<std::unique_ptr<LedgerState>> {
           if (this->storeBlock(block)) {
             return boost::optional<std::unique_ptr<LedgerState>>(

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -245,6 +245,7 @@ namespace iroha {
         auto &db = dbname.value();
         log_->info("Drop database {}", db);
         freeConnections();
+        // TODO mboldyrev 04.02.2019 IR-284 rework synchronization
         std::unique_lock<std::shared_timed_mutex> lock(drop_mutex);
         soci::session sql(*soci::factory_postgresql(),
                           postgres_options_.optionsStringWithoutDbName());

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -243,9 +243,9 @@ namespace iroha {
 
       if (auto dbname = postgres_options_.dbname()) {
         auto &db = dbname.value();
-        std::unique_lock<std::shared_timed_mutex> lock(drop_mutex);
         log_->info("Drop database {}", db);
         freeConnections();
+        std::unique_lock<std::shared_timed_mutex> lock(drop_mutex);
         soci::session sql(*soci::factory_postgresql(),
                           postgres_options_.optionsStringWithoutDbName());
         // perform dropping


### PR DESCRIPTION
### Description of the Change

A quite dirty fix of deadlock occurring when one thread holding a `soci` connection calls some method of `StorageImpl` that needs to acquire a lock, and another thread calling `StorageImpl::dropStorage()` that acquires that lock exclusively first, and then waits for the connections to free.

### Benefits

Quick fix.

### Possible Drawbacks 

The code became less thread safe. But keeping in mind that we provide no thread safety using `soci` at all, that seems not a big problem.

### Alternate Designs *[optional]*

Incapsulate shared mutexes with `soci` sessions in the  classes that use them (please see [IR-284](https://jira.hyperledger.org/browse/IR-284)). 