### PR TITLE
Refactor ordering service queues

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -362,7 +362,6 @@ void Irohad::initOrderingGate() {
                                      std::move(factory),
                                      proposal_factory,
                                      persistent_cache,
-                                     {blocks.back()->height(), 1},
                                      delay,
                                      log_manager_->getChild("Ordering"));
   log_->info("[Init] => init ordering gate - [{}]",

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -200,7 +200,6 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
             proposal_factory,
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-        consensus::Round initial_round,
         std::function<std::chrono::milliseconds(
             const synchronizer::SynchronizationEvent &)> delay_func,
         const logger::LoggerManagerTreePtr &ordering_log_manager) {
@@ -246,7 +245,6 @@ namespace iroha {
           std::move(cache),
           std::move(proposal_factory),
           std::move(tx_cache),
-          initial_round,
           ordering_log_manager->getChild("Gate")->getLogger());
     }
 
@@ -286,7 +284,6 @@ namespace iroha {
             proposal_factory,
         std::shared_ptr<TransportFactoryType> proposal_transport_factory,
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-        consensus::Round initial_round,
         std::function<std::chrono::milliseconds(
             const synchronizer::SynchronizationEvent &)> delay_func,
         logger::LoggerManagerTreePtr ordering_log_manager) {
@@ -309,7 +306,6 @@ namespace iroha {
           std::make_shared<ordering::cache::OnDemandCache>(),
           std::move(proposal_factory),
           std::move(tx_cache),
-          initial_round,
           std::move(delay_func),
           ordering_log_manager);
     }

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -72,7 +72,6 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          consensus::Round initial_round,
           std::function<std::chrono::milliseconds(
               const synchronizer::SynchronizationEvent &)> delay_func,
           const logger::LoggerManagerTreePtr &ordering_log_manager);
@@ -89,7 +88,6 @@ namespace iroha {
           const logger::LoggerManagerTreePtr &ordering_log_manager);
 
      public:
-
       /// Constructor.
       /// @param log - the logger to use for internal messages.
       OnDemandOrderingInit(logger::LoggerPtr log);
