### PR TITLE
Simplify shared_model::QueryResponse structure

### DIFF
--- a/iroha-cli/impl/query_response_handler.cpp
+++ b/iroha-cli/impl/query_response_handler.cpp
@@ -168,7 +168,8 @@ namespace iroha_cli {
 
   void QueryResponseHandler::handleTransactionsResponse(
       const iroha::protocol::QueryResponse &response) {
-    auto resp = shared_model::proto::TransactionsResponse(response);
+    iroha::protocol::QueryResponse response_copy{response};
+    shared_model::proto::TransactionsResponse resp{response_copy};
     auto txs = resp.transactions();
     std::for_each(txs.begin(), txs.end(), [this](auto &tx) {
       log_->info("[Transaction]");

--- a/shared_model/backend/protobuf/common_objects/proto_ref.hpp
+++ b/shared_model/backend/protobuf/common_objects/proto_ref.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_MODEL_PROTO_REF_HPP
+#define IROHA_SHARED_MODEL_PROTO_REF_HPP
+
+namespace shared_model {
+  namespace proto {
+    /**
+     * Generic class for handling references to proto objects.
+     * @tparam Iface is interface to inherit from
+     * @tparam Proto is protobuf container
+     */
+    template <typename Iface, typename Proto>
+    class ProtoRef : public Iface {
+     public:
+      using TransportType = Proto;
+
+      /*
+       * Construct object from transport.
+       */
+      explicit ProtoRef(Proto &ref) : proto_(ref) {}
+
+      Proto &proto_;
+    };
+  }  // namespace proto
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_MODEL_PROTO_REF_HPP

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
@@ -8,13 +8,15 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     AccountAssetResponse::AccountAssetResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          account_asset_response_{proto_->account_assets_response()},
-          account_assets_{account_asset_response_.account_assets().begin(),
-                          account_asset_response_.account_assets().end()},
+        iroha::protocol::QueryResponse &query_response)
+        : account_asset_response_{query_response.account_assets_response()},
+          account_assets_{query_response.mutable_account_assets_response()
+                              ->mutable_account_assets()
+                              ->begin(),
+                          query_response.mutable_account_assets_response()
+                              ->mutable_account_assets()
+                              ->end()},
           next_asset_id_{[this]() -> decltype(next_asset_id_) {
             if (account_asset_response_.opt_next_asset_id_case()
                 == iroha::protocol::AccountAssetResponse::kNextAssetId) {
@@ -22,19 +24,6 @@ namespace shared_model {
             }
             return boost::none;
           }()} {}
-
-    template AccountAssetResponse::AccountAssetResponse(
-        AccountAssetResponse::TransportType &);
-    template AccountAssetResponse::AccountAssetResponse(
-        const AccountAssetResponse::TransportType &);
-    template AccountAssetResponse::AccountAssetResponse(
-        AccountAssetResponse::TransportType &&);
-
-    AccountAssetResponse::AccountAssetResponse(const AccountAssetResponse &o)
-        : AccountAssetResponse(o.proto_) {}
-
-    AccountAssetResponse::AccountAssetResponse(AccountAssetResponse &&o)
-        : AccountAssetResponse(std::move(o.proto_)) {}
 
     const interface::types::AccountAssetCollectionType
     AccountAssetResponse::accountAssets() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_detail_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_detail_response.cpp
@@ -8,32 +8,17 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     AccountDetailResponse::AccountDetailResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          account_detail_response_{proto_->account_detail_response()},
-          next_record_id_{[this]() -> decltype(next_record_id_) {
-            if (this->account_detail_response_.has_next_record_id()) {
-              return AccountDetailRecordId{
-                  *this->proto_->mutable_account_detail_response()
-                       ->mutable_next_record_id()};
-            }
-            return boost::none;
-          }()} {}
-
-    template AccountDetailResponse::AccountDetailResponse(
-        AccountDetailResponse::TransportType &);
-    template AccountDetailResponse::AccountDetailResponse(
-        const AccountDetailResponse::TransportType &);
-    template AccountDetailResponse::AccountDetailResponse(
-        AccountDetailResponse::TransportType &&);
-
-    AccountDetailResponse::AccountDetailResponse(const AccountDetailResponse &o)
-        : AccountDetailResponse(o.proto_) {}
-
-    AccountDetailResponse::AccountDetailResponse(AccountDetailResponse &&o)
-        : AccountDetailResponse(std::move(o.proto_)) {}
+        iroha::protocol::QueryResponse &query_response)
+        : account_detail_response_{query_response.account_detail_response()},
+          next_record_id_{
+              [](auto &query_response) -> decltype(next_record_id_) {
+                if (query_response.has_next_record_id()) {
+                  return AccountDetailRecordId{
+                      *query_response.mutable_next_record_id()};
+                }
+                return boost::none;
+              }(*query_response.mutable_account_detail_response())} {}
 
     const interface::types::DetailType &AccountDetailResponse::detail() const {
       return account_detail_response_.detail();

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_response.cpp
@@ -10,10 +10,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    AccountResponse::AccountResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          account_response_{proto_->account_response()},
+    AccountResponse::AccountResponse(
+        iroha::protocol::QueryResponse &query_response)
+        : account_response_{query_response.account_response()},
           account_roles_{boost::accumulate(
               account_response_.account_roles(),
               AccountRolesIdType{},
@@ -21,19 +20,8 @@ namespace shared_model {
                 roles.push_back(interface::types::RoleIdType(role));
                 return std::move(roles);
               })},
-          account_{account_response_.account()} {}
-
-    template AccountResponse::AccountResponse(AccountResponse::TransportType &);
-    template AccountResponse::AccountResponse(
-        const AccountResponse::TransportType &);
-    template AccountResponse::AccountResponse(
-        AccountResponse::TransportType &&);
-
-    AccountResponse::AccountResponse(const AccountResponse &o)
-        : AccountResponse(o.proto_) {}
-
-    AccountResponse::AccountResponse(AccountResponse &&o)
-        : AccountResponse(std::move(o.proto_)) {}
+          account_{
+              *query_response.mutable_account_response()->mutable_account()} {}
 
     const interface::Account &AccountResponse::account() const {
       return account_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_asset_response.cpp
@@ -8,21 +8,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    AssetResponse::AssetResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          asset_response_{proto_->asset_response()},
-          asset_{asset_response_.asset()} {}
-
-    template AssetResponse::AssetResponse(AssetResponse::TransportType &);
-    template AssetResponse::AssetResponse(const AssetResponse::TransportType &);
-    template AssetResponse::AssetResponse(AssetResponse::TransportType &&);
-
-    AssetResponse::AssetResponse(const AssetResponse &o)
-        : AssetResponse(o.proto_) {}
-
-    AssetResponse::AssetResponse(AssetResponse &&o)
-        : AssetResponse(std::move(o.proto_)) {}
+    AssetResponse::AssetResponse(iroha::protocol::QueryResponse &query_response)
+        : asset_response_{query_response.asset_response()},
+          asset_{*query_response.mutable_asset_response()->mutable_asset()} {}
 
     const Asset &AssetResponse::asset() const {
       return asset_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_error_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_error_response.cpp
@@ -8,24 +8,10 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    BlockErrorResponse::BlockErrorResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          block_error_response{proto_->block_error_response()},
+    BlockErrorResponse::BlockErrorResponse(
+        iroha::protocol::BlockQueryResponse &block_query_response)
+        : block_error_response{block_query_response.block_error_response()},
           message_{block_error_response.message()} {}
-
-    template BlockErrorResponse::BlockErrorResponse(
-        BlockErrorResponse::TransportType &);
-    template BlockErrorResponse::BlockErrorResponse(
-        const BlockErrorResponse::TransportType &);
-    template BlockErrorResponse::BlockErrorResponse(
-        BlockErrorResponse::TransportType &&);
-
-    BlockErrorResponse::BlockErrorResponse(const BlockErrorResponse &o)
-        : BlockErrorResponse(o.proto_) {}
-
-    BlockErrorResponse::BlockErrorResponse(BlockErrorResponse &&o)
-        : BlockErrorResponse(std::move(o.proto_)) {}
 
     const interface::types::DescriptionType &BlockErrorResponse::message()
         const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
@@ -10,37 +10,27 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    BlockQueryResponse::BlockQueryResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
+    BlockQueryResponse::BlockQueryResponse(TransportType &&block_query_response)
+        : proto_(std::move(block_query_response)),
           variant_{[this] {
-            auto &&ar = *proto_;
+            auto &ar = proto_;
             int which = ar.GetDescriptor()
                             ->FindFieldByNumber(ar.response_case())
                             ->index();
             return shared_model::detail::variant_impl<
                 ProtoQueryResponseVariantType::types>::
-                template load<ProtoQueryResponseVariantType>(
-                    std::forward<decltype(ar)>(ar), which);
+                template load<ProtoQueryResponseVariantType>(ar, which);
           }()},
           ivariant_{variant_} {}
-
-    template BlockQueryResponse::BlockQueryResponse(
-        BlockQueryResponse::TransportType &);
-    template BlockQueryResponse::BlockQueryResponse(
-        const BlockQueryResponse::TransportType &);
-    template BlockQueryResponse::BlockQueryResponse(
-        BlockQueryResponse::TransportType &&);
-
-    BlockQueryResponse::BlockQueryResponse(const BlockQueryResponse &o)
-        : BlockQueryResponse(o.proto_) {}
-
-    BlockQueryResponse::BlockQueryResponse(BlockQueryResponse &&o) noexcept
-        : BlockQueryResponse(std::move(o.proto_)) {}
 
     const BlockQueryResponse::QueryResponseVariantType &
     BlockQueryResponse::get() const {
       return ivariant_;
+    }
+
+    const BlockQueryResponse::TransportType &BlockQueryResponse::getTransport()
+        const {
+      return proto_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_response.cpp
@@ -8,21 +8,12 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    BlockResponse::BlockResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          block_response_{proto_->block_response()},
-          block_{block_response_.block().block_v1()} {}
-
-    template BlockResponse::BlockResponse(BlockResponse::TransportType &);
-    template BlockResponse::BlockResponse(const BlockResponse::TransportType &);
-    template BlockResponse::BlockResponse(BlockResponse::TransportType &&);
-
-    BlockResponse::BlockResponse(const BlockResponse &o)
-        : BlockResponse(o.proto_) {}
-
-    BlockResponse::BlockResponse(BlockResponse &&o) noexcept
-        : BlockResponse(std::move(o.proto_)) {}
+    BlockResponse::BlockResponse(
+        iroha::protocol::BlockQueryResponse &block_query_response)
+        : block_response_{block_query_response.block_response()},
+          block_{*block_query_response.mutable_block_response()
+                      ->mutable_block()
+                      ->mutable_block_v1()} {}
 
     const Block &BlockResponse::block() const {
       return block_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
@@ -9,11 +9,11 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    ErrorQueryResponse::ErrorQueryResponse(QueryResponseType &&response)
-        : CopyableProto(std::forward<QueryResponseType>(response)),
+    ErrorQueryResponse::ErrorQueryResponse(
+        iroha::protocol::QueryResponse &query_response)
+        : error_response_(*query_response.mutable_error_response()),
           variant_{[this] {
-            auto &&ar = proto_->error_response();
+            auto &ar = error_response_;
 
             unsigned which = ar.GetDescriptor()
                                  ->FindFieldByName("reason")
@@ -22,23 +22,9 @@ namespace shared_model {
                                  ->index();
             return shared_model::detail::
                 variant_impl<ProtoQueryErrorResponseListType>::template load<
-                    ProtoQueryErrorResponseVariantType>(
-                    std::forward<decltype(ar)>(ar), which);
+                    ProtoQueryErrorResponseVariantType>(ar, which);
           }()},
           ivariant_{QueryErrorResponseVariantType{variant_}} {}
-
-    template ErrorQueryResponse::ErrorQueryResponse(
-        ErrorQueryResponse::TransportType &);
-    template ErrorQueryResponse::ErrorQueryResponse(
-        const ErrorQueryResponse::TransportType &);
-    template ErrorQueryResponse::ErrorQueryResponse(
-        ErrorQueryResponse::TransportType &&);
-
-    ErrorQueryResponse::ErrorQueryResponse(const ErrorQueryResponse &o)
-        : ErrorQueryResponse(o.proto_) {}
-
-    ErrorQueryResponse::ErrorQueryResponse(ErrorQueryResponse &&o) noexcept
-        : ErrorQueryResponse(std::move(o.proto_)) {}
 
     const ErrorQueryResponse::QueryErrorResponseVariantType &
     ErrorQueryResponse::get() const {
@@ -47,11 +33,11 @@ namespace shared_model {
 
     const ErrorQueryResponse::ErrorMessageType &
     ErrorQueryResponse::errorMessage() const {
-      return proto_->error_response().message();
+      return error_response_.message();
     }
 
     ErrorQueryResponse::ErrorCodeType ErrorQueryResponse::errorCode() const {
-      return proto_->error_response().error_code();
+      return error_response_.error_code();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_get_block_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_get_block_response.cpp
@@ -8,24 +8,12 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    GetBlockResponse::GetBlockResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          block_response_{proto_->block_response()},
-          block_{block_response_.block().block_v1()} {}
-
-    template GetBlockResponse::GetBlockResponse(
-        GetBlockResponse::TransportType &);
-    template GetBlockResponse::GetBlockResponse(
-        const GetBlockResponse::TransportType &);
-    template GetBlockResponse::GetBlockResponse(
-        GetBlockResponse::TransportType &&);
-
-    GetBlockResponse::GetBlockResponse(const GetBlockResponse &o)
-        : GetBlockResponse(o.proto_) {}
-
-    GetBlockResponse::GetBlockResponse(GetBlockResponse &&o)
-        : GetBlockResponse(std::move(o.proto_)) {}
+    GetBlockResponse::GetBlockResponse(
+        iroha::protocol::QueryResponse &query_response)
+        : block_response_{query_response.block_response()},
+          block_{*query_response.mutable_block_response()
+                      ->mutable_block()
+                      ->mutable_block_v1()} {}
 
     const interface::Block &GetBlockResponse::block() const {
       return block_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_peers_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_peers_response.cpp
@@ -5,28 +5,15 @@
 
 #include "backend/protobuf/query_responses/proto_peers_response.hpp"
 
-#include <boost/range/numeric.hpp>
-#include "backend/protobuf/common_objects/peer.hpp"
-
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    PeersResponse::PeersResponse(QueryResponseType &&query_response)
-        : CopyableProto(std::forward<QueryResponseType>(query_response)),
-          peers_response_{proto_->peers_response()},
-          peers_{proto_->mutable_peers_response()->mutable_peers()->begin(),
-                 proto_->mutable_peers_response()->mutable_peers()->end()} {}
-
-    template PeersResponse::PeersResponse(PeersResponse::TransportType &);
-    template PeersResponse::PeersResponse(const PeersResponse::TransportType &);
-    template PeersResponse::PeersResponse(PeersResponse::TransportType &&);
-
-    PeersResponse::PeersResponse(const PeersResponse &o)
-        : PeersResponse(o.proto_) {}
-
-    PeersResponse::PeersResponse(PeersResponse &&o)
-        : PeersResponse(std::move(o.proto_)) {}
+    PeersResponse::PeersResponse(iroha::protocol::QueryResponse &query_response)
+        : peers_response_{query_response.peers_response()},
+          peers_{
+              query_response.mutable_peers_response()->mutable_peers()->begin(),
+              query_response.mutable_peers_response()->mutable_peers()->end()} {
+    }
 
     interface::PeersForwardCollectionType PeersResponse::peers() const {
       return peers_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
@@ -9,18 +9,17 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          pending_transactions_page_response_{
-              proto_->pending_transactions_page_response()},
-          transactions_{proto_->mutable_pending_transactions_page_response()
-                            ->mutable_transactions()
-                            ->begin(),
-                        proto_->mutable_pending_transactions_page_response()
-                            ->mutable_transactions()
-                            ->end()},
+        iroha::protocol::QueryResponse &query_response)
+        : pending_transactions_page_response_{query_response
+                                                  .pending_transactions_page_response()},
+          transactions_{
+              query_response.mutable_pending_transactions_page_response()
+                  ->mutable_transactions()
+                  ->begin(),
+              query_response.mutable_pending_transactions_page_response()
+                  ->mutable_transactions()
+                  ->end()},
           next_batch_info_{
               [this]()
                   -> boost::optional<
@@ -37,21 +36,6 @@ namespace shared_model {
                 }
                 return boost::none;
               }()} {}
-
-    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        PendingTransactionsPageResponse::TransportType &);
-    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        const PendingTransactionsPageResponse::TransportType &);
-    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        PendingTransactionsPageResponse::TransportType &&);
-
-    PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        const PendingTransactionsPageResponse &o)
-        : PendingTransactionsPageResponse(o.proto_) {}
-
-    PendingTransactionsPageResponse::PendingTransactionsPageResponse(
-        PendingTransactionsPageResponse &&o)
-        : PendingTransactionsPageResponse(std::move(o.proto_)) {}
 
     interface::types::TransactionsCollectionType
     PendingTransactionsPageResponse::transactions() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
@@ -46,18 +46,16 @@ namespace shared_model {
   namespace proto {
 
     struct QueryResponse::Impl {
-      explicit Impl(const TransportType &ref) : proto_{ref} {}
       explicit Impl(TransportType &&ref) : proto_{std::move(ref)} {}
 
       TransportType proto_;
 
       const ProtoQueryResponseVariantType variant_{[this] {
-        const auto &ar = proto_;
+        auto &ar = proto_;
         int which =
             ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
         return shared_model::detail::variant_impl<ProtoQueryResponseListType>::
-            template load<ProtoQueryResponseVariantType>(
-                std::forward<decltype(ar)>(ar), which);
+            template load<ProtoQueryResponseVariantType>(ar, which);
       }()};
 
       const QueryResponseVariantType ivariant_{variant_};
@@ -66,13 +64,6 @@ namespace shared_model {
           iroha::hexstringToBytestring(proto_.query_hash()).get()};
     };
 
-    QueryResponse::QueryResponse(const QueryResponse &o)
-        : QueryResponse(o.impl_->proto_) {}
-    QueryResponse::QueryResponse(QueryResponse &&o) noexcept = default;
-
-    QueryResponse::QueryResponse(const TransportType &ref) {
-      impl_ = std::make_unique<Impl>(ref);
-    }
     QueryResponse::QueryResponse(TransportType &&ref) {
       impl_ = std::make_unique<Impl>(std::move(ref));
     }
@@ -89,10 +80,6 @@ namespace shared_model {
 
     const QueryResponse::TransportType &QueryResponse::getTransport() const {
       return impl_->proto_;
-    }
-
-    QueryResponse *QueryResponse::clone() const {
-      return new QueryResponse(impl_->proto_);
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
@@ -12,11 +12,10 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     RolePermissionsResponse::RolePermissionsResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          role_permissions_response_{proto_->role_permissions_response()},
+        iroha::protocol::QueryResponse &query_response)
+        : role_permissions_response_{query_response
+                                         .role_permissions_response()},
           role_permissions_{boost::accumulate(
               role_permissions_response_.permissions(),
               interface::RolePermissionSet{},
@@ -25,21 +24,6 @@ namespace shared_model {
                     static_cast<iroha::protocol::RolePermission>(permission)));
                 return std::forward<decltype(permissions)>(permissions);
               })} {}
-
-    template RolePermissionsResponse::RolePermissionsResponse(
-        RolePermissionsResponse::TransportType &);
-    template RolePermissionsResponse::RolePermissionsResponse(
-        const RolePermissionsResponse::TransportType &);
-    template RolePermissionsResponse::RolePermissionsResponse(
-        RolePermissionsResponse::TransportType &&);
-
-    RolePermissionsResponse::RolePermissionsResponse(
-        const RolePermissionsResponse &o)
-        : RolePermissionsResponse(o.proto_) {}
-
-    RolePermissionsResponse::RolePermissionsResponse(
-        RolePermissionsResponse &&o)
-        : RolePermissionsResponse(std::move(o.proto_)) {}
 
     const interface::RolePermissionSet &
     RolePermissionsResponse::rolePermissions() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_roles_response.cpp
@@ -10,26 +10,14 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    RolesResponse::RolesResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          roles_response_{proto_->roles_response()},
+    RolesResponse::RolesResponse(iroha::protocol::QueryResponse &query_response)
+        : roles_response_{query_response.roles_response()},
           roles_{boost::accumulate(roles_response_.roles(),
                                    RolesIdType{},
                                    [](auto &&roles, const auto &role) {
                                      roles.emplace_back(role);
                                      return std::move(roles);
                                    })} {}
-
-    template RolesResponse::RolesResponse(RolesResponse::TransportType &);
-    template RolesResponse::RolesResponse(const RolesResponse::TransportType &);
-    template RolesResponse::RolesResponse(RolesResponse::TransportType &&);
-
-    RolesResponse::RolesResponse(const RolesResponse &o)
-        : RolesResponse(o.proto_) {}
-
-    RolesResponse::RolesResponse(RolesResponse &&o)
-        : RolesResponse(std::move(o.proto_)) {}
 
     const RolesResponse::RolesIdType &RolesResponse::roles() const {
       return roles_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_signatories_response.cpp
@@ -11,10 +11,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
-    SignatoriesResponse::SignatoriesResponse(QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          signatories_response_{proto_->signatories_response()},
+    SignatoriesResponse::SignatoriesResponse(
+        iroha::protocol::QueryResponse &query_response)
+        : signatories_response_{query_response.signatories_response()},
           keys_{[this] {
             return boost::accumulate(
                 signatories_response_.keys(),
@@ -24,19 +23,6 @@ namespace shared_model {
                   return acc;
                 });
           }()} {}
-
-    template SignatoriesResponse::SignatoriesResponse(
-        SignatoriesResponse::TransportType &);
-    template SignatoriesResponse::SignatoriesResponse(
-        const SignatoriesResponse::TransportType &);
-    template SignatoriesResponse::SignatoriesResponse(
-        SignatoriesResponse::TransportType &&);
-
-    SignatoriesResponse::SignatoriesResponse(const SignatoriesResponse &o)
-        : SignatoriesResponse(o.proto_) {}
-
-    SignatoriesResponse::SignatoriesResponse(SignatoriesResponse &&o)
-        : SignatoriesResponse(std::move(o.proto_)) {}
 
     const interface::types::PublicKeyCollectionType &SignatoriesResponse::keys()
         const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_page_response.cpp
@@ -9,11 +9,9 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     TransactionsPageResponse::TransactionsPageResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          transactionPageResponse_{proto_->transactions_page_response()},
+        iroha::protocol::QueryResponse &query_response)
+        : transactionPageResponse_{query_response.transactions_page_response()},
           transactions_{transactionPageResponse_.transactions().begin(),
                         transactionPageResponse_.transactions().end()},
           next_hash_{[this]() -> boost::optional<interface::types::HashType> {
@@ -25,21 +23,6 @@ namespace shared_model {
                 return boost::none;
             }
           }()} {}
-
-    template TransactionsPageResponse::TransactionsPageResponse(
-        TransactionsPageResponse::TransportType &);
-    template TransactionsPageResponse::TransactionsPageResponse(
-        const TransactionsPageResponse::TransportType &);
-    template TransactionsPageResponse::TransactionsPageResponse(
-        TransactionsPageResponse::TransportType &&);
-
-    TransactionsPageResponse::TransactionsPageResponse(
-        const TransactionsPageResponse &o)
-        : TransactionsPageResponse(o.proto_) {}
-
-    TransactionsPageResponse::TransactionsPageResponse(
-        TransactionsPageResponse &&o)
-        : TransactionsPageResponse(std::move(o.proto_)) {}
 
     interface::types::TransactionsCollectionType
     TransactionsPageResponse::transactions() const {

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_response.cpp
@@ -8,26 +8,11 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryResponseType>
     TransactionsResponse::TransactionsResponse(
-        QueryResponseType &&queryResponse)
-        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
-          transaction_response_{proto_->transactions_response()},
+        iroha::protocol::QueryResponse &query_response)
+        : transaction_response_{query_response.transactions_response()},
           transactions_{transaction_response_.transactions().begin(),
                         transaction_response_.transactions().end()} {}
-
-    template TransactionsResponse::TransactionsResponse(
-        TransactionsResponse::TransportType &);
-    template TransactionsResponse::TransactionsResponse(
-        const TransactionsResponse::TransportType &);
-    template TransactionsResponse::TransactionsResponse(
-        TransactionsResponse::TransportType &&);
-
-    TransactionsResponse::TransactionsResponse(const TransactionsResponse &o)
-        : TransactionsResponse(o.proto_) {}
-
-    TransactionsResponse::TransactionsResponse(TransactionsResponse &&o)
-        : TransactionsResponse(std::move(o.proto_)) {}
 
     interface::types::TransactionsCollectionType
     TransactionsResponse::transactions() const {

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -6,38 +6,31 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ACCOUNT_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_ASSET_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/account_asset.hpp"
-
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "interfaces/common_objects/types.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
+
+#include "backend/protobuf/common_objects/account_asset.hpp"
+#include "interfaces/common_objects/types.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class AccountAssetResponse final
-        : public CopyableProto<interface::AccountAssetResponse,
-                               iroha::protocol::QueryResponse,
-                               AccountAssetResponse> {
+    class AccountAssetResponse final : public interface::AccountAssetResponse {
      public:
-      template <typename QueryResponseType>
-      explicit AccountAssetResponse(QueryResponseType &&queryResponse);
-
-      AccountAssetResponse(const AccountAssetResponse &o);
-
-      AccountAssetResponse(AccountAssetResponse &&o);
+      explicit AccountAssetResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       const interface::types::AccountAssetCollectionType accountAssets()
           const override;
 
-      boost::optional<interface::types::AssetIdType> nextAssetId() const override;
+      boost::optional<interface::types::AssetIdType> nextAssetId()
+          const override;
 
       size_t totalAccountAssetsNumber() const override;
 
      private:
       const iroha::protocol::AccountAssetResponse &account_asset_response_;
 
-      const std::vector<AccountAsset> account_assets_;
+      std::vector<AccountAsset> account_assets_;
       const boost::optional<interface::types::AssetIdType> next_asset_id_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
@@ -8,23 +8,17 @@
 
 #include "interfaces/query_responses/account_detail_response.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/common_objects/account_asset.hpp"
 #include "backend/protobuf/queries/proto_account_detail_record_id.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
     class AccountDetailResponse final
-        : public CopyableProto<interface::AccountDetailResponse,
-                               iroha::protocol::QueryResponse,
-                               AccountDetailResponse> {
+        : public interface::AccountDetailResponse {
      public:
-      template <typename QueryResponseType>
-      explicit AccountDetailResponse(QueryResponseType &&queryResponse);
-
-      AccountDetailResponse(const AccountDetailResponse &o);
-
-      AccountDetailResponse(AccountDetailResponse &&o);
+      explicit AccountDetailResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       const interface::types::DetailType &detail() const override;
 

--- a/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_response.hpp
@@ -6,24 +6,16 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ACCOUNT_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ACCOUNT_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/account.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/account_response.hpp"
+
+#include "backend/protobuf/common_objects/account.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class AccountResponse final
-        : public CopyableProto<interface::AccountResponse,
-                               iroha::protocol::QueryResponse,
-                               AccountResponse> {
+    class AccountResponse final : public interface::AccountResponse {
      public:
-      template <typename QueryResponseType>
-      explicit AccountResponse(QueryResponseType &&queryResponse);
-
-      AccountResponse(const AccountResponse &o);
-
-      AccountResponse(AccountResponse &&o);
+      explicit AccountResponse(iroha::protocol::QueryResponse &query_response);
 
       const interface::Account &account() const override;
 
@@ -34,7 +26,7 @@ namespace shared_model {
 
       const AccountRolesIdType account_roles_;
 
-      const shared_model::proto::Account account_;
+      Account account_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_asset_response.hpp
@@ -6,31 +6,23 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ASSET_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/asset.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/asset_response.hpp"
+
+#include "backend/protobuf/common_objects/asset.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class AssetResponse final
-        : public CopyableProto<interface::AssetResponse,
-                               iroha::protocol::QueryResponse,
-                               AssetResponse> {
+    class AssetResponse final : public interface::AssetResponse {
      public:
-      template <typename QueryResponseType>
-      explicit AssetResponse(QueryResponseType &&queryResponse);
-
-      AssetResponse(const AssetResponse &o);
-
-      AssetResponse(AssetResponse &&o);
+      explicit AssetResponse(iroha::protocol::QueryResponse &query_response);
 
       const Asset &asset() const override;
 
      private:
       const iroha::protocol::AssetResponse &asset_response_;
 
-      const Asset asset_;
+      Asset asset_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_block_error_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_error_response.hpp
@@ -6,23 +6,16 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCK_ERROR_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCK_ERROR_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/block_error_response.hpp"
+
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class BlockErrorResponse final
-        : public CopyableProto<interface::BlockErrorResponse,
-                               iroha::protocol::BlockQueryResponse,
-                               BlockErrorResponse> {
+    class BlockErrorResponse final : public interface::BlockErrorResponse {
      public:
-      template <typename QueryResponseType>
-      explicit BlockErrorResponse(QueryResponseType &&queryResponse);
-
-      BlockErrorResponse(const BlockErrorResponse &o);
-
-      BlockErrorResponse(BlockErrorResponse &&o);
+      explicit BlockErrorResponse(
+          iroha::protocol::BlockQueryResponse &block_query_response);
 
       const interface::types::DescriptionType &message() const override;
 

--- a/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
@@ -6,35 +6,32 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCK_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCK_QUERY_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/query_responses/block_query_response.hpp"
+
 #include "backend/protobuf/query_responses/proto_block_error_response.hpp"
 #include "backend/protobuf/query_responses/proto_block_response.hpp"
 #include "interfaces/queries/query.hpp"
-#include "interfaces/query_responses/block_query_response.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class BlockQueryResponse final
-        : public CopyableProto<interface::BlockQueryResponse,
-                               iroha::protocol::BlockQueryResponse,
-                               BlockQueryResponse> {
+    class BlockQueryResponse final : public interface::BlockQueryResponse {
      private:
       /// type of proto variant
       using ProtoQueryResponseVariantType =
           boost::variant<BlockResponse, BlockErrorResponse>;
 
      public:
-      template <typename QueryResponseType>
-      explicit BlockQueryResponse(QueryResponseType &&queryResponse);
+      using TransportType = iroha::protocol::BlockQueryResponse;
 
-      BlockQueryResponse(const BlockQueryResponse &o);
-
-      BlockQueryResponse(BlockQueryResponse &&o) noexcept;
+      explicit BlockQueryResponse(TransportType &&block_query_response);
 
       const QueryResponseVariantType &get() const override;
 
+      const TransportType &getTransport() const;
+
      private:
+      iroha::protocol::BlockQueryResponse proto_;
       const ProtoQueryResponseVariantType variant_;
       const QueryResponseVariantType ivariant_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_block_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_response.hpp
@@ -6,31 +6,24 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCK_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCK_RESPONSE_HPP
 
-#include "backend/protobuf/block.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/block_response.hpp"
+
+#include "backend/protobuf/block.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class BlockResponse final
-        : public CopyableProto<interface::BlockResponse,
-                               iroha::protocol::BlockQueryResponse,
-                               BlockResponse> {
+    class BlockResponse final : public interface::BlockResponse {
      public:
-      template <typename QueryResponseType>
-      explicit BlockResponse(QueryResponseType &&queryResponse);
-
-      BlockResponse(const BlockResponse &o);
-
-      BlockResponse(BlockResponse &&o) noexcept;
+      explicit BlockResponse(
+          iroha::protocol::BlockQueryResponse &block_query_response);
 
       const Block &block() const override;
 
      private:
       const iroha::protocol::BlockResponse &block_response_;
 
-      const Block block_;
+      Block block_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_concrete_error_query_response.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_CONCRETE_ERROR_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_CONCRETE_ERROR_QUERY_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/common_objects/proto_ref.hpp"
 #include "interfaces/query_responses/error_responses/no_account_assets_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_detail_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_error_response.hpp"
@@ -21,30 +21,29 @@
 namespace shared_model {
   namespace proto {
     using StatelessFailedErrorResponse =
-        TrivialProto<interface::StatelessFailedErrorResponse,
-                     iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::StatelessFailedErrorResponse,
+                 iroha::protocol::ErrorResponse>;
     using StatefulFailedErrorResponse =
-        TrivialProto<interface::StatefulFailedErrorResponse,
-                     iroha::protocol::ErrorResponse>;
-    using NoAccountErrorResponse =
-        TrivialProto<interface::NoAccountErrorResponse,
-                     iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::StatefulFailedErrorResponse,
+                 iroha::protocol::ErrorResponse>;
+    using NoAccountErrorResponse = ProtoRef<interface::NoAccountErrorResponse,
+                                            iroha::protocol::ErrorResponse>;
     using NoAccountAssetsErrorResponse =
-        TrivialProto<interface::NoAccountAssetsErrorResponse,
-                     iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::NoAccountAssetsErrorResponse,
+                 iroha::protocol::ErrorResponse>;
     using NoAccountDetailErrorResponse =
-        TrivialProto<interface::NoAccountDetailErrorResponse,
-                     iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::NoAccountDetailErrorResponse,
+                 iroha::protocol::ErrorResponse>;
     using NoSignatoriesErrorResponse =
-        TrivialProto<interface::NoSignatoriesErrorResponse,
-                     iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::NoSignatoriesErrorResponse,
+                 iroha::protocol::ErrorResponse>;
     using NotSupportedErrorResponse =
-        TrivialProto<interface::NotSupportedErrorResponse,
-                     iroha::protocol::ErrorResponse>;
-    using NoAssetErrorResponse = TrivialProto<interface::NoAssetErrorResponse,
-                                              iroha::protocol::ErrorResponse>;
-    using NoRolesErrorResponse = TrivialProto<interface::NoRolesErrorResponse,
-                                              iroha::protocol::ErrorResponse>;
+        ProtoRef<interface::NotSupportedErrorResponse,
+                 iroha::protocol::ErrorResponse>;
+    using NoAssetErrorResponse = ProtoRef<interface::NoAssetErrorResponse,
+                                          iroha::protocol::ErrorResponse>;
+    using NoRolesErrorResponse = ProtoRef<interface::NoRolesErrorResponse,
+                                          iroha::protocol::ErrorResponse>;
   }  // namespace proto
 }  // namespace shared_model
 

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -6,17 +6,14 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ERROR_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ERROR_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/query_responses/proto_concrete_error_query_response.hpp"
 #include "interfaces/query_responses/error_query_response.hpp"
+
+#include "backend/protobuf/query_responses/proto_concrete_error_query_response.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class ErrorQueryResponse final
-        : public CopyableProto<interface::ErrorQueryResponse,
-                               iroha::protocol::QueryResponse,
-                               ErrorQueryResponse> {
+    class ErrorQueryResponse final : public interface::ErrorQueryResponse {
      public:
       /// type of proto variant
       using ProtoQueryErrorResponseVariantType =
@@ -34,12 +31,8 @@ namespace shared_model {
       using ProtoQueryErrorResponseListType =
           ProtoQueryErrorResponseVariantType::types;
 
-      template <typename QueryResponseType>
-      explicit ErrorQueryResponse(QueryResponseType &&response);
-
-      ErrorQueryResponse(const ErrorQueryResponse &o);
-
-      ErrorQueryResponse(ErrorQueryResponse &&o) noexcept;
+      explicit ErrorQueryResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       const QueryErrorResponseVariantType &get() const override;
 
@@ -48,9 +41,11 @@ namespace shared_model {
       ErrorCodeType errorCode() const override;
 
      private:
-      const ProtoQueryErrorResponseVariantType variant_;
+      iroha::protocol::ErrorResponse &error_response_;
 
-      const QueryErrorResponseVariantType ivariant_;
+      ProtoQueryErrorResponseVariantType variant_;
+
+      QueryErrorResponseVariantType ivariant_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_get_block_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_get_block_response.hpp
@@ -6,31 +6,23 @@
 #ifndef IROHA_SHARED_MODEL_GET_BLOCK_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_GET_BLOCK_RESPONSE_HPP
 
-#include "backend/protobuf/block.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/block_response.hpp"
+
+#include "backend/protobuf/block.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetBlockResponse final
-        : public CopyableProto<interface::BlockResponse,
-                               iroha::protocol::QueryResponse,
-                               GetBlockResponse> {
+    class GetBlockResponse final : public interface::BlockResponse {
      public:
-      template <typename QueryResponseType>
-      explicit GetBlockResponse(QueryResponseType &&queryResponse);
-
-      GetBlockResponse(const GetBlockResponse &o);
-
-      GetBlockResponse(GetBlockResponse &&o);
+      explicit GetBlockResponse(iroha::protocol::QueryResponse &query_response);
 
       const interface::Block &block() const override;
 
      private:
       const iroha::protocol::BlockResponse &block_response_;
 
-      const Block block_;
+      Block block_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_peers_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_peers_response.hpp
@@ -6,31 +6,23 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_PEERS_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_PEERS_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/peer.hpp"
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/peers_response.hpp"
+
+#include "backend/protobuf/common_objects/peer.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class PeersResponse final
-        : public CopyableProto<interface::PeersResponse,
-                               iroha::protocol::QueryResponse,
-                               PeersResponse> {
+    class PeersResponse final : public interface::PeersResponse {
      public:
-      template <typename QueryResponseType>
-      explicit PeersResponse(QueryResponseType &&query_response);
-
-      PeersResponse(const PeersResponse &o);
-
-      PeersResponse(PeersResponse &&o);
+      explicit PeersResponse(iroha::protocol::QueryResponse &query_response);
 
       interface::PeersForwardCollectionType peers() const override;
 
      private:
       const iroha::protocol::PeersResponse &peers_response_;
 
-      const std::vector<Peer> peers_;
+      std::vector<Peer> peers_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
@@ -8,7 +8,6 @@
 
 #include "interfaces/query_responses/pending_transactions_page_response.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "qry_responses.pb.h"
@@ -16,17 +15,10 @@
 namespace shared_model {
   namespace proto {
     class PendingTransactionsPageResponse final
-        : public CopyableProto<interface::PendingTransactionsPageResponse,
-                               iroha::protocol::QueryResponse,
-                               PendingTransactionsPageResponse> {
+        : public interface::PendingTransactionsPageResponse {
      public:
-      template <typename QueryResponseType>
       explicit PendingTransactionsPageResponse(
-          QueryResponseType &&queryResponse);
-
-      PendingTransactionsPageResponse(const PendingTransactionsPageResponse &o);
-
-      PendingTransactionsPageResponse(PendingTransactionsPageResponse &&o);
+          iroha::protocol::QueryResponse &query_response);
 
       interface::types::TransactionsCollectionType transactions()
           const override;
@@ -40,7 +32,7 @@ namespace shared_model {
      private:
       const iroha::protocol::PendingTransactionsPageResponse
           &pending_transactions_page_response_;
-      const std::vector<proto::Transaction> transactions_;
+      const std::vector<Transaction> transactions_;
       boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
           next_batch_info_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_query_response.hpp
@@ -16,10 +16,6 @@ namespace shared_model {
      public:
       using TransportType = iroha::protocol::QueryResponse;
 
-      QueryResponse(const QueryResponse &o);
-      QueryResponse(QueryResponse &&o) noexcept;
-
-      explicit QueryResponse(const TransportType &queryResponse);
       explicit QueryResponse(TransportType &&queryResponse);
 
       ~QueryResponse() override;
@@ -29,9 +25,6 @@ namespace shared_model {
       const interface::types::HashType &queryHash() const override;
 
       const TransportType &getTransport() const;
-
-     protected:
-      QueryResponse *clone() const override;
 
      private:
       struct Impl;

--- a/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_role_permissions_response.hpp
@@ -6,30 +6,25 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ROLE_PERMISSIONS_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ROLE_PERMISSIONS_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/role_permissions.hpp"
+
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
     class RolePermissionsResponse final
-        : public CopyableProto<interface::RolePermissionsResponse,
-                               iroha::protocol::QueryResponse,
-                               RolePermissionsResponse> {
+        : public interface::RolePermissionsResponse {
      public:
-      template <typename QueryResponseType>
-      explicit RolePermissionsResponse(QueryResponseType &&queryResponse);
-
-      RolePermissionsResponse(const RolePermissionsResponse &o);
-
-      RolePermissionsResponse(RolePermissionsResponse &&o);
+      explicit RolePermissionsResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       const interface::RolePermissionSet &rolePermissions() const override;
 
       std::string toString() const override;
 
      private:
-      const iroha::protocol::RolePermissionsResponse &role_permissions_response_;
+      const iroha::protocol::RolePermissionsResponse
+          &role_permissions_response_;
 
       const interface::RolePermissionSet role_permissions_;
     };

--- a/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_roles_response.hpp
@@ -6,23 +6,15 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_ROLES_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_ROLES_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/query_responses/roles_response.hpp"
+
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class RolesResponse final
-        : public CopyableProto<interface::RolesResponse,
-                               iroha::protocol::QueryResponse,
-                               RolesResponse> {
+    class RolesResponse final : public interface::RolesResponse {
      public:
-      template <typename QueryResponseType>
-      explicit RolesResponse(QueryResponseType &&queryResponse);
-
-      RolesResponse(const RolesResponse &o);
-
-      RolesResponse(RolesResponse &&o);
+      explicit RolesResponse(iroha::protocol::QueryResponse &query_response);
 
       const RolesIdType &roles() const override;
 

--- a/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_signatories_response.hpp
@@ -6,24 +6,17 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_SIGNATORIES_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_SIGNATORIES_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "cryptography/public_key.hpp"
 #include "interfaces/query_responses/signatories_response.hpp"
+
+#include "cryptography/public_key.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class SignatoriesResponse final
-        : public CopyableProto<interface::SignatoriesResponse,
-                               iroha::protocol::QueryResponse,
-                               SignatoriesResponse> {
+    class SignatoriesResponse final : public interface::SignatoriesResponse {
      public:
-      template <typename QueryResponseType>
-      explicit SignatoriesResponse(QueryResponseType &&queryResponse);
-
-      SignatoriesResponse(const SignatoriesResponse &o);
-
-      SignatoriesResponse(SignatoriesResponse &&o);
+      explicit SignatoriesResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       const interface::types::PublicKeyCollectionType &keys() const override;
 

--- a/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transaction_response.hpp
@@ -6,25 +6,18 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_TRANSACTION_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PROTO_TRANSACTION_RESPONSE_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "interfaces/query_responses/transactions_response.hpp"
+
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/common_objects/types.hpp"
-#include "interfaces/query_responses/transactions_response.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class TransactionsResponse final
-        : public CopyableProto<interface::TransactionsResponse,
-                               iroha::protocol::QueryResponse,
-                               TransactionsResponse> {
+    class TransactionsResponse final : public interface::TransactionsResponse {
      public:
-      template <typename QueryResponseType>
-      explicit TransactionsResponse(QueryResponseType &&queryResponse);
-
-      TransactionsResponse(const TransactionsResponse &o);
-
-      TransactionsResponse(TransactionsResponse &&o);
+      explicit TransactionsResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       interface::types::TransactionsCollectionType transactions()
           const override;

--- a/shared_model/backend/protobuf/query_responses/proto_transactions_page_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transactions_page_response.hpp
@@ -8,7 +8,6 @@
 
 #include "interfaces/query_responses/transactions_page_response.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "qry_responses.pb.h"
@@ -16,16 +15,10 @@
 namespace shared_model {
   namespace proto {
     class TransactionsPageResponse final
-        : public CopyableProto<interface::TransactionsPageResponse,
-                               iroha::protocol::QueryResponse,
-                               TransactionsPageResponse> {
+        : public interface::TransactionsPageResponse {
      public:
-      template <typename QueryResponseType>
-      explicit TransactionsPageResponse(QueryResponseType &&queryResponse);
-
-      TransactionsPageResponse(const TransactionsPageResponse &o);
-
-      TransactionsPageResponse(TransactionsPageResponse &&o);
+      explicit TransactionsPageResponse(
+          iroha::protocol::QueryResponse &query_response);
 
       interface::types::TransactionsCollectionType transactions()
           const override;
@@ -37,7 +30,7 @@ namespace shared_model {
 
      private:
       const iroha::protocol::TransactionsPageResponse &transactionPageResponse_;
-      const std::vector<proto::Transaction> transactions_;
+      std::vector<proto::Transaction> transactions_;
       boost::optional<interface::types::HashType> next_hash_;
     };
   }  // namespace proto

--- a/shared_model/interfaces/query_responses/account_asset_response.hpp
+++ b/shared_model/interfaces/query_responses/account_asset_response.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_ACCOUNT_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ACCOUNT_ASSET_RESPONSE_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/optional.hpp>
-#include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/account_asset.hpp"
 #include "interfaces/common_objects/range_types.hpp"
 
@@ -16,7 +17,8 @@ namespace shared_model {
     /**
      * Provide response with account asset
      */
-    class AccountAssetResponse : public ModelPrimitive<AccountAssetResponse> {
+    class AccountAssetResponse
+        : public NonCopyableModelPrimitive<AccountAssetResponse> {
      public:
       /**
        * @return Account has Asset model

--- a/shared_model/interfaces/query_responses/account_detail_response.hpp
+++ b/shared_model/interfaces/query_responses/account_detail_response.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_ACCOUNT_DETAIL_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ACCOUNT_DETAIL_RESPONSE_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/optional.hpp>
-#include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/account_detail_record_id.hpp"
 
@@ -16,7 +17,8 @@ namespace shared_model {
     /**
      * Provide response with account asset
      */
-    class AccountDetailResponse : public ModelPrimitive<AccountDetailResponse> {
+    class AccountDetailResponse
+        : public NonCopyableModelPrimitive<AccountDetailResponse> {
      public:
       /**
        * @return Account has Asset model

--- a/shared_model/interfaces/query_responses/account_response.hpp
+++ b/shared_model/interfaces/query_responses/account_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ACCOUNT_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ACCOUNT_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -15,7 +16,7 @@ namespace shared_model {
     /**
      * Provide response with account
      */
-    class AccountResponse : public ModelPrimitive<AccountResponse> {
+    class AccountResponse : public NonCopyableModelPrimitive<AccountResponse> {
      public:
       /// Collection of role_id types
       using AccountRolesIdType = std::vector<types::RoleIdType>;

--- a/shared_model/interfaces/query_responses/asset_response.hpp
+++ b/shared_model/interfaces/query_responses/asset_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ASSET_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ASSET_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/asset.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Provide response with asset
      */
-    class AssetResponse : public ModelPrimitive<AssetResponse> {
+    class AssetResponse : public NonCopyableModelPrimitive<AssetResponse> {
      public:
       /**
        * @return Attached asset

--- a/shared_model/interfaces/query_responses/block_error_response.hpp
+++ b/shared_model/interfaces/query_responses/block_error_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_BLOCK_ERROR_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_BLOCK_ERROR_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,8 @@ namespace shared_model {
     /**
      * Provide response with error
      */
-    class BlockErrorResponse : public ModelPrimitive<BlockErrorResponse> {
+    class BlockErrorResponse
+        : public NonCopyableModelPrimitive<BlockErrorResponse> {
      public:
       /**
        * @return Attached error message

--- a/shared_model/interfaces/query_responses/block_query_response.hpp
+++ b/shared_model/interfaces/query_responses/block_query_response.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_BLOCK_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_BLOCK_QUERY_RESPONSE_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/variant.hpp>
-#include "interfaces/base/model_primitive.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -20,7 +21,8 @@ namespace shared_model {
      * responses available in the system. General note: this class is container
      * for QRs but not a base class.
      */
-    class BlockQueryResponse : public ModelPrimitive<BlockQueryResponse> {
+    class BlockQueryResponse
+        : public NonCopyableModelPrimitive<BlockQueryResponse> {
      private:
       /// Shortcut type for polymorphic wrapper
       template <typename... Value>

--- a/shared_model/interfaces/query_responses/block_response.hpp
+++ b/shared_model/interfaces/query_responses/block_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_BLOCK_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_BLOCK_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -17,7 +18,7 @@ namespace shared_model {
     /**
      * Provide response with block
      */
-    class BlockResponse : public ModelPrimitive<BlockResponse> {
+    class BlockResponse : public NonCopyableModelPrimitive<BlockResponse> {
      public:
       /**
        * @return Attached block

--- a/shared_model/interfaces/query_responses/error_query_response.hpp
+++ b/shared_model/interfaces/query_responses/error_query_response.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_QUERY_ERROR_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_QUERY_ERROR_RESPONSE_HPP
 
-#include <boost/variant.hpp>
+#include "interfaces/base/noncopyable_model_primitive.hpp"
 
-#include "interfaces/base/model_primitive.hpp"
+#include <boost/variant.hpp>
 #include "interfaces/query_responses/error_responses/no_account_assets_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_detail_error_response.hpp"
 #include "interfaces/query_responses/error_responses/no_account_error_response.hpp"
@@ -26,7 +26,8 @@ namespace shared_model {
      * QueryErrorResponse interface container for all concrete error responses
      * possible achieved in the system.
      */
-    class ErrorQueryResponse : public ModelPrimitive<ErrorQueryResponse> {
+    class ErrorQueryResponse
+        : public NonCopyableModelPrimitive<ErrorQueryResponse> {
      private:
       /// Shortcut type for const reference
       template <typename... Value>

--- a/shared_model/interfaces/query_responses/error_responses/abstract_error_response.hpp
+++ b/shared_model/interfaces/query_responses/error_responses/abstract_error_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_ABSTRACT_ERROR_RESPONSE_HPP
 #define IROHA_ABSTRACT_ERROR_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "utils/string_builder.hpp"
 
 namespace shared_model {
@@ -16,7 +17,7 @@ namespace shared_model {
      * @tparam Model - concrete model error response
      */
     template <typename Model>
-    class AbstractErrorResponse : public ModelPrimitive<Model> {
+    class AbstractErrorResponse : public NonCopyableModelPrimitive<Model> {
      private:
       /**
        * @return string representation of error reason

--- a/shared_model/interfaces/query_responses/peers_response.hpp
+++ b/shared_model/interfaces/query_responses/peers_response.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_PEERS_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PEERS_RESPONSE_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/range/any_range.hpp>
-#include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -19,7 +20,7 @@ namespace shared_model {
     /**
      * Provide response with peers in the network
      */
-    class PeersResponse : public ModelPrimitive<PeersResponse> {
+    class PeersResponse : public NonCopyableModelPrimitive<PeersResponse> {
      public:
       /**
        * @return a list of peers

--- a/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
@@ -6,9 +6,10 @@
 #ifndef IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
 
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include <boost/optional/optional_fwd.hpp>
 #include "cryptography/hash.hpp"
-#include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -19,7 +20,7 @@ namespace shared_model {
      * Response for paginated queries
      */
     class PendingTransactionsPageResponse
-        : public ModelPrimitive<PendingTransactionsPageResponse> {
+        : public NonCopyableModelPrimitive<PendingTransactionsPageResponse> {
      public:
       // TODO igor-egorov 2019-06-29 IR-570 Convert BatchInfo to a shared model
       // object

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_QUERY_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_QUERY_RESPONSE_HPP
 
-#include <boost/variant/variant_fwd.hpp>
+#include "interfaces/base/noncopyable_model_primitive.hpp"
 
-#include "interfaces/base/model_primitive.hpp"
+#include <boost/variant/variant_fwd.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -32,7 +32,7 @@ namespace shared_model {
      * available in the system.
      * General note: this class is container for QRs but not a base class.
      */
-    class QueryResponse : public ModelPrimitive<QueryResponse> {
+    class QueryResponse : public NonCopyableModelPrimitive<QueryResponse> {
      private:
       /// Shortcut type for const reference
       template <typename... Value>

--- a/shared_model/interfaces/query_responses/role_permissions.hpp
+++ b/shared_model/interfaces/query_responses/role_permissions.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ROLE_PERMISSIONS_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ROLE_PERMISSIONS_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/permissions.hpp"
 
@@ -16,7 +17,7 @@ namespace shared_model {
      * Response with all permissions related to role
      */
     class RolePermissionsResponse
-        : public ModelPrimitive<RolePermissionsResponse> {
+        : public NonCopyableModelPrimitive<RolePermissionsResponse> {
      public:
       /**
        * @return role permissions

--- a/shared_model/interfaces/query_responses/roles_response.hpp
+++ b/shared_model/interfaces/query_responses/roles_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_ROLES_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_ROLES_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,7 @@ namespace shared_model {
     /**
      * Provide response with all roles of the current system
      */
-    class RolesResponse : public ModelPrimitive<RolesResponse> {
+    class RolesResponse : public NonCopyableModelPrimitive<RolesResponse> {
      public:
       /// type of roles collection
       using RolesIdType = std::vector<types::RoleIdType>;

--- a/shared_model/interfaces/query_responses/signatories_response.hpp
+++ b/shared_model/interfaces/query_responses/signatories_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_SIGNATORIES_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_SIGNATORIES_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -14,7 +15,8 @@ namespace shared_model {
     /**
      * Container of asset, for fetching data.
      */
-    class SignatoriesResponse : public ModelPrimitive<SignatoriesResponse> {
+    class SignatoriesResponse
+        : public NonCopyableModelPrimitive<SignatoriesResponse> {
      public:
       /**
        * @return All public keys attached to account

--- a/shared_model/interfaces/query_responses/transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/transactions_page_response.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_TRANSACTIONS_PAGE_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_TRANSACTIONS_PAGE_RESPONSE_HPP
 
-#include <boost/optional/optional_fwd.hpp>
+#include "interfaces/base/noncopyable_model_primitive.hpp"
 
-#include "interfaces/base/model_primitive.hpp"
+#include <boost/optional/optional_fwd.hpp>
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -18,7 +18,7 @@ namespace shared_model {
      * Response for paginated queries
      */
     class TransactionsPageResponse
-        : public ModelPrimitive<TransactionsPageResponse> {
+        : public NonCopyableModelPrimitive<TransactionsPageResponse> {
      public:
       /**
        * @return transactions from this page

--- a/shared_model/interfaces/query_responses/transactions_response.hpp
+++ b/shared_model/interfaces/query_responses/transactions_response.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SHARED_MODEL_TRANSACTIONS_RESPONSE_HPP
 #define IROHA_SHARED_MODEL_TRANSACTIONS_RESPONSE_HPP
 
-#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/base/noncopyable_model_primitive.hpp"
+
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -15,7 +16,8 @@ namespace shared_model {
     /**
      * Container of asset, for fetching data.
      */
-    class TransactionsResponse : public ModelPrimitive<TransactionsResponse> {
+    class TransactionsResponse
+        : public NonCopyableModelPrimitive<TransactionsResponse> {
      public:
       /**
        * @return Attached transactions

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -630,8 +630,7 @@ namespace integration_framework {
 
     iroha::protocol::QueryResponse response;
     query_client_.Find(qry.getTransport(), response);
-    auto query_response =
-        shared_model::proto::QueryResponse(std::move(response));
+    shared_model::proto::QueryResponse query_response{std::move(response)};
 
     validation(query_response);
     return *this;

--- a/test/module/irohad/torii/query_service_test.cpp
+++ b/test/module/irohad/torii/query_service_test.cpp
@@ -107,7 +107,7 @@ TEST_F(QueryServiceTest, ValidWhenUniqueHash) {
 
   protocol::QueryResponse response;
   query_service->Find(query->getTransport(), response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{protocol::QueryResponse{response}};
   ASSERT_EQ(resp, *getResponse());
 }
 
@@ -131,7 +131,7 @@ TEST_F(QueryServiceTest, InvalidWhenDuplicateHash) {
   // second call of the same query
   query_service->Find(query->getTransport(), response);
   ASSERT_TRUE(response.has_error_response());
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{protocol::QueryResponse{response}};
   ASSERT_TRUE(boost::apply_visitor(
       shared_model::interface::QueryErrorResponseChecker<
           shared_model::interface::StatelessFailedErrorResponse>(),

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -28,12 +28,12 @@
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 #include "validators/protobuf/proto_query_validator.hpp"
 
+#include "framework/common_constants.hpp"
 #include "main/server_runner.hpp"
 #include "torii/processor/query_processor_impl.hpp"
 #include "torii/query_client.hpp"
 #include "torii/query_service.hpp"
 #include "utils/query_error_response_visitor.hpp"
-#include "framework/common_constants.hpp"
 
 constexpr size_t TimesFind = 1;
 static constexpr shared_model::interface::types::TransactionsNumberType
@@ -188,7 +188,8 @@ TEST_F(ToriiQueriesTest, FindWhenResponseInvalid) {
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(query.getTransport(),
                                                           response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_TRUE(stat.ok());
   // Must return Error Response
   ASSERT_TRUE(boost::apply_visitor(
@@ -233,7 +234,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
       model_query.getTransport(), response);
 
   ASSERT_TRUE(stat.ok());
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account
   ASSERT_TRUE(boost::apply_visitor(
@@ -276,7 +278,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
 
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
@@ -322,7 +325,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
@@ -371,7 +375,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account asset
@@ -425,7 +430,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
 
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_NO_THROW({
     const auto &asset_resp =
         boost::get<const shared_model::interface::AccountAssetResponse &>(
@@ -477,7 +483,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
   ASSERT_TRUE(stat.ok());
   // Must be invalid due to failed stateful validation caused by no permission
   // to read account
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_TRUE(boost::apply_visitor(
       shared_model::interface::QueryErrorResponseChecker<
           shared_model::interface::StatefulFailedErrorResponse>(),
@@ -517,7 +524,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
-  auto shared_response = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse shared_response{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_NO_THROW({
     auto resp_pubkey =
         *boost::get<const shared_model::interface::SignatoriesResponse &>(
@@ -586,7 +594,8 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   ASSERT_TRUE(stat.ok());
   // Should not return Error Response because tx is stateless and stateful valid
   ASSERT_FALSE(response.has_error_response());
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{
+      iroha::protocol::QueryResponse{response}};
   ASSERT_NO_THROW({
     const auto &tx_resp =
         boost::get<const shared_model::interface::TransactionsResponse &>(
@@ -616,7 +625,8 @@ TEST_F(ToriiQueriesTest, FindManyTimesWhereQueryServiceSync) {
 
     auto stat = client.Find(model_query.getTransport(), response);
     ASSERT_TRUE(stat.ok());
-    auto resp = shared_model::proto::QueryResponse(response);
+    shared_model::proto::QueryResponse resp{
+        iroha::protocol::QueryResponse{response}};
     // Must return Error Response
     ASSERT_TRUE(boost::apply_visitor(
         shared_model::interface::QueryErrorResponseChecker<

--- a/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_query_responses_test.cpp
@@ -31,7 +31,8 @@ TEST(QueryResponse, QueryResponseLoad) {
     auto field = desc->field(i);
     refl->SetAllocatedMessage(
         &response, refl->GetMessage(response, field).New(), field);
-    auto shared_response = shared_model::proto::QueryResponse(response);
+    shared_model::proto::QueryResponse shared_response{
+        iroha::protocol::QueryResponse{response}};
     ASSERT_EQ(i, shared_response.get().which());
     ASSERT_EQ(shared_response.queryHash(), shared_model::crypto::Hash(hash));
   });
@@ -58,7 +59,8 @@ TEST(QueryResponse, ErrorResponseLoad) {
       boost::irange(0, resp_reason_enum->value_count()), [&](auto i) {
         refl->SetEnumValue(
             error_resp, resp_reason, resp_reason_enum->value(i)->number());
-        auto shared_response = shared_model::proto::QueryResponse(response);
+        shared_model::proto::QueryResponse shared_response{
+            iroha::protocol::QueryResponse{response}};
         ASSERT_NO_THROW({
           ASSERT_EQ(
               i,

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -313,7 +313,7 @@ TEST_F(IrohadTest, SendQuery) {
   auto query = complete(baseQry(kAdminId).getRoles(), key_pair.get());
   auto client = torii_utils::QuerySyncClient(kAddress, kPort);
   client.Find(query.getTransport(), response);
-  auto resp = shared_model::proto::QueryResponse(response);
+  shared_model::proto::QueryResponse resp{std::move(response)};
 
   ASSERT_NO_THROW(
       boost::get<const shared_model::interface::RolesResponse &>(resp.get()));


### PR DESCRIPTION
### Description of the Change
Simplify `QueryResponse` structure by making the classes non-clonable and default-movable.
Top-level `QueryResponse` and `BlockQueryResponse` can only be initialized from rvalue reference, while other nested types can be only initialized from lvalue reference.

### Benefits
Less code, same logic.
Remove nested copies of account, asset, and blocks.

### Possible Drawbacks 
None