### PR TITLE
Fix/sh m race init

### DIFF
--- a/irohad/ametsuchi/impl/flat_file_block_storage.cpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.cpp
@@ -39,10 +39,6 @@ bool FlatFileBlockStorage::insert(
       });
 }
 
-bool FlatFileBlockStorage::insert(const shared_model::interface::Block &block) {
-  return insert(clone(block));
-}
-
 boost::optional<std::shared_ptr<const shared_model::interface::Block>>
 FlatFileBlockStorage::fetch(
     shared_model::interface::types::HeightType height) const {

--- a/irohad/ametsuchi/impl/flat_file_block_storage.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.hpp
@@ -27,8 +27,6 @@ namespace iroha {
       bool insert(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      bool insert(const shared_model::interface::Block &block) override;
-
       boost::optional<std::shared_ptr<const shared_model::interface::Block>>
       fetch(shared_model::interface::types::HeightType height) const override;
 

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -36,6 +36,8 @@ namespace shared_model {
       bool addSignature(const crypto::Signed &signed_blob,
                         const crypto::PublicKey &public_key) override;
 
+      const interface::types::HashType &hash() const override;
+
       interface::types::TimestampType createdTime() const override;
 
       interface::types::TransactionsNumberType txsNumber() const override;

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -57,6 +57,8 @@ namespace shared_model {
 
       interface::types::BlobType payload_blob_{
           [this] { return makeBlob(payload_); }()};
+
+      interface::types::HashType hash_ = makeHash(payload_blob_);
     };
 
     Block::Block(Block &&o) noexcept = default;
@@ -113,6 +115,10 @@ namespace shared_model {
                                                   signatures.end());
       }();
       return true;
+    }
+
+    const interface::types::HashType &Block::hash() const {
+      return impl_->hash_;
     }
 
     interface::types::TimestampType Block::createdTime() const {

--- a/shared_model/backend/protobuf/impl/transaction.cpp
+++ b/shared_model/backend/protobuf/impl/transaction.cpp
@@ -62,6 +62,8 @@ namespace shared_model {
         return SignatureSetType<proto::Signature>(signatures.begin(),
                                                   signatures.end());
       }()};
+
+      interface::types::HashType hash_ = makeHash(payload_blob_);
     };  // namespace proto
 
     Transaction::Transaction(const TransportType &transaction) {
@@ -140,6 +142,10 @@ namespace shared_model {
       }();
 
       return true;
+    }
+
+    const interface::types::HashType &Transaction::hash() const {
+      return impl_->hash_;
     }
 
     const Transaction::TransportType &Transaction::getTransport() const {

--- a/shared_model/backend/protobuf/impl/transaction.cpp
+++ b/shared_model/backend/protobuf/impl/transaction.cpp
@@ -38,8 +38,7 @@ namespace shared_model {
       interface::types::BlobType reduced_payload_blob_{
           [this] { return makeBlob(reduced_payload_); }()};
 
-      interface::types::HashType reduced_hash_{
-          shared_model::crypto::Sha3_256::makeHash(reduced_payload_blob_)};
+      interface::types::HashType reduced_hash_{makeHash(reduced_payload_blob_)};
 
       std::vector<proto::Command> commands_{
           reduced_payload_.mutable_commands()->begin(),
@@ -63,7 +62,7 @@ namespace shared_model {
                                                   signatures.end());
       }()};
 
-      interface::types::HashType hash_ = makeHash(payload_blob_);
+      interface::types::HashType hash_{makeHash(payload_blob_)};
     };  // namespace proto
 
     Transaction::Transaction(const TransportType &transaction) {

--- a/shared_model/backend/protobuf/proto_transport_factory.hpp
+++ b/shared_model/backend/protobuf/proto_transport_factory.hpp
@@ -48,6 +48,8 @@ namespace shared_model {
           if (payload_field_descriptor) {
             const auto &payload =
                 m.GetReflection()->GetMessage(m, payload_field_descriptor);
+            // TODO: 2019-03-21 @muratovv refactor with template parameter
+            // IR-422
             hash = HashProvider::makeHash(makeBlob(payload));
           }
           return iroha::expected::makeError(Error{hash, answer.reason()});

--- a/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
@@ -20,7 +20,8 @@ namespace shared_model {
               set.emplace(proto_->signature());
             }
             return set;
-          }()} {}
+          }()},
+          hash_(makeHash(payload_)) {}
 
     template BlocksQuery::BlocksQuery(BlocksQuery::TransportType &);
     template BlocksQuery::BlocksQuery(const BlocksQuery::TransportType &);
