### PR TITLE
Ordering init: removed peer query from ordering peers map

### DIFF
--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -451,7 +451,6 @@ Irohad::RunResult Irohad::initOrderingGate() {
       ordering_init.initOrderingGate(max_proposal_size_,
                                      proposal_delay_,
                                      std::move(hashes),
-                                     storage,
                                      transaction_factory,
                                      batch_parser,
                                      transaction_batch_factory_,

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -8,7 +8,6 @@
 
 #include <random>
 
-#include "ametsuchi/peer_query_factory.hpp"
 #include "ametsuchi/storage.hpp"
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
@@ -54,7 +53,6 @@ namespace iroha {
        * parameters
        */
       auto createConnectionManager(
-          std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
               async_call,
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,
@@ -107,8 +105,6 @@ namespace iroha {
        * @param delay timeout for ordering service response on proposal request
        * @param initial_hashes seeds for peer list permutations for first k
        * rounds they are required since hash of block i defines round i + k
-       * @param peer_query_factory factory for getLedgerPeers query required by
-       * connection manager
        * @param transaction_factory transport factory for transactions required
        * by ordering service network endpoint
        * @param batch_parser transaction batch parser required by ordering
@@ -125,8 +121,6 @@ namespace iroha {
           size_t max_number_of_transactions,
           std::chrono::milliseconds delay,
           std::vector<shared_model::interface::types::HashType> initial_hashes,
-          // TODO 30.01.2019 lebdron: IR-263 Remove PeerQueryFactory
-          std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
           std::shared_ptr<
               ordering::transport::OnDemandOsServerGrpc::TransportFactoryType>
               transaction_factory,


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Removed unneeded call to peer query in ordering creator. Current peers can be obtained from ledger state object.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Performance & Simplicity

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

someobody's piece of hard work, 23 lines of well-formatted code, are put to the edge of extinction by 5 arrogant lines

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
