### PR TITLE
Fix member init order warning

### DIFF
--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -96,9 +96,10 @@ namespace iroha {
           std::shared_ptr<const shared_model::interface::Proposal> proposal)
           const;
 
+      logger::LoggerPtr log_;
+
       /// max number of transactions passed to one ordering service
       size_t transaction_limit_;
-      logger::LoggerPtr log_;
       std::shared_ptr<OnDemandOrderingService> ordering_service_;
       std::shared_ptr<transport::OdOsNotification> network_client_;
       rxcpp::composite_subscription events_subscription_;

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -38,10 +38,10 @@ namespace integration_framework {
         vote_delay_(0ms),
         // amount of minutes in a day
         mst_expiration_time_(std::chrono::minutes(24 * 60)),
-        max_rounds_delay_(0ms),
-        stale_stream_max_rounds_(2),
         opt_mst_gossip_params_(boost::make_optional(
             mst_support, iroha::GossipPropagationStrategyParams{})),
+        max_rounds_delay_(0ms),
+        stale_stream_max_rounds_(2),
         irohad_log_manager_(std::move(irohad_log_manager)),
         log_(std::move(log)) {}
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change fixes the cause of complier warnings about member initialization order not matching member declaration order like this:
```
In file included from /opt/iroha/test/framework/integration_framework/iroha_instance.cpp:6:0:
/opt/iroha/test/framework/integration_framework/iroha_instance.hpp: In constructor 'integration_framework::IrohaInstance::IrohaInstance(bool, const string&, const string&, size_t, size_t, logger::LoggerManagerTreePtr, logger::LoggerPtr, const boost::optional<std::__cxx11::basic_string<char> >&)':
/opt/iroha/test/framework/integration_framework/iroha_instance.hpp:84:18: warning: 'integration_framework::IrohaInstance::stale_stream_max_rounds_' will be initialized after [-Wreorder]
     const size_t stale_stream_max_rounds_;
                  ^
/opt/iroha/test/framework/integration_framework/iroha_instance.hpp:82:9: warning:   'boost::optional<iroha::GossipPropagationStrategyParams> integration_framework::IrohaInstance::opt_mst_gossip_params_' [-Wreorder]
         opt_mst_gossip_params_;
         ^
/opt/iroha/test/framework/integration_framework/iroha_instance.cpp:21:3: warning:   when initialized here [-Wreorder]
```

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Less distracting warnings.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