@@ -64,6 +65,10 @@ namespace shared_model {
       // TODO: nickaleks IR-120 12.12.2018 remove set
       signatures_.emplace(proto_->signature());
       return true;
+    }
+
+    const interface::types::HashType &BlocksQuery::hash() const {
+      return hash_;
     }
 
     interface::types::TimestampType BlocksQuery::createdTime() const {

--- a/shared_model/backend/protobuf/queries/impl/proto_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query.cpp
@@ -75,7 +75,7 @@ namespace shared_model {
         return set;
       }()};
 
-      interface::types::HashType hash_ = makeHash(blob_);
+      interface::types::HashType hash_ = makeHash(payload_);
     };
 
     Query::Query(const Query &o) : Query(o.impl_->proto_) {}

--- a/shared_model/backend/protobuf/queries/impl/proto_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query.cpp
@@ -74,6 +74,8 @@ namespace shared_model {
         }
         return set;
       }()};
+
+      interface::types::HashType hash_ = makeHash(blob_);
     };
 
     Query::Query(const Query &o) : Query(o.impl_->proto_) {}
@@ -125,6 +127,10 @@ namespace shared_model {
       impl_->signatures_ =
           SignatureSetType<proto::Signature>{proto::Signature{*sig}};
       return true;
+    }
+
+    const interface::types::HashType &Query::hash() const {
+      return impl_->hash_;
     }
 
     interface::types::TimestampType Query::createdTime() const {

--- a/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
@@ -38,6 +38,8 @@ namespace shared_model {
       bool addSignature(const crypto::Signed &signed_blob,
                         const crypto::PublicKey &public_key) override;
 
+      const interface::types::HashType &hash() const override;
+
       interface::types::TimestampType createdTime() const override;
 
      private:
@@ -47,6 +49,8 @@ namespace shared_model {
       const interface::types::BlobType payload_;
 
       SignatureSetType<proto::Signature> signatures_;
+
+      interface::types::HashType hash_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -41,6 +41,8 @@ namespace shared_model {
       bool addSignature(const crypto::Signed &signed_blob,
                         const crypto::PublicKey &public_key) override;
 
+      const interface::types::HashType &hash() const override;
+
       interface::types::TimestampType createdTime() const override;
 
       const TransportType &getTransport() const;

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -44,6 +44,8 @@ namespace shared_model {
       bool addSignature(const crypto::Signed &signed_blob,
                         const crypto::PublicKey &public_key) override;
 
+      const interface::types::HashType &hash() const override;
+
       const TransportType &getTransport() const;
 
       interface::types::TimestampType createdTime() const override;

--- a/shared_model/cryptography/blob.hpp
+++ b/shared_model/cryptography/blob.hpp
@@ -72,7 +72,6 @@ namespace shared_model {
       Blob *clone() const override;
 
      private:
-      // TODO: 17/11/2017 luckychess use improved Lazy with references support
       Bytes blob_;
       std::string hex_;
     };

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -84,12 +84,7 @@ namespace shared_model {
         return this->hash() == rhs.hash();
       }
 
-      virtual const types::HashType &hash() const {
-        if (hash_ == boost::none) {
-          hash_.emplace(HashProvider::makeHash(payload()));
-        }
-        return *hash_;
-      }
+      virtual const types::HashType &hash() const = 0;
 
       // ------------------------| Primitive override |-------------------------
 
@@ -139,8 +134,10 @@ namespace shared_model {
       using SignatureSetType =
           std::unordered_set<T, SignatureSetTypeOps, SignatureSetTypeOps>;
 
-     private:
-      mutable boost::optional<types::HashType> hash_;
+     protected:
+      static auto makeHash(const types::BlobType &payload) {
+        return HashProvider::makeHash(payload);
+      }
     };
 
   }  // namespace interface

--- a/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
@@ -19,7 +19,12 @@ namespace shared_model {
 
     TransactionBatchImpl::TransactionBatchImpl(
         types::SharedTxsCollectionType transactions)
-        : transactions_(std::move(transactions)) {}
+        : transactions_(std::move(transactions)) {
+      reduced_hash_ = TransactionBatchHelpers::calculateReducedBatchHash(
+          transactions_ | boost::adaptors::transformed([](const auto &tx) {
+            return tx->reducedHash();
+          }));
+    }
 
     const types::SharedTxsCollectionType &TransactionBatchImpl::transactions()
         const {
@@ -27,13 +32,7 @@ namespace shared_model {
     }
 
     const types::HashType &TransactionBatchImpl::reducedHash() const {
-      if (not reduced_hash_) {
-        reduced_hash_ = TransactionBatchHelpers::calculateReducedBatchHash(
-            transactions_ | boost::adaptors::transformed([](const auto &tx) {
-              return tx->reducedHash();
-            }));
-      }
-      return reduced_hash_.value();
+      return reduced_hash_;
     }
 
     bool TransactionBatchImpl::hasAllSignatures() const {

--- a/shared_model/interfaces/iroha_internal/transaction_batch_impl.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_impl.hpp
@@ -40,7 +40,7 @@ namespace shared_model {
      private:
       types::SharedTxsCollectionType transactions_;
 
-      mutable boost::optional<types::HashType> reduced_hash_;
+      types::HashType reduced_hash_;
     };
 
   }  // namespace interface

--- a/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
+++ b/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
@@ -108,8 +108,14 @@ TEST_F(TxPresenceCacheTest, MissingThenCommittedHashTest) {
  */
 TEST_F(TxPresenceCacheTest, BatchHashTest) {
   shared_model::crypto::Hash hash1("1");
+  shared_model::crypto::Hash reduced_hash_1("r1");
+
   shared_model::crypto::Hash hash2("2");
+  shared_model::crypto::Hash reduced_hash_2("r2");
+
   shared_model::crypto::Hash hash3("3");
+  shared_model::crypto::Hash reduced_hash_3("r3");
+
   EXPECT_CALL(*mock_block_query, checkTxPresence(hash1))
       .WillOnce(Return(boost::make_optional<TxCacheStatusType>(
           tx_cache_status_responses::Rejected(hash1))));
@@ -121,13 +127,13 @@ TEST_F(TxPresenceCacheTest, BatchHashTest) {
           tx_cache_status_responses::Missing(hash3))));
   auto tx1 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx1, hash()).WillOnce(ReturnRefOfCopy(hash1));
-  EXPECT_CALL(*tx1, reducedHash()).WillOnce(ReturnRefOfCopy(hash1));
+  EXPECT_CALL(*tx1, reducedHash()).WillOnce(ReturnRefOfCopy(reduced_hash_1));
   auto tx2 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx2, hash()).WillOnce(ReturnRefOfCopy(hash2));
-  EXPECT_CALL(*tx2, reducedHash()).WillOnce(ReturnRefOfCopy(hash2));
+  EXPECT_CALL(*tx2, reducedHash()).WillOnce(ReturnRefOfCopy(reduced_hash_2));
   auto tx3 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx3, hash()).WillOnce(ReturnRefOfCopy(hash3));
-  EXPECT_CALL(*tx3, reducedHash()).WillOnce(ReturnRefOfCopy(hash3));
+  EXPECT_CALL(*tx3, reducedHash()).WillOnce(ReturnRefOfCopy(reduced_hash_3));
 
   shared_model::interface::types::SharedTxsCollectionType txs{tx1, tx2, tx3};
   TxPresenceCacheImpl cache(mock_storage);

--- a/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
+++ b/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
@@ -121,10 +121,13 @@ TEST_F(TxPresenceCacheTest, BatchHashTest) {
           tx_cache_status_responses::Missing(hash3))));
   auto tx1 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx1, hash()).WillOnce(ReturnRefOfCopy(hash1));
