### PR TITLE
Testing: moved negative amount tests to field_validator_test

### DIFF
--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -63,25 +63,6 @@ TEST_F(AddAssetQuantity, NoPermissions) {
 }
 
 /**
- * TODO mboldyrev 17.01.2019 IR-203 convert to a field validator unit test
- *
- * @given pair of users with all required permissions
- * @when execute tx with AddAssetQuantity command with negative amount
- * @then the tx hasn't passed stateless validation
- *       (aka skipProposal throws)
- */
-TEST_F(AddAssetQuantity, NegativeAmount) {
-  IntegrationTestFramework(1)
-      .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms())
-      .skipProposal()
-      .skipVerifiedProposal()
-      .skipBlock()
-      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, "-1.0")),
-              CHECK_STATELESS_INVALID);
-}
-
-/**
  * TODO mboldyrev 17.01.2019 IR-203 seems can be removed (covered by field
  * validator test and the above test)
  *

--- a/test/integration/acceptance/subtract_asset_qty_test.cpp
+++ b/test/integration/acceptance/subtract_asset_qty_test.cpp
@@ -120,25 +120,6 @@ TEST_F(SubtractAssetQuantity, NoPermissions) {
  * TODO mboldyrev 18.01.2019 IR-225 remove, covered by field validator test
  *
  * @given pair of users with all required permissions
- * @when execute tx with SubtractAssetQuantity command with negative amount
- * @then the tx hasn't passed stateless validation
- *       (aka skipProposal throws)
- */
-TEST_F(SubtractAssetQuantity, NegativeAmount) {
-  IntegrationTestFramework(1)
-      .setInitialState(kAdminKeypair)
-      .sendTx(makeUserWithPerms())
-      .skipProposal()
-      .skipBlock()
-      .sendTxAwait(replenish(), [](auto &) {})
-      .sendTx(complete(baseTx().subtractAssetQuantity(kAssetId, "-1.0")),
-              CHECK_STATELESS_INVALID);
-}
-
-/**
- * TODO mboldyrev 18.01.2019 IR-225 remove, covered by field validator test
- *
- * @given pair of users with all required permissions
  * @when execute tx with SubtractAssetQuantity command with zero amount
  * @then the tx hasn't passed stateless validation
  *       (aka skipProposal throws)

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -182,23 +182,6 @@ TEST_F(TransferAsset, NonexistentAsset) {
 }
 
 /**
- * TODO mboldyrev 18.01.2019 IR-226 convert to a field validator unit test
- *
- * @given pair of users with all required permissions
- * @when execute tx with TransferAsset command with negative amount
- * @then the tx hasn't passed stateless validation
- *       (aka skipProposal throws)
- */
-TEST_F(TransferAsset, NegativeAmount) {
-  IntegrationTestFramework(1)
-      .setInitialState(kAdminKeypair)
-      .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
-      .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
-      .sendTxAwait(addAssets(), CHECK_TXS_QUANTITY(1))
-      .sendTx(makeTransfer("-1.0"), CHECK_STATELESS_INVALID);
-}
-
-/**
  * TODO mboldyrev 18.01.2019 IR-226 remove, covered by field validator test
  *
  * @given pair of users with all required permissions

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -260,7 +260,11 @@ class FieldValidatorTest : public ValidatorsTest {
       {"zero_amount",
        [&] { amount = "0"; },
        false,
-       "Amount must be greater than 0, passed value: 0"}};
+       "Amount must be greater than 0, passed value: 0"},
+      {"negative_amount",
+       [&] { amount = "-100"; },
+       false,
+       "Amount must be greater than 0, passed value: -100"}};
 
   /**
    * Make test case for invalid peer address.


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

[IR-226](https://jira.hyperledger.org/browse/IR-226)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Three *the Big ITF* tests all differing from the "Basic" case in what field validator does to negative amount are removed. The corresponding test case added to field_validator_test module test which is smaller, faster, more precise and only one.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Less duplicated tests on *the Big ITF*.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
