### PR TITLE
MST: fixed expired incoming state logic

### DIFF
--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -55,7 +55,7 @@ namespace iroha {
     // ------------------| MstTransportNotification override |------------------
 
     void onNewState(const shared_model::crypto::PublicKey &from,
-                    ConstRefState new_state) override;
+                    MstState new_state) override;
 
     // ----------------------------| end override |-----------------------------
 

--- a/irohad/network/mst_transport.hpp
+++ b/irohad/network/mst_transport.hpp
@@ -23,9 +23,8 @@ namespace iroha {
        * @param from - key of the peer emitted the state
        * @param new_state - state propagated from peer
        */
-      virtual void onNewState(
-          const shared_model::crypto::PublicKey &from,
-          const MstState &new_state) = 0;
+      virtual void onNewState(const shared_model::crypto::PublicKey &from,
+                              MstState new_state) = 0;
 
       virtual ~MstTransportNotification() = default;
     };

--- a/test/framework/integration_framework/fake_peer/network/mst_message.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_message.hpp
@@ -12,9 +12,8 @@
 namespace integration_framework {
   namespace fake_peer {
     struct MstMessage final {
-      MstMessage(const shared_model::crypto::PublicKey &f,
-                 const iroha::MstState &s)
-          : from(f), state(s) {}
+      MstMessage(const shared_model::crypto::PublicKey &f, iroha::MstState s)
+          : from(f), state(std::move(s)) {}
       shared_model::crypto::PublicKey from;
       iroha::MstState state;
     };

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
@@ -10,10 +10,10 @@ namespace integration_framework {
 
     void MstNetworkNotifier::onNewState(
         const shared_model::crypto::PublicKey &from,
-        const iroha::MstState &new_state) {
+        iroha::MstState new_state) {
       std::lock_guard<std::mutex> guard(mst_subject_mutex_);
       mst_subject_.get_subscriber().on_next(
-          std::make_shared<MstMessage>(from, new_state));
+          std::make_shared<MstMessage>(from, std::move(new_state)));
     }
 
     rxcpp::observable<std::shared_ptr<MstMessage>>

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
@@ -21,7 +21,7 @@ namespace integration_framework {
         : public iroha::network::MstTransportNotification {
      public:
       void onNewState(const shared_model::crypto::PublicKey &from,
-                      const iroha::MstState &new_state) override;
+                      iroha::MstState new_state) override;
 
       rxcpp::observable<std::shared_ptr<MstMessage>> getObservable();
 

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -33,7 +33,7 @@ namespace iroha {
    public:
     MOCK_METHOD2(onNewState,
                  void(const shared_model::crypto::PublicKey &from,
-                      const MstState &state));
+                      MstState state));
   };
 
   /**


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change removes a very strange line the rationale behind which was not found:
https://github.com/hyperledger/iroha/blob/6c77597ab55163667931591e774f6a04d91b403b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp#L104

...and adds early removal of expired batches from incoming MstState. Also move semantics get used.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

see above

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

There remains a possibility that the removed line of code was helpful...

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

Regarding the removed line, it broke no tests when it was commented out.
Regarding the outdated batches, please see mst_processor_test `MstProcessorTest.receivedOutdatedState` test.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
