### PR TITLE
Refactor WsvRestorer to reuse existing block store

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -144,10 +144,9 @@ namespace iroha {
               log_manager_->getChild("TemporaryWorldStateView")));
     }
 
+    template <typename Factory>
     expected::Result<std::unique_ptr<MutableStorage>, std::string>
-    StorageImpl::createMutableStorage() {
-      boost::optional<shared_model::interface::types::HashType> top_hash;
-
+    StorageImpl::createMutableStorage(Factory factory) {
       std::shared_lock<std::shared_timed_mutex> lock(drop_mutex);
       if (connection_ == nullptr) {
         return expected::makeError("Connection was closed");
@@ -182,8 +181,14 @@ namespace iroha {
               std::make_shared<PostgresCommandExecutor>(*sql, perm_converter_),
               std::move(sql),
               factory_,
-              block_storage_factory_->create(),
+              factory(),
               log_manager_->getChild("MutableStorageImpl")));
+    }
+
+    expected::Result<std::unique_ptr<MutableStorage>, std::string>
+    StorageImpl::createMutableStorage() {
+      return createMutableStorage(
+          [this] { return block_storage_factory_->create(); });
     }
 
     boost::optional<std::shared_ptr<PeerQuery>> StorageImpl::createPeerQuery()
@@ -238,30 +243,7 @@ namespace iroha {
             this->commit(std::move(storage.value));
           },
           [&](const auto &error) { log_->error("{}", error.error); });
-
       return inserted;
