### PR TITLE
ITF: fixed init failure handling

### DIFF
--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -307,6 +307,7 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::setGenesisBlock(
       const shared_model::interface::Block &block) {
     iroha_instance_->makeGenesis(clone(block));
+    iroha_instance_->init();
     return *this;
   }
 
@@ -339,7 +340,7 @@ namespace integration_framework {
   IntegrationTestFramework &IntegrationTestFramework::recoverState(
       const Keypair &keypair) {
     initPipeline(keypair);
-    iroha_instance_->getIrohaInstance()->init();
+    iroha_instance_->init();
     subscribeQueuesAndRun();
     return *this;
   }

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -52,11 +52,21 @@ namespace integration_framework {
         irohad_log_manager_(std::move(irohad_log_manager)),
         log_(std::move(log)) {}
 
+  void IrohaInstance::init() {
+    auto init_result = instance_->init();
+    if (auto error =
+            boost::get<iroha::expected::Error<std::string>>(&init_result)) {
+      std::string error_msg("Irohad startup failed: ");
+      error_msg.append(error->error);
+      log_->critical("{}", error_msg);
+      throw(std::runtime_error(error_msg));
+    }
+  }
+
   void IrohaInstance::makeGenesis(
       std::shared_ptr<const shared_model::interface::Block> block) {
     instance_->storage->reset();
     rawInsertBlock(block);
-    instance_->init();
   }
 
   void IrohaInstance::rawInsertBlock(

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -52,6 +52,9 @@ namespace integration_framework {
                   logger::LoggerPtr log,
                   const boost::optional<std::string> &dbname = boost::none);
 
+    /// Initialize Irohad. Throws on error.
+    void init();
+
     void makeGenesis(
         std::shared_ptr<const shared_model::interface::Block> block);
 


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

When iroha fails initialization, ITF tests should not proceed normally, but rather an informative message should be displayed (if the error was not expected). This change makes ITF check the iroha initialization result and throw an exception with descriptive details on error.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Easier ITF tests debugging.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
