### PR TITLE
Add option to load peers from a file on startup

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -267,7 +267,7 @@ namespace iroha {
     }
 
     bool StorageImpl::insertPeer(const shared_model::interface::Peer &peer) {
-      log_->info("insert peer {}", peer.pubkey().hex());
+      log_->info("Insert peer {}", peer.pubkey().hex());
       soci::session sql(*connection_);
       PostgresWsvCommand wsv_command(sql);
       auto status = wsv_command.insertPeer(peer);
@@ -295,12 +295,12 @@ namespace iroha {
     }
 
     void StorageImpl::resetPeers() {
-      log_->info("remove everything from peers table");
+      log_->info("Remove everything from peers table");
       try {
         soci::session sql(*connection_);
         sql << reset_peers_;
       } catch (std::exception &e) {
-        log_->warn("peers reset failed, reason: {}", e.what());
+        log_->error("Failed to reset peers list, reason: {}", e.what());
       }
     }
 
@@ -492,10 +492,11 @@ namespace iroha {
                                 log_manager_->getChild("WsvQuery")->getLogger())
                    .getPeers()
             | [&storage](auto &&peers) {
-                return boost::optional<std::unique_ptr<LedgerState>>(
-                    std::make_unique<LedgerState>(
-                        std::make_shared<PeerList>(std::move(peers)),
-                        storage->getTopBlockHeight()));
+                return boost::optional<
+                    std::unique_ptr<LedgerState>>(std::make_unique<LedgerState>(
+                    std::make_shared<shared_model::interface::types::PeerList>(
+                        std::move(peers)),
+                    storage->getTopBlockHeight()));
               };
       } catch (std::exception &e) {
         storage->committed = false;
@@ -544,7 +545,8 @@ namespace iroha {
                 log_manager_->getChild("PostgresBlockQuery")->getLogger());
             return boost::optional<std::unique_ptr<LedgerState>>(
                 std::make_unique<LedgerState>(
-                    std::make_shared<PeerList>(std::move(peers)),
+                    std::make_shared<shared_model::interface::types::PeerList>(
+                        std::move(peers)),
                     block_query.getTopBlockHeight()));
           }
           return boost::none;

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -95,7 +95,11 @@ namespace iroha {
           const std::vector<std::shared_ptr<shared_model::interface::Block>>
               &blocks) override;
 
+      bool insertPeer(const shared_model::interface::Peer &peer) override;
+
       void reset() override;
+
+      void resetPeers() override;
 
       void dropStorage() override;
 
