### PR TITLE
SQL: moved reset sql statements to PgConnectionInit

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -200,21 +200,17 @@ namespace iroha {
         soci::session sql(*connection_);
         // rollback possible prepared transaction
         tryRollback(sql);
-        sql << reset_;
+        return PgConnectionInit::resetWsv(sql);
       } catch (std::exception &e) {
         return expected::makeError(e.what());
       }
-      return expected::Value<void>();
     }
 
     void StorageImpl::resetPeers() {
       log_->info("Remove everything from peers table");
-      try {
-        soci::session sql(*connection_);
-        sql << reset_peers_;
-      } catch (std::exception &e) {
-        log_->error("Failed to reset peers list, reason: {}", e.what());
-      }
+      soci::session sql(*connection_);
+      expected::resultToOptionalError(PgConnectionInit::resetPeers(sql)) |
+          [this](const auto &e) { this->log_->error("{}", e); };
     }
 
     void StorageImpl::dropStorage() {
@@ -531,27 +527,5 @@ namespace iroha {
       }
     }
 
-    const std::string &StorageImpl::reset_ = R"(
-TRUNCATE TABLE account_has_signatory RESTART IDENTITY CASCADE;
-TRUNCATE TABLE account_has_asset RESTART IDENTITY CASCADE;
-TRUNCATE TABLE role_has_permissions RESTART IDENTITY CASCADE;
-TRUNCATE TABLE account_has_roles RESTART IDENTITY CASCADE;
-TRUNCATE TABLE account_has_grantable_permissions RESTART IDENTITY CASCADE;
-TRUNCATE TABLE account RESTART IDENTITY CASCADE;
-TRUNCATE TABLE asset RESTART IDENTITY CASCADE;
-TRUNCATE TABLE domain RESTART IDENTITY CASCADE;
-TRUNCATE TABLE signatory RESTART IDENTITY CASCADE;
-TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
-TRUNCATE TABLE role RESTART IDENTITY CASCADE;
-TRUNCATE TABLE position_by_hash RESTART IDENTITY CASCADE;
-TRUNCATE TABLE tx_status_by_hash RESTART IDENTITY CASCADE;
-TRUNCATE TABLE height_by_account_set RESTART IDENTITY CASCADE;
-TRUNCATE TABLE index_by_creator_height RESTART IDENTITY CASCADE;
-TRUNCATE TABLE position_by_account_asset RESTART IDENTITY CASCADE;
-)";
-
-    const std::string &StorageImpl::reset_peers_ = R"(
-TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
-)";
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -186,10 +186,6 @@ namespace iroha {
       std::string prepared_block_name_;
 
       boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
-
-     protected:
-      static const std::string &reset_;
-      static const std::string &reset_peers_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/main/impl/pg_connection_init.cpp
+++ b/irohad/main/impl/pg_connection_init.cpp
@@ -298,3 +298,46 @@ CREATE TABLE IF NOT EXISTS position_by_account_asset (
     index bigint
 );
 )";
+
+iroha::expected::Result<void, std::string> PgConnectionInit::resetWsv(
+    soci::session &sql) {
+  try {
+    static const std::string reset = R"(
+      TRUNCATE TABLE account_has_signatory RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE account_has_asset RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE role_has_permissions RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE account_has_roles RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE account_has_grantable_permissions RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE account RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE asset RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE domain RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE signatory RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE role RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE position_by_hash RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE tx_status_by_hash RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE height_by_account_set RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE index_by_creator_height RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE position_by_account_asset RESTART IDENTITY CASCADE;
+    )";
+    sql << reset;
+  } catch (std::exception &e) {
+    return iroha::expected::makeError(std::string{"Failed to reset WSV: "}
+                                      + formatPostgresMessage(e.what()));
+  }
+  return expected::Value<void>();
+}
+
+iroha::expected::Result<void, std::string> PgConnectionInit::resetPeers(
+    soci::session &sql) {
+  try {
+    static const std::string reset_peers = R"(
+      TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
+    )";
+    sql << reset_peers;
+  } catch (std::exception &e) {
+    return iroha::expected::makeError(std::string{"Failed to reset peers: "}
+                                      + formatPostgresMessage(e.what()));
+  }
+  return expected::Value<void>();
+}

--- a/irohad/main/impl/pg_connection_init.hpp
+++ b/irohad/main/impl/pg_connection_init.hpp
@@ -49,6 +49,18 @@ namespace iroha {
           const std::string &dbname,
           const std::string &options_str_without_dbname);
 
+      /*
+       * Remove all records from the tables
+       * @return error message if reset has failed
+       */
+      static expected::Result<void, std::string> resetWsv(soci::session &sql);
+
+      /**
+       * Removes all peers from WSV
+       * @return error message if reset has failed
+       */
+      static expected::Result<void, std::string> resetPeers(soci::session &sql);
+
      private:
       /**
        * Function initializes existing connection pool


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Subj. This change is needed to be able to reset the tables in tests that do not use `StorageImpl` (strictly speaking the upcoming `ExecutorItf`).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Table manipulation statements gathered in single place.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

This place is called <pre>PgConnection**Init**</pre> anthough it does more than that.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
