### PR TITLE
Llogger: fixed patterns

### DIFF
--- a/docs/source/guides/configuration.rst
+++ b/docs/source/guides/configuration.rst
@@ -60,7 +60,11 @@ Environment-specific parameters
 Logging
 -------
 
-In Iroha logging can be adjusted as granularly as you want. Each component has its own logging configuration with properties inherited from its parent, able to be overriden through config file. This means all the component loggers are organized in a tree with a single root. The relevant section of the  configuration file contains the overriden values:
+In Iroha logging can be adjusted as granularly as you want. Each component
+has its own logging configuration with properties inherited from its parent,
+able to be overriden through config file. This means all the component loggers
+are organized in a tree with a single root. The relevant section of the
+configuration file contains the overriden values:
 
 .. code-block:: json
   :linenos:
@@ -89,6 +93,14 @@ In Iroha logging can be adjusted as granularly as you want. Each component has i
   }
 
 Every part of this config section is optional.
-- ``level`` sets the verbosity. Available valies are (in decreasing verbosity order): trace, debug, info, warning, error, critical.
-- ``patterns`` controls the formatting of each log string for different verbosity levels. Each value overrides the less verbose levels too. So in the example above, the "don't panic" pattern also applies to info and warning levels, and the trace level pattern is the only one that is not initialized in the config (it will be set to default hardcoded value).
-- ``children`` describes the overrides of child nodes. The keys are the names of the components, and the values have the same syntax and semantics as the root log configuration.
+
+- ``level`` sets the verbosity. Available valies are (in decreasing verbosity
+  order): trace, debug, info, warning, error, critical.
+- ``patterns`` controls the formatting of each log string for different
+  verbosity levels. Each value overrides the less verbose levels too. So in the
+  example above, the "don't panic" pattern also applies to info and warning
+  levels, and the trace level pattern is the only one that is not initialized
+  in the config (it will be set to default hardcoded value).
+- ``children`` describes the overrides of child nodes. The keys are the names
+  of the components, and the values have the same syntax and semantics as the
+  root log configuration.

--- a/docs/source/guides/configuration.rst
+++ b/docs/source/guides/configuration.rst
@@ -60,11 +60,11 @@ Environment-specific parameters
 Logging
 -------
 
-In Iroha logging can be adjusted as granularly as you want. Each component
-has its own logging configuration with properties inherited from its parent,
-able to be overriden through config file. This means all the component loggers
-are organized in a tree with a single root. The relevant section of the
-configuration file contains the overriden values:
+In Iroha logging can be adjusted as granularly as you want.
+Each component has its own logging configuration with properties inherited from
+its parent, able to be overriden through config file.
+This means all the component loggers are organized in a tree with a single root.
+The relevant section of the configuration file contains the overriding values:
 
 .. code-block:: json
   :linenos:
@@ -94,13 +94,20 @@ configuration file contains the overriden values:
 
 Every part of this config section is optional.
 
-- ``level`` sets the verbosity. Available valies are (in decreasing verbosity
-  order): trace, debug, info, warning, error, critical.
+- ``level`` sets the verbosity.
+  Available valies are (in decreasing verbosity order):
+  - ``trace`` print everything
+  - ``debug``
+  - ``info``
+  - ``warning
+  - ``error``
+  - ``critical`` print only critical messages
 - ``patterns`` controls the formatting of each log string for different
-  verbosity levels. Each value overrides the less verbose levels too. So in the
-  example above, the "don't panic" pattern also applies to info and warning
-  levels, and the trace level pattern is the only one that is not initialized
-  in the config (it will be set to default hardcoded value).
-- ``children`` describes the overrides of child nodes. The keys are the names
-  of the components, and the values have the same syntax and semantics as the
-  root log configuration.
+  verbosity levels.
+  Each value overrides the less verbose levels too.
+  So in the example above, the "don't panic" pattern also applies to info and
+  warning levels, and the trace level pattern is the only one that is not
+  initialized in the config (it will be set to default hardcoded value).
+- ``children`` describes the overrides of child nodes.
+  The keys are the names of the components, and the values have the same syntax
+  and semantics as the root log configuration.

--- a/docs/source/guides/configuration.rst
+++ b/docs/source/guides/configuration.rst
@@ -62,7 +62,7 @@ Logging
 
 In Iroha logging can be adjusted as granularly as you want.
 Each component has its own logging configuration with properties inherited from
-its parent, able to be overriden through config file.
+its parent, able to be overridden through config file.
 This means all the component loggers are organized in a tree with a single root.
 The relevant section of the configuration file contains the overriding values:
 
@@ -95,13 +95,15 @@ The relevant section of the configuration file contains the overriding values:
 Every part of this config section is optional.
 
 - ``level`` sets the verbosity.
-  Available valies are (in decreasing verbosity order):
-  - ``trace`` print everything
+  Available values are (in decreasing verbosity order):
+
+  - ``trace`` - print everything
   - ``debug``
   - ``info``
-  - ``warning
+  - ``warning``
   - ``error``
