### PR TITLE
Markdown to RST docs configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
-# Contributing guidelines
-
-:star::tada: First off, thanks for taking the time to contribute! :tada::star:
+First off, thanks for taking the time to contribute!
 
 The following is a short set of guidelines for contributing to Iroha.
 

--- a/deploy/ansible/roles/iroha-docker/README.md
+++ b/deploy/ansible/roles/iroha-docker/README.md
@@ -1,5 +1,5 @@
-## Description
-This role deploys multiple replicas of Iroha containers (one Iroha peer per container) on remote hosts. Each Iroha peer can communicate with others in two ways:
+##### Description
+[This role](https://github.com/hyperledger/iroha/tree/master/deploy/ansible/roles/iroha-docker) deploys multiple replicas of Iroha containers (one Iroha peer per container) on remote hosts. Each Iroha peer can communicate with others in two ways:
   - using public IP addresses or hostnames set in inventory list OR
   - using private IP addresses of the Docker overlay network
 
@@ -11,7 +11,7 @@ The second one can be used when there exists an overlay network between the host
 
 The second way is also suitable for local-only deployments.
 
-## Requirements
+##### Requirements
   Tested on Ubuntu 16.04, 18.04
   - Local:
     - python3, python3-dev
@@ -23,10 +23,10 @@ The second way is also suitable for local-only deployments.
 
     There is a role for setting up a remote part of the dependencies named `docker`. It works for Ubuntu OS only. Check `iroha-docker` playbook.
 
-### Note:
+**Note:**
 > `docker.io` package from Ubuntu repos will not work. Either use Ansible role or install Docker following official instructions for your OS flavor.
 
-## Quick Start
+##### Quick Start
 1. Install Ansible
     ```
     pip3 install ansible
@@ -46,15 +46,15 @@ The second way is also suitable for local-only deployments.
 This will deploy 6 Iroha Docker containers along with 6 Postgres containers on the remote host specified in `iroha.list` file. Remote user is `ubuntu`. Torii port of each container is exposed on the host. Iroha peer can be communicated over port defined in `iroha_torii_port` variable (50051 by default). Overall, each host will listen the following port range: `iroha_torii_port` ... `iroha_torii_port` + *number-of-containers* - 1.
 It will also install Docker along with required python modules. If you want to skip this step, comment out `docker` role in the playbook (`playbooks/iroha-docker/main.yml`)
 
-### Note:
+**Note:**
 > This command escalates privileges on a remote host during the run. It is required to be able to spin up Docker containers. We recommend to run the playbook using a passwordless remote sudo user.
 
-## Initial configuration
+##### Initial configuration
 
 See `defaults/main.yml` file to get more details about available configuration options.
 
-## Examples
-### Example 1
+##### Examples
+**Example 1**
 <!-- TODO: Cover more example cases -->
 Deploying 6 Iroha peers on two remote hosts communicating using public IP addresses. With 2 and 4 replicas on each host respectively.
 
@@ -90,10 +90,10 @@ Deploying 6 Iroha peers on two remote hosts communicating using public IP addres
 ansible-playbook -i inventory/iroha.list -b playbooks/iroha-docker/main.yml
 ```
 
-### Example 2
+**Example 2**
 Deploying 6 Iroha peers on two remote hosts communicating over overlay network (Calico) using custom hostnames.
 
 **TBD**
 
-### Caveats
+##### Caveats
 1. If `/usr/bin/python` does not exist on a remote host, Ansible will fail with the misleading message: `... Make sure this host can be reached over ssh`. This usually happens when Ansible uses Python 3. On Ubuntu systems `/usr/bin/python3` is not symlinked to `/usr/bin/python` which Ansible expects to find. The problem can be solved by setting `ansible_python_interpreter` variable to `/usr/bin/python3`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,8 +29,6 @@ templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
 source_suffix = ['.rst', '.md']
 
 # The master toctree document.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode'
+    'sphinx.ext.viewcode',
+    'm2r'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -30,7 +31,7 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/contribution/index.rst
+++ b/docs/source/contribution/index.rst
@@ -1,16 +1,4 @@
 Contribution
 ============
 
-.. Attention:: Contents are missing for now.
-
-Code of conduct
----------------
-
-Process
--------
-
-Communication
--------------
-
-Issue tracker
--------------
+.. mdinclude:: ../../../CONTRIBUTING.md

--- a/docs/source/guides/deployment.rst
+++ b/docs/source/guides/deployment.rst
@@ -159,64 +159,7 @@ In order to form a block, which includes more than a single peer, or requires cu
 Automated
 ---------
 
-Anyone can reuse existing Ansible Playbook in order to create a network of peers running Iroha.
-Currently, this is a solution for development and testing, in other words, a proof of concept, and cannot be used in production environment, due to some security flaws.
-For production network, a manual composing of genesis block is required.
-
-Prerequisites
-"""""""""""""
-
- * One ore more <virtual> machines with a Linux distributive installed.
- * SSH access to those machines
- * Ansible installed on a local machine
-
-Step-by-step guide
-""""""""""""""""""
-
-1. Create peers.list file in $IROHA_HOME/deploy/ansible/data
-
-2. Write all peers IP addresses followed by the internal port 10001 (e.g 31.192.120.36:10001)
-
-3. Open $IROHA_HOME/deploy/ansible/hosts file
-
-4. Write all IP addresses in [hosts] group
-
-5. Open terminal 
-
-6. Disable host key checking, because it can cause troubles due to interactive prompt
- 
-.. code-block:: shell
-
-    export ANSIBLE_HOST_KEY_CHECKING=False
-
-7. Go to ansible folder
-
-.. code-block:: shell
-
-    cd $IROHA_HOME/deploy/ansible
-
-8. Run playbook, providing your private key and hosts file
- 
-.. code-block:: shell
-
-    ansible-playbook --private-key=~/.ssh/iroha -i hosts provisioning.yml
-
-9. Wait until playbook finishes and then Iroha network is ready and up.
-
-Checking Iroha peer status
-""""""""""""""""""""""""""
-
-1. SSH into any of your machines
- 
-.. code-block:: shell
-
-    ssh -i ~/.ssh/iroha iroha@35.205.142.238
-
-2. Check Iroha container logs:
- 
-.. code-block:: shell
-
-    docker logs iroha 
+.. mdinclude:: ../../../deploy/ansible/roles/iroha-docker/README.md
 
 Dealing with troubles
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -33,3 +33,4 @@ typing==3.6.2
 urllib3==1.23
 watchdog==0.8.3
 yarg==0.1.9
+m2r


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

We are fixing the docs so .md's from the repo could be integrated into ReadTheDocs. 
Current PR is making it work and also adds one of such files into Contributing section. 

### Benefits

1. Less outdated docs - as soon as .md's change docs will change accordingly. 
2. Easy to put existing md docs into ReadTheDocs

### Possible Drawbacks 

Not everything transfers decently from md to rst. Though, when such files are used in docs, one can easily check the way it looks. 
In short, 100% pretty docs VS. Updated docs

### Usage Examples or Tests 

Docs can be included directly into the documentation files like this: 
`.. mdinclude:: ../../../CONTRIBUTING.md`

### Alternate Designs 

Transfering such files manually from .md to .rst: easy to miss something and very time-consuming 