### PR TITLE
Fix batch validator for use in block loader

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -112,6 +112,9 @@ Irohad::Irohad(const std::string &block_store_dir,
   validators_config_ =
       std::make_shared<shared_model::validation::ValidatorsConfig>(
           max_proposal_size_);
+  block_validators_config_ =
+      std::make_shared<shared_model::validation::ValidatorsConfig>(
+          max_proposal_size_, true);
   // Initializing storage at this point in order to insert genesis block before
   // initialization of iroha daemon
   initStorage();
@@ -418,7 +421,7 @@ void Irohad::initSimulator() {
       //  are validated in the ordering gate, where they are received from the
       //  ordering service.
       std::make_unique<shared_model::validation::DefaultUnsignedBlockValidator>(
-          validators_config_),
+          block_validators_config_),
       std::make_unique<shared_model::validation::ProtoBlockValidator>());
   simulator = std::make_shared<Simulator>(
       ordering_gate,
@@ -449,7 +452,7 @@ void Irohad::initBlockLoader() {
       loader_init.initBlockLoader(storage,
                                   storage,
                                   consensus_result_cache_,
-                                  validators_config_,
+                                  block_validators_config_,
                                   log_manager_->getChild("BlockLoader"));
 
   log_->info("[Init] => block loader");

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -229,6 +229,8 @@ class Irohad {
   // validators
   std::shared_ptr<shared_model::validation::ValidatorsConfig>
       validators_config_;
+  std::shared_ptr<shared_model::validation::ValidatorsConfig>
+      block_validators_config_;
   std::shared_ptr<iroha::validation::StatefulValidator> stateful_validator;
   std::shared_ptr<iroha::validation::ChainValidator> chain_validator;
 

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -28,12 +28,9 @@ auto BlockLoaderInit::createLoader(
     std::shared_ptr<shared_model::validation::ValidatorsConfig>
         validators_config,
     logger::LoggerPtr loader_log) {
-  auto block_loader_validators_config =
-      std::make_shared<shared_model::validation::ValidatorsConfig>(
-          validators_config->max_batch_size, true);
   shared_model::proto::ProtoBlockFactory factory(
       std::make_unique<shared_model::validation::DefaultSignedBlockValidator>(
-          block_loader_validators_config),
+          validators_config),
       std::make_unique<shared_model::validation::ProtoBlockValidator>());
   return std::make_shared<BlockLoaderImpl>(
       std::move(peer_query_factory), std::move(factory), std::move(loader_log));

--- a/irohad/main/impl/block_loader_init.cpp
+++ b/irohad/main/impl/block_loader_init.cpp
@@ -28,9 +28,12 @@ auto BlockLoaderInit::createLoader(
     std::shared_ptr<shared_model::validation::ValidatorsConfig>
         validators_config,
     logger::LoggerPtr loader_log) {
+  auto block_loader_validators_config =
+      std::make_shared<shared_model::validation::ValidatorsConfig>(
+          validators_config->max_batch_size, true);
   shared_model::proto::ProtoBlockFactory factory(
       std::make_unique<shared_model::validation::DefaultSignedBlockValidator>(
-          validators_config),
+          block_loader_validators_config),
       std::make_unique<shared_model::validation::ProtoBlockValidator>());
   return std::make_shared<BlockLoaderImpl>(
       std::move(peer_query_factory), std::move(factory), std::move(loader_log));

--- a/shared_model/backend/protobuf/impl/proto_block_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_factory.cpp
@@ -5,8 +5,9 @@
 
 #include "backend/protobuf/proto_block_factory.hpp"
 
+#include <sstream>
+
 #include <boost/assert.hpp>
-#include <iostream>
 #include "backend/protobuf/block.hpp"
 
 using namespace shared_model;
@@ -64,9 +65,14 @@ ProtoBlockFactory::unsafeCreateBlock(
   bool block_is_stateless_valid =
       not(proto_block_validation_result.hasErrors()
           or interface_block_validation_result.hasErrors());
-  BOOST_ASSERT_MSG(block_is_stateless_valid,
-                   "ProtoBlockFactory has created stateless invalid block");
-
+  std::stringstream validaton_results;
+  validaton_results << "ProtoBlockFactory has created stateless invalid block: "
+                    << "Proto validator response: "
+                    << proto_block_validation_result.reason()
+                    << "; Interface validator response: "
+                    << interface_block_validation_result.reason() << ";"
+                    << std::endl;
+  BOOST_ASSERT_MSG(block_is_stateless_valid, validaton_results.str().c_str());
   return model_proto_block;
 }
 

--- a/shared_model/validators/transaction_batch_validator.cpp
+++ b/shared_model/validators/transaction_batch_validator.cpp
@@ -80,7 +80,7 @@ namespace {
     }
 
     return BatchCheckResult::kOk;
-  }  // namespace
+  }
 }  // namespace
 
 namespace shared_model {

--- a/shared_model/validators/transaction_batch_validator.hpp
+++ b/shared_model/validators/transaction_batch_validator.hpp
@@ -24,6 +24,7 @@ namespace shared_model {
                           transactions) const;
 
       const uint64_t max_batch_size_;
+      const bool partial_ordered_batches_are_valid_;
     };
   }  // namespace validation
 }  // namespace shared_model

