### PR TITLE
Ametsuchi: fixed prepared block rollback at init

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -188,7 +188,7 @@ namespace iroha {
 
       bool prepared_blocks_enabled_;
 
-      std::atomic<bool> block_is_prepared;
+      std::atomic<bool> block_is_prepared_;
 
       std::string prepared_block_name_;
 


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Fixed erroneous prepared block rollback here:
![2019-05-16-09:26:57_412x85](https://user-images.githubusercontent.com/11086641/57831108-e3becc80-77bc-11e9-9cd9-364fefea2735.png)
Also renamed the member variable to fit the codestyle.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Fixed the error when rolling back nonexistent prepared transaction. Refactoring.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
