### PR TITLE
Fix hash set usage in OS. Fix block leaks in YacGate and Simulator

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -55,6 +55,9 @@ namespace iroha {
 
         if (not event.round_data) {
           current_block_ = boost::none;
+          // previous block is committed to block storage, it is safe to clear
+          // the cache
+          consensus_result_cache_->release();
           log_->debug("Agreed on nothing to commit");
         } else {
           current_block_ = event.round_data->block;

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -57,6 +57,8 @@ namespace iroha {
           current_block_ = boost::none;
           // previous block is committed to block storage, it is safe to clear
           // the cache
+          // TODO 2019-03-15 andrei: IR-405 Subscribe BlockLoaderService to
+          // BlockCreator::onBlock
           consensus_result_cache_->release();
           log_->debug("Agreed on nothing to commit");
         } else {

--- a/irohad/ordering/CMakeLists.txt
+++ b/irohad/ordering/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(on_demand_ordering_service
     on_demand_common
     tbb
     mst_hash
+    mst_state
     shared_model_interfaces
     consensus_round
     logger

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -9,14 +9,13 @@
 #include "ordering/on_demand_ordering_service.hpp"
 
 #include <map>
-#include <queue>
 #include <shared_mutex>
-#include <unordered_map>
 
 #include <tbb/concurrent_unordered_set.h>
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/hash.hpp"
+#include "multi_sig_transactions/state/mst_state.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 
 namespace iroha {
@@ -27,8 +26,9 @@ namespace iroha {
     namespace detail {
       using BatchSetType = tbb::concurrent_unordered_set<
           transport::OdOsNotification::TransactionBatchType,
-          model::PointerBatchHasher>;
-    }
+          model::PointerBatchHasher,
+          BatchHashEquality>;
+    }  // namespace detail
 
     class OnDemandOrderingServiceImpl : public OnDemandOrderingService {
      public:

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -15,6 +15,7 @@
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/hash.hpp"
+// TODO 2019-03-15 andrei: IR-403 Separate BatchHashEquality and MstState
 #include "multi_sig_transactions/state/mst_state.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -149,6 +149,7 @@ namespace iroha {
                                             rejected_hashes);
       crypto_signer_->sign(*block);
 
+      // TODO 2019-03-15 andrei: IR-404 Make last_block an explicit dependency
       last_block.reset();
 
       return block;

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -149,6 +149,8 @@ namespace iroha {
                                             rejected_hashes);
       crypto_signer_->sign(*block);
 
+      last_block.reset();
+
       return block;
     }
 


### PR DESCRIPTION
### Description of the Change
- Fix duplicate transactions in proposals due to missing `BatchHashEquality` comparator
- Fix block leaks in Simulator and YacGate

### Benefits
- No duplicate transactions in proposals
- Less memory usage

### Possible Drawbacks 
None

### Usage Examples or Tests
YacGateTest.CacheReleased, OnDemandOsTest.DuplicateTxTest
