### PR TITLE
Remove vectors from BlockQuery interface

### DIFF
--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -7,11 +7,9 @@
 #define IROHA_BLOCK_QUERY_HPP
 
 #include <boost/optional.hpp>
-#include <rxcpp/rx.hpp>
 #include "ametsuchi/tx_cache_response.hpp"
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/block.hpp"
-#include "interfaces/transaction.hpp"
 
 namespace iroha {
 
@@ -20,44 +18,27 @@ namespace iroha {
      * Public interface for queries on blocks and transactions
      */
     class BlockQuery {
-     protected:
-      using wTransaction =
-          std::shared_ptr<shared_model::interface::Transaction>;
-      using wBlock = std::shared_ptr<shared_model::interface::Block>;
-
      public:
+      using BlockResult =
+          expected::Result<std::unique_ptr<shared_model::interface::Block>,
+                           std::string>;
+
       virtual ~BlockQuery() = default;
 
       /**
-       * Get given number of blocks starting with given height.
-       * @param height - starting height
-       * @param count - number of blocks to retrieve
-       * @return observable of Model Block
+       * Retrieve block with given height from block storage
+       * @param height - height of a block to retrieve
+       * @return block with given height
        */
-      virtual std::vector<wBlock> getBlocks(
-          shared_model::interface::types::HeightType height,
-          uint32_t count) = 0;
-
-      /**
-       * Get all blocks starting from given height.
-       * @param from - starting height
-       * @return observable of Model Block
-       */
-      virtual std::vector<wBlock> getBlocksFrom(
+      virtual BlockResult getBlock(
           shared_model::interface::types::HeightType height) = 0;
-
-      /**
-       * Get given number of blocks from top.
-       * @param count - number of blocks to retrieve
-       * @return observable of Model Block
-       */
-      virtual std::vector<wBlock> getTopBlocks(uint32_t count) = 0;
 
       /**
        * Get height of the top block.
        * @return height
        */
-      virtual uint32_t getTopBlockHeight() = 0;
+      virtual shared_model::interface::types::HeightType
+      getTopBlockHeight() = 0;
 
       /**
        * Synchronously checks whether transaction with given hash is present in
@@ -69,12 +50,6 @@ namespace iroha {
        */
       virtual boost::optional<TxCacheStatusType> checkTxPresence(
           const shared_model::crypto::Hash &hash) = 0;
-
-      /**
-       * Get the top-most block
-       * @return result of Model Block or error message
-       */
-      virtual expected::Result<wBlock, std::string> getTopBlock() = 0;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_block_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_query.hpp
@@ -3,21 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef IROHA_POSTGRES_FLAT_BLOCK_QUERY_HPP
-#define IROHA_POSTGRES_FLAT_BLOCK_QUERY_HPP
+#ifndef IROHA_POSTGRES_BLOCK_QUERY_HPP
+#define IROHA_POSTGRES_BLOCK_QUERY_HPP
 
 #include "ametsuchi/block_query.hpp"
 
 #include <soci/soci.h>
 #include <boost/optional.hpp>
-#include "ametsuchi/impl/flat_file/flat_file.hpp"
+#include "ametsuchi/key_value_storage.hpp"
 #include "interfaces/iroha_internal/block_json_deserializer.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
-
-    class FlatFile;
 
     /**
      * Class which implements BlockQuery with a Postgres backend.
@@ -38,32 +36,15 @@ namespace iroha {
               converter,
           logger::LoggerPtr log);
 
-      std::vector<wBlock> getBlocks(
-          shared_model::interface::types::HeightType height,
-          uint32_t count) override;
-
-      std::vector<wBlock> getBlocksFrom(
+      BlockResult getBlock(
           shared_model::interface::types::HeightType height) override;
 
-      std::vector<wBlock> getTopBlocks(uint32_t count) override;
-
-      uint32_t getTopBlockHeight() override;
+      shared_model::interface::types::HeightType getTopBlockHeight() override;
 
       boost::optional<TxCacheStatusType> checkTxPresence(
           const shared_model::crypto::Hash &hash) override;
 
-      expected::Result<wBlock, std::string> getTopBlock() override;
-
      private:
-      /**
-       * Retrieve block with given id from block storage
-       * @param id - height of a block to retrieve
-       * @return block with given height
-       */
-      expected::Result<std::unique_ptr<shared_model::interface::Block>,
-                       std::string>
-      getBlock(shared_model::interface::types::HeightType id) const;
-
       std::unique_ptr<soci::session> psql_;
       soci::session &sql_;
 
@@ -76,4 +57,4 @@ namespace iroha {
   }  // namespace ametsuchi
 }  // namespace iroha
 
-#endif  // IROHA_POSTGRES_FLAT_BLOCK_QUERY_HPP
+#endif  // IROHA_POSTGRES_BLOCK_QUERY_HPP

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -34,6 +34,7 @@
 #include "interfaces/queries/get_transactions.hpp"
 #include "interfaces/queries/query.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
+#include "interfaces/transaction.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
 

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -276,8 +276,15 @@ int main(int argc, char *argv[]) {
   }
 
   // check if at least one block is available in the ledger
-  auto blocks_exist = irohad.storage->getBlockQuery()->getTopBlock().match(
-      [](const auto &) { return true; }, [](const auto &) { return false; });
+  auto block_query = irohad.storage->getBlockQuery();
+  if (not block_query) {
+    log->error("Cannot create BlockQuery");
+    return EXIT_FAILURE;
+  }
+  auto blocks_exist = block_query->getBlock(block_query->getTopBlockHeight())
+                          .match([](const auto &) { return true; },
+                                 [](const auto &) { return false; });
+  block_query.reset();
 
   if (not blocks_exist) {
     log->error(

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -31,16 +31,16 @@ namespace iroha {
                      const shared_model::crypto::PublicKey &peer_pubkey) = 0;
 
       /**
-       * Retrieve block by its block_hash from given peer
+       * Retrieve block by its block_height from given peer
        * @param peer_pubkey - peer for requesting blocks
-       * @param block_hash - requested block hash
+       * @param block_height - requested block height
        * @return block on success, nullopt on failure
        * TODO 14/02/17 (@l4l) IR-960 rework method with returning result
        */
       virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
       retrieveBlock(
           const shared_model::crypto::PublicKey &peer_pubkey,
-          const shared_model::interface::types::HashType &block_hash) = 0;
+          shared_model::interface::types::HeightType block_height) = 0;
 
       virtual ~BlockLoader() = default;
     };

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -47,7 +47,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
           return;
         }
 
-        proto::BlocksRequest request;
+        proto::BlockRequest request;
         grpc::ClientContext context;
         protocol::Block block;
 
@@ -77,7 +77,7 @@ rxcpp::observable<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlocks(
 }
 
 boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
-    const PublicKey &peer_pubkey, const types::HashType &block_hash) {
+    const PublicKey &peer_pubkey, types::HeightType block_height) {
   auto peer = findPeer(peer_pubkey);
   if (not peer) {
     log_->error("{}", kPeerNotFound);
@@ -88,8 +88,8 @@ boost::optional<std::shared_ptr<Block>> BlockLoaderImpl::retrieveBlock(
   grpc::ClientContext context;
   protocol::Block block;
 
-  // request block with specified hash
-  request.set_hash(toBinaryString(block_hash));
+  // request block with specified height
+  request.set_height(block_height);
 
   auto status = getPeerStub(**peer).retrieveBlock(&context, request, &block);
   if (not status.ok()) {

--- a/irohad/network/impl/block_loader_impl.hpp
+++ b/irohad/network/impl/block_loader_impl.hpp
@@ -33,7 +33,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<shared_model::interface::Block>>
       retrieveBlock(
           const shared_model::crypto::PublicKey &peer_pubkey,
-          const shared_model::interface::types::HashType &block_hash) override;
+          shared_model::interface::types::HeightType block_height) override;
 
      private:
       /**

--- a/irohad/network/impl/block_loader_service.hpp
+++ b/irohad/network/impl/block_loader_service.hpp
@@ -23,7 +23,7 @@ namespace iroha {
 
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,
-          const proto::BlocksRequest *request,
+          const proto::BlockRequest *request,
           ::grpc::ServerWriter<protocol::Block> *writer) override;
 
       grpc::Status retrieveBlock(::grpc::ServerContext *context,

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -87,15 +87,18 @@ namespace iroha {
 
       // Get last block from local ledger
       if (auto block_query_opt = block_query_factory_->createBlockQuery()) {
-        auto block_var = block_query_opt.value()->getTopBlock();
+        auto block_var =
+            (*block_query_opt)
+                ->getBlock((*block_query_opt)->getTopBlockHeight());
         if (auto e = boost::get<expected::Error<std::string>>(&block_var)) {
           log_->warn("Could not fetch last block: " + e->error);
           return boost::none;
         }
 
-        last_block = boost::get<expected::Value<
-            std::shared_ptr<shared_model::interface::Block>>>(&block_var)
-                         ->value;
+        last_block = std::move(
+            boost::get<expected::Value<
+                std::unique_ptr<shared_model::interface::Block>>>(&block_var)
+                ->value);
       } else {
         log_->error("could not create block query");
         return boost::none;

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -72,7 +72,7 @@ namespace iroha {
       logger::LoggerPtr log_;
 
       // last block
-      std::shared_ptr<shared_model::interface::Block> last_block;
+      std::unique_ptr<shared_model::interface::Block> last_block;
     };
   }  // namespace simulator
 }  // namespace iroha

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -5,13 +5,12 @@
 
 #include "torii/impl/command_service_impl.hpp"
 
-#include <thread>
-
 #include "ametsuchi/block_query.hpp"
 #include "common/byteutils.hpp"
 #include "common/is_any.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "interfaces/transaction.hpp"
 #include "interfaces/transaction_responses/not_received_tx_response.hpp"
 #include "logger/logger.hpp"
 

--- a/schema/loader.proto
+++ b/schema/loader.proto
@@ -8,15 +8,11 @@ package iroha.network.proto;
 
 import "block.proto";
 
-message BlocksRequest {
+message BlockRequest {
   uint64 height = 1;
 }
 
-message BlockRequest {
-  bytes hash = 1;
-}
-
 service Loader {
-  rpc retrieveBlocks (BlocksRequest) returns (stream iroha.protocol.Block);
+  rpc retrieveBlocks (BlockRequest) returns (stream iroha.protocol.Block);
   rpc retrieveBlock (BlockRequest) returns (iroha.protocol.Block);
 }

--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -35,11 +35,11 @@ namespace integration_framework {
             "Got a Loader.retrieveBlock call, but have no block storage!");
         return {};
       }
-      const auto block = block_storage->getBlockByHash(*request);
+      const auto block = block_storage->getBlockByHeight(request);
       if (!block) {
         getLogger()->debug(
             "Got a Loader.retrieveBlock call for {}, but have no such block!",
-            request->toString());
+            request);
         return {};
       }
       return block;

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
@@ -50,7 +50,7 @@ namespace integration_framework {
       /// Handler of grpc retrieveBlocks calls.
       grpc::Status retrieveBlocks(
           ::grpc::ServerContext *context,
-          const iroha::network::proto::BlocksRequest *request,
+          const iroha::network::proto::BlockRequest *request,
           ::grpc::ServerWriter<iroha::protocol::Block> *writer) override;
 
       /// Handler of grpc retrieveBlock calls.
@@ -67,7 +67,7 @@ namespace integration_framework {
 
       logger::LoggerPtr log_;
     };
-  }
-}
+  }  // namespace fake_peer
+}  // namespace integration_framework
 
 #endif /* INTEGRATION_FRAMEWORK_FAKE_PEER_LOADER_GRPC_HPP_ */

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -17,7 +17,7 @@ namespace shared_model {
   namespace crypto {
     class Keypair;
     class Hash;
-  }
+  }  // namespace crypto
   namespace interface {
     class CommonObjectsFactory;
     class Proposal;
@@ -29,7 +29,7 @@ namespace shared_model {
   namespace proto {
     class Block;
     class Proposal;
-  }
+  }  // namespace proto
 }  // namespace shared_model
 
 namespace iroha {
@@ -51,7 +51,7 @@ namespace iroha {
       struct VoteMessage;
     }  // namespace yac
     struct Round;
-  }    // namespace consensus
+  }  // namespace consensus
   namespace ordering {
     namespace transport {
       class OnDemandOsServerGrpc;
@@ -77,7 +77,7 @@ namespace integration_framework {
     struct MstMessage;
 
     using YacMessage = std::vector<iroha::consensus::yac::VoteMessage>;
-    using LoaderBlockRequest = std::shared_ptr<shared_model::crypto::Hash>;
+    using LoaderBlockRequest = shared_model::interface::types::HeightType;
     using LoaderBlocksRequest = shared_model::interface::types::HeightType;
     using LoaderBlockRequestResult =
         boost::optional<std::shared_ptr<const shared_model::proto::Block>>;

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -152,11 +152,18 @@ TEST_F(FakePeerExampleFixture, SynchronizeTheRightVersionOfForkedLedger) {
   // Create the valid branch, supported by the good fake peers:
   auto valid_block_storage =
       std::make_shared<fake_peer::BlockStorage>(getTestLogger("BlockStorage"));
-  for (const auto &block : itf.getIrohaInstance()
-                               .getIrohaInstance()
-                               ->getStorage()
-                               ->getBlockQuery()
-                               ->getBlocksFrom(1)) {
+  auto block_query =
+      itf.getIrohaInstance().getIrohaInstance()->getStorage()->getBlockQuery();
+  ASSERT_TRUE(block_query);
+  auto top_height = block_query->getTopBlockHeight();
+  for (decltype(top_height) i = 1; i <= top_height; ++i) {
+    auto block_result = block_query->getBlock(i);
+
+    std::shared_ptr<shared_model::interface::Block> block =
+        boost::get<iroha::expected::Value<
+            std::unique_ptr<shared_model::interface::Block>>>(
+            std::move(block_result))
+            .value;
     valid_block_storage->storeBlock(
         std::static_pointer_cast<shared_model::proto::Block>(block));
   }

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -100,7 +100,11 @@ TEST_F(AmetsuchiTest, GetBlocksCompletedWhenCalled) {
 
   apply(storage, block);
 
-  ASSERT_EQ(*blocks->getBlocks(1, 1)[0], *block);
+  ASSERT_EQ(*boost::get<iroha::expected::Value<
+                 std::unique_ptr<shared_model::interface::Block>>>(
+                 blocks->getBlock(1))
+                 .value,
+            *block);
 }
 
 TEST_F(AmetsuchiTest, SampleTest) {
@@ -149,10 +153,12 @@ TEST_F(AmetsuchiTest, SampleTest) {
   // Block store tests
   auto hashes = {block1->hash(), block2->hash()};
 
-  auto stored_blocks = blocks->getBlocks(1, 2);
-  ASSERT_EQ(2, stored_blocks.size());
-  for (size_t i = 0; i < stored_blocks.size(); i++) {
-    EXPECT_EQ(*(hashes.begin() + i), stored_blocks[i]->hash());
+  for (size_t i = 0; i < hashes.size(); i++) {
+    EXPECT_EQ(*(hashes.begin() + i),
+              boost::get<iroha::expected::Value<
+                  std::unique_ptr<shared_model::interface::Block>>>(
+                  blocks->getBlock(i + 1))
+                  .value->hash());
   }
 }
 

--- a/test/module/irohad/ametsuchi/mock_block_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_block_query.hpp
@@ -15,18 +15,14 @@ namespace iroha {
 
     class MockBlockQuery : public BlockQuery {
      public:
-      MOCK_METHOD2(getBlocks,
-                   std::vector<BlockQuery::wBlock>(
-                       shared_model::interface::types::HeightType, uint32_t));
-      MOCK_METHOD1(getBlocksFrom,
-                   std::vector<BlockQuery::wBlock>(
-                       shared_model::interface::types::HeightType));
-      MOCK_METHOD1(getTopBlocks, std::vector<BlockQuery::wBlock>(uint32_t));
-      MOCK_METHOD0(getTopBlock, expected::Result<wBlock, std::string>(void));
+      MOCK_METHOD1(
+          getBlock,
+          BlockQuery::BlockResult(shared_model::interface::types::HeightType));
       MOCK_METHOD1(checkTxPresence,
                    boost::optional<TxCacheStatusType>(
                        const shared_model::crypto::Hash &));
-      MOCK_METHOD0(getTopBlockHeight, uint32_t(void));
+      MOCK_METHOD0(getTopBlockHeight,
+                   shared_model::interface::types::HeightType());
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -55,7 +55,7 @@ namespace iroha {
           retrieveBlock,
           boost::optional<std::shared_ptr<shared_model::interface::Block>>(
               const shared_model::crypto::PublicKey &,
-              const shared_model::interface::types::HashType &));
+              shared_model::interface::types::HeightType));
     };
 
     class MockOrderingGate : public OrderingGate {

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -36,6 +36,7 @@ using namespace framework::test_subscriber;
 
 using ::testing::_;
 using ::testing::A;
+using ::testing::ByMove;
 using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -149,12 +150,14 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
               .build());
   const auto &proposal = validation_result->verified_proposal;
   shared_model::proto::Block block = makeBlock(proposal->height() - 1);
+  auto block_height = block.height();
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(1);
-  EXPECT_CALL(*query, getTopBlock())
-      .WillOnce(Return(expected::makeValue(wBlock(clone(block)))));
+  EXPECT_CALL(*query, getTopBlockHeight()).WillRepeatedly(Return(block_height));
+  EXPECT_CALL(*query, getBlock(block_height))
+      .WillOnce(Return(ByMove(
+          expected::makeValue(clone<shared_model::interface::Block>(block)))));
 
-  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block.height()));
   EXPECT_CALL(*validator, validate(_, _))
       .WillOnce(Invoke([&validation_result](const auto &p, auto &v) {
         return std::move(validation_result);
@@ -163,8 +166,7 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
   EXPECT_CALL(*crypto_signer, sign(A<shared_model::interface::Block &>()))
       .Times(1);
 
-  auto ledger_state =
-      std::make_shared<LedgerState>(ledger_peers, block.height());
+  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, block_height);
   auto ordering_event =
       OrderingEvent{proposal, consensus::Round{}, ledger_state};
 
@@ -200,8 +202,10 @@ TEST_F(SimulatorTest, FailWhenNoBlock) {
   auto proposal = makeProposal(2);
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(0);
-  EXPECT_CALL(*query, getTopBlock())
-      .WillOnce(Return(expected::makeError("no block")));
+  auto block_height = 1;
+  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
+  EXPECT_CALL(*query, getBlock(block_height))
+      .WillOnce(Return(ByMove(expected::makeError("no block"))));
 
   EXPECT_CALL(*validator, validate(_, _)).Times(0);
 
@@ -228,11 +232,14 @@ TEST_F(SimulatorTest, FailWhenSameAsProposalHeight) {
   auto proposal = makeProposal(2);
 
   auto block = makeBlock(proposal->height());
+  auto block_height = block.height();
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(0);
 
-  EXPECT_CALL(*query, getTopBlock())
-      .WillOnce(Return(expected::makeValue(wBlock(clone(block)))));
+  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
+  EXPECT_CALL(*query, getBlock(block_height))
+      .WillOnce(Return(ByMove(
+          expected::makeValue(clone<shared_model::interface::Block>(block)))));
 
   EXPECT_CALL(*validator, validate(_, _)).Times(0);
 
@@ -246,8 +253,7 @@ TEST_F(SimulatorTest, FailWhenSameAsProposalHeight) {
   auto block_wrapper = make_test_subscriber<CallExact>(simulator->onBlock(), 0);
   block_wrapper.subscribe();
 
-  auto ledger_state =
-      std::make_shared<LedgerState>(ledger_peers, block.height());
+  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, block_height);
   ordering_events.get_subscriber().on_next(
       OrderingEvent{proposal, consensus::Round{}, ledger_state});
 
@@ -298,10 +304,13 @@ TEST_F(SimulatorTest, SomeFailingTxs) {
             validation::CommandError{"SomeCommand", 1, "", true}});
   }
   shared_model::proto::Block block = makeBlock(proposal->height() - 1);
+  auto block_height = block.height();
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(1);
-  EXPECT_CALL(*query, getTopBlock())
-      .WillOnce(Return(expected::makeValue(wBlock(clone(block)))));
+  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
+  EXPECT_CALL(*query, getBlock(block_height))
+      .WillOnce(Return(ByMove(
+          expected::makeValue(clone<shared_model::interface::Block>(block)))));
 
   EXPECT_CALL(*validator, validate(_, _))
       .WillOnce(Invoke([&verified_proposal_and_errors](const auto &p, auto &v) {


### PR DESCRIPTION
### Description of the Change

Remove vectors from `BlockQuery` interface to avoid large runtime containers.
- Refactor `BlockLoader::retrieveBlock` with height to avoid linear blockstore search, and not to store `O(n)` blocks in memory.
- Refactor `BlockLoader::retrieveBlocks` not to store `O(n)` blocks in memory.

### Benefits
Possibility to synchronize a large blockstore

### Possible Drawbacks 
None