### PR TITLE
Startup: check initial peers presence

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -89,9 +89,11 @@ namespace iroha {
       /**
        * Insert blocks without validation
        * @param blocks - collection of blocks for insertion
-       * @return true if inserted
+       * @return final ledger if inserted, error description otherwise
        */
-      bool insertBlocks(
+      iroha::expected::Result<boost::optional<std::unique_ptr<LedgerState>>,
+                              std::string>
+      insertBlocks(
           const std::vector<std::shared_ptr<shared_model::interface::Block>>
               &blocks) override;
 

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -16,8 +16,8 @@ namespace iroha {
     expected::Result<void, std::string> WsvRestorerImpl::restoreWsv(
         Storage &storage) {
       // get all blocks starting from the genesis
-      std::vector<std::shared_ptr<shared_model::interface::Block>> blocks=
-      storage.getBlockQuery()->getBlocksFrom(1);
+      std::vector<std::shared_ptr<shared_model::interface::Block>> blocks =
+          storage.getBlockQuery()->getBlocksFrom(1);
 
       storage.reset();
 

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -13,18 +13,17 @@
 
 namespace iroha {
   namespace ametsuchi {
-    expected::Result<void, std::string> WsvRestorerImpl::restoreWsv(
-        Storage &storage) {
+    iroha::expected::Result<
+        boost::optional<std::unique_ptr<iroha::LedgerState>>,
+        std::string>
+    WsvRestorerImpl::restoreWsv(Storage &storage) {
       // get all blocks starting from the genesis
       std::vector<std::shared_ptr<shared_model::interface::Block>> blocks =
           storage.getBlockQuery()->getBlocksFrom(1);
 
       storage.reset();
 
-      if (not storage.insertBlocks(blocks))
-        return expected::makeError("cannot insert blocks");
-
-      return expected::Value<void>();
+      return storage.insertBlocks(blocks);
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
@@ -6,6 +6,7 @@
 #ifndef IROHA_WSVRESTORERIMPL_HPP
 #define IROHA_WSVRESTORERIMPL_HPP
 
+#include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/wsv_restorer.hpp"
 #include "common/result.hpp"
 
@@ -23,10 +24,13 @@ namespace iroha {
        * Recover WSV (World State View).
        * Drop storage and apply blocks one by one.
        * @param storage of blocks in ledger
-       * @return void on success, otherwise error string
+       * @return ledger state after restoration on success, otherwise error
+       * string
        */
-      virtual expected::Result<void, std::string> restoreWsv(
-          Storage &storage) override;
+      virtual iroha::expected::Result<
+          boost::optional<std::unique_ptr<iroha::LedgerState>>,
+          std::string>
+      restoreWsv(Storage &storage) override;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -54,11 +54,13 @@ namespace iroha {
       /**
        * Raw insertion of blocks without validation
        * @param blocks - collection of blocks for insertion
-       * @return true if inserted
+       * @return final ledger if inserted, error description otherwise
        */
-      virtual bool insertBlocks(
-          const std::vector<std::shared_ptr<shared_model::interface::Block>>
-              &blocks) = 0;
+      virtual iroha::expected::
+          Result<boost::optional<std::unique_ptr<LedgerState>>, std::string>
+          insertBlocks(
+              const std::vector<std::shared_ptr<shared_model::interface::Block>>
+                  &blocks) = 0;
 
       /**
        * method called when block is written to the storage

--- a/irohad/ametsuchi/wsv_restorer.hpp
+++ b/irohad/ametsuchi/wsv_restorer.hpp
@@ -22,10 +22,12 @@ namespace iroha {
       /**
        * Recover WSV (World State View).
        * @param storage storage of blocks in ledger
-       * @return void on success, otherwise error string
+       * @return ledger state after restoration on success, otherwise error
+       * string
        */
-      virtual expected::Result<void, std::string> restoreWsv(
-          Storage &storage) = 0;
+      virtual iroha::expected::
+          Result<boost::optional<std::unique_ptr<LedgerState>>, std::string>
+          restoreWsv(Storage &storage) = 0;
     };
 
   }  // namespace ametsuchi

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -117,13 +117,13 @@ class Irohad {
   /**
    * Initialization of whole objects in system
    */
-  virtual void init();
+  virtual RunResult init();
 
   /**
    * Restore World State View
    * @return true on success, false otherwise
    */
-  bool restoreWsv();
+  RunResult restoreWsv();
 
   /**
    * Drop wsv and block store
@@ -141,48 +141,48 @@ class Irohad {
  protected:
   // -----------------------| component initialization |------------------------
 
-  virtual void initStorage();
+  virtual RunResult initStorage();
 
-  virtual void initCryptoProvider();
+  virtual RunResult initCryptoProvider();
 
-  virtual void initBatchParser();
+  virtual RunResult initBatchParser();
 
-  virtual void initValidators();
+  virtual RunResult initValidators();
 
-  virtual void initNetworkClient();
+  virtual RunResult initNetworkClient();
 
-  virtual void initFactories();
+  virtual RunResult initFactories();
 
-  virtual void initPersistentCache();
+  virtual RunResult initPersistentCache();
 
-  virtual void initOrderingGate();
+  virtual RunResult initOrderingGate();
 
-  virtual void initSimulator();
+  virtual RunResult initSimulator();
 
-  virtual void initConsensusCache();
+  virtual RunResult initConsensusCache();
 
-  virtual void initBlockLoader();
+  virtual RunResult initBlockLoader();
 
-  virtual void initConsensusGate();
+  virtual RunResult initConsensusGate();
 
-  virtual void initSynchronizer();
+  virtual RunResult initSynchronizer();
 
-  virtual void initPeerCommunicationService();
+  virtual RunResult initPeerCommunicationService();
 
-  virtual void initStatusBus();
+  virtual RunResult initStatusBus();
 
-  virtual void initMstProcessor();
+  virtual RunResult initMstProcessor();
 
-  virtual void initPendingTxsStorage();
+  virtual RunResult initPendingTxsStorage();
 
-  virtual void initTransactionCommandService();
+  virtual RunResult initTransactionCommandService();
 
-  virtual void initQueryService();
+  virtual RunResult initQueryService();
 
   /**
    * Initialize WSV restorer
    */
-  virtual void initWsvRestorer();
+  virtual RunResult initWsvRestorer();
 
   // constructor dependencies
   std::string block_store_dir_;

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -271,7 +271,10 @@ int main(int argc, char *argv[]) {
   }
 
   // init pipeline components
-  irohad.init();
+  irohad.init().match([](const auto &) {},
+                      [&log](const auto &error) {
+                        log->critical("Irohad startup failed: {}", error.error);
+                      });
 
   auto handler = [](int s) { exit_requested.set_value(); };
   std::signal(SIGINT, handler);

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -127,8 +127,8 @@ namespace iroha {
        *         otherwise return this
        */
       template <typename Value>
-      constexpr Result<Value, E> and_res(const Result<Value, E> &new_res) const
-          noexcept {
+      constexpr Result<Value, E> operator&(
+          const Result<Value, E> &new_res) const noexcept {
         return visit_in_place(
             *this,
             [res = new_res](ValueType) { return res; },
@@ -147,8 +147,8 @@ namespace iroha {
        *         otherwise return this
        */
       template <typename Value>
-      constexpr Result<Value, E> or_res(const Result<Value, E> &new_res) const
-          noexcept {
+      constexpr Result<Value, E> operator|(
+          const Result<Value, E> &new_res) const noexcept {
         return visit_in_place(
             *this,
             [](ValueType val) -> Result<Value, E> { return val; },

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -42,9 +42,12 @@ namespace iroha {
                        std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(insertBlock,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD1(insertBlocks,
-                   bool(const std::vector<
-                        std::shared_ptr<shared_model::interface::Block>> &));
+      MOCK_METHOD1(
+          insertBlocks,
+          iroha::expected::Result<boost::optional<std::unique_ptr<LedgerState>>,
+                                  std::string>(
+              const std::vector<std::shared_ptr<shared_model::interface::Block>>
+                  &));
       MOCK_METHOD0(reset, void(void));
       MOCK_METHOD0(dropStorage, void(void));
       MOCK_METHOD0(freeConnections, void(void));

--- a/test/module/libs/common/result_test.cpp
+++ b/test/module/libs/common/result_test.cpp
@@ -148,74 +148,80 @@ TEST(ResultTest, ResultVoidError) {
 
 /**
  * @given Pair of results with some values
- * @when and_res function is invoked
+ * @when operator& is invoked
  * @then result contains the last value
  */
 TEST(ResultTest, AndResWithValVal) {
   Result<int, void> result = makeValue(5);
   Result<int, void> new_res = makeValue(4);
-  result.and_res(new_res).match([](Value<int> v) { ASSERT_EQ(4, v.value); },
-                                makeFailCase<Error<void>>(kErrorCaseMessage));
+  (result & new_res)
+      .match([](Value<int> v) { ASSERT_EQ(4, v.value); },
+             makeFailCase<Error<void>>(kErrorCaseMessage));
 }
 
 /**
  * @given Pair of results: first with error, second with value
- * @when and_res function is invoked
+ * @when operator& is invoked
  * @then result contains the first error
  */
 TEST(ResultTest, AndResWithErrVal) {
   Result<int, int> result = makeError(5);
   Result<int, int> new_res = makeValue(4);
-  result.and_res(new_res).match(makeFailCase<Value<int>>(kValueCaseMessage),
-                                [](Error<int> e) { ASSERT_EQ(5, e.error); });
+  (result & new_res)
+      .match(makeFailCase<Value<int>>(kValueCaseMessage),
+             [](Error<int> e) { ASSERT_EQ(5, e.error); });
 }
 
 /**
  * @given Pair of results: first with value, second with error
- * @when and_res function is invoked
+ * @when operator& is invoked
  * @then result contains the second error
  */
 TEST(ResultTest, AndResWithValErr) {
   Result<int, int> result = makeValue(5);
   Result<int, int> new_res = makeError(4);
-  result.and_res(new_res).match(makeFailCase<Value<int>>(kValueCaseMessage),
-                                [](Error<int> e) { ASSERT_EQ(4, e.error); });
+  (result & new_res)
+      .match(makeFailCase<Value<int>>(kValueCaseMessage),
+             [](Error<int> e) { ASSERT_EQ(4, e.error); });
 }
 
 /**
  * @given Pair of results with some values
- * @when or_res function is invoked
+ * @when operator| is invoked
  * @then result contains the first value
  */
 TEST(ResultTest, OrResWithValVal) {
   Result<int, void> result = makeValue(5);
   Result<int, void> new_res = makeValue(4);
-  result.or_res(new_res).match([](Value<int> v) { ASSERT_EQ(5, v.value); },
-                               makeFailCase<Error<void>>(kErrorCaseMessage));
+  (result | new_res)
+      .match([](Value<int> v) { ASSERT_EQ(5, v.value); },
+             makeFailCase<Error<void>>(kErrorCaseMessage));
 }
 
 /**
  * @given Pair of results: first with error, second with value
- * @when or_res function is invoked
+ * @when operator| is invoked
  * @then result contains the second value
  */
 TEST(ResultTest, OrResWithErrVal) {
   Result<int, int> result = makeError(5);
   Result<int, int> new_res = makeValue(4);
-  result.or_res(new_res).match([](Value<int> v) { ASSERT_EQ(4, v.value); },
-                               makeFailCase<Error<int>>(kErrorCaseMessage));
+  (result | new_res)
+      .match([](Value<int> v) { ASSERT_EQ(4, v.value); },
+             makeFailCase<Error<int>>(kErrorCaseMessage));
 }
 
 /**
  * @given Pair of results with some errors
- * @when or_res function is invoked
+ * @when operator| is invoked
  * @then result contains the last value
  */
 TEST(ResultTest, OrResWithErrErr) {
   Result<int, int> result = makeError(5);
   Result<int, int> new_res = makeError(4);
-  result.or_res(new_res).match(makeFailCase<Value<int>>(kValueCaseMessage),
-                               [](Error<int> e) { ASSERT_EQ(4, e.error); });
+  (result | new_res)
+      .match(makeFailCase<Value<int>>(kValueCaseMessage),
+             [](Error<int> e) { ASSERT_EQ(4, e.error); });
 }
 
 /**


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

[IR-460](https://jira.hyperledger.org/browse/IR-460)

### Description of the Change

- `Storage::insertBlocks` and `WsvRestorer::restoreWsv` return Result with LedgerState
-  check peers presence in WSV after restoration
- renamed `expected::Result` chaining operators
- refactored Irohad initialization functions result checking

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Meaningful error message if WSV has no peers at startup. Refactoring.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
