### PR TITLE
Fix ordering event scheduling

### DIFF
--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -158,6 +158,8 @@ namespace iroha {
      private:
       logger::LoggerPtr log_;
 
+      boost::optional<consensus::Round> last_received_round_;
+
       std::vector<std::shared_ptr<shared_model::interface::Peer>>
           current_peers_;
 


### PR DESCRIPTION
### Description of the Change
Reopened https://github.com/hyperledger/iroha/pull/30

Fix the case when the delayed events for previous round are scheduled after the most recent commit, making unnecessary requests to the Ordering Service and invocations of Simulator.

No more `Irohad/Simulator Last block height: 287, proposal height: 287` warnings.

### Benefits
No more useless requests to the ordering service

### Possible Drawbacks 
- OnDemandOrderingInit is not unit-testable 😿
- `log_` and `last_received_round_` are captured by `this`, which may cause use-after-free if the observable lifetime is not managed carefully.
