### PR TITLE
Reopened: Feature/on request proposal strategy

### DIFF
--- a/irohad/consensus/CMakeLists.txt
+++ b/irohad/consensus/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(consensus_round
     )
 target_link_libraries(consensus_round
     boost
+    shared_model_utils
     )
 
 add_library(gate_object

--- a/irohad/consensus/yac/impl/supermajority_checker_bft.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_bft.cpp
@@ -19,6 +19,12 @@ namespace iroha {
             agreed, all, detail::kSupermajorityCheckerKfPlus1Bft);
       }
 
+      bool SupermajorityCheckerBft::hasMajority(PeersNumberType voted,
+                                                PeersNumberType all) const {
+        return checkKfPlus1Majority(
+            voted, all, detail::kSupermajorityCheckerKfPlus1Bft);
+      }
+
       bool SupermajorityCheckerBft::canHaveSupermajority(
           const VoteGroups &votes, PeersNumberType all) const {
         const PeersNumberType largest_group =

--- a/irohad/consensus/yac/impl/supermajority_checker_bft.hpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_bft.hpp
@@ -23,6 +23,9 @@ namespace iroha {
         bool hasSupermajority(PeersNumberType current,
                               PeersNumberType all) const override;
 
+        bool hasMajority(PeersNumberType voted,
+                         PeersNumberType all) const override;
+
         bool canHaveSupermajority(const VoteGroups &votes,
                                   PeersNumberType all) const override;
       };

--- a/irohad/consensus/yac/impl/supermajority_checker_cft.cpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_cft.cpp
@@ -19,6 +19,12 @@ namespace iroha {
             agreed, all, detail::kSupermajorityCheckerKfPlus1Cft);
       }
 
+      bool SupermajorityCheckerCft::hasMajority(PeersNumberType voted,
+                                                PeersNumberType all) const {
+        return checkKfPlus1Majority(
+            voted, all, detail::kSupermajorityCheckerKfPlus1Cft);
+      }
+
       bool SupermajorityCheckerCft::canHaveSupermajority(
           const VoteGroups &votes, PeersNumberType all) const {
         const PeersNumberType largest_group =

--- a/irohad/consensus/yac/impl/supermajority_checker_cft.hpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_cft.hpp
@@ -23,6 +23,9 @@ namespace iroha {
         bool hasSupermajority(PeersNumberType current,
                               PeersNumberType all) const override;
 
+        bool hasMajority(PeersNumberType voted,
+                         PeersNumberType all) const override;
+
         bool canHaveSupermajority(const VoteGroups &votes,
                                   PeersNumberType all) const override;
       };

--- a/irohad/consensus/yac/impl/supermajority_checker_kf1.hpp
+++ b/irohad/consensus/yac/impl/supermajority_checker_kf1.hpp
@@ -34,6 +34,15 @@ namespace iroha {
         return agreed * k >= (k - 1) * (all - 1) + k;
       }
 
+      inline bool checkKfPlus1Majority(PeersNumberType agreed,
+                                            PeersNumberType all,
+                                            unsigned int k) {
+        if (agreed > all) {
+          return false;
+        }
+        return agreed * k > all - 1;
+      }
+
     }  // namespace yac
   }    // namespace consensus
 }  // namespace iroha

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -130,6 +130,7 @@ namespace iroha {
               current_hash_.vote_round, current_ledger_state_, block));
         }
 
