### PR TITLE
Fix issue with uncaught exception in logger

### DIFF
--- a/cmake/Modules/Findpq.cmake
+++ b/cmake/Modules/Findpq.cmake
@@ -41,22 +41,24 @@ if (NOT pq_FOUND)
       GIT_REPOSITORY  ${URL}
       GIT_TAG         ${VERSION}
       CONFIGURE_COMMAND
-                      ./configure --without-readline
+                      ./configure --without-readline --prefix=${EP_PREFIX}
                       CC=${CMAKE_C_COMPILER}
 
       BUILD_IN_SOURCE 1
       BUILD_COMMAND ${MAKE} COPT=${CMAKE_C_FLAGS} -C ./src/bin/pg_config &&
-                    ${MAKE} COPT=${CMAKE_C_FLAGS} -C ./src/interfaces/libpq
-      BUILD_BYPRODUCTS ${EP_PREFIX}/src/postgres_postgres/src/interfaces/libpq/libpq.a
-      INSTALL_COMMAND "" # remove install step
+                    ${MAKE} COPT=${CMAKE_C_FLAGS} -C ./src/interfaces/libpq &&
+                    ${MAKE} COPT=${CMAKE_C_FLAGS} -C ./src/backend ../../src/include/utils/fmgroids.h
+      BUILD_BYPRODUCTS ${EP_PREFIX}/lib/libpq.a
+      INSTALL_COMMAND make -C src/bin/pg_config install &&
+                      make -C src/interfaces/libpq install &&
+                      make -C src/include install
       TEST_COMMAND "" # remove test step
       UPDATE_COMMAND "" # remove update step
       )
-  externalproject_get_property(postgres_postgres source_dir)
-  set(postgres_INCLUDE_DIR ${source_dir}/src/include)
-  set(pq_INCLUDE_DIR ${source_dir}/src/interfaces/libpq)
-  set(pq_LIBRARY ${source_dir}/src/interfaces/libpq/libpq.a)
-  set(pg_config_EXECUTABLE ${source_dir}/src/bin/pg_config/pg_config)
+  set(postgres_INCLUDE_DIR ${EP_PREFIX}/include)
+  set(pq_INCLUDE_DIR ${EP_PREFIX}/include)
+  set(pq_LIBRARY ${EP_PREFIX}/lib/libpq.a)
+  set(pg_config_EXECUTABLE ${EP_PREFIX}/bin/pg_config)
   file(MAKE_DIRECTORY ${pq_INCLUDE_DIR} ${postgres_INCLUDE_DIR})
 
   add_dependencies(pg_config postgres_postgres)

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -168,7 +168,7 @@ namespace iroha {
       // boost::get of pointer returns pointer to requested type, or nullptr
       if (auto e =
               boost::get<expected::Error<std::string>>(&deserialized_block)) {
-        log_->error(e->error);
+        log_->error("{}", e->error);
         return result;
       }
 
@@ -261,7 +261,7 @@ namespace iroha {
             soci::use(query.creatorAccountId(), "account_id"),
             soci::use(keys, "pk");
       } catch (const std::exception &e) {
-        log_->error(e.what());
+        log_->error("{}", e.what());
         return false;
       }
 

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -42,7 +42,7 @@ namespace iroha {
             return boost::make_optional(std::shared_ptr<T>(std::move(v.value)));
           },
           [&](const auto &e) -> boost::optional<std::shared_ptr<T>> {
-            log_->error(e.error);
+            log_->error("{}", e.error);
             return boost::none;
           });
     }

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -230,7 +230,7 @@ namespace iroha {
             log_->info("block inserted: {}", inserted);
             this->commit(std::move(storage.value));
           },
-          [&](const auto &error) { log_->error(error.error); });
+          [&](const auto &error) { log_->error("{}", error.error); });
 
       return inserted;
     }
@@ -248,7 +248,7 @@ namespace iroha {
             this->commit(std::move(mutableStorage.value));
           },
           [&](const auto &error) {
-            log_->error(error.error);
+            log_->error("{}", error.error);
             inserted = false;
           });
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -190,7 +190,7 @@ void Irohad::initStorage() {
                                            log_manager_->getChild("Storage"));
   std::move(storageResult)
       .match([&](auto &&v) { storage = std::move(v.value); },
-             [&](const auto &error) { log_->error(error.error); });
+             [&](const auto &error) { log_->error("{}", error.error); });
 
   log_->info("[Init] => storage ({})", logger::logBool(storage));
 }
@@ -199,7 +199,7 @@ bool Irohad::restoreWsv() {
   return wsv_restorer_->restoreWsv(*storage).match(
       [](const auto &) { return true; },
       [this](const auto &error) {
-        log_->error(error.error);
+        log_->error("{}", error.error);
         return false;
       });
 }
@@ -737,7 +737,7 @@ Irohad::RunResult Irohad::run() {
             return {};
           },
           [&](const auto &e) -> RunResult {
-            log_->error(e.error);
+            log_->error("{}", e.error);
             return e;
           });
 }

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -42,7 +42,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
       [this, height, &peer_pubkey](auto subscriber) {
         auto peer = this->findPeer(peer_pubkey);
         if (not peer) {
-          log_->error(kPeerNotFound);
+          log_->error("{}", kPeerNotFound);
           subscriber.on_completed();
           return;
         }
@@ -67,7 +67,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
                     subscriber.on_next(std::move(result.value));
                   },
                   [this, &context](const auto &error) {
-                    log_->error(error.error);
+                    log_->error("{}", error.error);
                     context.TryCancel();
                   });
         }