+  EXPECT_CALL(*tx1, reducedHash()).WillOnce(ReturnRefOfCopy(hash1));
   auto tx2 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx2, hash()).WillOnce(ReturnRefOfCopy(hash2));
+  EXPECT_CALL(*tx2, reducedHash()).WillOnce(ReturnRefOfCopy(hash2));
   auto tx3 = std::make_shared<MockTransaction>();
   EXPECT_CALL(*tx3, hash()).WillOnce(ReturnRefOfCopy(hash3));
+  EXPECT_CALL(*tx3, reducedHash()).WillOnce(ReturnRefOfCopy(hash3));
 
   shared_model::interface::types::SharedTxsCollectionType txs{tx1, tx2, tx3};
   TxPresenceCacheImpl cache(mock_storage);

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -59,6 +59,8 @@ class YacGateTest : public ::testing::Test {
     auto prev_hash = Hash("prev hash");
     EXPECT_CALL(*block, prevHash())
         .WillRepeatedly(testing::ReturnRefOfCopy(prev_hash));
+    EXPECT_CALL(*block, hash())
+        .WillRepeatedly(testing::ReturnRefOfCopy(prev_hash));
     expected_block = block;
 
     auto signature = std::make_shared<MockSignature>();

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -57,10 +57,11 @@ class YacGateTest : public ::testing::Test {
         .WillRepeatedly(
             Return<shared_model::interface::types::SignatureRangeType>({}));
     auto prev_hash = Hash("prev hash");
+    auto current_hash = Hash("current hash");
     EXPECT_CALL(*block, prevHash())
         .WillRepeatedly(testing::ReturnRefOfCopy(prev_hash));
     EXPECT_CALL(*block, hash())
-        .WillRepeatedly(testing::ReturnRefOfCopy(prev_hash));
+        .WillRepeatedly(testing::ReturnRefOfCopy(current_hash));
     expected_block = block;
 
     auto signature = std::make_shared<MockSignature>();

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -47,6 +47,9 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   EXPECT_CALL(*block, payload())
       .WillRepeatedly(
           ReturnRefOfCopy(shared_model::crypto::Blob(std::string())));
+  EXPECT_CALL(*block, hash())
+      .WillRepeatedly(
+          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
 
   EXPECT_CALL(*block, signatures())
       .WillRepeatedly(
@@ -86,6 +89,9 @@ TEST(YacHashProviderTest, ToModelHashTest) {
                          std::shared_ptr<shared_model::interface::Signature>>>(
                          1, signature()))
                  | boost::adaptors::indirected));
+  EXPECT_CALL(*block, hash())
+      .WillRepeatedly(
+          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
 
   auto yac_hash = hash_provider.makeHash(iroha::simulator::BlockCreatorEvent{
       iroha::simulator::RoundData{proposal, block}, round});

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -53,6 +53,9 @@ class ChainValidationTest : public ::testing::Test {
         .WillRepeatedly(Return(signatures | boost::adaptors::indirected));
     EXPECT_CALL(*block, payload())
         .WillRepeatedly(ReturnRefOfCopy(shared_model::crypto::Blob{"blob"}));
+    EXPECT_CALL(*block, hash())
+        .WillRepeatedly(
+            testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
   }
 
   std::shared_ptr<iroha::consensus::yac::MockSupermajorityChecker>

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -41,6 +41,7 @@ struct MockBlock : public shared_model::interface::Block {
   MOCK_METHOD2(addSignature,
                bool(const shared_model::crypto::Signed &,
                     const shared_model::crypto::PublicKey &));
+  MOCK_CONST_METHOD0(hash, const shared_model::interface::types::HashType &());
   MOCK_CONST_METHOD0(clone, MockBlock *());
 };
 


### PR DESCRIPTION
### Description of the Change
The PR bring fixes in shared_model initialization:
* remove lazy initialization in Signable and TransactionBatchImpl
* remove redundant todo from blob.hpp

Also, PR contains fixes of the current develop branch. The fix could be moved in separate PR by reviewer's request.

### Benefits
Fix potential race in sh_m.