### PR TITLE
Add tests for font case sensivity of hex keys

### DIFF
--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -142,33 +142,48 @@ namespace shared_model {
         });
       }
 
-      auto addPeer(const interface::types::AddressType &address,
-                   const interface::types::PubkeyType &peer_key) const {
+      auto addPeerRaw(const interface::types::AddressType &address,
+                      const std::string &peer_key) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_peer();
           auto peer = command->mutable_peer();
           peer->set_address(address);
-          peer->set_peer_key(peer_key.hex());
+          peer->set_peer_key(peer_key);
+        });
+      }
+
+      auto addPeer(const interface::types::AddressType &address,
+                   const interface::types::PubkeyType &peer_key) const {
+        return addPeerRaw(address, peer_key.hex());
+      }
+
+      auto addSignatoryRaw(const interface::types::AccountIdType &account_id,
+                           const std::string &public_key) const {
+        return addCommand([&](auto proto_command) {
+          auto command = proto_command->mutable_add_signatory();
+          command->set_account_id(account_id);
+          command->set_public_key(public_key);
         });
       }
 
       auto addSignatory(const interface::types::AccountIdType &account_id,
                         const interface::types::PubkeyType &public_key) const {
+        return addSignatoryRaw(account_id, public_key.hex());
+      }
+
+      auto removeSignatoryRaw(const interface::types::AccountIdType &account_id,
+                              const std::string &public_key) const {
         return addCommand([&](auto proto_command) {
-          auto command = proto_command->mutable_add_signatory();
+          auto command = proto_command->mutable_remove_signatory();
           command->set_account_id(account_id);
-          command->set_public_key(public_key.hex());
+          command->set_public_key(public_key);
         });
       }
 
       auto removeSignatory(const interface::types::AccountIdType &account_id,
                            const interface::types::PubkeyType &public_key)
           const {
-        return addCommand([&](auto proto_command) {
-          auto command = proto_command->mutable_remove_signatory();
-          command->set_account_id(account_id);
-          command->set_public_key(public_key.hex());
-        });
+        return removeSignatoryRaw(account_id, public_key.hex());
       }
 
       auto appendRole(const interface::types::AccountIdType &account_id,
@@ -191,16 +206,23 @@ namespace shared_model {
         });
       }
 
-      auto createAccount(const interface::types::AccountNameType &account_name,
-                         const interface::types::DomainIdType &domain_id,
-                         const interface::types::PubkeyType &main_pubkey)
-          const {
+      auto createAccountRaw(
+          const interface::types::AccountNameType &account_name,
+          const interface::types::DomainIdType &domain_id,
+          const std::string &main_pubkey) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_create_account();
           command->set_account_name(account_name);
           command->set_domain_id(domain_id);
-          command->set_public_key(main_pubkey.hex());
+          command->set_public_key(main_pubkey);
         });
