### PR TITLE
Feature/ametsuchi commit result

### DIFF
--- a/irohad/ametsuchi/commit_result.hpp
+++ b/irohad/ametsuchi/commit_result.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_AMETSUCHI_COMMIT_RESULT_HPP
+#define IROHA_AMETSUCHI_COMMIT_RESULT_HPP
+
+#include <memory>
+#include <string>
+
+#include "ametsuchi/ledger_state.hpp"
+#include "common/result.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+
+    using CommitResult =
+        iroha::expected::Result<std::shared_ptr<const iroha::LedgerState>,
+                                std::string>;
+  }
+}  // namespace iroha
+
+#endif // IROHA_AMETSUCHI_COMMIT_RESULT_HPP

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -18,6 +18,7 @@
 namespace iroha {
   namespace ametsuchi {
     class BlockIndex;
+    class PeerQuery;
     class TransactionExecutor;
 
     class MutableStorageImpl : public MutableStorage {
@@ -25,8 +26,8 @@ namespace iroha {
 
      public:
       MutableStorageImpl(
-          shared_model::interface::types::HashType top_hash,
-          shared_model::interface::types::HeightType top_height,
+          boost::optional<std::shared_ptr<const iroha::LedgerState>>
+              ledger_state,
           std::shared_ptr<TransactionExecutor> transaction_executor,
           std::unique_ptr<soci::session> sql,
           std::shared_ptr<shared_model::interface::CommonObjectsFactory>
@@ -41,9 +42,8 @@ namespace iroha {
                      std::shared_ptr<shared_model::interface::Block>> blocks,
                  MutableStoragePredicate predicate) override;
 
-      shared_model::interface::types::HeightType getTopBlockHeight() const;
-
-      shared_model::interface::types::HashType getTopBlockHash() const;
+      boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      getLedgerState() const;
 
       ~MutableStorageImpl() override;
 
@@ -63,8 +63,7 @@ namespace iroha {
       bool apply(std::shared_ptr<const shared_model::interface::Block> block,
                  MutableStoragePredicate predicate);
 
-      shared_model::interface::types::HashType top_hash_;
-      shared_model::interface::types::HeightType top_height_;
+      boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
 
       std::unique_ptr<soci::session> sql_;
       std::unique_ptr<PeerQuery> peer_query_;

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -65,10 +65,9 @@ namespace {
    * @param storage - current storage
    * @param mutable_storage - mutable storage without blocks
    * @param block_query - current block storage
+   * @return commit status after applying the blocks
    */
-  iroha::expected::Result<boost::optional<std::unique_ptr<iroha::LedgerState>>,
-                          std::string>
-  reindexBlocks(
+  iroha::ametsuchi::CommitResult reindexBlocks(
       iroha::ametsuchi::Storage &storage,
       std::unique_ptr<iroha::ametsuchi::MutableStorage> &mutable_storage,
       std::shared_ptr<iroha::ametsuchi::BlockQuery> &block_query) {
@@ -90,24 +89,17 @@ namespace {
       }
     }
 
-    return iroha::expected::makeValue(
-        storage.commit(std::move(mutable_storage)));
+    return storage.commit(std::move(mutable_storage));
   }
 }  // namespace
 
 namespace iroha {
   namespace ametsuchi {
-    iroha::expected::Result<
-        boost::optional<std::unique_ptr<iroha::LedgerState>>,
-        std::string>
-    WsvRestorerImpl::restoreWsv(Storage &storage) {
+    CommitResult WsvRestorerImpl::restoreWsv(Storage &storage) {
       BlockStorageStubFactory storage_factory;
 
       return storage.createMutableStorage(storage_factory) |
-                 [&storage](auto &&mutable_storage)
-                 -> iroha::expected::Result<
-                     boost::optional<std::unique_ptr<iroha::LedgerState>>,
-                     std::string> {
+                 [&storage](auto &&mutable_storage) -> CommitResult {
         auto block_query = storage.getBlockQuery();
         if (not block_query) {
           return expected::makeError("Cannot create BlockQuery");

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
@@ -27,10 +27,7 @@ namespace iroha {
        * @return ledger state after restoration on success, otherwise error
        * string
        */
-      iroha::expected::Result<
-          boost::optional<std::unique_ptr<iroha::LedgerState>>,
-          std::string>
-      restoreWsv(Storage &storage) override;
+      CommitResult restoreWsv(Storage &storage) override;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/mutable_factory.hpp
+++ b/irohad/ametsuchi/mutable_factory.hpp
@@ -9,8 +9,8 @@
 #include <memory>
 
 #include <boost/optional.hpp>
+#include "ametsuchi/commit_result.hpp"
 #include "common/result.hpp"
-#include "ametsuchi/ledger_state.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -38,17 +38,20 @@ namespace iroha {
        * This transforms Ametsuchi to the new state consistent with
        * MutableStorage.
        * @param mutableStorage
-       * @return new state of the ledger, boost::none if commit failed
+       * @return the status of commit
        */
-      virtual boost::optional<std::unique_ptr<LedgerState>> commit(
+      virtual CommitResult commit(
           std::unique_ptr<MutableStorage> mutableStorage) = 0;
+
+      /// Check if prepared commits are enabled.
+      virtual bool preparedCommitEnabled() const = 0;
 
       /**
        * Try to apply prepared block to Ametsuchi.
-       * @return state of the ledger if commit is succesful, boost::none if
-       * prepared block failed to apply. WSV is not changed in this case.
+       * @param block The previously prepared block that will be committed now.
+       * @return Result of committing the prepared block.
        */
-      virtual boost::optional<std::unique_ptr<LedgerState>> commitPrepared(
+      virtual CommitResult commitPrepared(
           std::shared_ptr<const shared_model::interface::Block> block) = 0;
 
       virtual ~MutableFactory() = default;

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include <rxcpp/rx.hpp>
+#include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -21,7 +22,6 @@ namespace iroha {
   namespace ametsuchi {
 
     class WsvQuery;
-    class PeerQuery;
 
     /**
      * Mutable storage is used apply blocks to the storage.
@@ -33,14 +33,11 @@ namespace iroha {
        * Predicate type checking block
        * Function parameters:
        *  - Block - block to be checked
-       *  - PeerQuery - interface for ledger peers list retrieval
-       *  - HashType - hash of top block in blockchain
+       *  - LedgerState - the state of ledger on which the block is applied
        */
       using MutableStoragePredicate = std::function<bool(
           std::shared_ptr<const shared_model::interface::Block>,
-          // TODO 30.01.2019 lebdron: IR-265 Remove PeerQueryFactory
-          PeerQuery &,
-          const shared_model::interface::types::HashType &)>;
+          const LedgerState &)>;
 
       /**
        * Applies block without additional validation function

--- a/irohad/ametsuchi/wsv_restorer.hpp
+++ b/irohad/ametsuchi/wsv_restorer.hpp
@@ -5,7 +5,7 @@
 #ifndef IROHA_WSVRESTORER_HPP
 #define IROHA_WSVRESTORER_HPP
 
-#include "common/result.hpp"
+#include "ametsuchi/commit_result.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -25,9 +25,7 @@ namespace iroha {
        * @return ledger state after restoration on success, otherwise error
        * string
        */
-      virtual iroha::expected::
-          Result<boost::optional<std::unique_ptr<LedgerState>>, std::string>
-          restoreWsv(Storage &storage) = 0;
+      virtual CommitResult restoreWsv(Storage &storage) = 0;
     };
 
   }  // namespace ametsuchi

--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -24,10 +24,10 @@ namespace iroha {
 
     struct BaseGateObject {
       consensus::Round round;
-      std::shared_ptr<LedgerState> ledger_state;
+      std::shared_ptr<const LedgerState> ledger_state;
 
       BaseGateObject(consensus::Round round,
-                     std::shared_ptr<LedgerState> ledger_state)
+                     std::shared_ptr<const LedgerState> ledger_state)
           : round(std::move(round)), ledger_state(std::move(ledger_state)) {}
     };
 
@@ -36,7 +36,7 @@ namespace iroha {
       std::shared_ptr<shared_model::interface::Block> block;
 
       PairValid(consensus::Round round,
-                std::shared_ptr<LedgerState> ledger_state,
+                std::shared_ptr<const LedgerState> ledger_state,
                 std::shared_ptr<shared_model::interface::Block> block)
           : BaseGateObject(std::move(round), std::move(ledger_state)),
             block(std::move(block)) {}
@@ -47,7 +47,7 @@ namespace iroha {
 
       Synchronizable(
           consensus::Round round,
-          std::shared_ptr<LedgerState> ledger_state,
+          std::shared_ptr<const LedgerState> ledger_state,
           shared_model::interface::types::PublicKeyCollectionType public_keys)
           : BaseGateObject(std::move(round), std::move(ledger_state)),
             public_keys(std::move(public_keys)) {}
@@ -59,7 +59,7 @@ namespace iroha {
 
       VoteOther(
           consensus::Round round,
-          std::shared_ptr<LedgerState> ledger_state,
+          std::shared_ptr<const LedgerState> ledger_state,
           shared_model::interface::types::PublicKeyCollectionType public_keys,
           shared_model::interface::types::HashType hash)
           : Synchronizable(std::move(round),

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -58,7 +58,7 @@ namespace iroha {
         boost::optional<std::shared_ptr<shared_model::interface::Block>>
             current_block_;
         YacHash current_hash_;
-        std::shared_ptr<LedgerState> current_ledger_state_;
+        std::shared_ptr<const LedgerState> current_ledger_state_;
 
         rxcpp::observable<GateObject> published_events_;
         std::shared_ptr<YacPeerOrderer> orderer_;

--- a/irohad/network/impl/block_loader_service.cpp
+++ b/irohad/network/impl/block_loader_service.cpp
@@ -103,10 +103,7 @@ grpc::Status BlockLoaderService::retrieveBlock(
   }
 
   auto &block =
-      boost::get<
-          expected::Value<std::unique_ptr<shared_model::interface::Block>>>(
-          block_result)
-          .value;
+      boost::get<expected::ValueOf<decltype(block_result)>>(block_result).value;
 
   const auto &block_v1 =
       static_cast<shared_model::proto::Block *>(block.get())->getTransport();

--- a/irohad/network/ordering_gate_common.hpp
+++ b/irohad/network/ordering_gate_common.hpp
@@ -28,7 +28,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
           proposal;
       consensus::Round round;
-      std::shared_ptr<LedgerState> ledger_state;
+      std::shared_ptr<const LedgerState> ledger_state;
     };
 
     std::shared_ptr<const shared_model::interface::Proposal> getProposalUnsafe(

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -34,10 +34,10 @@ namespace iroha {
      public:
       struct RoundSwitch {
         consensus::Round next_round;
-        std::shared_ptr<LedgerState> ledger_state;
+        std::shared_ptr<const LedgerState> ledger_state;
 
         RoundSwitch(consensus::Round next_round,
-                    std::shared_ptr<LedgerState> ledger_state)
+                    std::shared_ptr<const LedgerState> ledger_state)
             : next_round(std::move(next_round)),
               ledger_state(std::move(ledger_state)) {}
       };

--- a/irohad/simulator/block_creator_common.hpp
+++ b/irohad/simulator/block_creator_common.hpp
@@ -34,7 +34,7 @@ namespace iroha {
     struct BlockCreatorEvent {
       boost::optional<RoundData> round_data;
       consensus::Round round;
-      std::shared_ptr<LedgerState> ledger_state;
+      std::shared_ptr<const LedgerState> ledger_state;
     };
 
     std::shared_ptr<shared_model::interface::Block> getBlockUnsafe(

--- a/irohad/simulator/verified_proposal_creator_common.hpp
+++ b/irohad/simulator/verified_proposal_creator_common.hpp
@@ -22,7 +22,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<validation::VerifiedProposalAndErrors>>
           verified_proposal_result;
       consensus::Round round;
-      std::shared_ptr<LedgerState> ledger_state;
+      std::shared_ptr<const LedgerState> ledger_state;
     };
 
     std::shared_ptr<validation::VerifiedProposalAndErrors>

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -8,6 +8,7 @@
 
 #include "synchronizer/synchronizer.hpp"
 
+#include "ametsuchi/commit_result.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "logger/logger_fwd.hpp"
@@ -49,8 +50,9 @@ namespace iroha {
        * @param start_height - the block from which to start synchronization
        * @param target_height - the block height that must be reached
        * @param public_keys - public keys of peers from which to ask the blocks
+       * @return Result of committing the downloaded blocks.
        */
-      boost::optional<std::unique_ptr<LedgerState>> downloadMissingBlocks(
+      ametsuchi::CommitResult downloadAndCommitMissingBlocks(
           const shared_model::interface::types::HeightType start_height,
           const shared_model::interface::types::HeightType target_height,
           const PublicKeysRange &public_keys);

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -30,7 +30,7 @@ namespace iroha {
     struct SynchronizationEvent {
       SynchronizationOutcomeType sync_outcome;
       consensus::Round round;
-      std::shared_ptr<iroha::LedgerState> ledger_state;
+      std::shared_ptr<const iroha::LedgerState> ledger_state;
     };
 
   }  // namespace synchronizer

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -5,8 +5,8 @@
 
 #include "validation/impl/chain_validator_impl.hpp"
 
+#include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/mutable_storage.hpp"
-#include "ametsuchi/peer_query.hpp"
 #include "consensus/yac/supermajority_checker.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
@@ -29,11 +29,10 @@ namespace iroha {
         ametsuchi::MutableStorage &storage) const {
       log_->info("validate chain...");
 
-      return storage.apply(
-          blocks,
-          [this](auto block, auto &queries, const auto &top_hash) {
-            return this->validateBlock(block, queries, top_hash);
-          });
+      return storage.apply(blocks,
+                           [this](auto block, const auto &ledger_state) {
+                             return this->validateBlock(block, ledger_state);
+                           });
     }
 
     bool ChainValidatorImpl::validatePreviousHash(
@@ -50,6 +49,22 @@ namespace iroha {
       }
 
       return same_prev_hash;
+    }
+
+    bool ChainValidatorImpl::validateHeight(
+        const shared_model::interface::Block &block,
+        const shared_model::interface::types::HeightType &top_height) const {
+      const bool valid_height = block.height() == top_height + 1;
+
+      if (not valid_height) {
+        log_->info(
+            "Block height {} is does not consequently follow the top block "
+            "height {}.",
+            block.height(),
+            top_height);
+      }
+
+      return valid_height;
     }
 
     bool ChainValidatorImpl::validatePeerSupermajority(
@@ -85,20 +100,14 @@ namespace iroha {
 
     bool ChainValidatorImpl::validateBlock(
         std::shared_ptr<const shared_model::interface::Block> block,
-        ametsuchi::PeerQuery &queries,
-        const shared_model::interface::types::HashType &top_hash) const {
-      log_->info("validate block: height {}, hash {}",
+        const iroha::LedgerState &ledger_state) const {
+      log_->debug("validate block: height {}, hash {}",
                  block->height(),
                  block->hash().hex());
 
-      auto peers = queries.getLedgerPeers();
-      if (not peers) {
-        log_->info("Cannot retrieve peers from storage");
-        return false;
-      }
-
-      return validatePreviousHash(*block, top_hash)
-          and validatePeerSupermajority(*block, *peers);
+      return validatePreviousHash(*block, ledger_state.top_block_info.top_hash)
+          and validateHeight(*block, ledger_state.top_block_info.height)
+          and validatePeerSupermajority(*block, ledger_state.ledger_peers);
     }
 
   }  // namespace validation

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -27,9 +27,7 @@ namespace iroha {
     }  // namespace yac
   }    // namespace consensus
 
-  namespace ametsuchi {
-    class PeerQuery;
-  }  // namespace ametsuchi
+  struct LedgerState;
 
   namespace validation {
     class ChainValidatorImpl : public ChainValidator {
@@ -49,6 +47,11 @@ namespace iroha {
           const shared_model::interface::Block &block,
           const shared_model::interface::types::HashType &top_hash) const;
 
+      /// Verifies whether block height directly follows top height
+      bool validateHeight(
+          const shared_model::interface::Block &block,
+          const shared_model::interface::types::HeightType &top_height) const;
+
       /// Verifies whether the block is signed by supermajority of peers
       bool validatePeerSupermajority(
           const shared_model::interface::Block &block,
@@ -61,9 +64,7 @@ namespace iroha {
        */
       bool validateBlock(
           std::shared_ptr<const shared_model::interface::Block> block,
-          // TODO 30.01.2019 lebdron: IR-265 Remove PeerQueryFactory
-          ametsuchi::PeerQuery &queries,
-          const shared_model::interface::types::HashType &top_hash) const;
+          const iroha::LedgerState &ledger_state) const;
 
       /**
        * Provide functions to check supermajority

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -321,7 +321,7 @@ namespace iroha {
     constexpr auto operator|(const Result<T, E> &r, Procedure f) ->
         typename std::enable_if<not std::is_same<decltype(f()), void>::value,
                                 decltype(f())>::type {
-      using return_type = decltype(f());
+      using return_type = typename BindReturnType<decltype(f()), E>::ReturnType;
       return r.match(
           [&f](const Value<T> &v) { return f(); },
           [](const Error<E> &e) { return return_type(makeError(e.error)); });
@@ -332,7 +332,7 @@ namespace iroha {
     constexpr auto operator|(Result<T, E> &&r, Procedure f) ->
         typename std::enable_if<not std::is_same<decltype(f()), void>::value,
                                 decltype(f())>::type {
-      using return_type = decltype(f());
+      using return_type = typename BindReturnType<decltype(f()), E>::ReturnType;
       return std::move(r).match(
           [&f](const auto &) { return f(); },
           [](auto &&e) { return return_type(makeError(std::move(e.error))); });

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -23,9 +23,10 @@ namespace shared_model {
 
   namespace interface {
 
+    class AccountAsset;
+    class Block;
     class Signature;
     class Transaction;
-    class AccountAsset;
     class Peer;
 
     namespace types {

--- a/shared_model/utils/string_builder.hpp
+++ b/shared_model/utils/string_builder.hpp
@@ -82,6 +82,37 @@ namespace shared_model {
       }
 
       /**
+       * Appends a new named collection to string
+       * @param c - iterable collection to append using toString method
+       */
+      template <typename Collection>
+      std::enable_if_t<
+          std::is_same<
+              typename std::decay<decltype(
+                  std::declval<Collection>().begin()->toString())>::type,
+              std::string>::value,
+          PrettyStringBuilder &>
+      appendAll(Collection &&c) {
+        appendAll(c, [](const auto &o) { return o.toString(); });
+        return *this;
+      }
+
+      /**
+       * Appends a new named collection to string
+       * @param c - iterable collection of pointers
+       */
+      template <typename Collection>
+      std::enable_if_t<std::is_same<typename std::decay<decltype(
+                                        (*std::declval<Collection>().begin())
+                                            ->toString())>::type,
+                                    std::string>::value,
+                       PrettyStringBuilder &>
+      appendAll(Collection &&c) {
+        appendAll(c, [](const auto &o) { return o->toString(); });
+        return *this;
+      }
+
+      /**
        * Finalizes appending and returns constructed string.
        * @return resulted string
        */

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -158,12 +158,10 @@ TEST_F(FakePeerExampleFixture, SynchronizeTheRightVersionOfForkedLedger) {
     auto block_result = block_query->getBlock(i);
 
     std::shared_ptr<shared_model::interface::Block> block =
-        boost::get<iroha::expected::Value<
-            std::unique_ptr<shared_model::interface::Block>>>(
-            std::move(block_result))
+        boost::get<decltype(block_result)::ValueType>(std::move(block_result))
             .value;
     valid_block_storage->storeBlock(
-        std::static_pointer_cast<shared_model::proto::Block>(block));
+        std::static_pointer_cast<const shared_model::proto::Block>(block));
   }
 
   // From now the itf peer is considered unreachable from the rest network. //

--- a/test/integration/validation/chain_validator_storage_test.cpp
+++ b/test/integration/validation/chain_validator_storage_test.cpp
@@ -12,6 +12,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "cryptography/keypair.hpp"
+#include "framework/result_fixture.hpp"
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 
@@ -99,7 +100,9 @@ namespace iroha {
       auto ms = createMutableStorage();
 
       ms->apply(block);
-      storage->commit(std::move(ms));
+      auto commit_result = storage->commit(std::move(ms));
+      EXPECT_TRUE(boost::get<expected::ValueOf<decltype(commit_result)>>(
+          (&commit_result)));
 
       return block;
     }

--- a/test/module/irohad/ametsuchi/mock_mutable_factory.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_factory.hpp
@@ -19,18 +19,17 @@ namespace iroha {
           createMutableStorage,
           expected::Result<std::unique_ptr<MutableStorage>, std::string>(void));
 
-      boost::optional<std::unique_ptr<LedgerState>> commit(
+      CommitResult commit(
           std::unique_ptr<MutableStorage> mutableStorage) override {
         // gmock workaround for non-copyable parameters
         return commit_(mutableStorage);
       }
 
-      MOCK_METHOD1(commitPrepared,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD1(commit_,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       std::unique_ptr<MutableStorage> &));
+      MOCK_CONST_METHOD0(preparedCommitEnabled, bool());
+      MOCK_METHOD1(
+          commitPrepared,
+          CommitResult(std::shared_ptr<const shared_model::interface::Block>));
+      MOCK_METHOD1(commit_, CommitResult(std::unique_ptr<MutableStorage> &));
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -21,8 +21,7 @@ namespace iroha {
                    std::shared_ptr<shared_model::interface::Block>>,
                std::function<
                    bool(std::shared_ptr<const shared_model::interface::Block>,
-                        PeerQuery &,
-                        const shared_model::interface::types::HashType &)>));
+                        const iroha::LedgerState &)>));
       MOCK_METHOD1(apply,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(applyPrepared,

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -35,12 +35,11 @@ namespace iroha {
           boost::optional<std::shared_ptr<QueryExecutor>>(
               std::shared_ptr<PendingTransactionStorage>,
               std::shared_ptr<shared_model::interface::QueryResponseFactory>));
-      MOCK_METHOD1(doCommit,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       MutableStorage *storage));
-      MOCK_METHOD1(commitPrepared,
-                   boost::optional<std::unique_ptr<LedgerState>>(
-                       std::shared_ptr<const shared_model::interface::Block>));
+      MOCK_METHOD1(doCommit, CommitResult(MutableStorage *storage));
+      MOCK_CONST_METHOD0(preparedCommitEnabled, bool());
+      MOCK_METHOD1(
+          commitPrepared,
+          CommitResult(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(insertBlock,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(createMutableStorage,
@@ -66,8 +65,7 @@ namespace iroha {
       on_commit() override {
         return notifier.get_observable();
       }
-      boost::optional<std::unique_ptr<LedgerState>> commit(
-          std::unique_ptr<MutableStorage> storage) override {
+      CommitResult commit(std::unique_ptr<MutableStorage> storage) override {
         return doCommit(storage.get());
       }
       rxcpp::subjects::subject<

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -1020,7 +1020,7 @@ namespace iroha {
             FAIL() << "could not apply block to the storage";
           }
         }
-        storage->commit(std::move(ms));
+        ASSERT_TRUE(val(storage->commit(std::move(ms))));
       }
 
       static constexpr shared_model::interface::types::HeightType
@@ -1281,7 +1281,7 @@ namespace iroha {
               FAIL() << "MutableStorage: " << error.error;
             });
         ms->apply(block);
-        storage->commit(std::move(ms));
+        ASSERT_TRUE(val(storage->commit(std::move(ms))));
       }
 
       void commitBlocks() {

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -41,10 +41,9 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
+  shared_model::crypto::Hash block_hash("hash");
   auto ledger_state = std::make_shared<LedgerState>(
-      shared_model::interface::types::PeerList{peer},
-      1,
-      shared_model::crypto::Hash{"hash"});
+      shared_model::interface::types::PeerList{peer}, 1, block_hash);
   auto proposal = std::make_shared<const MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(
@@ -54,8 +53,7 @@ TEST(YacHashProviderTest, MakeYacHashTest) {
       .WillRepeatedly(
           ReturnRefOfCopy(shared_model::crypto::Blob(std::string())));
   EXPECT_CALL(*block, hash())
-      .WillRepeatedly(
-          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
+      .WillRepeatedly(testing::ReturnRefOfCopy(block_hash));
 
   EXPECT_CALL(*block, signatures())
       .WillRepeatedly(
@@ -80,10 +78,9 @@ TEST(YacHashProviderTest, ToModelHashTest) {
   YacHashProviderImpl hash_provider;
   iroha::consensus::Round round{1, 0};
   auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
+  shared_model::crypto::Hash block_hash("hash");
   auto ledger_state = std::make_shared<LedgerState>(
-      shared_model::interface::types::PeerList{peer},
-      1,
-      shared_model::crypto::Hash{"hash"});
+      shared_model::interface::types::PeerList{peer}, 1, block_hash);
   auto proposal = std::make_shared<MockProposal>();
   EXPECT_CALL(*proposal, hash())
       .WillRepeatedly(
@@ -101,8 +98,7 @@ TEST(YacHashProviderTest, ToModelHashTest) {
                          1, signature()))
                  | boost::adaptors::indirected));
   EXPECT_CALL(*block, hash())
-      .WillRepeatedly(
-          testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
+      .WillRepeatedly(testing::ReturnRefOfCopy(block_hash));
 
   auto yac_hash = hash_provider.makeHash(iroha::simulator::BlockCreatorEvent{
       iroha::simulator::RoundData{proposal, block}, round, ledger_state});

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -38,7 +38,6 @@ using testing::ByMove;
 using testing::Return;
 
 using wPeer = std::shared_ptr<shared_model::interface::Peer>;
-using wBlock = std::shared_ptr<shared_model::interface::Block>;
 
 class BlockLoaderTest : public testing::Test {
  public:


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

*this is the rest of #13 that was not extracted into #63*

[IR-442](https://jira.hyperledger.org/browse/IR-442)

Makes commit operations produce a `CommitResult` object, which is an `expected::Result<std::shared_ptr<iroha::LedgerState>, std::string>`. A successful commit yields an actualized ledger state, and a failed - an error reason.

*additional changes to #13*

`commitPrepared` also returns a `CommitResult` object, but wrapped into an optional. The optional being unset means that the prepared blocks were not enabled (as it  previously was). The rest of errors are now represented with `Result` errors.

*UPDATE 2019.06.05*

Ledger state is now stored in `StorageImpl` and `MutableStorageImpl`.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Ledger state is updated then and only then, when a commit to storage happens. It is practical then to provide a new ledger state as a result of a successful commit and propagate it to all components that need it. Also peer query usage was reduced by means of reusing ledger state after commit.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
