### PR TITLE
Add tests for batch validator

### DIFF
--- a/test/framework/batch_helper.hpp
+++ b/test/framework/batch_helper.hpp
@@ -127,6 +127,32 @@ namespace framework {
     }
 
     /**
+     * Creates batch transactions, where every transaction has single signature
+     * @param batch_type - the type of batch to set to all transactions batch
+     * meta
+     * @param transactions_creators - vector of creator account ids for batch
+     * transactions
+     * @param now created time for every transaction
+     * @param quorum quorum for every transaction
+     * @return batch with the same size as size of range of pairs
+     */
+    auto createBatchOneSignTransactions(
+        const shared_model::interface::types::BatchType batch_type,
+        std::vector<shared_model::interface::types::AccountIdType>
+            transactions_creators,
+        size_t now = iroha::time::now(),
+        const shared_model::interface::types::QuorumType &quorum = 1) {
+      std::vector<std::pair<shared_model::interface::types::BatchType,
+                            shared_model::interface::types::AccountIdType>>
+          batch_types_and_creators;
+      for (const auto &creator : transactions_creators) {
+        batch_types_and_creators.emplace_back(batch_type, creator);
+      }
+      return createBatchOneSignTransactions(
+          batch_types_and_creators, now, quorum);
+    }
+
+    /**
      * Creates atomic batch from provided creator accounts
      * @param creators vector of creator account ids
      * @return unsigned batch of the same size as the size of creator account

--- a/test/module/shared_model/validators/CMakeLists.txt
+++ b/test/module/shared_model/validators/CMakeLists.txt
@@ -82,4 +82,5 @@ addtest(batch_validator_test
 target_link_libraries(batch_validator_test
     shared_model_proto_backend
     shared_model_stateless_validation
+    shared_model_interfaces_factories
     )

--- a/test/module/shared_model/validators/batch_validator_test.cpp
+++ b/test/module/shared_model/validators/batch_validator_test.cpp
@@ -5,4 +5,95 @@
 
 #include "validators/transaction_batch_validator.hpp"
 
-// TODO igor-egorov 23.04.2019 IR-454 Create tests for batch validator
+#include <gtest/gtest.h>
+#include "framework/batch_helper.hpp"
+#include "interfaces/iroha_internal/transaction_batch_impl.hpp"
+#include "module/irohad/common/validators_config.hpp"
+
+struct BatchValidatorFixture : public ::testing::Test {
+  auto getValidator(bool allow_partial_ordered_batches) {
+    auto config = std::make_shared<shared_model::validation::ValidatorsConfig>(
+        iroha::test::getTestsMaxBatchSize(), allow_partial_ordered_batches);
+    auto validator =
+        std::make_shared<shared_model::validation::BatchValidator>(config);
+    return validator;
+  }
+};
+
+/**
+ * @given a batch validator with allowed partial ordered batches
+ * @when an ordered batch with some transactions missing arrives
+ * @then the batch passes validation
+ */
+TEST_F(BatchValidatorFixture, PartialOrderedWhenPartialsAllowed) {
+  auto validator = getValidator(true);
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      shared_model::interface::types::BatchType::ORDERED,
+      {"alice@iroha", "bob@iroha", "donna@iroha"});
+  txs.pop_back();
+  auto batch =
+      std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
+  auto result = validator->validate(*batch);
+  ASSERT_FALSE(result.hasErrors());
+}
+
+/**
+ * @given a batch validator with disallowed partial ordered batches
+ * @when an atomic batch with some transactions missing arrives
+ * @then the batch fails validation
+ */
+TEST_F(BatchValidatorFixture, AtomicBatchWithMissingTransactions) {
+  auto validator = getValidator(false);
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      shared_model::interface::types::BatchType::ATOMIC,
+      {"alice@iroha", "bob@iroha", "donna@iroha"});
+  txs.pop_back();
+  auto batch =
+      std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
+  auto result = validator->validate(*batch);
+  ASSERT_TRUE(result.hasErrors());
+  ASSERT_THAT(
+      result.reason(),
+      ::testing::HasSubstr(
+          "Sizes of batch_meta and provided transactions are different"));
+}
+
+/**
+ * @given a batch validator with disallowed partial ordered batches
+ * @when an ordered batch with complete set of transactions arrives
+ * @then the batch passes validation
+ */
+TEST_F(BatchValidatorFixture, ComleteOrderedWhenPartialsDisallowed) {
+  auto validator = getValidator(false);
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      shared_model::interface::types::BatchType::ORDERED,
+      {"alice@iroha", "bob@iroha", "donna@iroha"});
+  auto batch =
+      std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
+  auto result = validator->validate(*batch);
+  ASSERT_FALSE(result.hasErrors());
+}
+
+/**
+ * @given a batch validator with allowed partial ordered batches
+ * @when an ordered batch with some transactions missing and the rest of
+ * transactions are reordered arrives
+ * @then the batch fails validation
+ */
+TEST_F(BatchValidatorFixture,
+       PartialOrderedWithMessedHashesWhenPartialsAllowed) {
+  auto validator = getValidator(true);
+  auto txs = framework::batch::createBatchOneSignTransactions(
+      shared_model::interface::types::BatchType::ORDERED,
+      {"alice@iroha", "bob@iroha", "donna@iroha"});
+  txs.pop_back();
+  ASSERT_EQ(txs.size(), 2);
+  std::swap(txs[0], txs[1]);
+  auto batch =
+      std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
+  auto result = validator->validate(*batch);
+  ASSERT_TRUE(result.hasErrors());
+  ASSERT_THAT(result.reason(),
+              ::testing::HasSubstr("Hashes of provided transactions and ones "
+                                   "in batch_meta are different"));
+}


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

This pr is opened instead of #31 

### Description of the Change

Add tests for the new logic inside batch validator.
Relates to #27

### Benefits

Increased tests coverage.

### Possible Drawbacks 

Not known

### Usage Examples or Tests 

`batch_validator_test`