+      }
+
+      auto createAccount(const interface::types::AccountNameType &account_name,
+                         const interface::types::DomainIdType &domain_id,
+                         const interface::types::PubkeyType &main_pubkey)
+          const {
+        return createAccountRaw(account_name, domain_id, main_pubkey.hex());
       }
 
       auto createDomain(const interface::types::DomainIdType &domain_id,

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -87,6 +87,11 @@ namespace integration_framework {
     using TransactionBatchType = shared_model::interface::TransactionBatch;
     using TransactionBatchSPtr = std::shared_ptr<TransactionBatchType>;
 
+   private:
+    std::mutex queue_mu;
+    std::condition_variable queue_cond;
+
+   public:
     /**
      * Construct test framework instance
      * @param maximum_proposal_size - Maximum number of transactions per
@@ -498,8 +503,6 @@ namespace integration_framework {
     std::shared_ptr<shared_model::interface::Peer> this_peer_;
 
    private:
-    std::mutex queue_mu;
-    std::condition_variable queue_cond;
     bool cleanup_on_exit_;
     std::vector<std::shared_ptr<fake_peer::FakePeer>> fake_peers_;
     std::vector<std::unique_ptr<ServerRunner>> fake_peers_servers_;

--- a/test/integration/acceptance/CMakeLists.txt
+++ b/test/integration/acceptance/CMakeLists.txt
@@ -217,3 +217,11 @@ target_link_libraries(set_account_quorum_test
     acceptance_fixture
     integration_framework
     )
+
+addtest(hex_keys_test
+   hex_keys_test.cpp
+   )
+target_link_libraries(hex_keys_test
+   acceptance_fixture
+   integration_framework
+   )

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -45,6 +45,8 @@ namespace {
 
 #define CHECK_COMMITTED BASE_CHECK_RESPONSE(CommittedTxResponse)
 
+#define CHECK_REJECTED BASE_CHECK_RESPONSE(RejectedTxResponse)
+
 #define CHECK_MST_PENDING BASE_CHECK_RESPONSE(MstPendingResponse)
 
 #define CHECK_TXS_QUANTITY(i) \

--- a/test/integration/acceptance/hex_keys_test.cpp
+++ b/test/integration/acceptance/hex_keys_test.cpp
@@ -1,0 +1,248 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "integration/acceptance/acceptance_fixture.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include "backend/protobuf/transaction.hpp"
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "datetime/time.hpp"
+#include "framework/integration_framework/integration_test_framework.hpp"
+#include "interfaces/permissions.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+
+using namespace shared_model;
+using namespace integration_framework;
+
+struct HexKeys : public AcceptanceFixture {
+  IntegrationTestFramework itf;
+  HexKeys() : itf(1), kNow(iroha::time::now()) {}
+
+  void SetUp() override {
+    using Role = interface::permissions::Role;
+    const interface::RolePermissionSet permissions = {Role::kAddSignatory,
+                                                      Role::kRemoveSignatory,
+                                                      Role::kAddPeer,
+                                                      Role::kCreateAccount,
+                                                      Role::kAppendRole};
+
+    itf.setInitialState(common_constants::kAdminKeypair)
+        .sendTxAwait(AcceptanceFixture::makeUserWithPerms(permissions),
+                     CHECK_TXS_QUANTITY(1));
+  }
+
+  auto addSignatory(
+      std::string key,
+      interface::types::TimestampType time,
+      interface::types::AccountIdType user_id = common_constants::kUserId) {
+    return AcceptanceFixture::baseTx().createdTime(time).addSignatoryRaw(
+        user_id, key);
+  }
+
+  auto removeSignatory(
+      std::string key,
+      interface::types::TimestampType time,
+      interface::types::AccountIdType user_id = common_constants::kUserId) {
+    return AcceptanceFixture::baseTx().createdTime(time).removeSignatoryRaw(
+        user_id, key);
+  }
+
+  auto createAccount(std::string key, interface::types::TimestampType time) {
+    return AcceptanceFixture::baseTx().createdTime(time).createAccountRaw(
+        common_constants::kSpectator, common_constants::kDomain, key);
+  }
+
+  auto addPeer(std::string key, interface::types::TimestampType time) {
+    const auto imaginary_address = "192.168.23.149:50051";
+    return AcceptanceFixture::baseTx().createdTime(time).addPeerRaw(
+        imaginary_address, key);
+  }
+
+  auto composeKeypairFromHex(std::string public_key, std::string private_key) {
+    return crypto::Keypair(
+        crypto::PublicKey(crypto::Blob::fromHexString(public_key)),
+        crypto::PrivateKey(crypto::Blob::fromHexString(private_key)));
+  }
+
+  const std::string kLowercasedKey =
+      "69d89f86bb0a00bb9123218303aead3ed1b377ae4b0dc20b37a8b5405a02a31d";
+  const std::string kUppercasedKey =
+      "69D89F86BB0A00BB9123218303AEAD3ED1B377AE4B0DC20B37A8B5405A02A31D";
+  const std::string kPrivateKey =
+      "44453ddcc65bc75f5a5acc32bb224e21915b73f543ce058d0dd50f56bfc6c812";
+  const interface::types::TimestampType kNow;
+};
+
+/**
+ * @given an account with kAddSignatory permission
+ * @when an the same public key is used twice but written in different case
+ * @then only first attempt to add the key succeeds
+ */
+TEST_F(HexKeys, AddSignatory) {
+  auto tx1 = complete(addSignatory(kLowercasedKey, kNow));
+  auto tx2 = complete(addSignatory(kUppercasedKey, kNow + 1));
+  auto hash1 = tx1.hash();
+  auto hash2 = tx2.hash();
+
+  itf.sendTx(tx1)
+      .checkStatus(hash1, CHECK_STATELESS_VALID)
+      .checkStatus(hash1, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash1, CHECK_STATEFUL_VALID)
+      .checkStatus(hash1, CHECK_COMMITTED)
+      .sendTx(tx2)
+      .checkStatus(hash2, CHECK_STATELESS_VALID)
+      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash2, CHECK_STATEFUL_INVALID)
+      .checkStatus(hash2, CHECK_REJECTED);
+}
+
+/**
+ * The same as the previous test, but the keys are swapped.
+ * Thus we ensure that there is no difference what case of the key is used
+ * first.
+ *
+ * @given an account with kAddSignatory permission
+ * @when an the same public key is used twice but written in different case
+ * @then only first attempt to add the key succeeds
+ */
+TEST_F(HexKeys, AddSignatoryReverse) {
+  auto tx1 = complete(addSignatory(kUppercasedKey, kNow));
+  auto tx2 = complete(addSignatory(kLowercasedKey, kNow + 1));
+  auto hash1 = tx1.hash();
+  auto hash2 = tx2.hash();
+
+  itf.sendTx(tx1)
+      .checkStatus(hash1, CHECK_STATELESS_VALID)
+      .checkStatus(hash1, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash1, CHECK_STATEFUL_VALID)
+      .checkStatus(hash1, CHECK_COMMITTED)
+      .sendTx(tx2)
+      .checkStatus(hash2, CHECK_STATELESS_VALID)
+      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash2, CHECK_STATEFUL_INVALID)
+      .checkStatus(hash2, CHECK_REJECTED);
+}
+
+/**
+ * @given a user with kAddSignatory and kRemoveSignatory permissions
+ * @when a user adds a signatory using uppercased key string
+ * @then the signatory can be removed using lowercased key string
+ */
+TEST_F(HexKeys, RemoveSignatoryUl) {
+  auto tx1 = complete(addSignatory(kUppercasedKey, kNow));
+  auto tx2 = complete(removeSignatory(kLowercasedKey, kNow + 1));
+  auto hash2 = tx2.hash();
+
+  itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
+      .sendTx(tx2)
+      .checkStatus(hash2, CHECK_STATELESS_VALID)
+      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash2, CHECK_STATEFUL_VALID)
+      .checkStatus(hash2, CHECK_COMMITTED);
+}
+
+/**
+ * @given a user with kAddSignatory and kRemoveSignatory permissions
+ * @when a user adds a signatory using lowercased key string
+ * @then the signatory can be removed using uppercased key string
+ */
+TEST_F(HexKeys, RemoveSignatorylU) {
+  auto tx1 = complete(addSignatory(kLowercasedKey, kNow));
+  auto tx2 = complete(removeSignatory(kUppercasedKey, kNow + 1));
+  auto hash2 = tx2.hash();
+
+  itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
+      .sendTx(tx2)
+      .checkStatus(hash2, CHECK_STATELESS_VALID)
+      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash2, CHECK_STATEFUL_VALID)
+      .checkStatus(hash2, CHECK_COMMITTED);
+}
+
+/**
+ * @given a user created with uppercased public key
+ * @when some additional key is added to the user
+ * @then the first key can be removed even when it passed in lower case to a
+ * command
+ */
+TEST_F(HexKeys, CreateAccountUl) {
+  auto user = common_constants::kCloseSpectatorId;
+  auto keypair = composeKeypairFromHex(kLowercasedKey, kPrivateKey);
+
+  // kUserId creates kCloseSpectatorId and appends the role with test
+  // permissions
+  auto tx1 = complete(createAccount(kUppercasedKey, kNow)
+                          .appendRole(user, common_constants::kRole));
+
+  // kCloseSpectatorId adds one more key to own account
+  auto tx2 =
+      complete(addSignatory(kPrivateKey, kNow + 1, user).creatorAccountId(user),
+               keypair);
+
+  // kCloseSpectatorId removes the initial key specifing it in other font case
+  auto tx3 = complete(
+      removeSignatory(kLowercasedKey, kNow + 2, user).creatorAccountId(user),
+      keypair);
+
+  itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(tx2, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(tx3, CHECK_TXS_QUANTITY(1));
+}
+
+/**
+ * The same as the previous test, but the keys are swapped.
+ * Thus we ensure that there is no difference what case of the key is used
+ * first.
+ *
+ * @given a user created with uppercased public key
+ * @when some additional key is added to the user
+ * @then the first key can be removed even when it passed in lower case to a
+ * command
+ */
+TEST_F(HexKeys, CreateAccountlU) {
+  auto user = common_constants::kCloseSpectatorId;
+  auto keypair = composeKeypairFromHex(kUppercasedKey, kPrivateKey);
+
+  // kUserId creates kCloseSpectatorId and appends the role with test
+  // permissions
+  auto tx1 = complete(createAccount(kLowercasedKey, kNow)
+                          .appendRole(user, common_constants::kRole));
+
+  // kCloseSpectatorId adds one more key to own account
+  auto tx2 =
+      complete(addSignatory(kPrivateKey, kNow + 1, user).creatorAccountId(user),
+               keypair);
+
+  // kCloseSpectatorId removes the initial key specifing it in other font
+  // case
+  auto tx3 = complete(
+      removeSignatory(kUppercasedKey, kNow + 2, user).creatorAccountId(user),
+      keypair);
+
+  itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(tx2, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(tx3, CHECK_TXS_QUANTITY(1));
+}
+
+/**
+ * @given an initialized peer
+ * @when a user tries to add another peer with the same key as the first peer
+ * has, but written in a different font case
+ * @then the transaction is considered as stateful invalid
+ */
+TEST_F(HexKeys, AddPeerSameKeyDifferentCase) {
+  std::string original_key = common_constants::kAdminKeypair.publicKey().hex();
+  std::string same_key_uppercased = original_key;
+  boost::to_upper(same_key_uppercased);
+  ASSERT_NE(original_key, same_key_uppercased);
+  auto tx = complete(addPeer(same_key_uppercased, kNow));
+  auto hash = tx.hash();
+
+  itf.sendTx(tx)
+      .checkStatus(hash, CHECK_STATELESS_VALID)
+      .checkStatus(hash, CHECK_ENOUGH_SIGNATURES)
+      .checkStatus(hash, CHECK_STATEFUL_INVALID)
+      .checkStatus(hash, CHECK_REJECTED);
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Some time ago the format of the way keys are passed to commands was changed from bytes arrays to strings.

This change introduces a set of tests for font case sensitivity for keys fields.

### Benefits

Increased test coverage.

### Possible Drawbacks 

Potentially the test can be written without ITF usage.

### Usage Examples or Tests 

`hex_keys_tests`
