### PR TITLE
Test Framework: TestDbManager

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -57,6 +57,10 @@ target_link_libraries(postgres_options
     logger
     )
 
+add_library(k_times_reconnection_strategy
+    impl/k_times_reconnection_strategy.cpp
+    )
+
 add_library(ametsuchi
     impl/command_executor.cpp
     impl/tx_executor.cpp
@@ -76,12 +80,12 @@ add_library(ametsuchi
     impl/tx_presence_cache_impl.cpp
     impl/in_memory_block_storage.cpp
     impl/in_memory_block_storage_factory.cpp
-    impl/k_times_reconnection_strategy.cpp
     )
 
 target_link_libraries(ametsuchi
     pg_connection_init
     flat_file_storage
+    k_times_reconnection_strategy
     postgres_storage
     logger
     logger_manager

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -52,6 +52,11 @@ target_compile_definitions(postgres_storage
     PRIVATE SOCI_USE_BOOST HAVE_BOOST
     )
 
+add_library(postgres_options impl/postgres_options.cpp)
+target_link_libraries(postgres_options
+    logger
+    )
+
 add_library(ametsuchi
     impl/command_executor.cpp
     impl/tx_executor.cpp
@@ -66,7 +71,6 @@ add_library(ametsuchi
     impl/postgres_indexer.cpp
     impl/postgres_block_index.cpp
     impl/wsv_restorer_impl.cpp
-    impl/postgres_options.cpp
     impl/postgres_query_executor.cpp
     impl/postgres_specific_query_executor.cpp
     impl/tx_presence_cache_impl.cpp
@@ -84,6 +88,7 @@ target_link_libraries(ametsuchi
     rxcpp
     libs_files
     common
+    postgres_options
     shared_model_interfaces
     shared_model_proto_backend_plain
     shared_model_stateless_validation

--- a/test/framework/CMakeLists.txt
+++ b/test/framework/CMakeLists.txt
@@ -76,4 +76,16 @@ target_compile_definitions(framework_sql_query
     PRIVATE SOCI_USE_BOOST HAVE_BOOST
     )
 
+add_library(test_db_manager test_db_manager.cpp)
+target_link_libraries(test_db_manager
+    gtest::main
+    integration_framework_config_helper
+    k_times_reconnection_strategy
+    logger_manager
+    pg_connection_init
+    postgres_options
+    SOCI::postgresql
+    SOCI::core
+    )
+
 add_subdirectory(executor_itf)

--- a/test/framework/test_db_manager.cpp
+++ b/test/framework/test_db_manager.cpp
@@ -1,0 +1,92 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "framework/test_db_manager.hpp"
+
+#include "ametsuchi/impl/k_times_reconnection_strategy.hpp"
+#include "ametsuchi/impl/pool_wrapper.hpp"
+#include "ametsuchi/impl/postgres_options.hpp"
+#include "framework/config_helper.hpp"
+#include "framework/result_gtest_checkers.hpp"
+#include "logger/logger_manager.hpp"
+#include "main/impl/pg_connection_init.hpp"
+
+using namespace framework::expected;
+using namespace integration_framework;
+using namespace iroha::ametsuchi;
+using namespace iroha::expected;
+using namespace iroha::integration_framework;
+
+static constexpr size_t kMaxRandomDbNameAttempts = 8;
+static constexpr size_t kMaxReconnectionAttempts = 8;
+
+/// Drops a database on destruction.
+class TestDbManager::DbDropper {
+ public:
+  DbDropper(std::unique_ptr<soci::session> management_session,
+            std::string dropped_db_name)
+      : management_session_(std::move(management_session)),
+        dropped_db_name_(std::move(dropped_db_name)) {}
+  ~DbDropper() {
+    *management_session_ << "DROP DATABASE " + dropped_db_name_;
+  }
+ private:
+  std::unique_ptr<soci::session> management_session_;
+  std::string dropped_db_name_;
+};
+
+Result<std::unique_ptr<TestDbManager>, std::string>
+TestDbManager::createWithRandomDbName(
+    size_t sessions, logger::LoggerManagerTreePtr log_manager) {
+  size_t random_db_name_attempts = 0;
+  static const auto default_creds = getPostgresCredsOrDefault();
+  while (random_db_name_attempts++ < kMaxRandomDbNameAttempts) {
+    auto pg_opts = std::make_unique<PostgresOptions>(
+        default_creds,
+        getRandomDbName(),
+        log_manager->getChild("PostgresOptions")->getLogger());
+    auto db_exists_result =
+        PgConnectionInit::checkIfWorkingDatabaseExists(*pg_opts);
+    if (auto e = resultToOptionalError(db_exists_result)) {
+      return std::move(e).value();
+    }
+    const bool db_exists = resultToOptionalValue(db_exists_result).value();
+    if (not db_exists) {
+      return PgConnectionInit::createDatabaseIfNotExist(*pg_opts) |
+          [&](bool db_was_created) {
+            EXPECT_TRUE(db_was_created);
+            return PgConnectionInit::prepareConnectionPool(
+                KTimesReconnectionStrategyFactory{kMaxReconnectionAttempts},
+                *pg_opts,
+                sessions,
+                log_manager->getChild("DbConnectionPool"));
+          }
+      |
+          [&pg_opts](auto &&pool_wrapper) {
+            auto db_dropper = std::make_unique<DbDropper>(
+                std::make_unique<soci::session>(
+                    *soci::factory_postgresql(),
+                    pg_opts->maintenanceConnectionString()),
+                pg_opts->workingDbName());
+            return std::unique_ptr<TestDbManager>(
+                new TestDbManager(std::move(pool_wrapper).connection_pool_,
+                                  std::move(db_dropper)));
+          };
+    }
+  }
+  return makeError(
+      std::string{"Failed to create new database with random name after "}
+      + std::to_string(random_db_name_attempts) + " attempts.");
+}
+
+std::unique_ptr<soci::session> TestDbManager::getSession() {
+  return std::make_unique<soci::session>(*connection_pool_);
+}
+
+TestDbManager::TestDbManager(
+    std::shared_ptr<soci::connection_pool> connection_pool,
+    std::unique_ptr<DbDropper> db_dropper)
+    : db_dropper_(std::move(db_dropper)),
+      connection_pool_(std::move(connection_pool)) {}

--- a/test/framework/test_db_manager.hpp
+++ b/test/framework/test_db_manager.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_DB_MANAGER_HPP
+#define TEST_DB_MANAGER_HPP
+
+#include "common/result.hpp"
+#include "logger/logger_manager_fwd.hpp"
+
+namespace soci {
+  class connection_pool;
+  class session;
+}
+
+namespace iroha {
+  namespace integration_framework {
+
+    /**
+     * Manages test database lifecycle.
+     * Creates a database to be used in tests. Drops it on being destroyed.
+     */
+    class TestDbManager {
+     public:
+      /**
+       * Create a new test database with random name. If generated name is
+       * already used, it will try several random alphanumeric names more.
+       * Attempts to get connection settings from environment variables
+       * (@see ::integration_framework::getPostgresCredsOrDefault()). Prepares
+       * the schema in the newly created database.
+       *
+       * @param sessions The number of sessions to create.
+       * @param log_manager A log manager to create loggers for child objects.
+       * @return TestDbManager instance on success, or string error otherwise.
+       */
+      static iroha::expected::Result<std::unique_ptr<TestDbManager>,
+                                     std::string>
+      createWithRandomDbName(size_t sessions,
+                             logger::LoggerManagerTreePtr log_manager);
+
+      /// Get a session.
+      std::unique_ptr<soci::session> getSession();
+
+     private:
+      class DbDropper;
+
+      TestDbManager(std::shared_ptr<soci::connection_pool> connection_pool,
+                    std::unique_ptr<DbDropper> db_dropper);
+
+      const std::unique_ptr<DbDropper> db_dropper_;
+
+      const std::shared_ptr<soci::connection_pool> connection_pool_;
+    };
+  }  // namespace integration_framework
+}  // namespace iroha
+
+#endif /* TEST_DB_MANAGER_HPP */


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change brings a test database manager, that creates a database to be used in tests and drops it on being destroyed. It is needed to share a database across multiple test runs and by doing so avoid the overhead of creating and dropping database for each test.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Will increase performance of executor tests.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
