### PR TITLE
Fix round number in SynchronizationEvent

### DIFF
--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -106,6 +106,7 @@ namespace iroha {
                   chain,
                   SynchronizationOutcomeType::kCommit,
                   blocks.back()->height() > expected_height
+                      // TODO 07.03.19 andrei: IR-387 Remove reject round
                       ? consensus::Round{blocks.back()->height(), 0}
                       : msg.round,
                   std::move(*ledger_state)};

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -102,10 +102,13 @@ namespace iroha {
             auto ledger_state = mutable_factory_->commit(std::move(storage));
 
             if (ledger_state) {
-              return SynchronizationEvent{chain,
-                                          SynchronizationOutcomeType::kCommit,
-                                          msg.round,
-                                          std::move(*ledger_state)};
+              return SynchronizationEvent{
+                  chain,
+                  SynchronizationOutcomeType::kCommit,
+                  blocks.back()->height() > expected_height
+                      ? consensus::Round{blocks.back()->height(), 0}
+                      : msg.round,
+                  std::move(*ledger_state)};
             } else {
               return boost::none;
             }

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -82,9 +82,10 @@ class SynchronizerTest : public ::testing::Test {
   }
 
   std::shared_ptr<shared_model::interface::Block> makeCommit(
+      shared_model::interface::types::HeightType height = kHeight,
       size_t time = iroha::time::now()) const {
     auto block = TestUnsignedBlockBuilder()
-                     .height(kHeight)
+                     .height(height)
                      .createdTime(time)
                      .build()
                      .signAndAddSignature(
@@ -94,7 +95,7 @@ class SynchronizerTest : public ::testing::Test {
     return std::make_shared<shared_model::proto::Block>(std::move(block));
   }
 
-  const shared_model::interface::types::HeightType kHeight{5};
+  static const shared_model::interface::types::HeightType kHeight{5};
 
   std::shared_ptr<MockChainValidator> chain_validator;
   std::shared_ptr<MockMutableFactory> mutable_factory;
@@ -207,6 +208,44 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
       // Check commit block
       ASSERT_EQ(block->height(), commit_message->height());
     });
+    ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
+    ASSERT_TRUE(block_wrapper.validate());
+  });
+
+  gate_outcome.get_subscriber().on_next(
+      consensus::VoteOther{public_keys, hash, consensus::Round{kHeight, 1}});
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @given A commit from consensus and initialized components
+ * @when gate have voted for other block and multiple blocks are loaded
+ * @then Successful commit
+ */
+TEST_F(SynchronizerTest, ValidWhenValidChainMultipleBlocks) {
+  DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
+      SetFactory(&createMockMutableStorage);
+
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
+
+  EXPECT_CALL(*mutable_factory, commit_(_))
+      .WillOnce(Return(ByMove(std::make_unique<LedgerState>(ledger_peers))));
+  EXPECT_CALL(*chain_validator, validateAndApply(_, _)).WillOnce(Return(true));
+  auto second_commit = makeCommit(kHeight + 1);
+  EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
+      .WillOnce(Return(rxcpp::observable<>::iterate(
+          std::vector<std::shared_ptr<shared_model::interface::Block>>{
+              commit_message, second_commit})));
+
+  auto wrapper =
+      make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
+  wrapper.subscribe([this](auto commit_event) {
+    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    auto block_wrapper =
+        make_test_subscriber<CallExact>(commit_event.synced_blocks, 2);
+    block_wrapper.subscribe();
+    ASSERT_EQ(commit_event.round.block_round, kHeight + 1);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
     ASSERT_TRUE(block_wrapper.validate());
   });


### PR DESCRIPTION
### Description of the Change
Pass top round from synchronizer in case a chain with multiple blocks higher than current round was downloaded.

### Benefits
Nodes retrieve proposal and vote in correct round after synchronization.

### Possible Drawbacks 
None

### Usage Examples or Tests 
SynchronizerTest.ValidWhenValidChainMultipleBlocks
