### PR TITLE
Replace TransportBuilder with ProtoBlocksQueryFactory in QueryService

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -285,6 +285,18 @@ void Irohad::initFactories() {
                                                  shared_model::proto::Query>>(
       std::move(query_validator), std::move(proto_query_validator));
 
+  auto blocks_query_validator = std::make_unique<
+      shared_model::validation::DefaultSignedBlocksQueryValidator>();
+  auto proto_blocks_query_validator =
+      std::make_unique<shared_model::validation::ProtoBlocksQueryValidator>();
+
+  blocks_query_factory =
+      std::make_shared<shared_model::proto::ProtoTransportFactory<
+          shared_model::interface::BlocksQuery,
+          shared_model::proto::BlocksQuery>>(
+          std::move(blocks_query_validator),
+          std::move(proto_blocks_query_validator));
+
   log_->info("[Init] => factories");
 }
 
@@ -595,7 +607,10 @@ void Irohad::initQueryService() {
       query_service_log_manager->getChild("Processor")->getLogger());
 
   query_service = std::make_shared<::torii::QueryService>(
-      query_processor, query_factory, query_service_log_manager->getLogger());
+      query_processor,
+      query_factory,
+      blocks_query_factory,
+      query_service_log_manager->getLogger());
 
   log_->info("[Init] => query service");
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -8,6 +8,7 @@
 
 #include "consensus/consensus_block_cache.hpp"
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
+#include "interfaces/queries/blocks_query.hpp"
 #include "interfaces/queries/query.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
