### PR TITLE
Reopened: Resending votes in yac transport

### DIFF
--- a/irohad/consensus/yac/CMakeLists.txt
+++ b/irohad/consensus/yac/CMakeLists.txt
@@ -43,6 +43,7 @@ target_compile_definitions(yac
 
 add_library(yac_transport
     transport/impl/network_impl.cpp
+    transport/impl/yac_network_sender.cpp
     impl/yac_crypto_provider_impl.cpp
     )
 target_link_libraries(yac_transport

--- a/irohad/consensus/yac/cluster_order.hpp
+++ b/irohad/consensus/yac/cluster_order.hpp
@@ -39,7 +39,7 @@ namespace iroha {
         /**
          * Provide current leader peer
          */
-        const shared_model::interface::Peer &currentLeader();
+        std::shared_ptr<shared_model::interface::Peer> currentLeader();
 
         /**
          * Switch to next peer as leader

--- a/irohad/consensus/yac/impl/cluster_order.cpp
+++ b/irohad/consensus/yac/impl/cluster_order.cpp
@@ -23,11 +23,12 @@ namespace iroha {
           : order_(std::move(order)) {}
 
       // TODO :  24/03/2018 x3medima17: make it const, IR-1164
-      const shared_model::interface::Peer &ClusterOrdering::currentLeader() {
+      std::shared_ptr<shared_model::interface::Peer>
+          ClusterOrdering::currentLeader() {
         if (index_ >= order_.size()) {
           index_ = 0;
         }
-        return *order_.at(index_);
+        return order_.at(index_);
       }
 
       bool ClusterOrdering::hasNext() const {

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -169,8 +169,7 @@ namespace iroha {
                    vote.hash.vote_hashes.proposal_hash,
                    vote.hash.vote_hashes.block_hash,
                    current_leader);
-
-        network_->sendState(current_leader, {vote});
+        propagateStateDirectly(current_leader, {vote});
         cluster_order_.switchToNext();
         auto has_next = cluster_order_.hasNext();
         lock.unlock();
@@ -279,7 +278,7 @@ namespace iroha {
                            last_round,
                            from->address());
                 auto votes = [](const auto &state) { return state.votes; };
-                this->propagateStateDirectly(*from,
+                this->propagateStateDirectly(from,
                                              visit_in_place(last_state, votes));
               };
             };
@@ -291,13 +290,14 @@ namespace iroha {
 
       void Yac::propagateState(const std::vector<VoteMessage> &msg) {
         for (const auto &peer : cluster_order_.getPeers()) {
-          propagateStateDirectly(*peer, msg);
+          propagateStateDirectly(peer, msg);
         }
       }
 
-      void Yac::propagateStateDirectly(const shared_model::interface::Peer &to,
-                                       const std::vector<VoteMessage> &msg) {
-        network_->sendState(to, msg);
+      void Yac::propagateStateDirectly(
+          std::shared_ptr<shared_model::interface::Peer> to,
+          const std::vector<VoteMessage> &msg) {
+        network_->sendState(std::move(to), msg);
       }
 
     }  // namespace yac

--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -35,8 +35,9 @@ namespace iroha {
         handler_ = handler;
       }
 
-      void NetworkImpl::sendState(const shared_model::interface::Peer &to,
-                                  const std::vector<VoteMessage> &state) {
+      YacNetworkWithFeedBack::SendStateReturnType NetworkImpl::sendState(
+          const shared_model::interface::Peer &to,
+          const std::vector<VoteMessage> &state) {
         createPeerConnection(to);
 
         proto::State request;
@@ -45,12 +46,58 @@ namespace iroha {
           *pb_vote = PbConverters::serializeVote(vote);
         }
 
-        async_call_->Call([&](auto context, auto cq) {
-          return peers_.at(to.address())->AsyncSendState(context, request, cq);
-        });
-
         log_->info(
             "Send votes bundle[size={}] to {}", state.size(), to.address());
+
+        auto log_outcome = [log = log_, destination_peer = to.toString()](
+                               const grpc::Status &status) {
+          log->info("Sent to {} with status details [{}]",
+                    destination_peer,
+                    status.ok() ? "OK" : status.error_details());
+        };
+
+        return async_call_
+            ->Call([&](auto context, auto cq) {
+              return peers_.at(to.address())
+                  ->AsyncSendState(context, request, cq);
+            })
+            .tap(log_outcome)
+            .map(
+                [](const auto &status) { return makeSendStateStatus(status); });
+      }
+
+      YacNetworkWithFeedBack::ValueStateReturnType
+      NetworkImpl::makeSendStateStatus(const grpc::Status &status) {
+        auto is_ok = [](const auto &code) {
+          return code == grpc::StatusCode::OK;
+        };
+
+        auto is_troubles_with_recipient = [](const auto &code) {
+          using namespace grpc;
+          std::set<StatusCode> codes = {StatusCode::CANCELLED,
+                                    StatusCode::INVALID_ARGUMENT,
+                                    StatusCode::UNAUTHENTICATED,
+                                    StatusCode::RESOURCE_EXHAUSTED,
+                                    StatusCode::ABORTED,
+                                    StatusCode::UNIMPLEMENTED,
+                                    StatusCode::UNAVAILABLE,
+                                    StatusCode::DATA_LOSS};
+          return codes.find(code) != codes.end();
+        };
+
+        auto code = status.error_code();
+
+        using namespace iroha::consensus::yac::sending_statuses;
+
+        if (is_ok(code)) {
+          return SuccessfulSent();
+        }
+
+        if (is_troubles_with_recipient(code)) {
+          return UnavailableReceiver();
+        }
+
+        return UnavailableNetwork();
       }
 
       grpc::Status NetworkImpl::SendState(

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -27,7 +27,8 @@ namespace iroha {
        * Class which provides implementation of transport for consensus based on
        * grpc
        */
-      class NetworkImpl : public YacNetwork, public proto::Yac::Service {
+      class NetworkImpl : public YacNetworkWithFeedBack,
+                          public proto::Yac::Service {
        public:
         explicit NetworkImpl(
             std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
@@ -39,8 +40,9 @@ namespace iroha {
         void subscribe(
             std::shared_ptr<YacNetworkNotifications> handler) override;
 
-        void sendState(const shared_model::interface::Peer &to,
-                       const std::vector<VoteMessage> &state) override;
+        YacNetworkWithFeedBack::SendStateReturnType sendState(
+            const shared_model::interface::Peer &to,
+            const std::vector<VoteMessage> &state) override;
 
         /**
          * Receive votes from another peer;
@@ -59,6 +61,9 @@ namespace iroha {
          * @param peer to instantiate connection with
          */
         void createPeerConnection(const shared_model::interface::Peer &peer);
+
+        static YacNetworkWithFeedBack::ValueStateReturnType makeSendStateStatus(
+            const grpc::Status &);
 
         /**
          * Mapping of peer objects to connections

--- a/irohad/consensus/yac/transport/impl/yac_network_sender.cpp
+++ b/irohad/consensus/yac/transport/impl/yac_network_sender.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "consensus/yac/transport/impl/yac_network_sender.hpp"
+
+#include "common/visitor.hpp"
+#include "consensus/yac/vote_message.hpp"
+
+using namespace iroha::consensus::yac;
+
+YacNetworkSender::YacNetworkSender(std::shared_ptr<TransportType> transport)
+    : transport_(std::move(transport)) {}
+
+void YacNetworkSender::subscribe(
+    std::shared_ptr<YacNetworkNotifications> handler) {
+  transport_->subscribe(std::move(handler));
+}
+
+void YacNetworkSender::sendState(PeerType to, StateType state) {
+  sendStateViaTransport(
+      to, std::make_shared<StateType>(std::move(state)), transport_);
+}
+
+void YacNetworkSender::sendStateViaTransport(
+    PeerType to,
+    StateInCollectionType state,
+    std::shared_ptr<TransportType> transport) {
+  transport->sendState(*to, *state)
+      .subscribe([transport = transport, to, state](const auto &result) {
+        iroha::visit_in_place(
+            result,
+            [transport, to, state](
+                const sending_statuses::UnavailableNetwork &) {
+              // assume the message is undelivered if troubles occur with our
+              // connection then it will resend the message
+
+              sendStateViaTransport(to, state, transport);
+            },
+            [&](const auto &) {
+              // if message delivers or recipient peer goes down then it
+              // will stop resending the message
+            });
+      });
+}

--- a/irohad/consensus/yac/transport/impl/yac_network_sender.hpp
+++ b/irohad/consensus/yac/transport/impl/yac_network_sender.hpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_YAC_NETWORK_SENDER_HPP
+#define IROHA_YAC_NETWORK_SENDER_HPP
+
+#include "consensus/yac/transport/yac_network_interface.hpp"
+
+#include <memory>
+#include <rxcpp/rx.hpp>
+#include <unordered_map>
+
+namespace iroha {
+  namespace consensus {
+    namespace yac {
+      /**
+       * Transport layer wrapper which retries to send messages if the network
+       * shut down
+       */
+      class YacNetworkSender : public YacNetwork {
+       public:
+        /// type of low transport level
+        using TransportType = YacNetworkWithFeedBack;
+
+        /// type of peer structure
+        using PeerType = std::shared_ptr<shared_model::interface::Peer>;
+
+        /// type of state
+        using StateType = std::vector<VoteMessage>;
+
+        YacNetworkSender(const YacNetworkSender &) = delete;
+        YacNetworkSender(YacNetworkSender &&) = delete;
+        YacNetworkSender &operator=(const YacNetworkSender &) = delete;
+        YacNetworkSender &operator=(YacNetworkSender &&) = delete;
+
+        /**
+         * Creates transport with redelivery property
+         * @param transport - instance of effective transport
+         */
+        YacNetworkSender(std::shared_ptr<TransportType> transport);
+
+        void subscribe(
+            std::shared_ptr<YacNetworkNotifications> handler) override;
+
+        void sendState(PeerType to, StateType state) override;
+
+       private:
+        using StateInCollectionType = std::shared_ptr<StateType>;
+        using StatesCollection =
+            std::unordered_map<PeerType, StateInCollectionType>;
+
+        static void sendStateViaTransport(
+            PeerType to,
+            StateInCollectionType state,
+            std::shared_ptr<TransportType> transport);
+
+        // ------------------------| Global state | ----------------------------
+        std::shared_ptr<TransportType> transport_;
+
+        // ------------------------| Current state | ---------------------------
+        StatesCollection undelivered_states_;
+      };
+    }  // namespace yac
+  }    // namespace consensus
+}  // namespace iroha
+#endif  // IROHA_YAC_NETWORK_SENDER_HPP

--- a/irohad/consensus/yac/transport/yac_network_interface.hpp
+++ b/irohad/consensus/yac/transport/yac_network_interface.hpp
@@ -6,7 +6,9 @@
 #ifndef IROHA_YAC_NETWORK_INTERFACE_HPP
 #define IROHA_YAC_NETWORK_INTERFACE_HPP
 
+#include <boost/variant.hpp>
 #include <memory>
+#include <rxcpp/rx.hpp>
 #include <vector>
 
 namespace shared_model {
@@ -22,6 +24,8 @@ namespace iroha {
       struct VoteMessage;
 
       class YacNetworkNotifications {
+        // TODO: 2019-03-20 @muratovv add method virtual void
+        // updatePeerList(...) IR-412
        public:
         /**
          * Callback on receiving collection of votes
@@ -33,6 +37,8 @@ namespace iroha {
       };
 
       class YacNetwork {
+        // TODO: 2019-03-20 @muratovv add method virtual void
+        // updatePeerList(...) IR-412
        public:
         virtual void subscribe(
             std::shared_ptr<YacNetworkNotifications> handler) = 0;
@@ -42,13 +48,61 @@ namespace iroha {
          * @param to - peer recipient
          * @param state - message for sending
          */
-        virtual void sendState(const shared_model::interface::Peer &to,
-                               const std::vector<VoteMessage> &state) = 0;
+        virtual void sendState(
+            std::shared_ptr<shared_model::interface::Peer> to,
+            std::vector<VoteMessage> state) = 0;
+
+        // TODO: add method virtual void updatePeerList();
 
         /**
          * Virtual destructor required for inheritance
          */
         virtual ~YacNetwork() = default;
+      };
+
+      /// namespace contains statuses of sending messages
+      namespace sending_statuses {
+        /// status presents successful delivery of a message
+        struct SuccessfulSent {};
+
+        /// status presents that something happens with our network connection
+        struct UnavailableNetwork {};
+
+        /// status presents that recipient peer shut down or has bad connection
+        struct UnavailableReceiver {};
+      }  // namespace sending_statuses
+
+      /**
+       * The interface introduces blocking approach for YAC transport
+       */
+      class YacNetworkWithFeedBack {
+        // TODO: 2019-03-20 @muratovv add method virtual void
+        // updatePeerList(...) IR-412
+       public:
+        virtual void subscribe(
+            std::shared_ptr<YacNetworkNotifications> handler) = 0;
+
+        using ValueStateReturnType =
+            boost::variant<sending_statuses::SuccessfulSent,
+                           sending_statuses::UnavailableNetwork,
+                           sending_statuses::UnavailableReceiver>;
+
+        using SendStateReturnType = rxcpp::observable<ValueStateReturnType>;
+
+        /**
+         * Directly share collection of votes.
+         * Note: method assumes blocking approach for the propagation
+         * @param to - peer recipient
+         * @param state - message for sending
+         * @return status of sending
+         */
+        virtual SendStateReturnType sendState(
+            const shared_model::interface::Peer &to,
+            const std::vector<VoteMessage> &state) = 0;
+
+        // TODO: add method virtual void updatePeerList();
+
+        ~YacNetworkWithFeedBack() = default;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -98,8 +98,9 @@ namespace iroha {
 
         // ------|Propagation|------
         void propagateState(const std::vector<VoteMessage> &msg);
-        void propagateStateDirectly(const shared_model::interface::Peer &to,
-                                    const std::vector<VoteMessage> &msg);
+        void propagateStateDirectly(
+            std::shared_ptr<shared_model::interface::Peer> to,
+            const std::vector<VoteMessage> &msg);
         void tryPropagateBack(const std::vector<VoteMessage> &state);
 
         // ------|Logger|------

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -13,6 +13,7 @@
 #include "consensus/yac/outcome_messages.hpp"
 #include "consensus/yac/timer.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
+#include "consensus/yac/transport/impl/yac_network_sender.hpp"
 #include "consensus/yac/yac.hpp"
 #include "consensus/yac/yac_gate.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
@@ -53,7 +54,8 @@ namespace iroha {
         auto createTimer(std::chrono::milliseconds delay_milliseconds);
 
         bool initialized_{false};
-        std::shared_ptr<NetworkImpl> consensus_network_;
+        std::shared_ptr<NetworkImpl> proto_yac_network;
+        std::shared_ptr<YacNetworkSender> yac_network;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/multi_sig_transactions/transport/CMakeLists.txt
+++ b/irohad/multi_sig_transactions/transport/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(mst_transport
     shared_model_stateless_validation
     shared_model_cryptography
     shared_model_proto_backend
+    async_grpc_client
     )

--- a/irohad/network/CMakeLists.txt
+++ b/irohad/network/CMakeLists.txt
@@ -40,3 +40,11 @@ add_library(ordering_gate_common
 target_link_libraries(ordering_gate_common
     boost
     )
+
+add_library(async_grpc_client INTERFACE
+    # impl/async_grpc_client.hpp
+    )
+
+target_link_libraries(async_grpc_client INTERFACE
+    rxcpp
+    )

--- a/irohad/ordering/CMakeLists.txt
+++ b/irohad/ordering/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(on_demand_ordering_service_transport_grpc
     logger
     ordering_grpc
     common
+    async_grpc_client
     )
 
 add_library(on_demand_connection_manager

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -12,6 +12,7 @@
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "consensus/yac/storage/yac_vote_storage.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
+#include "consensus/yac/transport/impl/yac_network_sender.hpp"
 #include "consensus/yac/yac.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 
@@ -106,6 +107,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
           return iroha::network::createClient<proto::Yac>(peer.address());
         },
         getTestLogger("YacNetwork"));
+    auto yac_network_wrapper = std::make_shared<YacNetworkSender>(network);
     crypto = std::make_shared<FixedCryptoProvider>(my_pub_key);
     timer = std::make_shared<TimerImpl>(std::chrono::milliseconds(delay),
                                         rxcpp::observe_on_new_thread());
@@ -116,14 +118,14 @@ class ConsensusSunnyDayTest : public ::testing::Test {
         YacVoteStorage(cleanup_strategy,
                        getSupermajorityChecker(kConsistencyModel),
                        getTestLoggerManager()->getChild("YacVoteStorage")),
-        network,
+        yac_network_wrapper,
         crypto,
         timer,
         order.value(),
         initial_round,
         rxcpp::observe_on_new_thread(),
         getTestLogger("Yac"));
-    network->subscribe(yac);
+    yac_network_wrapper->subscribe(yac);
 
     grpc::ServerBuilder builder;
     int port = 0;

--- a/test/module/irohad/consensus/yac/cluster_order_test.cpp
+++ b/test/module/irohad/consensus/yac/cluster_order_test.cpp
@@ -48,7 +48,7 @@ TEST_F(ClusterOrderTest, BadClusterOrderCreation) {
 TEST_F(ClusterOrderTest, ClusterOrderOnNext) {
   auto order = iroha::consensus::yac::ClusterOrdering::create(peers_list);
   ASSERT_TRUE(order);
-  ASSERT_EQ("1", order->currentLeader().address());
-  ASSERT_EQ("2", order->switchToNext().currentLeader().address());
-  ASSERT_EQ("1", order->switchToNext().currentLeader().address());
+  ASSERT_EQ("1", order->currentLeader()->address());
+  ASSERT_EQ("2", order->switchToNext().currentLeader()->address());
+  ASSERT_EQ("1", order->switchToNext().currentLeader()->address());
 }

--- a/test/module/irohad/consensus/yac/mock_yac_network.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_network.hpp
@@ -26,8 +26,8 @@ namespace iroha {
         }
 
         MOCK_METHOD2(sendState,
-                     void(const shared_model::interface::Peer &,
-                          const std::vector<VoteMessage> &));
+                     void(std::shared_ptr<shared_model::interface::Peer>,
+                          std::vector<VoteMessage>));
 
         MockYacNetwork() = default;
 


### PR DESCRIPTION
### Description of the Change
The PR introduces changes for resending votes. The feature is required due to we want to simulate the asynchronous environment among YAC processors.

### Design
    * Fix voting interface of consensus: now it requires value types for propagation.
    * Add new interface for proto transport level with has feedback about the status of sending
    * Add wrapper which can resend votes if it is required

### Possible Drawbacks
    * Lack of new proto transport test with different statuses.
    * Probably there are missing two things: the decline of existed calls and attempt limitation.
