### PR TITLE
Postgres block storage

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -23,8 +23,36 @@ target_link_libraries(pool_wrapper
     SOCI::core
     )
 
-add_library(ametsuchi
+add_library(flat_file_storage
     impl/flat_file/flat_file.cpp
+    impl/flat_file_block_storage.cpp
+    impl/flat_file_block_storage_factory.cpp
+    )
+
+target_link_libraries(flat_file_storage
+    libs_files
+    shared_model_proto_backend
+    logger
+    boost
+    )
+
+add_library(postgres_storage
+    impl/postgres_block_storage.cpp
+    impl/postgres_block_storage_factory.cpp
+    )
+
+target_link_libraries(postgres_storage
+    shared_model_proto_backend
+    logger
+    SOCI::core
+    SOCI::postgresql
+    )
+
+target_compile_definitions(postgres_storage
+    PRIVATE SOCI_USE_BOOST HAVE_BOOST
+    )
+
+add_library(ametsuchi
     impl/command_executor.cpp
     impl/tx_executor.cpp
     impl/storage_impl.cpp
@@ -42,12 +70,12 @@ add_library(ametsuchi
     impl/tx_presence_cache_impl.cpp
     impl/in_memory_block_storage.cpp
     impl/in_memory_block_storage_factory.cpp
-    impl/flat_file_block_storage.cpp
-    impl/flat_file_block_storage_factory.cpp
     impl/k_times_reconnection_strategy.cpp
     )
 
 target_link_libraries(ametsuchi
+    flat_file_storage
+    postgres_storage
     logger
     logger_manager
     rxcpp

--- a/irohad/ametsuchi/impl/postgres_block_storage.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.cpp
@@ -1,0 +1,151 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/postgres_block_storage.hpp"
+
+#include "common/hexutils.hpp"
+#include "logger/logger.hpp"
+
+using namespace iroha::ametsuchi;
+
+PostgresBlockStorage::PostgresBlockStorage(
+    soci::session &sql,
+    std::shared_ptr<BlockTransportFactory> block_factory,
+    logger::LoggerPtr log)
+    : sql_(sql),
+      block_factory_(std::move(block_factory)),
+      log_(std::move(log)) {}
+
+bool PostgresBlockStorage::insert(
+    std::shared_ptr<const shared_model::interface::Block> block) {
+  shared_model::interface::types::HeightType last_block = 0;
+  using T = boost::tuple<shared_model::interface::types::HeightType>;
+  auto result_last_block = execute<T>(
+      [&] { return (sql_.prepare << "SELECT MAX(height) FROM blocks"); });
+  try {
+    last_block =
+        flatMapValue<
+            boost::optional<shared_model::interface::types::HeightType>>(
+            result_last_block,
+            [](auto &last) { return boost::make_optional(last); })
+            .value_or(0);
+  } catch (const std::exception &e) {
+    log_->warn("Problem with a query result parsing: {}", e.what());
+  }
+
+  if (block->height() != last_block + 1) {
+    log_->warn(
+        "Only blocks with sequential heights could be inserted. Last block "
+        "height: {}, inserting: {}",
+        last_block,
+        block->height());
+    return false;
+  }
+
+  soci::statement st =
+      (sql_.prepare << "INSERT INTO blocks(height, block_data) VALUES(:height, "
+                       ":block_data)",
+       soci::use(block->height()),
+       soci::use(block->blob().hex()));
+  log_->debug("insert: {}", block->blob().hex());
+  try {
+    st.execute(true);
+    return true;
+  } catch (const std::exception &e) {
+    log_->warn(
+        "Failed to insert block {}, reason {}", block->height(), e.what());
+    return false;
+  }
+}
+
+boost::optional<std::shared_ptr<const shared_model::interface::Block>>
+PostgresBlockStorage::fetch(
+    shared_model::interface::types::HeightType height) const {
+  using T = boost::tuple<std::string>;
+  auto result = execute<T>([&] {
+    return (
+        sql_.prepare << "SELECT block_data FROM blocks WHERE height = :height",
+        soci::use(height));
+  });
+  return flatMapValue<
+      boost::optional<std::shared_ptr<const shared_model::interface::Block>>>(
+      result, [&](auto &block_data) {
+        log_->debug("fetched: {}", block_data);
+        auto byte_block = iroha::hexstringToBytestring(block_data);
+        if (not byte_block) {
+          return boost::optional<
+              std::shared_ptr<const shared_model::interface::Block>>(
+              boost::none);
+        }
+
+        iroha::protocol::Block_v1 block;
+        block.ParseFromString(*byte_block);
+        return block_factory_->build(std::move(block))
+            .match(
+                [&](auto &&v) {
+                  return boost::make_optional(
+                      std::shared_ptr<const shared_model::interface::Block>(
+                          std::move(v.value)));
+                },
+                [&](const auto &e)
+                    -> boost::optional<
+                        std::shared_ptr<const shared_model::interface::Block>> {
+                  log_->error("Could not build block at height {}: {}",
+                              height,
+                              e.error.error);
+                  return boost::none;
+                });
+      });
+}
+
+size_t PostgresBlockStorage::size() const {
+  using T = boost::tuple<shared_model::interface::types::HeightType>;
+  auto result = execute<T>(
+      [&] { return (sql_.prepare << "SELECT COUNT(*) FROM blocks"); });
+  return flatMapValue<
+             boost::optional<shared_model::interface::types::HeightType>>(
+             result, [](auto &count) { return boost::make_optional(count); })
+      .value_or(0);
+}
+
+void PostgresBlockStorage::clear() {
+  soci::statement st = sql_.prepare << "TRUNCATE blocks";
+  try {
+    st.execute(true);
+  } catch (const std::exception &e) {
+    log_->warn("Failed to clear blocks table, reason {}", e.what());
+  }
+}
+
+void PostgresBlockStorage::forEach(
+    iroha::ametsuchi::BlockStorage::FunctionType function) const {
+  using T = boost::tuple<shared_model::interface::types::HeightType>;
+  auto result_min = execute<T>(
+      [&] { return (sql_.prepare << "SELECT MIN(height) FROM blocks"); });
+  auto min =
+      flatMapValue<boost::optional<shared_model::interface::types::HeightType>>(
+          result_min, [](auto &min) { return boost::make_optional(min); })
+          .value_or(0);
+  auto result_max = execute<T>(
+      [&] { return (sql_.prepare << "SELECT MAX(height) FROM blocks"); });
+  auto max =
+      flatMapValue<boost::optional<shared_model::interface::types::HeightType>>(
+          result_max, [](auto &max) { return boost::make_optional(max); })
+          .value_or(0);
+  while (min <= max) {
+    function(*fetch(min));
+    ++min;
+  }
+}
+
+template <typename T, typename F>
+boost::optional<soci::rowset<T>> PostgresBlockStorage::execute(F &&f) const {
+  try {
+    return soci::rowset<T>{std::forward<F>(f)()};
+  } catch (const std::exception &e) {
+    log_->error("Failed to execute query: {}", e.what());
+    return boost::none;
+  }
+}

--- a/irohad/ametsuchi/impl/postgres_block_storage.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.hpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_POSTGRES_BLOCK_STORAGE_HPP
+#define IROHA_POSTGRES_BLOCK_STORAGE_HPP
+
+#include "ametsuchi/block_storage.hpp"
+
+#include "ametsuchi/impl/soci_utils.hpp"
+#include "backend/protobuf/block.hpp"
+#include "interfaces/iroha_internal/abstract_transport_factory.hpp"
+#include "logger/logger_fwd.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+    class PostgresBlockStorage : public BlockStorage {
+     public:
+      using BlockTransportFactory =
+          shared_model::interface::AbstractTransportFactory<
+              shared_model::interface::Block,
+              shared_model::proto::Block::TransportType>;
+
+      PostgresBlockStorage(soci::session &sql,
+                           std::shared_ptr<BlockTransportFactory> block_factory,
+                           logger::LoggerPtr log);
+
+      bool insert(
+          std::shared_ptr<const shared_model::interface::Block> block) override;
+
+      boost::optional<std::shared_ptr<const shared_model::interface::Block>>
+      fetch(shared_model::interface::types::HeightType height) const override;
+
+      size_t size() const override;
+
+      void clear() override;
+
+      void forEach(FunctionType function) const override;
+
+     private:
+      /**
+       * Executes given lambda of type F, catches exceptions if any, logs the
+       * message, and returns an optional rowset<T>
+       */
+      template <typename T, typename F>
+      boost::optional<soci::rowset<T>> execute(F &&f) const;
+
+      soci::session &sql_;
+      std::shared_ptr<BlockTransportFactory> block_factory_;
+      logger::LoggerPtr log_;
+    };
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif  // IROHA_POSTGRES_BLOCK_STORAGE_HPP

--- a/irohad/ametsuchi/impl/postgres_block_storage_factory.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage_factory.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/postgres_block_storage_factory.hpp"
+
+using namespace iroha::ametsuchi;
+
+PostgresBlockStorageFactory::PostgresBlockStorageFactory(
+    soci::session &sql,
+    std::shared_ptr<PostgresBlockStorage::BlockTransportFactory> block_factory,
+    logger::LoggerPtr log)
+    : sql_(sql),
+      block_factory_(std::move(block_factory)),
+      log_(std::move(log)) {}
+
+std::unique_ptr<BlockStorage> PostgresBlockStorageFactory::create() {
+  return std::make_unique<PostgresBlockStorage>(
+      sql_, std::move(block_factory_), std::move(log_));
+}

--- a/irohad/ametsuchi/impl/postgres_block_storage_factory.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage_factory.hpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_POSTGRES_BLOCK_STORAGE_FACTORY_HPP
+#define IROHA_POSTGRES_BLOCK_STORAGE_FACTORY_HPP
+
+#include "ametsuchi/block_storage_factory.hpp"
+
+#include "ametsuchi/impl/postgres_block_storage.hpp"
+#include "ametsuchi/impl/soci_utils.hpp"
+#include "backend/protobuf/proto_block_factory.hpp"
+#include "logger/logger_fwd.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+    class PostgresBlockStorageFactory : public BlockStorageFactory {
+     public:
+      PostgresBlockStorageFactory(
+          soci::session &sql,
+          std::shared_ptr<PostgresBlockStorage::BlockTransportFactory>
+              block_factory,
+          logger::LoggerPtr log);
+      std::unique_ptr<BlockStorage> create() override;
+
+     private:
+      soci::session &sql_;
+      std::shared_ptr<PostgresBlockStorage::BlockTransportFactory>
+          block_factory_;
+      logger::LoggerPtr log_;
+    };
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif  // IROHA_POSTGRES_BLOCK_STORAGE_FACTORY_HPP

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -83,6 +83,12 @@ target_link_libraries(flat_file_block_storage_test
     test_logger
     )
 
+addtest(postgres_block_storage_test postgres_block_storage_test.cpp)
+target_link_libraries(postgres_block_storage_test
+     ametsuchi
+     ametsuchi_fixture
+     )
+
 add_library(ametsuchi_fixture INTERFACE)
 target_link_libraries(ametsuchi_fixture INTERFACE
     integration_framework_config_helper

--- a/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
@@ -1,0 +1,175 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/postgres_block_storage.hpp"
+#include "ametsuchi/impl/postgres_block_storage_factory.hpp"
+
+#include "backend/protobuf/proto_transport_factory.hpp"
+#include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
+#include "module/shared_model/builders/protobuf/test_block_builder.hpp"
+#include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
+#include "module/shared_model/interface_mocks.hpp"
+#include "module/shared_model/validators/validators.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace shared_model::validation;
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+using MockBlockIValidator = MockValidator<shared_model::interface::Block>;
+using MockBlockPValidator = MockValidator<iroha::protocol::Block_v1>;
+
+class PostgresBlockStorageTest : public AmetsuchiTest {
+ public:
+  PostgresBlockStorageTest() {
+    ON_CALL(*mock_block_, height()).WillByDefault(Return(height_));
+    ON_CALL(*mock_block_, blob()).WillByDefault(ReturnRef(blob_));
+    ON_CALL(*mock_other_block_, height()).WillByDefault(Return(height_ + 2));
+    ON_CALL(*mock_other_block_, blob()).WillByDefault(ReturnRef(blob_));
+  }
+
+ protected:
+  void SetUp() override {
+    AmetsuchiTest::SetUp();
+
+    auto validator = std::make_unique<MockBlockIValidator>();
+    auto proto_validator = std::make_unique<MockBlockPValidator>();
+
+    block_factory_ =
+        std::make_shared<shared_model::proto::ProtoTransportFactory<
+            shared_model::interface::Block,
+            shared_model::proto::Block>>(std::move(validator),
+                                         std::move(proto_validator));
+
+    sql_ = std::make_unique<soci::session>(*soci::factory_postgresql(), pgopt_);
+    block_storage_ =
+        PostgresBlockStorageFactory(
+            *sql_, block_factory_, getTestLogger("PostgresBlockStorage"))
+            .create();
+    *sql_ << "CREATE TABLE IF NOT EXISTS blocks (height bigint PRIMARY KEY, "
+             "block_data text not null);";
+  }
+
+  void TearDown() override {
+    *sql_ << "DROP TABLE IF EXISTS blocks;";
+    sql_->close();
+    AmetsuchiTest::TearDown();
+  }
+
+  std::shared_ptr<PostgresBlockStorage::BlockTransportFactory> block_factory_;
+  std::unique_ptr<soci::session> sql_;
+  std::unique_ptr<BlockStorage> block_storage_;
+  std::shared_ptr<MockBlock> mock_block_ =
+      std::make_shared<NiceMock<MockBlock>>();
+  std::shared_ptr<MockBlock> mock_other_block_ =
+      std::make_shared<NiceMock<MockBlock>>();
+  shared_model::interface::types::HeightType height_ = 1;
+  shared_model::crypto::Blob blob_ = shared_model::crypto::Blob(
+      shared_model::crypto::Blob::Bytes{0, 1, 5, 17, 66, 255});
+  std::string creator_ = "user1@test";
+};
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when another block with height_ is inserted
+ * @then second insertion fails
+ */
+TEST_F(PostgresBlockStorageTest, InsertTest) {
+  ASSERT_TRUE(block_storage_->insert(mock_block_));
+  ASSERT_FALSE(block_storage_->insert(mock_block_));
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when another block with height_+2 is inserted
+ * @then second insertion fails
+ */
+TEST_F(PostgresBlockStorageTest, InsertNonSequentialTest) {
+  ASSERT_TRUE(block_storage_->insert(mock_block_));
+  ASSERT_FALSE(block_storage_->insert(mock_other_block_));
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when block with height_ is fetched
+ * @then it is returned
+ */
+TEST_F(PostgresBlockStorageTest, FetchExisting) {
+  auto tx = TestTransactionBuilder().creatorAccountId(creator_).build();
+  std::vector<shared_model::proto::Transaction> txs;
+  txs.push_back(std::move(tx));
+  auto block = TestBlockBuilder().height(height_).transactions(txs).build();
+
+  ASSERT_TRUE(block_storage_->insert(clone(block)));
+
+  auto block_var = *(block_storage_->fetch(block.height()));
+  ASSERT_EQ(block.blob(), block_var->blob());
+}
+
+/**
+ * @given initialized block storage without blocks
+ * @when block with height_ is fetched
+ * @then nothing is returned
+ */
+TEST_F(PostgresBlockStorageTest, FetchNonexistent) {
+  ASSERT_FALSE(block_storage_->fetch(height_));
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when size is fetched
+ * @then 1 is returned
+ */
+TEST_F(PostgresBlockStorageTest, Size) {
+  ASSERT_TRUE(block_storage_->insert(mock_block_));
+  ASSERT_EQ(1, block_storage_->size());
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when storage is cleared with clear
+ * @then no blocks are left in storage
+ */
+TEST_F(PostgresBlockStorageTest, Clear) {
+  ASSERT_TRUE(block_storage_->insert(mock_block_));
+  block_storage_->clear();
+  ASSERT_FALSE(block_storage_->fetch(height_));
+  ASSERT_EQ(0, block_storage_->size());
+}
+
+/**
+ * @given initialized block storage, two blocks with height_ and height_+1 are
+ * inserted
+ * @when forEach is called
+ * @then both blocks are visited, lambda is invoked twice
+ */
+TEST_F(PostgresBlockStorageTest, ForEach) {
+  auto tx = TestTransactionBuilder().creatorAccountId(creator_).build();
+  std::vector<shared_model::proto::Transaction> txs;
+  txs.push_back(std::move(tx));
+  auto block = TestBlockBuilder().height(height_).transactions(txs).build();
+  auto another_block =
+      TestBlockBuilder().height(height_ + 1).transactions(txs).build();
+
+  ASSERT_TRUE(block_storage_->insert(clone(block)));
+  ASSERT_TRUE(block_storage_->insert(clone(another_block)));
+
+  size_t count = 0;
+
+  block_storage_->forEach([&count, &block, &another_block](const auto &b) {
+    ++count;
+    if (b->height() == block.height()) {
+      ASSERT_EQ(b->blob(), block.blob());
+    } else if (b->height() == another_block.height()) {
+      ASSERT_EQ(b->blob(), another_block.blob());
+    } else {
+      FAIL() << "Unexpected block height returned: " << b->height();
+    }
+  });
+
+  ASSERT_EQ(2, count);
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Pull request adds implementation of BlockStorage interface based on Postgres database.

### Benefits

<!-- What benefits will be realized by the code change? -->

FlatFile storage implementation doesn't work well with large amount of blocks. Postgres-based implementation should provide a better scalability and an overall performance.

### Possible Drawbacks 
- `PostgresBlockStorage::forEach` fetches all block ids into the memory what could be a problem if storage contains too many blocks. My intention here is this function should not be called for very large storages since it will take too much time regardless of implementation.
- There is a [known issue](https://github.com/SOCI/soci/issues/501) with SOCI which leads to inability for a simple usage of Postgres's `bytea` data type; `text` type should be used so far. There is a [workaround](https://github.com/SOCI/soci/issues/501#issuecomment-245633230) but it should be tested.
- `PostgresBlockStorage::fetch` parses stored data into `protocol::Block` objects internally. This leads to impossibility to use mock blocks for some tests.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