-    }
-
-    iroha::expected::Result<boost::optional<std::unique_ptr<LedgerState>>,
-                            std::string>
-    StorageImpl::insertBlocks(
-        const std::vector<std::shared_ptr<shared_model::interface::Block>>
-            &blocks) {
-      log_->info("create mutable storage");
-      return createMutableStorage().match(
-          [&, this](auto &&mutableStorage) -> decltype(insertBlocks(blocks)) {
-            for (auto &block : blocks) {
-              if (not mutableStorage.value->apply(block)) {
-                return expected::makeError(block->toString()
-                                           + " could not be applied.");
-              }
-            }
-            return iroha::expected::makeValue(
-                this->commit(std::move(mutableStorage.value)));
-          },
-          [&](const auto &error) -> decltype(insertBlocks(blocks)) {
-            return std::move(error);
-          });
     }
 
     expected::Result<void, std::string> StorageImpl::insertPeer(
@@ -272,8 +254,47 @@ namespace iroha {
       return wsv_command.insertPeer(peer);
     }
 
+    expected::Result<std::unique_ptr<MutableStorage>, std::string>
+    StorageImpl::createMutableStorageWithoutBlockStorage() {
+      return createMutableStorage([] {
+        struct BlockStorageStub : public BlockStorage {
+          bool insert(std::shared_ptr<const shared_model::interface::Block>
+                          block) override {
+            return true;
+          }
+
+          boost::optional<std::shared_ptr<const shared_model::interface::Block>>
+          fetch(shared_model::interface::types::HeightType height)
+              const override {
+            return boost::none;
+          }
+
+          size_t size() const override {
+            return 0;
+          }
+
+          void clear() override {}
+
+          void forEach(FunctionType function) const override {}
+        };
+
+        return std::make_unique<BlockStorageStub>();
+      });
+    }
+
     void StorageImpl::reset() {
-      log_->info("drop wsv records from db tables");
+      resetWsv().match(
+          [this](auto &&v) {
+            log_->debug("drop blocks from disk");
+            block_store_->dropAll();
+          },
+          [this](auto &&e) {
+            log_->warn("Failed to drop WSV. Reason: {}", e.error);
+          });
+    }
+
+    expected::Result<void, std::string> StorageImpl::resetWsv() {
+      log_->debug("drop wsv records from db tables");
       try {
         soci::session sql(*connection_);
         // rollback possible prepared transaction
@@ -281,11 +302,10 @@ namespace iroha {
           rollbackPrepared(sql);
         }
         sql << reset_;
-        log_->info("drop blocks from disk");
-        block_store_->dropAll();
       } catch (std::exception &e) {
-        log_->warn("Drop wsv was failed. Reason: {}", e.what());
+        return expected::makeError(e.what());
       }
+      return expected::Value<void>();
     }
 
     void StorageImpl::resetPeers() {

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -78,29 +78,18 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::QueryResponseFactory>
               response_factory) const override;
 
-      /**
-       * Insert block without validation
-       * @param blocks - block for insertion
-       * @return true if all blocks are inserted
-       */
       bool insertBlock(
           std::shared_ptr<const shared_model::interface::Block> block) override;
-
-      /**
-       * Insert blocks without validation
-       * @param blocks - collection of blocks for insertion
-       * @return final ledger if inserted, error description otherwise
-       */
-      iroha::expected::Result<boost::optional<std::unique_ptr<LedgerState>>,
-                              std::string>
-      insertBlocks(
-          const std::vector<std::shared_ptr<shared_model::interface::Block>>
-              &blocks) override;
 
       expected::Result<void, std::string> insertPeer(
           const shared_model::interface::Peer &peer) override;
 
+      expected::Result<std::unique_ptr<MutableStorage>, std::string>
+      createMutableStorageWithoutBlockStorage() override;
+
       void reset() override;
+
+      expected::Result<void, std::string> resetWsv() override;
 
       void resetPeers() override;
 
@@ -150,6 +139,13 @@ namespace iroha {
       const PostgresOptions postgres_options_;
 
      private:
+      /**
+       * Create mutable storage with given block storage factory lambda
+       */
+      template <typename Factory>
+      expected::Result<std::unique_ptr<MutableStorage>, std::string>
+      createMutableStorage(Factory factory);
+
       /**
        * revert prepared transaction
        */

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -85,7 +85,7 @@ namespace iroha {
           const shared_model::interface::Peer &peer) override;
 
       expected::Result<std::unique_ptr<MutableStorage>, std::string>
-      createMutableStorageWithoutBlockStorage() override;
+      createMutableStorage(BlockStorageFactory &storage_factory) override;
 
       void reset() override;
 
@@ -139,13 +139,6 @@ namespace iroha {
       const PostgresOptions postgres_options_;
 
      private:
-      /**
-       * Create mutable storage with given block storage factory lambda
-       */
-      template <typename Factory>
-      expected::Result<std::unique_ptr<MutableStorage>, std::string>
-      createMutableStorage(Factory factory);
-
       /**
        * revert prepared transaction
        */

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -5,9 +5,8 @@
 
 #include "wsv_restorer_impl.hpp"
 
-#include <vector>
-
 #include "ametsuchi/block_query.hpp"
+#include "ametsuchi/mutable_storage.hpp"
 #include "ametsuchi/storage.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 
@@ -17,30 +16,44 @@ namespace iroha {
         boost::optional<std::unique_ptr<iroha::LedgerState>>,
         std::string>
     WsvRestorerImpl::restoreWsv(Storage &storage) {
-      auto block_query = storage.getBlockQuery();
-      if (not block_query) {
-        return expected::makeError("Cannot create BlockQuery");
-      }
-
-      // get all blocks starting from the genesis
-      std::vector<std::shared_ptr<shared_model::interface::Block>> blocks;
-      auto top_height = block_query->getTopBlockHeight();
-      for (decltype(top_height) i = 1; i <= top_height; ++i) {
-        auto block_result = block_query->getBlock(i);
-
-        if (auto e = boost::get<expected::Error<std::string>>(&block_result)) {
-          return expected::makeError(std::move(e)->error);
+      auto mutable_storage_result =
+          storage.createMutableStorageWithoutBlockStorage();
+      return mutable_storage_result | [&storage](auto &&mutable_storage)
+                 -> iroha::expected::Result<
+                     boost::optional<std::unique_ptr<iroha::LedgerState>>,
+                     std::string> {
+        auto block_query = storage.getBlockQuery();
+        if (not block_query) {
+          return expected::makeError("Cannot create BlockQuery");
         }
 
-        auto &block = boost::get<expected::Value<
-            std::unique_ptr<shared_model::interface::Block>>>(block_result)
-                          .value;
-        blocks.push_back(std::move(block));
-      }
+        return storage.resetWsv() |
+                   [&storage, &mutable_storage, &block_query]() mutable
+               -> iroha::expected::Result<
+                   boost::optional<std::unique_ptr<iroha::LedgerState>>,
+                   std::string> {
+          // apply all blocks starting from the genesis
+          auto top_height = block_query->getTopBlockHeight();
+          for (decltype(top_height) i = 1; i <= top_height; ++i) {
+            auto block_result = block_query->getBlock(i);
 
-      storage.reset();
+            if (auto e =
+                    boost::get<expected::Error<std::string>>(&block_result)) {
+              return expected::makeError(std::move(e)->error);
+            }
 
-      return storage.insertBlocks(blocks);
+            auto &block = boost::get<expected::Value<
+                std::unique_ptr<shared_model::interface::Block>>>(block_result)
+                              .value;
+            if (not mutable_storage->apply(std::move(block))) {
+              return expected::makeError("Cannot apply " + block->toString());
+            }
+          }
+
+          return expected::makeValue(
+              storage.commit(std::move(mutable_storage)));
+        };
+      };
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -6,9 +6,94 @@
 #include "wsv_restorer_impl.hpp"
 
 #include "ametsuchi/block_query.hpp"
+#include "ametsuchi/block_storage.hpp"
+#include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "ametsuchi/storage.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+
+namespace {
+  /**
+   * Stub implementation used to restore WSV. Check the method descriptions for
+   * details
+   */
+  class BlockStorageStub : public iroha::ametsuchi::BlockStorage {
+   public:
+    /**
+     * Returns true - MutableStorage may check if the block was inserted
+     * successfully
+     */
+    bool insert(
+        std::shared_ptr<const shared_model::interface::Block> block) override {
+      return true;
+    }
+
+    /**
+     * Returns boost::none - it is not required to fetch individual blocks
+     * during WSV reindexing
+     */
+    boost::optional<std::shared_ptr<const shared_model::interface::Block>>
+    fetch(shared_model::interface::types::HeightType height) const override {
+      return boost::none;
+    }
+
+    size_t size() const override {
+      return 0;
+    }
+
+    void clear() override {}
+
+    /**
+     * Does not iterate any blocks - it is not required to insert any additional
+     * blocks to the existing storage
+     */
+    void forEach(FunctionType function) const override {}
+  };
+
+  /**
+   * Factory for BlockStorageStub class
+   */
+  class BlockStorageStubFactory : public iroha::ametsuchi::BlockStorageFactory {
+   public:
+    std::unique_ptr<iroha::ametsuchi::BlockStorage> create() override {
+      return std::make_unique<BlockStorageStub>();
+    }
+  };
+
+  /**
+   * Reapply blocks from existing storage to WSV
+   * @param storage - current storage
+   * @param mutable_storage - mutable storage without blocks
+   * @param block_query - current block storage
+   */
+  iroha::expected::Result<boost::optional<std::unique_ptr<iroha::LedgerState>>,
+                          std::string>
+  reindexBlocks(
+      iroha::ametsuchi::Storage &storage,
+      std::unique_ptr<iroha::ametsuchi::MutableStorage> &mutable_storage,
+      std::shared_ptr<iroha::ametsuchi::BlockQuery> &block_query) {
+    // apply all blocks starting from the genesis
+    auto top_height = block_query->getTopBlockHeight();
+    for (decltype(top_height) i = 1; i <= top_height; ++i) {
+      auto block_result = block_query->getBlock(i);
+      auto result = block_result | [&mutable_storage](auto &&block)
+          -> iroha::expected::Result<void, std::string> {
+        if (not mutable_storage->apply(std::move(block))) {
+          return iroha::expected::makeError("Cannot apply "
+                                            + block->toString());
+        }
+        return iroha::expected::Value<void>();
+      };
+
+      if (auto e = boost::get<iroha::expected::Error<std::string>>(&result)) {
+        return *e;
+      }
+    }
+
+    return iroha::expected::makeValue(
+        storage.commit(std::move(mutable_storage)));
+  }
+}  // namespace
 
 namespace iroha {
   namespace ametsuchi {
@@ -16,8 +101,10 @@ namespace iroha {
         boost::optional<std::unique_ptr<iroha::LedgerState>>,
         std::string>
     WsvRestorerImpl::restoreWsv(Storage &storage) {
+      BlockStorageStubFactory storage_factory;
+
       auto mutable_storage_result =
-          storage.createMutableStorageWithoutBlockStorage();
+          storage.createMutableStorage(storage_factory);
       return mutable_storage_result | [&storage](auto &&mutable_storage)
                  -> iroha::expected::Result<
                      boost::optional<std::unique_ptr<iroha::LedgerState>>,
@@ -28,31 +115,9 @@ namespace iroha {
         }
 
         return storage.resetWsv() |
-                   [&storage, &mutable_storage, &block_query]() mutable
-               -> iroha::expected::Result<
-                   boost::optional<std::unique_ptr<iroha::LedgerState>>,
-                   std::string> {
-          // apply all blocks starting from the genesis
-          auto top_height = block_query->getTopBlockHeight();
-          for (decltype(top_height) i = 1; i <= top_height; ++i) {
-            auto block_result = block_query->getBlock(i);
-
-            if (auto e =
-                    boost::get<expected::Error<std::string>>(&block_result)) {
-              return expected::makeError(std::move(e)->error);
-            }
-
-            auto &block = boost::get<expected::Value<
-                std::unique_ptr<shared_model::interface::Block>>>(block_result)
-                              .value;
-            if (not mutable_storage->apply(std::move(block))) {
-              return expected::makeError("Cannot apply " + block->toString());
-            }
-          }
-
-          return expected::makeValue(
-              storage.commit(std::move(mutable_storage)));
-        };
+            [&storage, &mutable_storage, &block_query]() {
+              return reindexBlocks(storage, mutable_storage, block_query);
+            };
       };
     }
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -60,6 +60,8 @@ namespace iroha {
       virtual expected::Result<void, std::string> insertPeer(
           const shared_model::interface::Peer &peer) = 0;
 
+      using MutableFactory::createMutableStorage;
+
       /**
        * Creates a mutable storage from the current state
        * @return Created Result with mutable storage or error string

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -52,23 +52,20 @@ namespace iroha {
           std::shared_ptr<const shared_model::interface::Block> block) = 0;
 
       /**
-       * Raw insertion of blocks without validation
-       * @param blocks - collection of blocks for insertion
-       * @return final ledger if inserted, error description otherwise
-       */
-      virtual iroha::expected::
-          Result<boost::optional<std::unique_ptr<LedgerState>>, std::string>
-          insertBlocks(
-              const std::vector<std::shared_ptr<shared_model::interface::Block>>
-                  &blocks) = 0;
-
-      /**
        * Insert a peer into WSV
        * @param peer - peer to insert
        * @return error reason if not inserted
        */
       virtual expected::Result<void, std::string> insertPeer(
           const shared_model::interface::Peer &peer) = 0;
+
+      /**
+       * Creates a mutable storage, which does not store blocks, from the
+       * current state
+       * @return Created Result with mutable storage or error string
+       */
+      virtual expected::Result<std::unique_ptr<MutableStorage>, std::string>
+      createMutableStorageWithoutBlockStorage() = 0;
 
       /**
        * method called when block is written to the storage
@@ -82,6 +79,12 @@ namespace iroha {
        * Remove all records from the tables and remove all the blocks
        */
       virtual void reset() = 0;
+
+      /*
+       * Remove all records from the tables
+       * @return error message if reset has failed
+       */
+      virtual expected::Result<void, std::string> resetWsv() = 0;
 
       /**
        * Removes all peers from WSV

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -26,6 +26,7 @@ namespace iroha {
 
   namespace ametsuchi {
 
+    class BlockStorageFactory;
     class BlockQuery;
     class WsvQuery;
 
@@ -60,12 +61,11 @@ namespace iroha {
           const shared_model::interface::Peer &peer) = 0;
 
       /**
-       * Creates a mutable storage, which does not store blocks, from the
-       * current state
+       * Creates a mutable storage from the current state
        * @return Created Result with mutable storage or error string
        */
       virtual expected::Result<std::unique_ptr<MutableStorage>, std::string>
-      createMutableStorageWithoutBlockStorage() = 0;
+      createMutableStorage(BlockStorageFactory &storage_factory) = 0;
 
       /**
        * method called when block is written to the storage

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -195,7 +195,7 @@ namespace iroha {
      * result
      */
     template <typename T, typename E, typename Transform>
-    constexpr auto operator|(Result<T, E> r, Transform &&f) ->
+    constexpr auto operator|(const Result<T, E> &r, Transform &&f) ->
         typename std::enable_if<
             not std::is_same<decltype(f(std::declval<T>())), void>::value,
             decltype(f(std::declval<T>()))>::type {
@@ -206,19 +206,46 @@ namespace iroha {
     }
 
     /**
+     * Mutable alternative for bind with parameters
+     */
+    template <typename T, typename E, typename Transform>
+    constexpr auto operator|(Result<T, E> &r, Transform &&f) ->
+        typename std::enable_if<
+            not std::is_same<decltype(f(std::declval<T>())), void>::value,
+            decltype(f(std::declval<T>()))>::type {
+      using return_type = decltype(f(std::declval<T>()));
+      return r.match(
+          [&f](Value<T> &v) { return f(v.value); },
+          [](Error<E> &e) { return return_type(makeError(e.error)); });
+    }
+
+    /**
      * Bind operator overload for functions which do not accept anything as a
      * parameter. Allows execution of a sequence of unrelated functions, given
      * that all of them return Result
      * @param f function which accepts no parameters and returns result
      */
     template <typename T, typename E, typename Procedure>
-    constexpr auto operator|(Result<T, E> r, Procedure f) ->
+    constexpr auto operator|(const Result<T, E> &r, Procedure f) ->
         typename std::enable_if<not std::is_same<decltype(f()), void>::value,
                                 decltype(f())>::type {
       using return_type = decltype(f());
       return r.match(
           [&f](const Value<T> &v) { return f(); },
           [](const Error<E> &e) { return return_type(makeError(e.error)); });
+    }
+
+    /**
+     * Mutable alternative for bind without parameters
+     */
+    template <typename T, typename E, typename Procedure>
+    constexpr auto operator|(Result<T, E> &r, Procedure f) ->
+        typename std::enable_if<not std::is_same<decltype(f()), void>::value,
+                                decltype(f())>::type {
+      using return_type = decltype(f());
+      return r.match(
+          [&f](Value<T> &v) { return f(); },
+          [](Error<E> &e) { return return_type(makeError(e.error)); });
     }
 
     /**

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -42,16 +42,15 @@ namespace iroha {
                        std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(insertBlock,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD1(
-          insertBlocks,
-          iroha::expected::Result<boost::optional<std::unique_ptr<LedgerState>>,
-                                  std::string>(
-              const std::vector<std::shared_ptr<shared_model::interface::Block>>
-                  &));
+      MOCK_METHOD0(
+          createMutableStorageWithoutBlockStorage,
+          expected::Result<std::unique_ptr<MutableStorage>, std::string>());
+
       MOCK_METHOD1(insertPeer,
                    expected::Result<void, std::string>(
                        const shared_model::interface::Peer &));
       MOCK_METHOD0(reset, void(void));
+      MOCK_METHOD0(resetWsv, expected::Result<void, std::string>());
       MOCK_METHOD0(resetPeers, void(void));
       MOCK_METHOD0(dropStorage, void(void));
       MOCK_METHOD0(freeConnections, void(void));

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/storage.hpp"
 
 #include <gmock/gmock.h>
+#include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "ametsuchi/temporary_wsv.hpp"
 
@@ -42,9 +43,9 @@ namespace iroha {
                        std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(insertBlock,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD0(
-          createMutableStorageWithoutBlockStorage,
-          expected::Result<std::unique_ptr<MutableStorage>, std::string>());
+      MOCK_METHOD1(createMutableStorage,
+                   expected::Result<std::unique_ptr<MutableStorage>,
+                                    std::string>(BlockStorageFactory &));
 
       MOCK_METHOD1(insertPeer,
                    expected::Result<void, std::string>(


### PR DESCRIPTION
### Description of the Change
Create MutableStorage which does not store blocks, allowing to reindex existing blocks and commit WSV without taking additional space

### Benefits
Restore WSV without using additional storage

### Possible Drawbacks 
BlockStorageStub looks like a crutch, but it seems as the most viable solution which does not require major modifications to existing codebase
