### PR TITLE
Fix consensus transport and its fuzzing test

### DIFF
--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -59,8 +59,9 @@ namespace iroha {
           ::google::protobuf::Empty *response) {
         std::vector<VoteMessage> state;
         for (const auto &pb_vote : request->votes()) {
-          auto vote = *PbConverters::deserializeVote(pb_vote, log_);
-          state.push_back(vote);
+          if (auto vote = PbConverters::deserializeVote(pb_vote, log_)) {
+            state.push_back(*vote);
+          }
         }
         if (state.empty()) {
           log_->info("Received an empty votes collection");

--- a/irohad/consensus/yac/transport/yac_pb_converters.hpp
+++ b/irohad/consensus/yac/transport/yac_pb_converters.hpp
@@ -103,30 +103,44 @@ namespace iroha {
           auto vote = deserealizeRoundAndHashes(pb_vote);
 
           auto deserialize =
-              [&](auto &pubkey, auto &signature, auto &val, const auto &msg) {
-                factory
+              [&](auto &pubkey, auto &signature, const auto &msg) {
+                return factory
                     .createSignature(shared_model::crypto::PublicKey(pubkey),
                                      shared_model::crypto::Signed(signature))
                     .match(
-                        [&](iroha::expected::Value<
-                            std::unique_ptr<shared_model::interface::Signature>>
-                                &sig) { val = std::move(sig.value); },
-                        [&](iroha::expected::Error<std::string> &reason) {
+                        [&](iroha::expected::Value<std::unique_ptr<
+                                shared_model::interface::Signature>> &sig)
+                            -> boost::optional<std::unique_ptr<
+                                shared_model::interface::Signature>> {
+                          return std::move(sig).value;
+                        },
+                        [&](iroha::expected::Error<std::string> &reason)
+                            -> boost::optional<std::unique_ptr<
+                                shared_model::interface::Signature>> {
                           log->error(msg, reason.error);
+                          return boost::none;
                         });
               };
 
           if (pb_vote.hash().has_block_signature()) {
-            deserialize(pb_vote.hash().block_signature().pubkey(),
-                        pb_vote.hash().block_signature().signature(),
-                        vote.hash.block_signature,
-                        "Cannot build vote hash block signature: {}");
+            if (auto block_signature =
+                    deserialize(pb_vote.hash().block_signature().pubkey(),
+                                pb_vote.hash().block_signature().signature(),
+                                "Cannot build vote hash block signature: {}")) {
+              vote.hash.block_signature = *std::move(block_signature);
+            } else {
+              return boost::none;
+            }
           }
 
-          deserialize(pb_vote.signature().pubkey(),
-                      pb_vote.signature().signature(),
-                      vote.signature,
-                      "Cannot build vote signature: {}");
+          if (auto vote_signature =
+                  deserialize(pb_vote.signature().pubkey(),
+                              pb_vote.signature().signature(),
+                              "Cannot build vote signature: {}")) {
+            vote.signature = *std::move(vote_signature);
+          } else {
+            return boost::none;
+          }
 
           return vote;
         }

--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -79,7 +79,9 @@ target_link_libraries(consensus_fuzz
   gtest::gtest
   gmock::gmock
   yac_transport
+  yac
   protobuf-mutator
+  test_logger
   )
 
 add_executable(mst_fuzz mst_fuzz.cpp)

--- a/test/fuzzing/consensus_fuzz.cpp
+++ b/test/fuzzing/consensus_fuzz.cpp
@@ -7,31 +7,103 @@
 
 #include <libfuzzer/libfuzzer_macro.h>
 
+#include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"
+#include "consensus/round.hpp"
+#include "consensus/yac/cluster_order.hpp"
+#include "consensus/yac/impl/yac_crypto_provider_impl.hpp"
+#include "consensus/yac/storage/buffered_cleanup_strategy.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
-
+#include "consensus/yac/yac.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "framework/test_logger.hpp"
 #include "logger/dummy_logger.hpp"
+#include "logger/logger_manager.hpp"
+#include "module/irohad/common/validators_config.hpp"
 #include "module/irohad/consensus/yac/mock_yac_network.hpp"
+#include "module/irohad/consensus/yac/mock_yac_timer.hpp"
+#include "module/irohad/consensus/yac/yac_test_util.hpp"
+#include "validators/field_validator.hpp"
+
+#include "yac_mock.grpc.pb.h"
 
 using namespace testing;
 
 namespace fuzzing {
   struct ConsensusFixture {
-    std::shared_ptr<
-        NiceMock<iroha::consensus::yac::MockYacNetworkNotifications>>
-        notifications_;
+    std::shared_ptr<iroha::consensus::yac::Timer> timer_;
+    std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        common_objects_factory_;
+    std::shared_ptr<iroha::consensus::yac::YacCryptoProvider> crypto_provider_;
+    std::shared_ptr<iroha::consensus::yac::CleanupStrategy> cleanup_strategy_;
+    std::function<
+        std::unique_ptr<iroha::consensus::yac::proto::Yac::StubInterface>(
+            const shared_model::interface::Peer &)>
+        client_creator_;
+    const shared_model::crypto::Keypair keypair_;
+    std::shared_ptr<iroha::consensus::yac::YacNetworkNotifications> yac_;
     std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
         async_call_;
     std::shared_ptr<iroha::consensus::yac::NetworkImpl> network_;
+    iroha::consensus::Round initial_round_;
 
-    ConsensusFixture() {
-      notifications_ = std::make_shared<
-          NiceMock<iroha::consensus::yac::MockYacNetworkNotifications>>();
-      async_call_ = std::make_shared<
-          iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
-          logger::getDummyLoggerPtr());
+    ConsensusFixture()
+        : timer_(std::make_shared<iroha::consensus::yac::MockTimer>()),
+          cleanup_strategy_(std::make_shared<
+                            iroha::consensus::yac::BufferedCleanupStrategy>()),
+          client_creator_([](const shared_model::interface::Peer &peer) {
+            return std::make_unique<
+                iroha::consensus::yac::proto::MockYacStub>();
+          }),
+          keypair_(shared_model::crypto::DefaultCryptoAlgorithmType::
+                       generateKeypair()),
+          async_call_(std::make_shared<
+                      iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
+              logger::getDummyLoggerPtr())),
+          initial_round_{1, 1} {
       network_ = std::make_shared<iroha::consensus::yac::NetworkImpl>(
-          async_call_, logger::getDummyLoggerPtr());
-      network_->subscribe(notifications_);
+          async_call_, client_creator_, logger::getDummyLoggerPtr());
+
+      common_objects_factory_ =
+          std::make_shared<shared_model::proto::ProtoCommonObjectsFactory<
+              shared_model::validation::FieldValidator>>(
+              iroha::test::kTestsValidatorsConfig);
+
+      crypto_provider_ =
+          std::make_shared<iroha::consensus::yac::CryptoProviderImpl>(
+              keypair_, common_objects_factory_);
+
+      std::vector<std::shared_ptr<shared_model::interface::Peer>>
+          default_peers = [] {
+            std::vector<std::shared_ptr<shared_model::interface::Peer>> result;
+            for (size_t i = 0; i < 1; ++i) {
+              result.push_back(
+                  iroha::consensus::yac::makePeer(std::to_string(i)));
+            }
+            return result;
+          }();
+      auto initial_order =
+          iroha::consensus::yac::ClusterOrdering::create(default_peers);
+
+      if (not initial_order) {
+        throw "Initial peers order is not initialized";
+      }
+
+      yac_ = iroha::consensus::yac::Yac::create(
+          iroha::consensus::yac::YacVoteStorage(
+              cleanup_strategy_,
+              getSupermajorityChecker(
+                  iroha::consensus::yac::ConsistencyModel::kBft),
+              getTestLoggerManager()->getChild("YacVoteStorage")),
+          network_,
+          crypto_provider_,
+          timer_,
+          *initial_order,
+          initial_round_,
+          rxcpp::observe_on_one_worker(
+              rxcpp::schedulers::make_current_thread()),
+          getTestLoggerManager()->getChild("Yac")->getLogger());
+
+      network_->subscribe(yac_);
     }
   };
 }  // namespace fuzzing


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The test for consensus fuzzing now compiles and works.
The test uses not mocked consensus implementation.
The issue found by the test is fixed.

### Benefits

Increased test coverage.
The issue with votes deserialization in consensus transport is fixed.

### Possible Drawbacks 

Need to manually update consensus dependencies alongside with its usage in `application.cpp`

### Usage Examples or Tests 

```
scripts/run-iroha-dev.sh
cmake -H. -Bbuild -DLIB_SUFFIX=64 -DFUZZING=ON -DCMAKE_C_COMPILER=clang-7 -DCMAKE_CXX_COMPILER=clang++-7
cmake --build build --target consensus_fuzz -- -j4
build/test_bin/consensus_fuzz
```
