### PR TITLE
Resolve issue with unused tx_number field in block structure

### DIFF
--- a/shared_model/schema/block.proto
+++ b/shared_model/schema/block.proto
@@ -12,8 +12,6 @@ message Block_v1 {
   // everything that should be signed:
   message Payload {
     repeated Transaction transactions = 1;
-    uint32 tx_number = 2;  ///< The number of accepted transactions inside.
-                           ///< Maximum 16384 or 2^14.
     uint64 height = 3;          ///< The current block number in a ledger.
     string prev_block_hash = 4;  ///< Previous block hash.
     uint64 created_time = 5;


### PR DESCRIPTION
### Description of the Change
An used variable tx_number was present in the block schema. It was not used anywhere in the code so I removed it (One of the "good first issues" - IR157)

### Benefits
Less space will be used by a block.

### Possible Drawbacks 
None
