### PR TITLE
add peer test

### DIFF
--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -230,6 +230,11 @@ namespace integration_framework {
       return *keypair_;
     }
 
+    std::shared_ptr<shared_model::interface::Peer> FakePeer::getThisPeer()
+        const {
+      return this_peer_;
+    }
+
     rxcpp::observable<std::shared_ptr<MstMessage>>
     FakePeer::getMstStatesObservable() {
       return mst_network_notifier_->getObservable();

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -103,6 +103,9 @@ namespace integration_framework {
       /// Get the keypair of this peer.
       const shared_model::crypto::Keypair &getKeypair() const;
 
+      /// Get interface::Peer object for this instance.
+      std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
+
       /// Get the observable of MST states received by this peer.
       rxcpp::observable<std::shared_ptr<MstMessage>> getMstStatesObservable();
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -189,7 +189,7 @@ namespace integration_framework {
     }
   }
 
-  std::shared_ptr<FakePeer> IntegrationTestFramework::addInitialPeer(
+  std::shared_ptr<FakePeer> IntegrationTestFramework::addFakePeer(
       const boost::optional<Keypair> &key) {
     BOOST_ASSERT_MSG(this_peer_, "Need to set the ITF peer key first!");
     const auto port = port_guard_->getPort(kDefaultInternalPort);
@@ -212,10 +212,10 @@ namespace integration_framework {
   }
 
   std::vector<std::shared_ptr<fake_peer::FakePeer>>
-  IntegrationTestFramework::addInitialPeers(size_t amount) {
+  IntegrationTestFramework::addFakePeers(size_t amount) {
     std::vector<std::shared_ptr<fake_peer::FakePeer>> fake_peers;
     std::generate_n(std::back_inserter(fake_peers), amount, [this] {
-      auto fake_peer = addInitialPeer({});
+      auto fake_peer = addFakePeer({});
       fake_peer->setBehaviour(std::make_shared<fake_peer::HonestBehaviour>());
       return fake_peer;
     });

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -383,6 +383,11 @@ namespace integration_framework {
     iroha_instance_->run();
   }
 
+  std::shared_ptr<shared_model::interface::Peer>
+  IntegrationTestFramework::getThisPeer() const {
+    return this_peer_;
+  }
+
   rxcpp::observable<std::shared_ptr<iroha::MstState>>
   IntegrationTestFramework::getMstStateUpdateObservable() {
     return iroha_instance_->getIrohaInstance()

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -233,8 +233,7 @@ namespace integration_framework {
         shared_model::proto::TransactionBuilder()
             .creatorAccountId(kAdminId)
             .createdTime(iroha::time::now())
-            .addPeer(format_address(kLocalHost, internal_port_),
-                     key.publicKey())
+            .addPeer(getAddress(), key.publicKey())
             .createRole(kAdminRole, all_perms)
             .createRole(kDefaultRole, {})
             .createDomain(kDomain, kDefaultRole)
@@ -314,8 +313,7 @@ namespace integration_framework {
     my_key_ = keypair;
     this_peer_ =
         framework::expected::val(common_objects_factory_->createPeer(
-                                     format_address(kLocalHost, internal_port_),
-                                     keypair.publicKey()))
+                                     getAddress(), keypair.publicKey()))
             .value()
             .value;
     iroha_instance_->initPipeline(keypair, maximum_proposal_size_);
@@ -386,6 +384,10 @@ namespace integration_framework {
   std::shared_ptr<shared_model::interface::Peer>
   IntegrationTestFramework::getThisPeer() const {
     return this_peer_;
+  }
+
+  std::string IntegrationTestFramework::getAddress() const {
+    return format_address(kLocalHost, internal_port_);
   }
 
   rxcpp::observable<std::shared_ptr<iroha::MstState>>

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -116,12 +116,12 @@ namespace integration_framework {
     ~IntegrationTestFramework();
 
     /// Add a fake peer with given key.
-    std::shared_ptr<fake_peer::FakePeer> addInitialPeer(
+    std::shared_ptr<fake_peer::FakePeer> addFakePeer(
         const boost::optional<shared_model::crypto::Keypair> &key);
 
     /// Add the given amount of fake peers with generated default keys and
     /// "honest" behaviours.
-    std::vector<std::shared_ptr<fake_peer::FakePeer>> addInitialPeers(
+    std::vector<std::shared_ptr<fake_peer::FakePeer>> addFakePeers(
         size_t amount);
 
     /**

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -421,6 +421,9 @@ namespace integration_framework {
     /// Get interface::Peer object for this instance.
     std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
 
+    /// Get this node address.
+    std::string getAddress() const;
+
    protected:
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -418,6 +418,9 @@ namespace integration_framework {
     /// Start the ITF.
     void subscribeQueuesAndRun();
 
+    /// Get interface::Peer object for this instance.
+    std::shared_ptr<shared_model::interface::Peer> getThisPeer() const;
+
    protected:
     using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
 

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -25,6 +25,12 @@ target_link_libraries(add_asset_qty_test
     integration_framework
     )
 
+addtest(add_peer_test add_peer_test.cpp)
+target_link_libraries(add_peer_test
+    acceptance_fixture
+    integration_framework
+    )
+
 addtest(create_account_test create_account_test.cpp)
 target_link_libraries(create_account_test
     acceptance_fixture

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "datetime/time.hpp"
+#include "framework/integration_framework/fake_peer/fake_peer.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "framework/test_logger.hpp"
+#include "integration/acceptance/acceptance_fixture.hpp"
+#include "main/server_runner.hpp"
+#include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
+#include "module/shared_model/builders/protobuf/block.hpp"
+
+using namespace common_constants;
+using namespace shared_model;
+using namespace integration_framework;
+using namespace shared_model::interface::permissions;
+
+static constexpr std::chrono::seconds kMstStateWaitingTime(20);
+
+template <size_t N>
+void checkBlockHasNTxs(const std::shared_ptr<const interface::Block> &block) {
+  ASSERT_EQ(block->transactions().size(), N);
+}
+
+class FakePeerExampleFixture : public AcceptanceFixture {
+ public:
+  using FakePeer = fake_peer::FakePeer;
+
+  std::unique_ptr<IntegrationTestFramework> itf_;
+
+  /**
+   * Create honest fake iroha peers
+   *
+   * @param num_fake_peers - the amount of fake peers to create
+   */
+  void createFakePeers(size_t num_fake_peers) {
+    fake_peers_ = itf_->addFakePeers(num_fake_peers);
+  }
+
+  /**
+   * Prepare state of ledger:
+   * - create account of target user
+   * - add assets to admin
+   *
+   * @return reference to ITF
+   */
+  IntegrationTestFramework &prepareState() {
+    itf_->setGenesisBlock(itf_->defaultBlock()).subscribeQueuesAndRun();
+
+    auto permissions =
+        interface::RolePermissionSet({Role::kReceive, Role::kTransfer});
+
+    return itf_
+        ->sendTxAwait(makeUserWithPerms(permissions), checkBlockHasNTxs<1>)
+        .sendTxAwait(
+            complete(baseTx(kAdminId).addAssetQuantity(kAssetId, "20000.0"),
+                     kAdminKeypair),
+            checkBlockHasNTxs<1>);
+  }
+
+ protected:
+  void SetUp() override {
+    itf_ =
+        std::make_unique<IntegrationTestFramework>(1, boost::none, true, true);
+    itf_->initPipeline(kAdminKeypair);
+  }
+
+  std::vector<std::shared_ptr<FakePeer>> fake_peers_;
+};
+
+auto makePeerPointeeMatcher(interface::types::AddressType address,
+                            interface::types::PubkeyType pubkey) {
+  return ::testing::Truly(
+      [address = std::move(address),
+       pubkey = std::move(pubkey)](std::shared_ptr<interface::Peer> peer) {
+        return peer->address() == address and peer->pubkey() == pubkey;
+      });
+}
+
+auto makePeerPointeeMatcher(std::shared_ptr<interface::Peer> peer) {
+  return makePeerPointeeMatcher(peer->address(), peer->pubkey());
+}
+
+/**
+ * @given a network of single peer
+ * @when it receives a valid signed addPeer command
+ * @then the transaction is committed
+ *    @and the WSV reports that there are two peers: the initial and the added one
+ */
+TEST_F(FakePeerExampleFixture, CheckPeerIsAdded) {
+  // init the real peer with no other peers in the genesis block
+  auto &itf = prepareState();
+
+  const std::string new_peer_address = "127.0.0.1:1234";
+  const auto new_peer_pubkey =
+      shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair()
+          .publicKey();
+
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).addPeer(new_peer_address, new_peer_pubkey),
+               kAdminKeypair),
+      checkBlockHasNTxs<1>);
+
+  auto opt_peers = itf.getIrohaInstance()
+                       .getIrohaInstance()
+                       ->getStorage()
+                       ->createPeerQuery()
+                       .value()
+                       ->getLedgerPeers();
+
+  ASSERT_TRUE(opt_peers);
+  EXPECT_THAT(*opt_peers,
+              ::testing::UnorderedElementsAre(
+                  makePeerPointeeMatcher(itf.getThisPeer()),
+                  makePeerPointeeMatcher(new_peer_address, new_peer_pubkey)));
+}
+
+/**
+ * @given a network of single peer
+ * @given
+ * @when it receives a not fully signed transaction and then a new peer is added
+ * @then the first peer propagates MST state to the newly added peer
+ */
+TEST_F(FakePeerExampleFixture, MstStatePropagtesToNewPeer) {
+  // init the real peer with no other peers in the genesis block
+  auto &itf = prepareState();
+
+  // then create a fake peer
+  auto new_peer = itf.addFakePeer(boost::none);
+  auto mst_states_observable = new_peer->getMstStatesObservable().replay();
+  mst_states_observable.connect();
+  auto new_peer_server = new_peer->run();
+
+  // and add it with addPeer
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).addPeer(new_peer->getAddress(),
+                                        new_peer->getKeypair().publicKey()),
+               kAdminKeypair),
+      checkBlockHasNTxs<1>);
+
+  itf.sendTxWithoutValidation(complete(
+      baseTx(kAdminId)
+          .transferAsset(kAdminId, kUserId, kAssetId, "income", "500.0")
+          .quorum(2),
+      kAdminKeypair));
+
+  mst_states_observable
+      .timeout(kMstStateWaitingTime, rxcpp::observe_on_new_thread())
+      .take(1)
+      .as_blocking()
+      .subscribe([](const auto &) {},
+                 [](std::exception_ptr ep) {
+                   try {
+                     std::rethrow_exception(ep);
+                   } catch (const std::exception &e) {
+                     FAIL() << "Error waiting for MST state: " << e.what();
+                   }
+                 });
+
+  new_peer_server->shutdown();
+}

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -40,7 +40,7 @@ class FakePeerExampleFixture : public AcceptanceFixture {
    * @param num_fake_peers - the amount of fake peers to create
    */
   void createFakePeers(size_t num_fake_peers) {
-    fake_peers_ = itf_->addInitialPeers(num_fake_peers);
+    fake_peers_ = itf_->addFakePeers(num_fake_peers);
   }
 
   /**


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

[IR-450](https://jira.hyperledger.org/browse/IR-450)

Test for `addPeer` command. Two cases:
- addPeer command gets committed and the WSV has old peers plus the added one;
- peer gets incomplete MST and then new peer is added; MST state propagates to new peer.
- peer gets started with genesis block that does not contain it, and must synchronize with a running network after it has a corresponding addPeer command committed.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

increased test coverage

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

more time to wait for CI (~3.3sec)

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

`add_peer_test`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
