### PR TITLE
refactor iroha::expected::Result

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -129,9 +129,8 @@ int main(int argc, char *argv[]) {
         iroha::model::converters::PbBlockFactory().serialize(block).block_v1());
 
     shared_model::proto::ProtoBlockJsonConverter().serialize(bl).match(
-        [&logger,
-         &output_file](const iroha::expected::Value<std::string> &json) {
-          output_file << json.value;
+        [&logger, &output_file](auto &&json) {
+          output_file << std::move(json.value);
           logger->info("File saved to genesis.block");
         },
         [&logger](const auto &error) {

--- a/irohad/ametsuchi/impl/flat_file_block_storage.cpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.cpp
@@ -29,7 +29,7 @@ FlatFileBlockStorage::~FlatFileBlockStorage() {
 bool FlatFileBlockStorage::insert(
     std::shared_ptr<const shared_model::interface::Block> block) {
   return json_converter_->serialize(*block).match(
-      [&](const expected::Value<std::string> &block_json) {
+      [&](const auto &block_json) {
         return flat_file_storage_->add(block->height(),
                                        stringToBytes(block_json.value));
       },
@@ -49,13 +49,12 @@ FlatFileBlockStorage::fetch(
 
   return json_converter_->deserialize(bytesToString(*storage_block))
       .match(
-          [&](expected::Value<std::unique_ptr<shared_model::interface::Block>>
-                  &block) {
+          [&](auto &&block) {
             return boost::make_optional<
                 std::shared_ptr<const shared_model::interface::Block>>(
                 std::move(block.value));
           },
-          [&](expected::Error<std::string> &error)
+          [&](const auto &error)
               -> boost::optional<
                   std::shared_ptr<const shared_model::interface::Block>> {
             log_->warn("Error while block deserialization: {}", error.error);

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -55,12 +55,11 @@ namespace iroha {
           auto command_applied =
               boost::apply_visitor(*command_executor_, command.get());
 
-          return command_applied.match(
-              [](expected::Value<void> &) { return true; },
-              [&](expected::Error<CommandError> &e) {
-                log_->error(e.error.toString());
-                return false;
-              });
+          return command_applied.match([](const auto &) { return true; },
+                                       [&](const auto &e) {
+                                         log_->error(e.error.toString());
+                                         return false;
+                                       });
         };
 
         return std::all_of(transaction.commands().begin(),

--- a/irohad/ametsuchi/impl/postgres_block_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.cpp
@@ -48,14 +48,9 @@ namespace iroha {
         return result;
       }
       for (auto i = height; i <= to; i++) {
-        auto block = getBlock(i);
-        block.match(
-            [&result](
-                expected::Value<std::unique_ptr<shared_model::interface::Block>>
-                    &v) { result.emplace_back(std::move(v.value)); },
-            [this](const expected::Error<std::string> &e) {
-              log_->error(e.error);
-            });
+        getBlock(i).match(
+            [&result](auto &&v) { result.emplace_back(std::move(v.value)); },
+            [this](const auto &e) { log_->error(e.error); });
       }
       return result;
     }
@@ -107,13 +102,13 @@ namespace iroha {
     PostgresBlockQuery::getTopBlock() {
       return getBlock(block_store_.last_id())
           .match(
-              [](expected::Value<
-                  std::unique_ptr<shared_model::interface::Block>> &v)
+              [](auto &&v)
                   -> expected::Result<BlockQuery::wBlock, std::string> {
-                return expected::makeValue<BlockQuery::wBlock>(
+                return expected::makeValue<
+                    std::shared_ptr<shared_model::interface::Block>>(
                     std::move(v.value));
               },
-              [](expected::Error<std::string> &e)
+              [](auto &&e)
                   -> expected::Result<BlockQuery::wBlock, std::string> {
                 return expected::makeError(std::move(e.error));
               });

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -627,8 +627,7 @@ namespace iroha {
 
       return converter_->deserialize(bytesToString(*serialized_block))
           .match(
-              [this](iroha::expected::Value<
-                     std::unique_ptr<shared_model::interface::Block>> &block) {
+              [this](auto &&block) {
                 return this->query_response_factory_->createBlockResponse(
                     std::move(block.value), query_hash_);
               },

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -37,12 +37,11 @@ namespace iroha {
     boost::optional<std::shared_ptr<T>> PostgresWsvQuery::fromResult(
         shared_model::interface::CommonObjectsFactory::FactoryResult<
             std::unique_ptr<T>> &&result) {
-      return result.match(
-          [](iroha::expected::Value<std::unique_ptr<T>> &v) {
+      return std::move(result).match(
+          [](auto &&v) {
             return boost::make_optional(std::shared_ptr<T>(std::move(v.value)));
           },
-          [&](iroha::expected::Error<std::string> &e)
-              -> boost::optional<std::shared_ptr<T>> {
+          [&](const auto &e) -> boost::optional<std::shared_ptr<T>> {
             log_->error(e.error);
             return boost::none;
           });

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -107,8 +107,8 @@ namespace iroha {
           // in case of failed command, rollback and return
           auto cmd_is_valid =
               execute_command(commands[i])
-                  .match([](expected::Value<void> &) { return true; },
-                         [i, &cmd_error](expected::Error<CommandError> &error) {
+                  .match([](const auto &) { return true; },
+                         [i, &cmd_error](const auto &error) {
                            cmd_error = {error.error.command_name,
                                         error.error.error_code,
                                         error.error.error_extra,

--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
@@ -46,13 +46,8 @@ namespace iroha {
         // TODO 30.08.2018 andrei: IR-1670 Remove optional from YAC
         // CryptoProviderImpl::getVote
         factory_->createSignature(pubkey, signature)
-            .match(
-                [&](iroha::expected::Value<
-                    std::unique_ptr<shared_model::interface::Signature>> &sig) {
-                  vote.signature = std::move(sig.value);
-                },
-                [](iroha::expected::Error<std::string> &reason) {
-                });
+            .match([&](auto &&sig) { vote.signature = std::move(sig.value); },
+                   [](const auto &) {});
 
         return vote;
       }

--- a/irohad/consensus/yac/transport/yac_pb_converters.hpp
+++ b/irohad/consensus/yac/transport/yac_pb_converters.hpp
@@ -107,13 +107,10 @@ namespace iroha {
                 factory
                     .createSignature(shared_model::crypto::PublicKey(pubkey),
                                      shared_model::crypto::Signed(signature))
-                    .match(
-                        [&](iroha::expected::Value<
-                            std::unique_ptr<shared_model::interface::Signature>>
-                                &sig) { val = std::move(sig.value); },
-                        [&](iroha::expected::Error<std::string> &reason) {
-                          log->error(msg, reason.error);
-                        });
+                    .match([&](auto &&sig) { val = std::move(sig.value); },
+                           [&](const auto &reason) {
+                             log->error(msg, reason.error);
+                           });
               };
 
           if (pb_vote.hash().has_block_signature()) {

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
   // check if at least one block is available in the ledger
   auto blocks_exist = irohad.storage->getBlockQuery()->getTopBlock().match(
       [](const auto &) { return true; },
-      [](iroha::expected::Error<std::string> &) { return false; });
+      [](const auto &) { return false; });
 
   if (not blocks_exist) {
     log->error(

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -66,13 +66,12 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   }
   return proposal_factory_->build(response.proposal())
       .match(
-          [&](iroha::expected::Value<
-              std::unique_ptr<shared_model::interface::Proposal>> &v) {
+          [&](auto &&v) {
             return boost::make_optional(
                 std::shared_ptr<const OdOsNotification::ProposalType>(
                     std::move(v).value));
           },
-          [this](iroha::expected::Error<TransportFactoryType::Error> &error) {
+          [this](const auto &error) {
             log_->info(error.error.error);  // error
             return boost::optional<
                 std::shared_ptr<const OdOsNotification::ProposalType>>();

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -32,9 +32,8 @@ namespace iroha {
         validation::TransactionsErrors &transactions_errors_log,
         const shared_model::interface::Transaction &tx) {
       return temporary_wsv.apply(tx).match(
-          [](expected::Value<void> &) { return true; },
-          [&tx, &transactions_errors_log](
-              expected::Error<validation::CommandError> &error) {
+          [](const auto &) { return true; },
+          [&tx, &transactions_errors_log](auto &&error) {
             transactions_errors_log.emplace_back(validation::TransactionError{
                 tx.hash(), std::move(error.error)});
             return false;

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -81,10 +81,25 @@ namespace iroha {
        * @nocode
        */
       template <typename ValueMatch, typename ErrorMatch>
-      constexpr auto match(ValueMatch &&value_func, ErrorMatch &&error_func) {
+      constexpr auto match(ValueMatch &&value_func, ErrorMatch &&error_func) & {
         return visit_in_place(*this,
-                              std::forward<ValueMatch>(value_func),
-                              std::forward<ErrorMatch>(error_func));
+                              [f = std::forward<ValueMatch>(value_func)](
+                                  ValueType &v) { return f(v); },
+                              [f = std::forward<ErrorMatch>(error_func)](
+                                  ErrorType &e) { return f(e); });
+      }
+
+      /**
+       * Move alternative for match function
+       */
+      template <typename ValueMatch, typename ErrorMatch>
+      constexpr auto match(ValueMatch &&value_func,
+                           ErrorMatch &&error_func) && {
+        return visit_in_place(*this,
+                              [f = std::forward<ValueMatch>(value_func)](
+                                  ValueType &v) { return f(std::move(v)); },
+                              [f = std::forward<ErrorMatch>(error_func)](
+                                  ErrorType &e) { return f(std::move(e)); });
       }
 
       /**
@@ -92,10 +107,12 @@ namespace iroha {
        */
       template <typename ValueMatch, typename ErrorMatch>
       constexpr auto match(ValueMatch &&value_func,
-                           ErrorMatch &&error_func) const {
+                           ErrorMatch &&error_func) const & {
         return visit_in_place(*this,
-                              std::forward<ValueMatch>(value_func),
-                              std::forward<ErrorMatch>(error_func));
+                              [f = std::forward<ValueMatch>(value_func)](
+                                  const ValueType &v) { return f(v); },
+                              [f = std::forward<ErrorMatch>(error_func)](
+                                  const ErrorType &e) { return f(e); });
       }
 
       /**

--- a/shared_model/interfaces/iroha_internal/transaction_sequence_factory.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_sequence_factory.cpp
@@ -46,7 +46,9 @@ namespace shared_model {
       types::BatchesCollectionType batches;
       auto insert_batch =
           [&batches](iroha::expected::Value<std::unique_ptr<TransactionBatch>>
-                         &value) { batches.push_back(std::move(value.value)); };
+                         &&value) {
+            batches.push_back(std::move(value.value));
+          };
 
       validation::Answer result;
       if (transactions.empty()) {

--- a/test/framework/batch_helper.hpp
+++ b/test/framework/batch_helper.hpp
@@ -218,10 +218,8 @@ namespace framework {
           batch_validator);
       return batch_factory->createTransactionBatch(std::move(tx))
           .match(
-              [](iroha::expected::Value<std::unique_ptr<
-                     shared_model::interface::TransactionBatch>> &value)
-                  -> std::shared_ptr<
-                      shared_model::interface::TransactionBatch> {
+              [](auto &&value) -> std::shared_ptr<
+                                   shared_model::interface::TransactionBatch> {
                 return std::move(value.value);
               },
               [](const auto &err)

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -97,8 +97,8 @@ namespace integration_framework {
 
   void IrohaInstance::run() {
     instance_->run().match(
-        [](const Irohad::RunResult::ValueType &) {},
-        [](const Irohad::RunResult::ErrorType &error) {
+        [](const auto &) {},
+        [](const auto &error) {
           BOOST_THROW_EXCEPTION(std::runtime_error(error.error));
         });
   }

--- a/test/framework/sql_query.cpp
+++ b/test/framework/sql_query.cpp
@@ -41,12 +41,11 @@ namespace framework {
     boost::optional<std::shared_ptr<T>> SqlQuery::fromResult(
         shared_model::interface::CommonObjectsFactory::FactoryResult<
             std::unique_ptr<T>> &&result) {
-      return result.match(
-          [](iroha::expected::Value<std::unique_ptr<T>> &v) {
+      return std::move(result).match(
+          [](auto &&v) {
             return boost::make_optional(std::shared_ptr<T>(std::move(v.value)));
           },
-          [&](iroha::expected::Error<std::string> &e)
-              -> boost::optional<std::shared_ptr<T>> {
+          [&](const auto &e) -> boost::optional<std::shared_ptr<T>> {
             log_->error(e.error);
             return boost::none;
           });

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -54,9 +54,8 @@ namespace iroha {
                             perm_converter_,
                             std::move(block_storage_factory),
                             getTestLoggerManager()->getChild("Storage"))
-            .match([&](iroha::expected::Value<std::shared_ptr<StorageImpl>>
-                           &_storage) { storage = _storage.value; },
-                   [](iroha::expected::Error<std::string> &error) {
+            .match([&](const auto &_storage) { storage = _storage.value; },
+                   [](const auto &error) {
                      FAIL() << "StorageImpl: " << error.error;
                    });
         sql = std::make_shared<soci::session>(*soci::factory_postgresql(),

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -85,7 +85,7 @@ class BlockQueryTest : public AmetsuchiTest {
 
     for (const auto &b : {std::move(block1), std::move(block2)}) {
       converter->serialize(b).match(
-          [this, &b](const iroha::expected::Value<std::string> &json) {
+          [this, &b](const auto &json) {
             file->add(b.height(), iroha::stringToBytes(json.value));
             index->index(b);
             blocks_total++;

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -791,11 +791,9 @@ namespace iroha {
       void commitBlocks(shared_model::interface::types::HeightType
                             number_of_blocks = kLedgerHeight) {
         std::unique_ptr<MutableStorage> ms;
-        auto storageResult = storage->createMutableStorage();
-        storageResult.match(
-            [&ms](iroha::expected::Value<std::unique_ptr<MutableStorage>>
-                      &storage) { ms = std::move(storage.value); },
-            [](iroha::expected::Error<std::string> &error) {
+        storage->createMutableStorage().match(
+            [&ms](auto &&storage) { ms = std::move(storage.value); },
+            [](const auto &error) {
               FAIL() << "MutableStorage: " << error.error;
             });
 
@@ -1069,11 +1067,9 @@ namespace iroha {
       void apply(S &&storage,
                  std::shared_ptr<const shared_model::interface::Block> block) {
         std::unique_ptr<MutableStorage> ms;
-        auto storageResult = storage->createMutableStorage();
-        storageResult.match(
-            [&](iroha::expected::Value<std::unique_ptr<MutableStorage>>
-                    &_storage) { ms = std::move(_storage.value); },
-            [](iroha::expected::Error<std::string> &error) {
+        storage->createMutableStorage().match(
+            [&](auto &&_storage) { ms = std::move(_storage.value); },
+            [](const auto &error) {
               FAIL() << "MutableStorage: " << error.error;
             });
         ms->apply(block);

--- a/test/module/irohad/ametsuchi/storage_init_test.cpp
+++ b/test/module/irohad/ametsuchi/storage_init_test.cpp
@@ -91,11 +91,11 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
                       std::move(block_storage_factory_),
                       storage_log_manager_)
       .match(
-          [&storage](const Value<std::shared_ptr<StorageImpl>> &value) {
+          [&storage](const auto &value) {
             storage = value.value;
             SUCCEED();
           },
-          [](const Error<std::string> &error) { FAIL() << error.error; });
+          [](const auto &error) { FAIL() << error.error; });
   soci::session sql(*soci::factory_postgresql(), pg_opt_without_dbname_);
   int size;
   sql << "SELECT COUNT(datname) FROM pg_catalog.pg_database WHERE datname = "
@@ -120,9 +120,6 @@ TEST_F(StorageInitTest, CreateStorageWithInvalidPgOpt) {
                       perm_converter_,
                       std::move(block_storage_factory_),
                       storage_log_manager_)
-      .match(
-          [](const Value<std::shared_ptr<StorageImpl>> &) {
-            FAIL() << "storage created, but should not";
-          },
-          [](const Error<std::string> &) { SUCCEED(); });
+      .match([](const auto &) { FAIL() << "storage created, but should not"; },
+             [](const auto &) { SUCCEED(); });
 }

--- a/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
+++ b/test/module/irohad/ametsuchi/tx_presence_cache_test.cpp
@@ -154,8 +154,7 @@ TEST_F(TxPresenceCacheTest, BatchHashTest) {
                   }));
 
   batch_factory->createTransactionBatch(txs).match(
-      [&](iroha::expected::Value<
-          std::unique_ptr<shared_model::interface::TransactionBatch>> &batch) {
+      [&](const auto &batch) {
         auto batch_statuses = *cache.check(*batch.value);
         ASSERT_EQ(3, batch_statuses.size());
         tx_cache_status_responses::Rejected ts1;
@@ -171,7 +170,5 @@ TEST_F(TxPresenceCacheTest, BatchHashTest) {
         ASSERT_EQ(hash2, ts2.hash);
         ASSERT_EQ(hash3, ts3.hash);
       },
-      [&](iroha::expected::Error<std::string> &error) {
-        FAIL() << error.error;
-      });
+      [&](const auto &error) { FAIL() << error.error; });
 }

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -90,13 +90,8 @@ class ToriiQueriesTest : public testing::Test {
                                                 blocks_query_factory,
                                                 getTestLogger("QueryService")))
         .run()
-        .match(
-            [this](iroha::expected::Value<int> port) {
-              this->port = port.value;
-            },
-            [](iroha::expected::Error<std::string> err) {
-              FAIL() << err.error;
-            });
+        .match([this](auto port) { this->port = port.value; },
+               [](const auto &err) { FAIL() << err.error; });
 
     runner->waitForServersReady();
   }

--- a/test/module/irohad/torii/torii_service_query_test.cpp
+++ b/test/module/irohad/torii/torii_service_query_test.cpp
@@ -48,13 +48,8 @@ class ToriiQueryServiceTest : public ::testing::Test {
             blocks_query_factory,
             getTestLogger("QueryService")))
         .run()
-        .match(
-            [this](iroha::expected::Value<int> port) {
-              this->port = port.value;
-            },
-            [](iroha::expected::Error<std::string> err) {
-              FAIL() << err.error;
-            });
+        .match([this](auto port) { this->port = port.value; },
+               [](const auto &err) { FAIL() << err.error; });
 
     runner->waitForServersReady();
   }

--- a/test/module/shared_model/backend_proto/common_objects/proto_common_objects_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/common_objects/proto_common_objects_factory_test.cpp
@@ -38,11 +38,11 @@ TEST_F(PeerTest, ValidPeerInitialization) {
   auto peer = factory.createPeer(valid_address, valid_pubkey);
 
   peer.match(
-      [&](const ValueOf<decltype(peer)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->address(), valid_address);
         ASSERT_EQ(v.value->pubkey().hex(), valid_pubkey.hex());
       },
-      [](const ErrorOf<decltype(peer)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -53,9 +53,8 @@ TEST_F(PeerTest, ValidPeerInitialization) {
 TEST_F(PeerTest, InvalidPeerInitialization) {
   auto peer = factory.createPeer(invalid_address, valid_pubkey);
 
-  peer.match(
-      [](const ValueOf<decltype(peer)> &v) { FAIL() << "Expected error case"; },
-      [](const ErrorOf<decltype(peer)> &e) { SUCCEED(); });
+  peer.match([](const auto &v) { FAIL() << "Expected error case"; },
+             [](const auto &e) { SUCCEED(); });
 }
 
 class AccountTest : public ProtoFixture {
@@ -78,13 +77,13 @@ TEST_F(AccountTest, ValidAccountInitialization) {
       valid_account_id, valid_domain_id, valid_quorum, valid_json);
 
   account.match(
-      [&](const ValueOf<decltype(account)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->accountId(), valid_account_id);
         ASSERT_EQ(v.value->domainId(), valid_domain_id);
         ASSERT_EQ(v.value->quorum(), valid_quorum);
         ASSERT_EQ(v.value->jsonData(), valid_json);
       },
-      [](const ErrorOf<decltype(account)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -96,11 +95,8 @@ TEST_F(AccountTest, InvalidAccountInitialization) {
   auto account = factory.createAccount(
       invalid_account_id, valid_domain_id, valid_quorum, valid_json);
 
-  account.match(
-      [](const ValueOf<decltype(account)> &v) {
-        FAIL() << "Expected error case";
-      },
-      [](const ErrorOf<decltype(account)> &e) { SUCCEED(); });
+  account.match([](const auto &v) { FAIL() << "Expected error case"; },
+                [](const auto &e) { SUCCEED(); });
 }
 
 class AccountAssetTest : public ProtoFixture {
@@ -122,12 +118,12 @@ TEST_F(AccountAssetTest, ValidAccountAssetInitialization) {
       valid_account_id, valid_asset_id, valid_amount);
 
   account_asset.match(
-      [&](const ValueOf<decltype(account_asset)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->accountId(), valid_account_id);
         ASSERT_EQ(v.value->assetId(), valid_asset_id);
         ASSERT_EQ(v.value->balance(), valid_amount);
       },
-      [](const ErrorOf<decltype(account_asset)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -139,11 +135,8 @@ TEST_F(AccountAssetTest, InvalidAccountAssetInitialization) {
   auto account_asset = factory.createAccountAsset(
       invalid_account_id, valid_asset_id, valid_amount);
 
-  account_asset.match(
-      [](const ValueOf<decltype(account_asset)> &v) {
-        FAIL() << "Expected error case";
-      },
-      [](const ErrorOf<decltype(account_asset)> &e) { SUCCEED(); });
+  account_asset.match([](const auto &v) { FAIL() << "Expected error case"; },
+                      [](const auto &e) { SUCCEED(); });
 }
 
 class AssetTest : public ProtoFixture {
@@ -165,12 +158,12 @@ TEST_F(AssetTest, ValidAssetInitialization) {
       factory.createAsset(valid_asset_id, valid_domain_id, valid_precision);
 
   asset.match(
-      [&](const ValueOf<decltype(asset)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->assetId(), valid_asset_id);
         ASSERT_EQ(v.value->domainId(), valid_domain_id);
         ASSERT_EQ(v.value->precision(), valid_precision);
       },
-      [](const ErrorOf<decltype(asset)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -182,11 +175,8 @@ TEST_F(AssetTest, InvalidAssetInitialization) {
   auto asset =
       factory.createAsset(invalid_asset_id, valid_domain_id, valid_precision);
 
-  asset.match(
-      [](const ValueOf<decltype(asset)> &v) {
-        FAIL() << "Expected error case";
-      },
-      [](const ErrorOf<decltype(asset)> &e) { SUCCEED(); });
+  asset.match([](const auto &v) { FAIL() << "Expected error case"; },
+              [](const auto &e) { SUCCEED(); });
 }
 
 class DomainTest : public ProtoFixture {
@@ -206,11 +196,11 @@ TEST_F(DomainTest, ValidDomainInitialization) {
   auto domain = factory.createDomain(valid_domain_id, valid_role_id);
 
   domain.match(
-      [&](const ValueOf<decltype(domain)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->domainId(), valid_domain_id);
         ASSERT_EQ(v.value->defaultRole(), valid_role_id);
       },
-      [](const ErrorOf<decltype(domain)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -221,11 +211,8 @@ TEST_F(DomainTest, ValidDomainInitialization) {
 TEST_F(DomainTest, InvalidDomainInitialization) {
   auto domain = factory.createDomain(invalid_domain_id, valid_role_id);
 
-  domain.match(
-      [](const ValueOf<decltype(domain)> &v) {
-        FAIL() << "Expected error case";
-      },
-      [](const ErrorOf<decltype(domain)> &e) { SUCCEED(); });
+  domain.match([](const auto &v) { FAIL() << "Expected error case"; },
+               [](const auto &e) { SUCCEED(); });
 }
 
 class SignatureTest : public ProtoFixture {
@@ -245,11 +232,11 @@ TEST_F(SignatureTest, ValidSignatureInitialization) {
   auto signature = factory.createSignature(valid_pubkey, valid_data);
 
   signature.match(
-      [&](const ValueOf<decltype(signature)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(v.value->publicKey().hex(), valid_pubkey.hex());
         ASSERT_EQ(v.value->signedData().hex(), valid_data.hex());
       },
-      [](const ErrorOf<decltype(signature)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -260,9 +247,6 @@ TEST_F(SignatureTest, ValidSignatureInitialization) {
 TEST_F(SignatureTest, InvalidSignatureInitialization) {
   auto signature = factory.createSignature(invalid_pubkey, valid_data);
 
-  signature.match(
-      [](const ValueOf<decltype(signature)> &v) {
-        FAIL() << "Expected error case";
-      },
-      [](const ErrorOf<decltype(signature)> &e) { SUCCEED(); });
+  signature.match([](const auto &v) { FAIL() << "Expected error case"; },
+                  [](const auto &e) { SUCCEED(); });
 }

--- a/test/module/shared_model/backend_proto/proto_proposal_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_proposal_factory_test.cpp
@@ -54,12 +54,12 @@ TEST_F(ProposalFactoryTest, ValidProposalTest) {
   auto proposal = valid_factory.createProposal(height, time, txs);
 
   proposal.match(
-      [&](const ValueOf<decltype(proposal)> &v) {
+      [&](const auto &v) {
         ASSERT_EQ(txs, v.value->transactions());
         ASSERT_EQ(height, v.value->height());
         ASSERT_EQ(time, v.value->createdTime());
       },
-      [](const ErrorOf<decltype(proposal)> &e) { FAIL() << e.error; });
+      [](const auto &e) { FAIL() << e.error; });
 }
 
 /**
@@ -70,9 +70,6 @@ TEST_F(ProposalFactoryTest, ValidProposalTest) {
 TEST_F(ProposalFactoryTest, InvalidProposalTest) {
   auto proposal = factory.createProposal(height, time, txs);
 
-  proposal.match(
-      [&](const ValueOf<decltype(proposal)> &) {
-        FAIL() << "unexpected value case";
-      },
-      [](const ErrorOf<decltype(proposal)> &) { SUCCEED(); });
+  proposal.match([&](const auto &) { FAIL() << "unexpected value case"; },
+                 [](const auto &) { SUCCEED(); });
 }


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

### Description of the Change

Finally I got too tired of typing the arguments of iroha::expected::Result::match functions. Looking at its signature and docstring comment, I saw that the first matcher is for the value case, and the second - for the error. But this deduction did not happen, because both were just passed to some sort of apply_visitor, which does not care of visitors' positions. So I made a change before the visitor application, forcing the first visitor to accept value type, and the second - error type.
Benefits

### Benefits

<!-- What benefits will be realized by the code change? -->

saves some hair on your head. just see this:

```diff
-        auto block = getBlock(i);
-        block.match(
-            [&result](
-                expected::Value<std::unique_ptr<shared_model::interface::Block>>
-                    &v) { result.emplace_back(std::move(v.value)); },
-            [this](const expected::Error<std::string> &e) {
-              log_->error(e.error);
-            });
+        getBlock(i).match(
+            [&result](auto &&v) { result.emplace_back(std::move(v.value)); },
+            [this](const auto &e) { log_->error(e.error); });
```

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

just use auto type in matchers. don't forget about matched Result const- and ref-qualifiers: for example, if it is an rvalue (most common case), use either auto && or const auto & argument type in your machers.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
