### PR TITLE
Irohad: moved consensus objects earlier in destruction order

### DIFF
--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -299,12 +299,6 @@ class Irohad {
   // synchronizer
   std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;
 
-  // consensus gate
-  std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
-  rxcpp::composite_subscription consensus_gate_objects_lifetime;
-  rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_gate_objects;
-  rxcpp::composite_subscription consensus_gate_events_subscription;
-
   // pcs
   std::shared_ptr<iroha::network::PeerCommunicationService> pcs;
 
@@ -325,6 +319,12 @@ class Irohad {
 
   // query service
   std::shared_ptr<iroha::torii::QueryService> query_service;
+
+  // consensus gate
+  std::shared_ptr<iroha::network::ConsensusGate> consensus_gate;
+  rxcpp::composite_subscription consensus_gate_objects_lifetime;
+  rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_gate_objects;
+  rxcpp::composite_subscription consensus_gate_events_subscription;
 
   std::unique_ptr<ServerRunner> torii_server;
   std::unique_ptr<ServerRunner> internal_server;


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The root cause of the problem is the captured `this` pointer of `SynchronizerImpl` that is passed to an observer of consensus gate outcomes. This PR is a quick fix that only solves it in a near perspective, with a risk to face it somewhere else in the future. The solution method is making the consensus outcomes observable destroy before the synchronizer object pointed to by the captured `this`.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

fixed segfault during destruction.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Delaying a thorough solution.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
