### PR TITLE
Fix race bug in command service

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -205,10 +205,12 @@ namespace iroha {
               (*found)->get(),
               [](const auto &final_responses)
                   -> std::enable_if_t<
-                      FinalStatusValue<decltype(final_responses), bool>> {
-                return true;
-              },
-              [](const auto &rest_responses) { return false; });
+                      FinalStatusValue<decltype(final_responses)>,
+                      bool> { return true; },
+              [](const auto &rest_responses)
+                  -> std::enable_if_t<
+                      not FinalStatusValue<decltype(rest_responses)>,
+                      bool> { return false; });
         }
 
         if (has_final_status) {

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -195,62 +195,38 @@ namespace iroha {
       const auto status_issuer = "ToriiBatchProcessor";
       const auto &txs = batch->transactions();
 
-      bool cache_has_at_least_one_tx{false};
-      bool batch_has_mst_pending_tx{false};
-      std::tie(cache_has_at_least_one_tx, batch_has_mst_pending_tx) =
-          // this accumulate can be split on two parts to perform visit_in_place
-          // two times - one for cache lookup with booleans initialization and
-          // another for statuses pushing. That can allow to move a part of code
-          // to a separate method for simplification
-          std::accumulate(
-              txs.begin(),
-              txs.end(),
-              std::make_pair<bool, bool>(false, false),
-              [this, &status_issuer](std::pair<bool, bool> lookup_result,
-                                     const auto &tx) {
-                const auto &tx_hash = tx->hash();
-                if (auto found = cache_->findItem(tx_hash)) {
-                  iroha::visit_in_place(
-                      (*found)->get(),
-                      [this, &found, &lookup_result, &status_issuer](
-                          const shared_model::interface::MstPendingResponse &) {
-                        this->pushStatus(status_issuer, *found);
-                        lookup_result.second = true;
-                      },
-                      [this, &tx_hash, &status_issuer](
-                          const shared_model::interface::NotReceivedTxResponse
-                              &) {
-                        // This branch covers an impossible case (this cache
-                        // cannot contain NotReceivedTxResponse, because the tx
-                        // has reached processBatch method, which means that
-                        // the tx already has StatelessValid status).
-                        // That is why we are not updating its status inside
-                        // internal cache, but still pushing to status bus.
-                        this->pushStatus(
-                            status_issuer,
-                            status_factory_->makeStatelessValid(tx_hash));
-                      },
-                      [this, &found, &status_issuer](const auto &status) {
-                        this->pushStatus(status_issuer, *found);
-                      });
-                  lookup_result.first = true;
-                }
-                return lookup_result;
-              });
+      bool has_final_status{false};
+      has_final_status = std::accumulate(
+          txs.begin(), txs.end(), false, [this](auto res, const auto &tx) {
+            if (res) {
+              return res;
+            }
 
-      if (cache_has_at_least_one_tx and not batch_has_mst_pending_tx) {
-        // If a non-persistent cache says that a transaction has pending status
-        // that means we have to check persistent cache too.
-        // Non-persistent cache might be overflowed and mst replay become
-        // possible without checking persistent cache.
+            auto on_final_status = [] { return true; };
 
-        // If there are no pending statuses and the transaction is found in
-        // non-persistent cache, then it is considered as a replay and prevented
-        // from further propagation.
+            const auto &tx_hash = tx->hash();
+            if (auto found = cache_->findItem(tx_hash)) {
+              log_->debug("Found in cache: {}", **found);
+              return iroha::visit_in_place(
+                  (*found)->get(),
+                  [](const shared_model::interface::CommittedTxResponse &) {
+                    return true;
+                  },
+                  [](const shared_model::interface::RejectedTxResponse &) {
+                    return true;
+                  },
+                  [](const auto &rest_responses) { return false; });
+            } else {
+              return false;
+            }
+          });
 
-        // If non-persistent cache does not contain any info about a
-        // transaction, then we just check persistent cache.
-        log_->warn("Replayed batch would not be served. {}", *batch);
+      if (has_final_status) {
+        // if the transaction or batch has appeared in the cache with final
+        // status this guarantees the transaction was passed to a consensus
+        // before
+        log_->warn("Replayed batch would not be served - present in cache. {}",
+                   *batch);
         return;
       }
 
@@ -290,7 +266,9 @@ namespace iroha {
                 });
           });
       if (is_replay) {
-        log_->warn("Replayed batch would not be served. {}", *batch);
+        log_->warn(
+            "Replayed batch would not be served - present in database. {}",
+            *batch);
         return;
       }
 

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -203,10 +203,9 @@ namespace iroha {
           log_->debug("Found in cache: {}", **found);
           has_final_status = iroha::visit_in_place(
               (*found)->get(),
-              [](const shared_model::interface::CommittedTxResponse &) {
-                return true;
-              },
-              [](const shared_model::interface::RejectedTxResponse &) {
+              [](const auto &final_responses)
+                  -> std::enable_if_t<
+                      FinalStatusValue<decltype(final_responses), bool>> {
                 return true;
               },
               [](const auto &rest_responses) { return false; });
@@ -218,9 +217,8 @@ namespace iroha {
       }
 
       if (has_final_status) {
-        // if the transaction or batch has appeared in the cache with final
-        // status this guarantees the transaction was passed to a consensus
-        // before
+        // presence of the transaction or batch in the cache with final status
+        // guarantees that the transaction was passed to consensus before
         log_->warn("Replayed batch would not be served - present in cache. {}",
                    *batch);
         return;


### PR DESCRIPTION
Signed-off-by: Fedor Muratov <muratovfyodor@yandex.ru>

### Description of the Change
Fix bug when not committed/rejected transaction will not pass to Iroha's pipeline because it is a "replay".

### Benefits
Add fix for the problem. The idea of the fix to check only final statuses in the ram cache in command service. If there is a final status we will decline further checking of the transaction. Also, thanks @lebdron for cooperation in founding the bug.


### Possible Drawbacks 
Lack of tests. I hope we will discuss with reviewers about how to write the correct test for the situation.

