### PR TITLE
Remove redefinitions of redundant method in flat file storage

### DIFF
--- a/irohad/ametsuchi/impl/flat_file_block_storage.cpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.cpp
@@ -39,10 +39,6 @@ bool FlatFileBlockStorage::insert(
       });
 }
 
-bool FlatFileBlockStorage::insert(const shared_model::interface::Block &block) {
-  return insert(clone(block));
-}
-
 boost::optional<std::shared_ptr<const shared_model::interface::Block>>
 FlatFileBlockStorage::fetch(
     shared_model::interface::types::HeightType height) const {

--- a/irohad/ametsuchi/impl/flat_file_block_storage.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.hpp
@@ -27,8 +27,6 @@ namespace iroha {
       bool insert(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      bool insert(const shared_model::interface::Block &block) override;
-
       boost::optional<std::shared_ptr<const shared_model::interface::Block>>
       fetch(shared_model::interface::types::HeightType height) const override;
 


### PR DESCRIPTION
### Description of the Change
Remove redundant definition of the insert in flat file block storage.

### Benefits
Improve the stability of the project.