@@ -246,6 +247,12 @@ class Irohad {
       shared_model::interface::Query,
       iroha::protocol::Query>>
       query_factory;
+
+  // blocks query factory
+  std::shared_ptr<shared_model::interface::AbstractTransportFactory<
+      shared_model::interface::BlocksQuery,
+      iroha::protocol::BlocksQuery>>
+      blocks_query_factory;
 
   // persistent cache
   std::shared_ptr<iroha::ametsuchi::TxPresenceCache> persistent_cache;

--- a/irohad/torii/query_service.hpp
+++ b/irohad/torii/query_service.hpp
@@ -38,10 +38,15 @@ namespace iroha {
           shared_model::interface::AbstractTransportFactory<
               shared_model::interface::Query,
               iroha::protocol::Query>;
+      using BlocksQueryFactoryType =
+          shared_model::interface::AbstractTransportFactory<
+              shared_model::interface::BlocksQuery,
+              iroha::protocol::BlocksQuery>;
 
       QueryService(
           std::shared_ptr<iroha::torii::QueryProcessor> query_processor,
           std::shared_ptr<QueryFactoryType> query_factory,
+          std::shared_ptr<BlocksQueryFactoryType> blocks_query_factory,
           logger::LoggerPtr log);
 
       QueryService(const QueryService &) = delete;
@@ -68,6 +73,7 @@ namespace iroha {
      private:
       std::shared_ptr<iroha::torii::QueryProcessor> query_processor_;
       std::shared_ptr<QueryFactoryType> query_factory_;
+      std::shared_ptr<BlocksQueryFactoryType> blocks_query_factory_;
 
       // TODO 18.02.2019 lebdron: IR-336 Replace cache
       iroha::cache::Cache<shared_model::crypto::Hash,

--- a/shared_model/validators/blocks_query_validator.hpp
+++ b/shared_model/validators/blocks_query_validator.hpp
@@ -16,7 +16,8 @@ namespace shared_model {
      * @tparam FieldValidator - field validator type
      */
     template <typename FieldValidator>
-    class BlocksQueryValidator {
+    class BlocksQueryValidator
+        : public AbstractValidator<interface::BlocksQuery> {
      public:
       BlocksQueryValidator(
           const FieldValidator &field_validator = FieldValidator())

--- a/shared_model/validators/protobuf/proto_query_validator.cpp
+++ b/shared_model/validators/protobuf/proto_query_validator.cpp
@@ -55,5 +55,10 @@ namespace shared_model {
       return validateProtoQuery(query);
     }
 
+    Answer ProtoBlocksQueryValidator::validate(
+        const iroha::protocol::BlocksQuery &) const {
+      return {};
+    }
+
   }  // namespace validation
 }  // namespace shared_model

--- a/shared_model/validators/protobuf/proto_query_validator.hpp
+++ b/shared_model/validators/protobuf/proto_query_validator.hpp
@@ -19,6 +19,12 @@ namespace shared_model {
       Answer validate(const iroha::protocol::Query &query) const override;
     };
 
+    class ProtoBlocksQueryValidator
+        : public AbstractValidator<iroha::protocol::BlocksQuery> {
+     public:
+      Answer validate(const iroha::protocol::BlocksQuery &) const override;
+    };
+
   }  // namespace validation
 }  // namespace shared_model
 

--- a/test/fuzzing/find_fuzz.cpp
+++ b/test/fuzzing/find_fuzz.cpp
@@ -60,8 +60,23 @@ struct QueryFixture {
             shared_model::interface::Query,
             shared_model::proto::Query>>(std::move(query_validator),
                                          std::move(proto_query_validator));
+
+    auto blocks_query_validator = std::make_unique<
+        shared_model::validation::DefaultSignedBlocksQueryValidator>();
+    auto proto_blocks_query_validator =
+        std::make_unique<shared_model::validation::ProtoBlocksQueryValidator>();
+    auto blocks_query_factory =
+        std::make_shared<shared_model::proto::ProtoTransportFactory<
+            shared_model::interface::BlocksQuery,
+            shared_model::proto::BlocksQuery>>(
+            std::move(blocks_query_validator),
+            std::move(proto_blocks_query_validator));
+
     service_ = std::make_shared<iroha::torii::QueryService>(
-        qry_processor_, query_factory, logger::getDummyLoggerPtr());
+        qry_processor_,
+        query_factory,
+        blocks_query_factory,
+        logger::getDummyLoggerPtr());
   }
 };
 

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -52,11 +52,26 @@ class QueryServiceTest : public ::testing::Test {
         shared_model::interface::Query,
         shared_model::proto::Query>>(std::move(query_validator),
                                      std::move(proto_query_validator));
+
+    auto blocks_query_validator = std::make_unique<
+        shared_model::validation::DefaultSignedBlocksQueryValidator>();
+    auto proto_blocks_query_validator =
+        std::make_unique<shared_model::validation::ProtoBlocksQueryValidator>();
+
+    blocks_query_factory =
+        std::make_shared<shared_model::proto::ProtoTransportFactory<
+            shared_model::interface::BlocksQuery,
+            shared_model::proto::BlocksQuery>>(
+            std::move(blocks_query_validator),
+            std::move(proto_blocks_query_validator));
   }
 
   void init() {
-    query_service = std::make_shared<QueryService>(
-        query_processor, query_factory, getTestLogger("QueryService"));
+    query_service =
+        std::make_shared<QueryService>(query_processor,
+                                       query_factory,
+                                       blocks_query_factory,
+                                       getTestLogger("QueryService"));
   }
 
   std::unique_ptr<shared_model::interface::QueryResponse> getResponse() {
@@ -67,6 +82,7 @@ class QueryServiceTest : public ::testing::Test {
   std::shared_ptr<shared_model::proto::Query> query;
   std::shared_ptr<QueryService> query_service;
   std::shared_ptr<QueryService::QueryFactoryType> query_factory;
+  std::shared_ptr<QueryService::BlocksQueryFactoryType> blocks_query_factory;
   std::shared_ptr<MockQueryProcessor> query_processor;
 };
 

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -84,8 +84,10 @@ class ToriiQueriesTest : public testing::Test {
     //----------- Server run ----------------
     initQueryFactory();
     runner
-        ->append(std::make_unique<QueryService>(
-            qpi, query_factory, getTestLogger("QueryService")))
+        ->append(std::make_unique<QueryService>(qpi,
+                                                query_factory,
+                                                blocks_query_factory,
+                                                getTestLogger("QueryService")))
         .run()
         .match(
             [this](iroha::expected::Value<int> port) {
@@ -111,6 +113,18 @@ class ToriiQueriesTest : public testing::Test {
         shared_model::interface::Query,
         shared_model::proto::Query>>(std::move(query_validator),
                                      std::move(proto_query_validator));
+
+    auto blocks_query_validator = std::make_unique<
+        shared_model::validation::DefaultSignedBlocksQueryValidator>();
+    auto proto_blocks_query_validator =
+        std::make_unique<shared_model::validation::ProtoBlocksQueryValidator>();
+
+    blocks_query_factory =
+        std::make_shared<shared_model::proto::ProtoTransportFactory<
+            shared_model::interface::BlocksQuery,
+            shared_model::proto::BlocksQuery>>(
+            std::move(blocks_query_validator),
+            std::move(proto_blocks_query_validator));
   }
 
   std::unique_ptr<ServerRunner> runner;
@@ -127,6 +141,7 @@ class ToriiQueriesTest : public testing::Test {
   std::shared_ptr<shared_model::interface::QueryResponseFactory>
       query_response_factory;
   std::shared_ptr<QueryService::QueryFactoryType> query_factory;
+  std::shared_ptr<QueryService::BlocksQueryFactoryType> blocks_query_factory;
 
   const std::string ip = "127.0.0.1";
   int port;


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Remove legacy code.

### Benefits

A step towards bug resolution with maximum batch size.


### Possible Drawbacks 

Unknown

### Usage Examples or Tests 

query_service_test
find_fuzzing
torii_queries_test
torii_service_query_test


