### PR TITLE
Add pagination support to Pending Transactions Storage queries

### DIFF
--- a/docs/source/api/queries.rst
+++ b/docs/source/api/queries.rst
@@ -255,6 +255,100 @@ Purpose
 GetPendingTransactions is used for retrieving a list of pending (not fully signed) `multisignature transactions <../core_concepts/glossary.html#multisignature-transactions>`_
 or `batches of transactions <../core_concepts/glossary.html#batch-of-transactions>`__ issued by account of query creator.
 
+.. note:: This query uses pagination for quicker and more convenient query responses.
+
+Request Schema
+--------------
+
+.. code-block:: proto
+
+    message TxPaginationMeta {
+        uint32 page_size = 1;
+        oneof opt_first_tx_hash {
+            string first_tx_hash = 2;
+        }
+    }
+
+    message GetPendingTransactions {
+        TxPaginationMeta pagination_meta = 1;
+    }
+
+Request Structure
+-----------------
+
+.. csv-table::
+    :header: "Field", "Description", "Constraint", "Example"
+    :widths: 15, 30, 20, 15
+
+    "Page size", "maximum amount of transactions returned in the response", "page_size > 0", "5"
+    "First tx hash", "optional - hash of the first transaction in the starting batch", "hash in hex format", "bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929"
+
+All the user's semi-signed multisignature (pending) transactions can be queried.
+Maximum amount of transactions contained in a response can be limited by **page_size** field.
+All the pending transactions are stored till they have collected enough signatures or get expired.
+The mutual order of pending transactions or batches of transactions is preserved for a user.
+That allows a user to query all transactions sequentially - page by page.
+Each response may contain a reference to the next batch or transaction that can be queried.
+A page size can be greater than the size of the following batch (in transactions).
+In that case, several batches or transactions will be returned.
+During navigating over pages, the following batch can collect the missing signatures before it gets queried.
+This will result in stateful failed query response due to a missing hash of the batch.
+
+Example
+-------
+
+If there are two pending batches with tree transactions each and a user queries pending transactions
+with page size 5, then the transactions of the first batch will be in the response and a reference
+(first transaction hash and batch size, even if it is a single transaction in fact) to the second batch
+will be specified too.
+Transactions of the second batch are not included to the first response because the batch cannot be devided
+on several parts and only complete batches can be contained in a response.
+
+Response Schema
+---------------
+
+.. code-block:: proto
+
+    message PendingTransactionsPageResponse {
+        message BatchInfo {
+            string first_tx_hash = 1;
+            uint32 batch_size = 2;
+        }
+        repeated Transaction transactions = 1;
+        uint32 all_transactions_size = 2;
+        BatchInfo next_batch_info = 3;
+    }
+
+Response Structure
+------------------
+
+The response contains a list of `pending transactions <../core_concepts/glossary.html#pending-transactions>`_,
+the amount of all stored pending transactions for the user
+and the information requeired to query the subsequent page (if exists).
+
+.. csv-table::
+    :header: "Field", "Description", "Constraint", "Example"
+    :widths: 15, 30, 20, 15
+
+        "Transactions", "an array of pending transactions", "Pending transactions", "{tx1, tx2…}"
+        "All transactions size", "a number of stored transactions", "greater >= 0", "0"
+        "Next batch info", "A reference to the next page - the message might be not set in a response", "", ""
+        "First tx hash", "hash of the first transaction in the next batch",  "hash in hex format", "bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929"
+        "Batch size", "Minimum page size required to fetch the next batch", "greater > 0", "3"
+
+Get Pending Transactions (deprecated)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+  The query without parameters is deprecated now and will be removed in the following major Iroha release (2.0).
+  Please use the new query version instead: `Get Pending Transactions <#get-pending-transactions>`__.
+
+Purpose
+-------
+
+GetPendingTransactions is used for retrieving a list of pending (not fully signed) `multisignature transactions <../core_concepts/glossary.html#multisignature-transactions>`_
+or `batches of transactions <../core_concepts/glossary.html#batch-of-transactions>`__ issued by account of query creator.
+
 Request Schema
 --------------
 

--- a/docs/source/api/queries.rst
+++ b/docs/source/api/queries.rst
@@ -297,12 +297,12 @@ This will result in stateful failed query response due to a missing hash of the 
 Example
 -------
 
-If there are two pending batches with tree transactions each and a user queries pending transactions
+If there are two pending batches with three transactions each and a user queries pending transactions
 with page size 5, then the transactions of the first batch will be in the response and a reference
 (first transaction hash and batch size, even if it is a single transaction in fact) to the second batch
 will be specified too.
-Transactions of the second batch are not included to the first response because the batch cannot be devided
-on several parts and only complete batches can be contained in a response.
+Transactions of the second batch are not included in the first response because the batch cannot be devided
+into several parts and only complete batches can be contained in a response.
 
 Response Schema
 ---------------
@@ -324,17 +324,17 @@ Response Structure
 
 The response contains a list of `pending transactions <../core_concepts/glossary.html#pending-transactions>`_,
 the amount of all stored pending transactions for the user
-and the information requeired to query the subsequent page (if exists).
+and the information required to query the subsequent page (if exists).
 
 .. csv-table::
     :header: "Field", "Description", "Constraint", "Example"
     :widths: 15, 30, 20, 15
 
         "Transactions", "an array of pending transactions", "Pending transactions", "{tx1, tx2…}"
-        "All transactions size", "a number of stored transactions", "greater >= 0", "0"
+        "All transactions size", "the number of stored transactions", "all_transactions_size >= 0", "0"
         "Next batch info", "A reference to the next page - the message might be not set in a response", "", ""
         "First tx hash", "hash of the first transaction in the next batch",  "hash in hex format", "bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929"
-        "Batch size", "Minimum page size required to fetch the next batch", "greater > 0", "3"
+        "Batch size", "Minimum page size required to fetch the next batch", "batch_size > 0", "3"
 
 Get Pending Transactions (deprecated)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/architecture/index.rst
+++ b/docs/source/architecture/index.rst
@@ -6,7 +6,7 @@ Architecture
 .. toctree::
    :maxdepth: 2
 
-HL Iroha network consists of several essential components that provide the communication between the nodes. You can learn about them below. 
+HL Iroha network consists of several essential components that provide the communication between the nodes. You can learn about them below.
 
 .. image:: ../../image_assets/pipeline-diagram.png
 	:width: 80%
@@ -22,8 +22,10 @@ Entry point for `clients <../core_concepts/glossary.html#client>`__.
 Uses gRPC as a transport.
 In order to interact with Iroha anyone can use gRPC endpoints, described in `Commands <../api/commands.html>`__ and `Queries <../api/queries.html>`__ sections, or use `client libraries <../guides/libraries.html>`__.
 
-MstProcessor
-------------
+MST Processor
+-------------
+
+*Multisignature Transactions Processor*
 
 It is an internal gRPC service that sends and receives messages from other peers through `Gossip protocol <https://en.wikipedia.org/wiki/Gossip_protocol>`_.
 Its mission is to send out `multisignature transactions <../core_concepts/glossary.html#multisignature-transactions>`_ that have not received enough signatures to reach the `quorum <../core_concepts/glossary.html#quorum>`_ until it is reached.
@@ -39,12 +41,12 @@ Ordering Gate
 
 It is an internal Iroha component (gRPC client) that relays `transactions <../core_concepts/glossary.html#transaction>`__ from `Peer Communication Service <#peer-communication-service>`__ to `Ordering Service <#ordering-service>`__.
 Ordering Gate recieves `proposals <../core_concepts/glossary.html#proposal>`_ (potential blocks in the chain) from Ordering Service and sends them to `Simulator <#simulator>`__ for `stateful validation <../core_concepts/glossary.html#stateful-validation>`__.
-It also requests proposal from the Ordering Service based on the consensus round. 
+It also requests proposal from the Ordering Service based on the consensus round.
 
 Ordering Service
 ----------------
 
-Internal Iroha component (gRPC server) that receives messages from other `peers <../core_concepts/glossary.html#peer>`__ and combines several `transactions <../core_concepts/glossary.html#transaction>`__ that have been passed `stateless validation <../core_concepts/glossary.html#stateless-validation>`__ into a `proposal <../core_concepts/glossary.html#proposal>`__. 
+Internal Iroha component (gRPC server) that receives messages from other `peers <../core_concepts/glossary.html#peer>`__ and combines several `transactions <../core_concepts/glossary.html#transaction>`__ that have been passed `stateless validation <../core_concepts/glossary.html#stateless-validation>`__ into a `proposal <../core_concepts/glossary.html#proposal>`__.
 Each node has its own ordering service.
 Proposal creation could be triggered by one of the following events:
 
@@ -79,7 +81,7 @@ Block Consensus (YAC)
 *Consensus, as a component*
 
     Consensus is the heart of the blockchain - it preserves a consistent state among the `peers <../core_concepts/glossary.html#peer>`__ within a peer network.
-    Iroha uses own consensus algorithm called Yet Another Consensus (aka YAC). 
+    Iroha uses own consensus algorithm called Yet Another Consensus (aka YAC).
 
     You can check out a video where HL Iroha maintainer thoroughly explains the principles of consensus and YAC in particular `here <https://youtu.be/mzuAbalxOKo>`__.
 

--- a/docs/source/maintenance/index.rst
+++ b/docs/source/maintenance/index.rst
@@ -8,5 +8,3 @@ Hardware requirements, deployment process in details, aspects related to securit
     :caption: Table of contents
 
     permissions.rst
