### PR TITLE
Fix Windows build with MSVC

### DIFF
--- a/cmake/Modules/Finded25519.cmake
+++ b/cmake/Modules/Finded25519.cmake
@@ -53,6 +53,12 @@ set_target_properties(ed25519 PROPERTIES
     IMPORTED_LOCATION ${ed25519_LIBRARY}
     )
 
+if (MSVC)
+  set_target_properties(ed25519 PROPERTIES
+      INTERFACE_LINK_LIBRARIES bcrypt
+      )
+endif()
+
 if(ENABLE_LIBS_PACKAGING)
   add_install_step_for_lib(${ed25519_LIBRARY})
 endif()

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -33,8 +33,8 @@ boost::optional<Identifier> FlatFile::name_to_id(const std::string &name) {
     return boost::none;
   }
   try {
-    auto id = std::stoul(name);
-    return boost::make_optional<Identifier>(id);
+    Identifier id = std::stoul(name);
+    return boost::make_optional(id);
   } catch (const std::exception &e) {
     return boost::none;
   }

--- a/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
+++ b/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
@@ -7,6 +7,7 @@
 
 #include "common/visitor.hpp"
 
+using namespace iroha::consensus;
 using namespace iroha::consensus::yac;
 
 boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -80,7 +80,9 @@ OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
   {
     std::shared_lock<std::shared_timed_mutex> lock(proposals_mutex_);
     auto it = proposal_map_.find(round);
-    result = boost::make_optional(it != proposal_map_.end(), it->second);
+    if (it != proposal_map_.end()) {
+      result = it->second;
+    }
   }
   // space between '{}' and 'returning' is not missing, since either nothing, or
   // NOT with space is printed

--- a/libs/logger/CMakeLists.txt
+++ b/libs/logger/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(logger
 target_link_libraries(logger
     fmt
     spdlog
+    boost
 )
 # ensure that externals are downloaded before any dependants
 add_dependencies(logger

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -22,6 +22,8 @@ auto operator<<(StreamType &os, const T &object)
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+// Windows includes transitively included by format.h define interface as
+// struct, leading to compilation issues
 #undef interface
 
 namespace logger {
@@ -41,63 +43,63 @@ namespace logger {
   };
 
   class Logger {
-    public:
-     using Level = LogLevel;
+   public:
+    using Level = LogLevel;
 
-     virtual ~Logger() = default;
+    virtual ~Logger() = default;
 
-     // --- Logging functions ---
+    // --- Logging functions ---
 
-     template <typename... Args>
-     void trace(const std::string &format, const Args &... args) const {
-       log(LogLevel::kTrace, format, args...);
-     }
+    template <typename... Args>
+    void trace(const std::string &format, const Args &... args) const {
+      log(LogLevel::kTrace, format, args...);
+    }
 
-     template <typename... Args>
-     void debug(const std::string &format, const Args &... args) const {
-       log(LogLevel::kDebug, format, args...);
-     }
+    template <typename... Args>
+    void debug(const std::string &format, const Args &... args) const {
+      log(LogLevel::kDebug, format, args...);
+    }
 
-     template <typename... Args>
-     void info(const std::string &format, const Args &... args) const {
-       log(LogLevel::kInfo, format, args...);
-     }
+    template <typename... Args>
+    void info(const std::string &format, const Args &... args) const {
+      log(LogLevel::kInfo, format, args...);
+    }
 
-     template <typename... Args>
-     void warn(const std::string &format, const Args &... args) const {
-       log(LogLevel::kWarn, format, args...);
-     }
+    template <typename... Args>
+    void warn(const std::string &format, const Args &... args) const {
+      log(LogLevel::kWarn, format, args...);
+    }
 
-     template <typename... Args>
-     void error(const std::string &format, const Args &... args) const {
-       log(LogLevel::kError, format, args...);
-     }
+    template <typename... Args>
+    void error(const std::string &format, const Args &... args) const {
+      log(LogLevel::kError, format, args...);
+    }
 
-     template <typename... Args>
-     void critical(const std::string &format, const Args &... args) const {
-       log(LogLevel::kCritical, format, args...);
-     }
+    template <typename... Args>
+    void critical(const std::string &format, const Args &... args) const {
+      log(LogLevel::kCritical, format, args...);
+    }
 
-     template <typename... Args>
-     void log(Level level,
-              const std::string &format,
-              const Args &... args) const {
-       if (shouldLog(level)) {
-         try {
-           logInternal(level, fmt::format(format, args...));
-         } catch (const fmt::v5::format_error &error) {
-           std::string error_msg("Exception was thrown while logging: ");
-           logInternal(LogLevel::kError, error_msg.append(error.what()));
-         }
-       }
-     }
+    template <typename... Args>
+    void log(Level level,
+             const std::string &format,
+             const Args &... args) const {
+      if (shouldLog(level)) {
+        try {
+          logInternal(level, fmt::format(format, args...));
+        } catch (const fmt::v5::format_error &error) {
+          std::string error_msg("Exception was thrown while logging: ");
+          logInternal(LogLevel::kError, error_msg.append(error.what()));
+        }
+      }
+    }
 
-    protected:
-     virtual void logInternal(Level level, const std::string &s) const = 0;
+   protected:
+    virtual void logInternal(Level level, const std::string &s) const = 0;
 
-     /// Whether the configured logging level is at least as verbose as the
-     /// one given in parameter.
-     virtual bool shouldLog(Level level) const = 0;
+    /// Whether the configured logging level is at least as verbose as the
+    /// one given in parameter.
+    virtual bool shouldLog(Level level) const = 0;
   };
 
   /**

--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -22,6 +22,7 @@ auto operator<<(StreamType &os, const T &object)
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#undef interface
 
 namespace logger {
 

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -6,6 +6,7 @@
 #include "logger/logger_manager.hpp"
 
 #include <atomic>
+#include <ciso646>
 
 static const std::string kTagHierarchySeparator = "/";
 

--- a/libs/logger/logger_spdlog.cpp
+++ b/libs/logger/logger_spdlog.cpp
@@ -6,6 +6,7 @@
 #include "logger/logger_spdlog.hpp"
 
 #include <atomic>
+#include <ciso646>
 #include <mutex>
 
 #define SPDLOG_FMT_EXTERNAL


### PR DESCRIPTION
### Description of the Change
Fix Windows build with the current codebase:
- Add missing ed25519 library link with bcrypt
- Fix compilation issue with boost::make_optional in FlatFile
- Fix undefined behavior with parameter evaluation in OrderingService
- Add missing logger library link with boost

### Benefits
Successful build and run of irohad and iroha-cli with MSVC

### Possible Drawbacks 
None
