### PR TITLE
Fix key padding in tests

### DIFF
--- a/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
@@ -17,6 +17,8 @@ namespace iroha {
   namespace consensus {
     namespace yac {
 
+      // TODO 15.03.2019 mboldyrev IR-402
+      // fix the tests that impose requirements on mock public key format
       std::string padPubKeyString(const std::string &str) {
         using shared_model::crypto::DefaultCryptoAlgorithmType;
         assert(str.size() <= DefaultCryptoAlgorithmType::kPublicKeyLength);

--- a/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
@@ -17,6 +17,14 @@ namespace iroha {
   namespace consensus {
     namespace yac {
 
+      std::string padPubKeyString(const std::string &str) {
+        using shared_model::crypto::DefaultCryptoAlgorithmType;
+        assert(str.size() <= DefaultCryptoAlgorithmType::kPublicKeyLength);
+        std::string padded(DefaultCryptoAlgorithmType::kPublicKeyLength, '0');
+        std::copy(str.begin(), str.end(), padded.begin());
+        return padded;
+      }
+
       /**
        * Creates test signature with empty signed data, and provided pubkey
        * @param pub_key - public key to put in the signature
@@ -24,15 +32,10 @@ namespace iroha {
        */
       std::shared_ptr<shared_model::interface::Signature> createSig(
           const std::string &pub_key) {
-        auto tmp =
-            shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()
-                .publicKey();
-        std::string key(tmp.blob().size(), '0');
-        std::copy(pub_key.begin(), pub_key.end(), key.begin());
         auto sig = std::make_shared<MockSignature>();
         EXPECT_CALL(*sig, publicKey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::PublicKey(key)));
+                shared_model::crypto::PublicKey(padPubKeyString(pub_key))));
         EXPECT_CALL(*sig, signedData())
             .WillRepeatedly(
                 ::testing::ReturnRefOfCopy(shared_model::crypto::Signed("")));

--- a/test/module/irohad/consensus/yac/yac_test_util.hpp
+++ b/test/module/irohad/consensus/yac/yac_test_util.hpp
@@ -25,30 +25,33 @@ namespace iroha {
             .WillRepeatedly(::testing::ReturnRefOfCopy(address));
         EXPECT_CALL(*peer, pubkey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::interface::types::PubkeyType(address)));
+                shared_model::interface::types::PubkeyType(
+                    padPubKeyString(address))));
+
         return peer;
       }
 
       inline VoteMessage createVote(YacHash hash, const std::string &pub_key) {
         VoteMessage vote;
 
+        std::string padded_pub_key = padPubKeyString(pub_key);
         auto block_signature = std::make_shared<MockSignature>();
         EXPECT_CALL(*block_signature, publicKey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::PublicKey(pub_key)));
+                shared_model::crypto::PublicKey(padded_pub_key)));
         EXPECT_CALL(*block_signature, signedData())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::Signed(pub_key)));
+                shared_model::crypto::Signed(padded_pub_key)));
         hash.block_signature = block_signature;
         vote.hash = std::move(hash);
 
         auto signature = std::make_shared<MockSignature>();
         EXPECT_CALL(*signature, publicKey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::PublicKey(pub_key)));
+                shared_model::crypto::PublicKey(padded_pub_key)));
         EXPECT_CALL(*signature, signedData())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::Signed(pub_key)));
+                shared_model::crypto::Signed(padded_pub_key)));
 
         vote.signature = signature;
         return vote;


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change brings the keys in tests to a consistent padding scheme, which is necessary because keys generated in various ways can finally be compared somewhere. And when a public key occasionally gets checked by field validator, it must have a fixed length, so it is better to choose a padding scheme which makes keys of the required length.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Tests fixed. Padding done in single place.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Longer keys are harder to read.