-  - ``critical`` print only critical messages
+  - ``critical`` - print only critical messages
+
 - ``patterns`` controls the formatting of each log string for different
   verbosity levels.
   Each value overrides the less verbose levels too.

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -196,7 +196,7 @@ void getVal<logger::LoggerManagerTreePtr>(const std::string &path,
                                           const rapidjson::Value &src) {
   assert_fatal(src.IsObject(), path + " must be a logger tree config");
   logger::LoggerConfig root_config{logger::kDefaultLogLevel,
-                                   logger::getDefaultLogPatterns()};
+                                   logger::LogPatterns{}};
   updateLoggerConfig(path, root_config, src.GetObject());
   dest = std::make_shared<logger::LoggerManagerTree>(
       std::make_shared<const logger::LoggerConfig>(std::move(root_config)));

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -35,7 +35,8 @@ namespace logger {
       boost::optional<LogPatterns> patterns) {
     LoggerConfig child_config{
         log_level.value_or(config_->log_level),
-        patterns ? LogPatterns{*std::move(patterns)} : config_->patterns};
+        patterns ? std::move(patterns)->inherit(config_->patterns)
+                 : config_->patterns};
     // Operator new is employed due to private visibility of used constructor.
     LoggerManagerTreePtr child(new LoggerManagerTree(
         joinTags(full_tag_, tag),

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -52,9 +52,9 @@ namespace logger {
     static LogPatterns default_patterns;
     if (not is_initialized.test_and_set()) {
       default_patterns.setPattern(
-          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F] [th:%t] [%5l] [%n]: %v)");
+          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%5l][%n]: %v)");
       default_patterns.setPattern(LogLevel::kInfo,
-                                  R"([%Y-%m-%d %H:%M:%S.%F] [%L] [%n]: %v)");
+                                  R"([%Y-%m-%d %H:%M:%S.%F][%L][%n]: %v)");
     }
     return default_patterns;
   }
@@ -72,6 +72,19 @@ namespace logger {
     return getDefaultLogPatterns().getPattern(level);
   }
 
+  LogPatterns &LogPatterns::inherit(const LogPatterns &base) {
+    if (patterns_.empty()) {
+      patterns_ = base.patterns_;
+    } else {
+      for (auto it = base.patterns_.cbegin();
+           it != base.patterns_.cend() and it->first < patterns_.begin()->first;
+           ++it) {
+        patterns_.emplace(*it);
+      }
+    }
+    return *this;
+  }
+
   LoggerSpdlog::LoggerSpdlog(std::string tag, ConstLoggerConfigPtr config)
       : tag_(tag), config_(std::move(config)), logger_(getOrCreateLogger(tag)) {
     setupLogger();
@@ -83,7 +96,7 @@ namespace logger {
   }
 
   void LoggerSpdlog::logInternal(Level level, const std::string &s) const {
-    logger_->log(getSpdlogLogLevel(config_->log_level), s);
+    logger_->log(getSpdlogLogLevel(level), s);
   }
 
   bool LoggerSpdlog::shouldLog(Level level) const {

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -52,7 +52,7 @@ namespace logger {
     static LogPatterns default_patterns;
     if (not is_initialized.test_and_set()) {
       default_patterns.setPattern(
-          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%7l][%n]: %v)");
+          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%=7l][%n]: %v)");
       default_patterns.setPattern(LogLevel::kInfo,
                                   R"([%Y-%m-%d %H:%M:%S.%F][%L][%n]: %v)");
     }

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -52,7 +52,7 @@ namespace logger {
     static LogPatterns default_patterns;
     if (not is_initialized.test_and_set()) {
       default_patterns.setPattern(
-          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%=7l][%n]: %v)");
+          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%=8l][%n]: %v)");
       default_patterns.setPattern(LogLevel::kInfo,
                                   R"([%Y-%m-%d %H:%M:%S.%F][%L][%n]: %v)");
     }

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -52,7 +52,7 @@ namespace logger {
     static LogPatterns default_patterns;
     if (not is_initialized.test_and_set()) {
       default_patterns.setPattern(
-          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%5l][%n]: %v)");
+          LogLevel::kTrace, R"([%Y-%m-%d %H:%M:%S.%F][th:%t][%7l][%n]: %v)");
       default_patterns.setPattern(LogLevel::kInfo,
                                   R"([%Y-%m-%d %H:%M:%S.%F][%L][%n]: %v)");
     }

--- a/libs/logger/logger_spdlog.hpp
+++ b/libs/logger/logger_spdlog.hpp
@@ -38,6 +38,9 @@ namespace logger {
      */
     std::string getPattern(LogLevel level) const;
 
+    /// Inherit missing level overrides from another patterns
+    LogPatterns &inherit(const LogPatterns &base);
+
    private:
     std::map<LogLevel, std::string> patterns_;
   };


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Fixes:
- child config overrides only the patterns specified in it, while the unspecified are taken from parent config.
- log message contains the verbosity of message, not the logger.
- the default patterns are used in root logger only if there is no patterns specification for it.
- verbosity padding increased to fit `warning` in default pattern.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Logger behaves as expected.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
