### PR TITLE
Fix version of pyzmq

### DIFF
--- a/test/load/Dockerfile
+++ b/test/load/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6.6-alpine3.8
 
 RUN apk --no-cache add g++ \
-      && pip install locustio pyzmq
+      && pip install locustio pyzmq==17.1.2
 
 EXPOSE 8089 5557 5558
 

--- a/test/load/Dockerfile
+++ b/test/load/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6.6-alpine3.8
 
-RUN apk --no-cache add g++ \
-      && pip install locustio pyzmq==17.1.2
+RUN apk --no-cache add g++ zeromq-dev \
+      && pip install locustio pyzmq
 
 EXPOSE 8089 5557 5558
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Description of the Change

Yesterday, the team of ZMQ released their new version of wheel: https://pypi.org/project/pyzmq/#history 

Unfortunately it does not build, so I had to fix the version to the latest known working version, which is 17.1.2:
<img width="600" alt="2019-02-20 12 09 34" src="https://user-images.githubusercontent.com/11841667/53080545-f7ce9700-3509-11e9-8d1c-df24024948e3.png">
 
### Benefits

Now locust image can build!

### Possible Drawbacks 

None

### Usage Examples or Tests *[optional]*

`docker build -t iroha-locust .`