### PR TITLE
Decrease quantity of allocated proto query objects

### DIFF
--- a/shared_model/backend/protobuf/queries/impl/proto_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query.cpp
@@ -51,14 +51,14 @@ namespace shared_model {
       TransportType proto_;
 
       ProtoQueryVariantType variant_{[this] {
-        const auto &ar = proto_;
+        auto &ar = proto_;
         int which = ar.payload()
                         .GetDescriptor()
                         ->FindFieldByNumber(ar.payload().query_case())
                         ->index_in_oneof();
-        return shared_model::detail::variant_impl<ProtoQueryListType>::
-            template load<ProtoQueryVariantType>(std::forward<decltype(ar)>(ar),
-                                                 which);
+        return shared_model::detail::variant_impl<
+            ProtoQueryListType>::template load<ProtoQueryVariantType>(ar,
+                                                                      which);
       }()};
 
       QueryVariantType ivariant_{variant_};


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Avoid creation of redundant proto query object.

### Benefits

Reduced memory consumption.


### Usage Examples or Tests 

https://gist.github.com/igor-egorov/bcb3302997b799160c603ac30245189b
