### PR TITLE
Test Framework: TestDbManager

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -52,6 +52,11 @@ target_compile_definitions(postgres_storage
     PRIVATE SOCI_USE_BOOST HAVE_BOOST
     )
 
+add_library(postgres_options impl/postgres_options.cpp)
+target_link_libraries(postgres_options
+    logger
+    )
+
 add_library(ametsuchi
     impl/command_executor.cpp
     impl/tx_executor.cpp
@@ -65,7 +70,6 @@ add_library(ametsuchi
     impl/postgres_command_executor.cpp
     impl/postgres_block_index.cpp
     impl/wsv_restorer_impl.cpp
-    impl/postgres_options.cpp
     impl/postgres_query_executor.cpp
     impl/tx_presence_cache_impl.cpp
     impl/in_memory_block_storage.cpp
@@ -81,6 +85,7 @@ target_link_libraries(ametsuchi
     rxcpp
     libs_files
     common
+    postgres_options
     shared_model_interfaces
     shared_model_proto_backend_plain
     shared_model_stateless_validation

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -72,6 +72,7 @@ target_compile_definitions(framework_sql_query
 
 add_library(test_db_manager test_db_manager.cpp)
 target_link_libraries(test_db_manager
+  gtest::main
   pg_connection_init
   postgres_options
   )

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -70,4 +70,10 @@ target_compile_definitions(framework_sql_query
     PRIVATE SOCI_USE_BOOST HAVE_BOOST
     )
 
+add_library(test_db_manager test_db_manager.cpp)
+target_link_libraries(test_db_manager
+  pg_connection_init
+  postgres_options
+  )
+
 add_subdirectory(executor_itf)

--- a/test/framework/test_db_manager.cpp
+++ b/test/framework/test_db_manager.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/test_db_manager.hpp"
+
+#include "ametsuchi/impl/postgres_options.hpp"
+#include "framework/config_helper.hpp"
+#include "framework/result_gtest_checkers.hpp"
+#include "main/impl/pg_connection_init.hpp"
+
+using namespace framework::expected;
+using namespace integration_framework;
+using namespace iroha::ametsuchi;
+using namespace iroha::expected;
+using namespace iroha::integration_framework;
+
+static constexpr size_t kMaxRandomDbNameAttempts = 8;
+
+Result<std::unique_ptr<TestDbManager>, std::string>
+TestDbManager::createWithRandomDbName(logger::LoggerPtr pg_opts_log) {
+  size_t random_db_name_attempts = 0;
+  static const auto default_creds = getPostgresCredsOrDefault();
+  while (random_db_name_attempts++ < kMaxRandomDbNameAttempts) {
+    auto pg_opts = std::make_shared<const PostgresOptions>(
+        default_creds, getRandomDbName(), pg_opts_log);
+    auto db_exists_result =
+        PgConnectionInit::checkIfWorkingDatabaseIfExists(*pg_opts);
+    if (auto e = resultToOptionalError(db_exists_result)) {
+      return std::move(e).value();
+    }
+    if (not resultToOptionalValue(db_exists_result).value()) {
+      PgConnectionInit::createDatabaseIfNotExist(*pg_opts) |
+          [&pg_opts](bool db_was_created) {
+            EXPECT_TRUE(db_was_created);
+            return std::unique_ptr<TestDbManager>(
+                new TestDbManager(std::move(pg_opts)));
+          };
+    }
+  }
+  return makeError(
+      std::string{"Failed to create new database with random name after "}
+      + std::to_string(random_db_name_attempts) + " attempts.");
+}
+
+std::shared_ptr<const PostgresOptions> TestDbManager::getPostgresOptions()
+    const {
+  return pg_opts_;
+}
+
+TestDbManager::TestDbManager(std::shared_ptr<const PostgresOptions> pg_opts)
+    : pg_opts_(std::move(pg_opts)) {}
+
+TestDbManager::~TestDbManager() {
+  expectResultValue(PgConnectionInit::dropWorkingDatabase(*pg_opts_));
+}

--- a/test/framework/test_db_manager.hpp
+++ b/test/framework/test_db_manager.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_DB_MANAGER_HPP
+#define TEST_DB_MANAGER_HPP
+
+#include "common/result.hpp"
+#include "logger/logger_fwd.hpp"
+
+
+namespace iroha {
+  namespace ametsuchi {
+    class PostgresOptions;
+  }
+
+  namespace integration_framework {
+
+    /**
+     * Manages test database lifecycle.
+     * Creates a database to be used in tests. Drops it on being destroyed.
+     */
+    class TestDbManager {
+     public:
+      /**
+       * Create a new test database with random name. If generated name is
+       * already used, it will try several random alphanumeric names more.
+       * Attempts to get connection settings from environment variables
+       * (@see ::integration_framework::getPostgresCredsOrDefault()).
+       * @param pg_opts_log The logger to pass to PostgresOptions constructor.
+       * @return TestDbManager instance on success, or string error otherwise.
+       */
+      static iroha::expected::Result<std::unique_ptr<TestDbManager>,
+                                     std::string>
+      createWithRandomDbName(logger::LoggerPtr pg_opts_log);
+
+      /// Drops the created database.
+      ~TestDbManager();
+
+      /// Provides the connection options for the managed database.
+      std::shared_ptr<const iroha::ametsuchi::PostgresOptions>
+      getPostgresOptions() const;
+
+     private:
+      TestDbManager(
+          std::shared_ptr<const iroha::ametsuchi::PostgresOptions> pg_opts);
+
+      const std::shared_ptr<const iroha::ametsuchi::PostgresOptions> pg_opts_;
+    };
+  }  // namespace integration_framework
+}  // namespace iroha
+
+#endif /* TEST_DB_MANAGER_HPP */


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change brings a test database manager, that creates a database to be used in tests and drops it on being destroyed. It is needed to share a database across multiple test runs and by doing so avoid the overhead of creating and dropping database for each test.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Will increase performance of executor tests.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

The usage can be seen here: 
https://github.com/MBoldyrev/iroha/blob/3e8bc8579cf9485562c920085587677baacba392/test/integration/executor/executor_fixture.cpp#L64-L70

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
