### PR TITLE
Enable fuzzing build in CI by default

### DIFF
--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -8,6 +8,10 @@
 // functions we use when build iroha
 //
 
+def removeDirectory(String buildDir) {
+  sh "rm -rf ${buildDir}"
+}
+
 def cmakeConfigure(String buildDir, String cmakeOptions, String sourceTreeDir=".") {
   sh "cmake -H${sourceTreeDir} -B${buildDir} ${cmakeOptions}"
 }

--- a/.jenkinsci-new/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-linux-build-steps.groovy
@@ -98,6 +98,8 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
       utils.ccacheSetup(5)
       for (compiler in compilerVersions) {
         stage ("build ${compiler}"){
+          // Remove artifacts from the previous build
+          build.removeDirectory(buildDir)
           build.cmakeConfigure(buildDir, "-DCMAKE_CXX_COMPILER=${compilers[compiler]['cxx_compiler']} \
             -DCMAKE_C_COMPILER=${compilers[compiler]['cc_compiler']} \
             -DCMAKE_BUILD_TYPE=${build_type} \

--- a/.jenkinsci-new/builders/x64-mac-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-mac-build-steps.groovy
@@ -54,6 +54,8 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
 
     for (compiler in compilerVersions) {
       stage ("build ${compiler}"){
+        // Remove artifacts from the previous build
+        build.removeDirectory(buildDir)
         build.cmakeConfigure(buildDir,
         "-DCMAKE_CXX_COMPILER=${compilers[compiler]['cxx_compiler']} \
         -DCMAKE_C_COMPILER=${compilers[compiler]['cc_compiler']} \

--- a/.jenkinsci-new/builders/x64-mac-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-mac-build-steps.groovy
@@ -35,7 +35,7 @@ def testSteps(scmVars, String buildDir, List environment, String testList) {
 }
 
 def buildSteps(int parallelism, List compilerVersions, String build_type, boolean coverage, boolean testing, String testList,
-       boolean packagebuild, boolean useBTF, List environment) {
+       boolean packagebuild, boolean fuzzing, boolean useBTF, List environment) {
   withEnv(environment) {
     scmVars = checkout scm
     def build = load '.jenkinsci-new/build.groovy'
@@ -60,6 +60,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
         -DCMAKE_BUILD_TYPE=${build_type} \
         -DCOVERAGE=${cmakeBooleanOption[coverage]} \
         -DTESTING=${cmakeBooleanOption[testing]} \
+        -DFUZZING=${cmakeBooleanOption[fuzzing]} \
         -DPACKAGE_TGZ=${cmakeBooleanOption[packagebuild]} \
         -DUSE_BTF=${cmakeBooleanOption[useBTF]} \
         -DLIB_SUFFIX=64 ")

--- a/.jenkinsci-new/text-variables.groovy
+++ b/.jenkinsci-new/text-variables.groovy
@@ -66,7 +66,7 @@ cmd_description = """
          <li>
             <p>Build in parallel. 0 is choose default: 8 for Linux and 4 for Mac</p>
          </li>
-         <li>Ex:&nbsp;cppcheck = flase</li>
+         <li>Ex:&nbsp;parallelism = 2</li>
       </ul>
    </li>
    <li>
@@ -75,7 +75,7 @@ cmd_description = """
          <li>
             <p>Run test for each selected compiler, in jenkins will be several reports</p>
          </li>
-         <li>Ex:&nbsp;cppcheck = flase</li>
+         <li>Ex:&nbsp;testing = false</li>
       </ul>
    </li>
    <li>
@@ -112,13 +112,13 @@ cmd_description = """
       </ul>
    </li>
    <li>
-      <p><span style="color: #ff0000;"><strong>fuzzing</strong></span> = false</p>
+      <p><span style="color: #ff0000;"><strong>fuzzing</strong></span> = true</p>
       <ul>
          <li>
-            <p>builds fuzzing tests, work only with&nbsp;x64linux_compiler_list = ['clang6']</p>
+            <p>builds fuzzing tests</p>
          </li>
          <li>
-            <p>Ex:&nbsp;fuzzing=true; x64linux_compiler_list= ['clang6']; testing = true; testList = "(None)"</p>
+            <p>Ex:&nbsp;fuzzing=true; testing = true; testList = "(None)"</p>
          </li>
       </ul>
    </li>

--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -137,10 +137,10 @@ node ('master') {
 
   testing = true
   testList = '(module)'
+  fuzzing = true // testing = true
 
   sanitize = false
   cppcheck = false
-  fuzzing = false // x64linux_compiler_list= ['clang6']  testing = true testList = "(None)"
   coredumps = true
   sonar = false
   coverage = false
@@ -265,7 +265,7 @@ node ('master') {
     if(specialBranch && build_type == 'Debug'){
       x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
       parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, x64linux_compiler_list, 'Release', specialBranch, false,
-      false , testList, false, false, false, true, false, false, false, false, false, environmentList)}]
+      false, testList, false, false, false, true, false, false, false, false, false, environmentList)}]
     }
     x64LinuxPostSteps = new Builder.PostSteps(
       always: [{x64LinuxBuildScript.alwaysPostSteps(scmVars, environmentList, coredumps)}],
@@ -275,11 +275,11 @@ node ('master') {
   def x64MacBuildPostSteps = new Builder.PostSteps()
   if(!mac_compiler_list.isEmpty()){
     x64MacBuildSteps = [{x64BuildScript.buildSteps(parallelism==0 ?x64MacWorker.cpusAvailable : parallelism,
-      mac_compiler_list, build_type, coverage_mac, testing, testList, packageBuild, useBTF,  environmentList)}]
+      mac_compiler_list, build_type, coverage_mac, testing, testList, packageBuild, fuzzing, useBTF, environmentList)}]
     //If "master" or "dev" also run Release build
     if(specialBranch && build_type == 'Debug'){
       x64MacBuildSteps += [{x64BuildScript.buildSteps(parallelism==0 ?x64MacWorker.cpusAvailable : parallelism,
-        mac_compiler_list, 'Release', false, false, testList, true, false,  environmentList)}]
+        mac_compiler_list, 'Release', false, false, testList, true, false, false, environmentList)}]
     }
     x64MacBuildPostSteps = new Builder.PostSteps(
       always: [{x64BuildScript.alwaysPostSteps(environmentList)}],


### PR DESCRIPTION
### Description of the Change
Enable build of fuzzing targets by default on Linux and Mac, since compiler support was added by @luckychess .

### Benefits
No more pull requests fixing fuzzing targets build

### Possible Drawbacks 
None