-    ansible.rst
-

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -1165,7 +1165,7 @@ namespace iroha {
                                      q.paginationMeta()->pageSize(),
                                      q.paginationMeta()->firstTxHash())
             .match(
-                [this, &response_txs](const auto &response) {
+                [this, &response_txs](auto &&response) {
                   auto &interface_txs = response.value.transactions;
                   response_txs.reserve(interface_txs.size());
                   // TODO igor-egorov 2019-06-06 IR-555 avoid use of clone()
@@ -1176,21 +1176,20 @@ namespace iroha {
                   return query_response_factory_
                       ->createPendingTransactionsPageResponse(
                           std::move(response_txs),
-                          std::move(response.value.all_transactions_size),
+                          response.value.all_transactions_size,
                           std::move(response.value.next_batch_info),
                           query_hash_);
                 },
-                [this, &q](const auto &error) {
+                [this, &q](auto &&error) {
                   switch (error.error) {
-                    case iroha::PendingTransactionStorage::ErrorCode::NOT_FOUND:
+                    case iroha::PendingTransactionStorage::ErrorCode::kNotFound:
                       return query_response_factory_->createErrorQueryResponse(
                           shared_model::interface::QueryResponseFactory::
                               ErrorQueryType::kStatefulFailed,
                           std::string("The batch with specified first "
                                       "transaction hash not found, the hash: ")
                               + q.paginationMeta()->firstTxHash()->toString(),
-                          4,  // The newly introduced code for missing first tx
-                              // hash error
+                          4,  // missing first tx hash error
                           query_hash_);
                     default:
                       BOOST_ASSERT_MSG(false,
@@ -1201,7 +1200,7 @@ namespace iroha {
                               ErrorQueryType::kStatefulFailed,
                           std::string("Unknown type of error happened: ")
                               + std::to_string(error.error),
-                          1,  // The code for unknown internal error
+                          1,  // unknown internal error
                           query_hash_);
                   }
                 });

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -1159,16 +1159,65 @@ namespace iroha {
         const shared_model::interface::GetPendingTransactions &q) {
       std::vector<std::unique_ptr<shared_model::interface::Transaction>>
           response_txs;
-      auto interface_txs =
-          pending_txs_storage_->getPendingTransactions(creator_id_);
-      response_txs.reserve(interface_txs.size());
+      if (q.paginationMeta()) {
+        return pending_txs_storage_
+            ->getPendingTransactions(creator_id_,
+                                     q.paginationMeta()->pageSize(),
+                                     q.paginationMeta()->firstTxHash())
+            .match(
+                [this, &response_txs](const auto &response) {
+                  auto &interface_txs = response.value.transactions;
+                  response_txs.reserve(interface_txs.size());
+                  // TODO igor-egorov 2019-06-06 IR-555 avoid use of clone()
+                  std::transform(interface_txs.begin(),
+                                 interface_txs.end(),
+                                 std::back_inserter(response_txs),
+                                 [](auto &tx) { return clone(*tx); });
+                  return query_response_factory_
+                      ->createPendingTransactionsPageResponse(
+                          std::move(response_txs),
+                          std::move(response.value.all_transactions_size),
+                          std::move(response.value.next_batch_info),
+                          query_hash_);
+                },
+                [this, &q](const auto &error) {
+                  switch (error.error) {
+                    case iroha::PendingTransactionStorage::ErrorCode::NOT_FOUND:
+                      return query_response_factory_->createErrorQueryResponse(
+                          shared_model::interface::QueryResponseFactory::
+                              ErrorQueryType::kStatefulFailed,
+                          std::string("The batch with specified first "
+                                      "transaction hash not found, the hash: ")
+                              + q.paginationMeta()->firstTxHash()->toString(),
+                          4,  // The newly introduced code for missing first tx
+                              // hash error
+                          query_hash_);
+                    default:
+                      BOOST_ASSERT_MSG(false,
+                                       "Unknown and unhandled type of error "
+                                       "happend in pending txs storage");
+                      return query_response_factory_->createErrorQueryResponse(
+                          shared_model::interface::QueryResponseFactory::
+                              ErrorQueryType::kStatefulFailed,
+                          std::string("Unknown type of error happened: ")
+                              + std::to_string(error.error),
+                          1,  // The code for unknown internal error
+                          query_hash_);
+                  }
+                });
+      } else {  // TODO 2019-06-06 igor-egorov IR-516 remove deprecated
+                // interface
+        auto interface_txs =
+            pending_txs_storage_->getPendingTransactions(creator_id_);
+        response_txs.reserve(interface_txs.size());
 
-      std::transform(interface_txs.begin(),
-                     interface_txs.end(),
-                     std::back_inserter(response_txs),
-                     [](auto &tx) { return clone(*tx); });
-      return query_response_factory_->createTransactionsResponse(
-          std::move(response_txs), query_hash_);
+        std::transform(interface_txs.begin(),
+                       interface_txs.end(),
+                       std::back_inserter(response_txs),
+                       [](auto &tx) { return clone(*tx); });
+        return query_response_factory_->createTransactionsResponse(
+            std::move(response_txs), query_hash_);
+      }
     }
 
     template <typename ReturnValueType>

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -83,7 +83,7 @@ namespace iroha {
     void updatedBatchesNotify(ConstRefState state) const;
 
     /**
-     * Notify subscribers when some of the bathes get expired
+     * Notify subscribers when some of the batches get expired
      * @param state with those batches
      */
     void expiredBatchesNotify(ConstRefState state) const;

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
@@ -54,16 +54,16 @@ namespace iroha {
                    PendingTransactionStorage::ErrorCode>
   PendingTransactionStorageImpl::getPendingTransactions(
       const shared_model::interface::types::AccountIdType &account_id,
-      const shared_model::interface::types::TransactionsNumberType &page_size,
+      const shared_model::interface::types::TransactionsNumberType page_size,
       const boost::optional<shared_model::interface::types::HashType>
-          first_tx_hash) const {
+          &first_tx_hash) const {
     BOOST_ASSERT_MSG(page_size > 0, "Page size has to be positive");
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
     auto account_batches_iterator = storage_.find(account_id);
     if (storage_.end() == account_batches_iterator) {
       if (first_tx_hash) {
         return iroha::expected::makeError(
-            PendingTransactionStorage::ErrorCode::NOT_FOUND);
+            PendingTransactionStorage::ErrorCode::kNotFound);
       } else {
         return iroha::expected::makeValue(
             PendingTransactionStorage::Response{});
@@ -75,7 +75,7 @@ namespace iroha {
       auto index_iterator = account_batches.index.find(*first_tx_hash);
       if (account_batches.index.end() == index_iterator) {
         return iroha::expected::makeError(
-            PendingTransactionStorage::ErrorCode::NOT_FOUND);
+            PendingTransactionStorage::ErrorCode::kNotFound);
       }
       batch_iterator = index_iterator->second;
     }

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
@@ -100,6 +100,7 @@ namespace iroha {
       auto &txs = batch_iterator->get()->transactions();
       next_batch_info.first_tx_hash = txs.front()->hash();
       next_batch_info.batch_size = txs.size();
+      response.next_batch_info = std::move(next_batch_info);
     }
     return iroha::expected::makeValue(std::move(response));
   }

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
@@ -65,16 +65,31 @@ namespace iroha {
      */
     mutable std::shared_timed_mutex mutex_;
 
+    /**
+     * The struct represents an indexed storage of pending transactions or
+     * batches for a SINGLE account.
+     *
+     * "batches" field contains pointers to all pending batches associated with
+     * an account. Use of std::list allows us to automatically preserve their
+     * mutual order.
+     *
+     * "index" map allows performing random access to "batches" list. Thus, we
+     * can access any batch within the list in the most optimal way.
+     *
+     * "all transactions quantity" stores the sum of all transactions within
+     * stored batches. Used for query response and memory management.
+     */
     struct AccountBatches {
       std::list<std::shared_ptr<TransactionBatch>> batches;
       std::
           unordered_map<HashType, decltype(batches)::iterator, HashType::Hasher>
               index;
-      uint64_t all_transactions_quantity;
-
-      AccountBatches() : all_transactions_quantity(0) {}
+      uint64_t all_transactions_quantity{0};
     };
 
+    /**
+     * Maps account names with its storages of pending transactions or batches.
+     */
     std::unordered_map<AccountIdType, AccountBatches> storage_;
   };
 

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
@@ -42,9 +42,9 @@ namespace iroha {
 
     expected::Result<Response, ErrorCode> getPendingTransactions(
         const shared_model::interface::types::AccountIdType &account_id,
-        const shared_model::interface::types::TransactionsNumberType &page_size,
+        const shared_model::interface::types::TransactionsNumberType page_size,
         const boost::optional<shared_model::interface::types::HashType>
-            first_tx_hash) const override;
+            &first_tx_hash) const override;
 
    private:
     void updatedBatchesHandler(const SharedState &updated_batches);

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
@@ -6,10 +6,10 @@
 #ifndef IROHA_PENDING_TXS_STORAGE_IMPL_HPP
 #define IROHA_PENDING_TXS_STORAGE_IMPL_HPP
 
+#include <list>
 #include <set>
 #include <shared_mutex>
 #include <unordered_map>
-#include <unordered_set>
 
 #include <rxcpp/rx.hpp>
 #include "interfaces/iroha_internal/transaction_batch.hpp"
@@ -40,6 +40,12 @@ namespace iroha {
     SharedTxsCollectionType getPendingTransactions(
         const AccountIdType &account_id) const override;
 
+    expected::Result<Response, ErrorCode> getPendingTransactions(
+        const shared_model::interface::types::AccountIdType &account_id,
+        const shared_model::interface::types::TransactionsNumberType &page_size,
+        const boost::optional<shared_model::interface::types::HashType>
+            first_tx_hash) const override;
+
    private:
     void updatedBatchesHandler(const SharedState &updated_batches);
 
@@ -59,24 +65,17 @@ namespace iroha {
      */
     mutable std::shared_timed_mutex mutex_;
 
-    /**
-     * Storage is composed of two maps:
-     * Indices map contains relations of accounts and batch hashes. For each
-     * account there are listed hashes of batches, where the account has created
-     * at least one transaction.
-     *
-     * Batches map is used for storing and fast access to batches via batch
-     * hashes.
-     */
-    struct {
-      std::unordered_map<AccountIdType,
-                         std::unordered_set<HashType, HashType::Hasher>>
-          index;
-      std::unordered_map<HashType,
-                         std::shared_ptr<TransactionBatch>,
-                         HashType::Hasher>
-          batches;
-    } storage_;
+    struct AccountBatches {
+      std::list<std::shared_ptr<TransactionBatch>> batches;
+      std::
+          unordered_map<HashType, decltype(batches)::iterator, HashType::Hasher>
+              index;
+      uint64_t all_transactions_quantity;
+
+      AccountBatches() : all_transactions_quantity(0) {}
+    };
+
+    std::unordered_map<AccountIdType, AccountBatches> storage_;
   };
 
 }  // namespace iroha

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -6,9 +6,12 @@
 #ifndef IROHA_PENDING_TXS_STORAGE_HPP
 #define IROHA_PENDING_TXS_STORAGE_HPP
 
+#include <boost/optional.hpp>
 #include <rxcpp/rx.hpp>
+#include "common/result.hpp"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/query_responses/pending_transactions_page_response.hpp"
 
 namespace iroha {
 
@@ -18,13 +21,57 @@ namespace iroha {
   class PendingTransactionStorage {
    public:
     /**
+     * Possible error codes the storage may return instead of pending
+     * transactions list
+     */
+    enum ErrorCode {
+      NOT_FOUND,  // there is no batch which first tx has specified hash
+      EMPTY,      // storage has no pending batches or transactions for the user
+    };
+
+    /**
+     * Storage response message with sufficient interface for performing
+     * pagination over the storage contents
+     */
+    struct Response {
+      shared_model::interface::types::SharedTxsCollectionType transactions;
+      shared_model::interface::types::TransactionsNumberType
+          all_transactions_size;
+      boost::optional<
+          shared_model::interface::PendingTransactionsPageResponse::BatchInfo>
+          next_batch_info;
+
+      Response() : all_transactions_size(0) {}
+    };
+
+    /**
+     * DEPRECATED (Replaced by the following method with an extended interface)
+     * Going to be removed with the upcoming major release.
+     *
      * Get all the pending transactions associated with request originator
      * @param account_id - query creator
      * @return collection of interface::Transaction objects
      */
-    virtual shared_model::interface::types::SharedTxsCollectionType
-    getPendingTransactions(const shared_model::interface::types::AccountIdType
-                               &account_id) const = 0;
+    [[deprecated]] virtual shared_model::interface::types::
+        SharedTxsCollectionType
+        getPendingTransactions(
+            const shared_model::interface::types::AccountIdType &account_id)
+            const = 0;
+
+    /**
+     * Fetch pending transactions associated with request originator
+     * @param account_id - query creator
+     * @param page_size - requested page size
+     * @param first_tx_hash - an optional hash of the first transaction in the
+     * batch that will be the starting point of returned transactions sequence
+     * @return - Response message when query succeeded (next_batch_info might
+     * not be set when the end is reached). One of ErrorCode in case of error.
+     */
+    virtual expected::Result<Response, ErrorCode> getPendingTransactions(
+        const shared_model::interface::types::AccountIdType &account_id,
+        const shared_model::interface::types::TransactionsNumberType &page_size,
+        const boost::optional<shared_model::interface::types::HashType>
+            first_tx_hash) const = 0;
 
     virtual ~PendingTransactionStorage() = default;
   };

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -43,6 +43,7 @@ namespace iroha {
       Response() : all_transactions_size(0) {}
     };
 
+    // TODO igor-egorov 2019-06-06 IR-516 remove deprecated interface
     /**
      * DEPRECATED (Replaced by the following method with an extended interface)
      * Going to be removed with the upcoming major release.

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -26,7 +26,6 @@ namespace iroha {
      */
     enum ErrorCode {
       NOT_FOUND,  // there is no batch which first tx has specified hash
-      EMPTY,      // storage has no pending batches or transactions for the user
     };
 
     /**

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -25,7 +25,7 @@ namespace iroha {
      * transactions list
      */
     enum ErrorCode {
-      NOT_FOUND,  // there is no batch which first tx has specified hash
+      kNotFound,  // there is no batch which first tx has specified hash
     };
 
     /**
@@ -69,9 +69,9 @@ namespace iroha {
      */
     virtual expected::Result<Response, ErrorCode> getPendingTransactions(
         const shared_model::interface::types::AccountIdType &account_id,
-        const shared_model::interface::types::TransactionsNumberType &page_size,
+        const shared_model::interface::types::TransactionsNumberType page_size,
         const boost::optional<shared_model::interface::types::HashType>
-            first_tx_hash) const = 0;
+            &first_tx_hash) const = 0;
 
     virtual ~PendingTransactionStorage() = default;
   };

--- a/shared_model/backend/protobuf/CMakeLists.txt
+++ b/shared_model/backend/protobuf/CMakeLists.txt
@@ -62,6 +62,7 @@ if (IROHA_ROOT_PROJECT)
       query_responses/impl/proto_signatories_response.cpp
       query_responses/impl/proto_transaction_response.cpp
       query_responses/impl/proto_transaction_page_response.cpp
+      query_responses/impl/proto_pending_transactions_page_response.cpp
       query_responses/impl/proto_block_query_response.cpp
       query_responses/impl/proto_block_response.cpp
       query_responses/impl/proto_block_error_response.cpp

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -11,7 +11,6 @@
 #include "backend/protobuf/transaction.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/amount.hpp"
-#include "interfaces/query_responses/pending_transactions_page_response.hpp"
 
 namespace {
   /**
@@ -289,10 +288,9 @@ std::unique_ptr<shared_model::interface::QueryResponse> shared_model::proto::
        &all_transactions_size,
        &next_batch_info](
           iroha::protocol::QueryResponse &protocol_query_response) {
-        iroha::protocol::PendingTransactionsPageResponse
-            *protocol_specific_response =
-                protocol_query_response
-                    .mutable_pending_transactions_page_response();
+        auto *protocol_specific_response =
+            protocol_query_response
+                .mutable_pending_transactions_page_response();
         for (const auto &tx : transactions) {
           *protocol_specific_response->add_transactions() =
               static_cast<shared_model::proto::Transaction *>(tx.get())
@@ -301,9 +299,8 @@ std::unique_ptr<shared_model::interface::QueryResponse> shared_model::proto::
         protocol_specific_response->set_all_transactions_size(
             all_transactions_size);
         if (next_batch_info) {
-          iroha::protocol::PendingTransactionsPageResponse_BatchInfo
-              *next_batch_info_message =
-                  protocol_specific_response->mutable_next_batch_info();
+          auto *next_batch_info_message =
+              protocol_specific_response->mutable_next_batch_info();
           next_batch_info_message->set_first_tx_hash(
               next_batch_info->first_tx_hash.hex());
           next_batch_info_message->set_batch_size(next_batch_info->batch_size);

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -66,6 +66,15 @@ namespace shared_model {
           interface::types::TransactionsNumberType all_transactions_size,
           const crypto::Hash &query_hash) const override;
 
+      std::unique_ptr<interface::QueryResponse>
+      createPendingTransactionsPageResponse(
+          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+              transactions,
+          interface::types::TransactionsNumberType all_transactions_size,
+          boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+              next_batch_info,
+          const crypto::Hash &query_hash) const override;
+
       std::unique_ptr<interface::QueryResponse> createAssetResponse(
           interface::types::AssetIdType asset_id,
           interface::types::DomainIdType domain_id,

--- a/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
@@ -10,7 +10,9 @@ namespace shared_model {
 
     template <typename QueryType>
     GetPendingTransactions::GetPendingTransactions(QueryType &&query)
-        : CopyableProto(std::forward<QueryType>(query)) {}
+        : CopyableProto(std::forward<QueryType>(query)),
+          pending_transactions_{proto_->payload().get_pending_transactions()},
+          pagination_meta_{pending_transactions_.pagination_meta()} {}
 
     template GetPendingTransactions::GetPendingTransactions(
         GetPendingTransactions::TransportType &);
@@ -26,6 +28,11 @@ namespace shared_model {
     GetPendingTransactions::GetPendingTransactions(
         GetPendingTransactions &&o) noexcept
         : GetPendingTransactions(std::move(o.proto_)) {}
+
+    const interface::TxPaginationMeta &GetPendingTransactions::paginationMeta()
+        const {
+      return pagination_meta_;
+    }
 
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -6,10 +6,10 @@
 #ifndef IROHA_PROTO_GET_PENDING_TRANSACTIONS_HPP
 #define IROHA_PROTO_GET_PENDING_TRANSACTIONS_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "interfaces/queries/get_pending_transactions.hpp"
 
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -29,8 +29,8 @@ namespace shared_model {
       const interface::TxPaginationMeta &paginationMeta() const override;
 
      private:
-      const TxPaginationMeta pagination_meta_;
       const iroha::protocol::GetPendingTransactions &pending_transactions_;
+      const TxPaginationMeta pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -8,6 +8,8 @@
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_pending_transactions.hpp"
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
@@ -23,6 +25,12 @@ namespace shared_model {
       GetPendingTransactions(const GetPendingTransactions &o);
 
       GetPendingTransactions(GetPendingTransactions &&o) noexcept;
+
+      const interface::TxPaginationMeta &paginationMeta() const override;
+
+     private:
+      const TxPaginationMeta pagination_meta_;
+      const iroha::protocol::GetPendingTransactions &pending_transactions_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -7,8 +7,8 @@
 #define IROHA_PROTO_GET_PENDING_TRANSACTIONS_HPP
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "interfaces/queries/get_pending_transactions.hpp"
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
+#include "interfaces/queries/get_pending_transactions.hpp"
 
 #include "queries.pb.h"
 
@@ -26,11 +26,12 @@ namespace shared_model {
 
       GetPendingTransactions(GetPendingTransactions &&o) noexcept;
 
-      const interface::TxPaginationMeta &paginationMeta() const override;
+      boost::optional<const interface::TxPaginationMeta &> paginationMeta()
+          const override;
 
      private:
       const iroha::protocol::GetPendingTransactions &pending_transactions_;
-      const TxPaginationMeta pagination_meta_;
+      boost::optional<const TxPaginationMeta> pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp"
+#include "common/byteutils.hpp"
+
+namespace shared_model {
+  namespace proto {
+
+    template <typename QueryResponseType>
+    PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        QueryResponseType &&queryResponse)
+        : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
+          pending_transactions_page_response_{
+              proto_->pending_transactions_page_response()},
+          transactions_{
+              pending_transactions_page_response_.transactions().begin(),
+              pending_transactions_page_response_.transactions().end()},
+          next_batch_info_{
+              [this]()
+                  -> boost::optional<
+                      interface::PendingTransactionsPageResponse::BatchInfo> {
+                // switch (
+                //     pending_transactions_page_response_.next_page_tag_case())
+                //     {
+                //   case
+                //   iroha::protocol::TransactionsPageResponse::kNextTxHash:
+                //     return crypto::Hash::fromHexString(
+                //         pending_transactions_page_response_.next_tx_hash());
+                //   default:
+                //     return boost::none;
+                // }
+                return boost::none;
+              }()} {}
+
+    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        PendingTransactionsPageResponse::TransportType &);
+    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        const PendingTransactionsPageResponse::TransportType &);
+    template PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        PendingTransactionsPageResponse::TransportType &&);
+
+    PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        const PendingTransactionsPageResponse &o)
+        : PendingTransactionsPageResponse(o.proto_) {}
+
+    PendingTransactionsPageResponse::PendingTransactionsPageResponse(
+        PendingTransactionsPageResponse &&o)
+        : PendingTransactionsPageResponse(std::move(o.proto_)) {}
+
+    interface::types::TransactionsCollectionType
+    PendingTransactionsPageResponse::transactions() const {
+      return transactions_;
+    }
+
+    boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+    PendingTransactionsPageResponse::nextBatchInfo() const {
+      return next_batch_info_;
+    }
+
+    interface::types::TransactionsNumberType
+    PendingTransactionsPageResponse::allTransactionsSize() const {
+      return pending_transactions_page_response_.all_transactions_size();
+    }
+
+  }  // namespace proto
+}  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
@@ -15,23 +15,26 @@ namespace shared_model {
         : CopyableProto(std::forward<QueryResponseType>(queryResponse)),
           pending_transactions_page_response_{
               proto_->pending_transactions_page_response()},
-          transactions_{
-              pending_transactions_page_response_.transactions().begin(),
-              pending_transactions_page_response_.transactions().end()},
+          transactions_{proto_->mutable_pending_transactions_page_response()
+                            ->mutable_transactions()
+                            ->begin(),
+                        proto_->mutable_pending_transactions_page_response()
+                            ->mutable_transactions()
+                            ->end()},
           next_batch_info_{
               [this]()
                   -> boost::optional<
                       interface::PendingTransactionsPageResponse::BatchInfo> {
-                // switch (
-                //     pending_transactions_page_response_.next_page_tag_case())
-                //     {
-                //   case
-                //   iroha::protocol::TransactionsPageResponse::kNextTxHash:
-                //     return crypto::Hash::fromHexString(
-                //         pending_transactions_page_response_.next_tx_hash());
-                //   default:
-                //     return boost::none;
-                // }
+                if (pending_transactions_page_response_.has_next_batch_info()) {
+                  auto &next =
+                      pending_transactions_page_response_.next_batch_info();
+                  interface::PendingTransactionsPageResponse::BatchInfo
+                      next_batch;
+                  next_batch.first_tx_hash =
+                      crypto::Hash::fromHexString(next.first_tx_hash());
+                  next_batch.batch_size = next.batch_size();
+                  return next_batch;
+                }
                 return boost::none;
               }()} {}
 

--- a/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
@@ -9,8 +9,9 @@
 #include "backend/protobuf/query_responses/proto_account_detail_response.hpp"
 #include "backend/protobuf/query_responses/proto_account_response.hpp"
 #include "backend/protobuf/query_responses/proto_asset_response.hpp"
-#include "backend/protobuf/query_responses/proto_get_block_response.hpp"
 #include "backend/protobuf/query_responses/proto_error_query_response.hpp"
+#include "backend/protobuf/query_responses/proto_get_block_response.hpp"
+#include "backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp"
 #include "backend/protobuf/query_responses/proto_role_permissions_response.hpp"
 #include "backend/protobuf/query_responses/proto_roles_response.hpp"
 #include "backend/protobuf/query_responses/proto_signatories_response.hpp"
@@ -32,6 +33,7 @@ namespace {
                      shared_model::proto::RolesResponse,
                      shared_model::proto::RolePermissionsResponse,
                      shared_model::proto::TransactionsPageResponse,
+                     shared_model::proto::PendingTransactionsPageResponse,
                      shared_model::proto::GetBlockResponse>;
 
   /// list of types in variant

--- a/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_MODEL_PROTO_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
+#define IROHA_SHARED_MODEL_PROTO_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
+
+#include "interfaces/query_responses/pending_transactions_page_response.hpp"
+
+#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include "backend/protobuf/transaction.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "qry_responses.pb.h"
+
+namespace shared_model {
+  namespace proto {
+    class PendingTransactionsPageResponse final
+        : public CopyableProto<interface::PendingTransactionsPageResponse,
+                               iroha::protocol::QueryResponse,
+                               PendingTransactionsPageResponse> {
+     public:
+      template <typename QueryResponseType>
+      explicit PendingTransactionsPageResponse(
+          QueryResponseType &&queryResponse);
+
+      PendingTransactionsPageResponse(const PendingTransactionsPageResponse &o);
+
+      PendingTransactionsPageResponse(PendingTransactionsPageResponse &&o);
+
+      interface::types::TransactionsCollectionType transactions()
+          const override;
+
+      boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+      nextBatchInfo() const override;
+
+      interface::types::TransactionsNumberType allTransactionsSize()
+          const override;
+
+     private:
+      const iroha::protocol::PendingTransactionsPageResponse
+          &pending_transactions_page_response_;
+      const std::vector<proto::Transaction> transactions_;
+      boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+          next_batch_info_;
+    };
+  }  // namespace proto
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_MODEL_PROTO_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -252,6 +252,17 @@ namespace shared_model {
         });
       }
 
+      auto getPendingTransactions(
+          interface::types::TransactionsNumberType page_size,
+          const boost::optional<interface::types::HashType> &first_hash =
+              boost::none) const {
+        return queryField([&](auto proto_query) {
+          auto query = proto_query->mutable_get_pending_transactions();
+          setTxPaginationMeta(
+              query->mutable_pagination_meta(), page_size, first_hash);
+        });
+      }
+
       auto build() const {
         static_assert(S == (1 << TOTAL) - 1, "Required fields are not set");
         if (not query_.has_payload()) {

--- a/shared_model/interfaces/CMakeLists.txt
+++ b/shared_model/interfaces/CMakeLists.txt
@@ -61,6 +61,7 @@ if (IROHA_ROOT_PROJECT)
       query_responses/impl/block_query_response.cpp
       query_responses/impl/block_response.cpp
       query_responses/impl/transactions_page_response.cpp
+      query_responses/impl/pending_transactions_page_response.cpp
       transaction_responses/impl/tx_response.cpp
       iroha_internal/transaction_sequence.cpp
       iroha_internal/transaction_batch_impl.cpp

--- a/shared_model/interfaces/common_objects/types.hpp
+++ b/shared_model/interfaces/common_objects/types.hpp
@@ -55,6 +55,7 @@ namespace shared_model {
       using PermissionNameType = std::string;
       /// Permission set
       using PermissionSetType = std::set<PermissionNameType>;
+      // TODO igor-egorov 28.05.2019 IR-520 Inconsistent C++/Protobuf type sizes
       /// Type of Quorum used in transaction and set quorum
       using QuorumType = uint16_t;
       /// Type of timestamp
@@ -73,6 +74,7 @@ namespace shared_model {
       using AccountDetailKeyType = std::string;
       /// Type of account detail value
       using AccountDetailValueType = std::string;
+      // TODO igor-egorov 28.05.2019 IR-520 Inconsistent C++/Protobuf type sizes
       /// Type of a number of transactions in block and query response page
       using TransactionsNumberType = uint16_t;
       /// Type of the transfer message

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -14,6 +14,7 @@
 #include "interfaces/permissions.hpp"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "interfaces/query_responses/error_query_response.hpp"
+#include "interfaces/query_responses/pending_transactions_page_response.hpp"
 #include "interfaces/query_responses/query_response.hpp"
 
 namespace shared_model {
@@ -174,11 +175,29 @@ namespace shared_model {
           const crypto::Hash &query_hash) const = 0;
 
       /**
+       * Create paged response for pending transaction query
+       * @param transactions - list of transactions on the page
+       * @param all_transactions_size - total number of transactions among all
+       * the bathes in a pending storage for the user
+       * @param next_batch_info - optional struct with hash of the first
+       * transaction for the following batch and its size (if exists)
+       * @param query_hash - hash of the corresponding query
+       */
+      virtual std::unique_ptr<QueryResponse>
+      createPendingTransactionsPageResponse(
+          std::vector<std::unique_ptr<interface::Transaction>> transactions,
+          interface::types::TransactionsNumberType all_transactions_size,
+          boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+              next_batch_info,
+          const crypto::Hash &query_hash) const = 0;
+
+      /**
        * Create response for asset query
        * @param asset_id of asset to be inserted into the response
        * @param domain_id of asset to be inserted into the response
        * @param precision of asset to be inserted into the response
-       * @param query_hash - hash of the query, for which response is created
+       * @param query_hash - hash of the query, for which response is
+       * created
        * @return asset response
        */
       virtual std::unique_ptr<QueryResponse> createAssetResponse(

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -178,7 +178,7 @@ namespace shared_model {
        * Create paged response for pending transaction query
        * @param transactions - list of transactions on the page
        * @param all_transactions_size - total number of transactions among all
-       * the bathes in a pending storage for the user
+       * the batches in a pending storage for the user
        * @param next_batch_info - optional struct with hash of the first
        * transaction for the following batch and its size (if exists)
        * @param query_hash - hash of the corresponding query

--- a/shared_model/interfaces/queries/get_pending_transactions.hpp
+++ b/shared_model/interfaces/queries/get_pending_transactions.hpp
@@ -6,6 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_GET_PENDING_TRANSACTIONS_HPP
 #define IROHA_SHARED_MODEL_GET_PENDING_TRANSACTIONS_HPP
 
+#include <boost/optional.hpp>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -20,10 +21,12 @@ namespace shared_model {
     class GetPendingTransactions
         : public ModelPrimitive<GetPendingTransactions> {
      public:
+      // TODO igor-egorov 2019-06-06 IR-516 make page meta non-optional
       /**
        *  Get the query pagination metadata.
        */
-      virtual const TxPaginationMeta &paginationMeta() const = 0;
+      virtual boost::optional<const TxPaginationMeta &> paginationMeta()
+          const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/get_pending_transactions.hpp
+++ b/shared_model/interfaces/queries/get_pending_transactions.hpp
@@ -11,6 +11,7 @@
 
 namespace shared_model {
   namespace interface {
+    class TxPaginationMeta;
 
     /**
      * Get all pending (not fully signed) multisignature transactions or batches
@@ -19,6 +20,11 @@ namespace shared_model {
     class GetPendingTransactions
         : public ModelPrimitive<GetPendingTransactions> {
      public:
+      /**
+       *  Get the query pagination metadata.
+       */
+      virtual const TxPaginationMeta &paginationMeta() const = 0;
+
       std::string toString() const override;
 
       bool operator==(const ModelType &rhs) const override;

--- a/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
@@ -20,7 +20,7 @@ namespace shared_model {
     }
 
     bool GetPendingTransactions::operator==(const ModelType &rhs) const {
-      return true;
+      return paginationMeta() == rhs.paginationMeta();
     }
 
   }  // namespace interface

--- a/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
@@ -5,12 +5,15 @@
 
 #include "interfaces/queries/get_pending_transactions.hpp"
 
+#include "interfaces/queries/tx_pagination_meta.hpp"
+
 namespace shared_model {
   namespace interface {
 
     std::string GetPendingTransactions::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetPendingTransactions")
+          .append("pagination_meta", paginationMeta().toString())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
@@ -11,10 +11,12 @@ namespace shared_model {
   namespace interface {
 
     std::string GetPendingTransactions::toString() const {
-      return detail::PrettyStringBuilder()
-          .init("GetPendingTransactions")
-          .append("pagination_meta", paginationMeta().toString())
-          .finalize();
+      auto builder =
+          detail::PrettyStringBuilder().init("GetPendingTransactions");
+      if (paginationMeta()) {
+        builder.append("pagination_meta", paginationMeta()->toString());
+      }
+      return builder.finalize();
     }
 
     bool GetPendingTransactions::operator==(const ModelType &rhs) const {

--- a/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "interfaces/query_responses/pending_transactions_page_response.hpp"
+
 #include "interfaces/transaction.hpp"
 
 namespace shared_model {
@@ -19,7 +20,7 @@ namespace shared_model {
                                  std::to_string(allTransactionsSize()));
       if (auto next_batch_info = nextBatchInfo()) {
         builder
-            .append("next batch fist tx hash",
+            .append("next batch first tx hash",
                     next_batch_info->first_tx_hash.hex())
             .append("next batch size",
                     std::to_string(next_batch_info->batch_size));

--- a/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "interfaces/query_responses/pending_transactions_page_response.hpp"
+#include "interfaces/transaction.hpp"
+
+namespace shared_model {
+  namespace interface {
+
+    std::string PendingTransactionsPageResponse::toString() const {
+      auto builder = detail::PrettyStringBuilder()
+                         .init("PendingTransactionsPageResponse")
+                         .appendAll("transactions",
+                                    transactions(),
+                                    [](auto &tx) { return tx.toString(); })
+                         .append("all transactions size",
+                                 std::to_string(allTransactionsSize()));
+      if (auto next_batch_info = nextBatchInfo()) {
+        builder
+            .append("next batch fist tx hash",
+                    next_batch_info->first_tx_hash.hex())
+            .append("next batch size",
+                    std::to_string(next_batch_info->batch_size));
+      } else {
+        builder.append("no next batch info is set");
+      }
+      return builder.finalize();
+    }
+
+    bool PendingTransactionsPageResponse::operator==(
+        const ModelType &rhs) const {
+      return transactions() == rhs.transactions()
+          and nextBatchInfo() == rhs.nextBatchInfo()
+          and allTransactionsSize() == rhs.allTransactionsSize();
+    }
+
+  }  // namespace interface
+}  // namespace shared_model

--- a/shared_model/interfaces/query_responses/impl/query_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/query_response.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/query_responses/asset_response.hpp"
 #include "interfaces/query_responses/block_response.hpp"
 #include "interfaces/query_responses/error_query_response.hpp"
+#include "interfaces/query_responses/pending_transactions_page_response.hpp"
 #include "interfaces/query_responses/role_permissions.hpp"
 #include "interfaces/query_responses/roles_response.hpp"
 #include "interfaces/query_responses/signatories_response.hpp"

--- a/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
+#define IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
+
+#include <boost/optional/optional_fwd.hpp>
+
+#include "cryptography/hash.hpp"
+#include "interfaces/base/model_primitive.hpp"
+#include "interfaces/common_objects/range_types.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+
+    /**
+     * Response for paginated queries
+     */
+    class PendingTransactionsPageResponse
+        : public ModelPrimitive<PendingTransactionsPageResponse> {
+     public:
+      struct BatchInfo {
+        interface::types::HashType first_tx_hash;
+        interface::types::TransactionsNumberType batch_size;
+
+        bool operator==(const BatchInfo &rhs) const {
+          return first_tx_hash == rhs.first_tx_hash
+              and batch_size == rhs.batch_size;
+        }
+      };
+
+      /**
+       * @return transactions from this page
+       */
+      virtual types::TransactionsCollectionType transactions() const = 0;
+
+      /**
+       * @return next batch info to query the following page if exists
+       */
+      virtual boost::optional<BatchInfo> nextBatchInfo() const = 0;
+
+      /**
+       * @return total number of transactions for the query
+       */
+      virtual interface::types::TransactionsNumberType allTransactionsSize()
+          const = 0;
+
+      std::string toString() const override;
+
+      bool operator==(const ModelType &rhs) const override;
+    };
+  }  // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP

--- a/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
@@ -7,7 +7,6 @@
 #define IROHA_SHARED_MODEL_PENDING_TRANSACTIONS_PAGE_RESPONSE_HPP
 
 #include <boost/optional/optional_fwd.hpp>
-
 #include "cryptography/hash.hpp"
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/range_types.hpp"
@@ -22,6 +21,8 @@ namespace shared_model {
     class PendingTransactionsPageResponse
         : public ModelPrimitive<PendingTransactionsPageResponse> {
      public:
+      // TODO igor-egorov 2019-06-29 IR-570 Convert BatchInfo to a shared model
+      // object
       struct BatchInfo {
         interface::types::HashType first_tx_hash;
         interface::types::TransactionsNumberType batch_size;

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -46,12 +46,11 @@ namespace shared_model {
                                          ErrorQueryResponse,
                                          SignatoriesResponse,
                                          TransactionsResponse,
-                                         TransactionsPageResponse,
-                                         PendingTransactionsPageResponse,
                                          AssetResponse,
                                          RolesResponse,
                                          RolePermissionsResponse,
                                          TransactionsPageResponse,
+                                         PendingTransactionsPageResponse,
                                          BlockResponse>;
 
       /**

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -21,7 +21,6 @@ namespace shared_model {
     class ErrorQueryResponse;
     class SignatoriesResponse;
     class TransactionsResponse;
-    class TransactionsPageResponse;
     class PendingTransactionsPageResponse;
     class AssetResponse;
     class RolesResponse;

--- a/shared_model/interfaces/query_responses/query_response.hpp
+++ b/shared_model/interfaces/query_responses/query_response.hpp
@@ -21,6 +21,8 @@ namespace shared_model {
     class ErrorQueryResponse;
     class SignatoriesResponse;
     class TransactionsResponse;
+    class TransactionsPageResponse;
+    class PendingTransactionsPageResponse;
     class AssetResponse;
     class RolesResponse;
     class RolePermissionsResponse;
@@ -44,6 +46,8 @@ namespace shared_model {
                                          ErrorQueryResponse,
                                          SignatoriesResponse,
                                          TransactionsResponse,
+                                         TransactionsPageResponse,
+                                         PendingTransactionsPageResponse,
                                          AssetResponse,
                                          RolesResponse,
                                          RolePermissionsResponse,

--- a/shared_model/interfaces/query_responses/query_response_variant.hpp
+++ b/shared_model/interfaces/query_responses/query_response_variant.hpp
@@ -18,6 +18,8 @@ namespace boost {
       const shared_model::interface::ErrorQueryResponse &,
       const shared_model::interface::SignatoriesResponse &,
       const shared_model::interface::TransactionsResponse &,
+      const shared_model::interface::TransactionsPageResponse &,
+      const shared_model::interface::PendingTransactionsPageResponse &,
       const shared_model::interface::AssetResponse &,
       const shared_model::interface::RolesResponse &,
       const shared_model::interface::RolePermissionsResponse &>;

--- a/shared_model/interfaces/query_responses/query_response_variant.hpp
+++ b/shared_model/interfaces/query_responses/query_response_variant.hpp
@@ -18,11 +18,12 @@ namespace boost {
       const shared_model::interface::ErrorQueryResponse &,
       const shared_model::interface::SignatoriesResponse &,
       const shared_model::interface::TransactionsResponse &,
-      const shared_model::interface::TransactionsPageResponse &,
-      const shared_model::interface::PendingTransactionsPageResponse &,
       const shared_model::interface::AssetResponse &,
       const shared_model::interface::RolesResponse &,
-      const shared_model::interface::RolePermissionsResponse &>;
+      const shared_model::interface::RolePermissionsResponse &,
+      const shared_model::interface::TransactionsPageResponse &,
+      const shared_model::interface::PendingTransactionsPageResponse &,
+      const shared_model::interface::BlockResponse &>;
 }
 
 #endif  // IROHA_SHARED_MODEL_QUERY_RESPONSE_VARIANT_HPP

--- a/shared_model/schema/qry_responses.proto
+++ b/shared_model/schema/qry_responses.proto
@@ -97,6 +97,16 @@ message TransactionsPageResponse {
   }
 }
 
+message PendingTransactionsPageResponse {
+  message BatchInfo {
+    string first_tx_hash = 1;
+    uint32 batch_size = 2;
+  }
+  repeated Transaction transactions = 1;
+  uint32 all_transactions_size = 2;
+  BatchInfo next_batch_info = 3;
+}
+
 message QueryResponse {
   oneof response {
     AccountAssetResponse account_assets_response = 1;
@@ -109,6 +119,7 @@ message QueryResponse {
     RolesResponse roles_response = 8;
     RolePermissionsResponse role_permissions_response = 9;
     TransactionsPageResponse transactions_page_response = 11;
+    PendingTransactionsPageResponse pending_transactions_page_response = 13;
     BlockResponse block_response = 12;
   }
   string query_hash = 10;

--- a/shared_model/schema/queries.proto
+++ b/shared_model/schema/queries.proto
@@ -79,7 +79,7 @@ message GetRolePermissions{
 }
 
 message GetPendingTransactions {
-
+  TxPaginationMeta pagination_meta = 1;
 }
 
 message QueryPayloadMeta {

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -168,6 +168,10 @@ namespace shared_model {
           const interface::GetPendingTransactions &qry) const {
         ReasonsGroupType reason;
         reason.first = "GetPendingTransactions";
+        if (qry.paginationMeta()) {
+          // TODO igor-egorov 2019-06-06 IR-516 Make meta non-optional
+          validator_.validateTxPaginationMeta(reason, *qry.paginationMeta());
+        }
 
         return reason;
       }

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -19,6 +19,7 @@
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "backend/protobuf/proto_query_response_factory.hpp"
+#include "common/result.hpp"
 #include "datetime/time.hpp"
 #include "framework/common_constants.hpp"
 #include "framework/result_fixture.hpp"
@@ -751,7 +752,7 @@ namespace iroha {
 
       // validate result
       validatePageResponse(response, boost::none, 10);
-      }
+    }
 
     /**
      * @given account with all related permissions and 10 assets
@@ -1982,11 +1983,12 @@ namespace iroha {
     }
 
     /**
+     * TODO 2019-06-13 igor-egorov IR-516 Remove the test
      * @given initialized storage
      * @when get pending transactions
      * @then pending txs storage will be requested for query creator account
      */
-    TEST_F(QueryExecutorTest, TransactionsStorageIsAccessed) {
+    TEST_F(QueryExecutorTest, OldTransactionsStorageIsAccessed) {
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
                        .getPendingTransactions()
@@ -1996,6 +1998,47 @@ namespace iroha {
           .Times(1);
 
       executeQuery(query);
+    }
+
+    /**
+     * @given initialized storage
+     * @when get pending transactions
+     * @then pending txs storage will be requested for query creator account
+     */
+    TEST_F(QueryExecutorTest, TransactionsStorageIsAccessed) {
+      const auto kPageSize = 100u;
+      auto query = TestQueryBuilder()
+                       .creatorAccountId(account_id)
+                       .getPendingTransactions(kPageSize)
+                       .build();
+
+      EXPECT_CALL(*pending_txs_storage,
+                  getPendingTransactions(account_id, kPageSize, ::testing::_))
+          .Times(1);
+
+      executeQuery(query);
+    }
+
+    /**
+     * @given some pending txs storage
+     * @when a query is submitted and the storage responds with NOT_FOUND error
+     * @then query execturor produces correct stateful failed error
+     */
+    TEST_F(QueryExecutorTest, PendingTxsStorageWrongTxHash) {
+      const auto kPageSize = 100u;
+      const auto kFirstTxHash = shared_model::crypto::Hash(zero_string);
+      auto query = TestQueryBuilder()
+                       .creatorAccountId(account_id)
+                       .getPendingTransactions(kPageSize, kFirstTxHash)
+                       .build();
+
+      EXPECT_CALL(*pending_txs_storage,
+                  getPendingTransactions(account_id, kPageSize, ::testing::_))
+          .WillOnce(Return(iroha::expected::makeError(
+              PendingTransactionStorage::ErrorCode::NOT_FOUND)));
+
+      checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
+          executeQuery(query), 4);
     }
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -1988,7 +1988,7 @@ namespace iroha {
      * @when get pending transactions
      * @then pending txs storage will be requested for query creator account
      */
-    TEST_F(QueryExecutorTest, OldTransactionsStorageIsAccessed) {
+    TEST_F(QueryExecutorTest, OldTransactionsStorageIsAccessedOnGetPendingTxs) {
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)
                        .getPendingTransactions()
@@ -2005,7 +2005,7 @@ namespace iroha {
      * @when get pending transactions
      * @then pending txs storage will be requested for query creator account
      */
-    TEST_F(QueryExecutorTest, TransactionsStorageIsAccessed) {
+    TEST_F(QueryExecutorTest, TransactionsStorageIsAccessedOnGetPendingTxs) {
       const auto kPageSize = 100u;
       auto query = TestQueryBuilder()
                        .creatorAccountId(account_id)

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -2035,7 +2035,7 @@ namespace iroha {
       EXPECT_CALL(*pending_txs_storage,
                   getPendingTransactions(account_id, kPageSize, ::testing::_))
           .WillOnce(Return(iroha::expected::makeError(
-              PendingTransactionStorage::ErrorCode::NOT_FOUND)));
+              PendingTransactionStorage::ErrorCode::kNotFound)));
 
       checkStatefulError<shared_model::interface::StatefulFailedErrorResponse>(
           executeQuery(query), 4);

--- a/test/module/irohad/pending_txs_storage/CMakeLists.txt
+++ b/test/module/irohad/pending_txs_storage/CMakeLists.txt
@@ -16,3 +16,16 @@ target_link_libraries(pending_txs_storage_test
     shared_model_interfaces_factories
     test_logger
     )
+
+addtest(old_pending_txs_storage_test
+    old_pending_txs_storage_test.cpp
+    )
+target_link_libraries(old_pending_txs_storage_test
+    rxcpp
+    pending_txs_storage
+    shared_model_cryptography
+    shared_model_stateless_validation
+    shared_model_proto_backend
+    shared_model_interfaces_factories
+    test_logger
+    )

--- a/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
@@ -1,0 +1,288 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <rxcpp/rx.hpp>
+#include "datetime/time.hpp"
+#include "framework/test_logger.hpp"
+#include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
+#include "multi_sig_transactions/state/mst_state.hpp"
+#include "pending_txs_storage/impl/pending_txs_storage_impl.hpp"
+
+class OldPendingTxsStorageFixture : public ::testing::Test {
+ public:
+  using Batch = shared_model::interface::TransactionBatch;
+
+  /**
+   * Get the closest to now timestamp from the future but never return the same
+   * value twice.
+   * @return iroha timestamp
+   */
+  iroha::time::time_t getUniqueTime() {
+    static iroha::time::time_t latest_timestamp = 0;
+    auto now = iroha::time::now();
+    if (now > latest_timestamp) {
+      latest_timestamp = now;
+      return now;
+    } else {
+      return ++latest_timestamp;
+    }
+  }
+
+  std::shared_ptr<iroha::DefaultCompleter> completer_ =
+      std::make_shared<iroha::DefaultCompleter>(std::chrono::minutes(0));
+
+  logger::LoggerPtr mst_state_log_{getTestLogger("MstState")};
+  logger::LoggerPtr log_{getTestLogger("OldPendingTxsStorageFixture")};
+};
+
+/**
+ * Test that check that fixture common preparation procedures can be done
+ * successfully.
+ * @given empty MST state
+ * @when two mst transactions generated as batch
+ * @then the transactions can be added to MST state successfully
+ */
+TEST_F(OldPendingTxsStorageFixture, FixutureSelfCheck) {
+  auto state = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+
+  auto transactions =
+      addSignatures(makeTestBatch(txBuilder(1, getUniqueTime()),
+                                  txBuilder(1, getUniqueTime())),
+                    0,
+                    makeSignature("1", "pub_key_1"));
+
+  *state += transactions;
+  ASSERT_EQ(state->getBatches().size(), 1) << "Failed to prepare MST state";
+  ASSERT_EQ((*state->getBatches().begin())->transactions().size(), 2)
+      << "Test batch contains wrong amount of transactions";
+}
+
+/**
+ * Transactions insertion works in PendingTxsStorage
+ * @given Batch of two transactions and storage
+ * @when storage receives updated mst state with the batch
+ * @then list of pending transactions can be received for all batch creators
+ */
+TEST_F(OldPendingTxsStorageFixture, InsertionTest) {
+  auto state = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto transactions = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "alice@iroha"),
+                    txBuilder(2, getUniqueTime(), 2, "bob@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  *state += transactions;
+
+  auto updates = rxcpp::observable<>::create<decltype(state)>([&state](auto s) {
+    s.on_next(state);
+    s.on_completed();
+  });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+
+  iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
+  for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
+    auto pending = storage.getPendingTransactions(creator);
+    ASSERT_EQ(pending.size(), 2)
+        << "Wrong amount of pending transactions was retrieved for " << creator
+        << " account";
+
+    // generally it's illegal way to verify the correctness.
+    // here we can do it because the order is preserved by batch meta and there
+    // are no transactions non-related to requested account
+    for (auto i = 0u; i < pending.size(); ++i) {
+      ASSERT_EQ(*pending[i], *(transactions->transactions()[i]));
+    }
+  }
+}
+
+/**
+ * Updated batch replaces previously existed
+ * @given Batch with one transaction with one signature and storage
+ * @when transaction inside batch receives additional signature
+ * @then pending transactions response is also updated
+ */
+TEST_F(OldPendingTxsStorageFixture, SignaturesUpdate) {
+  auto state1 = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto state2 = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto transactions = addSignatures(
+      makeTestBatch(txBuilder(3, getUniqueTime(), 3, "alice@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  *state1 += transactions;
+  transactions =
+      addSignatures(transactions, 0, makeSignature("2", "pub_key_2"));
+  *state2 += transactions;
+
+  auto updates =
+      rxcpp::observable<>::create<decltype(state1)>([&state1, &state2](auto s) {
+        s.on_next(state1);
+        s.on_next(state2);
+        s.on_completed();
+      });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+
+  iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
+  auto pending = storage.getPendingTransactions("alice@iroha");
+  ASSERT_EQ(pending.size(), 1);
+  ASSERT_EQ(boost::size(pending.front()->signatures()), 2);
+}
+
+/**
+ * Storage correctly handles storing of several batches
+ * @given MST state update with three batches inside
+ * @when different users asks pending transactions
+ * @then users receives correct responses
+ */
+TEST_F(OldPendingTxsStorageFixture, SeveralBatches) {
+  auto state = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto batch1 = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "alice@iroha"),
+                    txBuilder(2, getUniqueTime(), 2, "bob@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  auto batch2 = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "alice@iroha"),
+                    txBuilder(3, getUniqueTime(), 3, "alice@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  auto batch3 = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "bob@iroha")),
+      0,
+      makeSignature("2", "pub_key_2"));
+  *state += batch1;
+  *state += batch2;
+  *state += batch3;
+
+  auto updates = rxcpp::observable<>::create<decltype(state)>([&state](auto s) {
+    s.on_next(state);
+    s.on_completed();
+  });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+
+  iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
+  auto alice_pending = storage.getPendingTransactions("alice@iroha");
+  ASSERT_EQ(alice_pending.size(), 4);
+
+  auto bob_pending = storage.getPendingTransactions("bob@iroha");
+  ASSERT_EQ(bob_pending.size(), 3);
+}
+
+/**
+ * New updates do not overwrite the whole state
+ * @given two MST updates with different batches
+ * @when updates arrives to storage sequentially
+ * @then updates don't overwrite the whole storage state
+ */
+TEST_F(OldPendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
+  auto state1 = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto batch1 = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "alice@iroha"),
+                    txBuilder(2, getUniqueTime(), 2, "bob@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  *state1 += batch1;
+  auto state2 = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  auto batch2 = addSignatures(
+      makeTestBatch(txBuilder(2, getUniqueTime(), 2, "alice@iroha"),
+                    txBuilder(3, getUniqueTime(), 3, "alice@iroha")),
+      0,
+      makeSignature("1", "pub_key_1"));
+  *state2 += batch2;
+
+  auto updates =
+      rxcpp::observable<>::create<decltype(state1)>([&state1, &state2](auto s) {
+        s.on_next(state1);
+        s.on_next(state2);
+        s.on_completed();
+      });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+
+  iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
+  auto alice_pending = storage.getPendingTransactions("alice@iroha");
+  ASSERT_EQ(alice_pending.size(), 4);
+
+  auto bob_pending = storage.getPendingTransactions("bob@iroha");
+  ASSERT_EQ(bob_pending.size(), 2);
+}
+
+/**
+ * Batches with fully signed transactions (prepared transactions) should be
+ * removed from storage
+ * @given a batch with semi-signed transaction as MST update
+ * @when the batch collects all the signatures
+ * @then storage removes the batch
+ */
+TEST_F(OldPendingTxsStorageFixture, PreparedBatch) {
+  auto state = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  std::shared_ptr<shared_model::interface::TransactionBatch> batch =
+      addSignatures(
+          makeTestBatch(txBuilder(3, getUniqueTime(), 3, "alice@iroha")),
+          0,
+          makeSignature("1", "pub_key_1"));
+  *state += batch;
+
+  rxcpp::subjects::subject<decltype(batch)> prepared_batches_subject;
+  auto updates = rxcpp::observable<>::create<decltype(state)>([&state](auto s) {
+    s.on_next(state);
+    s.on_completed();
+  });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+  iroha::PendingTransactionStorageImpl storage(
+      updates, prepared_batches_subject.get_observable(), dummy);
+
+  batch = addSignatures(batch,
+                        0,
+                        makeSignature("2", "pub_key_2"),
+                        makeSignature("3", "pub_key_3"));
+  prepared_batches_subject.get_subscriber().on_next(batch);
+  prepared_batches_subject.get_subscriber().on_completed();
+  auto pending = storage.getPendingTransactions("alice@iroha");
+  ASSERT_EQ(pending.size(), 0);
+}
+
+/**
+ * Batches with expired transactions should be removed from storage.
+ * @given a batch with semi-signed transaction as MST update
+ * @when the batch expires
+ * @then storage removes the batch
+ */
+TEST_F(OldPendingTxsStorageFixture, ExpiredBatch) {
+  auto state = std::make_shared<iroha::MstState>(
+      iroha::MstState::empty(mst_state_log_, completer_));
+  std::shared_ptr<shared_model::interface::TransactionBatch> batch =
+      addSignatures(
+          makeTestBatch(txBuilder(3, getUniqueTime(), 3, "alice@iroha")),
+          0,
+          makeSignature("1", "pub_key_1"));
+  *state += batch;
+
+  rxcpp::subjects::subject<decltype(batch)> expired_batches_subject;
+  auto updates = rxcpp::observable<>::create<decltype(state)>([&state](auto s) {
+    s.on_next(state);
+    s.on_completed();
+  });
+  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
+      [](auto s) { s.on_completed(); });
+  iroha::PendingTransactionStorageImpl storage(
+      updates, dummy, expired_batches_subject.get_observable());
+
+  expired_batches_subject.get_subscriber().on_next(batch);
+  expired_batches_subject.get_subscriber().on_completed();
+  auto pending = storage.getPendingTransactions("alice@iroha");
+  ASSERT_EQ(pending.size(), 0);
+}

--- a/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
@@ -45,7 +45,7 @@ class OldPendingTxsStorageFixture : public ::testing::Test {
  * @when two mst transactions generated as batch
  * @then the transactions can be added to MST state successfully
  */
-TEST_F(OldPendingTxsStorageFixture, FixutureSelfCheck) {
+TEST_F(OldPendingTxsStorageFixture, FixtureSelfCheck) {
   auto state = std::make_shared<iroha::MstState>(
       iroha::MstState::empty(mst_state_log_, completer_));
 
@@ -81,8 +81,7 @@ TEST_F(OldPendingTxsStorageFixture, InsertionTest) {
     s.on_next(state);
     s.on_completed();
   });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
 
   iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
@@ -126,8 +125,7 @@ TEST_F(OldPendingTxsStorageFixture, SignaturesUpdate) {
         s.on_next(state2);
         s.on_completed();
       });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
 
   iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
   auto pending = storage.getPendingTransactions("alice@iroha");
@@ -166,8 +164,7 @@ TEST_F(OldPendingTxsStorageFixture, SeveralBatches) {
     s.on_next(state);
     s.on_completed();
   });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
 
   iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
   auto alice_pending = storage.getPendingTransactions("alice@iroha");
@@ -207,8 +204,7 @@ TEST_F(OldPendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
         s.on_next(state2);
         s.on_completed();
       });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
 
   iroha::PendingTransactionStorageImpl storage(updates, dummy, dummy);
   auto alice_pending = storage.getPendingTransactions("alice@iroha");
@@ -240,8 +236,7 @@ TEST_F(OldPendingTxsStorageFixture, PreparedBatch) {
     s.on_next(state);
     s.on_completed();
   });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
   iroha::PendingTransactionStorageImpl storage(
       updates, prepared_batches_subject.get_observable(), dummy);
 
@@ -276,8 +271,7 @@ TEST_F(OldPendingTxsStorageFixture, ExpiredBatch) {
     s.on_next(state);
     s.on_completed();
   });
-  auto dummy = rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-      [](auto s) { s.on_completed(); });
+  auto dummy = rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
   iroha::PendingTransactionStorageImpl storage(
       updates, dummy, expired_batches_subject.get_observable());
 

--- a/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
@@ -39,7 +39,7 @@ class OldPendingTxsStorageFixture : public ::testing::Test {
 };
 
 /**
- * Test that check that fixture common preparation procedures can be done
+ * Test that checks that fixture common preparation procedures can be done
  * successfully.
  * @given empty MST state
  * @when two mst transactions generated as batch

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
@@ -22,7 +22,7 @@ namespace iroha {
         expected::Result<Response, ErrorCode>(
             const shared_model::interface::types::AccountIdType &account_id,
             const shared_model::interface::types::TransactionsNumberType
-                &page_size,
+                page_size,
             const boost::optional<shared_model::interface::types::HashType>
                 &first_tx_hash));
   };

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
@@ -24,7 +24,7 @@ namespace iroha {
             const shared_model::interface::types::TransactionsNumberType
                 &page_size,
             const boost::optional<shared_model::interface::types::HashType>
-                first_tx_hash));
+                &first_tx_hash));
   };
 
 }  // namespace iroha

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
@@ -13,9 +13,18 @@ namespace iroha {
 
   class MockPendingTransactionStorage : public PendingTransactionStorage {
    public:
-    MOCK_CONST_METHOD1(getPendingTransactions,
-                 shared_model::interface::types::SharedTxsCollectionType(
-                     const shared_model::interface::types::AccountIdType &accountId));
+    MOCK_CONST_METHOD1(
+        getPendingTransactions,
+        shared_model::interface::types::SharedTxsCollectionType(
+            const shared_model::interface::types::AccountIdType &account_id));
+    MOCK_CONST_METHOD3(
+        getPendingTransactions,
+        expected::Result<Response, ErrorCode>(
+            const shared_model::interface::types::AccountIdType &account_id,
+            const shared_model::interface::types::TransactionsNumberType
+                &page_size,
+            const boost::optional<shared_model::interface::types::HashType>
+                first_tx_hash));
   };
 
 }  // namespace iroha

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -32,18 +32,11 @@ class PendingTxsStorageFixture : public ::testing::Test {
   }
 
   auto dummyObservable() {
-    return rxcpp::observable<>::create<std::shared_ptr<Batch>>(
-        [](auto s) { s.on_completed(); });
+    return rxcpp::observable<>::empty<std::shared_ptr<Batch>>();
   }
 
   auto updatesObservable(std::vector<std::shared_ptr<iroha::MstState>> states) {
-    return rxcpp::observable<>::create<std::shared_ptr<iroha::MstState>>(
-        [states = std::move(states)](auto s) {
-          for (const auto &state : states) {
-            s.on_next(state);
-          }
-          s.on_completed();
-        });
+    return rxcpp::observable<>::iterate(states);
   }
 
   auto emptyState() {
@@ -73,7 +66,7 @@ class PendingTxsStorageFixture : public ::testing::Test {
  * @when two mst transactions generated as batch
  * @then the transactions can be added to MST state successfully
  */
-TEST_F(PendingTxsStorageFixture, FixutureSelfCheck) {
+TEST_F(PendingTxsStorageFixture, FixtureSelfCheck) {
   auto state = emptyState();
   auto transactions = twoTransactionsBatch();
   *state += transactions;
@@ -551,7 +544,7 @@ TEST_F(PendingTxsStorageFixture, QueryingWrongBatch) {
       },
       [](const auto &error) {
         ASSERT_EQ(error.error,
-                  iroha::PendingTransactionStorage::ErrorCode::NOT_FOUND);
+                  iroha::PendingTransactionStorage::ErrorCode::kNotFound);
       });
 }
 

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -11,6 +11,7 @@
 #include "multi_sig_transactions/state/mst_state.hpp"
 #include "pending_txs_storage/impl/pending_txs_storage_impl.hpp"
 
+// TODO igor-egorov 2019-06-24 IR-573 Refactor pending txs storage tests
 class PendingTxsStorageFixture : public ::testing::Test {
  public:
   using Batch = shared_model::interface::TransactionBatch;
@@ -60,7 +61,7 @@ class PendingTxsStorageFixture : public ::testing::Test {
 };
 
 /**
- * Test that check that fixture common preparation procedures can be done
+ * Test that checks that fixture common preparation procedures can be done
  * successfully.
  * @given empty MST state
  * @when two mst transactions generated as batch
@@ -96,10 +97,10 @@ TEST_F(PendingTxsStorageFixture, InsertionTest) {
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
-          ASSERT_EQ(response.value.all_transactions_size,
+          EXPECT_EQ(response.value.all_transactions_size,
                     txs->transactions().size());
-          ASSERT_EQ(pending_txs.size(), txs->transactions().size());
-          ASSERT_FALSE(response.value.next_batch_info);
+          EXPECT_EQ(pending_txs.size(), txs->transactions().size());
+          EXPECT_FALSE(response.value.next_batch_info);
           // generally it's illegal way to verify the correctness.
           // here we can do it because the order is preserved by batch meta and
           // there are no transactions non-related to requested account
@@ -108,8 +109,8 @@ TEST_F(PendingTxsStorageFixture, InsertionTest) {
           }
         },
         [](const auto &error) {
-          ASSERT_TRUE(false)
-              << "An error was not expected, the error code is " << error.error;
+          FAIL() << "An error was not expected, the error code is "
+                 << error.error;
         });
   }
 }
@@ -135,10 +136,10 @@ TEST_F(PendingTxsStorageFixture, ExactSize) {
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
-          ASSERT_EQ(response.value.all_transactions_size,
+          EXPECT_EQ(response.value.all_transactions_size,
                     txs->transactions().size());
-          ASSERT_EQ(pending_txs.size(), txs->transactions().size());
-          ASSERT_FALSE(response.value.next_batch_info);
+          EXPECT_EQ(pending_txs.size(), txs->transactions().size());
+          EXPECT_FALSE(response.value.next_batch_info);
           // generally it's illegal way to verify the correctness.
           // here we can do it because the order is preserved by batch meta and
           // there are no transactions non-related to requested account
@@ -147,8 +148,8 @@ TEST_F(PendingTxsStorageFixture, ExactSize) {
           }
         },
         [](const auto &error) {
-          ASSERT_TRUE(false)
-              << "An error was not expected, the error code is " << error.error;
+          FAIL() << "An error was not expected, the error code is "
+                 << error.error;
         });
   }
 }
@@ -176,18 +177,18 @@ TEST_F(PendingTxsStorageFixture, InsufficientSize) {
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
-          ASSERT_EQ(response.value.all_transactions_size,
+          EXPECT_EQ(response.value.all_transactions_size,
                     txs->transactions().size());
-          ASSERT_EQ(pending_txs.size(), 0);
-          ASSERT_TRUE(response.value.next_batch_info);
-          ASSERT_EQ(response.value.next_batch_info->first_tx_hash,
+          EXPECT_EQ(pending_txs.size(), 0);
+          EXPECT_TRUE(response.value.next_batch_info);
+          EXPECT_EQ(response.value.next_batch_info->first_tx_hash,
                     txs->transactions().front()->hash());
-          ASSERT_EQ(response.value.next_batch_info->batch_size,
+          EXPECT_EQ(response.value.next_batch_info->batch_size,
                     txs->transactions().size());
         },
         [](const auto &error) {
-          ASSERT_TRUE(false)
-              << "An error was not expected, the error code is " << error.error;
+          FAIL() << "An error was not expected, the error code is "
+                 << error.error;
         });
   }
 }
@@ -195,7 +196,7 @@ TEST_F(PendingTxsStorageFixture, InsufficientSize) {
 /**
  * Correctly formed response is returned when there are two batches are in the
  * storage and the page size is bigger than the size of the first batch and
- * lesser than the sum of the first and the second batches sizes.
+ * smaller than the sum of the first and the second batches sizes.
  */
 TEST_F(PendingTxsStorageFixture, BatchAndAHalfPageSize) {
   auto state1 = emptyState();
@@ -217,22 +218,22 @@ TEST_F(PendingTxsStorageFixture, BatchAndAHalfPageSize) {
     pending.match(
         [&](const auto &response) {
           auto &pending_txs = response.value.transactions;
-          ASSERT_EQ(
+          EXPECT_EQ(
               response.value.all_transactions_size,
               batch1->transactions().size() + batch2->transactions().size());
-          ASSERT_EQ(pending_txs.size(), batch1->transactions().size());
-          ASSERT_TRUE(response.value.next_batch_info);
-          ASSERT_EQ(response.value.next_batch_info->first_tx_hash,
+          EXPECT_EQ(pending_txs.size(), batch1->transactions().size());
+          EXPECT_TRUE(response.value.next_batch_info);
+          EXPECT_EQ(response.value.next_batch_info->first_tx_hash,
                     batch2->transactions().front()->hash());
-          ASSERT_EQ(response.value.next_batch_info->batch_size,
+          EXPECT_EQ(response.value.next_batch_info->batch_size,
                     batch2->transactions().size());
           for (auto i = 0u; i < pending_txs.size(); ++i) {
             ASSERT_EQ(*pending_txs[i], *(batch1->transactions()[i]));
           }
         },
         [](const auto &error) {
-          ASSERT_TRUE(false)
-              << "An error was not expected, the error code is " << error.error;
+          FAIL() << "An error was not expected, the error code is "
+                 << error.error;
         });
   }
 }
@@ -261,18 +262,18 @@ TEST_F(PendingTxsStorageFixture, StartFromTheSecondBatch) {
     pending.match(
         [&](const auto &response) {
           auto &pending_txs = response.value.transactions;
-          ASSERT_EQ(
+          EXPECT_EQ(
               response.value.all_transactions_size,
-              batch2->transactions().size() + batch2->transactions().size());
-          ASSERT_EQ(pending_txs.size(), batch2->transactions().size());
-          ASSERT_FALSE(response.value.next_batch_info);
+              batch1->transactions().size() + batch2->transactions().size());
+          EXPECT_EQ(pending_txs.size(), batch2->transactions().size());
+          EXPECT_FALSE(response.value.next_batch_info);
           for (auto i = 0u; i < pending_txs.size(); ++i) {
             ASSERT_EQ(*pending_txs[i], *(batch2->transactions()[i]));
           }
         },
         [](const auto &error) {
-          ASSERT_TRUE(false)
-              << "An error was not expected, the error code is " << error.error;
+          FAIL() << "An error was not expected, the error code is "
+                 << error.error;
         });
   }
 }
@@ -299,12 +300,12 @@ TEST_F(PendingTxsStorageFixture, NoPendingBatches) {
   response.match(
       [](const auto &response) {
         auto &pending_txs = response.value.transactions;
-        ASSERT_EQ(pending_txs.size(), 0);
-        ASSERT_EQ(response.value.all_transactions_size, 0);
+        EXPECT_EQ(pending_txs.size(), 0);
+        EXPECT_EQ(response.value.all_transactions_size, 0);
         auto &next_batch_info = response.value.next_batch_info;
         ASSERT_FALSE(next_batch_info);
       },
-      [](const auto &error) { ASSERT_TRUE(false) << error.error; });
+      [](const auto &error) { FAIL() << error.error; });
 }
 
 /**
@@ -335,12 +336,12 @@ TEST_F(PendingTxsStorageFixture, SignaturesUpdate) {
   pending.match(
       [&txs = transactions](const auto &response) {
         const auto &resp = response.value;
-        ASSERT_EQ(resp.transactions.size(), txs->transactions().size());
-        ASSERT_EQ(boost::size(resp.transactions.front()->signatures()), 2);
+        EXPECT_EQ(resp.transactions.size(), txs->transactions().size());
+        EXPECT_EQ(boost::size(resp.transactions.front()->signatures()), 2);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 }
 
@@ -378,8 +379,8 @@ TEST_F(PendingTxsStorageFixture, SeveralBatches) {
         ASSERT_EQ(response.value.transactions.size(), 4);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 
   auto bob_pending =
@@ -389,8 +390,8 @@ TEST_F(PendingTxsStorageFixture, SeveralBatches) {
         ASSERT_EQ(response.value.transactions.size(), 3);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 }
 
@@ -426,8 +427,8 @@ TEST_F(PendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
         ASSERT_EQ(response.value.transactions.size(), 4);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 
   auto bob_pending =
@@ -437,8 +438,8 @@ TEST_F(PendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
         ASSERT_EQ(response.value.transactions.size(), 2);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 }
 
@@ -478,8 +479,8 @@ TEST_F(PendingTxsStorageFixture, PreparedBatch) {
         ASSERT_EQ(response.value.transactions.size(), 0);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 }
 
@@ -514,8 +515,8 @@ TEST_F(PendingTxsStorageFixture, ExpiredBatch) {
         ASSERT_EQ(response.value.transactions.size(), 0);
       },
       [](const auto &error) {
-        ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                           << error.error;
+        FAIL() << "An error was not expected, the error code is "
+               << error.error;
       });
 }
 
@@ -539,8 +540,7 @@ TEST_F(PendingTxsStorageFixture, QueryingWrongBatch) {
       kThirdAccount, kPageSize, transactions->transactions().front()->hash());
   response.match(
       [](const auto &response) {
-        ASSERT_TRUE(false)
-            << "NOT_FOUND error was expected instead of a response";
+        FAIL() << "NOT_FOUND error was expected instead of a response";
       },
       [](const auto &error) {
         ASSERT_EQ(error.error,
@@ -568,8 +568,7 @@ TEST_F(PendingTxsStorageFixture, QueryAllTheBatches) {
     return batch->transactions().front()->hash();
   };
   auto errorResponseHandler = [](const auto &error) {
-    ASSERT_TRUE(false) << "An error was not expected, the error code is "
-                       << error.error;
+    FAIL() << "An error was not expected, the error code is " << error.error;
   };
 
   auto updates = updatesObservable({state1, state2});
@@ -582,12 +581,12 @@ TEST_F(PendingTxsStorageFixture, QueryAllTheBatches) {
     first_page.match(
         [&](const auto &first_response) {
           const auto &resp1 = first_response.value;
-          ASSERT_EQ(resp1.all_transactions_size,
+          EXPECT_EQ(resp1.all_transactions_size,
                     batchSize(batch1) + batchSize(batch2));
-          ASSERT_EQ(resp1.transactions.size(), batchSize(batch1));
-          ASSERT_TRUE(resp1.next_batch_info);
-          ASSERT_EQ(resp1.next_batch_info->batch_size, batchSize(batch2));
-          ASSERT_EQ(resp1.next_batch_info->first_tx_hash, firstHash(batch2));
+          EXPECT_EQ(resp1.transactions.size(), batchSize(batch1));
+          EXPECT_TRUE(resp1.next_batch_info);
+          EXPECT_EQ(resp1.next_batch_info->batch_size, batchSize(batch2));
+          EXPECT_EQ(resp1.next_batch_info->first_tx_hash, firstHash(batch2));
           for (auto i = 0u; i < resp1.transactions.size(); ++i) {
             ASSERT_EQ(*resp1.transactions[i], *(batch1->transactions()[i]));
           }
@@ -597,10 +596,10 @@ TEST_F(PendingTxsStorageFixture, QueryAllTheBatches) {
           second_page.match(
               [&](const auto &second_response) {
                 const auto &resp2 = second_response.value;
-                ASSERT_EQ(resp2.all_transactions_size,
+                EXPECT_EQ(resp2.all_transactions_size,
                           batchSize(batch1) + batchSize(batch2));
-                ASSERT_EQ(resp2.transactions.size(), batchSize(batch2));
-                ASSERT_FALSE(resp2.next_batch_info);
+                EXPECT_EQ(resp2.transactions.size(), batchSize(batch2));
+                EXPECT_FALSE(resp2.next_batch_info);
                 for (auto i = 0u; i < resp2.transactions.size(); ++i) {
                   ASSERT_EQ(*resp2.transactions[i],
                             *(batch2->transactions()[i]));

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -98,6 +98,10 @@ class ValidatorsTest : public ::testing::Test {
          [&](auto refl, auto msg, auto field) {
            refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
          }},
+        {"iroha.protocol.GetPendingTransactions.pagination_meta",
+         [&](auto refl, auto msg, auto field) {
+           refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);
+         }},
         {"iroha.protocol.GetAccountAssetTransactions.pagination_meta",
          [&](auto refl, auto msg, auto field) {
            refl->MutableMessage(msg, field)->CopyFrom(tx_pagination_meta);


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Add support of paginated queries to Pending Transactions Storage.

### Benefits

Improved API.
Introduced a way to iterate over pending transactions (batches of transactions) by reasonably sized chunks of data.

### Possible Drawbacks 

The old API (without pagination meta) is still supported and has to be removed by the following major Iroha update (the related issue is https://jira.hyperledger.org/browse/IR-516)

### Usage Examples or Tests 

```
old_pending_txs_storage_test
pending_txs_storage_test
postgres_query_executor_test
multisig_tx_pipeline_test
```