@@ -80,7 +80,7 @@ boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
     const PublicKey &peer_pubkey, const types::HashType &block_hash) {
   auto peer = findPeer(peer_pubkey);
   if (not peer) {
-    log_->error(kPeerNotFound);
+    log_->error("{}", kPeerNotFound);
     return boost::none;
   }
 
@@ -93,7 +93,7 @@ boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
 
   auto status = getPeerStub(**peer).retrieveBlock(&context, request, &block);
   if (not status.ok()) {
-    log_->warn(status.error_message());
+    log_->warn("{}", status.error_message());
     return boost::none;
   }
 
@@ -104,7 +104,7 @@ boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
                 std::shared_ptr<Block>(std::move(v.value)));
           },
           [this](const auto &e) -> boost::optional<std::shared_ptr<Block>> {
-            log_->error(e.error);
+            log_->error("{}", e.error);
             return boost::none;
           });
 }
@@ -114,7 +114,7 @@ BlockLoaderImpl::findPeer(const shared_model::crypto::PublicKey &pubkey) {
   auto peers = peer_query_factory_->createPeerQuery() |
       [](const auto &query) { return query->getLedgerPeers(); };
   if (not peers) {
-    log_->error(kPeerRetrieveFail);
+    log_->error("{}", kPeerRetrieveFail);
     return boost::none;
   }
 
@@ -124,7 +124,7 @@ BlockLoaderImpl::findPeer(const shared_model::crypto::PublicKey &pubkey) {
         return peer->pubkey().blob() == blob;
       });
   if (it == peers.value().end()) {
-    log_->error(kPeerFindFail);
+    log_->error("{}", kPeerFindFail);
     return boost::none;
   }
   return *it;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -72,7 +72,7 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
                     std::move(v).value));
           },
           [this](const auto &error) {
-            log_->info(error.error.error);  // error
+            log_->info("{}", error.error.error);  // error
             return boost::optional<
                 std::shared_ptr<const OdOsNotification::ProposalType>>();
           });

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -69,7 +69,7 @@ namespace iroha {
             // notify about failed txs
             const auto &errors = proposal_and_errors->rejected_transactions;
             for (const auto &tx_error : errors) {
-              log_->info(composeErrorMessage(tx_error));
+              log_->info("{}", composeErrorMessage(tx_error));
               this->publishStatus(TxStatusType::kStatefulFailed,
                                   tx_error.tx_hash,
                                   tx_error.error);

--- a/libs/common/files.cpp
+++ b/libs/common/files.cpp
@@ -16,7 +16,7 @@ void iroha::remove_dir_contents(const std::string &dir,
 
   bool exists = boost::filesystem::exists(dir, error_code);
   if (error_code != boost::system::errc::success) {
-    log->error(error_code.message());
+    log->error("{}", error_code.message());
     return;
   }
   if (not exists) {
@@ -26,7 +26,7 @@ void iroha::remove_dir_contents(const std::string &dir,
 
   bool is_dir = boost::filesystem::is_directory(dir, error_code);
   if (error_code != boost::system::errc::success) {
-    log->error(error_code.message());
+    log->error("{}", error_code.message());
     return;
   }
   if (not is_dir) {
@@ -37,6 +37,6 @@ void iroha::remove_dir_contents(const std::string &dir,
   for (auto entry : boost::filesystem::directory_iterator(dir)) {
     boost::filesystem::remove_all(entry.path(), error_code);
     if (error_code != boost::system::errc::success)
-      log->error(error_code.message());
+      log->error("{}", error_code.message());
   }
 }

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -82,7 +82,12 @@ namespace logger {
               const std::string &format,
               const Args &... args) const {
        if (shouldLog(level)) {
-         logInternal(level, fmt::format(format, args...));
+         try {
+           logInternal(level, fmt::format(format, args...));
+         } catch (const fmt::v5::format_error &error) {
+           std::string error_msg("Exception was thrown while logging: ");
+           logInternal(LogLevel::kError, error_msg.append(error.what()));
+         }
        }
      }
 

--- a/test/framework/sql_query.cpp
+++ b/test/framework/sql_query.cpp
@@ -46,7 +46,7 @@ namespace framework {
             return boost::make_optional(std::shared_ptr<T>(std::move(v.value)));
           },
           [&](const auto &e) -> boost::optional<std::shared_ptr<T>> {
-            log_->error(e.error);
+            log_->error("{}", e.error);
             return boost::none;
           });
     }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Pull request fixes irohad crash on receiving SetAccountDetail transaction with value field set to `"{}"`.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No crash^^

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Command doesn't pass stateful validation with message `command 'SetAccountDetail' with index '0' did not pass verification with code '1'`. Code 1 means "internal error" which isn't a user friendly message. I suggest either to create additional stateless validation rule or improve error message (or maybe even so some escaping for Postgres).

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

