### PR TITLE
CI never builds artifacts for develop branch

### DIFF
--- a/.jenkinsci-new/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-linux-build-steps.groovy
@@ -82,7 +82,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
     iC = dockerUtils.dockerPullOrBuild("${platform}-develop-build",
         "${env.GIT_RAW_BASE_URL}/${scmVars.GIT_COMMIT}/docker/develop/Dockerfile",
         "${env.GIT_RAW_BASE_URL}/${utils.previousCommitOrCurrent(scmVars)}/docker/develop/Dockerfile",
-        "${env.GIT_RAW_BASE_URL}/develop/docker/develop/Dockerfile",
+        "${env.GIT_RAW_BASE_URL}/master/docker/develop/Dockerfile",
         scmVars,
         environment,
         forceDockerDevelopBuild,

--- a/.jenkinsci-new/text-variables.groovy
+++ b/.jenkinsci-new/text-variables.groovy
@@ -156,7 +156,7 @@ cmd_description = """
       </ul>
    </li>
    <li>
-      <p><strong>doxygen</strong> = false (or = true if master|develop|dev ) </p>
+      <p><strong>doxygen</strong> = false (or = true if master ) </p>
       <ul>
          <li>
             <p>Build doxygen, if specialBranch== true will publish, if not specialBranch will upload it to jenkins,</p>
@@ -189,7 +189,7 @@ cmd_description = """
       </ul>
    </li>
    <li>
-      <p><strong>pushDockerTag</strong> = 'not-supposed-to-be-pushed'(or = latest if master, or = develop if develop|dev)</p>
+      <p><strong>pushDockerTag</strong> = 'not-supposed-to-be-pushed'(or = master if master)</p>
       <ul>
          <li>
             <p>if&nbsp;packagePush=true&nbsp;it the name of docker tag that will be pushed</p>
@@ -200,7 +200,7 @@ cmd_description = """
       </ul>
    </li>
    <li>
-      <p><strong>packagePush</strong> = false (or = true if master|develop|dev )</p>
+      <p><strong>packagePush</strong> = false (or = true if master )</p>
       <ul>
          <li>
             <p>push all packages and docker to the artifactory and docker hub</p>
@@ -233,7 +233,7 @@ cmd_description = """
       </ul>
    </li>
    <li>
-      <p><strong>specialBranch</strong> = false (or = true if master|develop|dev ),</p>
+      <p><strong>specialBranch</strong> = false (or = true if master ),</p>
       <ul>
          <li>
             <p>Not recommended to set, it used to decide push&nbsp;doxygen&nbsp;and&nbsp;iroha:develop-build&nbsp;or not, and force to run&nbsp;build_type = 'Release'</p>

--- a/.jenkinsci-new/utils/docker-pull-or-build.groovy
+++ b/.jenkinsci-new/utils/docker-pull-or-build.groovy
@@ -28,7 +28,7 @@ def dockerPullOrBuild(imageName, currentDockerfileURL, previousDockerfileURL, re
     referenceDockerfile = utils.getUrl(referenceDockerfileURL, "/tmp/${randDir}/referenceDockerfile")
     contextDir = "/tmp/${randDir}"
     if (utils.filesDiffer(currentDockerfile, referenceDockerfile) || forceBuild ) {
-      // Dockerfile is differ from develop
+      // Dockerfile is differ from reference
       if (utils.filesDiffer(currentDockerfile, previousDockerfile)) {
         // Dockerfile has been changed compared to both the previous commit and reference Dockerfile
         // Worst case scenario. We cannot count on the local cache
@@ -41,9 +41,9 @@ def dockerPullOrBuild(imageName, currentDockerfileURL, previousDockerfileURL, re
       }
     }
     else {
-      // Dockerfile is same as develop
-      if ( scmVars.GIT_LOCAL_BRANCH == "develop" && utils.filesDiffer(currentDockerfile, previousDockerfile)) {
-        // we in dev branch and docker file was changed
+      // Dockerfile is same as reference
+      if ( scmVars.GIT_LOCAL_BRANCH == "master" && utils.filesDiffer(currentDockerfile, previousDockerfile)) {
+        // we are in master branch and docker file was changed
         iC = docker.build("${env.DOCKER_REGISTRY_BASENAME}:${randDir}-${BUILD_NUMBER}", "${buildOptions} --no-cache -f ${currentDockerfile} ${contextDir}")
       } else {
         // try pulling image from Dockerhub, probably image is already there

--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -157,7 +157,7 @@ node ('master') {
   forceDockerDevelopBuild = false
   checkTag = sh(script: 'git describe --tags --exact-match ${scmVars.GIT_COMMIT}', returnStatus: true)
 
-  if (scmVars.GIT_LOCAL_BRANCH in ["master","develop"] || scmVars.CHANGE_BRANCH_LOCAL in ["develop"] || checkTag == 0 )
+  if (scmVars.GIT_LOCAL_BRANCH in ["master"] || checkTag == 0 )
     specialBranch =  true
   else
     specialBranch = false
@@ -168,10 +168,8 @@ node ('master') {
     doxygen = true
   }
 
-  if (scmVars.GIT_LOCAL_BRANCH == "develop")
-    pushDockerTag =  'develop'
-  else if (scmVars.GIT_LOCAL_BRANCH == 'master')
-    pushDockerTag = 'latest'
+  if (scmVars.GIT_LOCAL_BRANCH == "master")
+    pushDockerTag = 'master'
   else if (checkTag == 0 )
     pushDockerTag = sh(script: 'git describe --tags --exact-match ${GIT_COMMIT}', returnStdout: true).trim().replaceAll('-','_')
   else

--- a/docker/manifest.yaml
+++ b/docker/manifest.yaml
@@ -1,4 +1,4 @@
-# master branch
+# latest release
 image: hyperledger/iroha:latest
 manifests:
   -
@@ -20,24 +20,24 @@ manifests:
       architecture: arm64
       os: linux
 
-# develop branch
-image: hyperledger/iroha:develop
+# master branch
+image: hyperledger/iroha:master
 manifests:
   -
-    image: hyperledger/iroha:x86_64-develop
+    image: hyperledger/iroha:x86_64-master
     platform:
       architecture: amd64
       os: linux
       features:
         - sse
   -
-    image: hyperledger/iroha:armv7l-develop
+    image: hyperledger/iroha:armv7l-master
     platform:
       architecture: arm
       os: linux
       variant: v7
   -
-    image: hyperledger/iroha:aarch64-develop
+    image: hyperledger/iroha:aarch64-master
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
### Description of the Change

Development in the develop branch will be terminated. CI never builds artifacts for develop branch.
Artifacts for the master branch will be build with the "master" Docker Hub tag.

### Benefits

It is a requirement of the development team.
