### PR TITLE
Add top block hash to ledger state

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -131,6 +131,11 @@ namespace iroha {
       return top_height_;
     }
 
+    shared_model::interface::types::HashType
+    MutableStorageImpl::getTopBlockHash() const {
+      return top_hash_;
+    }
+
     MutableStorageImpl::~MutableStorageImpl() {
       if (not committed) {
         try {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -44,6 +44,8 @@ namespace iroha {
 
       shared_model::interface::types::HeightType getTopBlockHeight() const;
 
+      shared_model::interface::types::HashType getTopBlockHash() const;
+
       ~MutableStorageImpl() override;
 
      private:

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -703,11 +703,10 @@ namespace iroha {
                                 log_manager_->getChild("WsvQuery")->getLogger())
                    .getPeers()
             | [&storage](auto &&peers) {
-                return boost::optional<
-                    std::unique_ptr<LedgerState>>(std::make_unique<LedgerState>(
-                    std::make_shared<shared_model::interface::types::PeerList>(
-                        std::move(peers)),
-                    storage->getTopBlockHeight()));
+                return boost::optional<std::unique_ptr<LedgerState>>(
+                    std::make_unique<LedgerState>(std::move(peers),
+                                                  storage->getTopBlockHeight(),
+                                                  storage->getTopBlockHash()));
               };
       } catch (std::exception &e) {
         storage->committed = false;
@@ -749,16 +748,9 @@ namespace iroha {
                    | [this, &block, &sql](auto &&peers)
                    -> boost::optional<std::unique_ptr<LedgerState>> {
           if (this->storeBlock(block)) {
-            PostgresBlockQuery block_query(
-                sql,
-                *block_store_,
-                converter_,
-                log_manager_->getChild("PostgresBlockQuery")->getLogger());
             return boost::optional<std::unique_ptr<LedgerState>>(
                 std::make_unique<LedgerState>(
-                    std::make_shared<shared_model::interface::types::PeerList>(
-                        std::move(peers)),
-                    block_query.getTopBlockHeight()));
+                    std::move(peers), block->height(), block->hash()));
           }
           return boost::none;
         };

--- a/irohad/ametsuchi/ledger_state.hpp
+++ b/irohad/ametsuchi/ledger_state.hpp
@@ -11,17 +11,24 @@
 #include "interfaces/common_objects/types.hpp"
 
 namespace iroha {
-  struct LedgerState {
-    shared_model::interface::types::PeerList ledger_peers;
+  struct TopBlockInfo {
     shared_model::interface::types::HeightType height;
     shared_model::crypto::Hash top_hash;
+
+    TopBlockInfo(shared_model::interface::types::HeightType height,
+                 shared_model::crypto::Hash top_hash)
+        : height(height), top_hash(std::move(top_hash)) {}
+  };
+
+  struct LedgerState {
+    shared_model::interface::types::PeerList ledger_peers;
+    TopBlockInfo top_block_info;
 
     LedgerState(shared_model::interface::types::PeerList peers,
                 shared_model::interface::types::HeightType height,
                 shared_model::crypto::Hash top_hash)
         : ledger_peers(std::move(peers)),
-          height(height),
-          top_hash(std::move(top_hash)) {}
+          top_block_info(height, std::move(top_hash)) {}
   };
 }  // namespace iroha
 

--- a/irohad/ametsuchi/ledger_state.hpp
+++ b/irohad/ametsuchi/ledger_state.hpp
@@ -6,19 +6,22 @@
 #ifndef IROHA_LEDGER_STATE_HPP
 #define IROHA_LEDGER_STATE_HPP
 
-#include <memory>
-
+#include "cryptography/hash.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace iroha {
   struct LedgerState {
-    std::shared_ptr<shared_model::interface::types::PeerList> ledger_peers;
+    shared_model::interface::types::PeerList ledger_peers;
     shared_model::interface::types::HeightType height;
+    shared_model::crypto::Hash top_hash;
 
-    LedgerState(std::shared_ptr<shared_model::interface::types::PeerList> peers,
-                shared_model::interface::types::HeightType height)
-        : ledger_peers(std::move(peers)), height(height) {}
+    LedgerState(shared_model::interface::types::PeerList peers,
+                shared_model::interface::types::HeightType height,
+                shared_model::crypto::Hash top_hash)
+        : ledger_peers(std::move(peers)),
+          height(height),
+          top_hash(std::move(top_hash)) {}
   };
 }  // namespace iroha
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -86,7 +86,7 @@ namespace iroha {
         }
 
         auto order = orderer_->getOrdering(current_hash_,
-                                           *event.ledger_state->ledger_peers);
+                                           event.ledger_state->ledger_peers);
         if (not order) {
           log_->error("ordering doesn't provide peers => pass round");
           return;

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -223,7 +223,7 @@ Irohad::RunResult Irohad::restoreWsv() {
         }
         auto &ledger_state = value.value.value();  // value
         assert(ledger_state);
-        if (ledger_state->ledger_peers->empty()) {
+        if (ledger_state->ledger_peers.empty()) {
           return iroha::expected::makeError<std::string>(
               "Have no peers in WSV after restoration!");
         }
@@ -794,9 +794,7 @@ Irohad::RunResult Irohad::run() {
                 [](auto &&peer_query) { return peer_query->getLedgerPeers(); };
 
             auto initial_ledger_state = std::make_shared<LedgerState>(
-                std::make_unique<shared_model::interface::types::PeerList>(
-                    peers.value()),
-                block->height());
+                peers.value(), block->height(), block->hash());
 
             pcs->onSynchronization().subscribe(
                 ordering_init.sync_event_notifier.get_subscriber());

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -484,7 +484,6 @@ Irohad::RunResult Irohad::initSimulator() {
       ordering_gate,
       stateful_validator,
       storage,
-      storage,
       crypto_signer_,
       std::move(block_factory),
       log_manager_->getChild("Simulator")->getLogger());

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -22,12 +22,15 @@ namespace iroha {
     class BlockCreator {
      public:
       /**
-       * Creates a block from given proposal
+       * Creates a block from given proposal and ledger state - top block height
+       * and hash
        */
       virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
       processVerifiedProposal(
           const std::shared_ptr<validation::VerifiedProposalAndErrors>
-              &verified_proposal_and_errors) = 0;
+              &verified_proposal_and_errors,
+          shared_model::interface::types::HeightType height,
+          const shared_model::crypto::Hash &top_hash) = 0;
 
       /**
        * Emit blocks made from proposals

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -22,15 +22,13 @@ namespace iroha {
     class BlockCreator {
      public:
       /**
-       * Creates a block from given proposal and ledger state - top block height
-       * and hash
+       * Creates a block from given proposal and top block info
        */
       virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
       processVerifiedProposal(
           const std::shared_ptr<validation::VerifiedProposalAndErrors>
               &verified_proposal_and_errors,
-          shared_model::interface::types::HeightType height,
-          const shared_model::crypto::Hash &top_hash) = 0;
+          const TopBlockInfo &top_block_info) = 0;
 
       /**
        * Emit blocks made from proposals

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -52,10 +52,8 @@ namespace iroha {
           [this](const VerifiedProposalCreatorEvent &event) {
             if (event.verified_proposal_result) {
               auto proposal_and_errors = getVerifiedProposalUnsafe(event);
-              auto block =
-                  this->processVerifiedProposal(proposal_and_errors,
-                                                event.ledger_state->height,
-                                                event.ledger_state->top_hash);
+              auto block = this->processVerifiedProposal(
+                  proposal_and_errors, event.ledger_state->top_block_info);
               if (block) {
                 block_notifier_.get_subscriber().on_next(BlockCreatorEvent{
                     RoundData{proposal_and_errors->verified_proposal, *block},
@@ -110,8 +108,7 @@ namespace iroha {
     Simulator::processVerifiedProposal(
         const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
             &verified_proposal_and_errors,
-        shared_model::interface::types::HeightType height,
-        const shared_model::crypto::Hash &top_hash) {
+        const TopBlockInfo &top_block_info) {
       log_->info("process verified proposal");
 
       const auto &proposal = verified_proposal_and_errors->verified_proposal;
@@ -121,8 +118,8 @@ namespace iroha {
         rejected_hashes.push_back(rejected_tx.tx_hash);
       }
       std::shared_ptr<shared_model::interface::Block> block =
-          block_factory_->unsafeCreateBlock(height + 1,
-                                            top_hash,
+          block_factory_->unsafeCreateBlock(top_block_info.height + 1,
+                                            top_block_info.top_hash,
                                             proposal->createdTime(),
                                             proposal->transactions(),
                                             rejected_hashes);

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -47,8 +47,7 @@ namespace iroha {
       processVerifiedProposal(
           const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
               &verified_proposal_and_errors,
-          shared_model::interface::types::HeightType height,
-          const shared_model::crypto::Hash &top_hash) override;
+          const TopBlockInfo &top_block_info) override;
 
       rxcpp::observable<BlockCreatorEvent> onBlock() override;
 

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -10,7 +10,6 @@
 #include "simulator/verified_proposal_creator.hpp"
 
 #include <boost/optional.hpp>
-#include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/temporary_factory.hpp"
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
 #include "interfaces/iroha_internal/unsafe_block_factory.hpp"
@@ -30,7 +29,6 @@ namespace iroha {
           std::shared_ptr<network::OrderingGate> ordering_gate,
           std::shared_ptr<validation::StatefulValidator> statefulValidator,
           std::shared_ptr<ametsuchi::TemporaryFactory> factory,
-          std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<CryptoSignerType> crypto_signer,
           std::unique_ptr<shared_model::interface::UnsafeBlockFactory>
               block_factory,
@@ -48,7 +46,9 @@ namespace iroha {
       boost::optional<std::shared_ptr<shared_model::interface::Block>>
       processVerifiedProposal(
           const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
-              &verified_proposal_and_errors) override;
+              &verified_proposal_and_errors,
+          shared_model::interface::types::HeightType height,
+          const shared_model::crypto::Hash &top_hash) override;
 
       rxcpp::observable<BlockCreatorEvent> onBlock() override;
 
@@ -64,15 +64,11 @@ namespace iroha {
 
       std::shared_ptr<validation::StatefulValidator> validator_;
       std::shared_ptr<ametsuchi::TemporaryFactory> ametsuchi_factory_;
-      std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory_;
       std::shared_ptr<CryptoSignerType> crypto_signer_;
       std::unique_ptr<shared_model::interface::UnsafeBlockFactory>
           block_factory_;
 
       logger::LoggerPtr log_;
-
-      // last block
-      std::unique_ptr<shared_model::interface::Block> last_block;
     };
   }  // namespace simulator
 }  // namespace iroha

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -150,7 +150,8 @@ namespace iroha {
 
       auto top_block_height = getTopBlockHeight();
       if (not top_block_height) {
-        log_->error("Failed to synchronize: could not get my top block height.");
+        log_->error(
+            "Failed to synchronize: could not get my top block height.");
         return;
       }
 
@@ -182,7 +183,7 @@ namespace iroha {
       // TODO 11.04.2019 mboldyrev IR-442 use storage commit status type
       BOOST_ASSERT_MSG(ledger_state, "Commit failed!");
       if (ledger_state) {
-        new_height = (*ledger_state)->height;
+        new_height = (*ledger_state)->top_block_info.height;
       } else {
         log_->critical(
             "Synchronization cancelled because "

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -319,7 +319,7 @@ TEST_F(FakePeerExampleFixture, RealPeerIsAdded) {
           [height = block_with_add_peer.height(),
            itf_peer = itf_->getThisPeer(),
            initial_peer = initial_peer->getThisPeer()](const auto &sync_event) {
-            EXPECT_EQ(sync_event.ledger_state->height, height);
+            EXPECT_EQ(sync_event.ledger_state->top_block_info.height, height);
             EXPECT_THAT(sync_event.ledger_state->ledger_peers,
                         ::testing::UnorderedElementsAre(
                             makePeerPointeeMatcher(itf_peer),

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -91,7 +91,8 @@ auto makePeerPointeeMatcher(std::shared_ptr<interface::Peer> peer) {
  * @when it receives a valid signed addPeer command
  * @then the transaction is committed
  *    @and the ledger state after commit contains the two peers,
- *    @and the WSV reports that there are two peers: the initial and the added one
+ *    @and the WSV reports that there are two peers: the initial and the added
+ * one
  */
 TEST_F(FakePeerExampleFixture, FakePeerIsAdded) {
   // ------------------------ GIVEN ------------------------
@@ -127,7 +128,7 @@ TEST_F(FakePeerExampleFixture, FakePeerIsAdded) {
       .subscribe(
           [&, itf_peer = itf_->getThisPeer()](const auto &sync_event) {
             EXPECT_THAT(
-                *sync_event.ledger_state->ledger_peers,
+                sync_event.ledger_state->ledger_peers,
                 ::testing::UnorderedElementsAre(
                     makePeerPointeeMatcher(itf_peer),
                     makePeerPointeeMatcher(new_peer_address, new_peer_pubkey)));
@@ -259,7 +260,7 @@ TEST_F(FakePeerExampleFixture, RealPeerIsAdded) {
           .signAndAddSignature(initial_peer->getKeypair())
           .finish();
 
-  // provide the initial_peer with the blocks 
+  // provide the initial_peer with the blocks
   auto block_storage =
       std::make_shared<fake_peer::BlockStorage>(getTestLogger("BlockStorage"));
   block_storage->storeBlock(clone(genesis_block));
@@ -319,7 +320,7 @@ TEST_F(FakePeerExampleFixture, RealPeerIsAdded) {
            itf_peer = itf_->getThisPeer(),
            initial_peer = initial_peer->getThisPeer()](const auto &sync_event) {
             EXPECT_EQ(sync_event.ledger_state->height, height);
-            EXPECT_THAT(*sync_event.ledger_state->ledger_peers,
+            EXPECT_THAT(sync_event.ledger_state->ledger_peers,
                         ::testing::UnorderedElementsAre(
                             makePeerPointeeMatcher(itf_peer),
                             makePeerPointeeMatcher(initial_peer)));

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -97,11 +97,10 @@ class YacGateTest : public ::testing::Test {
                                          getTestLogger("YacGateImpl"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers =
-        std::make_shared<shared_model::interface::types::PeerList>(
-            shared_model::interface::types::PeerList{peer});
-    ledger_state = std::make_shared<iroha::LedgerState>(std::move(ledger_peers),
-                                                        block->height());
+    ledger_state = std::make_shared<iroha::LedgerState>(
+        shared_model::interface::types::PeerList{peer},
+        block->height(),
+        block->hash());
   }
 
   iroha::consensus::Round round{1, 1};

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -41,10 +41,10 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers =
-      std::make_shared<shared_model::interface::types::PeerList>(
-          shared_model::interface::types::PeerList{peer});
-  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
+  auto ledger_state = std::make_shared<LedgerState>(
+      shared_model::interface::types::PeerList{peer},
+      1,
+      shared_model::crypto::Hash{"hash"});
   auto proposal = std::make_shared<const MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(
@@ -80,10 +80,10 @@ TEST(YacHashProviderTest, ToModelHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-  auto ledger_peers =
-      std::make_shared<shared_model::interface::types::PeerList>(
-          shared_model::interface::types::PeerList{peer});
-  auto ledger_state = std::make_shared<LedgerState>(ledger_peers, 1);
+  auto ledger_state = std::make_shared<LedgerState>(
+      shared_model::interface::types::PeerList{peer},
+      1,
+      shared_model::crypto::Hash{"hash"});
   auto proposal = std::make_shared<MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -58,11 +58,10 @@ class OnDemandOrderingGateTest : public ::testing::Test {
         getTestLogger("OrderingGate"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers =
-        std::make_shared<shared_model::interface::types::PeerList>(
-            shared_model::interface::types::PeerList{peer});
-    ledger_state =
-        std::make_shared<LedgerState>(ledger_peers, round.block_round);
+    ledger_state = std::make_shared<LedgerState>(
+        shared_model::interface::types::PeerList{peer},
+        round.block_round,
+        shared_model::crypto::Hash{"hash"});
   }
 
   rxcpp::subjects::subject<
@@ -126,8 +125,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) {
     ASSERT_EQ(proposal, getProposalUnsafe(val).get());
-    EXPECT_EQ(*val.ledger_state->ledger_peers,
-              *event.ledger_state->ledger_peers);
+    EXPECT_EQ(val.ledger_state->ledger_peers, event.ledger_state->ledger_peers);
   });
 
   rounds.get_subscriber().on_next(event);
@@ -163,8 +161,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
       make_test_subscriber<CallExact>(ordering_gate->onProposal(), 1);
   gate_wrapper.subscribe([&](auto val) {
     ASSERT_EQ(proposal, getProposalUnsafe(val).get());
-    EXPECT_EQ(*val.ledger_state->ledger_peers,
-              *event.ledger_state->ledger_peers);
+    EXPECT_EQ(val.ledger_state->ledger_peers, event.ledger_state->ledger_peers);
   });
 
   rounds.get_subscriber().on_next(event);

--- a/test/module/irohad/simulator/simulator_mocks.hpp
+++ b/test/module/irohad/simulator/simulator_mocks.hpp
@@ -13,13 +13,12 @@ namespace iroha {
   namespace simulator {
     class MockBlockCreator : public BlockCreator {
      public:
-      MOCK_METHOD3(
+      MOCK_METHOD2(
           processVerifiedProposal,
           boost::optional<std::shared_ptr<shared_model::interface::Block>>(
               const std::shared_ptr<
                   iroha::validation::VerifiedProposalAndErrors> &,
-              shared_model::interface::types::HeightType,
-              const shared_model::crypto::Hash &));
+              const TopBlockInfo &));
       MOCK_METHOD0(onBlock, rxcpp::observable<BlockCreatorEvent>());
     };
   }  // namespace simulator

--- a/test/module/irohad/simulator/simulator_mocks.hpp
+++ b/test/module/irohad/simulator/simulator_mocks.hpp
@@ -13,11 +13,13 @@ namespace iroha {
   namespace simulator {
     class MockBlockCreator : public BlockCreator {
      public:
-      MOCK_METHOD1(
+      MOCK_METHOD3(
           processVerifiedProposal,
           boost::optional<std::shared_ptr<shared_model::interface::Block>>(
               const std::shared_ptr<
-                  iroha::validation::VerifiedProposalAndErrors> &));
+                  iroha::validation::VerifiedProposalAndErrors> &,
+              shared_model::interface::types::HeightType,
+              const shared_model::crypto::Hash &));
       MOCK_METHOD0(onBlock, rxcpp::observable<BlockCreatorEvent>());
     };
   }  // namespace simulator

--- a/test/module/irohad/simulator/simulator_test.cpp
+++ b/test/module/irohad/simulator/simulator_test.cpp
@@ -15,8 +15,6 @@
 #include "datetime/time.hpp"
 #include "framework/test_logger.hpp"
 #include "framework/test_subscriber.hpp"
-#include "module/irohad/ametsuchi/mock_block_query.hpp"
-#include "module/irohad/ametsuchi/mock_block_query_factory.hpp"
 #include "module/irohad/ametsuchi/mock_temporary_factory.hpp"
 #include "module/irohad/network/network_mocks.hpp"
 #include "module/irohad/validation/mock_stateful_validator.hpp"
@@ -52,13 +50,8 @@ class SimulatorTest : public ::testing::Test {
   void SetUp() override {
     validator = std::make_shared<MockStatefulValidator>();
     factory = std::make_shared<NiceMock<MockTemporaryFactory>>();
-    query = std::make_shared<MockBlockQuery>();
     ordering_gate = std::make_shared<MockOrderingGate>();
     crypto_signer = std::make_shared<CryptoSignerType>();
-    block_query_factory = std::make_shared<MockBlockQueryFactory>();
-    EXPECT_CALL(*block_query_factory, createBlockQuery())
-        .WillRepeatedly(testing::Return(boost::make_optional(
-            std::shared_ptr<iroha::ametsuchi::BlockQuery>(query))));
     block_factory = std::make_unique<shared_model::proto::ProtoBlockFactory>(
         std::make_unique<shared_model::validation::MockValidator<
             shared_model::interface::Block>>(),
@@ -71,7 +64,6 @@ class SimulatorTest : public ::testing::Test {
     simulator = std::make_shared<Simulator>(ordering_gate,
                                             validator,
                                             factory,
-                                            block_query_factory,
                                             crypto_signer,
                                             std::move(block_factory),
                                             getTestLogger("Simulator"));
@@ -79,8 +71,6 @@ class SimulatorTest : public ::testing::Test {
 
   std::shared_ptr<MockStatefulValidator> validator;
   std::shared_ptr<MockTemporaryFactory> factory;
-  std::shared_ptr<MockBlockQuery> query;
-  std::shared_ptr<MockBlockQueryFactory> block_query_factory;
   std::shared_ptr<MockOrderingGate> ordering_gate;
   std::shared_ptr<CryptoSignerType> crypto_signer;
   std::unique_ptr<shared_model::interface::UnsafeBlockFactory> block_factory;
@@ -90,14 +80,6 @@ class SimulatorTest : public ::testing::Test {
   shared_model::interface::types::PeerList ledger_peers{
       makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"))};
 };
-
-shared_model::proto::Block makeBlock(int height) {
-  return TestBlockBuilder()
-      .transactions(std::vector<shared_model::proto::Transaction>())
-      .height(height)
-      .prevHash(shared_model::crypto::Hash(std::string(32, '0')))
-      .build();
-}
 
 auto makeProposal(int height) {
   auto tx = shared_model::proto::TransactionBuilder()
@@ -147,14 +129,8 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
               .transactions(txs)
               .build());
   const auto &proposal = validation_result->verified_proposal;
-  shared_model::proto::Block block = makeBlock(proposal->height() - 1);
-  auto block_height = block.height();
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(1);
-  EXPECT_CALL(*query, getTopBlockHeight()).WillRepeatedly(Return(block_height));
-  EXPECT_CALL(*query, getBlock(block_height))
-      .WillOnce(Return(ByMove(
-          expected::makeValue(clone<shared_model::interface::Block>(block)))));
 
   EXPECT_CALL(*validator, validate(_, _))
       .WillOnce(Invoke([&validation_result](const auto &p, auto &v) {
@@ -164,8 +140,8 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
   EXPECT_CALL(*crypto_signer, sign(A<shared_model::interface::Block &>()))
       .Times(1);
 
-  auto ledger_state =
-      std::make_shared<LedgerState>(ledger_peers, block_height, block.hash());
+  auto ledger_state = std::make_shared<LedgerState>(
+      ledger_peers, proposal->height() - 1, shared_model::crypto::Hash{"hash"});
   auto ordering_event =
       OrderingEvent{proposal, consensus::Round{}, ledger_state};
 
@@ -194,72 +170,6 @@ TEST_F(SimulatorTest, ValidWhenPreviousBlock) {
 
   EXPECT_TRUE(proposal_wrapper.validate());
   EXPECT_TRUE(block_wrapper.validate());
-}
-
-TEST_F(SimulatorTest, FailWhenNoBlock) {
-  // height 2 proposal => height 1 block not present => no validated proposal
-  auto proposal = makeProposal(2);
-
-  EXPECT_CALL(*factory, createTemporaryWsv()).Times(0);
-  auto block_height = 1;
-  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
-  EXPECT_CALL(*query, getBlock(block_height))
-      .WillOnce(Return(ByMove(expected::makeError("no block"))));
-
-  EXPECT_CALL(*validator, validate(_, _)).Times(0);
-
-  EXPECT_CALL(*crypto_signer, sign(A<shared_model::interface::Block &>()))
-      .Times(0);
-
-  auto proposal_wrapper =
-      make_test_subscriber<CallExact>(simulator->onVerifiedProposal(), 0);
-  proposal_wrapper.subscribe();
-
-  auto block_wrapper = make_test_subscriber<CallExact>(simulator->onBlock(), 0);
-  block_wrapper.subscribe();
-
-  auto ledger_state = std::make_shared<LedgerState>(
-      ledger_peers, 0, shared_model::crypto::Hash{"hash"});
-  ordering_events.get_subscriber().on_next(
-      OrderingEvent{proposal, consensus::Round{}, ledger_state});
-
-  ASSERT_TRUE(proposal_wrapper.validate());
-  ASSERT_TRUE(block_wrapper.validate());
-}
-
-TEST_F(SimulatorTest, FailWhenSameAsProposalHeight) {
-  // proposal with height 2 => height 2 block present => no validated proposal
-  auto proposal = makeProposal(2);
-
-  auto block = makeBlock(proposal->height());
-  auto block_height = block.height();
-
-  EXPECT_CALL(*factory, createTemporaryWsv()).Times(0);
-
-  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
-  EXPECT_CALL(*query, getBlock(block_height))
-      .WillOnce(Return(ByMove(
-          expected::makeValue(clone<shared_model::interface::Block>(block)))));
-
-  EXPECT_CALL(*validator, validate(_, _)).Times(0);
-
-  EXPECT_CALL(*crypto_signer, sign(A<shared_model::interface::Block &>()))
-      .Times(0);
-
-  auto proposal_wrapper =
-      make_test_subscriber<CallExact>(simulator->onVerifiedProposal(), 0);
-  proposal_wrapper.subscribe();
-
-  auto block_wrapper = make_test_subscriber<CallExact>(simulator->onBlock(), 0);
-  block_wrapper.subscribe();
-
-  auto ledger_state =
-      std::make_shared<LedgerState>(ledger_peers, block_height, block.hash());
-  ordering_events.get_subscriber().on_next(
-      OrderingEvent{proposal, consensus::Round{}, ledger_state});
-
-  ASSERT_TRUE(proposal_wrapper.validate());
-  ASSERT_TRUE(block_wrapper.validate());
 }
 
 /**
@@ -304,14 +214,8 @@ TEST_F(SimulatorTest, SomeFailingTxs) {
             rejected_tx->hash(),
             validation::CommandError{"SomeCommand", 1, "", true}});
   }
-  shared_model::proto::Block block = makeBlock(proposal->height() - 1);
-  auto block_height = block.height();
 
   EXPECT_CALL(*factory, createTemporaryWsv()).Times(1);
-  EXPECT_CALL(*query, getTopBlockHeight()).WillOnce(Return(block_height));
-  EXPECT_CALL(*query, getBlock(block_height))
-      .WillOnce(Return(ByMove(
-          expected::makeValue(clone<shared_model::interface::Block>(block)))));
 
   EXPECT_CALL(*validator, validate(_, _))
       .WillOnce(Invoke([&verified_proposal_and_errors](const auto &p, auto &v) {

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -65,11 +65,10 @@ class TransactionProcessorTest : public ::testing::Test {
         getTestLogger("TransactionProcessor"));
 
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
-    auto ledger_peers =
-        std::make_shared<shared_model::interface::types::PeerList>(
-            shared_model::interface::types::PeerList{peer});
-    ledger_state =
-        std::make_shared<LedgerState>(ledger_peers, round.block_round - 1);
+    ledger_state = std::make_shared<LedgerState>(
+        shared_model::interface::types::PeerList{peer},
+        round.block_round - 1,
+        shared_model::crypto::Hash{"hash"});
   }
 
   auto base_tx() {


### PR DESCRIPTION
### Description of the Change
Remove block query dependency from Simulator by passing top block hash with LedgerState from storage commit

This is a part of https://github.com/hyperledger/iroha/pull/13

### Benefits
Less dependencies in Simulator

### Possible Drawbacks 
None