### PR TITLE
Fix clang-format output on CI

### DIFF
--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -66,7 +66,7 @@ def clangFormat (scmVars, environment) {
   withEnv(environment) {
     if (env.CHANGE_TARGET){
       sh"""
-        git diff origin/${env.CHANGE_TARGET} --name-only | grep -E '\\.cc|\\.cpp|\\.cxx|\\.C|\\.c++|\\.c\$|\\.CPP|\\.h|\\.hpp|\\.hh|\\.icc' | xargs clang-format -style=file -i || true
+        git diff origin/${env.CHANGE_TARGET} --name-only | grep -E '\\.(cc|cpp|cxx|C|c\\+\\+|c|CPP|h|hpp|hh|icc)\$' | xargs clang-format-7 -style=file -i || true
         git diff | tee  clang-format-report.txt
         git reset HEAD --hard
       """

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -34,7 +34,7 @@ RUN set -e; \
         # Pythons
         python-pip python3-pip python3-setuptools python-dev \
         # other
-        curl file gdb gdbserver ccache clang-format \
+        curl file gdb gdbserver ccache \
         gcovr cppcheck doxygen rsync graphviz graphviz-dev unzip vim zip pkg-config; \
     apt-get -y clean
 
@@ -42,7 +42,7 @@ RUN set -e; \
 RUN set -e; \
     if [ `uname -m` = "x86_64" ]; then \
       apt-get -y --no-install-recommends install \
-        clang-7 lldb-7 lld-7 libc++-7-dev libc++abi-7-dev; \
+        clang-7 lldb-7 lld-7 libc++-7-dev libc++abi-7-dev clang-format-7; \
       apt-get -y clean; \
     fi
 


### PR DESCRIPTION
### Description of the Change
- Update clang-format version from 3.8 to 7.1. Old version produced incorrect output
- Fix extension regexp for clang-format input. Now it does not include generic extensions starting with the letter c, only "c++".

### Benefits
Correct output, less misunderstandings from contributors

### Possible Drawbacks 
None
