### PR TITLE
Refactor/result bind

### DIFF
--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -76,7 +76,7 @@ namespace {
     auto top_height = block_query->getTopBlockHeight();
     for (decltype(top_height) i = 1; i <= top_height; ++i) {
       auto block_result = block_query->getBlock(i);
-      auto result = block_result | [&mutable_storage](auto &&block)
+      auto result = std::move(block_result) | [&mutable_storage](auto &&block)
           -> iroha::expected::Result<void, std::string> {
         if (not mutable_storage->apply(std::move(block))) {
           return iroha::expected::makeError("Cannot apply "
@@ -103,9 +103,8 @@ namespace iroha {
     WsvRestorerImpl::restoreWsv(Storage &storage) {
       BlockStorageStubFactory storage_factory;
 
-      auto mutable_storage_result =
-          storage.createMutableStorage(storage_factory);
-      return mutable_storage_result | [&storage](auto &&mutable_storage)
+      return storage.createMutableStorage(storage_factory) |
+                 [&storage](auto &&mutable_storage)
                  -> iroha::expected::Result<
                      boost::optional<std::unique_ptr<iroha::LedgerState>>,
                      std::string> {

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -11,6 +11,7 @@
 #include <grpc++/grpc++.h>
 #include "ametsuchi/storage.hpp"
 #include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"
+#include "common/bind.hpp"
 #include "common/irohad_version.hpp"
 #include "common/result.hpp"
 #include "crypto/keys_manager_impl.hpp"
@@ -281,9 +282,8 @@ int main(int argc, char *argv[]) {
     log->error("Cannot create BlockQuery");
     return EXIT_FAILURE;
   }
-  auto blocks_exist = block_query->getBlock(block_query->getTopBlockHeight())
-                          .match([](const auto &) { return true; },
-                                 [](const auto &) { return false; });
+  const bool blocks_exist{iroha::expected::hasValue(
+      block_query->getBlock(block_query->getTopBlockHeight()))};
   block_query.reset();
 
   if (not blocks_exist) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Now the bound transformation function may return one of: `Result`, `Value` or any other unwrapped value that is treated like a `Value`. Also, a rvalue-reference binding specialization is added. Two functions to convert a `Result`'s `Error` or `Value` to `boost::optional` are added.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Hopefully allows to write a simpler code.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

More code to maintain.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
