### PR TITLE
Testing: fixed initialization race of PostgreSQL credentials

### DIFF
--- a/test/framework/config_helper.cpp
+++ b/test/framework/config_helper.cpp
@@ -13,15 +13,14 @@
 #include <boost/uuid/uuid_io.hpp>
 
 namespace integration_framework {
-  const std::string kDefaultPostgresCreds =
-      "host=localhost "
-      "port=5432 "
-      "user=postgres "
-      "password=mysecretpassword";
-
   const std::string kDefaultWorkingDatabaseName{"iroha_default"};
 
   std::string getPostgresCredsOrDefault() {
+    static const std::string kDefaultPostgresCreds =
+        "host=localhost "
+        "port=5432 "
+        "user=postgres "
+        "password=mysecretpassword";
     return getPostgresCredsFromEnv().value_or(kDefaultPostgresCreds);
   }
 

--- a/test/framework/config_helper.hpp
+++ b/test/framework/config_helper.hpp
@@ -11,7 +11,6 @@
 #include <boost/optional.hpp>
 
 namespace integration_framework {
-  extern const std::string kDefaultPostgresCreds;
   extern const std::string kDefaultWorkingDatabaseName;
 
   std::string getPostgresCredsOrDefault();


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The static member `AmetsuchiTest::pgopt_` used the global constant `kDefaultPostgresCreds` defiined in another translation unit for initialization, which caused a race. Thanks @luckychess for pointing that out. This PR fixes the race.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Unbugging.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
