### PR TITLE
Yac gate behaves itself when a commit message from the future arrives

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -130,7 +130,6 @@ namespace iroha {
               current_hash_.vote_round, current_ledger_state_, block));
         }
 
-        current_hash_ = hash;
         auto public_keys = boost::copy_range<
             shared_model::interface::types::PublicKeyCollectionType>(
             msg.votes | boost::adaptors::transformed([](auto &vote) {
@@ -141,17 +140,15 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->info("Consensus skipped round, voted for nothing");
           current_block_ = boost::none;
-          return rxcpp::observable<>::just<GateObject>(
-              AgreementOnNone(current_hash_.vote_round,
-                              current_ledger_state_,
-                              std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(AgreementOnNone(
+              hash.vote_round, current_ledger_state_, std::move(public_keys)));
         }
 
         log_->info("Voted for another block, waiting for sync");
         current_block_ = boost::none;
         auto model_hash = hash_provider_->toModelHash(hash);
         return rxcpp::observable<>::just<GateObject>(
-            VoteOther(current_hash_.vote_round,
+            VoteOther(hash.vote_round,
                       current_ledger_state_,
                       std::move(public_keys),
                       std::move(model_hash)));
@@ -182,16 +179,12 @@ namespace iroha {
                         });
         if (not has_same_proposals) {
           log_->info("Proposal reject since all hashes are different");
-          return rxcpp::observable<>::just<GateObject>(
-              ProposalReject(current_hash_.vote_round,
-                             current_ledger_state_,
-                             std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(ProposalReject(
+              hash.vote_round, current_ledger_state_, std::move(public_keys)));
         }
         log_->info("Block reject since proposal hashes match");
-        return rxcpp::observable<>::just<GateObject>(
-            BlockReject(current_hash_.vote_round,
-                        current_ledger_state_,
-                        std::move(public_keys)));
+        return rxcpp::observable<>::just<GateObject>(BlockReject(
+            hash.vote_round, current_ledger_state_, std::move(public_keys)));
       }
     }  // namespace yac
   }    // namespace consensus


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The case when a node is not voted yet but has received votes for a round is possible.
That was a root cause of a rare issue, when a node was not switched to the next round (when reject commit message arrived).
As a result, the whole network can stop working (if there are enough of that buggy peers).

The change brings the correct round number propagation from Yac gate to Synchronizer.
Thus the peer goes to the correct round despite what was happen or received.

The new tests are created (`yac_gate_test -> CommitFromTheFuture` tests)

### Benefits

Proper Yac gate behavior.

### Possible Drawbacks 

¯\(°_o)/¯

### Usage Examples or Tests 

`yac_gate_test`

