### PR TITLE
Initial peers list in config file

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -87,7 +87,8 @@ Irohad::Irohad(const std::string &block_store_dir,
                const shared_model::crypto::Keypair &keypair,
                std::chrono::milliseconds max_rounds_delay,
                size_t stale_stream_max_rounds,
-               shared_model::interface::types::PeerList alternative_peers,
+               boost::optional<shared_model::interface::types::PeerList>
+                   opt_alternative_peers,
                logger::LoggerManagerTreePtr logger_manager,
                const boost::optional<GossipPropagationStrategyParams>
                    &opt_mst_gossip_params)
@@ -103,7 +104,7 @@ Irohad::Irohad(const std::string &block_store_dir,
       mst_expiration_time_(mst_expiration_time),
       max_rounds_delay_(max_rounds_delay),
       stale_stream_max_rounds_(stale_stream_max_rounds),
-      alternative_peers_(std::move(alternative_peers)),
+      opt_alternative_peers_(std::move(opt_alternative_peers)),
       opt_mst_gossip_params_(opt_mst_gossip_params),
       keypair(keypair),
       ordering_init(logger_manager->getLogger()),
@@ -132,7 +133,10 @@ void Irohad::init() {
   // Recover WSV from the existing ledger to be sure it is consistent
   initWsvRestorer();
   restoreWsv();
-  updatePeers();
+  if (opt_alternative_peers_) {
+    // replace the peers if the `--peers' flag is set on the command line
+    resetPeers(*opt_alternative_peers_);
+  }
 
   initCryptoProvider();
   initBatchParser();
@@ -207,14 +211,12 @@ bool Irohad::restoreWsv() {
       });
 }
 
