### PR TITLE
DOPS-486 Fix two test reports

### DIFF
--- a/.jenkinsci-new/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-linux-build-steps.groovy
@@ -31,7 +31,7 @@ def dockerManifestPush(dockerImageObj, String dockerTag, environment) {
 
 def testSteps(String buildDir, List environment, String testList) {
   withEnv(environment) {
-    sh "cd ${buildDir}; ctest --output-on-failure --no-compress-output --tests-regex '${testList}'  --test-action Test || true"
+    sh "cd ${buildDir}; rm -f Testing/*/Test.xml; ctest --output-on-failure --no-compress-output --tests-regex '${testList}'  --test-action Test || true"
     sh """ python .jenkinsci-new/helpers/platform_tag.py "Linux \$(uname -m)" \$(ls ${buildDir}/Testing/*/Test.xml) """
     // Mark build as UNSTABLE if there are any failed tests (threshold <100%)
     xunit testTimeMargin: '3000', thresholdMode: 2, thresholds: [passed(unstableThreshold: '100')], \


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

reopen of https://github.com/hyperledger/iroha/pull/54

### Description of the Change

If **Before merge to trunk** build was started  after  10 pm, it runs tests for all compiler, and name of report can contain name of second day for last compiler tests. 
this pr will clean old reports before run tests 
### Benefits
fix error  https://jenkins.soramitsu.co.jp/blue/organizations/jenkins/iroha%2Firoha-hyperledger/detail/PR-51/2/pipeline

### Possible Drawbacks 

None

