### PR TITLE
New logger: fixed creation race

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
   gflags::ShutDownCommandLineFlags();
   auto log_manager = std::make_shared<logger::LoggerManagerTree>(
                          logger::LoggerConfig{logger::LogLevel::kInfo,
-                                              logger::kDefaultLogPatterns})
+                                              logger::getDefaultLogPatterns()})
                          ->getChild("CLI");
   const auto logger = log_manager->getChild("Main")->getLogger();
   const auto responce_handler_log_manager =

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(iroha_conf_loader iroha_conf_loader.cpp)
 target_link_libraries(iroha_conf_loader
     iroha_conf_literals
     logger_manager
+    rapidjson
 )
 
 add_library(iroha_conf_literals iroha_conf_literals.cpp)

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(iroha_conf_loader
 )
 
 add_library(iroha_conf_literals iroha_conf_literals.cpp)
+add_dependencies(iroha_conf_literals logger_manager)
 target_include_directories(iroha_conf_literals PUBLIC ${fmt_INCLUDE_DIR})
 
 add_install_step_for_bin(irohad)

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(iroha_conf_loader
 )
 
 add_library(iroha_conf_literals iroha_conf_literals.cpp)
-add_dependencies(iroha_conf_literals logger_manager)
+add_dependencies(iroha_conf_literals logger)
 target_include_directories(iroha_conf_literals PUBLIC ${fmt_INCLUDE_DIR})
 
 add_install_step_for_bin(irohad)

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -196,7 +196,7 @@ void getVal<logger::LoggerManagerTreePtr>(const std::string &path,
                                           const rapidjson::Value &src) {
   assert_fatal(src.IsObject(), path + " must be a logger tree config");
   logger::LoggerConfig root_config{logger::kDefaultLogLevel,
-                                   logger::kDefaultLogPatterns};
+                                   logger::getDefaultLogPatterns()};
   updateLoggerConfig(path, root_config, src.GetObject());
   dest = std::make_shared<logger::LoggerManagerTree>(
       std::make_shared<const logger::LoggerConfig>(std::move(root_config)));

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -99,7 +99,7 @@ std::promise<void> exit_requested;
 
 logger::LoggerManagerTreePtr getDefaultLogManager() {
   return std::make_shared<logger::LoggerManagerTree>(logger::LoggerConfig{
-      logger::LogLevel::kInfo, logger::kDefaultLogPatterns});
+      logger::LogLevel::kInfo, logger::getDefaultLogPatterns()});
 }
 
 int main(int argc, char *argv[]) {

--- a/irohad/model/sha3_hash.cpp
+++ b/irohad/model/sha3_hash.cpp
@@ -18,7 +18,7 @@ namespace iroha {
       std::make_shared<logger::LoggerSpdlog>(
           "QueryFactory",
           std::make_shared<logger::LoggerConfig>(logger::LoggerConfig{
-              logger::kDefaultLogLevel, logger::kDefaultLogPatterns})));
+              logger::kDefaultLogLevel, logger::getDefaultLogPatterns()})));
 
   hash256_t hash(const model::Transaction &tx) {
     auto &&pb_dat = tx_factory.serialize(tx);

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -33,6 +33,17 @@ namespace {
         : it->second;
   }
 
+  std::shared_ptr<spdlog::logger> getOrCreateLogger(const std::string tag) {
+    std::shared_ptr<spdlog::logger> logger;
+    try {
+      logger = spdlog::stdout_color_mt(tag);
+    } catch (const spdlog::spdlog_ex &) {
+      logger = spdlog::get(tag);
+    }
+    assert(logger);
+    return logger;
+  }
+
 }  // namespace
 
 namespace logger {
@@ -59,9 +70,7 @@ namespace logger {
   }
 
   LoggerSpdlog::LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config)
