### PR TITLE
Ametsuchi: fixed asset quantity overflow detection

### DIFF
--- a/docs/source/api/commands.rst
+++ b/docs/source/api/commands.rst
@@ -54,7 +54,7 @@ Possible Stateful Validation Errors
     "1", "Could not add asset quantity", "Internal error happened", "Try again or contact developers"
     "2", "No such permissions", "Command's creator does not have permission to add asset quantity", "Grant the necessary permission"
     "3", "No such asset", "Cannot find asset with such name or such precision", "Make sure asset id and precision are correct"
-    "4", "Summation overflow", "Resulting amount of asset is greater than the system can support", "Make sure that resulting amount is less than 2^(256 - precision)"
+    "4", "Summation overflow", "Resulting asset quantity is greater than the system can support", "Make sure that resulting quantity is less than 2^256 / 10^asset_precision"
 
 Add peer
 --------
@@ -830,7 +830,7 @@ Possible Stateful Validation Errors
     "4", "No such destination account", "Cannot find account with such id to transfer money to", "Make sure destination account id is correct"
     "5", "No such asset found", "Cannot find such asset", "Make sure asset name and precision are correct"
     "6", "Not enough balance", "Source account's balance is too low to perform the operation", "Add asset to account or choose lower value to subtract"
-    "7", "Too much asset to transfer", "Resulting value of asset amount overflows destination account's amount", "Make sure final value is less than 2^(256 - precision)"
+    "7", "Too much asset to transfer", "Resulting asset quantity of destination account would exceed the allowed maximum", "Make sure that the final destination value is less than 2^256 / 10^asset_precision"
 
 .. [#f1] https://www.ietf.org/rfc/rfc1035.txt
 .. [#f2] https://www.ietf.org/rfc/rfc1123.txt

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -425,8 +425,9 @@ namespace iroha {
                       AND precision >= $3
 
                    UNION
-                   SELECT 4, value < (2::decimal ^ 256) / 10::decimal^$3
-                   FROM new_quantity
+                   SELECT 4, value < (2::decimal ^ 256) / (10::decimal ^ precision)
+                   FROM new_quantity, asset
+                   WHERE asset_id = $2
                ),
                inserted AS
                (
@@ -814,8 +815,9 @@ namespace iroha {
                   FROM new_src_quantity
 
                   UNION
-                  SELECT 7, value < (2::decimal ^ 256) / 10::decimal^$5
-                  FROM new_dest_quantity
+                  SELECT 7, value < (2::decimal ^ 256) / (10::decimal ^ precision)
+                  FROM new_dest_quantity, asset
+                  WHERE asset_id = $4
               ),
               insert_src AS
               (

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(integration_framework
     )
 
 add_library(common_test_constants common_constants.cpp)
+target_link_libraries(common_test_constants
+    shared_model_interfaces
+    )
 
 target_include_directories(integration_framework PUBLIC ${PROJECT_SOURCE_DIR}/test)
 

--- a/test/framework/common_constants.cpp
+++ b/test/framework/common_constants.cpp
@@ -42,4 +42,12 @@ namespace common_constants {
       DefaultCryptoAlgorithmType::generateKeypair();
   const Keypair kAnotherDomainUserKeypair =
       DefaultCryptoAlgorithmType::generateKeypair();
+
+  // misc
+  const shared_model::interface::Amount kAmountPrec1Max{
+      "1157920892373161954235709850086879078532"
+      "6998466564056403945758400791312963993.5"};  // (2**256 - 1) / 10**1
+  const shared_model::interface::Amount kAmountPrec2Max{
+      "1157920892373161954235709850086879078532"
+      "699846656405640394575840079131296399.35"};  // (2**256 - 1) / 10**2
 }  // namespace common_constants

--- a/test/framework/common_constants.hpp
+++ b/test/framework/common_constants.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "cryptography/keypair.hpp"
+#include "interfaces/common_objects/amount.hpp"
 
 static const uint32_t kMaxPageSize = std::numeric_limits<uint32_t>::max();
 using shared_model::crypto::Keypair;
@@ -45,6 +46,12 @@ namespace common_constants {
   extern const Keypair kUserKeypair;
   extern const Keypair kSameDomainUserKeypair;
   extern const Keypair kAnotherDomainUserKeypair;
+
+  // misc
+  extern const shared_model::interface::Amount
+      kAmountPrec1Max;  // maximum amount of asset with precision 1
+  extern const shared_model::interface::Amount
+      kAmountPrec2Max;  // maximum amount of asset with precision 2
 }  // namespace common_constants
 
 #endif /* IROHA_TEST_FRAMEWORK_COMMON_CONSTANTS_HPP_ */

--- a/test/integration/acceptance/add_asset_qty_test.cpp
+++ b/test/integration/acceptance/add_asset_qty_test.cpp
@@ -102,31 +102,28 @@ TEST_F(AddAssetQuantity, ZeroAmount) {
 }
 
 /**
- * TODO mboldyrev 17.01.2019 IR-203 remove, covered by
- * postgres_executor_test AddAccountAssetTest.Uint256Overflow
+ * TODO mboldyrev 17.01.2019 IR-203 convert to ExecutorItf test
  *
- * @given pair of users with all required permissions
- * @when execute two txes with AddAssetQuantity command with amount more than a
- * uint256 max half
- * @then first transaction is committed @and verified proposal is empty for the
- * second
+ * @given a user with all required permissions having the maximum allowed
+ * quantity of an asset with precision 1
+ * @when execute a tx with AddAssetQuantity command for that asset with the
+ * smallest possible quantity
+ * @then the last transaction is not committed
  */
-TEST_F(AddAssetQuantity, Uint256DestOverflow) {
-  std::string uint256_halfmax =
-      "578960446186580977117854925043439539266349923328202820197287920039565648"
-      "19966.0";  // 2**255 - 2
+TEST_F(AddAssetQuantity, DestOverflowPrecision1) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTx(makeUserWithPerms())
       .skipProposal()
       .skipVerifiedProposal()
       .skipBlock()
-      // Add first half of the maximum
+      // Add the maximum quantity
       .sendTxAwait(
-          complete(baseTx().addAssetQuantity(kAssetId, uint256_halfmax)),
+          complete(baseTx().addAssetQuantity(kAssetId,
+                                             kAmountPrec1Max.toStringRepr())),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-      // Add second half of the maximum
-      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, uint256_halfmax)))
+      // Add the smallest quantity
+      .sendTx(complete(baseTx().addAssetQuantity(kAssetId, "0.1")))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -280,26 +280,25 @@ TEST_F(TransferAsset, MoreThanHas) {
  *
  * @given pair of users with all required permissions, and tx sender's balance
  * is replenished if required
- * @when execute two txes with TransferAsset command with amount more than a
- * uint256 max half
+ * @when execute two txes with TransferAsset command: one with the largest and
+ * another the smallest possible quantity
  * @then first transaction is commited @and there is an empty verified proposal
  * for the second
  */
-TEST_F(TransferAsset, Uint256DestOverflow) {
-  std::string uint256_halfmax =
-      "578960446186580977117854925043439539266349923328202820197287920039565648"
-      "19966.0";  // 2**255 - 2
+TEST_F(TransferAsset, DestOverflowPrecision1) {
   IntegrationTestFramework(1)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(makeFirstUser(), CHECK_TXS_QUANTITY(1))
       .sendTxAwait(makeSecondUser(), CHECK_TXS_QUANTITY(1))
-      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS_QUANTITY(1))
-      // Send first half of the maximum
-      .sendTxAwait(makeTransfer(uint256_halfmax), CHECK_TXS_QUANTITY(1))
-      // Restore self balance
-      .sendTxAwait(addAssets(uint256_halfmax), CHECK_TXS_QUANTITY(1))
-      // Send second half of the maximum
-      .sendTx(makeTransfer(uint256_halfmax))
+      .sendTxAwait(addAssets(kAmountPrec1Max.toStringRepr()),
+                   CHECK_TXS_QUANTITY(1))
+      // Send the largest possible quantity
+      .sendTxAwait(makeTransfer(kAmountPrec1Max.toStringRepr()),
+                   CHECK_TXS_QUANTITY(1))
+      // Restore sender's balance
+      .sendTxAwait(addAssets("0.1"), CHECK_TXS_QUANTITY(1))
+      // Send the smallest possible quantity
+      .sendTx(makeTransfer("0.1"))
       .skipProposal()
       .checkVerifiedProposal(
           [](auto &proposal) { ASSERT_EQ(proposal->transactions().size(), 0); })

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(postgres_executor_test
     framework_sql_query
     pg_connection_init
     test_logger
+    common_test_constants
     )
 
 addtest(postgres_query_executor_test postgres_query_executor_test.cpp)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Prior to this change, the maximum asset quantity was computed as `2^(256-p)`, where `p` is the asset precision. This had a weird consequence that an asset with greater `p` would have a greater significand* limit that will not fit a 256-bit integer.

___
*) significand means `M` in `N = M * e ^ p` floating point notation

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Now the мантисса limit is always uint256_max, regardless the asset precision. Also the involved SQL got prettified (to my taste).

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

See the `*Overflow*` tests in `add_asset_qty_test` and `postgres_executor_test`.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
