### PR TITLE
Added nightly builds for CI

### DIFF
--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -38,8 +38,6 @@ def sonarScanner(scmVars, environment) {
   withEnv(environment) {
     withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN'), string(credentialsId: 'SORABOT_TOKEN', variable: 'SORABOT_TOKEN')]) {
       sonar_option = ""
-      print "debug env"
-      print env
       if (env.CHANGE_ID != null) {
         sonar_option = "-Dsonar.github.pullRequest=${env.CHANGE_ID}"
       }

--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -38,12 +38,14 @@ def sonarScanner(scmVars, environment) {
   withEnv(environment) {
     withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN'), string(credentialsId: 'SORABOT_TOKEN', variable: 'SORABOT_TOKEN')]) {
       sonar_option = ""
-      if (scmVars.CHANGE_ID != null)
+      if (scmVars.CHANGE_ID != null) {
         print "debug env"
         print env
         sonar_option = "-Dsonar.github.pullRequest=${env.CHANGE_ID}"
-      else
+      }
+      else {
         print "************** Warning No 'CHANGE_ID' Present run sonar without org.sonar.plugins.github.PullRequest *****************"
+      }
       // do analysis by sorabot
       sh """
         sonar-scanner \

--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -39,7 +39,9 @@ def sonarScanner(scmVars, environment) {
     withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN'), string(credentialsId: 'SORABOT_TOKEN', variable: 'SORABOT_TOKEN')]) {
       sonar_option = ""
       if (scmVars.CHANGE_ID != null)
-        sonar_option = "-Dsonar.github.pullRequest=${scmVars.CHANGE_ID}"
+        print "debug env"
+        print env
+        sonar_option = "-Dsonar.github.pullRequest=${env.CHANGE_ID}"
       else
         print "************** Warning No 'CHANGE_ID' Present run sonar without org.sonar.plugins.github.PullRequest *****************"
       // do analysis by sorabot

--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -38,8 +38,8 @@ def sonarScanner(scmVars, environment) {
   withEnv(environment) {
     withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN'), string(credentialsId: 'SORABOT_TOKEN', variable: 'SORABOT_TOKEN')]) {
       sonar_option = ""
-      if (CHANGE_ID != null)
-        sonar_option = "-Dsonar.github.pullRequest=${CHANGE_ID}"
+      if (scmVars.CHANGE_ID != null)
+        sonar_option = "-Dsonar.github.pullRequest=${scmVars.CHANGE_ID}"
       else
         print "************** Warning No 'CHANGE_ID' Present run sonar without org.sonar.plugins.github.PullRequest *****************"
       // do analysis by sorabot

--- a/.jenkinsci-new/build.groovy
+++ b/.jenkinsci-new/build.groovy
@@ -38,9 +38,9 @@ def sonarScanner(scmVars, environment) {
   withEnv(environment) {
     withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN'), string(credentialsId: 'SORABOT_TOKEN', variable: 'SORABOT_TOKEN')]) {
       sonar_option = ""
-      if (scmVars.CHANGE_ID != null) {
-        print "debug env"
-        print env
+      print "debug env"
+      print env
+      if (env.CHANGE_ID != null) {
         sonar_option = "-Dsonar.github.pullRequest=${env.CHANGE_ID}"
       }
       else {

--- a/.jenkinsci-new/text-variables.groovy
+++ b/.jenkinsci-new/text-variables.groovy
@@ -7,7 +7,7 @@
 // Text variable for jenkins job description
 //
 
-param_chose_opt = 'Default\nBranch commit\nOn open PR\nCommit in Open PR\nBefore merge to trunk\nCustom command'
+param_chose_opt = 'Default\nBranch commit\nOn open PR\nCommit in Open PR\nBefore merge to trunk\nNightly build\nCustom command'
 
 param_descriptions = """
 <p>
@@ -16,6 +16,7 @@ param_descriptions = """
   <strong>On open PR -</strong> Linux/gcc v5, MacOS/appleclang, Windows/msvc; Test: All; Coverage; Analysis: cppcheck, sonar, codestyle;<br />
   <strong>Commit in Open PR</strong> - Same as Branch commit<br />
   <strong>Before merge to trunk</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; Build type: Debug when Release; useBTF=true<br />
+  <strong>Nightly build</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; Build type: Debug when Release; useBTF=true; sanitize<br />
   <strong>Custom command</strong> - enter command below, Ex: build_type='Release'; testing=false;<br />
 </p>
 """

--- a/.jenkinsci-new/text-variables.groovy
+++ b/.jenkinsci-new/text-variables.groovy
@@ -15,8 +15,8 @@ param_descriptions = """
   <strong>Branch commit</strong> - Linux/gcc v5; Test: Smoke, Unit;<br />
   <strong>On open PR -</strong> Linux/gcc v5, MacOS/appleclang, Windows/msvc; Test: All; Coverage; Analysis: cppcheck, sonar, codestyle;<br />
   <strong>Commit in Open PR</strong> - Same as Branch commit<br />
-  <strong>Before merge to trunk</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; Build type: Debug when Release; useBTF=true<br />
-  <strong>Nightly build</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; Build type: Debug when Release; useBTF=true; sanitize<br />
+  <strong>Before merge to trunk</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true<br />
+  <strong>Nightly build</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true; sanitize<br />
   <strong>Custom command</strong> - enter command below, Ex: build_type='Release'; testing=false;<br />
 </p>
 """

--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -15,19 +15,19 @@ class Worker {
 class Builder {
   // can't get to work without 'static'
   static class PostSteps {
-    List success
-    List failure
-    List unstable
-    List always
-    List aborted
+    List success = []
+    List failure = []
+    List unstable = []
+    List always = []
+    List aborted = []
   }
-  List buildSteps
+  List buildSteps = []
   PostSteps postSteps
 }
 
 class Build {
-  String name
-  String type
+  String name = ''
+  String type = ''
   Builder builder
   Worker worker
 }
@@ -66,9 +66,9 @@ def build(Build build) {
       // ALWAYS
       finally {
         if (currentBuild.currentResult == 'SUCCESS')
-           gitNotify ("Jenkins: " + build.name, "Finish", 'SUCCESS')
+          gitNotify ("Jenkins: " + build.name, "Finish", 'SUCCESS')
         else
-           gitNotify ("Jenkins: " + build.name, currentBuild.currentResult, 'FAILURE')
+          gitNotify ("Jenkins: " + build.name, currentBuild.currentResult, 'FAILURE')
 
         build.builder.postSteps.always.each {
           it()
@@ -95,7 +95,9 @@ def cmd_sanitize(String cmd){
 }
 
 def gitNotify (context, description, status, targetUrl='' ){
-  githubNotify context: context, credentialsId: 'SORABOT_TOKEN_AND_LOGIN', description: description, status: status, targetUrl: targetUrl
+  if (build_scenario != 'Nightly build') {
+    githubNotify context: context, credentialsId: 'SORABOT_TOKEN_AND_LOGIN', description: description, status: status, targetUrl: targetUrl
+  }
 }
 
 stage('Prepare environment'){
@@ -221,6 +223,21 @@ node ('master') {
         sonar = true
         codestyle = true
         useBTF = true
+        break;
+     case 'Nightly build':
+        x64linux_compiler_list = ['gcc5','gcc7', 'clang6' , 'clang7']
+        mac_compiler_list = ['appleclang']
+        win_compiler_list = ['msvc']
+        testing = true
+        testList = '()'
+        coverage = true
+        cppcheck = true
+        sonar = true
+        codestyle = true
+        useBTF = true
+        sanitize = true
+        packagePush=false
+        doxygen=false
         break;
      case 'Custom command':
         if (cmd_sanitize(params.custom_cmd)){

--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -236,6 +236,7 @@ node ('master') {
         codestyle = true
         useBTF = true
         sanitize = true
+        specialBranch=false
         packagePush=false
         doxygen=false
         break;


### PR DESCRIPTION
Signed-off-by: Roman Gavrilov <kogeler@gmail.com>

### Description of the Change

Added nightly builds for CI.

It includes:
- x64linux_compiler_list = ['gcc5','gcc7', 'clang6' , 'clang7']
- mac_compiler_list = ['appleclang']
- win_compiler_list = ['msvc']
- testing = true
- testList = '()'
- coverage = true
- cppcheck = true
- sonar = true
- codestyle = true
- useBTF = true
- sanitize = true
- packagePush=false
- doxygen=false

### Benefits

We can check the quality of the code as much as possible in the off-peak hours