-      : tag_(tag),
-        config_(std::move(config)),
-        logger_(spdlog::stdout_color_mt(tag)) {
+      : tag_(tag), config_(std::move(config)), logger_(getOrCreateLogger(tag)) {
     setupLogger();
   }
 

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -5,6 +5,7 @@
 
 #include "logger/logger_spdlog.hpp"
 
+#include <atomic>
 #include <mutex>
 
 #define SPDLOG_FMT_EXTERNAL
@@ -48,13 +49,16 @@ namespace {
 
 namespace logger {
 
-  const LogPatterns kDefaultLogPatterns = ([] {
-    LogPatterns p;
-    p.setPattern(LogLevel::kTrace,
-                 R"([%Y-%m-%d %H:%M:%S.%F] [th:%t] [%5l] [%n]: %v)");
-    p.setPattern(LogLevel::kInfo, kDefaultPattern);
-    return p;
-  })();
+  LogPatterns getDefaultLogPatterns() {
+    static std::atomic_flag is_initialized = ATOMIC_FLAG_INIT;
+    static LogPatterns default_patterns;
+    if (not is_initialized.test_and_set()) {
+      default_patterns.setPattern(
+          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F] [th:%t] [%5l] [%n]: %v)");
+      default_patterns.setPattern(LogLevel::kInfo, kDefaultPattern);
+    }
+    return default_patterns;
+  }
 
   void LogPatterns::setPattern(LogLevel level, std::string pattern) {
     patterns_[level] = pattern;

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -16,8 +16,6 @@
 
 namespace {
 
-  const std::string kDefaultPattern = R"([%Y-%m-%d %H:%M:%S.%F] [%L] [%n]: %v)";
-
   spdlog::level::level_enum getSpdlogLogLevel(logger::LogLevel level) {
     static const std::map<logger::LogLevel, const spdlog::level::level_enum>
         kSpdLogLevels = {
@@ -55,7 +53,8 @@ namespace logger {
     if (not is_initialized.test_and_set()) {
       default_patterns.setPattern(
           LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F] [th:%t] [%5l] [%n]: %v)");
-      default_patterns.setPattern(LogLevel::kInfo, kDefaultPattern);
+      default_patterns.setPattern(LogLevel::kInfo,
+                                  R"([%Y-%m-%d %H:%M:%S.%F] [%L] [%n]: %v)");
     }
     return default_patterns;
   }
@@ -70,7 +69,7 @@ namespace logger {
         return it->second;
       }
     }
-    return kDefaultPattern;
+    return getDefaultLogPatterns().getPattern(level);
   }
 
   LoggerSpdlog::LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config)

--- a/libs/logger/logger_spdlog.hpp
+++ b/libs/logger/logger_spdlog.hpp
@@ -23,7 +23,7 @@ namespace logger {
 
   using ConstLoggerConfigPtr = std::shared_ptr<const LoggerConfig>;
 
-  extern const LogPatterns kDefaultLogPatterns;
+  LogPatterns getDefaultLogPatterns();
 
   /// Patterns for logging depending on the log level.
   class LogPatterns {

--- a/test/framework/test_logger.cpp
+++ b/test/framework/test_logger.cpp
@@ -10,7 +10,7 @@
 logger::LoggerManagerTreePtr getTestLoggerManager() {
   static logger::LoggerManagerTreePtr log_manager(
       std::make_shared<logger::LoggerManagerTree>(logger::LoggerConfig{
-          logger::LogLevel::kInfo, logger::kDefaultLogPatterns}));
+          logger::LogLevel::kInfo, logger::getDefaultLogPatterns()}));
   return log_manager->getChild("Test");
 }
 

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -45,7 +45,7 @@ static logger::LoggerManagerTreePtr getIrohadTestLoggerManager() {
   if (!irohad_test_logger_manager) {
     irohad_test_logger_manager =
         std::make_shared<logger::LoggerManagerTree>(logger::LoggerConfig{
-            logger::LogLevel::kInfo, logger::kDefaultLogPatterns});
+            logger::LogLevel::kInfo, logger::getDefaultLogPatterns()});
   }
   return irohad_test_logger_manager->getChild("IrohadTest");
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

In spdlog one cannot create two loggers with the same tag. But in the logger manager, loggers are created with lock-free compare-exchange method, which implies multiple logger instances creation. This fix makes them reuse the `spdlog::logger` objects with the `spdlog::get` library thread-safe function.

Also, an initialization race fixed for `logger::kDefaultLogPatterns` and rapidjson lib to iroha_conf_loader.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Fixed a race leading to crash.

<!-- What benefits will be realized by the code change? -->
