### PR TITLE
Refactor ProtoQueryResponseFactory::createTransactionsPageResponse

### DIFF
--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -523,7 +523,7 @@ namespace iroha {
               auto next_hash = response_txs.back()->hash();
               response_txs.pop_back();
               return query_response_factory_->createTransactionsPageResponse(
-                  std::move(response_txs), next_hash, total_size, query_hash_);
+                  std::move(response_txs), total_size, query_hash_, next_hash);
             }
 
             return query_response_factory_->createTransactionsPageResponse(

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -6,6 +6,8 @@
 #ifndef IROHA_PROTO_QUERY_RESPONSE_FACTORY_HPP
 #define IROHA_PROTO_QUERY_RESPONSE_FACTORY_HPP
 
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
 #include "interfaces/iroha_internal/query_response_factory.hpp"
 
 namespace shared_model {
@@ -53,15 +55,10 @@ namespace shared_model {
       std::unique_ptr<interface::QueryResponse> createTransactionsPageResponse(
           std::vector<std::unique_ptr<shared_model::interface::Transaction>>
               transactions,
-          const crypto::Hash &next_tx_hash,
           interface::types::TransactionsNumberType all_transactions_size,
-          const crypto::Hash &query_hash) const override;
-
-      std::unique_ptr<interface::QueryResponse> createTransactionsPageResponse(
-          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
-              transactions,
-          interface::types::TransactionsNumberType all_transactions_size,
-          const crypto::Hash &query_hash) const override;
+          const crypto::Hash &query_hash,
+          boost::optional<const crypto::Hash &> next_tx_hash =
+              boost::none) const override;
 
       std::unique_ptr<interface::QueryResponse> createAssetResponse(
           interface::types::AssetIdType asset_id,

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -137,33 +137,20 @@ namespace shared_model {
       /**
        * Create response for transactions pagination query
        * @param transactions - list of transactions in this page
+       * @param all_transactions_size - total number of transactions
+       * for this query
+       * @param query_hash - hash of the query, for which response is created
        * @param next_tx_hash - hash of the transaction after
        * the last in the page
-       * @param all_transactions_size - total number of transactions
-       * for this query
-       * @param query_hash - hash of the query, for which response is created
-       * @return transactions response
-       */
-      virtual std::unique_ptr<QueryResponse> createTransactionsPageResponse(
-          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
-              transactions,
-          const crypto::Hash &next_tx_hash,
-          interface::types::TransactionsNumberType all_transactions_size,
-          const crypto::Hash &query_hash) const = 0;
-
-      /**
-       * Create response for transactions pagination query without next hash
-       * @param transactions - list of transactions in this page
-       * @param all_transactions_size - total number of transactions
-       * for this query
-       * @param query_hash - hash of the query, for which response is created
        * @return transactions response
        */
       virtual std::unique_ptr<QueryResponse> createTransactionsPageResponse(
           std::vector<std::unique_ptr<shared_model::interface::Transaction>>
               transactions,
           interface::types::TransactionsNumberType all_transactions_size,
-          const crypto::Hash &query_hash) const = 0;
+          const crypto::Hash &query_hash,
+          boost::optional<const crypto::Hash &> next_tx_hash =
+              boost::none) const = 0;
 
       /**
        * Create response for asset query

--- a/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
@@ -327,7 +327,7 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateTransactionsPageResponse) {
     transactions_test_copy.push_back(std::move(tx_copy));
   }
   auto query_response = response_factory->createTransactionsPageResponse(
-      std::move(transactions), kNextTxHash, kTransactionsNumber, kQueryHash);
+      std::move(transactions), kTransactionsNumber, kQueryHash, kNextTxHash);
 
   ASSERT_TRUE(query_response);
   EXPECT_EQ(query_response->queryHash(), kQueryHash);


### PR DESCRIPTION
### Description of the Change
Refactored with boost::optional so that there is only 1 method ProtoQueryResponseFactory::createTransactionsPageResponse
### Benefits
No duplicate code
### Possible Drawbacks 
None