### PR TITLE
Prevent CommandValidatorVisitor objects from copying

### DIFF
--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -36,11 +36,14 @@ namespace shared_model {
     /**
      * Visitor used by transaction validator to validate each command
      * @tparam FieldValidator - field validator type
+     * @note this class is not a thread safe and never going to
+     * so copy constructor is disabled explicitly
      */
     template <typename FieldValidator>
     class CommandValidatorVisitor
         : public boost::static_visitor<ReasonsGroupType> {
      public:
+      CommandValidatorVisitor(const CommandValidatorVisitor &) = delete;
       CommandValidatorVisitor(
           const FieldValidator &validator = FieldValidator())
           : validator_(validator) {}
@@ -266,7 +269,7 @@ namespace shared_model {
         }
 
         for (const auto &command : tx.commands()) {
-          auto reason = boost::apply_visitor(command_validator_, command.get());
+          auto reason = boost::apply_visitor(CommandValidator(), command.get());
           if (not reason.second.empty()) {
             answer.addReason(std::move(reason));
           }
@@ -277,10 +280,8 @@ namespace shared_model {
 
      public:
       explicit TransactionValidator(
-          const FieldValidator &field_validator = FieldValidator(),
-          const CommandValidator &command_validator = CommandValidator())
-          : field_validator_(field_validator),
-            command_validator_(command_validator) {}
+          const FieldValidator &field_validator = FieldValidator())
+          : field_validator_(field_validator) {}
 
       /**
        * Applies validation to given transaction
@@ -308,7 +309,6 @@ namespace shared_model {
 
      protected:
       FieldValidator field_validator_;
-      CommandValidator command_validator_;
     };
 
   }  // namespace validation

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -36,14 +36,17 @@ namespace shared_model {
     /**
      * Visitor used by transaction validator to validate each command
      * @tparam FieldValidator - field validator type
-     * @note this class is not a thread safe and never going to
-     * so copy constructor is disabled explicitly
+     * @note this class is not thread safe and never going to be
+     * so copy constructor and assignment operator are disabled explicitly
      */
     template <typename FieldValidator>
     class CommandValidatorVisitor
         : public boost::static_visitor<ReasonsGroupType> {
      public:
       CommandValidatorVisitor(const CommandValidatorVisitor &) = delete;
+      CommandValidatorVisitor &operator=(const CommandValidatorVisitor &) =
+          delete;
+
       CommandValidatorVisitor(
           const FieldValidator &validator = FieldValidator())
           : validator_(validator) {}


### PR DESCRIPTION
### Description of the Change
Pull request fixes data race in CommandValidatorVisitor.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
One issue less.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
It's still possible to revive this data race (a bit harder since I disabled copy constructor for CommandValidatorVisitor but not impossible).  