+        current_hash_ = hash;
         auto public_keys = boost::copy_range<
             shared_model::interface::types::PublicKeyCollectionType>(
             msg.votes | boost::adaptors::transformed([](auto &vote) {
@@ -140,15 +141,17 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->info("Consensus skipped round, voted for nothing");
           current_block_ = boost::none;
-          return rxcpp::observable<>::just<GateObject>(AgreementOnNone(
-              hash.vote_round, current_ledger_state_, std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(
+              AgreementOnNone(current_hash_.vote_round,
+                              current_ledger_state_,
+                              std::move(public_keys)));
         }
 
         log_->info("Voted for another block, waiting for sync");
         current_block_ = boost::none;
         auto model_hash = hash_provider_->toModelHash(hash);
         return rxcpp::observable<>::just<GateObject>(
-            VoteOther(hash.vote_round,
+            VoteOther(current_hash_.vote_round,
                       current_ledger_state_,
                       std::move(public_keys),
                       std::move(model_hash)));
@@ -179,12 +182,16 @@ namespace iroha {
                         });
         if (not has_same_proposals) {
           log_->info("Proposal reject since all hashes are different");
-          return rxcpp::observable<>::just<GateObject>(ProposalReject(
-              hash.vote_round, current_ledger_state_, std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(
+              ProposalReject(current_hash_.vote_round,
+                             current_ledger_state_,
+                             std::move(public_keys)));
         }
         log_->info("Block reject since proposal hashes match");
-        return rxcpp::observable<>::just<GateObject>(BlockReject(
-            hash.vote_round, current_ledger_state_, std::move(public_keys)));
+        return rxcpp::observable<>::just<GateObject>(
+            BlockReject(current_hash_.vote_round,
+                        current_ledger_state_,
+                        std::move(public_keys)));
       }
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -130,7 +130,6 @@ namespace iroha {
               current_hash_.vote_round, current_ledger_state_, block));
         }
 
-        current_hash_ = hash;
         auto public_keys = boost::copy_range<
             shared_model::interface::types::PublicKeyCollectionType>(
             msg.votes | boost::adaptors::transformed([](auto &vote) {
@@ -141,17 +140,15 @@ namespace iroha {
           // if consensus agreed on nothing for commit
           log_->info("Consensus skipped round, voted for nothing");
           current_block_ = boost::none;
-          return rxcpp::observable<>::just<GateObject>(
-              AgreementOnNone(current_hash_.vote_round,
-                              current_ledger_state_,
-                              std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(AgreementOnNone(
+              hash.vote_round, current_ledger_state_, std::move(public_keys)));
         }
 
         log_->info("Voted for another block, waiting for sync");
         current_block_ = boost::none;
         auto model_hash = hash_provider_->toModelHash(hash);
         return rxcpp::observable<>::just<GateObject>(
-            VoteOther(current_hash_.vote_round,
+            VoteOther(hash.vote_round,
                       current_ledger_state_,
                       std::move(public_keys),
                       std::move(model_hash)));
@@ -182,16 +179,12 @@ namespace iroha {
                         });
         if (not has_same_proposals) {
           log_->info("Proposal reject since all hashes are different");
-          return rxcpp::observable<>::just<GateObject>(
-              ProposalReject(current_hash_.vote_round,
-                             current_ledger_state_,
-                             std::move(public_keys)));
+          return rxcpp::observable<>::just<GateObject>(ProposalReject(
+              hash.vote_round, current_ledger_state_, std::move(public_keys)));
         }
         log_->info("Block reject since proposal hashes match");
-        return rxcpp::observable<>::just<GateObject>(
-            BlockReject(current_hash_.vote_round,
-                        current_ledger_state_,
-                        std::move(public_keys)));
+        return rxcpp::observable<>::just<GateObject>(BlockReject(
+            hash.vote_round, current_ledger_state_, std::move(public_keys)));
       }
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/supermajority_checker.hpp
+++ b/irohad/consensus/yac/supermajority_checker.hpp
@@ -50,6 +50,15 @@ namespace iroha {
                                       PeersNumberType all) const = 0;
 
         /**
+         * Check if majority of votes is achieved
+         * @param voted - number of voted peers
+         * @param all - number of all peers in network
+         * @return true if majority is reached
+         */
+        virtual bool hasMajority(PeersNumberType voted,
+                                 PeersNumberType all) const = 0;
+
+        /**
          * Check if supermajority is possible
          * @param voted - numbers of peers voted for each option
          * @param all - number of peers in round

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -36,6 +36,7 @@
 #include "multi_sig_transactions/transport/mst_transport_stub.hpp"
 #include "network/impl/block_loader_impl.hpp"
 #include "network/impl/peer_communication_service_impl.hpp"
+#include "ordering/impl/kick_out_proposal_creation_strategy.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 #include "ordering/impl/on_demand_ordering_gate.hpp"
 #include "pending_txs_storage/impl/pending_txs_storage_impl.hpp"
@@ -388,6 +389,14 @@ void Irohad::initOrderingGate() {
     return reject_delay;
   };
 
+  std::shared_ptr<iroha::ordering::ProposalCreationStrategy> proposal_strategy =
+      std::make_shared<ordering::KickOutProposalCreationStrategy>(
+          getSupermajorityChecker(kConsensusConsistencyModel));
+
+  auto field_validator =
+      std::make_shared<shared_model::validation::FieldValidator>(
+          validators_config_);
+
   ordering_gate =
       ordering_init.initOrderingGate(max_proposal_size_,
                                      proposal_delay_,
@@ -401,7 +410,10 @@ void Irohad::initOrderingGate() {
                                      proposal_factory,
                                      persistent_cache,
                                      delay,
-                                     log_manager_->getChild("Ordering"));
+                                     log_manager_->getChild("Ordering"),
+                                     field_validator,
+                                     proposal_strategy,
+                                     keypair.publicKey());
   log_->info("[Init] => init ordering gate - [{}]",
              logger::logBool(ordering_gate));
 }

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -13,6 +13,7 @@
 #include "interfaces/common_objects/types.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
+#include "ordering/impl/kick_out_proposal_creation_strategy.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 #include "ordering/impl/on_demand_connection_manager.hpp"
 #include "ordering/impl/on_demand_ordering_gate.hpp"
@@ -53,12 +54,14 @@ namespace iroha {
             async_call,
         std::shared_ptr<TransportFactoryType> proposal_transport_factory,
         std::chrono::milliseconds delay,
+        shared_model::crypto::PublicKey my_key,
         const logger::LoggerManagerTreePtr &ordering_log_manager) {
       return std::make_shared<ordering::transport::OnDemandOsClientGrpcFactory>(
           std::move(async_call),
           std::move(proposal_transport_factory),
           [] { return std::chrono::system_clock::now(); },
           delay,
+          my_key,
           ordering_log_manager->getChild("NetworkClient")->getLogger());
     }
 
@@ -69,6 +72,7 @@ namespace iroha {
         std::shared_ptr<TransportFactoryType> proposal_transport_factory,
         std::chrono::milliseconds delay,
         std::vector<shared_model::interface::types::HashType> initial_hashes,
+        shared_model::crypto::PublicKey my_key,
         const logger::LoggerManagerTreePtr &ordering_log_manager) {
       // since top block will be the first in commit_notifier observable,
       // hashes of two previous blocks are prepended
@@ -193,6 +197,7 @@ namespace iroha {
           createNotificationFactory(std::move(async_call),
                                     std::move(proposal_transport_factory),
                                     delay,
+                                    my_key,
                                     ordering_log_manager),
           peers,
           ordering_log_manager->getChild("ConnectionManager")->getLogger());
@@ -205,6 +210,7 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
             proposal_factory,
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
         std::function<std::chrono::milliseconds(
             const synchronizer::SynchronizationEvent &)> delay_func,
         size_t max_number_of_transactions,
@@ -264,6 +270,7 @@ namespace iroha {
           std::move(cache),
           std::move(proposal_factory),
           std::move(tx_cache),
+          std::move(creation_strategy),
           max_number_of_transactions,
           ordering_log_manager->getChild("Gate")->getLogger());
     }
@@ -273,11 +280,13 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
             proposal_factory,
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
         const logger::LoggerManagerTreePtr &ordering_log_manager) {
       return std::make_shared<ordering::OnDemandOrderingServiceImpl>(
           max_number_of_transactions,
           std::move(proposal_factory),
           std::move(tx_cache),
+          creation_strategy,
           ordering_log_manager->getChild("Service")->getLogger());
     }
 
@@ -307,16 +316,23 @@ namespace iroha {
         std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
         std::function<std::chrono::milliseconds(
             const synchronizer::SynchronizationEvent &)> delay_func,
-        logger::LoggerManagerTreePtr ordering_log_manager) {
+        logger::LoggerManagerTreePtr ordering_log_manager,
+        std::shared_ptr<shared_model::validation::FieldValidator>
+            field_validator,
+        std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
+        shared_model::crypto::PublicKey my_key) {
       auto ordering_service = createService(max_number_of_transactions,
                                             proposal_factory,
                                             tx_cache,
+                                            creation_strategy,
                                             ordering_log_manager);
       service = std::make_shared<ordering::transport::OnDemandOsServerGrpc>(
           ordering_service,
           std::move(transaction_factory),
           std::move(batch_parser),
           std::move(transaction_batch_factory),
+          field_validator,
+          creation_strategy,
           ordering_log_manager->getChild("Server")->getLogger());
       return createGate(
           ordering_service,
@@ -325,10 +341,12 @@ namespace iroha {
                                   std::move(proposal_transport_factory),
                                   delay,
                                   std::move(initial_hashes),
+                                  my_key,
                                   ordering_log_manager),
           std::make_shared<ordering::cache::OnDemandCache>(),
           std::move(proposal_factory),
           std::move(tx_cache),
+          std::move(creation_strategy),
           std::move(delay_func),
           max_number_of_transactions,
           ordering_log_manager);

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -21,7 +21,7 @@
 #include "ordering/impl/on_demand_os_server_grpc.hpp"
 #include "ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp"
 #include "ordering/on_demand_ordering_service.hpp"
-#include "ordering/on_demand_os_transport.hpp"
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
 
 namespace iroha {
   namespace network {
@@ -46,6 +46,7 @@ namespace iroha {
               async_call,
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay,
+          shared_model::crypto::PublicKey my_key,
           const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       /**
@@ -60,6 +61,7 @@ namespace iroha {
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay,
           std::vector<shared_model::interface::types::HashType> initial_hashes,
+          shared_model::crypto::PublicKey my_key,
           const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       /**
@@ -73,6 +75,7 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
           std::function<std::chrono::milliseconds(
               const synchronizer::SynchronizationEvent &)> delay_func,
           size_t max_number_of_transactions,
@@ -87,6 +90,7 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
           const logger::LoggerManagerTreePtr &ordering_log_manager);
 
       rxcpp::composite_subscription sync_event_notifier_lifetime_;
@@ -119,6 +123,10 @@ namespace iroha {
        * requests to ordering service and processing responses
        * @param proposal_factory factory required by ordering service to produce
        * proposals
+       * @param field_validator - provides a dependency for validating peer keys
+       * @param creation_strategy - provides a strategy for creaing proposals in
+       * OS
+       * @param my_key - public key of instantiated peer
        * @return initialized ordering gate
        */
       std::shared_ptr<network::OrderingGate> initOrderingGate(
@@ -142,7 +150,11 @@ namespace iroha {
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
           std::function<std::chrono::milliseconds(
               const synchronizer::SynchronizationEvent &)> delay_func,
-          logger::LoggerManagerTreePtr ordering_log_manager);
+          logger::LoggerManagerTreePtr ordering_log_manager,
+          std::shared_ptr<shared_model::validation::FieldValidator>
+              field_validator,
+          std::shared_ptr<ordering::ProposalCreationStrategy> creation_strategy,
+          shared_model::crypto::PublicKey my_key);
 
       /// gRPC service for ordering service
       std::shared_ptr<ordering::proto::OnDemandOrdering::Service> service;

--- a/irohad/ordering/CMakeLists.txt
+++ b/irohad/ordering/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(on_demand_common
 
 add_library(on_demand_ordering_service
     impl/on_demand_ordering_service_impl.cpp
+    impl/kick_out_proposal_creation_strategy.cpp
     )
 
 target_link_libraries(on_demand_ordering_service

--- a/irohad/ordering/impl/kick_out_proposal_creation_strategy.cpp
+++ b/irohad/ordering/impl/kick_out_proposal_creation_strategy.cpp
@@ -1,0 +1,59 @@
+#include <utility>
+
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ordering/impl/kick_out_proposal_creation_strategy.hpp"
+
+#include <algorithm>
+#include "interfaces/common_objects/peer.hpp"
+
+using namespace iroha::ordering;
+
+KickOutProposalCreationStrategy::KickOutProposalCreationStrategy(
+    std::shared_ptr<SupermajorityCheckerType> majority_checker)
+    : majority_checker_(std::move(majority_checker)) {}
+
+void KickOutProposalCreationStrategy::onCollaborationOutcome(
+    const PeerList &peers) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  RoundCollectionType last_requested;
+  for (const auto &peer : peers) {
+    auto iter = last_requested_.find(peer);
+    if (iter != last_requested_.end()) {
+      last_requested.insert(*iter);
+    } else {
+      last_requested.insert({peer, RoundType{0, 0}});
+    }
+  }
+  last_requested_ = last_requested;
+}
+
+void KickOutProposalCreationStrategy::shouldCreateRound(
+    RoundType round, const std::function<void()> &on_create) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  uint64_t counter = std::count_if(
+      last_requested_.begin(),
+      last_requested_.end(),
+      [&round](const auto &elem) { return elem.second >= round; });
+
+  if(not majority_checker_->hasMajority(counter, last_requested_.size())) {
+    on_create();
+  }
+}
+
+boost::optional<ProposalCreationStrategy::RoundType>
+KickOutProposalCreationStrategy::onProposalRequest(const PeerType &who,
+                                                   RoundType requested_round) {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto iter = last_requested_.find(who);
+    if (iter != last_requested_.end() and iter->second < requested_round) {
+      iter->second = requested_round;
+    }
+  }
+
+  return boost::none;
+}

--- a/irohad/ordering/impl/kick_out_proposal_creation_strategy.hpp
+++ b/irohad/ordering/impl/kick_out_proposal_creation_strategy.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_KICK_OUT_PROPOSAL_CREATION_STRATEGY_HPP
+#define IROHA_KICK_OUT_PROPOSAL_CREATION_STRATEGY_HPP
+
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include "consensus/yac/supermajority_checker.hpp"
+#include "multi_sig_transactions/hash.hpp"
+
+namespace iroha {
+  namespace ordering {
+
+    class KickOutProposalCreationStrategy : public ProposalCreationStrategy {
+     public:
+      using SupermajorityCheckerType =
+          iroha::consensus::yac::SupermajorityChecker;
+      KickOutProposalCreationStrategy(
+          std::shared_ptr<SupermajorityCheckerType> majority_checker);
+
+      /**
+       * Update peers state with new peers.
+       * Note: the method removes peers which are not participating in consensus
+       * and adds new with minimal round
+       * @param peers - list of peers which fetched in the last round
+       */
+      void onCollaborationOutcome(const PeerList &peers) override;
+
+      void shouldCreateRound(RoundType round,
+                             const std::function<void()> &on_create) override;
+
+      boost::optional<RoundType> onProposalRequest(
+          const PeerType &who, RoundType requested_round) override;
+
+     private:
+      using RoundCollectionType =
+          std::unordered_map<shared_model::crypto::PublicKey,
+                             RoundType,
+                             iroha::model::BlobHasher>;
+
+      std::mutex mutex_;
+      std::shared_ptr<SupermajorityCheckerType> majority_checker_;
+      RoundCollectionType last_requested_;
+    };
+  }  // namespace ordering
+}  // namespace iroha
+
+#endif  // IROHA_KICK_OUT_PROPOSAL_CREATION_STRATEGY_HPP

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -11,6 +11,7 @@
 #include <shared_mutex>
 
 #include <rxcpp/rx.hpp>
+#include "interfaces/common_objects/peer.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -12,12 +12,14 @@
 
 #include <boost/variant.hpp>
 #include <rxcpp/rx.hpp>
+#include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
 #include "logger/logger_fwd.hpp"
 #include "ordering/impl/ordering_gate_cache/ordering_gate_cache.hpp"
 #include "ordering/on_demand_ordering_service.hpp"
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -55,6 +57,7 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy,
           size_t transaction_limit,
           logger::LoggerPtr log);
 
@@ -97,6 +100,7 @@ namespace iroha {
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;
       std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache_;
+      std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy_;
 
       rxcpp::composite_subscription proposal_notifier_lifetime_;
       rxcpp::subjects::subject<network::OrderingEvent> proposal_notifier_;

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -31,16 +31,15 @@ OnDemandOrderingServiceImpl::OnDemandOrderingServiceImpl(
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
         proposal_factory,
     std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+    std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy,
     logger::LoggerPtr log,
-    size_t number_of_proposals,
-    const consensus::Round &initial_round)
+    size_t number_of_proposals)
     : transaction_limit_(transaction_limit),
       number_of_proposals_(number_of_proposals),
       proposal_factory_(std::move(proposal_factory)),
       tx_cache_(std::move(tx_cache)),
-      log_(std::move(log)) {
-  onCollaborationOutcome(initial_round);
-}
+      proposal_creation_strategy_(std::move(proposal_creation_strategy)),
+      log_(std::move(log)) {}
 
 // -------------------------| OnDemandOrderingService |-------------------------
 
@@ -79,6 +78,7 @@ OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
       result;
   {
     std::shared_lock<std::shared_timed_mutex> lock(proposals_mutex_);
+    // todo add force initialization of proposal
     auto it = proposal_map_.find(round);
     result = boost::make_optional(it != proposal_map_.end(), it->second);
   }
@@ -129,66 +129,48 @@ getTransactions(size_t requested_tx_amount,
 
 void OnDemandOrderingServiceImpl::packNextProposals(
     const consensus::Round &round) {
-  /*
-   * The possible cases can be visualised as a diagram, where:
-   * o - current round, x - next round, v - target round
-   *
-   *   0 1 2
-   * 0 o x v
-   * 1 x v .
-   * 2 v . .
-   *
-   * Reject case:
-   *
-   *   0 1 2 3
-   * 0 . o x v
-   * 1 x v . .
-   * 2 v . . .
-   *
-   * (0,1) - current round. Round (0,2) is closed for transactions.
-   * Round (0,3) is now receiving transactions.
-   * Rounds (1,) and (2,) do not change.
-   *
-   * Commit case:
-   *
-   *   0 1 2
-   * 0 . . .
-   * 1 o x v
-   * 2 x v .
-   * 3 v . .
-   *
-   * (1,0) - current round. The diagram is similar to the initial case.
-   */
-
-  size_t discarded_txs_quantity;
-  auto now = iroha::time::now();
-  auto generate_proposal = [this, now, &discarded_txs_quantity](
-                               consensus::Round round, const auto &txs) {
-    auto proposal = proposal_factory_->unsafeCreateProposal(
-        round.block_round, now, txs | boost::adaptors::indirected);
-    proposal_map_.erase(round);
-    proposal_map_.emplace(round, std::move(proposal));
-    log_->debug(
-        "packNextProposal: data has been fetched for {}. "
-        "Number of transactions in proposal = {}. Discarded {} "
-        "transactions.",
-        round,
-        txs.size(),
-        discarded_txs_quantity);
-  };
-
   if (not pending_batches_.empty()) {
+    size_t discarded_txs_quantity;
     auto txs = getTransactions(
         transaction_limit_, pending_batches_, discarded_txs_quantity);
-    if (not txs.empty()) {
-      generate_proposal({round.block_round, round.reject_round + 1}, txs);
-      generate_proposal({round.block_round + 1, kFirstRejectRound}, txs);
-    }
+    log_->debug("Discarded {} transactions", discarded_txs_quantity);
+    auto now = iroha::time::now();
+    // create proposals for the next commit and reject rounds
+    tryCreateProposal({round.block_round, round.reject_round + 1}, txs, now);
+    tryCreateProposal({round.block_round + 1, kFirstRejectRound}, txs, now);
   }
 
   if (round.reject_round == kFirstRejectRound) {
     std::lock_guard<std::shared_timed_mutex> lock(batches_mutex_);
     pending_batches_.clear();
+  }
+}
+
+void OnDemandOrderingServiceImpl::tryCreateProposal(
+    iroha::consensus::Round round,
+    const TransactionsCollectionType &txs,
+    shared_model::interface::types::TimestampType created_time) {
+  if (not txs.empty()) {
+    bool is_invoked = false;
+    proposal_creation_strategy_->shouldCreateRound(round, [&] {
+      auto proposal = proposal_factory_->unsafeCreateProposal(
+          round.block_round, created_time, txs | boost::adaptors::indirected);
+      proposal_map_.erase(round);
+      proposal_map_.emplace(round, std::move(proposal));
+      is_invoked = true;
+    });
+    if (is_invoked) {
+      log_->debug(
+          "packNextProposal: data has been fetched for {}. "
+          "Number of transactions in proposal = {}.",
+          round,
+          txs.size());
+    } else {
+      log_->debug("Proposal for {} not created by the strategy", round);
+    }
+
+  } else {
+    log_->debug("No transactions to create a proposal for {}", round);
   }
 }
 

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -18,6 +18,7 @@
 // TODO 2019-03-15 andrei: IR-403 Separate BatchHashEquality and MstState
 #include "multi_sig_transactions/state/mst_state.hpp"
 #include "ordering/impl/on_demand_common.hpp"
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -46,17 +47,15 @@ namespace iroha {
        * @param log to print progress
        * @param number_of_proposals - number of stored proposals, older will be
        * removed. Default value is 3
-       * @param initial_round - first round of agreement.
-       * Default value is {2, kFirstRejectRound} since genesis block height is 1
        */
       OnDemandOrderingServiceImpl(
           size_t transaction_limit,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+          std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy,
           logger::LoggerPtr log,
-          size_t number_of_proposals = 3,
-          const consensus::Round &initial_round = {2, kFirstRejectRound});
+          size_t number_of_proposals = 3);
 
       // --------------------- | OnDemandOrderingService |_---------------------
 
@@ -75,6 +74,14 @@ namespace iroha {
        * Note: method is not thread-safe
        */
       void packNextProposals(const consensus::Round &round);
+
+      using TransactionsCollectionType =
+          std::vector<std::shared_ptr<shared_model::interface::Transaction>>;
+
+      void tryCreateProposal(
+          consensus::Round round,
+          const TransactionsCollectionType &txs,
+          shared_model::interface::types::TimestampType created_time);
 
       /**
        * Removes last elements if it is required
@@ -121,6 +128,11 @@ namespace iroha {
        * Processed transactions cache used for replay prevention
        */
       std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache_;
+
+      /**
+       *
+       */
+      std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy_;
 
       /**
        * Logger instance

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -7,6 +7,7 @@
 
 #include "backend/protobuf/proposal.hpp"
 #include "backend/protobuf/transaction.hpp"
+#include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "logger/logger.hpp"
@@ -23,13 +24,15 @@ OnDemandOsClientGrpc::OnDemandOsClientGrpc(
     std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<TimepointType()> time_provider,
     std::chrono::milliseconds proposal_request_timeout,
+    shared_model::interface::types::PubkeyType my_key,
     logger::LoggerPtr log)
     : log_(std::move(log)),
       stub_(std::move(stub)),
       async_call_(std::move(async_call)),
       proposal_factory_(std::move(proposal_factory)),
       time_provider_(std::move(time_provider)),
-      proposal_request_timeout_(proposal_request_timeout) {}
+      proposal_request_timeout_(proposal_request_timeout),
+      my_key_(std::move(my_key)) {}
 
 void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
   proto::BatchesRequest request;
@@ -40,6 +43,8 @@ void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
               ->getTransport());
     }
   }
+
+  *request.mutable_peer_key() = shared_model::crypto::toBinaryString(my_key_);
 
   log_->debug("Propagating: '{}'", request.DebugString());
 
@@ -53,8 +58,12 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   grpc::ClientContext context;
   context.set_deadline(time_provider_() + proposal_request_timeout_);
   proto::ProposalRequest request;
+
   request.mutable_round()->set_block_round(round.block_round);
   request.mutable_round()->set_reject_round(round.reject_round);
+
+  *request.mutable_peer_key() = shared_model::crypto::toBinaryString(my_key_);
+
   proto::ProposalResponse response;
   auto status = stub_->RequestProposal(&context, request, &response);
   if (not status.ok()) {
@@ -85,11 +94,13 @@ OnDemandOsClientGrpcFactory::OnDemandOsClientGrpcFactory(
     std::shared_ptr<TransportFactoryType> proposal_factory,
     std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
     OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
+    shared_model::interface::types::PubkeyType my_key,
     logger::LoggerPtr client_log)
     : async_call_(std::move(async_call)),
       proposal_factory_(std::move(proposal_factory)),
       time_provider_(time_provider),
       proposal_request_timeout_(proposal_request_timeout),
+      my_key_(std::move(my_key)),
       client_log_(std::move(client_log)) {}
 
 std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
@@ -100,5 +111,6 @@ std::unique_ptr<OdOsNotification> OnDemandOsClientGrpcFactory::create(
       proposal_factory_,
       time_provider_,
       proposal_request_timeout_,
+      my_key_,
       client_log_);
 }

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -8,6 +8,8 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "logger/logger_fwd.hpp"
 #include "network/impl/async_grpc_client.hpp"
@@ -40,6 +42,7 @@ namespace iroha {
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
+            shared_model::interface::types::PubkeyType my_key,
             logger::LoggerPtr log);
 
         void onBatches(CollectionType batches) override;
@@ -55,6 +58,7 @@ namespace iroha {
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
+        shared_model::interface::types::PubkeyType my_key_;
       };
 
       class OnDemandOsClientGrpcFactory : public OdOsNotificationFactory {
@@ -66,6 +70,7 @@ namespace iroha {
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
             OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
+            shared_model::interface::types::PubkeyType my_key,
             logger::LoggerPtr client_log);
 
         /**
@@ -83,6 +88,7 @@ namespace iroha {
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
+        shared_model::interface::types::PubkeyType my_key_;
         logger::LoggerPtr client_log_;
       };
 

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -9,8 +9,10 @@
 
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include "backend/protobuf/common_objects/peer.hpp"
 #include "backend/protobuf/proposal.hpp"
 #include "common/bind.hpp"
+#include "cryptography/public_key.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "logger/logger.hpp"
 
@@ -24,11 +26,15 @@ OnDemandOsServerGrpc::OnDemandOsServerGrpc(
         batch_parser,
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory,
+    std::shared_ptr<shared_model::validation::FieldValidator> field_validator,
+    std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy,
     logger::LoggerPtr log)
     : ordering_service_(ordering_service),
       transaction_factory_(std::move(transaction_factory)),
       batch_parser_(std::move(batch_parser)),
       batch_factory_(std::move(transaction_batch_factory)),
+      field_validator_(std::move(field_validator)),
+      proposal_creation_strategy_(proposal_creation_strategy),
       log_(std::move(log)) {}
 
 shared_model::interface::types::SharedTxsCollectionType
@@ -84,7 +90,9 @@ grpc::Status OnDemandOsServerGrpc::SendBatches(
         return acc;
       });
 
-  ordering_service_->onBatches(std::move(batches));
+  fetchPeer(request->peer_key()) | [this, &batches](auto &&peer) {
+    ordering_service_->onBatches(std::move(batches));
+  };
 
   return ::grpc::Status::OK;
 }
@@ -93,12 +101,29 @@ grpc::Status OnDemandOsServerGrpc::RequestProposal(
     ::grpc::ServerContext *context,
     const proto::ProposalRequest *request,
     proto::ProposalResponse *response) {
-  ordering_service_->onRequestProposal(
-      {request->round().block_round(), request->round().reject_round()})
-      | [&](auto &&proposal) {
-          *response->mutable_proposal() =
-              static_cast<const shared_model::proto::Proposal *>(proposal.get())
-                  ->getTransport();
-        };
+  fetchPeer(request->peer_key()) | [this, &request, &response](auto &&peer) {
+    consensus::Round round{request->round().block_round(),
+                           request->round().reject_round()};
+    proposal_creation_strategy_->onProposalRequest(peer, round);
+    ordering_service_->onRequestProposal(round) | [&](auto &&proposal) {
+      *response->mutable_proposal() =
+          static_cast<const shared_model::proto::Proposal *>(proposal.get())
+              ->getTransport();
+    };
+  };
   return ::grpc::Status::OK;
+}
+
+boost::optional<shared_model::crypto::PublicKey>
+OnDemandOsServerGrpc::fetchPeer(const std::string &pub_key) const {
+  shared_model::crypto::PublicKey key{pub_key};
+  shared_model::validation::ReasonsGroupType reason;
+  field_validator_->validatePubkey(reason, key);
+  if (not reason.second.empty()) {
+    shared_model::validation::Answer answer;
+    answer.addReason(std::move(reason));
+    log_->error("Failed to parse peer key struct, {}", answer.reason());
+    return boost::none;
+  }
+  return key;
 }

--- a/irohad/ordering/impl/on_demand_os_server_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.hpp
@@ -8,11 +8,14 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include <boost/optional.hpp>
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
 #include "logger/logger_fwd.hpp"
 #include "ordering.grpc.pb.h"
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
+#include "validators/field_validator.hpp"
 
 namespace iroha {
   namespace ordering {
@@ -35,6 +38,10 @@ namespace iroha {
                 batch_parser,
             std::shared_ptr<shared_model::interface::TransactionBatchFactory>
                 transaction_batch_factory,
+            std::shared_ptr<shared_model::validation::FieldValidator>
+                field_validator,
+            std::shared_ptr<ProposalCreationStrategy>
+                proposal_creation_strategy,
             logger::LoggerPtr log);
 
         grpc::Status SendBatches(::grpc::ServerContext *context,
@@ -47,6 +54,9 @@ namespace iroha {
             proto::ProposalResponse *response) override;
 
        private:
+        boost::optional<shared_model::crypto::PublicKey> fetchPeer(
+            const std::string &pub_key) const;
+
         /**
          * Flat map transport transactions to shared model
          */
@@ -60,6 +70,9 @@ namespace iroha {
             batch_parser_;
         std::shared_ptr<shared_model::interface::TransactionBatchFactory>
             batch_factory_;
+        std::shared_ptr<shared_model::validation::FieldValidator>
+            field_validator_;
+        std::shared_ptr<ProposalCreationStrategy> proposal_creation_strategy_;
 
         logger::LoggerPtr log_;
       };

--- a/irohad/ordering/ordering_service_proposal_creation_strategy.hpp
+++ b/irohad/ordering/ordering_service_proposal_creation_strategy.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_ORDERING_SERVICE_PROPOSAL_CREATION_STRATEGY_HPP
+#define IROHA_ORDERING_SERVICE_PROPOSAL_CREATION_STRATEGY_HPP
+
+#include <boost/optional.hpp>
+#include <boost/range/any_range.hpp>
+#include "consensus/round.hpp"
+#include "cryptography/public_key.hpp"
+
+namespace iroha {
+  namespace ordering {
+
+    /**
+     * Class provides a strategy for creation proposals regarding to new rounds
+     * and requests from other peers
+     */
+    class ProposalCreationStrategy {
+     public:
+      /// shortcut for peer type
+      using PeerType = shared_model::crypto::PublicKey;
+      /// shortcut for round type
+      using RoundType = consensus::Round;
+      /// collection of peers type
+      using PeerList = boost::
+          any_range<PeerType, boost::forward_traversal_tag, const PeerType>;
+
+      /**
+       * Indicates the start of new round.
+       * @param peers - peers which participate in new round
+       */
+      virtual void onCollaborationOutcome(const PeerList &peers) = 0;
+
+      /**
+       * @param round - new consensus round
+       * @param on_create - lambda which invokes when the round should be
+       * created
+       */
+      virtual void shouldCreateRound(
+          RoundType round, const std::function<void()> &on_create) = 0;
+
+      /**
+       * Notify the strategy about proposal request
+       * @param who - peer which requests the proposal
+       * @param requested_round - in which round proposal is requested
+       * @return round where proposal is required to be created immediately
+       */
+      virtual boost::optional<RoundType> onProposalRequest(
+          const PeerType &who, RoundType requested_round) = 0;
+
+      virtual ~ProposalCreationStrategy() = default;
+    };
+  }  // namespace ordering
+}  // namespace iroha
+
+#endif  // IROHA_ORDERING_SERVICE_PROPOSAL_CREATION_STRATEGY_HPP

--- a/schema/ordering.proto
+++ b/schema/ordering.proto
@@ -21,10 +21,12 @@ message ProposalRound {
 
 message BatchesRequest {
   repeated protocol.Transaction transactions = 1;
+  bytes peer_key = 2;
 }
 
 message ProposalRequest {
   ProposalRound round = 1;
+  bytes peer_key = 2;
 }
 
 message ProposalResponse {

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -77,7 +77,11 @@ namespace integration_framework {
             transaction_batch_factory,
         std::shared_ptr<iroha::ordering::transport::OnDemandOsClientGrpc::
                             TransportFactoryType> proposal_factory,
+        std::shared_ptr<shared_model::validation::FieldValidator>
+            field_validator,
         std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache,
+        std::shared_ptr<iroha::ordering::ProposalCreationStrategy>
+            proposal_creation_strategy,
         logger::LoggerManagerTreePtr log_manager)
         : log_(log_manager->getLogger()),
           log_manager_(std::move(log_manager)),
@@ -89,6 +93,8 @@ namespace integration_framework {
           transaction_factory_(transaction_factory),
           transaction_batch_factory_(transaction_batch_factory),
           proposal_factory_(std::move(proposal_factory)),
+          field_validator_(std::move(field_validator)),
+          proposal_creation_strategy_(std::move(proposal_creation_strategy)),
           batch_parser_(batch_parser),
           listen_ip_(listen_ip),
           internal_port_(internal_port),
@@ -149,6 +155,8 @@ namespace integration_framework {
           transaction_factory_,
           batch_parser_,
           transaction_batch_factory_,
+          field_validator_,
+          proposal_creation_strategy_,
           ordering_log_manager_->getChild("Transport")->getLogger());
 
       initialized_ = true;
@@ -387,6 +395,7 @@ namespace integration_framework {
               proposal_factory_,
               [] { return std::chrono::system_clock::now(); },
               timeout,
+              keypair_->publicKey(),
               ordering_log_manager_->getChild("NetworkClient")->getLogger())
               .create(*real_peer_);
       return on_demand_os_transport->onRequestProposal(round);

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -66,7 +66,11 @@ namespace integration_framework {
               transaction_batch_factory,
           std::shared_ptr<iroha::ordering::transport::OnDemandOsClientGrpc::
                               TransportFactoryType> proposal_factory,
+          std::shared_ptr<shared_model::validation::FieldValidator>
+              field_validator,
           std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache,
+          std::shared_ptr<iroha::ordering::ProposalCreationStrategy>
+              proposal_creation_strategy,
           logger::LoggerManagerTreePtr log_manager);
 
       ~FakePeer();
@@ -219,6 +223,10 @@ namespace integration_framework {
       std::shared_ptr<iroha::ordering::transport::OnDemandOsClientGrpc::
                           TransportFactoryType>
           proposal_factory_;
+      std::shared_ptr<shared_model::validation::FieldValidator>
+          field_validator_;
+      std::shared_ptr<iroha::ordering::ProposalCreationStrategy>
+          proposal_creation_strategy_;
       std::shared_ptr<shared_model::interface::TransactionBatchParser>
           batch_parser_;
 

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -17,7 +17,7 @@ namespace shared_model {
   namespace crypto {
     class Keypair;
     class Hash;
-  }
+  }  // namespace crypto
   namespace interface {
     class CommonObjectsFactory;
     class Proposal;
@@ -29,6 +29,9 @@ namespace shared_model {
   namespace proto {
     class Block;
     class Proposal;
+  }  // namespace proto
+  namespace validation {
+    class FieldValidator;
   }
 }  // namespace shared_model
 
@@ -51,13 +54,14 @@ namespace iroha {
       struct VoteMessage;
     }  // namespace yac
     struct Round;
-  }    // namespace consensus
+  }  // namespace consensus
   namespace ordering {
     namespace transport {
       class OnDemandOsServerGrpc;
     }
     class OrderingGateTransportGrpc;
     class OrderingServiceTransportGrpc;
+    class ProposalCreationStrategy;
   }  // namespace ordering
   class MstState;
 }  // namespace iroha

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -30,6 +30,7 @@
 #include "network/impl/async_grpc_client.hpp"
 #include "network/mst_transport.hpp"
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
 #include "torii/command_client.hpp"
 #include "torii/query_client.hpp"
 
@@ -490,7 +491,10 @@ namespace integration_framework {
     std::shared_ptr<
         iroha::ordering::transport::OnDemandOsClientGrpc::TransportFactoryType>
         proposal_factory_;
+    std::shared_ptr<shared_model::validation::FieldValidator> field_validator_;
     std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache_;
+    std::shared_ptr<iroha::ordering::ProposalCreationStrategy>
+        proposal_creation_strategy_;
     std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
     std::shared_ptr<iroha::consensus::yac::YacNetwork> yac_transport_;
 

--- a/test/module/irohad/consensus/yac/mock_yac_supermajority_checker.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_supermajority_checker.hpp
@@ -17,6 +17,7 @@ namespace iroha {
       class MockSupermajorityChecker : public SupermajorityChecker {
        public:
         MOCK_CONST_METHOD2(hasSupermajority, bool(PeersNumberType, PeersNumberType));
+        MOCK_CONST_METHOD2(hasMajority, bool(PeersNumberType, PeersNumberType));
         MOCK_CONST_METHOD2(canHaveSupermajority,
                            bool(const VoteGroups &, PeersNumberType));
       };

--- a/test/module/irohad/consensus/yac/supermajority_checker_test.cpp
+++ b/test/module/irohad/consensus/yac/supermajority_checker_test.cpp
@@ -11,7 +11,6 @@
 
 #include <boost/foreach.hpp>
 #include "boost/tuple/tuple.hpp"
-#include "consensus/yac/supermajority_checker.hpp"
 #include "logger/logger.hpp"
 
 #include "framework/test_logger.hpp"
@@ -45,6 +44,10 @@ class SupermajorityCheckerTest
     return total_peers - getAllowedFaultyPeers(total_peers);
   }
 
+  size_t getMajority(size_t total_peers) const {
+    return getAllowedFaultyPeers(total_peers) + 1;
+  }
+
   std::string modelToString() const {
     return "`" + std::to_string(getK()) + " * f + 1' "
         + (GetParam() == ConsistencyModel::kBft ? "BFT" : "CFT") + " model";
@@ -53,6 +56,10 @@ class SupermajorityCheckerTest
   bool hasSupermajority(PeersNumberType current,
                         PeersNumberType all) const override {
     return checker->hasSupermajority(current, all);
+  }
+
+  bool hasMajority(PeersNumberType voted, PeersNumberType all) const {
+    return checker->hasMajority(voted, all);
   }
 
   bool canHaveSupermajority(const VoteGroups &votes,
@@ -72,13 +79,13 @@ INSTANTIATE_TEST_CASE_P(Instance,
                         ::testing::Values(ConsistencyModel::kCft,
                                           ConsistencyModel::kBft),
                         // empty argument for the macro
-                        );
+);
 
 INSTANTIATE_TEST_CASE_P(Instance,
                         BftSupermajorityCheckerTest,
                         ::testing::Values(ConsistencyModel::kBft),
                         // empty argument for the macro
-                        );
+);
 
 /**
  * @given 2 participants
@@ -88,7 +95,7 @@ INSTANTIATE_TEST_CASE_P(Instance,
 TEST_P(CftAndBftSupermajorityCheckerTest, SuperMajorityCheckWithSize2) {
   log_->info("-----------| F(x, 2), x in [0..3] |-----------");
 
-  size_t A = 2; // number of all peers
+  size_t A = 2;  // number of all peers
   for (size_t i = 0; i < 4; ++i) {
     if (i >= getSupermajority(A)  // enough votes
         and i <= A                // not more than total peers amount
@@ -109,10 +116,10 @@ TEST_P(CftAndBftSupermajorityCheckerTest, SuperMajorityCheckWithSize2) {
  * @when check range of voted participants
  * @then correct result
  */
-TEST_P(SupermajorityCheckerTest, SuperMajorityCheckWithSize4) {
+TEST_P(CftAndBftSupermajorityCheckerTest, SuperMajorityCheckWithSize4) {
   log_->info("-----------| F(x, 4), x in [0..5] |-----------");
 
-  size_t A = 6; // number of all peers
+  size_t A = 6;  // number of all peers
   for (size_t i = 0; i < 5; ++i) {
     if (i >= getSupermajority(A)  // enough votes
         and i <= A                // not more than total peers amount
@@ -124,6 +131,24 @@ TEST_P(SupermajorityCheckerTest, SuperMajorityCheckWithSize4) {
       ASSERT_FALSE(hasSupermajority(i, A))
           << i << " votes out of " << A << " are not a supermajority in "
           << modelToString();
+    }
+  }
+}
+
+/**
+ * @given 4 participants
+ * @when check range of voted participants
+ * @then correct result
+ */
+TEST_P(CftAndBftSupermajorityCheckerTest, MajorityWithSize4) {
+  size_t A = 4;
+  for (size_t i = 0; i < 5; ++i) {
+    if (i >= getMajority(A) and i <= A) {
+      ASSERT_TRUE(hasMajority(i, A))
+          << i << " votes out of " << A << " in " << modelToString();
+    } else {
+      ASSERT_FALSE(hasMajority(i, A))
+          << i << " votes out of " << A << " in " << modelToString();
     }
   }
 }
@@ -153,8 +178,8 @@ TEST_P(CftAndBftSupermajorityCheckerTest, OneLargeAndManySingleVoteGroups) {
   };
 
   struct Case {
-    size_t V; // Voted peers
-    size_t A; // All peers
+    size_t V;  // Voted peers
+    size_t A;  // All peers
   };
 
   for (const auto &c : std::initializer_list<Case>({{6, 7}, {8, 12}})) {

--- a/test/module/irohad/ordering/CMakeLists.txt
+++ b/test/module/irohad/ordering/CMakeLists.txt
@@ -40,3 +40,10 @@ target_link_libraries(on_demand_cache_test
     on_demand_ordering_gate
     shared_model_interfaces_factories
     )
+
+addtest(kick_out_proposal_creation_strategy_test
+    kick_out_proposal_creation_strategy_test.cpp
+    )
+target_link_libraries(kick_out_proposal_creation_strategy_test
+    on_demand_ordering_service
+    )

--- a/test/module/irohad/ordering/kick_out_proposal_creation_strategy_test.cpp
+++ b/test/module/irohad/ordering/kick_out_proposal_creation_strategy_test.cpp
@@ -1,0 +1,210 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ordering/impl/kick_out_proposal_creation_strategy.hpp"
+
+#include <vector>
+
+// dependencies for the concurrent test
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "module/irohad/consensus/yac/mock_yac_supermajority_checker.hpp"
+
+using namespace iroha::ordering;
+
+using testing::_;
+using testing::Return;
+
+class KickOutProposalCreationStrategyTest : public testing::Test {
+ public:
+  void SetUp() override {
+    is_invoked = false;
+
+    for (auto i = 0u; i < number_of_peers; ++i) {
+      peers.emplace_back(std::to_string(i));
+    }
+
+    supermajority_checker_ =
+        std::make_shared<iroha::consensus::yac::MockSupermajorityChecker>();
+    strategy_ = std::make_shared<KickOutProposalCreationStrategy>(
+        supermajority_checker_);
+  }
+
+  std::shared_ptr<KickOutProposalCreationStrategy> strategy_;
+  std::shared_ptr<iroha::consensus::yac::MockSupermajorityChecker>
+      supermajority_checker_;
+
+  std::vector<KickOutProposalCreationStrategy::PeerType> peers;
+  size_t number_of_peers = 7;
+  size_t f = 2;
+  bool is_invoked;
+  std::function<void()> invocation_checker = [this] { is_invoked = true; };
+};
+
+/**
+ * @given initialized kickOutStrategy
+ *        @and onCollaborationOutcome is invoked for the first round
+ * @when  onProposal calls F times with different peers for further rounds
+ * @then  shouldCreateRound returns true
+ */
+TEST_F(KickOutProposalCreationStrategyTest, OnNonMaliciousCase) {
+  EXPECT_CALL(*supermajority_checker_, hasMajority(0, number_of_peers))
+      .WillOnce(Return(false));
+
+  strategy_->onCollaborationOutcome(peers);
+
+  strategy_->shouldCreateRound({2, 0}, invocation_checker);
+  ASSERT_EQ(true, is_invoked);
+  is_invoked = false;
+
+  for (auto i = 0u; i < f; ++i) {
+    strategy_->onProposalRequest(peers.at(i), {2, 0});
+  }
+
+  EXPECT_CALL(*supermajority_checker_, hasMajority(f, number_of_peers))
+      .WillOnce(Return(false));
+  strategy_->shouldCreateRound({2, 0}, invocation_checker);
+  ASSERT_EQ(true, is_invoked);
+}
+
+/**
+ * @given initialized kickOutStrategy
+ *        @and onCollaborationOutcome is invoked for the first round
+ * @when  onProposal calls F + 1 times with different peers for further rounds
+ * @then  onCollaborationOutcome returns false
+ */
+TEST_F(KickOutProposalCreationStrategyTest, OnMaliciousCase) {
+  strategy_->onCollaborationOutcome(peers);
+
+  auto requested = f + 1;
+  for (auto i = 0u; i < requested; ++i) {
+    strategy_->onProposalRequest(peers.at(i), {2, 0});
+  }
+
+  EXPECT_CALL(*supermajority_checker_, hasMajority(requested, number_of_peers))
+      .WillOnce(Return(true));
+  strategy_->shouldCreateRound({2, 0}, invocation_checker);
+  ASSERT_EQ(false, is_invoked);
+}
+
+/**
+ * @given initialized kickOutStrategy
+ *        @and onCollaborationOutcome is invoked for the first round
+ * @when  onProposal calls F + 1 times with one peer
+ * @then  onCollaborationOutcome call returns true
+ */
+TEST_F(KickOutProposalCreationStrategyTest, RepeadedRequest) {
+  strategy_->onCollaborationOutcome(peers);
+
+  auto requested = f + 1;
+  for (auto i = 0u; i < requested; ++i) {
+    strategy_->onProposalRequest(peers.at(0), {2, 0});
+  }
+  EXPECT_CALL(*supermajority_checker_, hasMajority(1, number_of_peers))
+      .WillOnce(Return(false));
+  strategy_->shouldCreateRound({2, 0}, invocation_checker);
+  ASSERT_EQ(true, is_invoked);
+}
+
+/**
+ * @given initialized kickOutStrategy
+ *        @and onCollaborationOutcome is invoked for the first round
+ * @when  onProposal calls F times different peers
+ *        @and 1 time with unknown peer
+ * @then  onCollaborationOutcome call returns true
+ */
+TEST_F(KickOutProposalCreationStrategyTest, UnknownPeerRequestsProposal) {
+  strategy_->onCollaborationOutcome(peers);
+
+  for (auto i = 0u; i < f; ++i) {
+    strategy_->onProposalRequest(peers.at(i), {2, 0});
+  }
+  strategy_->onProposalRequest(shared_model::crypto::PublicKey{"unknown"},
+                               {2, 0});
+  EXPECT_CALL(*supermajority_checker_, hasMajority(f, number_of_peers))
+      .WillOnce(Return(false));
+  strategy_->shouldCreateRound({2, 0}, invocation_checker);
+  ASSERT_EQ(true, is_invoked);
+}
+
+/**
+ * This is a probabilistic concurrent test which guarantees safety of lambda
+ * invocation calls in shouldCreateRound method
+ * @given main_thread - lambda which responsible for updating round counter and
+ * shouldCreateRound invocation. Lambda emulates work in on demand ordering
+ * service.
+ *        @and requester_thread - lambda which calls onProposalRequest with
+ * corresponding round. The lambda emulates requester peers in on demand
+ * ordering service.
+ *
+ * @when  starts main_thread and two worker threads
+ * @then  check that situation where lambda in shouldCreateRound see
+ * inconsistent state
+ *
+ * @note: The test is disabled because of CI can't perform concurrent tests well
+ */
+TEST_F(KickOutProposalCreationStrategyTest, DISABLED_ConcurrentTest) {
+  EXPECT_CALL(*supermajority_checker_, hasMajority(0, number_of_peers))
+      .WillRepeatedly(Return(false));
+  EXPECT_CALL(*supermajority_checker_, hasMajority(1, number_of_peers))
+      .WillRepeatedly(Return(false));
+  EXPECT_CALL(*supermajority_checker_, hasMajority(2, number_of_peers))
+      .WillRepeatedly(Return(true));
+
+  std::atomic<uint64_t> commit_round{1};
+
+  size_t number_of_threads = 2;
+  std::vector<uint64_t> last_requested(number_of_threads);
+
+  std::mutex mutex;
+
+  auto main_thread = [this, &commit_round, &last_requested, &mutex]() {
+    for (int i = 0; i < 10000; ++i) {
+      auto round = iroha::consensus::Round{commit_round.load(), 0};
+      strategy_->onCollaborationOutcome(peers);
+      bool all_the_same = false;
+      uint64_t last_val = 0;
+      {
+        std::lock_guard<std::mutex> guard(mutex);
+        all_the_same = std::all_of(last_requested.begin(),
+                                   last_requested.end(),
+                                   [&last_requested](const auto &val) {
+                                     return last_requested.at(0) == val;
+                                   });
+        last_val = last_requested.at(0);
+      }
+      strategy_->shouldCreateRound(round, [&] {
+        if (all_the_same) {
+          ASSERT_NE(round.block_round, last_val);
+        }
+      });
+      ++commit_round;
+    }
+  };
+
+  auto requester_thread =
+      [this, &commit_round, &last_requested, &mutex](size_t num) {
+        for (int i = 0; i < 10000; ++i) {
+          auto round = iroha::consensus::Round{commit_round.load(), 0};
+          strategy_->onProposalRequest(peers.at(num), round);
+          {
+            std::lock_guard<std::mutex> guard(mutex);
+            last_requested.at(num) = round.block_round;
+          }
+        }
+      };
+
+  std::thread main(main_thread);
+  std::thread _0(requester_thread, 0);
+  std::thread _1(requester_thread, 1);
+
+  main.join();
+  _0.join();
+  _1.join();
+}

--- a/test/module/irohad/ordering/mock_proposal_creation_strategy.hpp
+++ b/test/module/irohad/ordering/mock_proposal_creation_strategy.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_MOCK_PROPOSAL_CREATION_STRATEGY_HPP
+#define IROHA_MOCK_PROPOSAL_CREATION_STRATEGY_HPP
+
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
+
+#include <gmock/gmock.h>
+
+namespace iroha {
+  namespace ordering {
+    class MockProposalCreationStrategy : public ProposalCreationStrategy {
+     public:
+      MOCK_METHOD1(onCollaborationOutcome, void(const PeerList &));
+      MOCK_METHOD2(shouldCreateRound,
+                   void(RoundType, const std::function<void()> &));
+      MOCK_METHOD2(onProposalRequest,
+                   boost::optional<RoundType>(const PeerType &, RoundType));
+    };
+  }  // namespace ordering
+}  // namespace iroha
+
+#endif  // IROHA_MOCK_PROPOSAL_CREATION_STRATEGY_HPP

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -11,7 +11,9 @@
 #include "framework/test_subscriber.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
 #include "module/irohad/ametsuchi/mock_tx_presence_cache.hpp"
+#include "module/irohad/consensus/yac/yac_test_util.hpp"
 #include "module/irohad/ordering/mock_on_demand_os_notification.hpp"
+#include "module/irohad/ordering/mock_proposal_creation_strategy.hpp"
 #include "module/irohad/ordering/ordering_mocks.hpp"
 #include "module/shared_model/interface_mocks.hpp"
 #include "ordering/impl/on_demand_common.hpp"
@@ -41,6 +43,8 @@ class OnDemandOrderingGateTest : public ::testing::Test {
     auto ufactory = std::make_unique<NiceMock<MockUnsafeProposalFactory>>();
     factory = ufactory.get();
     tx_cache = std::make_shared<ametsuchi::MockTxPresenceCache>();
+    proposal_creation_strategy =
+        std::make_shared<MockProposalCreationStrategy>();
     ON_CALL(*tx_cache,
             check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
         .WillByDefault(
@@ -54,7 +58,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
         cache,
         std::move(ufactory),
         tx_cache,
-        1000,
+        proposal_creation_strategy,1000,
         getTestLogger("OrderingGate"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
@@ -71,6 +75,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
   std::shared_ptr<MockOdOsNotification> notification;
   NiceMock<MockUnsafeProposalFactory> *factory;
   std::shared_ptr<ametsuchi::MockTxPresenceCache> tx_cache;
+  std::shared_ptr<MockProposalCreationStrategy> proposal_creation_strategy;
   std::shared_ptr<OnDemandOrderingGate> ordering_gate;
 
   std::shared_ptr<cache::MockOrderingGateCache> cache;

--- a/test/module/irohad/ordering/proposal_creation_strategy_stub.hpp
+++ b/test/module/irohad/ordering/proposal_creation_strategy_stub.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PROPOSAL_CREATION_STRATEGY_STUB_HPP
+#define IROHA_PROPOSAL_CREATION_STRATEGY_STUB_HPP
+
+#include "ordering/ordering_service_proposal_creation_strategy.hpp"
+
+namespace iroha {
+  namespace ordering {
+
+    /**
+     * Stub implementation for testing purposes.
+     */
+    struct ProposalCreationStrategyStub final
+        : public ProposalCreationStrategy {
+     public:
+      void onCollaborationOutcome(const PeerList &peers) override {}
+
+      void shouldCreateRound(RoundType round,
+                             const std::function<void()> &) override {}
+
+      boost::optional<RoundType> onProposalRequest(
+          const PeerType &who, RoundType requested_round) override {
+        return boost::none;
+      }
+    };
+
+  }  // namespace ordering
+}  // namespace iroha
+
+#endif  // IROHA_PROPOSAL_CREATION_STRATEGY_STUB_HPP


### PR DESCRIPTION
# Description of the Change
The initial intention of the PR is to introduce a strategy for preventing the creation of proposals in OS. But this pr contains dependent changes for the proper working of the strategy.

# Benefits
Add round optimization for faster collaboration. Also, Closer to release state.

# Possible Drawbacks
A lot of different features which introduce in one PR
List of features:
    * Creation strategy interface in OS
    * Strategy which prevents the creation of proposals
    * OS\OG transport contains peer key in net interaction
    * Supermajority has a new method

# Alternate Designs [optional]
The transport layer is not backward compatible - introduces peer key of the sending side. There is an alternative with meta information in the request.