### PR TITLE
expected::Result improvements

### DIFF
--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -338,6 +338,12 @@ namespace iroha {
           [](auto &&e) { return return_type(makeError(std::move(e.error))); });
     }
 
+    /// operator |= is a shortcut for `Result = Result | function'
+    template <typename R, typename F>
+    constexpr auto operator|=(R &r, F &&f) -> decltype(r = r | f) {
+      return r = r | std::forward<F>(f);
+    }
+
     /**
      * Polymorphic Result is simple alias for result type, which can be used to
      * work with polymorphic objects. It is achieved by wrapping V and E in a

--- a/test/framework/result_gtest_checkers.hpp
+++ b/test/framework/result_gtest_checkers.hpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_RESULT_GTEST_CHECKERS_HPP
+#define IROHA_RESULT_GTEST_CHECKERS_HPP
+
+#include "common/result.hpp"
+
+#include <gtest/gtest.h>
+
+namespace framework {
+  namespace expected {
+    namespace detail {
+      std::string getMessage(const std::string &s) {
+        return s;
+      }
+
+      template <typename T>
+      auto getMessage(const T &o) -> std::enable_if_t<
+          std::is_same<decltype(o.toString()), std::string>::value,
+          std::string> {
+        return o.toString();
+      }
+
+      template <typename T>
+      auto getMessage(const T &o) -> std::enable_if_t<
+          std::is_same<decltype(o->toString()), std::string>::value,
+          std::string> {
+        return o->toString();
+      }
+    }  // namespace detail
+
+    template <typename V, typename E>
+    void expectResultValue(const iroha::expected::Result<V, E> &r) {
+      EXPECT_TRUE(iroha::expected::hasValue(r))
+          << "Value expected, but got error: "
+          << detail::getMessage(
+                 iroha::expected::resultToOptionalError(r).value());
+    }
+
+    template <typename V, typename E>
+    void assertResultValue(const iroha::expected::Result<V, E> &r) {
+      ASSERT_TRUE(iroha::expected::hasValue(r))
+          << "Value expected, but got error: "
+          << detail::getMessage(
+                 iroha::expected::resultToOptionalError(r).value());
+    }
+
+    template <typename V, typename E>
+    void expectResultError(const iroha::expected::Result<V, E> &r) {
+      EXPECT_TRUE(iroha::expected::hasError(r))
+          << "Error expected, but got value: "
+          << detail::getMessage(
+                 iroha::expected::resultToOptionalValue(r).value());
+    }
+
+    template <typename V, typename E>
+    void assertResultError(const iroha::expected::Result<V, E> &r) {
+      ASSERT_TRUE(iroha::expected::hasError(r))
+          << "Error expected, but got value: "
+          << detail::getMessage(
+                 iroha::expected::resultToOptionalValue(r).value());
+    }
+
+  }  // namespace expected
+}  // namespace framework
+
+#endif  // IROHA_RESULT_GTEST_CHECKERS_HPP


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- use `std::decay<T>` when needed
- added `operator |=` which is a shortcut for `Result = Result | function`
- added helpers to expect and assert `Error` and `Value`, printing `toString()` in case of failure.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Better type deduction in `Result`-related functions. New operator makes code prettier.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
