### PR TITLE
ametsuchi: use a default database name when user does not provide one

### DIFF
--- a/docs/source/guides/configuration.rst
+++ b/docs/source/guides/configuration.rst
@@ -13,7 +13,7 @@ at ``example/config.sample``
     "block_store_path": "/tmp/block_store/",
     "torii_port": 50051,
     "internal_port": 10001,
-    "pg_opt": "host=localhost port=5432 user=postgres password=mysecretpassword",
+    "pg_opt": "host=localhost port=5432 user=postgres password=mysecretpassword dbname=iroha",
     "max_proposal_size": 10,
     "proposal_delay": 5000,
     "vote_delay": 5000,
@@ -35,9 +35,13 @@ Deployment-specific parameters
 - ``internal_port`` sets the port for internal communications: ordering
   service, consensus and block loader.
 - ``pg_opt`` is used for setting credentials of PostgreSQL: hostname, port,
-  username and password.
+  username, password and database name.
+  All data except the database name are mandatory.
+  If database name is not provided, a default one gets used.
 - ``log`` is an optional parameter controlling log output verbosity and format
   (see below).
+
+.. warning:: Unspecified database name support is deprecated and will be removed!
 
 Environment-specific parameters
 -------------------------------

--- a/irohad/ametsuchi/impl/postgres_options.cpp
+++ b/irohad/ametsuchi/impl/postgres_options.cpp
@@ -9,6 +9,7 @@
 #include <regex>
 
 #include <boost/algorithm/string.hpp>
+#include "logger/logger.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -16,7 +17,9 @@ namespace iroha {
     // regex to fetch dbname from pg_opt string
     const static std::regex e("\\bdbname=([^ ]*)");
 
-    PostgresOptions::PostgresOptions(const std::string &pg_opt)
+    PostgresOptions::PostgresOptions(const std::string &pg_opt,
+                                     std::string default_dbname,
+                                     logger::LoggerPtr log)
         : pg_opt_(pg_opt) {
       std::smatch m;
 
@@ -36,7 +39,11 @@ namespace iroha {
         pg_opt_without_db_name_ =
             std::string(pg_opt_without_db_name_.begin(), end);
       } else {
-        dbname_ = boost::none;
+        log->warn(
+            "Database name not provided. Using default one: \"{}\". This "
+            "behaviour is deprecated!",
+            default_dbname);
+        dbname_ = std::move(default_dbname);
         pg_opt_without_db_name_ = pg_opt_;
       }
     }
@@ -49,7 +56,7 @@ namespace iroha {
       return pg_opt_without_db_name_;
     }
 
