### PR TITLE
GetAccountAssets pagination trunk

### DIFF
--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -901,8 +901,9 @@ namespace iroha {
                           shared_model::interface::Amount(amount)));
                     });
             });
+            // TODO mboldyrev 2019.05.17 IR-473 implement pagination
             return query_response_factory_->createAccountAssetResponse(
-                assets, query_hash_);
+                assets, assets.size(), boost::none, query_hash_);
           },
           notEnoughPermissionsResponse(perm_converter_,
                                        Role::kGetMyAccAst,

--- a/shared_model/backend/protobuf/CMakeLists.txt
+++ b/shared_model/backend/protobuf/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(shared_model_proto_backend
     queries/impl/proto_blocks_query.cpp
     queries/impl/proto_query_payload_meta.cpp
     queries/impl/proto_tx_pagination_meta.cpp
+    queries/impl/proto_asset_pagination_meta.cpp
     )
 
 if (IROHA_ROOT_PROJECT)

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -59,9 +59,13 @@ shared_model::proto::ProtoQueryResponseFactory::createAccountAssetResponse(
     std::vector<std::tuple<interface::types::AccountIdType,
                            interface::types::AssetIdType,
                            shared_model::interface::Amount>> assets,
+    size_t total_assets_number,
+    boost::optional<shared_model::interface::types::AssetIdType> next_asset_id,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
-      [assets = std::move(assets)](
+      [assets = std::move(assets),
+       total_assets_number,
+       next_asset_id = std::move(next_asset_id)](
           iroha::protocol::QueryResponse &protocol_query_response) {
         iroha::protocol::AccountAssetResponse *protocol_specific_response =
             protocol_query_response.mutable_account_assets_response();
@@ -70,6 +74,10 @@ shared_model::proto::ProtoQueryResponseFactory::createAccountAssetResponse(
           asset->set_account_id(std::move(std::get<0>(assets.at(i))));
           asset->set_asset_id(std::move(std::get<1>(assets.at(i))));
           asset->set_balance(std::get<2>(assets.at(i)).toStringRepr());
+        }
+        protocol_specific_response->set_total_number(total_assets_number);
+        if (next_asset_id) {
+          protocol_specific_response->set_next_asset_id(*next_asset_id);
         }
       },
       query_hash);

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -17,6 +17,9 @@ namespace shared_model {
           std::vector<std::tuple<interface::types::AccountIdType,
                                  interface::types::AssetIdType,
                                  shared_model::interface::Amount>> assets,
+          size_t total_assets_number,
+          boost::optional<shared_model::interface::types::AssetIdType>
+              next_asset_id,
           const crypto::Hash &query_hash) const override;
 
       std::unique_ptr<interface::QueryResponse> createAccountDetailResponse(

--- a/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
+
+namespace types = shared_model::interface::types;
+
+using namespace shared_model::proto;
+
+AssetPaginationMeta::AssetPaginationMeta(const TransportType &query)
+    : CopyableProto(query) {}
+
+AssetPaginationMeta::AssetPaginationMeta(TransportType &&query)
+    : CopyableProto(std::move(query)) {}
+
+AssetPaginationMeta::AssetPaginationMeta(const AssetPaginationMeta &o)
+    : AssetPaginationMeta(*o.proto_) {}
+
+AssetPaginationMeta::AssetPaginationMeta(AssetPaginationMeta &&o) noexcept
+    : CopyableProto(std::move(*o.proto_)) {}
+
+types::TransactionsNumberType AssetPaginationMeta::pageSize() const {
+  return proto_->page_size();
+}
+
+boost::optional<types::AssetIdType> AssetPaginationMeta::firstAssetId() const {
+  if (proto_->opt_first_asset_id_case()
+      == TransportType::OptFirstAssetIdCase::OPT_FIRST_ASSET_ID_NOT_SET) {
+    return boost::none;
+  }
+  return proto_->first_asset_id();
+}

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
@@ -11,7 +11,16 @@ namespace shared_model {
     template <typename QueryType>
     GetAccountAssets::GetAccountAssets(QueryType &&query)
         : CopyableProto(std::forward<QueryType>(query)),
-          account_assets_{proto_->payload().get_account_assets()} {}
+          account_assets_{proto_->payload().get_account_assets()},
+          pagination_meta_{
+              [this]() -> boost::optional<const AssetPaginationMeta> {
+                if (this->account_assets_.has_pagination_meta()) {
+                  return AssetPaginationMeta{
+                      this->account_assets_.pagination_meta()};
+                } else {
+                  return boost::none;
+                }
+              }()} {}
 
     template GetAccountAssets::GetAccountAssets(
         GetAccountAssets::TransportType &);
@@ -28,6 +37,14 @@ namespace shared_model {
 
     const interface::types::AccountIdType &GetAccountAssets::accountId() const {
       return account_assets_.account_id();
+    }
+
+    boost::optional<const interface::AssetPaginationMeta &>
+    GetAccountAssets::paginationMeta() const {
+      if (pagination_meta_) {
+        return pagination_meta_.value();
+      }
+      return boost::none;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_PROTO_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
+#define IROHA_SHARED_PROTO_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
+
+#include "interfaces/queries/asset_pagination_meta.hpp"
+
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "queries.pb.h"
+
+namespace shared_model {
+  namespace proto {
+
+    /// Provides query metadata for AccountAsset list pagination.
+    class AssetPaginationMeta final
+        : public CopyableProto<interface::AssetPaginationMeta,
+                               iroha::protocol::AssetPaginationMeta,
+                               AssetPaginationMeta> {
+     public:
+      explicit AssetPaginationMeta(const TransportType &query);
+      explicit AssetPaginationMeta(TransportType &&query);
+      AssetPaginationMeta(const AssetPaginationMeta &o);
+      AssetPaginationMeta(AssetPaginationMeta &&o) noexcept;
+
+      interface::types::TransactionsNumberType pageSize() const override;
+
+      boost::optional<interface::types::AssetIdType> firstAssetId()
+          const override;
+    };
+  }  // namespace proto
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_PROTO_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP

--- a/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
@@ -6,8 +6,10 @@
 #ifndef IROHA_PROTO_GET_ACCOUNT_ASSETS_H
 #define IROHA_PROTO_GET_ACCOUNT_ASSETS_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_account_assets.hpp"
+
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
@@ -26,10 +28,14 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
+      boost::optional<const interface::AssetPaginationMeta &> paginationMeta()
+          const override;
+
      private:
       // ------------------------------| fields |-------------------------------
 
       const iroha::protocol::GetAccountAssets &account_assets_;
+      const boost::optional<const AssetPaginationMeta> pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
@@ -14,7 +14,14 @@ namespace shared_model {
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           account_asset_response_{proto_->account_assets_response()},
           account_assets_{account_asset_response_.account_assets().begin(),
-                          account_asset_response_.account_assets().end()} {}
+                          account_asset_response_.account_assets().end()},
+          next_asset_id_{[this]() -> decltype(next_asset_id_) {
+            if (account_asset_response_.opt_next_asset_id_case()
+                == iroha::protocol::AccountAssetResponse::kNextAssetId) {
+              return this->account_asset_response_.next_asset_id();
+            }
+            return boost::none;
+          }()} {}
 
     template AccountAssetResponse::AccountAssetResponse(
         AccountAssetResponse::TransportType &);
@@ -32,6 +39,15 @@ namespace shared_model {
     const interface::types::AccountAssetCollectionType
     AccountAssetResponse::accountAssets() const {
       return account_assets_;
+    }
+
+    boost::optional<interface::types::AssetIdType>
+    AccountAssetResponse::nextAssetId() const {
+      return next_asset_id_;
+    }
+
+    size_t AccountAssetResponse::totalAccountAssetsNumber() const {
+      return account_asset_response_.total_number();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -7,6 +7,7 @@
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_ASSET_RESPONSE_HPP
 
 #include "backend/protobuf/common_objects/account_asset.hpp"
+
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
@@ -29,10 +30,15 @@ namespace shared_model {
       const interface::types::AccountAssetCollectionType accountAssets()
           const override;
 
+      boost::optional<interface::types::AssetIdType> nextAssetId() const override;
+
+      size_t totalAccountAssetsNumber() const override;
+
      private:
       const iroha::protocol::AccountAssetResponse &account_asset_response_;
 
       const std::vector<AccountAsset> account_assets_;
+      const boost::optional<interface::types::AssetIdType> next_asset_id_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -165,11 +165,19 @@ namespace shared_model {
         });
       }
 
-      auto getAccountAssets(const interface::types::AccountIdType &account_id)
-          const {
+      auto getAccountAssets(
+          const interface::types::AccountIdType &account_id,
+          size_t page_size,
+          boost::optional<shared_model::interface::types::AssetIdType>
+              first_asset_id) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_assets();
           query->set_account_id(account_id);
+          auto pagination_meta = query->mutable_pagination_meta();
+          pagination_meta->set_page_size(page_size);
+          if (first_asset_id) {
+            pagination_meta->set_first_asset_id(*first_asset_id);
+          }
         });
       }
 

--- a/shared_model/interfaces/CMakeLists.txt
+++ b/shared_model/interfaces/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(shared_model_interfaces
     queries/impl/blocks_query.cpp
     queries/impl/query_payload_meta.cpp
     queries/impl/tx_pagination_meta.cpp
+    queries/impl/asset_pagination_meta.cpp
     common_objects/impl/amount.cpp
     common_objects/impl/signature.cpp
     common_objects/impl/peer.cpp

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include <boost/optional.hpp>
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/asset.hpp"
 #include "interfaces/permissions.hpp"
@@ -38,6 +39,10 @@ namespace shared_model {
       /**
        * Create response for account asset query
        * @param assets to be inserted into the response
+       * @param total_assets_number the number of all assets as opposed to the
+       * page size
+       * @param next_asset_id if there are more assets ofter the provided ones,
+       * this specifies the id of the first following asset; otherwise none
        * @param query_hash - hash of the query, for which response is created
        * @return account asset response
        */
@@ -45,6 +50,9 @@ namespace shared_model {
           std::vector<std::tuple<types::AccountIdType,
                                  types::AssetIdType,
                                  shared_model::interface::Amount>> assets,
+          size_t total_assets_number,
+          boost::optional<shared_model::interface::types::AssetIdType>
+              next_asset_id,
           const crypto::Hash &query_hash) const = 0;
 
       /**

--- a/shared_model/interfaces/queries/asset_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/asset_pagination_meta.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
+#define IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
+
+#include <boost/optional.hpp>
+#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+
+    /// Provides query metadata for asset list pagination.
+    class AssetPaginationMeta : public ModelPrimitive<AssetPaginationMeta> {
+     public:
+
+      /// Get the requested page size.
+      virtual types::TransactionsNumberType pageSize() const = 0;
+
+      /// Get the first requested asset, if provided.
+      virtual boost::optional<types::AssetIdType> firstAssetId() const = 0;
+
+      std::string toString() const override;
+
+      bool operator==(const ModelType &rhs) const override;
+    };
+
+  }  // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP

--- a/shared_model/interfaces/queries/get_account_assets.hpp
+++ b/shared_model/interfaces/queries/get_account_assets.hpp
@@ -6,11 +6,14 @@
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_ASSETS_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_ASSETS_HPP
 
+#include <boost/optional.hpp>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
   namespace interface {
+    class AssetPaginationMeta;
+
     /**
      * Query for get all account's assets and balance
      */
@@ -20,6 +23,11 @@ namespace shared_model {
        * @return account identifier
        */
       virtual const types::AccountIdType &accountId() const = 0;
+
+      /// Get the query pagination metadata.
+      // TODO 2019.05.24 mboldyrev IR-516 remove optional
+      virtual boost::optional<const interface::AssetPaginationMeta &>
+      paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/impl/asset_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/asset_pagination_meta.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "interfaces/queries/asset_pagination_meta.hpp"
+
+using namespace shared_model::interface;
+
+bool AssetPaginationMeta::operator==(const ModelType &rhs) const {
+  return pageSize() == rhs.pageSize() and firstAssetId() == rhs.firstAssetId();
+}
+
+std::string AssetPaginationMeta::toString() const {
+  return detail::PrettyStringBuilder()
+      .init("AssetPaginationMeta")
+      .append("page_size", std::to_string(pageSize()))
+      .append("first_asset_id", firstAssetId().value_or("(none)"))
+      .finalize();
+}

--- a/shared_model/interfaces/queries/impl/get_account_assets.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_assets.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/queries/get_account_assets.hpp"
 
+#include "interfaces/queries/asset_pagination_meta.hpp"
+
 namespace shared_model {
   namespace interface {
 
@@ -12,6 +14,8 @@ namespace shared_model {
       return detail::PrettyStringBuilder()
           .init("GetAccountAssets")
           .append("account_id", accountId())
+          .append("pagination_meta",
+                  paginationMeta() ? paginationMeta()->toString() : "(not set)")
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/account_asset_response.hpp
+++ b/shared_model/interfaces/query_responses/account_asset_response.hpp
@@ -6,6 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_ACCOUNT_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ACCOUNT_ASSET_RESPONSE_HPP
 
+#include <boost/optional.hpp>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/account_asset.hpp"
 #include "interfaces/common_objects/range_types.hpp"
@@ -21,6 +22,10 @@ namespace shared_model {
        * @return Account has Asset model
        */
       virtual const types::AccountAssetCollectionType accountAssets() const = 0;
+
+      virtual boost::optional<types::AssetIdType> nextAssetId() const = 0;
+
+      virtual size_t totalAccountAssetsNumber() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/query_responses/impl/account_asset_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/account_asset_response.cpp
@@ -10,15 +10,20 @@ namespace shared_model {
   namespace interface {
 
     std::string AccountAssetResponse::toString() const {
-      auto response =
-          detail::PrettyStringBuilder().init("AccountAssetResponse");
-      for (const auto &asset : accountAssets())
-        response.append(asset.toString());
-      return response.finalize();
+      return detail::PrettyStringBuilder()
+          .init("AccountAssetResponse")
+          .appendAll(
+              "assets", accountAssets(), [](auto &tx) { return tx.toString(); })
+          .append("total assets number",
+                  std::to_string(totalAccountAssetsNumber()))
+          .append("next asset id", nextAssetId().value_or("(none)"))
+          .finalize();
     }
 
     bool AccountAssetResponse::operator==(const ModelType &rhs) const {
-      return accountAssets() == rhs.accountAssets();
+      return accountAssets() == rhs.accountAssets()
+          and totalAccountAssetsNumber() == rhs.totalAccountAssetsNumber()
+          and nextAssetId() == rhs.nextAssetId();
     }
 
   }  // namespace interface

--- a/shared_model/schema/qry_responses.proto
+++ b/shared_model/schema/qry_responses.proto
@@ -37,6 +37,10 @@ message AccountAsset {
 // *** Responses *** //
 message AccountAssetResponse {
   repeated AccountAsset account_assets = 1;
+  uint32 total_number = 2;
+  oneof opt_next_asset_id {
+    string next_asset_id = 3;
+  }
 }
 
 message AccountDetailResponse {

--- a/shared_model/schema/queries.proto
+++ b/shared_model/schema/queries.proto
@@ -15,6 +15,13 @@ message TxPaginationMeta {
   }
 }
 
+message AssetPaginationMeta {
+  uint32 page_size = 1;
+  oneof opt_first_asset_id {
+    string first_asset_id = 2;
+  }
+}
+
 message GetAccount {
   string account_id = 1;
 }
@@ -44,6 +51,7 @@ message GetTransactions {
 
 message GetAccountAssets {
   string account_id = 1;
+  AssetPaginationMeta pagination_meta = 2;
 }
 
 message GetAccountDetail {

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -13,6 +13,7 @@
 #include "cryptography/crypto_provider/crypto_verifier.hpp"
 #include "interfaces/common_objects/amount.hpp"
 #include "interfaces/common_objects/peer.hpp"
+#include "interfaces/queries/asset_pagination_meta.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
 #include "validators/field_validator.hpp"
@@ -385,10 +386,8 @@ namespace shared_model {
       return boost::none;
     }
 
-    void FieldValidator::validateTxPaginationMeta(
-        ReasonsGroupType &reason,
-        const interface::TxPaginationMeta &tx_pagination_meta) const {
-      const auto page_size = tx_pagination_meta.pageSize();
+    void validatePaginationMetaPageSize(ReasonsGroupType &reason,
+                                        const size_t &page_size) {
       if (page_size <= 0) {
         reason.second.push_back(
             (boost::format(
@@ -396,9 +395,25 @@ namespace shared_model {
              % (page_size == 0 ? "zero" : "negative") % page_size)
                 .str());
       }
+    }
+
+    void FieldValidator::validateTxPaginationMeta(
+        ReasonsGroupType &reason,
+        const interface::TxPaginationMeta &tx_pagination_meta) const {
+      validatePaginationMetaPageSize(reason, tx_pagination_meta.pageSize());
       const auto first_hash = tx_pagination_meta.firstTxHash();
       if (first_hash) {
         validateHash(reason, *first_hash);
+      }
+    }
+
+    void FieldValidator::validateAssetPaginationMeta(
+        ReasonsGroupType &reason,
+        const interface::AssetPaginationMeta &asset_pagination_meta) const {
+      validatePaginationMetaPageSize(reason, asset_pagination_meta.pageSize());
+      const auto first_asset_id = asset_pagination_meta.firstAssetId();
+      if (first_asset_id) {
+        validateAssetId(reason, *first_asset_id);
       }
     }
 

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -21,6 +21,7 @@ namespace shared_model {
     class Amount;
     class BatchMeta;
     class Peer;
+    class AssetPaginationMeta;
     class TxPaginationMeta;
   }  // namespace interface
 
@@ -168,6 +169,10 @@ namespace shared_model {
       void validateTxPaginationMeta(
           ReasonsGroupType &reason,
           const interface::TxPaginationMeta &tx_pagination_meta) const;
+
+      void validateAssetPaginationMeta(
+          ReasonsGroupType &reason,
+          const interface::AssetPaginationMeta &asset_pagination_meta) const;
 
      private:
       const static std::string account_name_pattern_;

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -116,6 +116,9 @@ namespace shared_model {
         reason.first = "GetAccountAssets";
 
         validator_.validateAccountId(reason, qry.accountId());
+        if (qry.paginationMeta()) {
+          validator_.validateAssetPaginationMeta(reason, *qry.paginationMeta());
+        }
         return reason;
       }
 

--- a/test/framework/common_constants.hpp
+++ b/test/framework/common_constants.hpp
@@ -6,10 +6,12 @@
 #ifndef IROHA_TEST_FRAMEWORK_COMMON_CONSTANTS_HPP_
 #define IROHA_TEST_FRAMEWORK_COMMON_CONSTANTS_HPP_
 
+#include <limits>
 #include <string>
 
 #include "cryptography/keypair.hpp"
 
+static const uint32_t kMaxPageSize = std::numeric_limits<uint32_t>::max();
 using shared_model::crypto::Keypair;
 
 namespace common_constants {

--- a/test/integration/acceptance/query_permission_test_ast.cpp
+++ b/test/integration/acceptance/query_permission_test_ast.cpp
@@ -5,6 +5,7 @@
 
 #include "integration/acceptance/query_permission_test_ast.hpp"
 
+#include "framework/common_constants.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
 
 using shared_model::interface::Amount;
@@ -79,6 +80,7 @@ shared_model::proto::Query QueryPermissionAssets::makeQuery(
     const interface::types::AccountIdType &target,
     const interface::types::AccountIdType &spectator,
     const crypto::Keypair &spectator_keypair) {
-  return fixture.complete(fixture.baseQry(spectator).getAccountAssets(target),
+  return fixture.complete(fixture.baseQry(spectator).getAccountAssets(
+                              target, kMaxPageSize, boost::none),
                           spectator_keypair);
 }

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -9,6 +9,7 @@
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
+#include "framework/common_constants.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
@@ -402,7 +403,7 @@ TEST_F(TransferAsset, BigPrecision) {
   auto make_query = [this](std::string account_id) {
     return baseQry()
         .creatorAccountId(kAdminId)
-        .getAccountAssets(account_id)
+        .getAccountAssets(account_id, kMaxPageSize, boost::none)
         .build()
         .signAndAddSignature(kAdminKeypair)
         .finish();

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -19,6 +19,7 @@
 #include "ametsuchi/mutable_storage.hpp"
 #include "backend/protobuf/proto_query_response_factory.hpp"
 #include "datetime/time.hpp"
+#include "framework/common_constants.hpp"
 #include "framework/result_fixture.hpp"
 #include "framework/test_logger.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -517,7 +518,7 @@ namespace iroha {
       addPerms({shared_model::interface::permissions::Role::kGetMyAccAst});
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
-                       .getAccountAssets(account_id)
+                       .getAccountAssets(account_id, kMaxPageSize, boost::none)
                        .build();
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
@@ -536,7 +537,7 @@ namespace iroha {
       addPerms({shared_model::interface::permissions::Role::kGetAllAccAst});
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
-                       .getAccountAssets(account_id2)
+                       .getAccountAssets(account_id2, kMaxPageSize, boost::none)
                        .build();
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
@@ -555,7 +556,7 @@ namespace iroha {
       addPerms({shared_model::interface::permissions::Role::kGetDomainAccAst});
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
-                       .getAccountAssets(account_id2)
+                       .getAccountAssets(account_id2, kMaxPageSize, boost::none)
                        .build();
       auto result = executeQuery(query);
       checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
@@ -572,10 +573,11 @@ namespace iroha {
      */
     TEST_F(GetAccountAssetExecutorTest, InvalidDifferentDomain) {
       addPerms({shared_model::interface::permissions::Role::kGetDomainAccAst});
-      auto query = TestQueryBuilder()
-                       .creatorAccountId(account_id)
-                       .getAccountAssets(another_account_id)
-                       .build();
+      auto query =
+          TestQueryBuilder()
+              .creatorAccountId(account_id)
+              .getAccountAssets(another_account_id, kMaxPageSize, boost::none)
+              .build();
       auto result = executeQuery(query);
       checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
           std::move(result), kNoPermissions);
@@ -588,10 +590,11 @@ namespace iroha {
      */
     TEST_F(GetAccountAssetExecutorTest, DISABLED_InvalidNoAccount) {
       addPerms({shared_model::interface::permissions::Role::kGetAllAccAst});
-      auto query = TestQueryBuilder()
-                       .creatorAccountId(account_id)
-                       .getAccountAssets("some@domain")
-                       .build();
+      auto query =
+          TestQueryBuilder()
+              .creatorAccountId(account_id)
+              .getAccountAssets("some@domain", kMaxPageSize, boost::none)
+              .build();
       auto result = executeQuery(query);
       checkStatefulError<shared_model::interface::NoAccountAssetsErrorResponse>(
           std::move(result), kNoStatefulError);

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -33,6 +33,7 @@
 #include "torii/query_client.hpp"
 #include "torii/query_service.hpp"
 #include "utils/query_error_response_visitor.hpp"
+#include "framework/common_constants.hpp"
 
 constexpr size_t TimesFind = 1;
 static constexpr shared_model::interface::types::TransactionsNumberType
@@ -350,14 +351,15 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   iroha::protocol::QueryResponse response;
 
-  auto model_query = shared_model::proto::QueryBuilder()
-                         .creatorAccountId(creator)
-                         .queryCounter(1)
-                         .createdTime(iroha::time::now())
-                         .getAccountAssets(accountb_id)
-                         .build()
-                         .signAndAddSignature(pair)
-                         .finish();
+  auto model_query =
+      shared_model::proto::QueryBuilder()
+          .creatorAccountId(creator)
+          .queryCounter(1)
+          .createdTime(iroha::time::now())
+          .getAccountAssets(accountb_id, kMaxPageSize, boost::none)
+          .build()
+          .signAndAddSignature(pair)
+          .finish();
 
   auto *r = query_response_factory
                 ->createErrorQueryResponse(
@@ -396,7 +398,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
                          .creatorAccountId(creator)
                          .queryCounter(1)
                          .createdTime(iroha::time::now())
-                         .getAccountAssets(creator)
+                         .getAccountAssets(creator, kMaxPageSize, boost::none)
                          .build()
                          .signAndAddSignature(pair)
                          .finish();

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -409,7 +409,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
       assets;
   assets.push_back(std::make_tuple(account_id, asset_id, amount));
   auto *r = query_response_factory
-                ->createAccountAssetResponse(assets, model_query.hash())
+                ->createAccountAssetResponse(
+                    assets, assets.size(), boost::none, model_query.hash())
                 .release();
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))

--- a/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
@@ -92,8 +92,8 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateAccountAssetResponse) {
                         shared_model::interface::Amount(std::to_string(i))));
   }
 
-  query_responses.push_back(
-      response_factory->createAccountAssetResponse(assets, kQueryHash));
+  query_responses.push_back(response_factory->createAccountAssetResponse(
+      assets, assets.size(), boost::none, kQueryHash));
 
   for (auto &query_response : query_responses) {
     ASSERT_TRUE(query_response);

--- a/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/irange.hpp>
+#include "framework/common_constants.hpp"
 
 /**
  * For each protobuf query type
@@ -50,6 +51,9 @@ TEST(ProtoQueryBuilder, Builder) {
   {
     auto &query = *payload.mutable_get_account_assets();
     query.set_account_id(account_id);
+    auto pagination_meta = query.mutable_pagination_meta();
+    pagination_meta->set_page_size(kMaxPageSize);
+    pagination_meta->set_first_asset_id(asset_id);
   }
 
   auto keypair =
@@ -65,7 +69,7 @@ TEST(ProtoQueryBuilder, Builder) {
   auto query = shared_model::proto::QueryBuilder()
                    .createdTime(created_time)
                    .creatorAccountId(account_id)
-                   .getAccountAssets(account_id)
+                   .getAccountAssets(account_id, kMaxPageSize, asset_id)
                    .queryCounter(query_counter)
                    .build();
 

--- a/test/module/shared_model/validators/query_validator_test.cpp
+++ b/test/module/shared_model/validators/query_validator_test.cpp
@@ -44,9 +44,10 @@ TEST_F(QueryValidatorTest, StatelessValidTest) {
       [this](auto field, auto query) {
         // Will throw key exception in case new field is added
         try {
-          field_setters.at(field->name())(query->GetReflection(), query, field);
+          field_setters.at(field->full_name())(
+              query->GetReflection(), query, field);
         } catch (const std::out_of_range &e) {
-          FAIL() << "Missing field setter: " << field->name();
+          FAIL() << "Missing field setter: " << field->full_name();
         }
       },
       [&] {

--- a/test/module/shared_model/validators/transaction_validator_test.cpp
+++ b/test/module/shared_model/validators/transaction_validator_test.cpp
@@ -74,8 +74,12 @@ TEST_F(TransactionValidatorTest, StatelessValidTest) {
       },
       [this](auto field, auto command) {
         // Will throw key exception in case new field is added
-        field_setters.at(field->name())(
-            command->GetReflection(), command, field);
+        try {
+          field_setters.at(field->full_name())(
+              command->GetReflection(), command, field);
+        } catch (const std::out_of_range &e) {
+          FAIL() << "Missing field setter: " << field->full_name();
+        }
       },
       [] {});
 

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -36,38 +36,77 @@ class ValidatorsTest : public ::testing::Test {
     auto addEnum = setField(&google::protobuf::Reflection::AddEnumValue);
     auto setEnum = setField(&google::protobuf::Reflection::SetEnumValue);
 
-    for (const auto &id : {"account_id", "src_account_id"}) {
-      field_setters[id] = setString(account_id);
-    }
-    for (const auto &id : {"role_name", "default_role", "role_id"}) {
-      field_setters[id] = setString(role_name);
-    }
-    field_setters["public_key"] = setString(public_key);
-    field_setters["dest_account_id"] = setString(dest_id);
-    field_setters["asset_id"] = setString(asset_id);
-    field_setters["account_name"] = setString(account_name);
-    field_setters["domain_id"] = setString(domain_id);
-    field_setters["asset_name"] = setString(asset_name);
-    field_setters["precision"] = setUInt32(precision);
-    field_setters["permissions"] = addEnum(role_permission);
-    field_setters["grantable_permissions"] = addEnum(grantable_permission);
-    field_setters["permission"] = setEnum(role_permission);
-    field_setters["grantable_permission"] = setEnum(grantable_permission);
-    field_setters["key"] = setString(detail_key);
-    field_setters["writer"] = setString(writer);
-    field_setters["detail"] = setString(detail_key);
-    field_setters["value"] = setString("");
-    field_setters["tx_hashes"] = addString(hash);
-    field_setters["quorum"] = setUInt32(quorum);
-    field_setters["description"] = setString("");
-    field_setters["amount"] = setString(amount);
-    field_setters["peer"] = [&](auto refl, auto msg, auto field) {
-      refl->MutableMessage(msg, field)->CopyFrom(peer);
-    };
-    field_setters["pagination_meta"] = [&](auto refl, auto msg, auto field) {
-      refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
-    };
-    field_setters["height"] = setUInt64(height);
+    field_setters = {
+        {"iroha.protocol.GetAccount.account_id", setString(account_id)},
+        {"iroha.protocol.GetSignatories.account_id", setString(account_id)},
+        {"iroha.protocol.GetAccountTransactions.account_id",
+         setString(account_id)},
+        {"iroha.protocol.GetAccountAssetTransactions.account_id",
+         setString(account_id)},
+        {"iroha.protocol.GetAccountAssets.account_id", setString(account_id)},
+        {"iroha.protocol.GetAccountDetail.account_id", setString(account_id)},
+        {"iroha.protocol.TransferAsset.src_account_id", setString(account_id)},
+        {"iroha.protocol.AddSignatory.account_id", setString(account_id)},
+        {"iroha.protocol.AppendRole.account_id", setString(account_id)},
+        {"iroha.protocol.DetachRole.account_id", setString(account_id)},
+        {"iroha.protocol.GrantPermission.account_id", setString(account_id)},
+        {"iroha.protocol.RemoveSignatory.account_id", setString(account_id)},
+        {"iroha.protocol.RevokePermission.account_id", setString(account_id)},
+        {"iroha.protocol.SetAccountDetail.account_id", setString(account_id)},
+        {"iroha.protocol.SetAccountQuorum.account_id", setString(account_id)},
+        {"iroha.protocol.AppendRole.role_name", setString(role_name)},
+        {"iroha.protocol.DetachRole.role_name", setString(role_name)},
+        {"iroha.protocol.CreateRole.role_name", setString(role_name)},
+        {"iroha.protocol.CreateDomain.default_role", setString(role_name)},
+        {"iroha.protocol.GetRolePermissions.role_id", setString(role_name)},
+        {"iroha.protocol.AddSignatory.public_key", setString(public_key)},
+        {"iroha.protocol.CreateAccount.public_key", setString(public_key)},
+        {"iroha.protocol.RemoveSignatory.public_key", setString(public_key)},
+        {"iroha.protocol.TransferAsset.dest_account_id", setString(dest_id)},
+        {"iroha.protocol.AddAssetQuantity.asset_id", setString(asset_id)},
+        {"iroha.protocol.TransferAsset.asset_id", setString(asset_id)},
+        {"iroha.protocol.SubtractAssetQuantity.asset_id", setString(asset_id)},
+        {"iroha.protocol.GetAccountAssetTransactions.asset_id",
+         setString(asset_id)},
+        {"iroha.protocol.GetAssetInfo.asset_id", setString(asset_id)},
+        {"iroha.protocol.CreateAccount.account_name", setString(account_name)},
+        {"iroha.protocol.CreateAsset.domain_id", setString(domain_id)},
+        {"iroha.protocol.CreateAccount.domain_id", setString(domain_id)},
+        {"iroha.protocol.CreateDomain.domain_id", setString(domain_id)},
+        {"iroha.protocol.CreateAsset.asset_name", setString(asset_name)},
+        {"iroha.protocol.CreateAsset.precision", setUInt32(precision)},
+        {"iroha.protocol.CreateRole.permissions", addEnum(role_permission)},
+        {"iroha.protocol.GrantPermission.permission",
+         setEnum(grantable_permission)},
+        {"iroha.protocol.RevokePermission.permission",
+         setEnum(grantable_permission)},
+        {"iroha.protocol.SetAccountDetail.key", setString(detail_key)},
+        {"iroha.protocol.GetAccountDetail.key", setString(detail_key)},
+        {"iroha.protocol.GetAccountDetail.writer", setString(writer)},
+        {"iroha.protocol.SetAccountDetail.value", setString("")},
+        {"iroha.protocol.GetTransactions.tx_hashes", addString(hash)},
+        {"iroha.protocol.SetAccountQuorum.quorum", setUInt32(quorum)},
+        {"iroha.protocol.TransferAsset.description", setString("")},
+        {"iroha.protocol.AddAssetQuantity.amount", setString(amount)},
+        {"iroha.protocol.TransferAsset.amount", setString(amount)},
+        {"iroha.protocol.SubtractAssetQuantity.amount", setString(amount)},
+        {"iroha.protocol.AddPeer.peer",
+         [&](auto refl, auto msg, auto field) {
+           refl->MutableMessage(msg, field)->CopyFrom(peer);
+         }},
+        {"iroha.protocol.GetAccountTransactions.pagination_meta",
+         [&](auto refl, auto msg, auto field) {
+           refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
+         }},
+        {"iroha.protocol.GetAccountAssetTransactions.pagination_meta",
+         [&](auto refl, auto msg, auto field) {
+           refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
+         }},
+        {"iroha.protocol.GetAccountAssets.pagination_meta",
+         [&](auto refl, auto msg, auto field) {
+           refl->MutableMessage(msg, field)->CopyFrom(assets_pagination_meta);
+         }},
+        {"iroha.protocol.GetBlock.height", setUInt64(height)}};
   }
 
   /**
@@ -190,6 +229,7 @@ class ValidatorsTest : public ::testing::Test {
     peer.set_address(address_localhost);
     peer.set_peer_key(public_key);
     tx_pagination_meta.set_page_size(10);
+    assets_pagination_meta.set_page_size(10);
   }
 
   size_t public_key_size{0};
@@ -224,6 +264,7 @@ class ValidatorsTest : public ::testing::Test {
   decltype(iroha::time::now()) created_time;
   iroha::protocol::QueryPayloadMeta meta;
   iroha::protocol::TxPaginationMeta tx_pagination_meta;
+  iroha::protocol::AssetPaginationMeta assets_pagination_meta;
 
   // List all used fields in commands
   std::unordered_map<


### PR DESCRIPTION

[IR-473](https://jira.hyperledger.org/browse/IR-473)
[POW-090](https://soramitsu.atlassian.net/wiki/spaces/IS/pages/1120239703/POW+N+090+AccountAsset+Pagination)

### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

GetAccountAssets pagination!

From now on GetAccountAssets query without pagination meta is considered deprecated.

### Benefits

GetAccountAssets gets paginatied!

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