@@ -115,8 +113,6 @@ namespace iroha {
        * requests to ordering service and processing responses
        * @param proposal_factory factory required by ordering service to produce
        * proposals
-       * @param initial_round initial value for current round used in
-       * OnDemandOrderingGate
        * @return initialized ordering gate
        */
       std::shared_ptr<network::OrderingGate> initOrderingGate(
@@ -137,7 +133,6 @@ namespace iroha {
               proposal_factory,
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          consensus::Round initial_round,
           std::function<std::chrono::milliseconds(
               const synchronizer::SynchronizationEvent &)> delay_func,
           logger::LoggerManagerTreePtr ordering_log_manager);

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -62,7 +62,7 @@ namespace iroha {
 
       ~OnDemandConnectionManager() override;
 
-      void onBatches(consensus::Round round, CollectionType batches) override;
+      void onBatches(CollectionType batches) override;
 
       boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
           consensus::Round round) override;

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -18,6 +18,20 @@
 using namespace iroha;
 using namespace iroha::ordering;
 
+std::string OnDemandOrderingGate::BlockEvent::toString() const {
+  return shared_model::detail::PrettyStringBuilder()
+      .init("BlockEvent")
+      .append(round.toString())
+      .finalize();
+}
+
+std::string OnDemandOrderingGate::EmptyEvent::toString() const {
+  return shared_model::detail::PrettyStringBuilder()
+      .init("EmptyEvent")
+      .append(round.toString())
+      .finalize();
+}
+
 OnDemandOrderingGate::OnDemandOrderingGate(
     std::shared_ptr<OnDemandOrderingService> ordering_service,
     std::shared_ptr<transport::OdOsNotification> network_client,
@@ -30,20 +44,11 @@ OnDemandOrderingGate::OnDemandOrderingGate(
       ordering_service_(std::move(ordering_service)),
       network_client_(std::move(network_client)),
       events_subscription_(events.subscribe([this](auto event) {
-        // exclusive lock
-        consensus::Round current_round_;
-        visit_in_place(event,
-                       [this, &current_round_](const BlockEvent &block_event) {
-                         // block committed, increment block round
-                         log_->debug("BlockEvent. {}", block_event.round);
-                         current_round_ = block_event.round;
-                       },
-                       [this, &current_round_](const EmptyEvent &empty_event) {
-                         // no blocks committed, increment reject round
-                         log_->debug("EmptyEvent");
-                         current_round_ = empty_event.round;
-                       });
-        log_->debug("Current: {}", current_round_);
+        consensus::Round current_round =
+            visit_in_place(event, [this, &current_round](const auto &event) {
+              log_->debug("{}", event);
+              return event.round;
+            });
 
         visit_in_place(event,
                        [this](const BlockEvent &block_event) {
@@ -64,14 +69,14 @@ OnDemandOrderingGate::OnDemandOrderingGate(
         }
 
         // notify our ordering service about new round
-        ordering_service_->onCollaborationOutcome(current_round_);
+        ordering_service_->onCollaborationOutcome(current_round);
 
         // request proposal for the current round
         auto proposal = this->processProposalRequest(
-            network_client_->onRequestProposal(current_round_));
+            network_client_->onRequestProposal(current_round));
         // vote for the object received from the network
         proposal_notifier_.get_subscriber().on_next(
-            network::OrderingEvent{std::move(proposal), current_round_});
+            network::OrderingEvent{std::move(proposal), current_round});
       })),
       cache_(std::move(cache)),
       proposal_factory_(std::move(factory)),

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -25,27 +25,25 @@ OnDemandOrderingGate::OnDemandOrderingGate(
     std::shared_ptr<cache::OrderingGateCache> cache,
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory> factory,
     std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-    consensus::Round initial_round,
     logger::LoggerPtr log)
     : log_(std::move(log)),
       ordering_service_(std::move(ordering_service)),
       network_client_(std::move(network_client)),
       events_subscription_(events.subscribe([this](auto event) {
         // exclusive lock
-        std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+        consensus::Round current_round_;
         visit_in_place(event,
-                       [this](const BlockEvent &block_event) {
+                       [this, &current_round_](const BlockEvent &block_event) {
                          // block committed, increment block round
                          log_->debug("BlockEvent. {}", block_event.round);
                          current_round_ = block_event.round;
                        },
-                       [this](const EmptyEvent &empty_event) {
+                       [this, &current_round_](const EmptyEvent &empty_event) {
                          // no blocks committed, increment reject round
                          log_->debug("EmptyEvent");
                          current_round_ = empty_event.round;
                        });
         log_->debug("Current: {}", current_round_);
-        lock.unlock();
 
         visit_in_place(event,
                        [this](const BlockEvent &block_event) {
@@ -61,7 +59,6 @@ OnDemandOrderingGate::OnDemandOrderingGate(
         cache_->addToBack(batches);
         if (not batches.empty()) {
           network_client_->onBatches(
-              current_round_,
               transport::OdOsNotification::CollectionType{batches.begin(),
                                                           batches.end()});
         }
@@ -78,8 +75,7 @@ OnDemandOrderingGate::OnDemandOrderingGate(
       })),
       cache_(std::move(cache)),
       proposal_factory_(std::move(factory)),
-      tx_cache_(std::move(tx_cache)),
-      current_round_(initial_round) {}
+      tx_cache_(std::move(tx_cache)) {}
 
 OnDemandOrderingGate::~OnDemandOrderingGate() {
   events_subscription_.unsubscribe();
@@ -89,9 +85,8 @@ void OnDemandOrderingGate::propagateBatch(
     std::shared_ptr<shared_model::interface::TransactionBatch> batch) {
   cache_->addToBack({batch});
 
-  std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   network_client_->onBatches(
-      current_round_, transport::OdOsNotification::CollectionType{batch});
+      transport::OdOsNotification::CollectionType{batch});
 }
 
 rxcpp::observable<network::OrderingEvent> OnDemandOrderingGate::onProposal() {

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -62,7 +62,6 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          consensus::Round initial_round,
           logger::LoggerPtr log);
 
       ~OnDemandOrderingGate() override;
@@ -102,9 +101,7 @@ namespace iroha {
           proposal_factory_;
       std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache_;
 
-      consensus::Round current_round_;
       rxcpp::subjects::subject<network::OrderingEvent> proposal_notifier_;
-      mutable std::shared_timed_mutex mutex_;
     };
 
   }  // namespace ordering

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -40,6 +40,8 @@ namespace iroha {
         consensus::Round round;
         /// hashes of processed transactions
         cache::OrderingGateCache::HashesSetType hashes;
+
+        std::string toString() const;
       };
 
       /**
@@ -48,6 +50,8 @@ namespace iroha {
       struct EmptyEvent {
         /// next round number
         consensus::Round round;
+
+        std::string toString() const;
       };
 
       using BlockRoundEventType = boost::variant<BlockEvent, EmptyEvent>;

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -99,10 +99,12 @@ OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
  * Get transactions from the given batches queue. Does not break batches -
  * continues getting all the transactions from the ongoing batch until the
  * required amount is collected.
+ * @tparam Lambda - type of side effect function for batches
  * @param requested_tx_amount - amount of transactions to get
  * @param tx_batches_queue - the queue to get transactions from
  * @param discarded_txs_amount - the amount of discarded txs
-
+ * @param batch_operation - side effect function to be performed on each
+ * inserted batch. Passed pointer could be modified
  * @return transactions
  */
 template <typename Lambda>
@@ -206,8 +208,8 @@ void OnDemandOrderingServiceImpl::packNextProposals(
     auto txs = get_transactions(next_round_batches_, [](auto &) {});
 
     if (not txs.empty()) {
-      generate_proposal({round.block_round, round.reject_round + 1}, txs);
-      generate_proposal({round.block_round + 1, round.reject_round}, txs);
+      generate_proposal({round.block_round, kNextRejectRoundConsumer}, txs);
+      generate_proposal({round.block_round + 1, kNextCommitRoundConsumer}, txs);
     }
   }
 }

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -69,27 +69,10 @@ void OnDemandOrderingServiceImpl::onBatches(consensus::Round round,
                    batch->reducedHash().hex());
         return not this->batchAlreadyProcessed(*batch);
       });
-  auto it = current_proposals_.find(round);
-  if (it == current_proposals_.end()) {
-    it =
-        std::find_if(current_proposals_.begin(),
-                     current_proposals_.end(),
-                     [&round](const auto &p) {
-                       auto request_reject_round = round.reject_round;
-                       auto reject_round = p.first.reject_round;
-                       return request_reject_round == reject_round
-                           or (request_reject_round >= 2 and reject_round >= 2);
-                     });
-    if (it == current_proposals_.end()) {
-      log_->critical("No place to store the batches!");
-      assert(false);  // terminate if in debug build
-      return;
-    }
-    log_->debug("onBatches => collection will be inserted to {}", it->first);
-  }
-  std::for_each(unprocessed_batches.begin(),
-                unprocessed_batches.end(),
-                [&it](auto &obj) { it->second.push(std::move(obj)); });
+  std::for_each(
+      unprocessed_batches.begin(),
+      unprocessed_batches.end(),
+      [this](auto &obj) { current_round_batches_.push(std::move(obj)); });
   log_->debug("onBatches => collection is inserted");
 }
 
@@ -123,21 +106,24 @@ OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
 
  * @return transactions
  */
+template <typename Lambda>
 static std::vector<std::shared_ptr<shared_model::interface::Transaction>>
 getTransactions(size_t requested_tx_amount,
                 tbb::concurrent_queue<TransactionBatchType> &tx_batches_queue,
-                boost::optional<size_t &> discarded_txs_amount) {
+                boost::optional<size_t &> discarded_txs_amount,
+                Lambda batch_operation) {
   TransactionBatchType batch;
   std::vector<std::shared_ptr<shared_model::interface::Transaction>> collection;
   std::unordered_set<std::string> inserted;
 
   while (collection.size() < requested_tx_amount
-         and tx_batches_queue.try_pop(batch)
-         and inserted.insert(batch->reducedHash().hex()).second) {
-    collection.insert(
-        std::end(collection),
-        std::make_move_iterator(std::begin(batch->transactions())),
-        std::make_move_iterator(std::end(batch->transactions())));
+         and tx_batches_queue.try_pop(batch)) {
+    if (inserted.insert(batch->reducedHash().hex()).second) {
+      collection.insert(std::end(collection),
+                        std::begin(batch->transactions()),
+                        std::end(batch->transactions()));
+      batch_operation(batch);
+    }
   }
 
   if (discarded_txs_amount) {
@@ -152,40 +138,6 @@ getTransactions(size_t requested_tx_amount,
 
 void OnDemandOrderingServiceImpl::packNextProposals(
     const consensus::Round &round) {
-  auto close_round = [this](consensus::Round round) {
-    log_->debug("close {}", round);
-
-    auto it = current_proposals_.find(round);
-    if (it != current_proposals_.end()) {
-      log_->debug("proposal found");
-      if (not it->second.empty()) {
-        log_->debug("Mutable proposal generation for round {}", round);
-        size_t discarded_txs_amount;
-        auto txs = getTransactions(transaction_limit_, it->second, discarded_txs_amount);
-        if (not txs.empty()) {
-          log_->debug("Number of transactions in proposal = {}", txs.size());
-          auto proposal = proposal_factory_->unsafeCreateProposal(
-              round.block_round,
-              iroha::time::now(),
-              std::move(txs) | boost::adaptors::indirected);
-          proposal_map_.emplace(round, std::move(proposal));
-          log_->debug(
-              "packNextProposal: data has been fetched for {}. "
-              "Discarded {} transactions.",
-              round,
-              discarded_txs_amount);
-          round_queue_.push(round);
-        }
-      }
-      current_proposals_.erase(it);
-    }
-  };
-
-  auto open_round = [this](consensus::Round round) {
-    log_->debug("open {}", round);
-    current_proposals_[round];
-  };
-
   /*
    * The possible cases can be visualised as a diagram, where:
    * o - current round, x - next round, v - target round
@@ -217,23 +169,48 @@ void OnDemandOrderingServiceImpl::packNextProposals(
    * (1,0) - current round. The diagram is similar to the initial case.
    */
 
-  // close next reject round
-  close_round({round.block_round, round.reject_round + 1});
+  size_t discarded_txs_amount;
+  auto get_transactions = [this, &discarded_txs_amount](auto &queue,
+                                                        auto lambda) {
+    return getTransactions(
+        transaction_limit_, queue, discarded_txs_amount, lambda);
+  };
 
-  if (round.reject_round == kFirstRejectRound) {
-    // new block round
-    close_round({round.block_round + 1, round.reject_round});
+  auto now = iroha::time::now();
+  auto generate_proposal = [this, now, &discarded_txs_amount](
+                               consensus::Round round, const auto &txs) {
+    auto proposal = proposal_factory_->unsafeCreateProposal(
+        round.block_round, now, txs | boost::adaptors::indirected);
+    proposal_map_.emplace(round, std::move(proposal));
+    round_queue_.push(round);
+    log_->debug(
+        "packNextProposal: data has been fetched for {}. "
+        "Number of transactions in proposal = {}. Discarded {} "
+        "transactions.",
+        round,
+        txs.size(),
+        discarded_txs_amount);
+  };
 
-    // remove current queues
-    current_proposals_.clear();
-    // initialize the 3 diagonal rounds from the commit case diagram
-    open_round({round.block_round + 1, kNextRejectRoundConsumer});
-    open_round({round.block_round + 2, kNextCommitRoundConsumer});
+  if (not current_round_batches_.empty()) {
+    auto txs = get_transactions(current_round_batches_, [this](auto &batch) {
+      next_round_batches_.push(std::move(batch));
+    });
+
+    if (not txs.empty() and round.reject_round != kFirstRejectRound) {
+      generate_proposal({round.block_round, round.reject_round + 1}, txs);
+    }
   }
 
-  // new reject round
-  open_round(
-      {round.block_round, currentRejectRoundConsumer(round.reject_round)});
+  if (not next_round_batches_.empty()
+      and round.reject_round == kFirstRejectRound) {
+    auto txs = get_transactions(next_round_batches_, [](auto &) {});
+
+    if (not txs.empty()) {
+      generate_proposal({round.block_round, round.reject_round + 1}, txs);
+      generate_proposal({round.block_round + 1, round.reject_round}, txs);
+    }
+  }
 }
 
 void OnDemandOrderingServiceImpl::tryErase() {

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -57,11 +57,10 @@ void OnDemandOrderingServiceImpl::onCollaborationOutcome(
 
 // ----------------------------| OdOsNotification |-----------------------------
 
-void OnDemandOrderingServiceImpl::onBatches(consensus::Round round,
-                                            CollectionType batches) {
+void OnDemandOrderingServiceImpl::onBatches(CollectionType batches) {
   // read lock
   std::shared_lock<std::shared_timed_mutex> guard(lock_);
-  log_->info("onBatches => collection size = {}, {}", batches.size(), round);
+  log_->info("onBatches => collection size = {}", batches.size());
 
   auto unprocessed_batches =
       boost::adaptors::filter(batches, [this](const auto &batch) {

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -51,7 +51,7 @@ namespace iroha {
 
       // ----------------------- | OdOsNotification | --------------------------
 
-      void onBatches(consensus::Round, CollectionType batches) override;
+      void onBatches(CollectionType batches) override;
 
       boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
           consensus::Round round) override;

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -102,10 +102,8 @@ namespace iroha {
       /**
        * Proposals for current rounds
        */
-      std::unordered_map<consensus::Round,
-                         tbb::concurrent_queue<TransactionBatchType>,
-                         consensus::RoundTypeHasher>
-          current_proposals_;
+      tbb::concurrent_queue<TransactionBatchType> current_round_batches_,
+          next_round_batches_;
 
       /**
        * Read write mutex for public methods

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -100,7 +100,7 @@ namespace iroha {
           proposal_map_;
 
       /**
-       * Proposals for current rounds
+       * Collections of batches for current and next rounds
        */
       tbb::concurrent_queue<TransactionBatchType> current_round_batches_,
           next_round_batches_;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -31,11 +31,8 @@ OnDemandOsClientGrpc::OnDemandOsClientGrpc(
       time_provider_(std::move(time_provider)),
       proposal_request_timeout_(proposal_request_timeout) {}
 
-void OnDemandOsClientGrpc::onBatches(consensus::Round round,
-                                     CollectionType batches) {
+void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
   proto::BatchesRequest request;
-  request.mutable_round()->set_block_round(round.block_round);
-  request.mutable_round()->set_reject_round(round.reject_round);
   for (auto &batch : batches) {
     for (auto &transaction : batch->transactions()) {
       *request.add_transactions() = std::move(

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -42,7 +42,7 @@ namespace iroha {
             std::chrono::milliseconds proposal_request_timeout,
             logger::LoggerPtr log);
 
-        void onBatches(consensus::Round round, CollectionType batches) override;
+        void onBatches(CollectionType batches) override;
 
         boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
             consensus::Round round) override;

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -65,8 +65,6 @@ grpc::Status OnDemandOsServerGrpc::SendBatches(
     ::grpc::ServerContext *context,
     const proto::BatchesRequest *request,
     ::google::protobuf::Empty *response) {
-  consensus::Round round{request->round().block_round(),
-                         request->round().reject_round()};
   auto transactions = deserializeTransactions(request);
 
   auto batch_candidates = batch_parser_->parseBatches(std::move(transactions));
@@ -86,7 +84,7 @@ grpc::Status OnDemandOsServerGrpc::SendBatches(
         return acc;
       });
 
-  ordering_service_->onBatches(round, std::move(batches));
+  ordering_service_->onBatches(std::move(batches));
 
   return ::grpc::Status::OK;
 }

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -48,11 +48,9 @@ namespace iroha {
 
         /**
          * Callback on receiving transactions
-         * @param round - expected proposal round
          * @param batches - vector of passed transaction batches
          */
-        virtual void onBatches(consensus::Round round,
-                               CollectionType batches) = 0;
+        virtual void onBatches(CollectionType batches) = 0;
 
         /**
          * Callback on request about proposal

--- a/schema/ordering.proto
+++ b/schema/ordering.proto
@@ -20,8 +20,7 @@ message ProposalRound {
 }
 
 message BatchesRequest {
-  ProposalRound round = 1;
-  repeated protocol.Transaction transactions = 2;
+  repeated protocol.Transaction transactions = 1;
 }
 
 message ProposalRequest {

--- a/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
+++ b/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
@@ -15,7 +15,7 @@ namespace iroha {
     namespace transport {
 
       struct MockOdOsNotification : public OdOsNotification {
-        MOCK_METHOD2(onBatches, void(consensus::Round, CollectionType));
+        MOCK_METHOD1(onBatches, void(CollectionType));
 
         MOCK_METHOD1(onRequestProposal,
                      boost::optional<std::shared_ptr<const ProposalType>>(

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -83,7 +83,7 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
 
   auto set_expect = [&](OnDemandConnectionManager::PeerType type,
                         consensus::Round round) {
-    EXPECT_CALL(*connections[type], onBatches(round, collection)).Times(1);
+    EXPECT_CALL(*connections[type], onBatches(collection)).Times(1);
   };
 
   set_expect(
@@ -94,7 +94,7 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
   set_expect(OnDemandConnectionManager::kNextRoundCommitConsumer,
              {round.block_round + 2, kNextCommitRoundConsumer});
 
-  manager->onBatches(round, collection);
+  manager->onBatches(collection);
 }
 
 /**

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -79,20 +79,14 @@ TEST_F(OnDemandConnectionManagerTest, FactoryUsed) {
  */
 TEST_F(OnDemandConnectionManagerTest, onBatches) {
   OdOsNotification::CollectionType collection;
-  consensus::Round round{1, 2};
 
-  auto set_expect = [&](OnDemandConnectionManager::PeerType type,
-                        consensus::Round round) {
+  auto set_expect = [&](OnDemandConnectionManager::PeerType type) {
     EXPECT_CALL(*connections[type], onBatches(collection)).Times(1);
   };
 
-  set_expect(
-      OnDemandConnectionManager::kCurrentRoundRejectConsumer,
-      {round.block_round, currentRejectRoundConsumer(round.reject_round)});
-  set_expect(OnDemandConnectionManager::kNextRoundRejectConsumer,
-             {round.block_round + 1, kNextRejectRoundConsumer});
-  set_expect(OnDemandConnectionManager::kNextRoundCommitConsumer,
-             {round.block_round + 2, kNextCommitRoundConsumer});
+  set_expect(OnDemandConnectionManager::kCurrentRoundRejectConsumer);
+  set_expect(OnDemandConnectionManager::kNextRoundRejectConsumer);
+  set_expect(OnDemandConnectionManager::kNextRoundCommitConsumer);
 
   manager->onBatches(collection);
 }

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -53,7 +53,6 @@ class OnDemandOrderingGateTest : public ::testing::Test {
                                                cache,
                                                std::move(ufactory),
                                                tx_cache,
-                                               initial_round,
                                                getTestLogger("OrderingGate"));
   }
 
@@ -81,7 +80,7 @@ TEST_F(OnDemandOrderingGateTest, propagateBatch) {
   OdOsNotification::CollectionType collection{batch};
 
   EXPECT_CALL(*cache, addToBack(UnorderedElementsAre(batch))).Times(1);
-  EXPECT_CALL(*notification, onBatches(initial_round, collection)).Times(1);
+  EXPECT_CALL(*notification, onBatches(collection)).Times(1);
 
   ordering_gate->propagateBatch(batch);
 }
@@ -272,8 +271,7 @@ TEST_F(OnDemandOrderingGateTest, PopNonEmptyBatchesFromTheCache) {
 
   EXPECT_CALL(*cache, addToBack(UnorderedElementsAreArray(collection)))
       .Times(1);
-  EXPECT_CALL(*notification,
-              onBatches(round, UnorderedElementsAreArray(collection)))
+  EXPECT_CALL(*notification, onBatches(UnorderedElementsAreArray(collection)))
       .Times(1);
 
   rounds.get_subscriber().on_next(OnDemandOrderingGate::BlockEvent{round, {}});
@@ -291,7 +289,7 @@ TEST_F(OnDemandOrderingGateTest, PopEmptyBatchesFromTheCache) {
   EXPECT_CALL(*cache, pop()).WillOnce(Return(empty_collection));
   EXPECT_CALL(*cache, addToBack(UnorderedElementsAreArray(empty_collection)))
       .Times(1);
-  EXPECT_CALL(*notification, onBatches(_, _)).Times(0);
+  EXPECT_CALL(*notification, onBatches(_)).Times(0);
 
   rounds.get_subscriber().on_next(OnDemandOrderingGate::BlockEvent{round, {}});
 }

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -65,8 +65,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
 
   std::shared_ptr<cache::MockOrderingGateCache> cache;
 
-  const consensus::Round initial_round = {1, kFirstRejectRound},
-                         round = {2, kFirstRejectRound};
+  const consensus::Round round = {2, kFirstRejectRound};
 };
 
 /**

--- a/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
@@ -96,10 +96,8 @@ TEST_F(OnDemandOsClientGrpcTest, onBatches) {
       std::make_unique<shared_model::interface::TransactionBatchImpl>(
           shared_model::interface::types::SharedTxsCollectionType{
               std::make_unique<shared_model::proto::Transaction>(tx)}));
-  client->onBatches(round, std::move(collection));
+  client->onBatches(std::move(collection));
 
-  ASSERT_EQ(request.round().block_round(), round.block_round);
-  ASSERT_EQ(request.round().reject_round(), round.reject_round);
   ASSERT_EQ(request.transactions()
                 .Get(0)
                 .payload()

--- a/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
@@ -64,8 +64,8 @@ struct OnDemandOsServerGrpcTest : public ::testing::Test {
 /**
  * Separate action required because CollectionType is non-copyable
  */
-ACTION_P(SaveArg1Move, var) {
-  *var = std::move(arg1);
+ACTION_P(SaveArg0Move, var) {
+  *var = std::move(arg0);
 }
 
 /**
@@ -93,11 +93,8 @@ TEST_F(OnDemandOsServerGrpcTest, SendBatches) {
                             shared_model::interface::TransactionBatchImpl>(
                             cand));
                   }));
-  EXPECT_CALL(*notification, onBatches(round, _))
-      .WillOnce(SaveArg1Move(&collection));
+  EXPECT_CALL(*notification, onBatches(_)).WillOnce(SaveArg0Move(&collection));
   proto::BatchesRequest request;
-  request.mutable_round()->set_block_round(round.block_round);
-  request.mutable_round()->set_reject_round(round.reject_round);
   request.add_transactions()
       ->mutable_payload()
       ->mutable_reduced_payload()

--- a/test/module/irohad/ordering/on_demand_os_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_test.cpp
@@ -73,12 +73,10 @@ class OnDemandOsTest : public ::testing::Test {
 
   /**
    * Generate transactions with provided range
-   * @param os - ordering service for insertion
    * @param range - pair of [from, to)
    */
-  void generateTransactionsAndInsert(consensus::Round round,
-                                     std::pair<uint64_t, uint64_t> range) {
-    os->onBatches(round, generateTransactions(range));
+  void generateTransactionsAndInsert(std::pair<uint64_t, uint64_t> range) {
+    os->onBatches(generateTransactions(range));
   }
 
   OnDemandOrderingService::CollectionType generateTransactions(
@@ -135,7 +133,7 @@ TEST_F(OnDemandOsTest, EmptyRound) {
  * @then  check that previous round has all transaction
  */
 TEST_F(OnDemandOsTest, NormalRound) {
-  generateTransactionsAndInsert(target_round, {1, 2});
+  generateTransactionsAndInsert({1, 2});
 
   os->onCollaborationOutcome(commit_round);
 
@@ -150,7 +148,7 @@ TEST_F(OnDemandOsTest, NormalRound) {
  * AND the rest of transactions isn't appeared in next after next round
  */
 TEST_F(OnDemandOsTest, OverflowRound) {
-  generateTransactionsAndInsert(target_round, {1, transaction_limit * 2});
+  generateTransactionsAndInsert({1, transaction_limit * 2});
 
   os->onCollaborationOutcome(commit_round);
 
@@ -181,7 +179,7 @@ TEST_F(OnDemandOsTest, DISABLED_ConcurrentInsert) {
 
   auto call = [this](auto bounds) {
     for (auto i = bounds.first; i < bounds.second; ++i) {
-      this->generateTransactionsAndInsert(target_round, {i, i + 1});
+      this->generateTransactionsAndInsert({i, i + 1});
     }
   };
 
@@ -203,7 +201,7 @@ TEST_F(OnDemandOsTest, Erase) {
   for (auto i = commit_round.block_round;
        i < commit_round.block_round + proposal_limit;
        ++i) {
-    generateTransactionsAndInsert({i + 1, commit_round.reject_round}, {1, 2});
+    generateTransactionsAndInsert({1, 2});
     os->onCollaborationOutcome({i, commit_round.reject_round});
     ASSERT_TRUE(os->onRequestProposal({i + 1, commit_round.reject_round}));
   }
@@ -211,7 +209,7 @@ TEST_F(OnDemandOsTest, Erase) {
   for (consensus::BlockRoundType i = commit_round.block_round + proposal_limit;
        i < commit_round.block_round + 2 * proposal_limit;
        ++i) {
-    generateTransactionsAndInsert({i + 1, commit_round.reject_round}, {1, 2});
+    generateTransactionsAndInsert({1, 2});
     os->onCollaborationOutcome({i, commit_round.reject_round});
     ASSERT_FALSE(os->onRequestProposal(
         {i + 1 - proposal_limit, commit_round.reject_round}));
@@ -228,7 +226,7 @@ TEST_F(OnDemandOsTest, EraseReject) {
   for (auto i = reject_round.reject_round;
        i < reject_round.reject_round + proposal_limit;
        ++i) {
-    generateTransactionsAndInsert({reject_round.block_round, i + 1}, {1, 2});
+    generateTransactionsAndInsert({1, 2});
     os->onCollaborationOutcome({reject_round.block_round, i});
     ASSERT_TRUE(os->onRequestProposal({reject_round.block_round, i + 1}));
   }
@@ -237,7 +235,7 @@ TEST_F(OnDemandOsTest, EraseReject) {
            reject_round.reject_round + proposal_limit;
        i < reject_round.reject_round + 2 * proposal_limit;
        ++i) {
-    generateTransactionsAndInsert({reject_round.block_round, i + 1}, {1, 2});
+    generateTransactionsAndInsert({1, 2});
     os->onCollaborationOutcome({reject_round.block_round, i});
     ASSERT_FALSE(os->onRequestProposal(
         {reject_round.block_round, i + 1 - proposal_limit}));
@@ -280,7 +278,7 @@ TEST_F(OnDemandOsTest, UseFactoryForProposal) {
       .WillOnce(Return(ByMove(makeMockProposal())))
       .WillOnce(Return(ByMove(makeMockProposal())));
 
-  generateTransactionsAndInsert(target_round, {1, 2});
+  generateTransactionsAndInsert({1, 2});
 
   os->onCollaborationOutcome(commit_round);
 
@@ -306,7 +304,7 @@ TEST_F(OnDemandOsTest, AlreadyProcessedProposalDiscarded) {
       .WillOnce(Return(std::vector<iroha::ametsuchi::TxCacheStatusType>{
           iroha::ametsuchi::tx_cache_status_responses::Committed()}));
 
-  os->onBatches(initial_round, batches);
+  os->onBatches(batches);
 
   os->onCollaborationOutcome(commit_round);
 
@@ -328,7 +326,7 @@ TEST_F(OnDemandOsTest, PassMissingTransaction) {
       .WillOnce(Return(std::vector<iroha::ametsuchi::TxCacheStatusType>{
           iroha::ametsuchi::tx_cache_status_responses::Missing()}));
 
-  os->onBatches(target_round, batches);
+  os->onBatches(batches);
 
   os->onCollaborationOutcome(commit_round);
 
@@ -360,7 +358,7 @@ TEST_F(OnDemandOsTest, SeveralTransactionsOneCommited) {
       .WillOnce(Return(std::vector<iroha::ametsuchi::TxCacheStatusType>{
           iroha::ametsuchi::tx_cache_status_responses::Missing()}));
 
-  os->onBatches(target_round, batches);
+  os->onBatches(batches);
 
   os->onCollaborationOutcome(commit_round);
 

--- a/test/module/irohad/ordering/on_demand_os_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_test.cpp
@@ -277,6 +277,7 @@ TEST_F(OnDemandOsTest, UseFactoryForProposal) {
       initial_round);
 
   EXPECT_CALL(*mock_factory, unsafeCreateProposal(_, _, _))
+      .WillOnce(Return(ByMove(makeMockProposal())))
       .WillOnce(Return(ByMove(makeMockProposal())));
 
   generateTransactionsAndInsert(target_round, {1, 2});

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -36,7 +36,7 @@ namespace iroha {
     }  // namespace cache
 
     struct MockOnDemandOrderingService : public OnDemandOrderingService {
-      MOCK_METHOD2(onBatches, void(consensus::Round, CollectionType));
+      MOCK_METHOD1(onBatches, void(CollectionType));
 
       MOCK_METHOD1(onRequestProposal,
                    boost::optional<std::shared_ptr<const ProposalType>>(


### PR DESCRIPTION
### Description of the Change
Use two queues in ordering service for transactions, one for current reject round, and another for future reject and commit rounds.

### Benefits
Less memory usage in case the ordering service is used for multiple rounds.

### Possible Drawbacks 
Two proposals are stored for next rounds instead of one.



