### PR TITLE
RC4 Hotfix 1 - TemporaryWsv deadlock, checkTxPresence performance

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -100,6 +100,12 @@ namespace iroha {
         return expected::makeError("Connection was closed");
       }
       auto sql = std::make_unique<soci::session>(*connection_);
+      // if we create temporary storage, then we intend to validate a new
+      // proposal. this means that any state prepared before that moment is not
+      // needed and must be removed to prevent locking
+      if (block_is_prepared) {
+        rollbackPrepared(*sql);
+      }
 
       return expected::makeValue<std::unique_ptr<TemporaryWsv>>(
           std::make_unique<TemporaryWsvImpl>(
@@ -118,7 +124,7 @@ namespace iroha {
       auto sql = std::make_unique<soci::session>(*connection_);
       // if we create mutable storage, then we intend to mutate wsv
       // this means that any state prepared before that moment is not needed
-      // and must be removed to preventy locking
+      // and must be removed to prevent locking
       if (block_is_prepared) {
         rollbackPrepared(*sql);
       }

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -553,6 +553,7 @@ DROP TABLE IF EXISTS signatory;
 DROP TABLE IF EXISTS peer;
 DROP TABLE IF EXISTS role;
 DROP TABLE IF EXISTS height_by_hash;
+DROP INDEX IF EXISTS tx_status_by_hash_hash_index;
 DROP TABLE IF EXISTS tx_status_by_hash;
 DROP TABLE IF EXISTS height_by_account_set;
 DROP TABLE IF EXISTS index_by_creator_height;
@@ -654,6 +655,7 @@ CREATE TABLE IF NOT EXISTS tx_status_by_hash (
     hash varchar,
     status boolean
 );
+CREATE INDEX IF NOT EXISTS tx_status_by_hash_hash_index ON tx_status_by_hash USING hash (hash);
 
 CREATE TABLE IF NOT EXISTS height_by_account_set (
     account_id text,

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -155,6 +155,7 @@ CREATE TABLE IF NOT EXISTS tx_status_by_hash (
     hash varchar,
     status boolean
 );
+CREATE INDEX IF NOT EXISTS tx_status_by_hash_hash_index ON tx_status_by_hash USING hash (hash);
 
 CREATE TABLE IF NOT EXISTS height_by_account_set (
     account_id text,

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -667,3 +667,21 @@ TEST_F(PreparedBlockTest, CommitPreparedFailsAfterCommit) {
   shared_model::interface::Amount resultingBalance{"15.00"};
   validateAccountAsset(sql_query, "admin@test", "coin#test", resultingBalance);
 }
+
+/**
+ * @given Storage with prepared state
+ * @when another temporary wsv is created and transaction is applied
+ * @then previous state is dropped and new transaction is applied successfully
+ */
+TEST_F(PreparedBlockTest, TemporaryWsvUnlocks) {
+  auto result = temp_wsv->apply(*initial_tx);
+  ASSERT_TRUE(framework::expected::val(result));
+  storage->prepareBlock(std::move(temp_wsv));
+
+  using framework::expected::val;
+  temp_wsv = std::move(val(storage->createTemporaryWsv())->value);
+
+  result = temp_wsv->apply(*initial_tx);
+  ASSERT_TRUE(framework::expected::val(result));
+  storage->prepareBlock(std::move(temp_wsv));
+}


### PR DESCRIPTION
### Description of the Change
- Add rollback before TemporaryWsv creation to prevent a deadlock in reject case, if a block was prepared before voting
- Add hash index for transaction status table to prevent sequential scan on each query

### Benefits
Improved performance

### Possible Drawbacks 
One more query in the pipeline, hash index is not WAL logged

### Usage Examples or Tests
PreparedBlockTest.TemporaryWsvUnlocks

### Alternate Designs 
Use btree instead of hash index