-bool Irohad::updatePeers() {
-  // drop old peers and insert new ones if --peers flag is set
-  if (not alternative_peers_.empty()) {
-    storage->resetPeers();
-    for (const auto &peer : alternative_peers_) {
-      if (not storage->insertPeer(*peer)) {
-        return false;
-      }
+bool Irohad::resetPeers(
+    shared_model::interface::types::PeerList alternative_peers) {
+  storage->resetPeers();
+  for (const auto &peer : alternative_peers) {
+    if (not storage->insertPeer(*peer)) {
+      return false;
     }
   }
   return true;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -93,7 +93,7 @@ class Irohad {
    * transactions
    * @param stale_stream_max_rounds - maximum number of rounds between
    * consecutive status emissions
-   * @param alternative_peers - alternative peer list
+   * @param opt_alternative_peers - optional alternative initial peers list
    * @param logger_manager - the logger manager to use
    * @param opt_mst_gossip_params - parameters for Gossip MST propagation
    * (optional). If not provided, disables mst processing support
@@ -111,7 +111,8 @@ class Irohad {
          const shared_model::crypto::Keypair &keypair,
          std::chrono::milliseconds max_rounds_delay,
          size_t stale_stream_max_rounds,
-         shared_model::interface::types::PeerList alternative_peers,
+         boost::optional<shared_model::interface::types::PeerList>
+             opt_alternative_peers,
          logger::LoggerManagerTreePtr logger_manager,
          const boost::optional<iroha::GossipPropagationStrategyParams>
              &opt_mst_gossip_params = boost::none);
@@ -128,10 +129,11 @@ class Irohad {
   bool restoreWsv();
 
   /**
-   * Replaces peers in WSV by external provided peers list if any
+   * Replaces peers in WSV with an externally provided peers list
+   * @param alternative_peers - the peers to place into WSV
    * @return true on success
    */
-  bool updatePeers();
+  bool resetPeers(shared_model::interface::types::PeerList alternative_peers);
 
   /**
    * Drop wsv and block store
@@ -205,7 +207,8 @@ class Irohad {
   std::chrono::minutes mst_expiration_time_;
   std::chrono::milliseconds max_rounds_delay_;
   size_t stale_stream_max_rounds_;
-  shared_model::interface::types::PeerList alternative_peers_;
+  const boost::optional<shared_model::interface::types::PeerList>
+      opt_alternative_peers_;
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 

--- a/irohad/main/iroha_conf_literals.cpp
+++ b/irohad/main/iroha_conf_literals.cpp
@@ -29,4 +29,7 @@ namespace config_members {
       {"warning", logger::LogLevel::kWarn},
       {"error", logger::LogLevel::kError},
       {"critical", logger::LogLevel::kCritical}};
+  const char *Address = "address";
+  const char *PublicKey = "public_key";
+  const char *InitialPeers = "initial_peers";
 }  // namespace config_members

--- a/irohad/main/iroha_conf_literals.hpp
+++ b/irohad/main/iroha_conf_literals.hpp
@@ -29,6 +29,10 @@ namespace config_members {
   extern const char *LogPatternsSection;
   extern const char *LogChildrenSection;
   extern const std::unordered_map<std::string, logger::LogLevel> LogLevels;
+  extern const char *InitialPeers;
+  extern const char *Address;
+  extern const char *PublicKey;
+
 }  // namespace config_members
 
 #endif  // IROHA_CONF_LITERALS_HPP

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -28,291 +28,286 @@ static_assert(kBadJsonPrintOffsset <= kBadJsonPrintLength,
               "The place of error is out of the printed string boundaries!");
 
 /**
- * Adds the children logger configs from parent logger JSON object to parent
- * logger config. The parent logger JSON object is searched for the children
- * config section, and the children configs are parsed and created if the
- * section is present.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param parent_config - the parent logger config
- * @param parent_obj - the parent logger json configuration
+ * A class for reading a structure from a JSON node.
  */
-void addChildrenLoggerConfigs(const std::string &path,
-                              const logger::LoggerManagerTreePtr &parent_config,
-                              const rapidjson::Value::ConstObject &parent_obj);
-
-/**
- * Overrides the logger configuration with the values from JSON object.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param cfg - the configuration to use as base
- * @param obj - the JSON object to take overrides from
- */
-void updateLoggerConfig(const std::string &path,
-                        logger::LoggerConfig &cfg,
-                        const rapidjson::Value::ConstObject &obj);
-
-/**
- * Gets a value by a key from a JSON object, if present.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param dest - the variable to store the value
- * @param obj - the source JSON object
- * @param key - the key for the requested value
- * @return true if the value was loaded, otherwise false.
- */
-template <typename TDest, typename TKey>
-bool tryGetValByKey(const std::string &path,
-                    TDest &dest,
-                    const rapidjson::Value::ConstObject &obj,
-                    const TKey &key);
-
-/**
- * Gets an optional value by a key from a JSON object.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param obj - the source JSON object
- * @param key - the key for the requested value
- * @return the value if present in the JSON object, otherwise boost::none.
- */
-template <typename TDest, typename TKey>
-boost::optional<TDest> getOptValByKey(const std::string &path,
-                                      const rapidjson::Value::ConstObject &obj,
-                                      const TKey &key);
-
-/**
- * Adds one sublevel to the path denoting a place in config tree.
- * @param parent - the location of the sublevel
- * @param child - the name of sublevel
- * @return the path to the sublevel
- */
-template <typename TChild>
-inline std::string sublevelPath(std::string parent, TChild child) {
-  std::stringstream child_sstream;
-  child_sstream << child;
-  return std::move(parent) + "/" + child_sstream.str();
-}
-
-/**
- * Gets a value by a key from a JSON object. Throws an exception if the value
- * was not loaded.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param dest - the variable to store the value
- * @param obj - the source JSON object
- * @param key - the key for the requested value
- */
-template <typename TDest, typename TKey>
-void getValByKey(const std::string &path,
-                 TDest &dest,
-                 const rapidjson::Value::ConstObject &obj,
-                 const TKey &key);
-
-/**
- * Throws a runtime exception if the given condition is false.
- * @param condition
- * @param error - error message
- */
-inline void assert_fatal(bool condition, std::string error) {
-  if (!condition) {
-    throw std::runtime_error(error);
+class JsonDeserializerImpl {
+ public:
+  /**
+   * Load the data from rapidjson::Value. Checks the JSON type and throws
+   * exception if it is wrong.
+   * @tparam TDest - the type of data to read from JSON
+   * @param src - the source JSON to read the data from
+   * @param path - optional path that is used to denote the possible error
+   * place.
+   * @return the deserialized data
+   */
+  template <typename TDest>
+  TDest deserialize(const rapidjson::Value &src,
+                    boost::optional<std::string> path = boost::none) {
+    TDest dest;
+    getVal(path.value_or(""), dest, src);
+    return dest;
   }
-}
 
-// ------------ getVal(path, dst, src) ------------
-// getVal is a set of functions that load the value from rapidjson::Value to a
-// given destination variable. They check the JSON type and throw exception if
-// it is wrong. The path argument is used to denote the possible error place.
-
-template <typename TDest>
-typename std::enable_if<not std::numeric_limits<TDest>::is_integer>::type
-getVal(const std::string &path, TDest &, const rapidjson::Value &) {
-  BOOST_THROW_EXCEPTION(
-      std::runtime_error("Wrong type. Should never reach here."));
-}
-
-template <typename TDest>
-typename std::enable_if<std::numeric_limits<TDest>::is_integer>::type getVal(
-    const std::string &path, TDest &dest, const rapidjson::Value &src) {
-  assert_fatal(src.IsInt64(), path + " must be an integer");
-  const int64_t val = src.GetInt64();
-  assert_fatal(val >= std::numeric_limits<TDest>::min()
-                   && val <= std::numeric_limits<TDest>::max(),
-               path + ": integer value out of range");
-  dest = val;
-}
-
-template <>
-void getVal<bool>(const std::string &path,
-                  bool &dest,
-                  const rapidjson::Value &src) {
-  assert_fatal(src.IsBool(), path + " must be a boolean");
-  dest = src.GetBool();
-}
-
-template <>
-void getVal<std::string>(const std::string &path,
-                         std::string &dest,
-                         const rapidjson::Value &src) {
-  assert_fatal(src.IsString(), path + " must be a string");
-  dest = src.GetString();
-}
-
-template <>
-void getVal<logger::LogLevel>(const std::string &path,
-                              logger::LogLevel &dest,
-                              const rapidjson::Value &src) {
-  std::string level_str;
-  getVal(path, level_str, src);
-  const auto it = config_members::LogLevels.find(level_str);
-  if (it == config_members::LogLevels.end()) {
-    BOOST_THROW_EXCEPTION(std::runtime_error(
-        "Wrong log level at " + path + ": must be one of '"
-        + boost::algorithm::join(
-              config_members::LogLevels | boost::adaptors::map_keys, "', '")
-        + "'."));
+ private:
+  // ------------ getVal(path, dst, src) ------------
+  // getVal is a set of functions that load the value from rapidjson::Value to
+  // a given destination variable. They check the JSON type and throw exception
+  // if it is wrong. The path argument is used to denote the possible error
+  // place.
+  template <typename TDest>
+  typename std::enable_if<not std::numeric_limits<TDest>::is_integer>::type
+  getVal(const std::string &path, TDest &, const rapidjson::Value &) {
+    BOOST_THROW_EXCEPTION(
+        std::runtime_error("Wrong type. Should never reach here."));
   }
-  dest = it->second;
-}
 
-template <>
-void getVal<logger::LogPatterns>(const std::string &path,
-                                 logger::LogPatterns &dest,
-                                 const rapidjson::Value &src) {
-  assert_fatal(src.IsObject(),
-               path + " must be a map from log level to pattern");
-  for (const auto &pattern_entry : src.GetObject()) {
-    logger::LogLevel level;
-    std::string pattern_str;
-    getVal(sublevelPath(path, "(level name)"), level, pattern_entry.name);
-    getVal(sublevelPath(path, "(pattern)"), pattern_str, pattern_entry.value);
-    dest.setPattern(level, pattern_str);
+  template <typename TDest>
+  typename std::enable_if<std::numeric_limits<TDest>::is_integer>::type getVal(
+      const std::string &path, TDest &dest, const rapidjson::Value &src) {
+    assert_fatal(src.IsInt64(), path + " must be an integer");
+    const int64_t val = src.GetInt64();
+    assert_fatal(val >= std::numeric_limits<TDest>::min()
+                     && val <= std::numeric_limits<TDest>::max(),
+                 path + ": integer value out of range");
+    dest = val;
   }
-}
 
-template <>
-void getVal<logger::LoggerManagerTreePtr>(const std::string &path,
-                                          logger::LoggerManagerTreePtr &dest,
-                                          const rapidjson::Value &src) {
-  assert_fatal(src.IsObject(), path + " must be a logger tree config");
-  logger::LoggerConfig root_config{logger::kDefaultLogLevel,
-                                   logger::LogPatterns{}};
-  updateLoggerConfig(path, root_config, src.GetObject());
-  dest = std::make_shared<logger::LoggerManagerTree>(
-      std::make_shared<const logger::LoggerConfig>(std::move(root_config)));
-  addChildrenLoggerConfigs(path, dest, src.GetObject());
-}
-
-template <>
-void getVal<IrohadConfig>(const std::string &path,
-                          IrohadConfig &dest,
-                          const rapidjson::Value &src) {
-  assert_fatal(src.IsObject(),
-               path + " Irohad config top element must be an object.");
-  const auto obj = src.GetObject();
-  getValByKey(path, dest.block_store_path, obj, config_members::BlockStorePath);
-  getValByKey(path, dest.torii_port, obj, config_members::ToriiPort);
-  getValByKey(path, dest.internal_port, obj, config_members::InternalPort);
-  getValByKey(path, dest.pg_opt, obj, config_members::PgOpt);
-  getValByKey(
-      path, dest.max_proposal_size, obj, config_members::MaxProposalSize);
-  getValByKey(path, dest.proposal_delay, obj, config_members::ProposalDelay);
-  getValByKey(path, dest.vote_delay, obj, config_members::VoteDelay);
-  getValByKey(path, dest.mst_support, obj, config_members::MstSupport);
-  getValByKey(
-      path, dest.mst_expiration_time, obj, config_members::MstExpirationTime);
-  getValByKey(
-      path, dest.max_round_delay_ms, obj, config_members::MaxRoundsDelay);
-  getValByKey(path,
-              dest.stale_stream_max_rounds,
-              obj,
-              config_members::StaleStreamMaxRounds);
-  getValByKey(path, dest.logger_manager, obj, config_members::LogSection);
-}
-
-// ------------ end of getVal(path, dst, src) ------------
-
-void updateLoggerConfig(const std::string &path,
-                        logger::LoggerConfig &cfg,
-                        const rapidjson::Value::ConstObject &obj) {
-  tryGetValByKey(path, cfg.log_level, obj, config_members::LogLevel);
-  tryGetValByKey(path, cfg.patterns, obj, config_members::LogPatternsSection);
-}
-
-template <typename TDest, typename TKey>
-bool tryGetValByKey(const std::string &path,
-                    TDest &dest,
-                    const rapidjson::Value::ConstObject &obj,
-                    const TKey &key) {
-  const auto it = obj.FindMember(key);
-  if (it == obj.MemberEnd()) {
-    return false;
-  } else {
-    getVal(sublevelPath(path, key), dest, it->value);
-    return true;
+  template <>
+  void getVal<bool>(const std::string &path,
+                    bool &dest,
+                    const rapidjson::Value &src) {
+    assert_fatal(src.IsBool(), path + " must be a boolean");
+    dest = src.GetBool();
   }
-}
 
-template <typename TDest, typename TKey>
-bool tryGetValByKey(const std::string &path,
-                    boost::optional<TDest> &dest,
-                    const rapidjson::Value::ConstObject &obj,
-                    const TKey &key) {
-  dest = getOptValByKey<TDest>(path, obj, key);
-  return true; // value loaded any way, either from file or boost::none
-}
+  template <>
+  void getVal<std::string>(const std::string &path,
+                           std::string &dest,
+                           const rapidjson::Value &src) {
+    assert_fatal(src.IsString(), path + " must be a string");
+    dest = src.GetString();
+  }
 
-template <typename TDest, typename TKey>
-boost::optional<TDest> getOptValByKey(const std::string &path,
-                                      const rapidjson::Value::ConstObject &obj,
-                                      const TKey &key) {
-  TDest val;
-  return boost::make_optional(tryGetValByKey(path, val, obj, key), val);
-}
+  template <>
+  void getVal<logger::LogLevel>(const std::string &path,
+                                logger::LogLevel &dest,
+                                const rapidjson::Value &src) {
+    std::string level_str;
+    getVal(path, level_str, src);
+    const auto it = config_members::LogLevels.find(level_str);
+    if (it == config_members::LogLevels.end()) {
+      BOOST_THROW_EXCEPTION(std::runtime_error(
+          "Wrong log level at " + path + ": must be one of '"
+          + boost::algorithm::join(
+                config_members::LogLevels | boost::adaptors::map_keys, "', '")
+          + "'."));
+    }
+    dest = it->second;
+  }
 
-/**
- * Gets a value by a key from a JSON object. Throws an exception if the value
- * was not loaded.
- * @param path - current config node path used to denote the possible error
- *    place.
- * @param dest - the variable to store the value
- * @param obj - the source JSON object
- * @param key - the key for the requested value
- */
-template <typename TDest, typename TKey>
-void getValByKey(const std::string &path,
-                 TDest &dest,
-                 const rapidjson::Value::ConstObject &obj,
-                 const TKey &key) {
-  assert_fatal(tryGetValByKey(path, dest, obj, key),
-               path + " has no key '" + key + "'.");
-}
-
-void addChildrenLoggerConfigs(const std::string &path,
-                              const logger::LoggerManagerTreePtr &parent_config,
-                              const rapidjson::Value::ConstObject &parent_obj) {
-  const auto it = parent_obj.FindMember(config_members::LogChildrenSection);
-  if (it != parent_obj.MemberEnd()) {
-    auto children_section_path =
-        sublevelPath(path, config_members::LogChildrenSection);
-    for (const auto &child_json : it->value.GetObject()) {
-      assert_fatal(child_json.name.IsString(),
-                   "Child logger key must be a string holding its tag.");
-      assert_fatal(child_json.value.IsObject(),
-                   "Child logger value must be a JSON object.");
-      auto child_tag = child_json.name.GetString();
-      const auto child_obj = child_json.value.GetObject();
-      auto child_path = sublevelPath(children_section_path, child_tag);
-      auto child_conf = parent_config->registerChild(
-          std::move(child_tag),
-          getOptValByKey<logger::LogLevel>(
-              child_path, child_obj, config_members::LogLevel),
-          getOptValByKey<logger::LogPatterns>(
-              child_path, child_obj, config_members::LogPatternsSection));
-      addChildrenLoggerConfigs(std::move(child_path), child_conf, child_obj);
+  template <>
+  void getVal<logger::LogPatterns>(const std::string &path,
+                                   logger::LogPatterns &dest,
+                                   const rapidjson::Value &src) {
+    assert_fatal(src.IsObject(),
+                 path + " must be a map from log level to pattern");
+    for (const auto &pattern_entry : src.GetObject()) {
+      logger::LogLevel level;
+      std::string pattern_str;
+      getVal(sublevelPath(path, "(level name)"), level, pattern_entry.name);
+      getVal(sublevelPath(path, "(pattern)"), pattern_str, pattern_entry.value);
+      dest.setPattern(level, pattern_str);
     }
   }
-}
+
+  template <>
+  void getVal<logger::LoggerManagerTreePtr>(const std::string &path,
+                                            logger::LoggerManagerTreePtr &dest,
+                                            const rapidjson::Value &src) {
+    assert_fatal(src.IsObject(), path + " must be a logger tree config");
+    logger::LoggerConfig root_config{logger::kDefaultLogLevel,
+                                     logger::LogPatterns{}};
+    updateLoggerConfig(path, root_config, src.GetObject());
+    dest = std::make_shared<logger::LoggerManagerTree>(
+        std::make_shared<const logger::LoggerConfig>(std::move(root_config)));
+    addChildrenLoggerConfigs(path, dest, src.GetObject());
+  }
+
+  template <>
+  void getVal<IrohadConfig>(const std::string &path,
+                            IrohadConfig &dest,
+                            const rapidjson::Value &src) {
+    assert_fatal(src.IsObject(),
+                 path + " Irohad config top element must be an object.");
+    const auto obj = src.GetObject();
+    getValByKey(
+        path, dest.block_store_path, obj, config_members::BlockStorePath);
+    getValByKey(path, dest.torii_port, obj, config_members::ToriiPort);
+    getValByKey(path, dest.internal_port, obj, config_members::InternalPort);
+    getValByKey(path, dest.pg_opt, obj, config_members::PgOpt);
+    getValByKey(
+        path, dest.max_proposal_size, obj, config_members::MaxProposalSize);
+    getValByKey(path, dest.proposal_delay, obj, config_members::ProposalDelay);
+    getValByKey(path, dest.vote_delay, obj, config_members::VoteDelay);
+    getValByKey(path, dest.mst_support, obj, config_members::MstSupport);
+    getValByKey(
+        path, dest.mst_expiration_time, obj, config_members::MstExpirationTime);
+    getValByKey(
+        path, dest.max_round_delay_ms, obj, config_members::MaxRoundsDelay);
+    getValByKey(path,
+                dest.stale_stream_max_rounds,
+                obj,
+                config_members::StaleStreamMaxRounds);
+    getValByKey(path, dest.logger_manager, obj, config_members::LogSection);
+  }
+
+  // ------------ end of getVal(path, dst, src) ------------
+
+  /**
+   * Adds the children logger configs from parent logger JSON object to parent
+   * logger config. The parent logger JSON object is searched for the children
+   * config section, and the children configs are parsed and created if the
+   * section is present.
+   * @param path - current config node path used to denote the possible error
+   *    place.
+   * @param parent_config - the parent logger config
+   * @param parent_obj - the parent logger json configuration
+   */
+  void addChildrenLoggerConfigs(
+      const std::string &path,
+      const logger::LoggerManagerTreePtr &parent_config,
+      const rapidjson::Value::ConstObject &parent_obj) {
+    const auto it = parent_obj.FindMember(config_members::LogChildrenSection);
+    if (it != parent_obj.MemberEnd()) {
+      auto children_section_path =
+          sublevelPath(path, config_members::LogChildrenSection);
+      for (const auto &child_json : it->value.GetObject()) {
+        assert_fatal(child_json.name.IsString(),
+                     "Child logger key must be a string holding its tag.");
+        assert_fatal(child_json.value.IsObject(),
+                     "Child logger value must be a JSON object.");
+        auto child_tag = child_json.name.GetString();
+        const auto child_obj = child_json.value.GetObject();
+        auto child_path = sublevelPath(children_section_path, child_tag);
+        auto child_conf = parent_config->registerChild(
+            std::move(child_tag),
+            getOptValByKey<logger::LogLevel>(
+                child_path, child_obj, config_members::LogLevel),
+            getOptValByKey<logger::LogPatterns>(
+                child_path, child_obj, config_members::LogPatternsSection));
+        addChildrenLoggerConfigs(std::move(child_path), child_conf, child_obj);
+      }
+    }
+  }
+
+  /**
+   * Overrides the logger configuration with the values from JSON object.
+   * @param path - current config node path used to denote the possible error
+   *    place.
+   * @param cfg - the configuration to use as base
+   * @param obj - the JSON object to take overrides from
+   */
+  void updateLoggerConfig(const std::string &path,
+                          logger::LoggerConfig &cfg,
+                          const rapidjson::Value::ConstObject &obj) {
+    tryGetValByKey(path, cfg.log_level, obj, config_members::LogLevel);
+    tryGetValByKey(path, cfg.patterns, obj, config_members::LogPatternsSection);
+  }
+
+  /**
+   * Gets a value by a key from a JSON object, if present.
+   * @param path - current config node path used to denote the possible error
+   *    place.
+   * @param dest - the variable to store the value
+   * @param obj - the source JSON object
+   * @param key - the key for the requested value
+   * @return true if the value was loaded, otherwise false.
+   */
+  template <typename TDest, typename TKey>
+  bool tryGetValByKey(const std::string &path,
+                      TDest &dest,
+                      const rapidjson::Value::ConstObject &obj,
+                      const TKey &key) {
+    const auto it = obj.FindMember(key);
+    if (it == obj.MemberEnd()) {
+      return false;
+    } else {
+      getVal(sublevelPath(path, key), dest, it->value);
+      return true;
+    }
+  }
+
+  /// A variant of tryGetValByKey for optional destination
+  template <typename TDest, typename TKey>
+  bool tryGetValByKey(const std::string &path,
+                      boost::optional<TDest> &dest,
+                      const rapidjson::Value::ConstObject &obj,
+                      const TKey &key) {
+    dest = getOptValByKey<TDest>(path, obj, key);
+    return true;  // value loaded any way, either from file or boost::none
+  }
+
+
+  /**
+   * Gets an optional value by a key from a JSON object.
+   * @param path - current config node path used to denote the possible error
+   *    place.
+   * @param obj - the source JSON object
+   * @param key - the key for the requested value
+   * @return the value if present in the JSON object, otherwise boost::none.
+   */
+  template <typename TDest, typename TKey>
+  boost::optional<TDest> getOptValByKey(
+      const std::string &path,
+      const rapidjson::Value::ConstObject &obj,
+      const TKey &key) {
+    TDest val;
+    return boost::make_optional(tryGetValByKey(path, val, obj, key), val);
+  }
+
+  /**
+   * Gets a value by a key from a JSON object. Throws an exception if the value
+   * was not loaded.
+   * @param path - current config node path used to denote the possible error
+   *    place.
+   * @param dest - the variable to store the value
+   * @param obj - the source JSON object
+   * @param key - the key for the requested value
+   */
+  template <typename TDest, typename TKey>
+  void getValByKey(const std::string &path,
+                   TDest &dest,
+                   const rapidjson::Value::ConstObject &obj,
+                   const TKey &key) {
+    assert_fatal(tryGetValByKey(path, dest, obj, key),
+                 path + " has no key '" + key + "'.");
+  }
+
+  /**
+   * Adds one sublevel to the path denoting a place in config tree.
+   * @param parent - the location of the sublevel
+   * @param child - the name of sublevel
+   * @return the path to the sublevel
+   */
+  template <typename TChild>
+  inline std::string sublevelPath(std::string parent, TChild child) {
+    std::stringstream child_sstream;
+    child_sstream << child;
+    return std::move(parent) + "/" + child_sstream.str();
+  }
+
+  /**
+   * Throws a runtime exception if the given condition is false.
+   * @param condition
+   * @param error - error message
+   */
+  inline void assert_fatal(bool condition, std::string error) {
+    if (!condition) {
+      throw std::runtime_error(error);
+    }
+  }
+};
 
 std::string reportJsonParsingError(const rapidjson::Document &doc,
                                    const std::string &conf_path,
@@ -334,12 +329,14 @@ IrohadConfig parse_iroha_config(const std::string &conf_path) {
     std::ifstream ifs_iroha(conf_path);
     rapidjson::IStreamWrapper isw(ifs_iroha);
     doc.ParseStream(isw);
-    assert_fatal(not doc.HasParseError(),
-                 reportJsonParsingError(doc, conf_path, ifs_iroha));
+    if (doc.HasParseError()) {
+      throw std::runtime_error(
+          reportJsonParsingError(doc, conf_path, ifs_iroha));
+    }
     return doc;
   }()};
 
-  IrohadConfig config;
-  getVal("", config, doc);
+  JsonDeserializerImpl parser;
+  IrohadConfig config = parser.deserialize<IrohadConfig>(doc);
   return config;
 }

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "interfaces/common_objects/common_objects_factory.hpp"
+#include "interfaces/common_objects/types.hpp"
 #include "logger/logger_manager.hpp"
 
 struct IrohadConfig {
@@ -24,6 +26,7 @@ struct IrohadConfig {
   boost::optional<uint32_t> max_round_delay_ms;
   boost::optional<uint32_t> stale_stream_max_rounds;
   boost::optional<logger::LoggerManagerTreePtr> logger_manager;
+  boost::optional<shared_model::interface::types::PeerList> initial_peers;
 };
 
 /**
@@ -31,6 +34,9 @@ struct IrohadConfig {
  * @param conf_path is a path to iroha's config
  * @return a parsed equivalent of that file
  */
-IrohadConfig parse_iroha_config(const std::string &conf_path);
+IrohadConfig parse_iroha_config(
+    const std::string &conf_path,
+    std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        common_objects_factory);
 
 #endif  // IROHA_CONF_LOADER_HPP

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -7,6 +7,7 @@
 #define IROHA_SHARED_MODEL_TYPES_HPP
 
 #include <cstdint>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- JSON config loader was refactored: now it is a class, not a set of functions. It is needed to initialize it with a common objects factory
- JSON config loader was taught to load `Peer`s.
- optional initial peers list was added to the irhhad config, and the command line argument removed
- the overriding initial peers list passed to `Irohad` constructor is made `optional` to be consistent with the project's code style.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

peer list moved to config, refactoring.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