@@ -188,6 +192,7 @@ namespace iroha {
      protected:
       static const std::string &drop_;
       static const std::string &reset_;
+      static const std::string &reset_peers_;
       static const std::string &init_;
     };
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/ledger_state.hpp
+++ b/irohad/ametsuchi/ledger_state.hpp
@@ -12,13 +12,11 @@
 #include "interfaces/common_objects/types.hpp"
 
 namespace iroha {
-  using PeerList = std::vector<std::shared_ptr<shared_model::interface::Peer>>;
-
   struct LedgerState {
-    std::shared_ptr<PeerList> ledger_peers;
+    std::shared_ptr<shared_model::interface::types::PeerList> ledger_peers;
     shared_model::interface::types::HeightType height;
 
-    LedgerState(std::shared_ptr<PeerList> peers,
+    LedgerState(std::shared_ptr<shared_model::interface::types::PeerList> peers,
                 shared_model::interface::types::HeightType height)
         : ledger_peers(std::move(peers)), height(height) {}
   };

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -61,6 +61,13 @@ namespace iroha {
               &blocks) = 0;
 
       /**
+       * Inserts peer into WSV
+       * @param peer - peer to insert
+       * @return true if inserted
+       */
+      virtual bool insertPeer(const shared_model::interface::Peer &peer) = 0;
+
+      /**
        * method called when block is written to the storage
        * @return observable with the Block committed
        */
@@ -72,6 +79,11 @@ namespace iroha {
        * Remove all records from the tables and remove all the blocks
        */
       virtual void reset() = 0;
+
+      /**
+       * Removes all saved peers
+       */
+      virtual void resetPeers() = 0;
 
       /**
        * Remove all information from ledger

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -61,7 +61,7 @@ namespace iroha {
               &blocks) = 0;
 
       /**
-       * Inserts peer into WSV
+       * Insert a peer into WSV
        * @param peer - peer to insert
        * @return true if inserted
        */
@@ -81,7 +81,7 @@ namespace iroha {
       virtual void reset() = 0;
 
       /**
-       * Removes all saved peers
+       * Removes all peers from WSV
        */
       virtual void resetPeers() = 0;
 

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -21,6 +21,12 @@ target_link_libraries(raw_block_loader
     logger
     )
 
+add_library(peers_file_reader impl/peers_file_reader_impl.cpp)
+target_link_libraries(peers_file_reader
+    shared_model_interfaces
+    parser
+    )
+
 add_library(application
     application.cpp
     # TODO andrei 08.11.2018 IR-1851 Create separate targets for initialization
@@ -61,6 +67,7 @@ add_executable(irohad irohad.cpp)
 target_link_libraries(irohad
     application
     raw_block_loader
+    peers_file_reader
     gflags
     rapidjson
     keys_manager

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -75,23 +75,22 @@ static constexpr iroha::consensus::yac::ConsistencyModel
 /**
  * Configuring iroha daemon
  */
-Irohad::Irohad(
-    const std::string &block_store_dir,
-    const std::string &pg_conn,
-    const std::string &listen_ip,
-    size_t torii_port,
-    size_t internal_port,
-    size_t max_proposal_size,
-    std::chrono::milliseconds proposal_delay,
-    std::chrono::milliseconds vote_delay,
-    std::chrono::minutes mst_expiration_time,
-    const shared_model::crypto::Keypair &keypair,
-    std::chrono::milliseconds max_rounds_delay,
-    size_t stale_stream_max_rounds,
-    std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers,
-    logger::LoggerManagerTreePtr logger_manager,
-    const boost::optional<GossipPropagationStrategyParams>
-        &opt_mst_gossip_params)
+Irohad::Irohad(const std::string &block_store_dir,
+               const std::string &pg_conn,
+               const std::string &listen_ip,
+               size_t torii_port,
+               size_t internal_port,
+               size_t max_proposal_size,
+               std::chrono::milliseconds proposal_delay,
+               std::chrono::milliseconds vote_delay,
+               std::chrono::minutes mst_expiration_time,
+               const shared_model::crypto::Keypair &keypair,
+               std::chrono::milliseconds max_rounds_delay,
+               size_t stale_stream_max_rounds,
+               shared_model::interface::types::PeerList alternative_peers,
+               logger::LoggerManagerTreePtr logger_manager,
+               const boost::optional<GossipPropagationStrategyParams>
+                   &opt_mst_gossip_params)
     : block_store_dir_(block_store_dir),
       pg_conn_(pg_conn),
       listen_ip_(listen_ip),
@@ -104,7 +103,7 @@ Irohad::Irohad(
       mst_expiration_time_(mst_expiration_time),
       max_rounds_delay_(max_rounds_delay),
       stale_stream_max_rounds_(stale_stream_max_rounds),
-      initial_peers_(std::move(initial_peers)),
+      alternative_peers_(std::move(alternative_peers)),
       opt_mst_gossip_params_(opt_mst_gossip_params),
       keypair(keypair),
       ordering_init(logger_manager->getLogger()),
@@ -210,11 +209,10 @@ bool Irohad::restoreWsv() {
 
 bool Irohad::updatePeers() {
   // drop old peers and insert new ones if --peers flag is set
-  if (not initial_peers_.empty()) {
+  if (not alternative_peers_.empty()) {
     storage->resetPeers();
-    for (const auto &peer : initial_peers_) {
+    for (const auto &peer : alternative_peers_) {
       if (not storage->insertPeer(*peer)) {
-        log_->error("Peer insertion failed");
         return false;
       }
     }
@@ -738,7 +736,9 @@ Irohad::RunResult Irohad::run() {
                 [](auto &&peer_query) { return peer_query->getLedgerPeers(); };
 
             auto initial_ledger_state = std::make_shared<LedgerState>(
-                std::make_unique<PeerList>(peers.value()), block->height());
+                std::make_unique<shared_model::interface::types::PeerList>(
+                    peers.value()),
+                block->height());
 
             pcs->onSynchronization().subscribe(
                 ordering_init.sync_event_notifier.get_subscriber());

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -93,26 +93,29 @@ class Irohad {
    * transactions
    * @param stale_stream_max_rounds - maximum number of rounds between
    * consecutive status emissions
+   *
    * @param logger_manager - the logger manager to use
    * @param opt_mst_gossip_params - parameters for Gossip MST propagation
    * (optional). If not provided, disables mst processing support
    * TODO mboldyrev 03.11.2018 IR-1844 Refactor the constructor.
    */
-  Irohad(const std::string &block_store_dir,
-         const std::string &pg_conn,
-         const std::string &listen_ip,
-         size_t torii_port,
-         size_t internal_port,
-         size_t max_proposal_size,
-         std::chrono::milliseconds proposal_delay,
-         std::chrono::milliseconds vote_delay,
-         std::chrono::minutes mst_expiration_time,
-         const shared_model::crypto::Keypair &keypair,
-         std::chrono::milliseconds max_rounds_delay,
-         size_t stale_stream_max_rounds,
-         logger::LoggerManagerTreePtr logger_manager,
-         const boost::optional<iroha::GossipPropagationStrategyParams>
-             &opt_mst_gossip_params = boost::none);
+  Irohad(
+      const std::string &block_store_dir,
+      const std::string &pg_conn,
+      const std::string &listen_ip,
+      size_t torii_port,
+      size_t internal_port,
+      size_t max_proposal_size,
+      std::chrono::milliseconds proposal_delay,
+      std::chrono::milliseconds vote_delay,
+      std::chrono::minutes mst_expiration_time,
+      const shared_model::crypto::Keypair &keypair,
+      std::chrono::milliseconds max_rounds_delay,
+      size_t stale_stream_max_rounds,
+      std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers,
+      logger::LoggerManagerTreePtr logger_manager,
+      const boost::optional<iroha::GossipPropagationStrategyParams>
+          &opt_mst_gossip_params = boost::none);
 
   /**
    * Initialization of whole objects in system
@@ -124,6 +127,8 @@ class Irohad {
    * @return true on success, false otherwise
    */
   bool restoreWsv();
+
+  bool updatePeers();
 
   /**
    * Drop wsv and block store
@@ -197,6 +202,7 @@ class Irohad {
   std::chrono::minutes mst_expiration_time_;
   std::chrono::milliseconds max_rounds_delay_;
   size_t stale_stream_max_rounds_;
+  std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers_;
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -93,29 +93,28 @@ class Irohad {
    * transactions
    * @param stale_stream_max_rounds - maximum number of rounds between
    * consecutive status emissions
-   *
+   * @param alternative_peers - alternative peer list
    * @param logger_manager - the logger manager to use
    * @param opt_mst_gossip_params - parameters for Gossip MST propagation
    * (optional). If not provided, disables mst processing support
    * TODO mboldyrev 03.11.2018 IR-1844 Refactor the constructor.
    */
-  Irohad(
-      const std::string &block_store_dir,
-      const std::string &pg_conn,
-      const std::string &listen_ip,
-      size_t torii_port,
-      size_t internal_port,
-      size_t max_proposal_size,
-      std::chrono::milliseconds proposal_delay,
-      std::chrono::milliseconds vote_delay,
-      std::chrono::minutes mst_expiration_time,
-      const shared_model::crypto::Keypair &keypair,
-      std::chrono::milliseconds max_rounds_delay,
-      size_t stale_stream_max_rounds,
-      std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers,
-      logger::LoggerManagerTreePtr logger_manager,
-      const boost::optional<iroha::GossipPropagationStrategyParams>
-          &opt_mst_gossip_params = boost::none);
+  Irohad(const std::string &block_store_dir,
+         const std::string &pg_conn,
+         const std::string &listen_ip,
+         size_t torii_port,
+         size_t internal_port,
+         size_t max_proposal_size,
+         std::chrono::milliseconds proposal_delay,
+         std::chrono::milliseconds vote_delay,
+         std::chrono::minutes mst_expiration_time,
+         const shared_model::crypto::Keypair &keypair,
+         std::chrono::milliseconds max_rounds_delay,
+         size_t stale_stream_max_rounds,
+         shared_model::interface::types::PeerList alternative_peers,
+         logger::LoggerManagerTreePtr logger_manager,
+         const boost::optional<iroha::GossipPropagationStrategyParams>
+             &opt_mst_gossip_params = boost::none);
 
   /**
    * Initialization of whole objects in system
@@ -128,6 +127,10 @@ class Irohad {
    */
   bool restoreWsv();
 
+  /**
+   * Replaces peers in WSV by external provided peers list if any
+   * @return true on success
+   */
   bool updatePeers();
 
   /**
@@ -202,7 +205,7 @@ class Irohad {
   std::chrono::minutes mst_expiration_time_;
   std::chrono::milliseconds max_rounds_delay_;
   size_t stale_stream_max_rounds_;
-  std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers_;
+  shared_model::interface::types::PeerList alternative_peers_;
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 

--- a/irohad/main/impl/peers_file_reader_impl.cpp
+++ b/irohad/main/impl/peers_file_reader_impl.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "peers_file_reader_impl.hpp"
+
+#include <fstream>
+
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "parser/parser.hpp"
+
+using namespace iroha::main;
+
+boost::optional<std::string> PeersFileReaderImpl::openFile(
+    const std::string &name) {
+  std::ifstream file(name);
+  if (not file) {
+    return boost::none;
+  }
+
+  std::string str((std::istreambuf_iterator<char>(file)),
+                  std::istreambuf_iterator<char>());
+  return str;
+}
+
+boost::optional<std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+PeersFileReaderImpl::readPeers(
+    const std::string &peers_data,
+    std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        common_objects_factory) {
+  auto strings = parser::split(peers_data);
+  if (strings.size() % 2 != 0) {
+    return boost::none;
+  }
+
+  std::vector<std::unique_ptr<shared_model::interface::Peer>> peers{};
+
+  for (uint32_t i = 0; i < strings.size(); i += 2) {
+    shared_model::interface::types::AddressType address = strings.at(i);
+    shared_model::interface::types::PubkeyType key(
+        shared_model::interface::types::PubkeyType::fromHexString(
+            strings.at(i + 1)));
+    auto peer = common_objects_factory->createPeer(address, key);
+
+    if (auto e = boost::get<expected::Error<std::string>>(&peer)) {
+      return boost::none;
+    }
+
+    peers.emplace_back(std::move(
+        boost::get<
+            expected::Value<std::unique_ptr<shared_model::interface::Peer>>>(
+            &peer)
+            ->value));
+  }
+  return boost::make_optional<
+      std::vector<std::unique_ptr<shared_model::interface::Peer>>>(
+      std::move(peers));
+}

--- a/irohad/main/impl/peers_file_reader_impl.hpp
+++ b/irohad/main/impl/peers_file_reader_impl.hpp
@@ -12,13 +12,22 @@ namespace iroha {
   namespace main {
     class PeersFileReaderImpl : public PeersFileReader {
      public:
-      boost::optional<std::string> openFile(const std::string &name) override;
+      /**
+       * Creates new PeersFileReaderImpl object
+       * @param common_objects_factory - factory to create peers
+       */
+      explicit PeersFileReaderImpl(
+          std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+              common_objects_factory);
 
-      boost::optional<
-          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
-      readPeers(const std::string &peers_data,
-                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-                    common_objects_factory) override;
+      expected::Result<shared_model::interface::types::PeerList, std::string>
+      readPeers(const std::string &name) override;
+
+     private:
+      boost::optional<std::string> openFile(const std::string &name);
+
+      std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+          common_objects_factory_;
     };
   }  // namespace main
 }  // namespace iroha

--- a/irohad/main/impl/peers_file_reader_impl.hpp
+++ b/irohad/main/impl/peers_file_reader_impl.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEERS_FILE_READER_IMPL_HPP
+#define IROHA_PEERS_FILE_READER_IMPL_HPP
+
+#include "main/peers_file_reader.hpp"
+
+namespace iroha {
+  namespace main {
+    class PeersFileReaderImpl : public PeersFileReader {
+     public:
+      boost::optional<std::string> openFile(const std::string &name) override;
+
+      boost::optional<
+          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+      readPeers(const std::string &peers_data,
+                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+                    common_objects_factory) override;
+    };
+  }  // namespace main
+}  // namespace iroha
+
+#endif  // IROHA_PEERS_FILE_READER_IMPL_HPP

--- a/irohad/main/peers_file_reader.hpp
+++ b/irohad/main/peers_file_reader.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEERS_FILE_READER_HPP
+#define IROHA_PEERS_FILE_READER_HPP
+
+#include <boost/optional.hpp>
+#include "interfaces/common_objects/common_objects_factory.hpp"
+#include "interfaces/common_objects/peer.hpp"
+
+namespace iroha {
+  namespace main {
+    /**
+     * Peers reader interface from a file
+     */
+    class PeersFileReader {
+     public:
+      /**
+       * Opens file with peers and returns its contents
+       * @param name - file name to open
+       * @return optional for a file contents or boost::none
+       */
+      virtual boost::optional<std::string> openFile(
+          const std::string &name) = 0;
+
+      /**
+       * Parses peers from a provided string
+       * @param peers_data - peers string to parse
+       * @param common_objects_factory - factory to create peers
+       * @return optional for collection of peers or boost::none
+       */
+      virtual boost::optional<
+          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+      readPeers(const std::string &peers_data,
+                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+                    common_objects_factory) = 0;
+    };
+  }  // namespace main
+}  // namespace iroha
+
+#endif  // IROHA_PEERS_FILE_READER_HPP

--- a/irohad/main/peers_file_reader.hpp
+++ b/irohad/main/peers_file_reader.hpp
@@ -18,24 +18,13 @@ namespace iroha {
     class PeersFileReader {
      public:
       /**
-       * Opens file with peers and returns its contents
-       * @param name - file name to open
-       * @return optional for a file contents or boost::none
-       */
-      virtual boost::optional<std::string> openFile(
-          const std::string &name) = 0;
-
-      /**
        * Parses peers from a provided string
-       * @param peers_data - peers string to parse
-       * @param common_objects_factory - factory to create peers
-       * @return optional for collection of peers or boost::none
+       * @param name - file to read peers from
+       * @return Result for collection of peers
        */
-      virtual boost::optional<
-          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
-      readPeers(const std::string &peers_data,
-                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
-                    common_objects_factory) = 0;
+      virtual expected::Result<shared_model::interface::types::PeerList,
+                               std::string>
+      readPeers(const std::string &name) = 0;
     };
   }  // namespace main
 }  // namespace iroha

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -25,6 +25,7 @@ namespace shared_model {
     class Signature;
     class Transaction;
     class AccountAsset;
+    class Peer;
 
     namespace types {
       /// Type of hash
@@ -57,8 +58,6 @@ namespace shared_model {
       using QuorumType = uint16_t;
       /// Type of timestamp
       using TimestampType = uint64_t;
-      /// Type of peer address
-      using AddressType = std::string;
       /// Type of counter
       using CounterType = uint64_t;
       /// Type of account name
@@ -77,6 +76,9 @@ namespace shared_model {
       using TransactionsNumberType = uint16_t;
       /// Type of the transfer message
       using DescriptionType = std::string;
+      /// Type of peers collection
+      using PeerList =
+          std::vector<std::shared_ptr<shared_model::interface::Peer>>;
 
       enum class BatchType { ATOMIC = 0, ORDERED = 1 };
 

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -78,7 +78,7 @@ namespace integration_framework {
 
   void IrohaInstance::initPipeline(
       const shared_model::crypto::Keypair &key_pair, size_t max_proposal_size) {
-    auto peers = std::vector<std::unique_ptr<shared_model::interface::Peer>>{};
+    shared_model::interface::types::PeerList alternative_peers{};
     instance_ = std::make_shared<TestIrohad>(block_store_dir_,
                                              pg_conn_,
                                              listen_ip_,
@@ -91,7 +91,7 @@ namespace integration_framework {
                                              key_pair,
                                              max_rounds_delay_,
                                              stale_stream_max_rounds_,
-                                             std::move(peers),
+                                             std::move(alternative_peers),
                                              irohad_log_manager_,
                                              log_,
                                              opt_mst_gossip_params_);

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -78,6 +78,7 @@ namespace integration_framework {
 
   void IrohaInstance::initPipeline(
       const shared_model::crypto::Keypair &key_pair, size_t max_proposal_size) {
+    auto peers = std::vector<std::unique_ptr<shared_model::interface::Peer>>{};
     instance_ = std::make_shared<TestIrohad>(block_store_dir_,
                                              pg_conn_,
                                              listen_ip_,
@@ -90,6 +91,7 @@ namespace integration_framework {
                                              key_pair,
                                              max_rounds_delay_,
                                              stale_stream_max_rounds_,
+                                             std::move(peers),
                                              irohad_log_manager_,
                                              log_,
                                              opt_mst_gossip_params_);

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -21,6 +21,7 @@
 namespace shared_model {
   namespace interface {
     class Block;
+    class Peer;
   }  // namespace interface
   namespace crypto {
     class Keypair;

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -28,6 +28,8 @@ namespace integration_framework {
                const shared_model::crypto::Keypair &keypair,
                std::chrono::milliseconds max_rounds_delay,
                size_t stale_stream_max_rounds,
+               std::vector<std::unique_ptr<shared_model::interface::Peer>>
+                   initial_peers,
                logger::LoggerManagerTreePtr irohad_log_manager,
                logger::LoggerPtr log,
                const boost::optional<iroha::GossipPropagationStrategyParams>
@@ -44,6 +46,7 @@ namespace integration_framework {
                  keypair,
                  max_rounds_delay,
                  stale_stream_max_rounds,
+                 std::move(initial_peers),
                  std::move(irohad_log_manager),
                  opt_mst_gossip_params),
           log_(std::move(log)) {}

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -28,8 +28,7 @@ namespace integration_framework {
                const shared_model::crypto::Keypair &keypair,
                std::chrono::milliseconds max_rounds_delay,
                size_t stale_stream_max_rounds,
-               std::vector<std::unique_ptr<shared_model::interface::Peer>>
-                   initial_peers,
+               shared_model::interface::types::PeerList alternative_peers,
                logger::LoggerManagerTreePtr irohad_log_manager,
                logger::LoggerPtr log,
                const boost::optional<iroha::GossipPropagationStrategyParams>
@@ -46,7 +45,7 @@ namespace integration_framework {
                  keypair,
                  max_rounds_delay,
                  stale_stream_max_rounds,
-                 std::move(initial_peers),
+                 std::move(alternative_peers),
                  std::move(irohad_log_manager),
                  opt_mst_gossip_params),
           log_(std::move(log)) {}

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -45,7 +45,9 @@ namespace iroha {
       MOCK_METHOD1(insertBlocks,
                    bool(const std::vector<
                         std::shared_ptr<shared_model::interface::Block>> &));
+      MOCK_METHOD1(insertPeer, bool(const shared_model::interface::Peer &));
       MOCK_METHOD0(reset, void(void));
+      MOCK_METHOD0(resetPeers, void(void));
       MOCK_METHOD0(dropStorage, void(void));
       MOCK_METHOD0(freeConnections, void(void));
       MOCK_METHOD1(prepareBlock_, void(std::unique_ptr<TemporaryWsv> &));

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -98,7 +98,8 @@ class YacGateTest : public ::testing::Test {
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
     auto ledger_peers =
-        std::make_shared<iroha::PeerList>(iroha::PeerList{peer});
+        std::make_shared<shared_model::interface::types::PeerList>(
+            shared_model::interface::types::PeerList{peer});
     ledger_state = std::make_shared<iroha::LedgerState>(std::move(ledger_peers),
                                                         block->height());
   }

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -41,7 +41,9 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
+  auto ledger_peers =
+      std::make_shared<shared_model::interface::types::PeerList>(
+          shared_model::interface::types::PeerList{peer});
   auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
   auto proposal = std::make_shared<const MockProposal>();
   EXPECT_CALL(*proposal, hash())
@@ -78,7 +80,9 @@ TEST(YacHashProviderTest, ToModelHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
+  auto ledger_peers =
+      std::make_shared<shared_model::interface::types::PeerList>(
+          shared_model::interface::types::PeerList{peer});
   auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
   auto proposal = std::make_shared<MockProposal>();
   EXPECT_CALL(*proposal, hash())

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -58,7 +58,9 @@ class OnDemandOrderingGateTest : public ::testing::Test {
         getTestLogger("OrderingGate"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
+    auto ledger_peers =
+        std::make_shared<shared_model::interface::types::PeerList>(
+            shared_model::interface::types::PeerList{peer});
     ledger_state =
         std::make_shared<LedgerState>(ledger_peers, round.block_round);
   }

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -86,8 +86,10 @@ class SimulatorTest : public ::testing::Test {
   rxcpp::subjects::subject<OrderingEvent> ordering_events;
 
   std::shared_ptr<Simulator> simulator;
-  std::shared_ptr<PeerList> ledger_peers = std::make_shared<PeerList>(
-      PeerList{makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"))});
+  std::shared_ptr<shared_model::interface::types::PeerList> ledger_peers =
+      std::make_shared<shared_model::interface::types::PeerList>(
+          shared_model::interface::types::PeerList{
+              makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"))});
 };
 
 shared_model::proto::Block makeBlock(int height) {

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -64,7 +64,7 @@ class SynchronizerTest : public ::testing::Test {
     consensus_gate = std::make_shared<MockConsensusGate>();
     block_query = std::make_shared<::testing::NiceMock<MockBlockQuery>>();
 
-    ledger_peers = std::make_shared<PeerList>();
+    ledger_peers = std::make_shared<shared_model::interface::types::PeerList>();
     for (int i = 0; i < 3; ++i) {
       // TODO mboldyrev 21.03.2019 IR-424 Avoid using honest crypto
       ledger_peer_keys.emplace_back(
@@ -123,7 +123,7 @@ class SynchronizerTest : public ::testing::Test {
   std::shared_ptr<shared_model::interface::Block> commit_message;
   shared_model::interface::types::PublicKeyCollectionType public_keys;
   shared_model::interface::types::HashType hash;
-  std::shared_ptr<PeerList> ledger_peers;
+  std::shared_ptr<shared_model::interface::types::PeerList> ledger_peers;
   std::shared_ptr<LedgerState> ledger_state;
   std::vector<shared_model::crypto::Keypair> ledger_peer_keys;
 

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -65,7 +65,9 @@ class TransactionProcessorTest : public ::testing::Test {
         getTestLogger("TransactionProcessor"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
+    auto ledger_peers =
+        std::make_shared<shared_model::interface::types::PeerList>(
+            shared_model::interface::types::PeerList{peer});
     ledger_state =
         std::make_shared<LedgerState>(ledger_peers, round.block_round - 1);
   }


### PR DESCRIPTION
### Description of the Change

Pull request adds command line option to load peers list from a file on startup.

### Benefits

<!-- What benefits will be realized by the code change? -->

It could be useful in scenarios when many peers in a current network state are malicious.

### Possible Drawbacks 

- Usage of a potentially deprecated PostgresWsvCommand class
- Lack of tests for PeersFileReaderImpl (not sure should I add add them or not)

### Usage Examples or Tests 

Create file `peers` with line `127.0.0.1:10001 bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929` (feel free to add more peers) and
run `irohad` with option `--peers peers`
