### PR TITLE
Add fix for commit direct propagation

### DIFF
--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -18,6 +18,12 @@
 #include "interfaces/common_objects/peer.hpp"
 #include "logger/logger.hpp"
 
+// TODO: 2019-03-04 @muratovv refactor std::vector<VoteMessage> with a
+// separate class IR-374
+auto &getRound(const std::vector<iroha::consensus::yac::VoteMessage> &state) {
+  return state.at(0).hash.vote_round;
+}
+
 namespace iroha {
   namespace consensus {
     namespace yac {
@@ -137,55 +143,77 @@ namespace iroha {
         // TODO 10.06.2018 andrei: IR-1407 move YAC propagation strategy to a
         // separate entity
 
-        answer | [&](const auto &answer) {
-          auto &proposal_round = state.at(0).hash.vote_round;
+        iroha::match_in_place(
+            answer,
+            [&](const auto &answer) {
+              auto &proposal_round = getRound(state);
 
-          /*
-           * It is possible that a new peer with an outdated peers list may
-           * collect an outcome from a smaller number of peers which are
-           * included in set of `f` peers in the system. The new peer will not
-           * accept our message with valid supermajority because he cannot apply
-           * votes from unknown peers.
-           */
-          if (state.size() > 1) {
-            // some peer has already collected commit/reject, so it is sent
-            if (vote_storage_.getProcessingState(proposal_round)
-                == ProposalState::kNotSentNotProcessed) {
-              vote_storage_.nextProcessingState(proposal_round);
-              log_->info(
-                  "Received supermajority of votes for {}, skip propagation",
-                  proposal_round);
-            }
-          }
-
-          auto processing_state =
-              vote_storage_.getProcessingState(proposal_round);
-
-          auto votes = [](const auto &state) { return state.votes; };
-
-          switch (processing_state) {
-            case ProposalState::kNotSentNotProcessed:
-              vote_storage_.nextProcessingState(proposal_round);
-              log_->info("Propagate state {} to whole network", proposal_round);
-              this->propagateState(visit_in_place(answer, votes));
-              break;
-            case ProposalState::kSentNotProcessed:
-              vote_storage_.nextProcessingState(proposal_round);
-              log_->info("Pass outcome for {} to pipeline", proposal_round);
-              this->closeRound();
-              notifier_.get_subscriber().on_next(answer);
-              break;
-            case ProposalState::kSentProcessed:
-              if (state.size() == 1) {
-                this->findPeer(state.at(0)) | [&](const auto &from) {
-                  log_->info("Propagate state {} directly to {}",
-                             proposal_round,
-                             from->address());
-                  this->propagateStateDirectly(*from,
-                                               visit_in_place(answer, votes));
-                };
+              /*
+               * It is possible that a new peer with an outdated peers list may
+               * collect an outcome from a smaller number of peers which are
+               * included in set of `f` peers in the system. The new peer will
+               * not accept our message with valid supermajority because he
+               * cannot apply votes from unknown peers.
+               */
+              if (state.size() > 1) {
+                // some peer has already collected commit/reject, so it is sent
+                if (vote_storage_.getProcessingState(proposal_round)
+                    == ProposalState::kNotSentNotProcessed) {
+                  vote_storage_.nextProcessingState(proposal_round);
+                  log_->info(
+                      "Received supermajority of votes for {}, skip "
+                      "propagation",
+                      proposal_round);
+                }
               }
-              break;
+
+              auto processing_state =
+                  vote_storage_.getProcessingState(proposal_round);
+
+              auto votes = [](const auto &state) { return state.votes; };
+
+              switch (processing_state) {
+                case ProposalState::kNotSentNotProcessed:
+                  vote_storage_.nextProcessingState(proposal_round);
+                  log_->info("Propagate state {} to whole network",
+                             proposal_round);
+                  this->propagateState(visit_in_place(answer, votes));
+                  break;
+                case ProposalState::kSentNotProcessed:
+                  vote_storage_.nextProcessingState(proposal_round);
+                  log_->info("Pass outcome for {} to pipeline", proposal_round);
+                  this->closeRound();
+                  notifier_.get_subscriber().on_next(answer);
+                  break;
+                case ProposalState::kSentProcessed:
+                  tryPropagateBack(state);
+                  break;
+              }
+            },
+            // sent a state which didn't match with current one
+            [&]() { tryPropagateBack(state); });
+      }
+
+      void Yac::tryPropagateBack(const std::vector<VoteMessage> &state) {
+        // yac back propagation will work  only if another peer is in
+        // propagation stage because if peer sends list of votes this means that
+        // state is already committed
+        if (state.size() != 1) {
+          return;
+        }
+
+        vote_storage_.getLastFinalizedRound() | [&](const auto &last_round) {
+          if (getRound(state) <= last_round) {
+            vote_storage_.getState(last_round) | [&](const auto &last_state) {
+              this->findPeer(state.at(0)) | [&](const auto &from) {
+                log_->info("Propagate state {} directly to {}",
+                           last_round,
+                           from->address());
+                auto votes = [](const auto &state) { return state.votes; };
+                this->propagateStateDirectly(*from,
+                                             visit_in_place(last_state, votes));
+              };
+            };
           }
         };
       }

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -186,12 +186,12 @@ namespace iroha {
                   notifier_.get_subscriber().on_next(answer);
                   break;
                 case ProposalState::kSentProcessed:
-                  tryPropagateBack(state);
+                  this->tryPropagateBack(state);
                   break;
               }
             },
             // sent a state which didn't match with current one
-            [&]() { tryPropagateBack(state); });
+            [&]() { this->tryPropagateBack(state); });
       }
 
       void Yac::tryPropagateBack(const std::vector<VoteMessage> &state) {

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -195,7 +195,7 @@ namespace iroha {
       }
 
       void Yac::tryPropagateBack(const std::vector<VoteMessage> &state) {
-        // yac back propagation will work  only if another peer is in
+        // yac back propagation will work only if another peer is in
         // propagation stage because if peer sends list of votes this means that
         // state is already committed
         if (state.size() != 1) {

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -19,20 +19,29 @@ namespace iroha {
 
       // --------| private api |--------
 
+      namespace {
+        /**
+         * Find storage with corresponding key
+         * @tparam T - storage type
+         * @param storage - ref or const ref for the storage
+         * @param round - required round
+         * @return iterator for the storage
+         */
+        template <typename T>
+        auto findStorage(T &storage, const Round &round) {
+          return std::find_if(
+              storage.begin(), storage.end(), [&round](const auto &storage) {
+                return storage.getStorageKey() == round;
+              });
+        }
+      }  // namespace
+
       auto YacVoteStorage::getProposalStorage(const Round &round) {
-        return std::find_if(proposal_storages_.begin(),
-                            proposal_storages_.end(),
-                            [&round](const auto &storage) {
-                              return storage.getStorageKey() == round;
-                            });
+        return findStorage(proposal_storages_, round);
       }
 
       auto YacVoteStorage::getProposalStorage(const Round &round) const {
-        return std::find_if(proposal_storages_.begin(),
-                            proposal_storages_.end(),
-                            [&round](const auto &storage) {
-                              return storage.getStorageKey() == round;
-                            });
+        return findStorage(proposal_storages_, round);
       }
 
       boost::optional<std::vector<YacProposalStorage>::iterator>

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -136,6 +136,19 @@ namespace iroha {
          */
         void nextProcessingState(const Round &round);
 
+        /**
+         * Get last by order finalized round
+         * @return round if it exists
+         */
+        boost::optional<Round> getLastFinalizedRound() const;
+
+        /**
+         * Get state attached to passed round
+         * @param round - target round for finding
+         * @return state if round exists and finalized
+         */
+        boost::optional<Answer> getState(const Round &round) const;
+
        private:
         // --------| fields |--------
 
@@ -160,6 +173,9 @@ namespace iroha {
          * storage
          */
         std::shared_ptr<CleanupStrategy> strategy_;
+
+        /// last finalized round
+        boost::optional<Round> last_round_;
 
         std::shared_ptr<SupermajorityChecker> supermajority_checker_;
 

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -70,6 +70,7 @@ namespace iroha {
          * @return iterator to proposal storage
          */
         auto getProposalStorage(const Round &round);
+        auto getProposalStorage(const Round &round) const;
 
         /**
          * Find existed proposal storage or create new if required
@@ -143,8 +144,8 @@ namespace iroha {
         boost::optional<Round> getLastFinalizedRound() const;
 
         /**
-         * Get state attached to passed round
-         * @param round - target round for finding
+         * Get the state attached of a past round
+         * @param round - required round
          * @return state if round exists and finalized
          */
         boost::optional<Answer> getState(const Round &round) const;

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -85,6 +85,7 @@ namespace iroha {
         void propagateState(const std::vector<VoteMessage> &msg);
         void propagateStateDirectly(const shared_model::interface::Peer &to,
                                     const std::vector<VoteMessage> &msg);
+        void tryPropagateBack(const std::vector<VoteMessage> &state);
 
         // ------|Fields|------
         YacVoteStorage vote_storage_;

--- a/test/module/irohad/consensus/yac/CMakeLists.txt
+++ b/test/module/irohad/consensus/yac/CMakeLists.txt
@@ -98,4 +98,5 @@ target_link_libraries(buffered_cleanup_strategy_test
 addtest(yac_synchronization_test yac_synchronization_test.cpp)
 target_link_libraries(yac_synchronization_test
     yac
+    test_logger
     )

--- a/test/module/irohad/consensus/yac/CMakeLists.txt
+++ b/test/module/irohad/consensus/yac/CMakeLists.txt
@@ -94,3 +94,8 @@ target_link_libraries(buffered_cleanup_strategy_test
     yac
     consensus_round
     )
+
+addtest(yac_synchronization_test yac_synchronization_test.cpp)
+target_link_libraries(yac_synchronization_test
+    yac
+    )

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -137,7 +137,7 @@ TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyVote) {
       .WillRepeatedly(Return(true));
   std::vector<std::vector<VoteMessage>> messages;
   EXPECT_CALL(*network, sendState(_, _))
-      .Times(default_peers.size())
+      .Times(default_peers.size() + 1)
       .WillRepeatedly(Invoke(
           [&](const auto &, const auto &msg) { messages.push_back(msg); }));
 
@@ -154,7 +154,7 @@ TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyVote) {
   }
 
   // verify that on_commit subscribers are notified
-  ASSERT_EQ(default_peers.size() + 1, messages.size());
+  ASSERT_EQ(default_peers.size() + 2, messages.size());
 }
 
 /**

--- a/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
@@ -47,8 +47,8 @@ class NetworkUtil {
         peers.end(),
         std::vector<VoteMessage>(),
         [&, this](auto vector, const auto &peer_number) {
-          vector.push_back(createVote(
-              peer_number, createHash(r, block_hash, proposal_hash)));
+          vector.push_back(this->createVote(
+              peer_number, this->createHash(r, block_hash, proposal_hash)));
           return std::move(vector);
         });
   }

--- a/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "module/irohad/consensus/yac/yac_fixture.hpp"
+
+#include "common/hexutils.hpp"
+
+using namespace iroha::consensus::yac;
+
+using ::testing::_;
+using ::testing::Return;
+
+/**
+ * The class helps to create fake network for unit testing of consensus
+ */
+class NetworkUtil {
+ public:
+  /// creates fake network of number_of_peers size
+  NetworkUtil(size_t number_of_peers) {
+    for (size_t i = 0; i < number_of_peers; ++i) {
+      peers_.push_back(makePeer(std::to_string(i)));
+    }
+    order_ = ClusterOrdering::create(peers_);
+  }
+
+  auto createHash(const iroha::consensus::Round &r,
+                  const std::string &block_hash = "default_block",
+                  const std::string &proposal_hash = "default_proposal") const {
+    return YacHash(r, proposal_hash, block_hash);
+  }
+
+  auto createVote(size_t from, const YacHash &yac_hash) const {
+    return iroha::consensus::yac::createVote(
+        yac_hash,
+        *iroha::hexstringToBytestring(peers_.at(from)->pubkey().hex()));
+  }
+  /// create votes of peers by their number
+  auto createVotes(
+      const std::vector<size_t> &peers,
+      const iroha::consensus::Round &r,
+      const std::string &block_hash = "default_block",
+      const std::string &proposal_hash = "default_proposal") const {
+    return std::accumulate(
+        peers.begin(),
+        peers.end(),
+        std::vector<VoteMessage>(),
+        [&, this](auto vector, const auto &peer_number) {
+          vector.push_back(createVote(
+              peer_number, createHash(r, block_hash, proposal_hash)));
+          return std::move(vector);
+        });
+  }
+
+  std::vector<std::shared_ptr<shared_model::interface::Peer>> peers_;
+  boost::optional<ClusterOrdering> order_;
+};
+
+class YacSynchronizationTest : public YacTest {
+ public:
+  /// inits initial state and commits some rounds
+  void initAndCommitState(const NetworkUtil &network_util) {
+    initYac(*network_util.order_);
+    EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*timer, deny()).Times(10);
+
+    size_t number_of_committed_rounds = 10;
+
+    for (auto i = 0u; i < number_of_committed_rounds; i++) {
+      iroha::consensus::Round r{i, 0};
+      yac->vote(network_util.createHash(r), *network_util.order_);
+      yac->onState(network_util.createVotes({1, 2, 3, 4, 5, 6}, r));
+    }
+    EXPECT_CALL(*network, sendState(_, _)).Times(8);
+    yac->vote(network_util.createHash({10, 0}), *network_util.order_);
+  }
+};
+
+/**
+ * @given Yac which stores commit
+ * @when  Vote from known peer from old round which was presented in the cache
+ * @then  Yac sends commit for the last round
+ */
+TEST_F(YacSynchronizationTest, SynchronizationOncommitInTheCahe) {
+  NetworkUtil network_util(7);
+
+  initAndCommitState(network_util);
+
+  yac->onState(network_util.createVotes({0}, iroha::consensus::Round{1, 0}));
+}
+
+/**
+ * @given Yac which stores commit
+ * @when  Vote from known peer from old round which presents in a cache
+ * @then  Yac sends commit for the last round
+ */
+TEST_F(YacSynchronizationTest, SynchronizationOnCommitOutOfTheCahe) {
+  NetworkUtil network_util(7);
+
+  initAndCommitState(network_util);
+
+  yac->onState(network_util.createVotes({0}, iroha::consensus::Round{9, 0}));
+}
+
+/**
+ * @given Yac received reject
+ * @when  Vote from known peer from old round which doesn't present in the cache
+ * @then  Yac sends last commit
+ */
+TEST_F(YacSynchronizationTest, SynchronizationRejectOutOfTheCahe) {
+  NetworkUtil network_util(7);
+
+  initAndCommitState(network_util);
+
+  yac->onState(network_util.createVotes({0}, iroha::consensus::Round{5, 5}));
+}

--- a/test/module/irohad/consensus/yac/yac_test_util.hpp
+++ b/test/module/irohad/consensus/yac/yac_test_util.hpp
@@ -20,20 +20,27 @@ namespace iroha {
 
       inline std::shared_ptr<shared_model::interface::Peer> makePeer(
           const std::string &address) {
-        auto key = std::string(32, '0');
-        std::copy(address.begin(), address.end(), key.begin());
         auto peer = std::make_shared<MockPeer>();
         EXPECT_CALL(*peer, address())
             .WillRepeatedly(::testing::ReturnRefOfCopy(address));
         EXPECT_CALL(*peer, pubkey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::interface::types::PubkeyType(key)));
-
+                shared_model::interface::types::PubkeyType(address)));
         return peer;
       }
 
       inline VoteMessage createVote(YacHash hash, const std::string &pub_key) {
         VoteMessage vote;
+
+        auto block_signature = std::make_shared<MockSignature>();
+        EXPECT_CALL(*block_signature, publicKey())
+            .WillRepeatedly(::testing::ReturnRefOfCopy(
+                shared_model::crypto::PublicKey(pub_key)));
+        EXPECT_CALL(*block_signature, signedData())
+            .WillRepeatedly(::testing::ReturnRefOfCopy(
+                shared_model::crypto::Signed(pub_key)));
+        hash.block_signature = block_signature;
+        vote.hash = std::move(hash);
 
         auto signature = std::make_shared<MockSignature>();
         EXPECT_CALL(*signature, publicKey())
@@ -43,9 +50,7 @@ namespace iroha {
             .WillRepeatedly(::testing::ReturnRefOfCopy(
                 shared_model::crypto::Signed(pub_key)));
 
-        hash.block_signature = signature;
-        vote.hash = std::move(hash);
-        vote.signature = createSig(pub_key);
+        vote.signature = signature;
         return vote;
       }
 


### PR DESCRIPTION
### Description of the Change
Add fix for direct propagation in Yac. If a peer sends a vote for the old round we will share last finalized state.

### Benefits
Fix of synchronization in some cases.

### Possible Drawbacks 
No so elegant solution: YAC checks stateless invariants inside functions, vote storage responsibility is increased.

