### PR TITLE
Simplify shared_model::Command structure

### DIFF
--- a/shared_model/backend/protobuf/commands/impl/proto_add_asset_quantity.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_asset_quantity.cpp
@@ -8,25 +8,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    AddAssetQuantity::AddAssetQuantity(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          add_asset_quantity_{proto_->add_asset_quantity()},
+    AddAssetQuantity::AddAssetQuantity(iroha::protocol::Command &command)
+        : add_asset_quantity_{command.add_asset_quantity()},
           amount_{add_asset_quantity_.amount()} {}
-
-    // TODO 30/05/2018 andrei Reduce boilerplate code in variant classes
-    template AddAssetQuantity::AddAssetQuantity(
-        AddAssetQuantity::TransportType &);
-    template AddAssetQuantity::AddAssetQuantity(
-        const AddAssetQuantity::TransportType &);
-    template AddAssetQuantity::AddAssetQuantity(
-        AddAssetQuantity::TransportType &&);
-
-    AddAssetQuantity::AddAssetQuantity(const AddAssetQuantity &o)
-        : AddAssetQuantity(o.proto_) {}
-
-    AddAssetQuantity::AddAssetQuantity(AddAssetQuantity &&o) noexcept
-        : AddAssetQuantity(std::move(o.proto_)) {}
 
     const interface::types::AssetIdType &AddAssetQuantity::assetId() const {
       return add_asset_quantity_.asset_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_peer.cpp
@@ -8,19 +8,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    AddPeer::AddPeer(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          add_peer_{proto_->add_peer()},
-          peer_{*proto_->mutable_add_peer()->mutable_peer()} {}
-
-    template AddPeer::AddPeer(AddPeer::TransportType &);
-    template AddPeer::AddPeer(const AddPeer::TransportType &);
-    template AddPeer::AddPeer(AddPeer::TransportType &&);
-
-    AddPeer::AddPeer(const AddPeer &o) : AddPeer(o.proto_) {}
-
-    AddPeer::AddPeer(AddPeer &&o) noexcept : AddPeer(std::move(o.proto_)) {}
+    AddPeer::AddPeer(iroha::protocol::Command &command)
+        : add_peer_{command.add_peer()},
+          peer_{*command.mutable_add_peer()->mutable_peer()} {}
 
     const interface::Peer &AddPeer::peer() const {
       return peer_;

--- a/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
@@ -4,26 +4,15 @@
  */
 
 #include "backend/protobuf/commands/proto_add_signatory.hpp"
+
 #include "cryptography/hash.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    AddSignatory::AddSignatory(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          add_signatory_{proto_->add_signatory()},
+    AddSignatory::AddSignatory(iroha::protocol::Command &command)
+        : add_signatory_{command.add_signatory()},
           pubkey_{crypto::Hash::fromHexString(add_signatory_.public_key())} {}
-
-    template AddSignatory::AddSignatory(AddSignatory::TransportType &);
-    template AddSignatory::AddSignatory(const AddSignatory::TransportType &);
-    template AddSignatory::AddSignatory(AddSignatory::TransportType &&);
-
-    AddSignatory::AddSignatory(const AddSignatory &o)
-        : AddSignatory(o.proto_) {}
-
-    AddSignatory::AddSignatory(AddSignatory &&o) noexcept
-        : AddSignatory(std::move(o.proto_)) {}
 
     const interface::types::AccountIdType &AddSignatory::accountId() const {
       return add_signatory_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_append_role.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_append_role.cpp
@@ -8,19 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    AppendRole::AppendRole(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          append_role_{proto_->append_role()} {}
-
-    template AppendRole::AppendRole(AppendRole::TransportType &);
-    template AppendRole::AppendRole(const AppendRole::TransportType &);
-    template AppendRole::AppendRole(AppendRole::TransportType &&);
-
-    AppendRole::AppendRole(const AppendRole &o) : AppendRole(o.proto_) {}
-
-    AppendRole::AppendRole(AppendRole &&o) noexcept
-        : AppendRole(std::move(o.proto_)) {}
+    AppendRole::AppendRole(iroha::protocol::Command &command)
+        : append_role_{command.append_role()} {}
 
     const interface::types::AccountIdType &AppendRole::accountId() const {
       return append_role_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_command.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_command.cpp
@@ -21,7 +21,6 @@
 #include "backend/protobuf/commands/proto_set_quorum.hpp"
 #include "backend/protobuf/commands/proto_subtract_asset_quantity.hpp"
 #include "backend/protobuf/commands/proto_transfer_asset.hpp"
-#include "logger/logger.hpp"
 #include "utils/variant_deserializer.hpp"
 
 namespace {
@@ -67,8 +66,6 @@ namespace shared_model {
       CommandVariantType ivariant_{variant_};
     };
 
-    Command::Command(Command &&o) noexcept = default;
-
     Command::Command(TransportType &ref) {
       impl_ = std::make_unique<Impl>(ref);
     }
@@ -77,11 +74,6 @@ namespace shared_model {
 
     const Command::CommandVariantType &Command::get() const {
       return impl_->ivariant_;
-    }
-
-    Command *Command::clone() const {
-      throw std::runtime_error(
-          "tried to clone a proto command, which is uncloneable");
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
@@ -4,26 +4,15 @@
  */
 
 #include "backend/protobuf/commands/proto_create_account.hpp"
+
 #include "cryptography/hash.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    CreateAccount::CreateAccount(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          create_account_{proto_->create_account()},
+    CreateAccount::CreateAccount(iroha::protocol::Command &command)
+        : create_account_{command.create_account()},
           pubkey_{crypto::Hash::fromHexString(create_account_.public_key())} {}
-
-    template CreateAccount::CreateAccount(CreateAccount::TransportType &);
-    template CreateAccount::CreateAccount(const CreateAccount::TransportType &);
-    template CreateAccount::CreateAccount(CreateAccount::TransportType &&);
-
-    CreateAccount::CreateAccount(const CreateAccount &o)
-        : CreateAccount(o.proto_) {}
-
-    CreateAccount::CreateAccount(CreateAccount &&o) noexcept
-        : CreateAccount(std::move(o.proto_)) {}
 
     const interface::types::PubkeyType &CreateAccount::pubkey() const {
       return pubkey_;

--- a/shared_model/backend/protobuf/commands/impl/proto_create_asset.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_asset.cpp
@@ -8,21 +8,10 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    CreateAsset::CreateAsset(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          create_asset_{proto_->create_asset()},
+    CreateAsset::CreateAsset(iroha::protocol::Command &command)
+        : create_asset_{command.create_asset()},
           precision_{
               static_cast<const PrecisionType>(create_asset_.precision())} {}
-
-    template CreateAsset::CreateAsset(CreateAsset::TransportType &);
-    template CreateAsset::CreateAsset(const CreateAsset::TransportType &);
-    template CreateAsset::CreateAsset(CreateAsset::TransportType &&);
-
-    CreateAsset::CreateAsset(const CreateAsset &o) : CreateAsset(o.proto_) {}
-
-    CreateAsset::CreateAsset(CreateAsset &&o) noexcept
-        : CreateAsset(std::move(o.proto_)) {}
 
     const interface::types::AssetNameType &CreateAsset::assetName() const {
       return create_asset_.asset_name();

--- a/shared_model/backend/protobuf/commands/impl/proto_create_domain.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_domain.cpp
@@ -8,20 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    CreateDomain::CreateDomain(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          create_domain_{proto_->create_domain()} {}
-
-    template CreateDomain::CreateDomain(CreateDomain::TransportType &);
-    template CreateDomain::CreateDomain(const CreateDomain::TransportType &);
-    template CreateDomain::CreateDomain(CreateDomain::TransportType &&);
-
-    CreateDomain::CreateDomain(const CreateDomain &o)
-        : CreateDomain(o.proto_) {}
-
-    CreateDomain::CreateDomain(CreateDomain &&o) noexcept
-        : CreateDomain(std::move(o.proto_)) {}
+    CreateDomain::CreateDomain(iroha::protocol::Command &command)
+        : create_domain_{command.create_domain()} {}
 
     const interface::types::DomainIdType &CreateDomain::domainId() const {
       return create_domain_.domain_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
@@ -11,10 +11,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    CreateRole::CreateRole(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          create_role_{proto_->create_role()},
+    CreateRole::CreateRole(iroha::protocol::Command &command)
+        : create_role_{command.create_role()},
           role_permissions_{boost::accumulate(
               create_role_.permissions(),
               interface::RolePermissionSet{},
@@ -23,15 +21,6 @@ namespace shared_model {
                     static_cast<iroha::protocol::RolePermission>(perm)));
                 return std::forward<decltype(acc)>(acc);
               })} {}
-
-    template CreateRole::CreateRole(CreateRole::TransportType &);
-    template CreateRole::CreateRole(const CreateRole::TransportType &);
-    template CreateRole::CreateRole(CreateRole::TransportType &&);
-
-    CreateRole::CreateRole(const CreateRole &o) : CreateRole(o.proto_) {}
-
-    CreateRole::CreateRole(CreateRole &&o) noexcept
-        : CreateRole(std::move(o.proto_)) {}
 
     const interface::types::RoleIdType &CreateRole::roleName() const {
       return create_role_.role_name();

--- a/shared_model/backend/protobuf/commands/impl/proto_detach_role.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_detach_role.cpp
@@ -8,19 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    DetachRole::DetachRole(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          detach_role_{proto_->detach_role()} {}
-
-    template DetachRole::DetachRole(DetachRole::TransportType &);
-    template DetachRole::DetachRole(const DetachRole::TransportType &);
-    template DetachRole::DetachRole(DetachRole::TransportType &&);
-
-    DetachRole::DetachRole(const DetachRole &o) : DetachRole(o.proto_) {}
-
-    DetachRole::DetachRole(DetachRole &&o) noexcept
-        : DetachRole(std::move(o.proto_)) {}
+    DetachRole::DetachRole(iroha::protocol::Command &command)
+        : detach_role_{command.detach_role()} {}
 
     const interface::types::AccountIdType &DetachRole::accountId() const {
       return detach_role_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_grant_permission.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_grant_permission.cpp
@@ -4,27 +4,14 @@
  */
 
 #include "backend/protobuf/commands/proto_grant_permission.hpp"
+
 #include "backend/protobuf/permissions.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    GrantPermission::GrantPermission(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          grant_permission_{proto_->grant_permission()} {}
-
-    template GrantPermission::GrantPermission(GrantPermission::TransportType &);
-    template GrantPermission::GrantPermission(
-        const GrantPermission::TransportType &);
-    template GrantPermission::GrantPermission(
-        GrantPermission::TransportType &&);
-
-    GrantPermission::GrantPermission(const GrantPermission &o)
-        : GrantPermission(o.proto_) {}
-
-    GrantPermission::GrantPermission(GrantPermission &&o) noexcept
-        : GrantPermission(std::move(o.proto_)) {}
+    GrantPermission::GrantPermission(iroha::protocol::Command &command)
+        : grant_permission_{command.grant_permission()} {}
 
     const interface::types::AccountIdType &GrantPermission::accountId() const {
       return grant_permission_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
@@ -4,28 +4,16 @@
  */
 
 #include "backend/protobuf/commands/proto_remove_signatory.hpp"
+
 #include "cryptography/hash.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    RemoveSignatory::RemoveSignatory(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          remove_signatory_{proto_->remove_signatory()},
-          pubkey_{crypto::Hash::fromHexString(remove_signatory_.public_key())} {}
-
-    template RemoveSignatory::RemoveSignatory(RemoveSignatory::TransportType &);
-    template RemoveSignatory::RemoveSignatory(
-        const RemoveSignatory::TransportType &);
-    template RemoveSignatory::RemoveSignatory(
-        RemoveSignatory::TransportType &&);
-
-    RemoveSignatory::RemoveSignatory(const RemoveSignatory &o)
-        : RemoveSignatory(o.proto_) {}
-
-    RemoveSignatory::RemoveSignatory(RemoveSignatory &&o) noexcept
-        : RemoveSignatory(std::move(o.proto_)) {}
+    RemoveSignatory::RemoveSignatory(iroha::protocol::Command &command)
+        : remove_signatory_{command.remove_signatory()},
+          pubkey_{crypto::Hash::fromHexString(remove_signatory_.public_key())} {
+    }
 
     const interface::types::AccountIdType &RemoveSignatory::accountId() const {
       return remove_signatory_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_revoke_permission.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_revoke_permission.cpp
@@ -4,28 +4,14 @@
  */
 
 #include "backend/protobuf/commands/proto_revoke_permission.hpp"
+
 #include "backend/protobuf/permissions.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    RevokePermission::RevokePermission(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          revoke_permission_{proto_->revoke_permission()} {}
-
-    template RevokePermission::RevokePermission(
-        RevokePermission::TransportType &);
-    template RevokePermission::RevokePermission(
-        const RevokePermission::TransportType &);
-    template RevokePermission::RevokePermission(
-        RevokePermission::TransportType &&);
-
-    RevokePermission::RevokePermission(const RevokePermission &o)
-        : RevokePermission(o.proto_) {}
-
-    RevokePermission::RevokePermission(RevokePermission &&o) noexcept
-        : RevokePermission(std::move(o.proto_)) {}
+    RevokePermission::RevokePermission(iroha::protocol::Command &command)
+        : revoke_permission_{command.revoke_permission()} {}
 
     const interface::types::AccountIdType &RevokePermission::accountId() const {
       return revoke_permission_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_set_account_detail.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_set_account_detail.cpp
@@ -8,23 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    SetAccountDetail::SetAccountDetail(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          set_account_detail_{proto_->set_account_detail()} {}
-
-    template SetAccountDetail::SetAccountDetail(
-        SetAccountDetail::TransportType &);
-    template SetAccountDetail::SetAccountDetail(
-        const SetAccountDetail::TransportType &);
-    template SetAccountDetail::SetAccountDetail(
-        SetAccountDetail::TransportType &&);
-
-    SetAccountDetail::SetAccountDetail(const SetAccountDetail &o)
-        : SetAccountDetail(o.proto_) {}
-
-    SetAccountDetail::SetAccountDetail(SetAccountDetail &&o) noexcept
-        : SetAccountDetail(std::move(o.proto_)) {}
+    SetAccountDetail::SetAccountDetail(iroha::protocol::Command &command)
+        : set_account_detail_{command.set_account_detail()} {}
 
     const interface::types::AccountIdType &SetAccountDetail::accountId() const {
       return set_account_detail_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_set_quorum.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_set_quorum.cpp
@@ -8,19 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    SetQuorum::SetQuorum(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          set_account_quorum_{proto_->set_account_quorum()} {}
-
-    template SetQuorum::SetQuorum(SetQuorum::TransportType &);
-    template SetQuorum::SetQuorum(const SetQuorum::TransportType &);
-    template SetQuorum::SetQuorum(SetQuorum::TransportType &&);
-
-    SetQuorum::SetQuorum(const SetQuorum &o) : SetQuorum(o.proto_) {}
-
-    SetQuorum::SetQuorum(SetQuorum &&o) noexcept
-        : SetQuorum(std::move(o.proto_)) {}
+    SetQuorum::SetQuorum(iroha::protocol::Command &command)
+        : set_account_quorum_{command.set_account_quorum()} {}
 
     const interface::types::AccountIdType &SetQuorum::accountId() const {
       return set_account_quorum_.account_id();

--- a/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_subtract_asset_quantity.cpp
@@ -8,25 +8,10 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    SubtractAssetQuantity::SubtractAssetQuantity(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          subtract_asset_quantity_{proto_->subtract_asset_quantity()},
-          amount_{subtract_asset_quantity_.amount()} {}
-
-    template SubtractAssetQuantity::SubtractAssetQuantity(
-        SubtractAssetQuantity::TransportType &);
-    template SubtractAssetQuantity::SubtractAssetQuantity(
-        const SubtractAssetQuantity::TransportType &);
-    template SubtractAssetQuantity::SubtractAssetQuantity(
-        SubtractAssetQuantity::TransportType &&);
-
-    SubtractAssetQuantity::SubtractAssetQuantity(const SubtractAssetQuantity &o)
-        : SubtractAssetQuantity(o.proto_) {}
-
     SubtractAssetQuantity::SubtractAssetQuantity(
-        SubtractAssetQuantity &&o) noexcept
-        : SubtractAssetQuantity(std::move(o.proto_)) {}
+        iroha::protocol::Command &command)
+        : subtract_asset_quantity_{command.subtract_asset_quantity()},
+          amount_{subtract_asset_quantity_.amount()} {}
 
     const interface::types::AssetIdType &SubtractAssetQuantity::assetId()
         const {

--- a/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_transfer_asset.cpp
@@ -8,21 +8,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename CommandType>
-    TransferAsset::TransferAsset(CommandType &&command)
-        : CopyableProto(std::forward<CommandType>(command)),
-          transfer_asset_{proto_->transfer_asset()},
+    TransferAsset::TransferAsset(iroha::protocol::Command &command)
+        : transfer_asset_{command.transfer_asset()},
           amount_{transfer_asset_.amount()} {}
-
-    template TransferAsset::TransferAsset(TransferAsset::TransportType &);
-    template TransferAsset::TransferAsset(const TransferAsset::TransportType &);
-    template TransferAsset::TransferAsset(TransferAsset::TransportType &&);
-
-    TransferAsset::TransferAsset(const TransferAsset &o)
-        : TransferAsset(o.proto_) {}
-
-    TransferAsset::TransferAsset(TransferAsset &&o) noexcept
-        : TransferAsset(std::move(o.proto_)) {}
 
     const interface::Amount &TransferAsset::amount() const {
       return amount_;

--- a/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_asset_quantity.hpp
@@ -8,23 +8,14 @@
 
 #include "interfaces/commands/add_asset_quantity.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
 #include "interfaces/common_objects/amount.hpp"
 
 namespace shared_model {
   namespace proto {
-    class AddAssetQuantity final
-        : public CopyableProto<interface::AddAssetQuantity,
-                               iroha::protocol::Command,
-                               AddAssetQuantity> {
+    class AddAssetQuantity final : public interface::AddAssetQuantity {
      public:
-      template <typename CommandType>
-      explicit AddAssetQuantity(CommandType &&command);
-
-      AddAssetQuantity(const AddAssetQuantity &o);
-
-      AddAssetQuantity(AddAssetQuantity &&o) noexcept;
+      explicit AddAssetQuantity(iroha::protocol::Command &command);
 
       const interface::types::AssetIdType &assetId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_add_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_peer.hpp
@@ -6,30 +6,24 @@
 #ifndef IROHA_PROTO_ADD_PEER_HPP
 #define IROHA_PROTO_ADD_PEER_HPP
 
+#include "interfaces/commands/add_peer.hpp"
+
 #include "backend/protobuf/common_objects/peer.hpp"
 #include "commands.pb.h"
-#include "interfaces/commands/add_peer.hpp"
 #include "interfaces/common_objects/peer.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    class AddPeer final : public CopyableProto<interface::AddPeer,
-                                               iroha::protocol::Command,
-                                               AddPeer> {
+    class AddPeer final : public interface::AddPeer {
      public:
-      template <typename CommandType>
-      explicit AddPeer(CommandType &&command);
-
-      AddPeer(const AddPeer &o);
-
-      AddPeer(AddPeer &&o) noexcept;
+      explicit AddPeer(iroha::protocol::Command &command);
 
       const interface::Peer &peer() const override;
 
      private:
       const iroha::protocol::AddPeer &add_peer_;
-      const proto::Peer peer_;
+      proto::Peer peer_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_PROTO_ADD_SIGNATORY_HPP
 #define IROHA_PROTO_ADD_SIGNATORY_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/commands/add_signatory.hpp"
+
 #include "commands.pb.h"
 #include "cryptography/public_key.hpp"
-#include "interfaces/commands/add_signatory.hpp"
 
 namespace shared_model {
   namespace proto {
-    class AddSignatory final : public CopyableProto<interface::AddSignatory,
-                                                    iroha::protocol::Command,
-                                                    AddSignatory> {
+    class AddSignatory final : public interface::AddSignatory {
      public:
-      template <typename CommandType>
-      explicit AddSignatory(CommandType &&command);
-
-      AddSignatory(const AddSignatory &o);
-
-      AddSignatory(AddSignatory &&o) noexcept;
+      explicit AddSignatory(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_append_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_append_role.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_PROTO_APPEND_ROLE_HPP
 #define IROHA_PROTO_APPEND_ROLE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/append_role.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
 
-    class AppendRole final : public CopyableProto<interface::AppendRole,
-                                                  iroha::protocol::Command,
-                                                  AppendRole> {
+    class AppendRole final : public interface::AppendRole {
      public:
-      template <typename CommandType>
-      explicit AppendRole(CommandType &&command);
-
-      AppendRole(const AppendRole &o);
-
-      AppendRole(AppendRole &&o) noexcept;
+      explicit AppendRole(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_command.hpp
+++ b/shared_model/backend/protobuf/commands/proto_command.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_COMMAND_HPP
 #define IROHA_SHARED_MODEL_PROTO_COMMAND_HPP
 
-#include "commands.pb.h"
 #include "interfaces/commands/command.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
@@ -16,24 +17,15 @@ namespace shared_model {
      public:
       using TransportType = iroha::protocol::Command;
 
-      Command(Command &&o) noexcept;
-
       explicit Command(TransportType &ref);
 
       ~Command() override;
 
       const CommandVariantType &get() const override;
 
-     protected:
-      // TODO [IR-126] Akvinikym 13.12.18: Rework inheritance hierarchy so that
-      // this clone will disappear
-      Command *clone() const override;
-
      private:
       struct Impl;
       std::unique_ptr<Impl> impl_;
-
-      void logError(const std::string &message) const;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_create_account.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_account.hpp
@@ -8,23 +8,15 @@
 
 #include "interfaces/commands/create_account.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "commands.pb.h"
 #include "cryptography/public_key.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    class CreateAccount final : public CopyableProto<interface::CreateAccount,
-                                                     iroha::protocol::Command,
-                                                     CreateAccount> {
+    class CreateAccount final : public interface::CreateAccount {
      public:
-      template <typename CommandType>
-      explicit CreateAccount(CommandType &&command);
-
-      CreateAccount(const CreateAccount &o);
-
-      CreateAccount(CreateAccount &&o) noexcept;
+      explicit CreateAccount(iroha::protocol::Command &command);
 
       const interface::types::PubkeyType &pubkey() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_create_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_asset.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_PROTO_CREATE_ASSET_HPP
 #define IROHA_PROTO_CREATE_ASSET_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/create_asset.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
 
-    class CreateAsset final : public CopyableProto<interface::CreateAsset,
-                                                   iroha::protocol::Command,
-                                                   CreateAsset> {
+    class CreateAsset final : public interface::CreateAsset {
      public:
-      template <typename CommandType>
-      explicit CreateAsset(CommandType &&command);
-
-      CreateAsset(const CreateAsset &o);
-
-      CreateAsset(CreateAsset &&o) noexcept;
+      explicit CreateAsset(iroha::protocol::Command &command);
 
       const interface::types::AssetNameType &assetName() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_create_domain.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_domain.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_PROTO_CREATE_DOMAIN_HPP
 #define IROHA_PROTO_CREATE_DOMAIN_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/create_domain.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
 
-    class CreateDomain final : public CopyableProto<interface::CreateDomain,
-                                                    iroha::protocol::Command,
-                                                    CreateDomain> {
+    class CreateDomain final : public interface::CreateDomain {
      public:
-      template <typename CommandType>
-      explicit CreateDomain(CommandType &&command);
-
-      CreateDomain(const CreateDomain &o);
-
-      CreateDomain(CreateDomain &&o) noexcept;
+      explicit CreateDomain(iroha::protocol::Command &command);
 
       const interface::types::DomainIdType &domainId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_create_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_role.hpp
@@ -5,23 +5,16 @@
 #ifndef IROHA_PROTO_CREATE_ROLE_HPP
 #define IROHA_PROTO_CREATE_ROLE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/create_role.hpp"
+
+#include "commands.pb.h"
 #include "interfaces/permissions.hpp"
 
 namespace shared_model {
   namespace proto {
-    class CreateRole final : public CopyableProto<interface::CreateRole,
-                                                  iroha::protocol::Command,
-                                                  CreateRole> {
+    class CreateRole final : public interface::CreateRole {
      public:
-      template <typename CommandType>
-      explicit CreateRole(CommandType &&command);
-
-      CreateRole(const CreateRole &o);
-
-      CreateRole(CreateRole &&o) noexcept;
+      explicit CreateRole(iroha::protocol::Command &command);
 
       const interface::types::RoleIdType &roleName() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_detach_role.hpp
+++ b/shared_model/backend/protobuf/commands/proto_detach_role.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_PROTO_DETACH_ROLE_HPP
 #define IROHA_PROTO_DETACH_ROLE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/detach_role.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
 
-    class DetachRole final : public CopyableProto<interface::DetachRole,
-                                                  iroha::protocol::Command,
-                                                  DetachRole> {
+    class DetachRole final : public interface::DetachRole {
      public:
-      template <typename CommandType>
-      explicit DetachRole(CommandType &&command);
-
-      DetachRole(const DetachRole &o);
-
-      DetachRole(DetachRole &&o) noexcept;
+      explicit DetachRole(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_grant_permission.hpp
@@ -6,24 +6,16 @@
 #ifndef IROHA_PROTO_GRANT_PERMISSION_HPP
 #define IROHA_PROTO_GRANT_PERMISSION_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/grant_permission.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
 
-    class GrantPermission final
-        : public CopyableProto<interface::GrantPermission,
-                               iroha::protocol::Command,
-                               GrantPermission> {
+    class GrantPermission final : public interface::GrantPermission {
      public:
-      template <typename CommandType>
-      explicit GrantPermission(CommandType &&command);
-
-      GrantPermission(const GrantPermission &o);
-
-      GrantPermission(GrantPermission &&o) noexcept;
+      explicit GrantPermission(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
@@ -6,25 +6,17 @@
 #ifndef IROHA_PROTO_REMOVE_SIGNATORY_HPP
 #define IROHA_PROTO_REMOVE_SIGNATORY_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/commands/remove_signatory.hpp"
+
 #include "commands.pb.h"
 #include "cryptography/public_key.hpp"
-#include "interfaces/commands/remove_signatory.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    class RemoveSignatory final
-        : public CopyableProto<interface::RemoveSignatory,
-                               iroha::protocol::Command,
-                               RemoveSignatory> {
+    class RemoveSignatory final : public interface::RemoveSignatory {
      public:
-      template <typename CommandType>
-      explicit RemoveSignatory(CommandType &&command);
-
-      RemoveSignatory(const RemoveSignatory &o);
-
-      RemoveSignatory(RemoveSignatory &&o) noexcept;
+      explicit RemoveSignatory(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
+++ b/shared_model/backend/protobuf/commands/proto_revoke_permission.hpp
@@ -6,23 +6,15 @@
 #ifndef IROHA_PROTO_REVOKE_PERMISSION_HPP
 #define IROHA_PROTO_REVOKE_PERMISSION_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/revoke_permission.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class RevokePermission final
-        : public CopyableProto<interface::RevokePermission,
-                               iroha::protocol::Command,
-                               RevokePermission> {
+    class RevokePermission final : public interface::RevokePermission {
      public:
-      template <typename CommandType>
-      explicit RevokePermission(CommandType &&command);
-
-      RevokePermission(const RevokePermission &o);
-
-      RevokePermission(RevokePermission &&o) noexcept;
+      explicit RevokePermission(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_account_detail.hpp
@@ -6,23 +6,15 @@
 #ifndef IROHA_PROTO_SET_ACCOUNT_DETAIL_HPP
 #define IROHA_PROTO_SET_ACCOUNT_DETAIL_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/set_account_detail.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class SetAccountDetail final
-        : public CopyableProto<interface::SetAccountDetail,
-                               iroha::protocol::Command,
-                               SetAccountDetail> {
+    class SetAccountDetail final : public interface::SetAccountDetail {
      public:
-      template <typename CommandType>
-      explicit SetAccountDetail(CommandType &&command);
-
-      SetAccountDetail(const SetAccountDetail &o);
-
-      SetAccountDetail(SetAccountDetail &&o) noexcept;
+      explicit SetAccountDetail(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
+++ b/shared_model/backend/protobuf/commands/proto_set_quorum.hpp
@@ -6,22 +6,15 @@
 #ifndef IROHA_PROTO_SET_QUORUM_HPP
 #define IROHA_PROTO_SET_QUORUM_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/set_quorum.hpp"
+
+#include "commands.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class SetQuorum final : public CopyableProto<interface::SetQuorum,
-                                                 iroha::protocol::Command,
-                                                 SetQuorum> {
+    class SetQuorum final : public interface::SetQuorum {
      public:
-      template <typename CommandType>
-      explicit SetQuorum(CommandType &&command);
-
-      SetQuorum(const SetQuorum &o);
-
-      SetQuorum(SetQuorum &&o) noexcept;
+      explicit SetQuorum(iroha::protocol::Command &command);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
+++ b/shared_model/backend/protobuf/commands/proto_subtract_asset_quantity.hpp
@@ -6,24 +6,17 @@
 #ifndef IROHA_PROTO_SUBTRACT_ASSET_QUANTITY_HPP
 #define IROHA_PROTO_SUBTRACT_ASSET_QUANTITY_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/subtract_asset_quantity.hpp"
+
+#include "commands.pb.h"
 #include "interfaces/common_objects/amount.hpp"
 
 namespace shared_model {
   namespace proto {
     class SubtractAssetQuantity final
-        : public CopyableProto<interface::SubtractAssetQuantity,
-                               iroha::protocol::Command,
-                               SubtractAssetQuantity> {
+        : public interface::SubtractAssetQuantity {
      public:
-      template <typename CommandType>
-      explicit SubtractAssetQuantity(CommandType &&command);
-
-      SubtractAssetQuantity(const SubtractAssetQuantity &o);
-
-      SubtractAssetQuantity(SubtractAssetQuantity &&o) noexcept;
+      explicit SubtractAssetQuantity(iroha::protocol::Command &command);
 
       const interface::types::AssetIdType &assetId() const override;
 

--- a/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
+++ b/shared_model/backend/protobuf/commands/proto_transfer_asset.hpp
@@ -6,24 +6,17 @@
 #ifndef IROHA_PROTO_TRANSFER_ASSET_HPP
 #define IROHA_PROTO_TRANSFER_ASSET_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "commands.pb.h"
 #include "interfaces/commands/transfer_asset.hpp"
+
+#include "commands.pb.h"
 #include "interfaces/common_objects/amount.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    class TransferAsset final : public CopyableProto<interface::TransferAsset,
-                                                     iroha::protocol::Command,
-                                                     TransferAsset> {
+    class TransferAsset final : public interface::TransferAsset {
      public:
-      template <typename CommandType>
-      explicit TransferAsset(CommandType &&command);
-
-      TransferAsset(const TransferAsset &o);
-
-      TransferAsset(TransferAsset &&o) noexcept;
+      explicit TransferAsset(iroha::protocol::Command &command);
 
       const interface::Amount &amount() const override;
 

--- a/shared_model/interfaces/base/noncopyable_model_primitive.hpp
+++ b/shared_model/interfaces/base/noncopyable_model_primitive.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_NONCOPYABLE_MODEL_PRIMITIVE_HPP
+#define IROHA_NONCOPYABLE_MODEL_PRIMITIVE_HPP
+
+#include <ciso646>
+
+#include "utils/string_builder.hpp"
+
+namespace shared_model {
+  namespace interface {
+    /**
+     * Base class of domain objects which are not intended to be copied.
+     * @tparam Model - shared model type
+     */
+    template <typename Model>
+    class NonCopyableModelPrimitive {
+     public:
+      using ModelType = Model;
+
+      NonCopyableModelPrimitive() = default;
+
+      NonCopyableModelPrimitive(const NonCopyableModelPrimitive &) = delete;
+      NonCopyableModelPrimitive &operator=(const NonCopyableModelPrimitive &) =
+          delete;
+
+      NonCopyableModelPrimitive(NonCopyableModelPrimitive &&) noexcept =
+          default;
+
+      /**
+       * Make string representation of object for development
+       * @return string with internal state of object
+       */
+      virtual std::string toString() const {
+        return detail::PrettyStringBuilder()
+            .init("NonCopyablePrimitive")
+            .append("address", std::to_string(reinterpret_cast<uint64_t>(this)))
+            .finalize();
+      }
+
+      virtual bool operator==(const ModelType &rhs) const = 0;
+
+      virtual bool operator!=(const ModelType &rhs) const {
+        return not(*this == rhs);
+      }
+
+      virtual ~NonCopyableModelPrimitive() = default;
+    };
+  }  // namespace interface
+}  // namespace shared_model
+#endif  // IROHA_NONCOPYABLE_MODEL_PRIMITIVE_HPP

--- a/shared_model/interfaces/commands/add_asset_quantity.hpp
+++ b/shared_model/interfaces/commands/add_asset_quantity.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ADD_ASSET_QUANTITY_HPP
 #define IROHA_SHARED_MODEL_ADD_ASSET_QUANTITY_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/amount.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -16,7 +17,8 @@ namespace shared_model {
     /**
      * Add amount of asset to an account
      */
-    class AddAssetQuantity : public ModelPrimitive<AddAssetQuantity> {
+    class AddAssetQuantity
+        : public NonCopyableModelPrimitive<AddAssetQuantity> {
      public:
       /**
        * @return asset identifier

--- a/shared_model/interfaces/commands/add_peer.hpp
+++ b/shared_model/interfaces/commands/add_peer.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ADD_PEER_HPP
 #define IROHA_SHARED_MODEL_ADD_PEER_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -16,7 +17,7 @@ namespace shared_model {
     /**
      * Add new peer to Iroha
      */
-    class AddPeer : public ModelPrimitive<AddPeer> {
+    class AddPeer : public NonCopyableModelPrimitive<AddPeer> {
      public:
       /**
        * Return peer to be added by the command.

--- a/shared_model/interfaces/commands/add_signatory.hpp
+++ b/shared_model/interfaces/commands/add_signatory.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ADD_SIGNATORY_HPP
 #define IROHA_SHARED_MODEL_ADD_SIGNATORY_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Add new signatory to account
      */
-    class AddSignatory : public ModelPrimitive<AddSignatory> {
+    class AddSignatory : public NonCopyableModelPrimitive<AddSignatory> {
      public:
       /**
        * @return New signatory is identified with public key

--- a/shared_model/interfaces/commands/append_role.hpp
+++ b/shared_model/interfaces/commands/append_role.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_APPEND_ROLE_HPP
 #define IROHA_SHARED_MODEL_APPEND_ROLE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Add role to account used in Iroha
      */
-    class AppendRole : public ModelPrimitive<AppendRole> {
+    class AppendRole : public NonCopyableModelPrimitive<AppendRole> {
      public:
       /**
        * @return Account to add the role

--- a/shared_model/interfaces/commands/command.hpp
+++ b/shared_model/interfaces/commands/command.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_COMMAND_HPP
 #define IROHA_SHARED_MODEL_COMMAND_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/variant/variant_fwd.hpp>
-#include "interfaces/base/model_primitive.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -33,7 +34,7 @@ namespace shared_model {
      * Class provides commands container for all commands in system.
      * General note: this class is container for commands, not a base class.
      */
-    class Command : public ModelPrimitive<Command> {
+    class Command : public NonCopyableModelPrimitive<Command> {
      private:
       /// const reference shortcut type
       template <typename... Value>

--- a/shared_model/interfaces/commands/create_account.hpp
+++ b/shared_model/interfaces/commands/create_account.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_CREATE_ACCOUNT_HPP
 #define IROHA_SHARED_MODEL_CREATE_ACCOUNT_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Create acccount in Iroha domain
      */
-    class CreateAccount : public ModelPrimitive<CreateAccount> {
+    class CreateAccount : public NonCopyableModelPrimitive<CreateAccount> {
      public:
       /**
        * @return Name of the account to create in Iroha

--- a/shared_model/interfaces/commands/create_asset.hpp
+++ b/shared_model/interfaces/commands/create_asset.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_CREATE_ASSET_HPP
 #define IROHA_SHARED_MODEL_CREATE_ASSET_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Create asset in Iroha domain
      */
-    class CreateAsset : public ModelPrimitive<CreateAsset> {
+    class CreateAsset : public NonCopyableModelPrimitive<CreateAsset> {
      public:
       /**
        * @return Asset name to create

--- a/shared_model/interfaces/commands/create_domain.hpp
+++ b/shared_model/interfaces/commands/create_domain.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_CREATE_DOMAIN_HPP
 #define IROHA_SHARED_MODEL_CREATE_DOMAIN_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Create domain in Iroha
      */
-    class CreateDomain : public ModelPrimitive<CreateDomain> {
+    class CreateDomain : public NonCopyableModelPrimitive<CreateDomain> {
      public:
       /**
        * @return Id of the domain to create

--- a/shared_model/interfaces/commands/create_role.hpp
+++ b/shared_model/interfaces/commands/create_role.hpp
@@ -6,10 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_CREATE_ROLE_HPP
 #define IROHA_SHARED_MODEL_CREATE_ROLE_HPP
 
-#include <numeric>
-#include <set>
+#include "interfaces/base/noncopyable_model_primitive.hpp"
 
-#include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/permissions.hpp"
 
@@ -18,7 +16,7 @@ namespace shared_model {
     /**
      * Create new role in Iroha
      */
-    class CreateRole : public ModelPrimitive<CreateRole> {
+    class CreateRole : public NonCopyableModelPrimitive<CreateRole> {
      public:
       /**
        * @return Id of the domain to create

--- a/shared_model/interfaces/commands/detach_role.hpp
+++ b/shared_model/interfaces/commands/detach_role.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_DETACH_ROLE_HPP
 #define IROHA_SHARED_MODEL_DETACH_ROLE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Remove role from account used in Iroha
      */
-    class DetachRole : public ModelPrimitive<DetachRole> {
+    class DetachRole : public NonCopyableModelPrimitive<DetachRole> {
      public:
       /**
        * @return Account to remove the role

--- a/shared_model/interfaces/commands/grant_permission.hpp
+++ b/shared_model/interfaces/commands/grant_permission.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_GRANT_PERMISSION_HPP
 #define IROHA_SHARED_MODEL_GRANT_PERMISSION_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/permissions.hpp"
 
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Grant permission to the account
      */
-    class GrantPermission : public ModelPrimitive<GrantPermission> {
+    class GrantPermission : public NonCopyableModelPrimitive<GrantPermission> {
      public:
       /**
        * @return Id of the account to whom grant permission

--- a/shared_model/interfaces/commands/remove_signatory.hpp
+++ b/shared_model/interfaces/commands/remove_signatory.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_REMOVE_SIGNATORY_HPP
 #define IROHA_SHARED_MODEL_REMOVE_SIGNATORY_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Remove signatory from the account
      */
-    class RemoveSignatory : public ModelPrimitive<RemoveSignatory> {
+    class RemoveSignatory : public NonCopyableModelPrimitive<RemoveSignatory> {
      public:
       /**
        * @return account from which remove signatory

--- a/shared_model/interfaces/commands/revoke_permission.hpp
+++ b/shared_model/interfaces/commands/revoke_permission.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_REVOKE_PERMISSION_HPP
 #define IROHA_SHARED_MODEL_REVOKE_PERMISSION_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/permissions.hpp"
 
@@ -15,7 +16,8 @@ namespace shared_model {
     /**
      * Revoke permission from account
      */
-    class RevokePermission : public ModelPrimitive<RevokePermission> {
+    class RevokePermission
+        : public NonCopyableModelPrimitive<RevokePermission> {
      public:
       /**
        * @return account from which revoke permission

--- a/shared_model/interfaces/commands/set_account_detail.hpp
+++ b/shared_model/interfaces/commands/set_account_detail.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_SET_ACCOUNT_DETAIL_HPP
 #define IROHA_SHARED_MODEL_SET_ACCOUNT_DETAIL_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -15,7 +16,8 @@ namespace shared_model {
     /**
      * Set key-value pair of given account
      */
-    class SetAccountDetail : public ModelPrimitive<SetAccountDetail> {
+    class SetAccountDetail
+        : public NonCopyableModelPrimitive<SetAccountDetail> {
      public:
       /**
        * @return Identity of user to set account detail

--- a/shared_model/interfaces/commands/set_quorum.hpp
+++ b/shared_model/interfaces/commands/set_quorum.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_SET_QUORUM_HPP
 #define IROHA_SHARED_MODEL_SET_QUORUM_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Set quorum of the account
      */
-    class SetQuorum : public ModelPrimitive<SetQuorum> {
+    class SetQuorum : public NonCopyableModelPrimitive<SetQuorum> {
      public:
       /**
        * @return Id of the account to set quorum

--- a/shared_model/interfaces/commands/subtract_asset_quantity.hpp
+++ b/shared_model/interfaces/commands/subtract_asset_quantity.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_SUBTRACT_ASSET_QUANTITY_HPP
 #define IROHA_SHARED_MODEL_SUBTRACT_ASSET_QUANTITY_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/amount.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -16,7 +17,8 @@ namespace shared_model {
     /**
      * Subtract amount of asset from an account
      */
-    class SubtractAssetQuantity : public ModelPrimitive<SubtractAssetQuantity> {
+    class SubtractAssetQuantity
+        : public NonCopyableModelPrimitive<SubtractAssetQuantity> {
      public:
       /**
        * @return asset identifier

--- a/shared_model/interfaces/commands/transfer_asset.hpp
+++ b/shared_model/interfaces/commands/transfer_asset.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_TRANSFER_ASSET_HPP
 #define IROHA_SHARED_MODEL_TRANSFER_ASSET_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/amount.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Grant permission to account
      */
-    class TransferAsset : public ModelPrimitive<TransferAsset> {
+    class TransferAsset : public NonCopyableModelPrimitive<TransferAsset> {
      public:
       /**
        * @return Id of the account from which transfer assets

--- a/test/module/shared_model/CMakeLists.txt
+++ b/test/module/shared_model/CMakeLists.txt
@@ -32,3 +32,7 @@ target_link_libraries(commands_mocks_factory
     gtest::main
     gmock::main
     )
+# avoid compilation error due to missing operator<< in Command variant types
+target_compile_definitions(commands_mocks_factory
+    PUBLIC BOOST_NO_IOSTREAM
+    )

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -34,51 +34,43 @@ namespace shared_model {
   namespace interface {
     struct MockCommand : public shared_model::interface::Command {
       MOCK_CONST_METHOD0(get, const Command::CommandVariantType &());
-      MOCK_CONST_METHOD0(clone, Command *());
     };
 
     struct MockAddAssetQuantity
         : public shared_model::interface::AddAssetQuantity {
       MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
       MOCK_CONST_METHOD0(amount, const Amount &());
-      MOCK_CONST_METHOD0(clone, AddAssetQuantity *());
     };
 
     struct MockAddPeer : public shared_model::interface::AddPeer {
       MOCK_CONST_METHOD0(peer, const Peer &());
-      MOCK_CONST_METHOD0(clone, MockAddPeer *());
     };
 
     struct MockAddSignatory : public shared_model::interface::AddSignatory {
       MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
-      MOCK_CONST_METHOD0(clone, MockAddSignatory *());
     };
 
     struct MockAppendRole : public shared_model::interface::AppendRole {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
-      MOCK_CONST_METHOD0(clone, MockAppendRole *());
     };
 
     struct MockCreateAccount : public shared_model::interface::CreateAccount {
       MOCK_CONST_METHOD0(accountName, const types::AccountNameType &());
       MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
       MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
-      MOCK_CONST_METHOD0(clone, MockCreateAccount *());
     };
 
     struct MockCreateAsset : public shared_model::interface::CreateAsset {
       MOCK_CONST_METHOD0(assetName, const types::AssetNameType &());
       MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
       MOCK_CONST_METHOD0(precision, const PrecisionType &());
-      MOCK_CONST_METHOD0(clone, MockCreateAsset *());
     };
 
     struct MockCreateDomain : public shared_model::interface::CreateDomain {
       MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
       MOCK_CONST_METHOD0(userDefaultRole, const types::RoleIdType &());
-      MOCK_CONST_METHOD0(clone, MockCreateDomain *());
     };
 
     struct MockCreateRole : public shared_model::interface::CreateRole {
@@ -89,13 +81,11 @@ namespace shared_model {
       MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
       MOCK_CONST_METHOD0(rolePermissions, const RolePermissionSet &());
       MOCK_CONST_METHOD0(toString, std::string());
-      MOCK_CONST_METHOD0(clone, MockCreateRole *());
     };
 
     struct MockDetachRole : public shared_model::interface::DetachRole {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(roleName, const types::RoleIdType &());
-      MOCK_CONST_METHOD0(clone, MockDetachRole *());
     };
 
     struct MockGrantPermission
@@ -108,14 +98,12 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
       MOCK_CONST_METHOD0(toString, std::string());
-      MOCK_CONST_METHOD0(clone, MockGrantPermission *());
     };
 
     struct MockRemoveSignatory
         : public shared_model::interface::RemoveSignatory {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
-      MOCK_CONST_METHOD0(clone, MockRemoveSignatory *());
     };
 
     struct MockRevokePermission
@@ -128,7 +116,6 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(permissionName, permissions::Grantable());
       MOCK_CONST_METHOD0(toString, std::string());
-      MOCK_CONST_METHOD0(clone, MockRevokePermission *());
     };
 
     struct MockSetAccountDetail
@@ -136,20 +123,17 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(key, const types::AccountDetailKeyType &());
       MOCK_CONST_METHOD0(value, const types::AccountDetailValueType &());
-      MOCK_CONST_METHOD0(clone, MockSetAccountDetail *());
     };
 
     struct MockSetQuorum : public shared_model::interface::SetQuorum {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(newQuorum, types::QuorumType());
-      MOCK_CONST_METHOD0(clone, MockSetQuorum *());
     };
 
     struct MockSubtractAssetQuantity
         : public shared_model::interface::SubtractAssetQuantity {
       MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
       MOCK_CONST_METHOD0(amount, const Amount &());
-      MOCK_CONST_METHOD0(clone, MockSubtractAssetQuantity *());
     };
 
     struct MockTransferAsset : public shared_model::interface::TransferAsset {
@@ -158,7 +142,6 @@ namespace shared_model {
       MOCK_CONST_METHOD0(assetId, const types::AssetIdType &());
       MOCK_CONST_METHOD0(amount, const Amount &());
       MOCK_CONST_METHOD0(description, const types::DescriptionType &());
-      MOCK_CONST_METHOD0(clone, MockTransferAsset *());
     };
   }  // namespace interface
 }  // namespace shared_model


### PR DESCRIPTION
### Description of the Change
Simplify `Command` structure by making the classes non-clonable and default-movable.

### Benefits
Less code, same logic

### Possible Drawbacks 
None