--- a/shared_model/validators/validators_common.cpp
+++ b/shared_model/validators/validators_common.cpp
@@ -10,8 +10,11 @@
 namespace shared_model {
   namespace validation {
 
-    ValidatorsConfig::ValidatorsConfig(const uint64_t max_batch_size)
-        : max_batch_size(max_batch_size) {}
+    ValidatorsConfig::ValidatorsConfig(uint64_t max_batch_size,
+                                       bool partial_ordered_batches_are_valid)
+        : max_batch_size(max_batch_size),
+          partial_ordered_batches_are_valid(partial_ordered_batches_are_valid) {
+    }
 
     bool validateHexString(const std::string &str) {
       static const std::regex hex_regex{R"([0-9a-fA-F]*)"};

--- a/shared_model/validators/validators_common.hpp
+++ b/shared_model/validators/validators_common.hpp
@@ -16,9 +16,13 @@ namespace shared_model {
      * A validator may read only specific fields.
      */
     struct ValidatorsConfig {
-      ValidatorsConfig(const uint64_t max_batch_size);
+      ValidatorsConfig(uint64_t max_batch_size,
+                       bool partial_ordered_batches_are_valid = false);
       /// Maximum allowed amount of transactions within a batch
       const uint64_t max_batch_size;
+
+      /// Turns on special batches validation logic for blocks from synchronizer
+      const bool partial_ordered_batches_are_valid;
     };
 
     /**

--- a/shared_model/validators/validators_common.hpp
+++ b/shared_model/validators/validators_common.hpp
@@ -21,7 +21,8 @@ namespace shared_model {
       /// Maximum allowed amount of transactions within a batch
       const uint64_t max_batch_size;
 
-      /// Turns on special batches validation logic for blocks from synchronizer
+      /// Batch meta can contain more hashes of batch transactions than it
+      /// actually has. Used for block validation
       const bool partial_ordered_batches_are_valid;
     };
 

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -75,3 +75,11 @@ target_link_libraries(proposal_validator_test
     shared_model_interfaces_factories
     shared_model_stateless_validation
     )
+
+addtest(batch_validator_test
+    batch_validator_test.cpp
+    )
+target_link_libraries(batch_validator_test
+    shared_model_proto_backend
+    shared_model_stateless_validation
+    )

--- a/test/module/shared_model/validators/batch_validator_test.cpp
+++ b/test/module/shared_model/validators/batch_validator_test.cpp
@@ -1,0 +1,8 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "validators/transaction_batch_validator.hpp"
+
+// TODO igor-egorov 23.04.2019 IR-454 Create tests for batch validator


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

The missing logic of batches validation was added.
Now in some cases, we check only the order of transactions appearance in batch meta of an "ordered" batch.
The equality of batch meta hashes quantity to batch transactions quantity is required for:
* atomic batches - always
* ordered batches - only when we handle user's input and the batch was not submitted for stateful validation yet (after the stateful validation, some transactions can fail the validation and be removed from the batch, but the batch meta remains untouched)

### Benefits

Proper batch validation.
No issues when partial ordered batches are received within blocks acquired from synchronizer or wsv restorer.

### Possible Drawbacks 

Unit tests are going to be created.

Also it is GOOD TO HAVE integration test.

### Usage Examples or Tests 

No existing tests are broken.
