### PR TITLE
* Add checking of persistent cache on start status stream

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -129,7 +129,7 @@ namespace iroha {
       using ResponsePtrType =
           std::shared_ptr<shared_model::interface::TransactionResponse>;
       auto initial_status = cache_->findItem(hash).value_or([&] {
-        // if cache_ didn't contain some status there is required to check
+        // if cache_ doesn't contain some status there is required to check
         // persistent cache
 
         log_->debug("tx {} don't present in cache", hash);

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -129,8 +129,29 @@ namespace iroha {
       using ResponsePtrType =
           std::shared_ptr<shared_model::interface::TransactionResponse>;
       auto initial_status = cache_->findItem(hash).value_or([&] {
-        log_->debug("tx is not received: {}", hash);
-        return status_factory_->makeNotReceived(hash);
+        // if cache_ didn't contain some status there is required to check
+        // persistent cache
+
+        log_->debug("tx {} don't present in cache", hash);
+        auto from_persistent_cache = tx_presence_cache_->check(hash);
+        if (not from_persistent_cache) {
+          // TODO andrei 30.11.18 IR-51 Handle database error
+          log_->warn("Check hash presence database error. {}", hash);
+          return status_factory_->makeNotReceived(hash);
+        }
+        return iroha::visit_in_place(
+            *from_persistent_cache,
+            [this,
+             &hash](const iroha::ametsuchi::tx_cache_status_responses::Committed
+                        &) { return status_factory_->makeCommitted(hash); },
+            [this, &hash](
+                const iroha::ametsuchi::tx_cache_status_responses::Rejected &) {
+              return status_factory_->makeRejected(hash);
+            },
+            [this, &hash](
+                const iroha::ametsuchi::tx_cache_status_responses::Missing &) {
+              return status_factory_->makeNotReceived(hash);
+            });
       }());
       return status_bus_
           ->statuses()

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -132,7 +132,7 @@ namespace iroha {
         // if cache_ doesn't contain some status there is required to check
         // persistent cache
 
-        log_->debug("tx {} don't present in cache", hash);
+        log_->debug("tx {} isn't present in cache", hash);
         auto from_persistent_cache = tx_presence_cache_->check(hash);
         if (not from_persistent_cache) {
           // TODO andrei 30.11.18 IR-51 Handle database error

--- a/irohad/torii/impl/command_service_impl.hpp
+++ b/irohad/torii/impl/command_service_impl.hpp
@@ -24,6 +24,7 @@ namespace iroha {
      */
     class CommandServiceImpl : public CommandService {
      public:
+      // TODO: 2019-03-13 @muratovv fix with abstract cache type IR-397
       using CacheType = iroha::cache::Cache<
           shared_model::crypto::Hash,
           std::shared_ptr<shared_model::interface::TransactionResponse>,

--- a/test/module/irohad/torii/CMakeLists.txt
+++ b/test/module/irohad/torii/CMakeLists.txt
@@ -56,3 +56,11 @@ target_link_libraries(command_service_replay_test
     torii_service
     test_logger
     )
+
+addtest(command_service_test
+        command_service_test.cpp
+        )
+target_link_libraries(command_service_test
+        torii_service
+        test_logger
+        )

--- a/test/module/irohad/torii/CMakeLists.txt
+++ b/test/module/irohad/torii/CMakeLists.txt
@@ -58,9 +58,9 @@ target_link_libraries(command_service_replay_test
     )
 
 addtest(command_service_test
-        command_service_test.cpp
-        )
+    command_service_test.cpp
+    )
 target_link_libraries(command_service_test
-        torii_service
-        test_logger
-        )
+    torii_service
+    test_logger
+    )

--- a/test/module/irohad/torii/command_service_test.cpp
+++ b/test/module/irohad/torii/command_service_test.cpp
@@ -37,7 +37,7 @@ class CommandServiceTest : public Test {
     log_ = getTestLogger("CommandServiceTest");
   }
 
-  void bindCommandService() {
+  void initCommandService() {
     command_service_ = std::make_shared<iroha::torii::CommandServiceImpl>(
         transaction_processor_,
         storage_,
@@ -69,7 +69,6 @@ class CommandServiceTest : public Test {
 TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
   using HashType = shared_model::crypto::Hash;
   auto hash = HashType("a");
-  auto opt_hash = boost::optional<HashType>("a");
   iroha::ametsuchi::TxCacheStatusType ret_value{
       iroha::ametsuchi::tx_cache_status_responses::Committed{hash}};
 
@@ -80,11 +79,10 @@ TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
       .Times(1)
       .WillOnce(Return(ret_value));
   EXPECT_CALL(*status_bus_, statuses())
-      .Times(2)
       .WillRepeatedly(Return(
           rxcpp::observable<>::empty<iroha::torii::StatusBus::Objects>()));
 
-  bindCommandService();
+  initCommandService();
   auto wrapper = framework::test_subscriber::make_test_subscriber<
       framework::test_subscriber::CallExact>(
       command_service_->getStatusStream(hash), 1);

--- a/test/module/irohad/torii/command_service_test.cpp
+++ b/test/module/irohad/torii/command_service_test.cpp
@@ -64,7 +64,7 @@ class CommandServiceTest : public Test {
  *        @and hash with passed consensus but not present in runtime cache
  * @when  invoke getStatusStream by hash
  * @then  verify that code checks run-time and persistent caches for the hash
- *        @and return notReceived status
+ *        @and return CommittedTxResponse status
  */
 TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
   using HashType = shared_model::crypto::Hash;
@@ -87,6 +87,12 @@ TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
   bindCommandService();
   auto wrapper = framework::test_subscriber::make_test_subscriber<
       framework::test_subscriber::CallExact>(
-      command_service_->getStatusStream(hash), 0);
+      command_service_->getStatusStream(hash), 1);
+  wrapper.subscribe([](const auto &tx_response) {
+    return iroha::visit_in_place(
+        tx_response->get(),
+        [](const shared_model::interface::CommittedTxResponse &) {},
+        [](const auto &a) { FAIL() << "Wrong response!"; });
+  });
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/torii/command_service_test.cpp
+++ b/test/module/irohad/torii/command_service_test.cpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "torii/impl/command_service_impl.hpp"
+
+#include <gtest/gtest.h>
+#include "backend/protobuf/proto_tx_status_factory.hpp"
+#include "cryptography/hash.hpp"
+#include "cryptography/public_key.hpp"
+#include "framework/test_logger.hpp"
+#include "framework/test_subscriber.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
+#include "module/irohad/ametsuchi/mock_storage.hpp"
+#include "module/irohad/ametsuchi/mock_tx_presence_cache.hpp"
+#include "module/irohad/torii/torii_mocks.hpp"
+#include "module/shared_model/interface_mocks.hpp"
+
+using namespace testing;
+
+class CommandServiceTest : public Test {
+ public:
+  void SetUp() override {
+    transaction_processor_ =
+        std::make_shared<iroha::torii::MockTransactionProcessor>();
+    storage_ = std::make_shared<iroha::ametsuchi::MockStorage>();
+
+    status_bus_ = std::make_shared<iroha::torii::MockStatusBus>();
+
+    tx_status_factory_ =
+        std::make_shared<shared_model::proto::ProtoTxStatusFactory>();
+    cache_ = std::make_shared<iroha::torii::CommandServiceImpl::CacheType>();
+    tx_presence_cache_ =
+        std::make_shared<iroha::ametsuchi::MockTxPresenceCache>();
+
+    log_ = getTestLogger("CommandServiceTest");
+  }
+
+  void bindCommandService() {
+    command_service_ = std::make_shared<iroha::torii::CommandServiceImpl>(
+        transaction_processor_,
+        storage_,
+        status_bus_,
+        tx_status_factory_,
+        cache_,
+        tx_presence_cache_,
+        log_);
+  }
+
+  std::shared_ptr<iroha::torii::MockTransactionProcessor>
+      transaction_processor_;
+  std::shared_ptr<iroha::ametsuchi::MockStorage> storage_;
+  std::shared_ptr<iroha::torii::MockStatusBus> status_bus_;
+  std::shared_ptr<shared_model::interface::TxStatusFactory> tx_status_factory_;
+  std::shared_ptr<iroha::ametsuchi::MockTxPresenceCache> tx_presence_cache_;
+  logger::LoggerPtr log_;
+  std::shared_ptr<iroha::torii::CommandServiceImpl::CacheType> cache_;
+  std::shared_ptr<iroha::torii::CommandService> command_service_;
+};
+
+/**
+ * @given intialized command service
+ *        @and hash with passed consensus but not present in runtime cache
+ * @when  invoke getStatusStream by hash
+ * @then  verify that code checks run-time and persistent caches for the hash
+ *        @and return notReceived status
+ */
+TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
+  using HashType = shared_model::crypto::Hash;
+  auto hash = HashType("a");
+  auto opt_hash = boost::optional<HashType>("a");
+  iroha::ametsuchi::TxCacheStatusType ret_value{
+      iroha::ametsuchi::tx_cache_status_responses::Committed{hash}};
+
+  // TODO: 2019-03-13 @muratovv add expect call for runtime cache invocation
+  // IR-397
+  EXPECT_CALL(*tx_presence_cache_,
+              check(Matcher<const shared_model::crypto::Hash &>(_)))
+      .Times(1)
+      .WillOnce(Return(ret_value));
+  EXPECT_CALL(*status_bus_, statuses())
+      .Times(2)
+      .WillRepeatedly(
+          Return(rxcpp::observable<>::create<iroha::torii::StatusBus::Objects>(
+              [](auto s) { s.on_completed(); })));
+
+  bindCommandService();
+  auto wrapper = framework::test_subscriber::make_test_subscriber<
+      framework::test_subscriber::CallExact>(
+      command_service_->getStatusStream(hash), 0);
+  ASSERT_TRUE(wrapper.validate());
+}

--- a/test/module/irohad/torii/command_service_test.cpp
+++ b/test/module/irohad/torii/command_service_test.cpp
@@ -81,9 +81,8 @@ TEST_F(CommandServiceTest, getStatusStreamWithAbsentHash) {
       .WillOnce(Return(ret_value));
   EXPECT_CALL(*status_bus_, statuses())
       .Times(2)
-      .WillRepeatedly(
-          Return(rxcpp::observable<>::create<iroha::torii::StatusBus::Objects>(
-              [](auto s) { s.on_completed(); })));
+      .WillRepeatedly(Return(
+          rxcpp::observable<>::empty<iroha::torii::StatusBus::Objects>()));
 
   bindCommandService();
   auto wrapper = framework::test_subscriber::make_test_subscriber<

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -18,7 +18,6 @@
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
 #include "interfaces/transaction.hpp"
 
-
 // TODO: 2019-01-18 @muratovv Separate file by classes IR-229
 struct MockBlock : public shared_model::interface::Block {
   MOCK_CONST_METHOD0(txsNumber,
@@ -112,6 +111,14 @@ struct MockTransactionBatch : public shared_model::interface::TransactionBatch {
   MOCK_CONST_METHOD0(clone, MockTransactionBatch *());
 };
 
+namespace shared_model {
+  namespace interface {
+    std::ostream &operator<<(std::ostream &os, const TransactionBatch &resp) {
+      return os << resp.toString();
+    }
+  }  // namespace interface
+}  // namespace shared_model
+
 /**
  * Creates mock batch with provided hash
  * @param hash -- const ref to reduced hash to be returned by the batch
@@ -180,8 +187,10 @@ struct MockPeer : public shared_model::interface::Peer {
 inline auto makePeer(const std::string &address,
                      const shared_model::crypto::PublicKey &pub_key) {
   auto peer = std::make_shared<MockPeer>();
-  EXPECT_CALL(*peer, address()).WillRepeatedly(testing::ReturnRefOfCopy(address));
-  EXPECT_CALL(*peer, pubkey()).WillRepeatedly(testing::ReturnRefOfCopy(pub_key));
+  EXPECT_CALL(*peer, address())
+      .WillRepeatedly(testing::ReturnRefOfCopy(address));
+  EXPECT_CALL(*peer, pubkey())
+      .WillRepeatedly(testing::ReturnRefOfCopy(pub_key));
   return peer;
 }
 
@@ -234,21 +243,21 @@ struct MockCommonObjectsFactory
 };
 
 struct MockDomain : public shared_model::interface::Domain {
-    MOCK_CONST_METHOD0(domainId,
-                       shared_model::interface::types::DomainIdType &());
-    MOCK_CONST_METHOD0(defaultRole,
-                       shared_model::interface::types::RoleIdType &());
-    MOCK_CONST_METHOD0(clone, MockDomain *());
+  MOCK_CONST_METHOD0(domainId,
+                     shared_model::interface::types::DomainIdType &());
+  MOCK_CONST_METHOD0(defaultRole,
+                     shared_model::interface::types::RoleIdType &());
+  MOCK_CONST_METHOD0(clone, MockDomain *());
 };
 
 struct MockAccount : public shared_model::interface::Account {
-    MOCK_CONST_METHOD0(accountId,
-                       shared_model::interface::types::AccountIdType &());
-    MOCK_CONST_METHOD0(domainId,
-                       shared_model::interface::types::DomainIdType &());
-    MOCK_CONST_METHOD0(quorum, shared_model::interface::types::QuorumType());
-    MOCK_CONST_METHOD0(jsonData, shared_model::interface::types::JsonType &());
-    MOCK_CONST_METHOD0(clone, MockAccount *());
+  MOCK_CONST_METHOD0(accountId,
+                     shared_model::interface::types::AccountIdType &());
+  MOCK_CONST_METHOD0(domainId,
+                     shared_model::interface::types::DomainIdType &());
+  MOCK_CONST_METHOD0(quorum, shared_model::interface::types::QuorumType());
+  MOCK_CONST_METHOD0(jsonData, shared_model::interface::types::JsonType &());
+  MOCK_CONST_METHOD0(clone, MockAccount *());
 };
 
 #endif  // IROHA_SHARED_MODEL_INTERFACE_MOCKS_HPP


### PR DESCRIPTION
Signed-off-by: Fedor Muratov <muratovfyodor@yandex.ru>

### Description of the Change
Add fix for status stream initialization. If runtime cache doesn't contain any value we are going to check the persistent cache for the value.

### Benefits
Fix misleading behavior.

### Possible Drawbacks 
Possible to improve tests.