-    boost::optional<std::string> PostgresOptions::dbname() const {
+    const std::string &PostgresOptions::dbname() const {
       return dbname_;
     }
 

--- a/irohad/ametsuchi/impl/postgres_options.hpp
+++ b/irohad/ametsuchi/impl/postgres_options.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_POSTGRES_OPTIONS_HPP
 #define IROHA_POSTGRES_OPTIONS_HPP
 
-#include <boost/optional.hpp>
 #include <unordered_map>
 #include "common/result.hpp"
+#include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -19,11 +19,15 @@ namespace iroha {
      */
     class PostgresOptions {
      public:
-
       /**
-       * Prohibit initialization of the PostgresOptions with no params
+       * @param pg_opt The connection options string.
+       * @param default_dbname The default name of database to use when one is
+       * not provided in pg_opt.
+       * @param log Logger for internal messages.
        */
-      PostgresOptions() = delete;
+      PostgresOptions(const std::string &pg_opt,
+                      std::string default_dbname,
+                      logger::LoggerPtr log);
 
       /**
        * @return full pg_opt string with options
@@ -35,14 +39,12 @@ namespace iroha {
        */
       std::string optionsStringWithoutDbName() const;
 
-      boost::optional<std::string> dbname() const;
-
-      explicit PostgresOptions(const std::string &pg_opt);
+      const std::string &dbname() const;
 
      private:
       const std::string pg_opt_;
       std::string pg_opt_without_db_name_;
-      boost::optional<std::string> dbname_;
+      std::string dbname_;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/postgres_options.hpp
+++ b/irohad/ametsuchi/impl/postgres_options.hpp
@@ -24,6 +24,9 @@ namespace iroha {
        * @param default_dbname The default name of database to use when one is
        * not provided in pg_opt.
        * @param log Logger for internal messages.
+       *
+       * TODO 2019.06.07 mboldyrev IR-556 make dbname required & remove the
+       * default.
        */
       PostgresOptions(const std::string &pg_opt,
                       std::string default_dbname,

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -199,7 +199,6 @@ namespace iroha {
       std::string prepared_block_name_;
 
      protected:
-      static const std::string &drop_;
       static const std::string &reset_;
       static const std::string &reset_peers_;
       static const std::string &init_;

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(storage_init_test
 addtest(postgres_options_test postgres_options_test.cpp)
 target_link_libraries(postgres_options_test
     ametsuchi
+    test_logger
     )
 
 addtest(postgres_executor_test postgres_executor_test.cpp)

--- a/test/module/irohad/ametsuchi/postgres_options_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_options_test.cpp
@@ -6,8 +6,15 @@
 #include "ametsuchi/impl/postgres_options.hpp"
 
 #include <gtest/gtest.h>
+#include "framework/test_logger.hpp"
+#include "logger/logger_manager.hpp"
 
 using namespace iroha::ametsuchi;
+
+static const logger::LoggerPtr test_log =
+    getTestLoggerManager()->getChild("PostgresOptions")->getLogger();
+
+static const std::string default_dbname{"default_dbname"};
 
 /**
  * @given pg_opt string with param1, param2 and dbname
@@ -19,13 +26,11 @@ using namespace iroha::ametsuchi;
 TEST(PostgresOptionsTest, DBnameParamExist) {
   std::string dbname = "irohadb";
   std::string pg_opt_string = "param1=val1 dbname=" + dbname + " param2=val2";
-  auto pg_opt = PostgresOptions(pg_opt_string);
+  auto pg_opt = PostgresOptions(pg_opt_string, default_dbname, test_log);
 
-  auto obtained_dbname = pg_opt.dbname();
-  ASSERT_TRUE(obtained_dbname);
-  ASSERT_EQ(obtained_dbname.value(), dbname);
-  ASSERT_EQ(pg_opt.optionsString(), pg_opt_string);
-  ASSERT_EQ(pg_opt.optionsStringWithoutDbName(), "param1=val1 param2=val2");
+  EXPECT_EQ(pg_opt.dbname(), dbname);
+  EXPECT_EQ(pg_opt.optionsString(), pg_opt_string);
+  EXPECT_EQ(pg_opt.optionsStringWithoutDbName(), "param1=val1 param2=val2");
 }
 
 /**
@@ -37,10 +42,9 @@ TEST(PostgresOptionsTest, DBnameParamExist) {
  */
 TEST(PostgresOptionsTest, DBnameParamNotExist) {
   std::string pg_opt_string = "param1=val1 param2=val2";
-  auto pg_opt = PostgresOptions(pg_opt_string);
+  auto pg_opt = PostgresOptions(pg_opt_string, default_dbname, test_log);
 
-  auto obtained_dbname = pg_opt.dbname();
-  ASSERT_FALSE(obtained_dbname);
-  ASSERT_EQ(pg_opt.optionsString(), pg_opt_string);
-  ASSERT_EQ(pg_opt.optionsStringWithoutDbName(), pg_opt_string);
+  EXPECT_EQ(pg_opt.dbname(), default_dbname);
+  EXPECT_EQ(pg_opt.optionsString(), pg_opt_string);
+  EXPECT_EQ(pg_opt.optionsStringWithoutDbName(), pg_opt_string);
 }


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

When a user does not specify the database name, a default one gets used, and a deprecation warning is displayed.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Uniform DB handling.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
