### PR TITLE
Fix mac ci

### DIFF
--- a/.jenkinsci-new/builders/x64-mac-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-mac-build-steps.groovy
@@ -10,7 +10,7 @@
 
 def testSteps(scmVars, String buildDir, List environment, String testList) {
   withEnv(environment) {
-      sh """
+      sh """#!/bin/bash
         export IROHA_POSTGRES_PASSWORD=${IROHA_POSTGRES_PASSWORD}; \
         export IROHA_POSTGRES_USER=${IROHA_POSTGRES_USER}; \
         mkdir -p /var/jenkins/${scmVars.GIT_COMMIT}-${BUILD_NUMBER}; \


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>


### Description of the Change

Recently we changed Jenkins default `shell` from `bash` to empty line to support windows. 
Some build now fail. This pr is aimed to fix it. 

### Benefits

Fix mac ci

### Possible Drawbacks 

None
