### PR TITLE
Fix Memory Leak in irohad

### DIFF
--- a/cmake/Modules/Findsoci.cmake
+++ b/cmake/Modules/Findsoci.cmake
@@ -1,5 +1,5 @@
 set(_SOCI_REQUIRED_VARS SOCI_INCLUDE_DIR SOCI_LIBRARY SOCI_postgresql_PLUGIN)
-set(LIB_SUFFIX 64)
+
 add_library(SOCI::core UNKNOWN IMPORTED)
 add_library(SOCI::postgresql UNKNOWN IMPORTED)
 

--- a/cmake/Modules/Findsoci.cmake
+++ b/cmake/Modules/Findsoci.cmake
@@ -1,5 +1,5 @@
 set(_SOCI_REQUIRED_VARS SOCI_INCLUDE_DIR SOCI_LIBRARY SOCI_postgresql_PLUGIN)
-
+set(LIB_SUFFIX 64)
 add_library(SOCI::core UNKNOWN IMPORTED)
 add_library(SOCI::postgresql UNKNOWN IMPORTED)
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -95,7 +95,9 @@ Irohad::Irohad(const std::string &block_store_dir,
   initStorage();
 }
 
-Irohad::~Irohad() = default;
+Irohad::~Irohad() {
+  consensus_gate_events_subscription.unsubscribe();
+}
 
 /**
  * Initializing iroha daemon
@@ -400,6 +402,7 @@ void Irohad::initConsensusGate() {
                                               async_call_,
                                               common_objects_factory_);
   consensus_gate->onOutcome().subscribe(
+      consensus_gate_events_subscription,
       consensus_gate_objects.get_subscriber());
   log_->info("[Init] => consensus gate");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -263,6 +263,7 @@ class Irohad {
   // consensus gate
   std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
   rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_gate_objects;
+  rxcpp::composite_subscription consensus_gate_events_subscription;
 
   // synchronizer
   std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "main/impl/consensus_init.hpp"
@@ -52,7 +40,7 @@ namespace iroha {
       }
 
       auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
-        return std::make_shared<TimerImpl>([delay_milliseconds] {
+        return std::make_shared<TimerImpl>([delay_milliseconds, this] {
           // static factory with a single thread
           //
           // observe_on_new_thread -- coordination which creates new thread with
@@ -63,21 +51,8 @@ namespace iroha {
           // scheduler is also a factory for workers in that timeline.
           //
           // coordination is a factory for coordinators and has a scheduler.
-          //
-          // coordinator has a worker, and is a factory for coordinated
-          // observables, subscribers and schedulable functions.
-          //
-          // A new thread scheduler is created
-          // by calling .create_coordinator().get_scheduler()
-          //
-          // static allows to reuse the same thread in subsequent calls to this
-          // lambda
-          static rxcpp::observe_on_one_worker coordination(
-              rxcpp::observe_on_new_thread()
-                  .create_coordinator()
-                  .get_scheduler());
           return rxcpp::observable<>::timer(
-              std::chrono::milliseconds(delay_milliseconds), coordination);
+              std::chrono::milliseconds(delay_milliseconds), coordination_);
         });
       }
 

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -1,18 +1,6 @@
 /**
- * Copyright Soramitsu Co., Ltd. 2018 All Rights Reserved.
- * http://soramitsu.co.jp
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef IROHA_CONSENSUS_INIT_HPP
@@ -68,6 +56,16 @@ namespace iroha {
                 async_call,
             std::shared_ptr<shared_model::interface::CommonObjectsFactory>
                 common_objects_factory);
+
+        // coordinator has a worker, and a factory for coordinated
+        // observables, subscribers and schedulable functions.
+        //
+        // A new thread scheduler is created
+        // by calling .create_coordinator().get_scheduler()
+        rxcpp::observe_on_one_worker coordination_{
+            rxcpp::observe_on_new_thread()
+                .create_coordinator()
+                .get_scheduler()};
 
        public:
         std::shared_ptr<YacGate> initConsensusGate(


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Fix a mem leak, that could not lead to a linear increase of memory consumption.

### Benefits

Less leaks.

### Possible Drawbacks 

None?

### Usage Examples or Tests

valgrind irohad

you have to use gcc + valgrind on Ubuntu-like linux (not bsd), other configurations are poorly supported by valgrind
