### PR TITLE
Fixing doc page

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,215 @@
+.. contents:: **Table of Contents**
+   :depth: 3
+
+First off, thanks for taking the time to contribute!
+
+The following is a short set of guidelines for contributing to Iroha.
+
+How Can I Contribute?
+---------------------
+
+Reporting Bugs
+~~~~~~~~~~~~~~
+
+*Bug* is an error, design flaw, failure or fault in Iroha that causes it
+to produce an incorrect or unexpected result, or to behave in unintended
+ways.
+
+Bugs are tracked as `JIRA
+issues <https://jira.hyperledger.org/projects/IR/issues/IR-275?filter=allopenissues&orderby=issuetype+ASC%2C+priority+DESC%2C+updated+DESC>`__
+in Hyperledger Jira.
+
+To submit a bug, `create new
+issue <https://jira.hyperledger.org/secure/CreateIssue.jspa>`__ and
+include these details:
+
++---------------------+------------------------------------------------------+
+| Field               | What to enter                                        |
++=====================+======================================================+
+| Project             | Iroha (IR)                                           |
++---------------------+------------------------------------------------------+
+| Issue Type          | Bug                                                  |
++---------------------+------------------------------------------------------+
+| Summary             | Essence of the problem                               |
++---------------------+------------------------------------------------------+
+| Description         | What the issue is about; if you have any logs,       |
+|                     | please provide them                                  |
++---------------------+------------------------------------------------------+
+| Priority            | You can use Medium though if you see the issue as a  |
+|                     | high priority, please choose that                    |
++---------------------+------------------------------------------------------+
+| Environment         | Your OS, device's specs, Virtual Environment if you  |
+|                     | use one, version of Iroha etc.                       |
++---------------------+------------------------------------------------------+
+
+Reporting Vulnerabilities
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While we try to be proactive in preventing security problems, we do not
+assume they’ll never come up.
+
+It is standard practice to responsibly and privately disclose to the
+vendor (Hyperledger organization) a security problem before publicizing,
+so a fix can be prepared, and damage from the vulnerability minimized.
+
+Before the First Major Release (1.0) all vulnerabilities are considered
+to be bugs, so feel free to submit them as described above. After the
+First Major Release please utilize `a bug bounty program
+here <https://hackerone.com/hyperledger>`__ in order to submit
+vulnerabilities and get your reward.
+
+In any case — feel free to reach to any of existing maintainers in
+Rocket.Chat private messages or in an e-mail (check CONTRIBUTORS.md
+file) if you want to discuss whether your discovery is a vulnerability
+or a bug.
+
+Suggesting Improvements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+An *improvement* is a code or idea, which makes **existing** code or
+design faster, more stable, portable, secure or better in any other way.
+
+Improvements are tracked as `JIRA
+improvements <https://jira.hyperledger.org/browse/IR-184?jql=project%20%3D%20IR%20and%20issuetype%20%3D%20Improvement%20ORDER%20BY%20updated%20DESC>`__.
+To submit new improvement, `create new
+issue <https://jira.hyperledger.org/secure/CreateIssue.jspa>`__ and
+include these details:
+
++---------------------+------------------------------------------------------+
+| Field               | What to enter                                        |
++=====================+======================================================+
+| Project             | Iroha (IR)                                           |
++---------------------+------------------------------------------------------+
+| Issue Type          | Improvement                                          |
++---------------------+------------------------------------------------------+
+| Summary             | Essence of the idea                                  |
++---------------------+------------------------------------------------------+
+| Description         | What the idea is about; if you have any code         |
+|                     | suggestions, you are welcome to add them here        |
++---------------------+------------------------------------------------------+
+| Priority            | You can use Medium                                   |
++---------------------+------------------------------------------------------+
+| Assign              | You can assign the task to yourself if you are       |
+|                     | planning on working on it                            |
++---------------------+------------------------------------------------------+
+
+Asking Questions
+~~~~~~~~~~~~~~~~
+
+A *question* is any discussion that is typically neigher a bug, nor
+feature request or improvement. If you have a question like "How do I do
+X?" - this paragraph is for you.
+
+Please post your question in `your favourite
+messenger <#places-where-community-is-active>`__ so members of the
+community could help you. You can also help others!
+
+Your First Code Contribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read our `C++ Style Guide <#c-style-guide>`__ and start with
+beginner-friendly issues with JIRA label
+`good-first-issue <https://jira.hyperledger.org/issues/?jql=project%20%3D%20IR%20and%20labels%20%3D%20good-first-issue%20ORDER%20BY%20updated%20DESC>`__.
+Indicate somehow that you are working on this task: get in touch with
+maintainers team, community or simply assign this issue to yourself.
+
+Pull Requests
+~~~~~~~~~~~~~
+
+-  Fill in `the required template <.github/PULL_REQUEST_TEMPLATE.md>`__
+
+-  End all files with a newline
+
+-  **Write tests** for new code. Test coverage for new code must be at
+   least 70%
+
+-  Every pull request should be reviewed and **get at least two
+   approvals from maintainers team**. Check who is a current maintainer
+   in
+   `MAINTAINERS.md <https://github.com/hyperledger/iroha/blob/master/MAINTAINERS.md>`__
+   file
+
+-  When you've finished work make sure that you've got all passing CI
+   checks — after that **squash and merge** your pull request
+
+-  Follow the `C++ Style Guide <#c-style-guide>`__
+
+-  Follow the `Git Style Guide <#git-style-guide>`__
+
+-  **Document new code** based on the `Documentation
+   Styleguide <#documentation-styleguide>`__
+
+-  When working with **PRs from forks** check `this
+   manual <https://help.github.com/articles/checking-out-pull-requests-locally>`__
+
+Styleguides
+-----------
+
+Git Style Guide
+~~~~~~~~~~~~~~~
+
+-  **Sign-off every commit** with `DCO <https://github.com/apps/dco>`__:
+   ``Signed-off-by: $NAME <$EMAIL>``. You can do it automatically using
+   ``git commit -s``
+-  **Use present tense** ("Add feature", not "Added feature").
+-  **Use imperative mood** ("Deploy docker to..." not "Deploys docker
+   to...").
+-  Write meaningful commit message.
+-  Limit the first line of commit message to 50 characters or less
+-  First line of commit message must contain summary of work done,
+   second line must contain empty line, third and other lines can
+   contain list of commit changes
+
+C++ Style Guide
+~~~~~~~~~~~~~~~
+
+-  Use clang-format
+   `settings <https://github.com/hyperledger/iroha/blob/master/.clang-format>`__
+   file. There are guides available on the internet (e.g. `Kratos
+   wiki <https://github.com/KratosMultiphysics/Kratos/wiki/How-to-configure-clang%E2%80%90format>`__)
+-  Follow
+   `CppCoreGuidelines <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>`__
+   and `Cpp Best
+   Practices <https://lefticus.gitbooks.io/cpp-best-practices>`__.
+-  Avoid
+   `platform-dependent <https://stackoverflow.com/questions/1558194/learning-and-cross-platform-development-c>`__
+   code.
+-  Use `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`__.
+-  Use `camelCase <https://en.wikipedia.org/wiki/Camel_case>`__ for
+   class names and methods, use
+   `snake\_case <https://en.wikipedia.org/wiki/Snake_case>`__ for
+   variables.
+
+Documentation Styleguide
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Use
+   `Doxygen <http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html>`__.
+-  Document all public API: methods, functions, members, templates,
+   classes...
+
+Places where community is active
+--------------------------------
+
+Our community members are active at:
+
++--------------+-------------------------------------------------------------+
+| Service      | Link                                                        |
++==============+=============================================================+
+| RocketChat   | https://chat.hyperledger.org/channel/iroha                  |
++--------------+-------------------------------------------------------------+
+| StackOverflo | https://stackoverflow.com/questions/tagged/hyperledger-iroh |
+| w            | a                                                           |
++--------------+-------------------------------------------------------------+
+| Mailing List | hyperledger-iroha@lists.hyperledger.org                     |
++--------------+-------------------------------------------------------------+
+| Gitter       | https://gitter.im/hyperledger-iroha/Lobby                   |
++--------------+-------------------------------------------------------------+
+| Telegram     | https://t.me/hl\_iroha                                      |
++--------------+-------------------------------------------------------------+
+| YouTube      | https://www.youtube.com/channel/UCYlK9OrZo9hvNYFuf0vrwww    |
++--------------+-------------------------------------------------------------+
+
+--------------
+
+Thank you for reading the document!

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Yes, in [Java](https://github.com/hyperledger/iroha-java), [Python](https://gith
 ### Want to help us develop Iroha?
 
 That's great! 
-Check out [this document](https://github.com/hyperledger/iroha/blob/master/CONTRIBUTING.md)
+Check out [this document](https://github.com/hyperledger/iroha/blob/master/CONTRIBUTING.rst)
 
 ## Need help?
 

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -192,7 +192,7 @@ RUN set -e; \
 # install soci
 RUN set -e; \
     git clone https://github.com/SOCI/soci /tmp/soci; \
-    (cd /tmp/soci ; git checkout 1f2343e32822549df85660c0eb7acea3f0e5ed8d); \
+    (cd /tmp/soci ; git checkout 349ce86b79e63b99ba95200bc4bd1d83791e9094); \
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DSOCI_CXX_C11=ON \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -191,7 +191,7 @@ RUN set -e; \
 # install soci
 RUN set -e; \
     git clone https://github.com/SOCI/soci /tmp/soci; \
-    (cd /tmp/soci ; git checkout 1f2343e32822549df85660c0eb7acea3f0e5ed8d); \
+    (cd /tmp/soci ; git checkout 349ce86b79e63b99ba95200bc4bd1d83791e9094); \
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DSOCI_CXX_C11=ON \

--- a/docs/source/contribution/index.rst
+++ b/docs/source/contribution/index.rst
@@ -1,4 +1,4 @@
 Contribution
 ============
 
-.. mdinclude:: ../../../CONTRIBUTING.md
+.. include:: ../../../CONTRIBUTING.rst

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -5,7 +5,6 @@
 
 #include "multi_sig_transactions/state/mst_state.hpp"
 
-#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,7 +122,7 @@ parts:
       make -C src/include install DESTDIR=$SNAPCRAFT_PART_INSTALL
   soci:
     source: https://github.com/SOCI/soci.git
-    source-commit: 1f2343e32822549df85660c0eb7acea3f0e5ed8d
+    source-commit: 349ce86b79e63b99ba95200bc4bd1d83791e9094
     plugin: cmake
     configflags:
      - -DSOCI_CXX_C11=ON

--- a/test/module/irohad/consensus/yac/supermajority_checker_test.cpp
+++ b/test/module/irohad/consensus/yac/supermajority_checker_test.cpp
@@ -157,7 +157,7 @@ TEST_P(CftAndBftSupermajorityCheckerTest, OneLargeAndManySingleVoteGroups) {
     size_t A; // All peers
   };
 
-  for (const auto &c : std::initializer_list<Case>({{6, 7}, {8, 12}})) {
+  for (const auto &c : std::vector<Case>{{6, 7}, {8, 12}}) {
     log_->info("--------| ProofOfReject(x, {0}, {1}), x in [1..{0}] |---------",
                c.V,
                c.A);


### PR DESCRIPTION
Let's change .md to .rst

### Description of the Change
Change the format from .md to .rst because Table of Contents doesn't work and wrong nesting on [contribution](https://iroha.readthedocs.io/en/latest/contribution/index.html) page.

### Benefits
It will allow us to fix not-working references on [contribution](https://iroha.readthedocs.io/en/latest/contribution/index.html) page. Moreover, it will allow us not to write Table of Contents manually since now it will be generated automatically. Also, with these changes, we have the correct nesting and enumeration of content.
Before:
![image](https://user-images.githubusercontent.com/17848843/58387177-57f63d00-8013-11e9-895a-28fe7ba68bf7.png)
After you apply these commits:
![image](https://user-images.githubusercontent.com/17848843/58387187-8bd16280-8013-11e9-9ac3-c6820462512b.png)


### Possible Drawback
If later you want to change the page you either need to learn .rts format or use auto-converters such as pandoc to make .rts out of .md.