### PR TITLE
Clones removing, interfaces refactoring(IR-522)

### DIFF
--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -25,6 +25,8 @@ namespace shared_model {
       interface::types::TransactionsCollectionType transactions()
           const override;
 
+      interface::types::TransactionsCollectionType stealTransactions() override;
+
       interface::types::HeightType height() const override;
 
       const interface::types::HashType &prevHash() const override;

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -59,7 +59,7 @@ namespace shared_model {
           [this] { return makeBlob(payload_); }()};
 
       interface::types::HashType hash_ = makeHash(payload_blob_);
-    };
+    }; // struct Block::Impl
 
     Block::Block(Block &&o) noexcept = default;
 
@@ -73,6 +73,9 @@ namespace shared_model {
 
     interface::types::TransactionsCollectionType Block::transactions() const {
       return impl_->transactions_;
+    }
+    interface::types::TransactionsCollectionType Block::stealTransactions() {
+      return std::move(impl_->transactions_);
     }
 
     interface::types::HeightType Block::height() const {

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -220,7 +220,7 @@ shared_model::proto::ProtoQueryResponseFactory::createSignatoriesResponse(
 
 std::unique_ptr<shared_model::interface::QueryResponse>
 shared_model::proto::ProtoQueryResponseFactory::createTransactionsResponse(
-    std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+    std::vector<std::shared_ptr<shared_model::interface::Transaction>>
         transactions,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
@@ -268,7 +268,7 @@ shared_model::proto::ProtoQueryResponseFactory::createTransactionsPageResponse(
 
 std::unique_ptr<shared_model::interface::QueryResponse> shared_model::proto::
     ProtoQueryResponseFactory::createPendingTransactionsPageResponse(
-        std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+        std::vector<std::shared_ptr<shared_model::interface::Transaction>>
             transactions,
         interface::types::TransactionsNumberType all_transactions_size,
         boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -52,7 +52,7 @@ namespace shared_model {
           const crypto::Hash &query_hash) const override;
 
       std::unique_ptr<interface::QueryResponse> createTransactionsResponse(
-          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+          std::vector<std::shared_ptr<shared_model::interface::Transaction>>
               transactions,
           const crypto::Hash &query_hash) const override;
 
@@ -65,7 +65,7 @@ namespace shared_model {
 
       std::unique_ptr<interface::QueryResponse>
       createPendingTransactionsPageResponse(
-          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+          std::vector<std::shared_ptr<shared_model::interface::Transaction>>
               transactions,
           interface::types::TransactionsNumberType all_transactions_size,
           boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -34,6 +34,14 @@ namespace shared_model {
       virtual types::TransactionsCollectionType transactions() const = 0;
 
       /**
+       * This method moves all transactions from block.
+       * So you should not use both transactions() and stealTransactions()
+       * after that method has been invoked.
+       * @return collection of transactions by move
+       */
+      virtual types::TransactionsCollectionType stealTransactions() = 0;
+
+      /**
        * @return collection of rejected transactions' hashes
        */
       virtual interface::types::HashCollectionType

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -147,7 +147,7 @@ namespace shared_model {
        * @return transactions response
        */
       virtual std::unique_ptr<QueryResponse> createTransactionsResponse(
-          std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+          std::vector<std::shared_ptr<shared_model::interface::Transaction>>
               transactions,
           const crypto::Hash &query_hash) const = 0;
 
@@ -179,7 +179,7 @@ namespace shared_model {
        */
       virtual std::unique_ptr<QueryResponse>
       createPendingTransactionsPageResponse(
-          std::vector<std::unique_ptr<interface::Transaction>> transactions,
+          std::vector<std::shared_ptr<interface::Transaction>> transactions,
           interface::types::TransactionsNumberType all_transactions_size,
           boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
               next_batch_info,

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -551,13 +551,12 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
   std::string account_id = "accountA";
   auto creator = "a@domain";
   std::vector<wTransaction> txs;
-  std::vector<shared_model::proto::Transaction> proto_txs;
+  std::vector<wTransaction> response_txs;
   for (size_t i = 0; i < 3; ++i) {
     std::shared_ptr<shared_model::interface::Transaction> current =
         clone(TestTransactionBuilder().creatorAccountId(account_id).build());
     txs.push_back(current);
-    proto_txs.push_back(
-        *std::static_pointer_cast<shared_model::proto::Transaction>(current));
+    response_txs.emplace_back(current);
   }
 
   EXPECT_CALL(*wsv_query, getSignatories(creator))
@@ -573,13 +572,6 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
                          .build()
                          .signAndAddSignature(pair)
                          .finish();
-
-  std::vector<std::unique_ptr<shared_model::interface::Transaction>>
-      response_txs;
-  std::transform(std::begin(proto_txs),
-                 std::end(proto_txs),
-                 std::back_inserter(response_txs),
-                 [](const auto &proto_tx) { return clone(proto_tx); });
 
   auto *r = query_response_factory
                 ->createTransactionsResponse(std::move(response_txs),

--- a/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
@@ -288,7 +288,7 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateTransactionsResponse) {
 
   constexpr int kTransactionsNumber = 5;
 
-  std::vector<std::unique_ptr<shared_model::interface::Transaction>>
+  std::vector<std::shared_ptr<shared_model::interface::Transaction>>
       transactions, transactions_test_copy;
   for (auto i = 0; i < kTransactionsNumber; ++i) {
     auto tx = std::make_unique<shared_model::proto::Transaction>(

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -26,6 +26,8 @@ struct MockBlock : public shared_model::interface::Block {
   MOCK_CONST_METHOD0(
       transactions,
       shared_model::interface::types::TransactionsCollectionType());
+  MOCK_METHOD0(stealTransactions,
+               shared_model::interface::types::TransactionsCollectionType());
   MOCK_CONST_METHOD0(rejected_transactions_hashes,
                      shared_model::interface::types::HashCollectionType());
   MOCK_CONST_METHOD0(height, shared_model::interface::types::HeightType());


### PR DESCRIPTION
Signed-off-by: exctues <alexnamecode@gmail.com>

### Description of the Change
Make a method to return transactions by move so that we don't need to clone them. Change Interfaces so that we don't need to convert them via cloning just to pass as an argument.
### Benefits
Performance, less code.
### Possible Drawbacks 
No.