### PR TITLE
Fix the rest of memory leaks

### DIFF
--- a/cmake/Modules/Findsoci.cmake
+++ b/cmake/Modules/Findsoci.cmake
@@ -1,5 +1,5 @@
 set(_SOCI_REQUIRED_VARS SOCI_INCLUDE_DIR SOCI_LIBRARY SOCI_postgresql_PLUGIN)
-set(LIB_SUFFIX 64)
+
 add_library(SOCI::core UNKNOWN IMPORTED)
 add_library(SOCI::postgresql UNKNOWN IMPORTED)
 

--- a/cmake/Modules/Findsoci.cmake
+++ b/cmake/Modules/Findsoci.cmake
@@ -1,5 +1,5 @@
 set(_SOCI_REQUIRED_VARS SOCI_INCLUDE_DIR SOCI_LIBRARY SOCI_postgresql_PLUGIN)
-
+set(LIB_SUFFIX 64)
 add_library(SOCI::core UNKNOWN IMPORTED)
 add_library(SOCI::postgresql UNKNOWN IMPORTED)
 

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -63,9 +63,7 @@ namespace iroha {
         // A new thread scheduler is created
         // by calling .create_coordinator().get_scheduler()
         rxcpp::observe_on_one_worker coordination_{
-            rxcpp::observe_on_new_thread()
-                .create_coordinator()
-                .get_scheduler()};
+            rxcpp::observe_on_new_thread()};
 
        public:
         std::shared_ptr<YacGate> initConsensusGate(

--- a/irohad/torii/impl/status_bus_impl.cpp
+++ b/irohad/torii/impl/status_bus_impl.cpp
@@ -8,7 +8,11 @@
 namespace iroha {
   namespace torii {
     StatusBusImpl::StatusBusImpl(rxcpp::observe_on_one_worker worker)
-        : worker_(worker), subject_(worker_) {}
+        : worker_(worker), subject_(worker_, cs_) {}
+
+    StatusBusImpl::~StatusBusImpl() {
+      cs_.unsubscribe();
+    }
 
     void StatusBusImpl::publish(StatusBus::Objects resp) {
       subject_.get_subscriber().on_next(resp);

--- a/irohad/torii/impl/status_bus_impl.hpp
+++ b/irohad/torii/impl/status_bus_impl.hpp
@@ -18,12 +18,15 @@ namespace iroha {
       StatusBusImpl(
           rxcpp::observe_on_one_worker worker = rxcpp::observe_on_new_thread());
 
+      ~StatusBusImpl() override;
+
       void publish(StatusBus::Objects) override;
       /// Subscribers will be invoked in separate thread
       rxcpp::observable<StatusBus::Objects> statuses() override;
 
       // Need to create once, otherwise will create thread for each subscriber
       rxcpp::observe_on_one_worker worker_;
+      rxcpp::composite_subscription cs_;
       rxcpp::subjects::synchronize<StatusBus::Objects, decltype(worker_)>
           subject_;
     };


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Fix the rest of memory leaks in irohad.


### Benefits

Clean valgrind report.

### Possible Drawbacks 

?

### Usage Examples or Tests

valgrind irohad (under Ubuntu-like environment with GNU compiler)

```diff
 ==15232== LEAK SUMMARY:
+==15232==    definitely lost: 0 bytes in 0 blocks
+==15232==    indirectly lost: 0 bytes in 0 blocks
+==15232==      possibly lost: 0 bytes in 0 blocks
 ==15232==    still reachable: 176,875 bytes in 1,787 blocks
 ==15232==         suppressed: 0 bytes in 0 blocks
```


Thanks to @lebdron!
