### PR TITLE
rx subscription manager

### DIFF
--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -33,3 +33,8 @@ target_link_libraries(libs_timeout INTERFACE
   common
   rxcpp
   )
+
+add_library(subscription_manager subscription_manager.cpp)
+target_link_libraries(subscription_manager
+    rxcpp
+    )

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -36,5 +36,5 @@ target_link_libraries(libs_timeout INTERFACE
 
 add_library(subscription_manager subscription_manager.cpp)
 target_link_libraries(subscription_manager
-    rxcpp
-    )
+  rxcpp
+  )

--- a/libs/common/subscription_manager.cpp
+++ b/libs/common/subscription_manager.cpp
@@ -11,12 +11,12 @@ using namespace iroha::utils;
 
 SubscriptionManager::~SubscriptionManager() {
   std::for_each(
-          subscriptions.begin(),
-          subscriptions.end(),
-          [this](const auto &subscription) { subscription.unsubscribe(); });
+      subscriptions.begin(),
+      subscriptions.end(),
+      [this](const auto &subscription) { subscription.unsubscribe(); });
 }
 
 void SubscriptionManager::addSubscription(
-        rxcpp::composite_subscription &&subscription) {
+    rxcpp::composite_subscription &&subscription) {
   subscriptions.push_back(subscription);
 }

--- a/libs/common/subscription_manager.cpp
+++ b/libs/common/subscription_manager.cpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common/subscription_manager.hpp"
+
+#include <algorithm>
+
+using namespace iroha::utils;
+
+SubscriptionManager::~SubscriptionManager() {
+  std::for_each(
+          subscriptions.begin(),
+          subscriptions.end(),
+          [this](const auto &subscription) { subscription.unsubscribe(); });
+}
+
+void SubscriptionManager::addSubscription(
+        rxcpp::composite_subscription &&subscription) {
+  subscriptions.push_back(subscription);
+}

--- a/libs/common/subscription_manager.cpp
+++ b/libs/common/subscription_manager.cpp
@@ -13,7 +13,7 @@ SubscriptionManager::~SubscriptionManager() {
   std::for_each(
       subscriptions.begin(),
       subscriptions.end(),
-      [this](const auto &subscription) { subscription.unsubscribe(); });
+      [](const auto &subscription) { subscription.unsubscribe(); });
 }
 
 void SubscriptionManager::addSubscription(

--- a/libs/common/subscription_manager.hpp
+++ b/libs/common/subscription_manager.hpp
@@ -19,10 +19,10 @@ namespace iroha {
      * Note: class is NOT thread-safe
      */
     class SubscriptionManager {
-    public:
+     public:
       virtual ~SubscriptionManager();
 
-    protected:
+     protected:
       /**
        * Add new subscription for the management
        */

--- a/libs/common/subscription_manager.hpp
+++ b/libs/common/subscription_manager.hpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SUBSCRIPTION_MANAGER_HPP
+#define IROHA_SUBSCRIPTION_MANAGER_HPP
+
+#include <rxcpp/rx.hpp>
+#include <vector>
+
+namespace iroha {
+  namespace utils {
+    /**
+     * Class is responsible for managing subscriptions
+     * Typical use case of the class is private inheritance and pushing own
+     * subscriptions via addSubscription method. Dtor guarantee that all
+     * subscriptions will be unsubscribed.
+     * Note: class is NOT thread-safe
+     */
+    class SubscriptionManager {
+    public:
+      virtual ~SubscriptionManager();
+
+    protected:
+      /**
+       * Add new subscription for the management
+       */
+      void addSubscription(rxcpp::composite_subscription &&subscription);
+
+      /// list of all subscriptions
+      std::vector<rxcpp::composite_subscription> subscriptions;
+    };
+  }  // namespace utils
+}  // namespace iroha
+#endif  // IROHA_SUBSCRIPTION_MANAGER_HPP


### PR DESCRIPTION
### Description of the Change
Add naive but useful implementation of subscription manager for rx subscriptions.

### Benefits

Don't miss your subscriptions in dtor

### Possible Drawbacks 
Additional inheritance level. But in fact, the class is a mixin.

### Usage Examples or Tests *[optional]*
```addSubscription(observer.subcribe(...))```

### Alternate Designs *[optional]*
* addSubscription could return a reference for subscription for further usage
* thread safety
