### PR TITLE
Ametsuchi: CommitStatus

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-##Hello! 
+## Hello! 
 
 It is great that you've decided to contribute to Hyperledger Iroha by telling us more about the issue you've encountered!
 The thing is that we now create and store issues only in [Hyperledger JIRA](https://jira.hyperledger.org) so we would kindly ask you to create your issue there. 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,7 @@
 ## Hello! 
 
 It is great that you've decided to contribute to Hyperledger Iroha by telling us more about the issue you've encountered!
-The thing is that we now create and store issues only in [Hyperledger JIRA](https://jira.hyperledger.org) so we would kindly ask you to create your issue there. 
-That way you will be able to track it in JIRA with your [LFID](https://identity.linuxfoundation.org/) account. 
+The thing is that we now create and store issues only in [Hyperledger JIRA](https://jira.hyperledger.org/projects/IR) so we would kindly ask you to create your issue there. 
+That way you will be able to track it in JIRA with your [LFID](https://www.youtube.com/watch?v=EEc4JRyaAoA) account. 
 
 Still, if it is more convenient for you to create an issue on GitHub, our Yozhik Bot will carefully transfer it to JIRA and close the issue here. 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+##Hello! 
+
+It is great that you've decided to contribute to Hyperledger Iroha by telling us more about the issue you've encountered!
+The thing is that we now create and store issues only in [Hyperledger JIRA](https://jira.hyperledger.org) so we would kindly ask you to create your issue there. 
+That way you will be able to track it in JIRA with your [LFID](https://identity.linuxfoundation.org/) account. 
+
+Still, if it is more convenient for you to create an issue on GitHub, our Yozhik Bot will carefully transfer it to JIRA and close the issue here. 

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -23,7 +23,7 @@ namespace iroha {
      protected:
       using wTransaction =
           std::shared_ptr<shared_model::interface::Transaction>;
-      using wBlock = std::shared_ptr<shared_model::interface::Block>;
+      using wBlock = std::shared_ptr<const shared_model::interface::Block>;
 
      public:
       virtual ~BlockQuery() = default;

--- a/irohad/ametsuchi/commit_status.hpp
+++ b/irohad/ametsuchi/commit_status.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_AMETSUCHI_COMMIT_STATUS_HPP
+#define IROHA_AMETSUCHI_COMMIT_STATUS_HPP
+
+#include <memory>
+#include <string>
+
+#include "ametsuchi/ledger_state.hpp"
+#include "common/result.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+
+    using CommitStatus =
+        iroha::expected::Result<std::shared_ptr<iroha::LedgerState>,
+                                std::string>;
+  }
+}  // namespace iroha
+
+#endif // IROHA_AMETSUCHI_COMMIT_STATUS_HPP

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -43,6 +43,7 @@ namespace iroha {
                  MutableStoragePredicate predicate) override;
 
       shared_model::interface::types::HeightType getTopBlockHeight() const;
+      shared_model::interface::types::HashType getTopBlockHash() const;
 
       ~MutableStorageImpl() override;
 

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -19,6 +19,7 @@
 namespace iroha {
   namespace ametsuchi {
     class BlockIndex;
+    class PeerQuery;
     class PostgresCommandExecutor;
 
     class MutableStorageImpl : public MutableStorage {

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -247,6 +247,10 @@ namespace iroha {
                                    log_->error(
                                        "Block could not be applied to "
                                        "MutableStorage: {}.",
+                                       block->hash());
+                                   log_->debug(
+                                       "The block that could not be applied to "
+                                       "MutableStorage is {}.",
                                        block);
                                  }
                                  return applied;

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -17,6 +17,7 @@
 #include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/impl/postgres_options.hpp"
 #include "ametsuchi/key_value_storage.hpp"
+#include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/common_objects_factory.hpp"
 #include "interfaces/iroha_internal/block_json_converter.hpp"
 #include "interfaces/permission_to_string.hpp"
@@ -92,7 +93,7 @@ namespace iroha {
        * @return true if inserted
        */
       bool insertBlocks(
-          const std::vector<std::shared_ptr<shared_model::interface::Block>>
+          const shared_model::interface::types::SharedBlocksForwardRange
               &blocks) override;
 
       void reset() override;
@@ -101,7 +102,7 @@ namespace iroha {
 
       void freeConnections() override;
 
-      boost::optional<std::unique_ptr<LedgerState>> commit(
+      CommitStatus commit(
           std::unique_ptr<MutableStorage> mutable_storage) override;
 
       boost::optional<std::unique_ptr<LedgerState>> commitPrepared(

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -58,8 +58,9 @@ namespace iroha {
                           WHERE account_id = :account_id) AS CTE3(quorum))");
 
       try {
+        auto keys_range_size = boost::size(keys_range);
         *sql_ << (query % keys).str(), soci::into(signatories_valid),
-            soci::use(boost::size(keys_range), "signatures_count"),
+            soci::use(keys_range_size, "signatures_count"),
             soci::use(transaction.creatorAccountId(), "account_id");
       } catch (const std::exception &e) {
         auto error_str = "Transaction " + transaction.toString()

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -16,8 +16,7 @@ namespace iroha {
     expected::Result<void, std::string> WsvRestorerImpl::restoreWsv(
         Storage &storage) {
       // get all blocks starting from the genesis
-      std::vector<std::shared_ptr<shared_model::interface::Block>> blocks=
-      storage.getBlockQuery()->getBlocksFrom(1);
+      auto blocks = storage.getBlockQuery()->getBlocksFrom(1);
 
       storage.reset();
 

--- a/irohad/ametsuchi/ledger_state.hpp
+++ b/irohad/ametsuchi/ledger_state.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "cryptography/hash.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -15,12 +16,14 @@ namespace iroha {
   using PeerList = std::vector<std::shared_ptr<shared_model::interface::Peer>>;
 
   struct LedgerState {
-    std::shared_ptr<PeerList> ledger_peers;
+    PeerList ledger_peers;
     shared_model::interface::types::HeightType height;
+    shared_model::crypto::Hash top_hash;
 
-    LedgerState(std::shared_ptr<PeerList> peers,
-                shared_model::interface::types::HeightType height)
-        : ledger_peers(std::move(peers)), height(height) {}
+    LedgerState(PeerList peers,
+                shared_model::interface::types::HeightType height,
+                shared_model::crypto::Hash top_hash)
+        : ledger_peers(std::move(peers)), height(height), top_hash(top_hash) {}
   };
 }  // namespace iroha
 

--- a/irohad/ametsuchi/mutable_factory.hpp
+++ b/irohad/ametsuchi/mutable_factory.hpp
@@ -9,8 +9,8 @@
 #include <memory>
 
 #include <boost/optional.hpp>
+#include "ametsuchi/commit_status.hpp"
 #include "common/result.hpp"
-#include "ametsuchi/ledger_state.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -38,9 +38,9 @@ namespace iroha {
        * This transforms Ametsuchi to the new state consistent with
        * MutableStorage.
        * @param mutableStorage
-       * @return new state of the ledger, boost::none if commit failed
+       * @return the status of commit
        */
-      virtual boost::optional<std::unique_ptr<LedgerState>> commit(
+      virtual CommitStatus commit(
           std::unique_ptr<MutableStorage> mutableStorage) = 0;
 
       /**

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include <rxcpp/rx.hpp>
+#include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -33,14 +34,11 @@ namespace iroha {
        * Predicate type checking block
        * Function parameters:
        *  - Block - block to be checked
-       *  - PeerQuery - interface for ledger peers list retrieval
-       *  - HashType - hash of top block in blockchain
+       *  - LedgerState - the state of ledger on which the block is applied
        */
       using MutableStoragePredicate = std::function<bool(
           std::shared_ptr<const shared_model::interface::Block>,
-          // TODO 30.01.2019 lebdron: IR-265 Remove PeerQueryFactory
-          PeerQuery &,
-          const shared_model::interface::types::HashType &)>;
+          const LedgerState &)>;
 
       /**
        * Applies block without additional validation function

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -22,7 +22,6 @@ namespace iroha {
   namespace ametsuchi {
 
     class WsvQuery;
-    class PeerQuery;
 
     /**
      * Mutable storage is used apply blocks to the storage.

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -10,11 +10,13 @@
 
 #include <rxcpp/rx.hpp>
 #include "ametsuchi/block_query_factory.hpp"
+#include "ametsuchi/commit_status.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "ametsuchi/query_executor_factory.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "common/result.hpp"
+#include "interfaces/common_objects/range_types.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -57,7 +59,7 @@ namespace iroha {
        * @return true if inserted
        */
       virtual bool insertBlocks(
-          const std::vector<std::shared_ptr<shared_model::interface::Block>>
+          const shared_model::interface::types::SharedBlocksForwardRange
               &blocks) = 0;
 
       /**

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -86,7 +86,7 @@ namespace iroha {
         }
 
         auto order = orderer_->getOrdering(current_hash_,
-                                           *event.ledger_state->ledger_peers);
+                                           event.ledger_state->ledger_peers);
         if (not order) {
           log_->error("ordering doesn't provide peers => pass round");
           return;

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -33,7 +33,7 @@ grpc::Status BlockLoaderService::retrieveBlocks(
   std::for_each(blocks.begin(), blocks.end(), [&writer](const auto &block) {
     protocol::Block proto_block;
     *proto_block.mutable_block_v1() =
-        std::dynamic_pointer_cast<shared_model::proto::Block>(block)
+        std::dynamic_pointer_cast<const shared_model::proto::Block>(block)
             ->getTransport();
 
     writer->Write(proto_block);
@@ -98,7 +98,7 @@ grpc::Status BlockLoaderService::retrieveBlock(
   }
 
   auto block_v1 =
-      std::static_pointer_cast<shared_model::proto::Block>(*found_block)
+      std::static_pointer_cast<const shared_model::proto::Block>(*found_block)
           ->getTransport();
   *response->mutable_block_v1() = block_v1;
   return grpc::Status::OK;

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -93,9 +93,8 @@ namespace iroha {
           return boost::none;
         }
 
-        last_block = boost::get<expected::Value<
-            std::shared_ptr<shared_model::interface::Block>>>(&block_var)
-                         ->value;
+        last_block =
+            boost::get<decltype(block_var)::ValueType>(&block_var)->value;
       } else {
         log_->error("could not create block query");
         return boost::none;

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -72,7 +72,7 @@ namespace iroha {
       logger::LoggerPtr log_;
 
       // last block
-      std::shared_ptr<shared_model::interface::Block> last_block;
+      std::shared_ptr<const shared_model::interface::Block> last_block;
     };
   }  // namespace simulator
 }  // namespace iroha

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -8,6 +8,7 @@
 
 #include "synchronizer/synchronizer.hpp"
 
+#include "ametsuchi/commit_status.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "logger/logger_fwd.hpp"
@@ -50,7 +51,7 @@ namespace iroha {
        * @param target_height - the block height that must be reached
        * @param public_keys - public keys of peers from which to ask the blocks
        */
-      boost::optional<std::unique_ptr<LedgerState>> downloadMissingBlocks(
+      ametsuchi::CommitStatus downloadAndCommitMissingBlocks(
           const shared_model::interface::types::HeightType start_height,
           const shared_model::interface::types::HeightType target_height,
           const PublicKeysRange &public_keys);

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -7,7 +7,6 @@
 
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/mutable_storage.hpp"
-#include "ametsuchi/peer_query.hpp"
 #include "consensus/yac/supermajority_checker.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -31,6 +31,8 @@ namespace iroha {
     class PeerQuery;
   }  // namespace ametsuchi
 
+  struct LedgerState;
+
   namespace validation {
     class ChainValidatorImpl : public ChainValidator {
      public:
@@ -49,6 +51,11 @@ namespace iroha {
           const shared_model::interface::Block &block,
           const shared_model::interface::types::HashType &top_hash) const;
 
+      /// Verifies whether block height directly follows top height
+      bool validateHeight(
+          const shared_model::interface::Block &block,
+          const shared_model::interface::types::HeightType &top_height) const;
+
       /// Verifies whether the block is signed by supermajority of peers
       bool validatePeerSupermajority(
           const shared_model::interface::Block &block,
@@ -61,9 +68,7 @@ namespace iroha {
        */
       bool validateBlock(
           std::shared_ptr<const shared_model::interface::Block> block,
-          // TODO 30.01.2019 lebdron: IR-265 Remove PeerQueryFactory
-          ametsuchi::PeerQuery &queries,
-          const shared_model::interface::types::HashType &top_hash) const;
+          const iroha::LedgerState &ledger_state) const;
 
       /**
        * Provide functions to check supermajority

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -27,10 +27,6 @@ namespace iroha {
     }  // namespace yac
   }    // namespace consensus
 
-  namespace ametsuchi {
-    class PeerQuery;
-  }  // namespace ametsuchi
-
   struct LedgerState;
 
   namespace validation {

--- a/shared_model/interfaces/common_objects/range_types.hpp
+++ b/shared_model/interfaces/common_objects/range_types.hpp
@@ -6,6 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_RANGE_TYPES_HPP
 #define IROHA_SHARED_MODEL_RANGE_TYPES_HPP
 
+#include <memory>
+
 #include <boost/range/any_range.hpp>
 #include "interfaces/common_objects/types.hpp"
 
@@ -36,6 +38,10 @@ namespace shared_model {
           boost::any_range<HashType,
                            boost::forward_traversal_tag,
                            const HashType &>;
+      using SharedBlocksForwardRange =
+          boost::any_range<std::shared_ptr<const Block>,
+                           boost::forward_traversal_tag,
+                           const std::shared_ptr<const Block> &>;
 
     }  // namespace types
   }    // namespace interface

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -22,9 +22,10 @@ namespace shared_model {
 
   namespace interface {
 
+    class AccountAsset;
+    class Block;
     class Signature;
     class Transaction;
-    class AccountAsset;
 
     namespace types {
       /// Type of hash

--- a/shared_model/utils/string_builder.hpp
+++ b/shared_model/utils/string_builder.hpp
@@ -82,6 +82,37 @@ namespace shared_model {
       }
 
       /**
+       * Appends a new named collection to string
+       * @param c - iterable collection to append using toString method
+       */
+      template <typename Collection>
+      std::enable_if_t<
+          std::is_same<
+              typename std::decay<decltype(
+                  std::declval<Collection>().begin()->toString())>::type,
+              std::string>::value,
+          PrettyStringBuilder &>
+      appendAll(Collection &&c) {
+        appendAll(c, [](const auto &o) { return o.toString(); });
+        return *this;
+      }
+
+      /**
+       * Appends a new named collection to string
+       * @param c - iterable collection of pointers
+       */
+      template <typename Collection>
+      std::enable_if_t<std::is_same<typename std::decay<decltype(
+                                        (*std::declval<Collection>().begin())
+                                            ->toString())>::type,
+                                    std::string>::value,
+                       PrettyStringBuilder &>
+      appendAll(Collection &&c) {
+        appendAll(c, [](const auto &o) { return o->toString(); });
+        return *this;
+      }
+
+      /**
        * Finalizes appending and returns constructed string.
        * @return resulted string
        */

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -233,6 +233,11 @@ namespace integration_framework {
       return *keypair_;
     }
 
+    std::shared_ptr<shared_model::interface::Peer> FakePeer::getThisPeer()
+        const {
+      return this_peer_;
+    }
+
     rxcpp::observable<std::shared_ptr<MstMessage>>
     FakePeer::getMstStatesObservable() {
       return mst_network_notifier_->getObservable();

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -157,6 +157,7 @@ namespace integration_framework {
 
     FakePeer &FakePeer::setBehaviour(
         const std::shared_ptr<Behaviour> &behaviour) {
+      std::lock_guard<std::shared_timed_mutex> lock(behaviour_mutex_);
       ensureInitialized();
       behaviour_ = behaviour;
       behaviour_->setup(shared_from_this(),
@@ -164,7 +165,8 @@ namespace integration_framework {
       return *this;
     }
 
-    const std::shared_ptr<Behaviour> &FakePeer::getBehaviour() const {
+    std::shared_ptr<Behaviour> FakePeer::getBehaviour() const {
+      std::shared_lock<std::shared_timed_mutex> lock(behaviour_mutex_);
       return behaviour_;
     }
 

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -249,8 +249,6 @@ namespace integration_framework {
       std::shared_ptr<Behaviour> behaviour_;
       std::shared_ptr<BlockStorage> block_storage_;
       ProposalStorage proposal_storage_;
-
-      mutable std::shared_timed_mutex behaviour_mutex_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -80,7 +80,7 @@ namespace integration_framework {
       FakePeer &setBehaviour(const std::shared_ptr<Behaviour> &behaviour);
 
       /// Get the behaviour assigned to this peer, if any, otherwise nullptr.
-      const std::shared_ptr<Behaviour> &getBehaviour() const;
+      std::shared_ptr<Behaviour> getBehaviour() const;
 
       /// Assign this peer a block storage. Used by behaviours.
       FakePeer &setBlockStorage(
@@ -249,6 +249,8 @@ namespace integration_framework {
       std::shared_ptr<Behaviour> behaviour_;
       std::shared_ptr<BlockStorage> block_storage_;
       ProposalStorage proposal_storage_;
+
+      mutable std::shared_timed_mutex behaviour_mutex_;
     };
 
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -103,6 +103,9 @@ namespace integration_framework {
       /// Get the keypair of this peer.
       const shared_model::crypto::Keypair &getKeypair() const;
 
+      /// Get interface::Peer object for this instance.
+      std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
+
       /// Get the observable of MST states received by this peer.
       rxcpp::observable<std::shared_ptr<MstMessage>> getMstStatesObservable();
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -189,7 +189,7 @@ namespace integration_framework {
     }
   }
 
-  std::shared_ptr<FakePeer> IntegrationTestFramework::addInitialPeer(
+  std::shared_ptr<FakePeer> IntegrationTestFramework::addFakePeer(
       const boost::optional<Keypair> &key) {
     BOOST_ASSERT_MSG(this_peer_, "Need to set the ITF peer key first!");
     const auto port = port_guard_->getPort(kDefaultInternalPort);
@@ -212,10 +212,10 @@ namespace integration_framework {
   }
 
   std::vector<std::shared_ptr<fake_peer::FakePeer>>
-  IntegrationTestFramework::addInitialPeers(size_t amount) {
+  IntegrationTestFramework::addFakePeers(size_t amount) {
     std::vector<std::shared_ptr<fake_peer::FakePeer>> fake_peers;
     std::generate_n(std::back_inserter(fake_peers), amount, [this] {
-      auto fake_peer = addInitialPeer({});
+      auto fake_peer = addFakePeer({});
       fake_peer->setBehaviour(std::make_shared<fake_peer::HonestBehaviour>());
       return fake_peer;
     });

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -383,6 +383,11 @@ namespace integration_framework {
     iroha_instance_->run();
   }
 
+  std::shared_ptr<shared_model::interface::Peer>
+  IntegrationTestFramework::getThisPeer() const {
+    return this_peer_;
+  }
+
   rxcpp::observable<std::shared_ptr<iroha::MstState>>
   IntegrationTestFramework::getMstStateUpdateObservable() {
     return iroha_instance_->getIrohaInstance()

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -233,8 +233,7 @@ namespace integration_framework {
         shared_model::proto::TransactionBuilder()
             .creatorAccountId(kAdminId)
             .createdTime(iroha::time::now())
-            .addPeer(format_address(kLocalHost, internal_port_),
-                     key.publicKey())
+            .addPeer(getAddress(), key.publicKey())
             .createRole(kAdminRole, all_perms)
             .createRole(kDefaultRole, {})
             .createDomain(kDomain, kDefaultRole)
@@ -314,8 +313,7 @@ namespace integration_framework {
     my_key_ = keypair;
     this_peer_ =
         framework::expected::val(common_objects_factory_->createPeer(
-                                     format_address(kLocalHost, internal_port_),
-                                     keypair.publicKey()))
+                                     getAddress(), keypair.publicKey()))
             .value()
             .value;
     iroha_instance_->initPipeline(keypair, maximum_proposal_size_);
@@ -386,6 +384,10 @@ namespace integration_framework {
   std::shared_ptr<shared_model::interface::Peer>
   IntegrationTestFramework::getThisPeer() const {
     return this_peer_;
+  }
+
+  std::string IntegrationTestFramework::getAddress() const {
+    return format_address(kLocalHost, internal_port_);
   }
 
   rxcpp::observable<std::shared_ptr<iroha::MstState>>

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -116,12 +116,12 @@ namespace integration_framework {
     ~IntegrationTestFramework();
 
     /// Add a fake peer with given key.
-    std::shared_ptr<fake_peer::FakePeer> addInitialPeer(
+    std::shared_ptr<fake_peer::FakePeer> addFakePeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
 
     /// Add the given amount of fake peers with generated default keys and
     /// "honest" behaviours.
-    std::vector<std::shared_ptr<fake_peer::FakePeer>> addInitialPeers(
+    std::vector<std::shared_ptr<fake_peer::FakePeer>> addFakePeers(
         size_t amount);
 
     /**

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -421,6 +421,9 @@ namespace integration_framework {
     /// Get interface::Peer object for this instance.
     std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
 
+    /// Get this node address.
+    std::string getAddress() const;
+
    protected:
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -418,6 +418,9 @@ namespace integration_framework {
     /// Start the ITF.
     void subscribeQueuesAndRun();
 
+    /// Get interface::Peer object for this instance.
+    std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
+
    protected:
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -25,6 +25,12 @@ target_link_libraries(add_asset_qty_test
     integration_framework
     )
 
+addtest(add_peer_test add_peer_test.cpp)
+target_link_libraries(add_peer_test
+    acceptance_fixture
+    integration_framework
+    )
+
 addtest(create_account_test create_account_test.cpp)
 target_link_libraries(create_account_test
     acceptance_fixture

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -221,7 +221,7 @@ class AcceptanceFixture : public ::testing::Test {
  private:
   iroha::time::time_t initial_time;
   /// number of created transactions, used to provide unique time
-  int nonce_counter;
+  std::atomic_int nonce_counter;
 };
 
 #endif  // IROHA_ACCEPTANCE_FIXTURE_HPP

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "datetime/time.hpp"
+#include "framework/integration_framework/fake_peer/fake_peer.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/test_logger.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "main/server_runner.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
+#include "module/shared_model/builders/protobuf/block.hpp"
+
+using namespace common_constants;
+using namespace shared_model;
+using namespace integration_framework;
+using namespace shared_model::interface::permissions;
+
+static constexpr std::chrono::seconds kMstStateWaitingTime(20);
+
+template <size_t N>
+void checkBlockHasNTxs(const std::shared_ptr<const interface::Block> &block) {
+  ASSERT_EQ(block->transactions().size(), N);
+}
+
+class FakePeerExampleFixture : public AcceptanceFixture {
+ public:
+  using FakePeer = fake_peer::FakePeer;
+
+  std::unique_ptr<IntegrationTestFramework> itf_;
+
+  /**
+   * Create honest fake iroha peers
+   *
+   * @param num_fake_peers - the amount of fake peers to create
+   */
+  void createFakePeers(size_t num_fake_peers) {
+    fake_peers_ = itf_->addFakePeers(num_fake_peers);
+  }
+
+  /**
+   * Prepare state of ledger:
+   * - create account of target user
+   * - add assets to admin
+   *
+   * @return reference to ITF
+   */
+  IntegrationTestFramework &prepareState() {
+    itf_->setGenesisBlock(itf_->defaultBlock()).subscribeQueuesAndRun();
+
+    auto permissions =
+        interface::RolePermissionSet({Role::kReceive, Role::kTransfer});
+
+    return itf_
+        ->sendTxAwait(makeUserWithPerms(permissions), checkBlockHasNTxs<1>)
+        .sendTxAwait(
+            complete(baseTx(kAdminId).addAssetQuantity(kAssetId, "20000.0"),
+                     kAdminKeypair),
+            checkBlockHasNTxs<1>);
+  }
+
+ protected:
+  void SetUp() override {
+    itf_ =
+        std::make_unique<IntegrationTestFramework>(1, boost::none, true, true);
+    itf_->initPipeline(kAdminKeypair);
+  }
+
+  std::vector<std::shared_ptr<FakePeer>> fake_peers_;
+};
+
+auto makePeerPointeeMatcher(interface::types::AddressType address,
+                            interface::types::PubkeyType pubkey) {
+  return ::testing::Truly(
+      [address = std::move(address),
+       pubkey = std::move(pubkey)](std::shared_ptr<interface::Peer> peer) {
+        return peer->address() == address and peer->pubkey() == pubkey;
+      });
+}
+
+auto makePeerPointeeMatcher(std::shared_ptr<interface::Peer> peer) {
+  return makePeerPointeeMatcher(peer->address(), peer->pubkey());
+}
+
+/**
+ * @given a network of single peer
+ * @when it receives a valid signed addPeer command
+ * @then the transaction is committed
+ *    @and the WSV reports that there are two peers: the initial and the added one
+ */
+TEST_F(FakePeerExampleFixture, CheckPeerIsAdded) {
+  // init the real peer with no other peers in the genesis block
+  auto &itf = prepareState();
+
+  const std::string new_peer_address = "127.0.0.1:1234";
+  const auto new_peer_pubkey =
+      shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()
+          .publicKey();
+
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).addPeer(new_peer_address, new_peer_pubkey),
+               kAdminKeypair),
+      checkBlockHasNTxs<1>);
+
+  auto opt_peers = itf.getIrohaInstance()
+                       .getIrohaInstance()
+                       ->getStorage()
+                       ->createPeerQuery()
+                       .value()
+                       ->getLedgerPeers();
+
+  ASSERT_TRUE(opt_peers);
+  EXPECT_THAT(*opt_peers,
+              ::testing::UnorderedElementsAre(
+                  makePeerPointeeMatcher(itf.getThisPeer()),
+                  makePeerPointeeMatcher(new_peer_address, new_peer_pubkey)));
+}
+
+/**
+ * @given a network of single peer
+ * @given
+ * @when it receives a not fully signed transaction and then a new peer is added
+ * @then the first peer propagates MST state to the newly added peer
+ */
+TEST_F(FakePeerExampleFixture, MstStatePropagtesToNewPeer) {
+  // init the real peer with no other peers in the genesis block
+  auto &itf = prepareState();
+
+  // then create a fake peer
+  auto new_peer = itf.addFakePeer(boost::none);
+  auto mst_states_observable = new_peer->getMstStatesObservable().replay();
+  mst_states_observable.connect();
+  auto new_peer_server = new_peer->run();
+
+  // and add it with addPeer
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).addPeer(new_peer->getAddress(),
+                                        new_peer->getKeypair().publicKey()),
+               kAdminKeypair),
+      checkBlockHasNTxs<1>);
+
+  itf.sendTxWithoutValidation(complete(
+      baseTx(kAdminId)
+          .transferAsset(kAdminId, kUserId, kAssetId, "income", "500.0")
+          .quorum(2),
+      kAdminKeypair));
+
+  mst_states_observable
+      .timeout(kMstStateWaitingTime, rxcpp::observe_on_new_thread())
+      .take(1)
+      .as_blocking()
+      .subscribe([](const auto &) {},
+                 [](std::exception_ptr ep) {
+                   try {
+                     std::rethrow_exception(ep);
+                   } catch (const std::exception &e) {
+                     FAIL() << "Error waiting for MST state: " << e.what();
+                   }
+                 });
+
+  new_peer_server->shutdown();
+}

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -158,7 +158,7 @@ TEST_F(FakePeerExampleFixture, SynchronizeTheRightVersionOfForkedLedger) {
                                ->getBlockQuery()
                                ->getBlocksFrom(1)) {
     valid_block_storage->storeBlock(
-        std::static_pointer_cast<shared_model::proto::Block>(block));
+        std::static_pointer_cast<const shared_model::proto::Block>(block));
   }
 
   // From now the itf peer is considered unreachable from the rest network. //

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -40,7 +40,7 @@ class FakePeerExampleFixture : public AcceptanceFixture {
    * @param num_fake_peers - the amount of fake peers to create
    */
   void createFakePeers(size_t num_fake_peers) {
-    fake_peers_ = itf_->addInitialPeers(num_fake_peers);
+    fake_peers_ = itf_->addFakePeers(num_fake_peers);
   }
 
   /**

--- a/test/integration/validation/chain_validator_storage_test.cpp
+++ b/test/integration/validation/chain_validator_storage_test.cpp
@@ -12,6 +12,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "cryptography/keypair.hpp"
+#include "framework/result_fixture.hpp"
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 
@@ -99,7 +100,9 @@ namespace iroha {
       auto ms = createMutableStorage();
 
       ms->apply(block);
-      storage->commit(std::move(ms));
+      auto commit_result = storage->commit(std::move(ms));
+      EXPECT_TRUE(boost::get<expected::ValueOf<decltype(commit_result)>>(
+          (&commit_result)));
 
       return block;
     }

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -22,6 +22,7 @@
 using namespace iroha::ametsuchi;
 using namespace framework::test_subscriber;
 using namespace shared_model::interface::permissions;
+using framework::expected::val;
 
 auto zero_string = std::string(32, '0');
 auto fake_hash = shared_model::crypto::Hash(zero_string);
@@ -92,7 +93,7 @@ void apply(S &&storage,
         FAIL() << "MutableStorage: " << error.error;
       });
   ms->apply(block);
-  storage->commit(std::move(ms));
+  ASSERT_TRUE(val(storage->commit(std::move(ms))));
 }
 
 TEST_F(AmetsuchiTest, GetBlocksCompletedWhenCalled) {
@@ -408,7 +409,7 @@ TEST_F(AmetsuchiTest, TestingStorageWhenCommitBlock) {
 
   mutable_storage->apply(expected_block);
 
-  storage->commit(std::move(mutable_storage));
+  ASSERT_TRUE(val(storage->commit(std::move(mutable_storage))));
 
   ASSERT_TRUE(wrapper.validate());
   wrapper.unsubscribe();
@@ -575,7 +576,6 @@ class PreparedBlockTest : public AmetsuchiTest {
     genesis_block = createBlock({*genesis_tx});
     initial_tx = clone(createAddAsset("5.00"));
     apply(storage, genesis_block);
-    using framework::expected::val;
     temp_wsv = std::move(val(storage->createTemporaryWsv())->value);
   }
 
@@ -644,7 +644,7 @@ TEST_F(PreparedBlockTest, PrepareBlockCommitDifferentBlock) {
   auto block = createBlock({other_tx}, 2);
 
   auto result = temp_wsv->apply(*initial_tx);
-  ASSERT_TRUE(framework::expected::val(result));
+  ASSERT_TRUE(val(result));
   storage->prepareBlock(std::move(temp_wsv));
 
   apply(storage, block);
@@ -688,13 +688,12 @@ TEST_F(PreparedBlockTest, CommitPreparedFailsAfterCommit) {
  */
 TEST_F(PreparedBlockTest, TemporaryWsvUnlocks) {
   auto result = temp_wsv->apply(*initial_tx);
-  ASSERT_TRUE(framework::expected::val(result));
+  ASSERT_TRUE(val(result));
   storage->prepareBlock(std::move(temp_wsv));
 
-  using framework::expected::val;
   temp_wsv = std::move(val(storage->createTemporaryWsv())->value);
 
   result = temp_wsv->apply(*initial_tx);
-  ASSERT_TRUE(framework::expected::val(result));
+  ASSERT_TRUE(val(result));
   storage->prepareBlock(std::move(temp_wsv));
 }

--- a/test/module/irohad/ametsuchi/mock_mutable_factory.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_factory.hpp
@@ -19,7 +19,7 @@ namespace iroha {
           createMutableStorage,
           expected::Result<std::unique_ptr<MutableStorage>, std::string>(void));
 
-      boost::optional<std::unique_ptr<LedgerState>> commit(
+      CommitStatus commit(
           std::unique_ptr<MutableStorage> mutableStorage) override {
         // gmock workaround for non-copyable parameters
         return commit_(mutableStorage);
@@ -28,9 +28,7 @@ namespace iroha {
       MOCK_METHOD1(commitPrepared,
                    boost::optional<std::unique_ptr<LedgerState>>(
                        std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD1(commit_,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       std::unique_ptr<MutableStorage> &));
+      MOCK_METHOD1(commit_, CommitStatus(std::unique_ptr<MutableStorage> &));
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -21,8 +21,7 @@ namespace iroha {
                    std::shared_ptr<shared_model::interface::Block>>,
                std::function<
                    bool(std::shared_ptr<const shared_model::interface::Block>,
-                        PeerQuery &,
-                        const shared_model::interface::types::HashType &)>));
+                        const iroha::LedgerState &)>));
       MOCK_METHOD1(apply,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(applyPrepared,

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -34,17 +34,16 @@ namespace iroha {
           boost::optional<std::shared_ptr<QueryExecutor>>(
               std::shared_ptr<PendingTransactionStorage>,
               std::shared_ptr<shared_model::interface::QueryResponseFactory>));
-      MOCK_METHOD1(doCommit,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       MutableStorage *storage));
+      MOCK_METHOD1(doCommit, CommitStatus(MutableStorage *storage));
       MOCK_METHOD1(commitPrepared,
                    boost::optional<std::unique_ptr<LedgerState>>(
                        std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(insertBlock,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD1(insertBlocks,
-                   bool(const std::vector<
-                        std::shared_ptr<shared_model::interface::Block>> &));
+      MOCK_METHOD1(
+          insertBlocks,
+          bool(const shared_model::interface::types::SharedBlocksForwardRange
+                   &));
       MOCK_METHOD0(reset, void(void));
       MOCK_METHOD0(dropStorage, void(void));
       MOCK_METHOD0(freeConnections, void(void));
@@ -59,8 +58,7 @@ namespace iroha {
       on_commit() override {
         return notifier.get_observable();
       }
-      boost::optional<std::unique_ptr<LedgerState>> commit(
-          std::unique_ptr<MutableStorage> storage) override {
+      CommitStatus commit(std::unique_ptr<MutableStorage> storage) override {
         return doCommit(storage.get());
       }
       rxcpp::subjects::subject<

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -814,7 +814,7 @@ namespace iroha {
             FAIL() << "could not apply block to the storage";
           }
         }
-        storage->commit(std::move(ms));
+        ASSERT_TRUE(val(storage->commit(std::move(ms))));
       }
 
       static constexpr shared_model::interface::types::HeightType
@@ -1077,7 +1077,7 @@ namespace iroha {
               FAIL() << "MutableStorage: " << error.error;
             });
         ms->apply(block);
-        storage->commit(std::move(ms));
+        ASSERT_TRUE(val(storage->commit(std::move(ms))));
       }
 
       void commitBlocks() {

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -97,10 +97,8 @@ class YacGateTest : public ::testing::Test {
                                          getTestLogger("YacGateImpl"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers =
-        std::make_shared<iroha::PeerList>(iroha::PeerList{peer});
-    ledger_state = std::make_shared<iroha::LedgerState>(std::move(ledger_peers),
-                                                        block->height());
+    ledger_state = std::make_shared<iroha::LedgerState>(
+        iroha::PeerList{peer}, block->height(), block->hash());
   }
 
   iroha::consensus::Round round{1, 1};

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -41,8 +41,9 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
-  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
+  shared_model::crypto::Hash block_hash("hash");
+  auto ledger_state =
+      std::make_shared<LedgerState>(PeerList{peer}, 1, block_hash);
   auto proposal = std::make_shared<const MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(
@@ -52,8 +53,7 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
       .WillRepeatedly(
           ReturnRefOfCopy(shared_model::crypto::Blob(std::string())));
   EXPECT_CALL(*block, hash())
-      .WillRepeatedly(
-          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
+      .WillRepeatedly(testing::ReturnRefOfCopy(block_hash));
 
   EXPECT_CALL(*block, signatures())
       .WillRepeatedly(
@@ -78,8 +78,9 @@ TEST(YacHashProviderTest, ToModelHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
-  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
+  shared_model::crypto::Hash block_hash("hash");
+  auto ledger_state =
+      std::make_shared<LedgerState>(PeerList{peer}, 1, block_hash);
   auto proposal = std::make_shared<MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(
@@ -97,8 +98,7 @@ TEST(YacHashProviderTest, ToModelHashTest) {
                          1, signature()))
                  | boost::adaptors::indirected));
   EXPECT_CALL(*block, hash())
-      .WillRepeatedly(
-          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
+      .WillRepeatedly(testing::ReturnRefOfCopy(block_hash));
 
   auto yac_hash = hash_provider.makeHash(iroha::simulator::BlockCreatorEvent{
       iroha::simulator::RoundData{proposal, block}, round, ledger_state});

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -37,7 +37,7 @@ using testing::A;
 using testing::Return;
 
 using wPeer = std::shared_ptr<shared_model::interface::Peer>;
-using wBlock = std::shared_ptr<shared_model::interface::Block>;
+using wBlock = std::shared_ptr<const shared_model::interface::Block>;
 
 class BlockLoaderTest : public testing::Test {
  public:
@@ -281,8 +281,8 @@ TEST_F(BlockLoaderTest, ValidWhenBlockMissing) {
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
   EXPECT_CALL(*storage, getBlocksFrom(1))
-      .WillOnce(
-          Return(std::vector<std::shared_ptr<shared_model::interface::Block>>{
+      .WillOnce(Return(
+          std::vector<std::shared_ptr<const shared_model::interface::Block>>{
               prev_block, cur_block}));
 
   auto block = loader->retrieveBlock(peer_key, prev_block->hash());
@@ -308,8 +308,8 @@ TEST_F(BlockLoaderTest, ValidWithEmptyCache) {
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
   EXPECT_CALL(*storage, getBlocksFrom(1))
-      .WillOnce(
-          Return(std::vector<std::shared_ptr<shared_model::interface::Block>>{
+      .WillOnce(Return(
+          std::vector<std::shared_ptr<const shared_model::interface::Block>>{
               prev_block, cur_block}));
 
   auto block = loader->retrieveBlock(peer_key, prev_block->hash());
@@ -327,8 +327,9 @@ TEST_F(BlockLoaderTest, NoBlocksInStorage) {
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
   EXPECT_CALL(*storage, getBlocksFrom(1))
-      .WillOnce(Return(
-          std::vector<std::shared_ptr<shared_model::interface::Block>>{}));
+      .WillOnce(
+          Return(std::vector<
+                 std::shared_ptr<const shared_model::interface::Block>>{}));
 
   auto block = loader->retrieveBlock(peer_key, kPrevHash);
   ASSERT_FALSE(block);

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -58,9 +58,8 @@ class OnDemandOrderingGateTest : public ::testing::Test {
         getTestLogger("OrderingGate"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
-    ledger_state =
-        std::make_shared<LedgerState>(ledger_peers, round.block_round);
+    ledger_state = std::make_shared<LedgerState>(
+        PeerList{peer}, round.block_round, top_block_hash);
   }
 
   rxcpp::subjects::subject<
@@ -77,6 +76,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
 
   const consensus::Round round = {2, kFirstRejectRound};
 
+  shared_model::crypto::Hash top_block_hash{"top_block_hash"};
   std::shared_ptr<LedgerState> ledger_state;
 };
 
@@ -124,8 +124,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) {
     ASSERT_EQ(proposal, getProposalUnsafe(val).get());
-    EXPECT_EQ(*val.ledger_state->ledger_peers,
-              *event.ledger_state->ledger_peers);
+    EXPECT_EQ(val.ledger_state->ledger_peers, event.ledger_state->ledger_peers);
   });
 
   rounds.get_subscriber().on_next(event);
@@ -161,8 +160,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) {
     ASSERT_EQ(proposal, getProposalUnsafe(val).get());
-    EXPECT_EQ(*val.ledger_state->ledger_peers,
-              *event.ledger_state->ledger_peers);
+    EXPECT_EQ(val.ledger_state->ledger_peers, event.ledger_state->ledger_peers);
   });
 
   rounds.get_subscriber().on_next(event);

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -64,12 +64,12 @@ class SynchronizerTest : public ::testing::Test {
     consensus_gate = std::make_shared<MockConsensusGate>();
     block_query = std::make_shared<::testing::NiceMock<MockBlockQuery>>();
 
-    ledger_peers = std::make_shared<PeerList>();
+    PeerList ledger_peers;
     for (int i = 0; i < 3; ++i) {
       // TODO mboldyrev 21.03.2019 IR-424 Avoid using honest crypto
       ledger_peer_keys.emplace_back(
           shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair());
-      ledger_peers->emplace_back(
+      ledger_peers.emplace_back(
           makePeer(std::to_string(i), ledger_peer_keys.back().publicKey()));
     }
 
@@ -98,7 +98,8 @@ class SynchronizerTest : public ::testing::Test {
                                            block_loader,
                                            getTestLogger("Synchronizer"));
 
-    ledger_state = std::make_shared<LedgerState>(ledger_peers, kHeight - 1);
+    ledger_state =
+        std::make_shared<LedgerState>(ledger_peers, kHeight - 1, hash);
   }
 
   std::shared_ptr<shared_model::interface::Block> makeCommit(
@@ -123,7 +124,7 @@ class SynchronizerTest : public ::testing::Test {
   std::shared_ptr<shared_model::interface::Block> commit_message;
   shared_model::interface::types::PublicKeyCollectionType public_keys;
   shared_model::interface::types::HashType hash;
-  std::shared_ptr<PeerList> ledger_peers;
+  PeerList ledger_peers;
   std::shared_ptr<LedgerState> ledger_state;
   std::vector<shared_model::crypto::Keypair> ledger_peer_keys;
 
@@ -219,15 +220,15 @@ TEST_F(SynchronizerTest, ValidWhenSingleCommitSynchronized) {
       .WillOnce(Return(ByMove(boost::none)));
   mutableStorageExpectChain(*mutable_factory, {commit_message});
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(
-          Return(ByMove(std::make_unique<LedgerState>(ledger_peers, kHeight))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   EXPECT_CALL(*chain_validator, validateAndApply(_, _)).Times(0);
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _)).Times(0);
 
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this](auto commit_event) {
-    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
 
@@ -273,8 +274,8 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
   EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(
-          Return(ByMove(std::make_unique<LedgerState>(ledger_peers, kHeight))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({commit_message}), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
@@ -283,7 +284,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChain) {
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this](auto commit_event) {
-    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
 
@@ -306,8 +307,8 @@ TEST_F(SynchronizerTest, ValidWhenValidChainMultipleBlocks) {
 
   const auto target_height = kHeight + 1;
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(Return(
-          ByMove(std::make_unique<LedgerState>(ledger_peers, target_height))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, target_height, hash)))));
   std::vector<std::shared_ptr<shared_model::interface::Block>> commits{
       commit_message, makeCommit(target_height)};
   EXPECT_CALL(*chain_validator, validateAndApply(ChainEq(commits), _))
@@ -318,7 +319,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChainMultipleBlocks) {
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this, target_height](auto commit_event) {
-    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
     ASSERT_EQ(commit_event.round.block_round, target_height);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
@@ -339,8 +340,8 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
       SetFactory(&createMockMutableStorage);
   EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(3);
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(Return(ByMove(boost::optional<std::unique_ptr<LedgerState>>(
-          std::make_unique<LedgerState>(ledger_peers, kHeight)))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   {
     InSequence s;  // ensures the call order
     EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({}), _))
@@ -374,14 +375,14 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
  * @then it will try until success
  */
 TEST_F(SynchronizerTest, RetrieveBlockSeveralFailures) {
-  const size_t number_of_failures{ledger_peers->size() + 2};
+  const size_t number_of_failures{ledger_peers.size() + 2};
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
   EXPECT_CALL(*mutable_factory, createMutableStorage())
       .Times(number_of_failures + 1);
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(Return(ByMove(boost::optional<std::unique_ptr<LedgerState>>(
-          std::make_unique<LedgerState>(ledger_peers, kHeight)))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
       .WillRepeatedly(Return(rxcpp::observable<>::just(commit_message)));
 
@@ -480,14 +481,14 @@ TEST_F(SynchronizerTest, NoneOutcome) {
 TEST_F(SynchronizerTest, VotedForBlockCommitPrepared) {
   EXPECT_CALL(*mutable_factory, commitPrepared(_))
       .WillOnce(Return(ByMove(boost::optional<std::unique_ptr<LedgerState>>(
-          std::make_unique<LedgerState>(ledger_peers, kHeight)))));
+          std::make_unique<LedgerState>(ledger_peers, kHeight, hash)))));
 
   EXPECT_CALL(*mutable_factory, commit_(_)).Times(0);
 
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this](auto commit_event) {
-    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
 
@@ -511,8 +512,8 @@ TEST_F(SynchronizerTest, VotedForOtherCommitPrepared) {
   EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(
-          Return(ByMove(std::make_unique<LedgerState>(ledger_peers, kHeight))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
 
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
       .WillRepeatedly(Return(rxcpp::observable<>::just(commit_message)));
@@ -541,7 +542,9 @@ TEST_F(SynchronizerTest, VotedForThisCommitPreparedFailure) {
 
   mutableStorageExpectChain(*mutable_factory, {commit_message});
 
-  EXPECT_CALL(*mutable_factory, commit_(_)).Times(1);
+  EXPECT_CALL(*mutable_factory, commit_(_))
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
 
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
@@ -563,7 +566,7 @@ TEST_F(SynchronizerTest, CommitFailureVoteSameBlock) {
       .WillOnce(Return(ByMove(boost::none)));
   mutableStorageExpectChain(*mutable_factory, {commit_message});
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(Return(ByMove(boost::none)));
+      .WillOnce(Return(ByMove(expected::makeError(""))));
   EXPECT_CALL(*chain_validator, validateAndApply(_, _)).Times(0);
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _)).Times(0);
 
@@ -588,8 +591,8 @@ TEST_F(SynchronizerTest, CommitFailureVoteOther) {
   mutableStorageExpectChain(*mutable_factory, {});
 
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(
-          Return(ByMove(std::make_unique<LedgerState>(ledger_peers, kHeight))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({commit_message}), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
@@ -616,8 +619,8 @@ TEST_F(SynchronizerTest, OneRoundDifference) {
   EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
 
   EXPECT_CALL(*mutable_factory, commit_(_))
-      .WillOnce(
-          Return(ByMove(std::make_unique<LedgerState>(ledger_peers, kHeight))));
+      .WillOnce(Return(ByMove(expected::makeValue(
+          std::make_shared<LedgerState>(ledger_peers, kHeight, hash)))));
   EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({commit_message}), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
@@ -626,7 +629,7 @@ TEST_F(SynchronizerTest, OneRoundDifference) {
   auto wrapper =
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this](auto commit_event) {
-    EXPECT_EQ(*this->ledger_peers, *commit_event.ledger_state->ledger_peers);
+    EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kNothing);
   });
 

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -65,9 +65,9 @@ class TransactionProcessorTest : public ::testing::Test {
         getTestLogger("TransactionProcessor"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers = std::make_shared<PeerList>(PeerList{peer});
-    ledger_state =
-        std::make_shared<LedgerState>(ledger_peers, round.block_round - 1);
+    shared_model::crypto::Hash top_block_hash("top_block_hash");
+    ledger_state = std::make_shared<LedgerState>(
+        PeerList{peer}, round.block_round - 1, top_block_hash);
   }
 
   auto base_tx() {

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -8,7 +8,6 @@
 #include <boost/range/adaptor/indirected.hpp>
 #include "framework/test_logger.hpp"
 #include "module/irohad/ametsuchi/mock_mutable_storage.hpp"
-#include "module/irohad/ametsuchi/mock_peer_query.hpp"
 #include "module/irohad/consensus/yac/mock_yac_supermajority_checker.hpp"
 #include "module/shared_model/interface_mocks.hpp"
 

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -32,7 +32,6 @@ class ChainValidationTest : public ::testing::Test {
     validator = std::make_shared<ChainValidatorImpl>(
         supermajority_checker, getTestLogger("ChainValidato"));
     storage = std::make_shared<MockMutableStorage>();
-    query = std::make_shared<MockPeerQuery>();
     peers = std::vector<std::shared_ptr<shared_model::interface::Peer>>();
 
     auto peer = std::make_shared<MockPeer>();
@@ -47,7 +46,7 @@ class ChainValidationTest : public ::testing::Test {
             shared_model::interface::types::PubkeyType(std::string(32, '0'))));
     signatures.push_back(signature);
 
-    EXPECT_CALL(*block, height()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*block, height()).WillRepeatedly(Return(height));
     EXPECT_CALL(*block, prevHash()).WillRepeatedly(testing::ReturnRef(hash));
     EXPECT_CALL(*block, signatures())
         .WillRepeatedly(Return(signatures | boost::adaptors::indirected));
@@ -63,11 +62,12 @@ class ChainValidationTest : public ::testing::Test {
           std::make_shared<iroha::consensus::yac::MockSupermajorityChecker>();
   std::shared_ptr<ChainValidatorImpl> validator;
   std::shared_ptr<MockMutableStorage> storage;
-  std::shared_ptr<MockPeerQuery> query;
 
   std::vector<std::shared_ptr<shared_model::interface::Signature>> signatures;
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;
   shared_model::crypto::Hash hash = shared_model::crypto::Hash("valid hash");
+  shared_model::interface::types::HeightType prev_height = 1;
+  shared_model::interface::types::HeightType height = prev_height + 1;
   std::shared_ptr<MockBlock> block = std::make_shared<MockBlock>();
   rxcpp::observable<std::shared_ptr<shared_model::interface::Block>> blocks =
       rxcpp::observable<>::just(
@@ -85,10 +85,9 @@ TEST_F(ChainValidationTest, ValidCase) {
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(DoAll(SaveArg<0>(&block_signatures_amount), Return(true)));
 
-  EXPECT_CALL(*query, getLedgerPeers()).WillOnce(Return(peers));
-
   EXPECT_CALL(*storage, apply(blocks, _))
-      .WillOnce(InvokeArgument<1>(block, ByRef(*query), ByRef(hash)));
+      .WillOnce(
+          InvokeArgument<1>(block, LedgerState{peers, prev_height, hash}));
 
   ASSERT_TRUE(validator->validateAndApply(blocks, *storage));
   ASSERT_EQ(boost::size(block->signatures()), block_signatures_amount);
@@ -104,13 +103,12 @@ TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
   shared_model::crypto::Hash another_hash =
       shared_model::crypto::Hash(std::string(32, '1'));
 
-  ON_CALL(*supermajority_checker, hasSupermajority(_, _))
-      .WillByDefault(Return(true));
-
-  EXPECT_CALL(*query, getLedgerPeers()).WillOnce(Return(peers));
+  EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
+      .WillRepeatedly(Return(true));
 
   EXPECT_CALL(*storage, apply(blocks, _))
-      .WillOnce(InvokeArgument<1>(block, ByRef(*query), ByRef(another_hash)));
+      .WillOnce(InvokeArgument<1>(
+          block, LedgerState{peers, prev_height, another_hash}));
 
   ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
 }
@@ -126,10 +124,9 @@ TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(DoAll(SaveArg<0>(&block_signatures_amount), Return(false)));
 
-  EXPECT_CALL(*query, getLedgerPeers()).WillOnce(Return(peers));
-
   EXPECT_CALL(*storage, apply(blocks, _))
-      .WillOnce(InvokeArgument<1>(block, ByRef(*query), ByRef(hash)));
+      .WillOnce(
+          InvokeArgument<1>(block, LedgerState{peers, prev_height, hash}));
 
   ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
   ASSERT_EQ(boost::size(block->signatures()), block_signatures_amount);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

[IR-442](https://jira.hyperledger.org/browse/IR-442)

Makes commit operations produce a `CommitStatus` object, which is an `expected::Result<std::shared_ptr<iroha::LedgerState>, std::string>`. A successful commit yields an actualized ledger state, and a failed - an error reason.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Ledger state is updated then and only then, when a commit to storage happens. It is practical then to provide a new ledger state as a result of a successful commit and propagate it to all components that need it. Also peer query usage was reduced by means of reusing ledger state after commit.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
