### PR TITLE
CMake: fix BUILD_SHARED_LIBS flag

### DIFF
--- a/iroha-cli/CMakeLists.txt
+++ b/iroha-cli/CMakeLists.txt
@@ -22,7 +22,6 @@ add_library(client
     impl/grpc_response_handler.cpp
     )
 target_link_libraries(client
-    interactive_cli
     ed25519_crypto
     logger
     rapidjson
@@ -45,6 +44,8 @@ add_executable(iroha-cli
     validators.cpp
     )
 target_link_libraries(iroha-cli
+    interactive_cli
+    model_crypto_provider
     client
     cli-flags_validators
     keys_manager

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(ametsuchi
     )
 
 target_link_libraries(ametsuchi
+    pg_connection_init
     flat_file_storage
     postgres_storage
     logger

--- a/irohad/model/CMakeLists.txt
+++ b/irohad/model/CMakeLists.txt
@@ -15,19 +15,19 @@ target_link_libraries(sha3_hash
     )
 
 add_library(model
-    model_crypto_provider_impl.cpp
     impl/model_operators.cpp
     )
 
 target_link_libraries(model
-    hash
-    sha3_hash
-    rxcpp
-    logger
-    schema
-    ed25519_crypto
-    rapidjson
     common
+    rxcpp
+    )
+
+add_library(model_crypto_provider
+    model_crypto_provider_impl.cpp
+    )
+target_link_libraries(model_crypto_provider
+    sha3_hash
     )
 
 add_library(model_registrations INTERFACE)

--- a/irohad/model/converters/CMakeLists.txt
+++ b/irohad/model/converters/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(json_model_converters
     schema
     ed25519_crypto
     common
+    logger
     )
 
 add_library(pb_model_converters
@@ -32,4 +33,5 @@ target_link_libraries(pb_model_converters
     ed25519_crypto
     common
     boost
+    logger
     )

--- a/irohad/model/generators/CMakeLists.txt
+++ b/irohad/model/generators/CMakeLists.txt
@@ -14,4 +14,5 @@ target_link_libraries(model_generators
     model
     generator
     keys_manager
+    sha3_hash
     )

--- a/libs/parser/CMakeLists.txt
+++ b/libs/parser/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(parser STATIC parser.cpp)
+add_library(parser parser.cpp)
 
 target_link_libraries( parser
     boost

--- a/test/module/irohad/model/CMakeLists.txt
+++ b/test/module/irohad/model/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 addtest(model_crypto_provider_test model_crypto_provider_test.cpp)
 target_link_libraries(model_crypto_provider_test
+    model_crypto_provider
     model
     hash
     ed25519_crypto
@@ -24,6 +25,7 @@ target_link_libraries(transaction_converter_test
 addtest(block_converter_test converters/pb_block_test.cpp)
 target_link_libraries(block_converter_test
     pb_model_converters
+    sha3_hash
     )
 
 addtest(query_responses_test converters/pb_query_responses_test.cpp)
@@ -34,11 +36,13 @@ target_link_libraries(query_responses_test
 addtest(model_operators_test operators/model_operators_test.cpp)
 target_link_libraries(model_operators_test
     model
+    sha3_hash
     )
 
 addtest(json_command_converter_test converters/json_commands_test.cpp)
 target_link_libraries(json_command_converter_test
     json_model_converters
+    sha3_hash
     )
 
 addtest(json_transaction_converter_test converters/json_transaction_test.cpp)


### PR DESCRIPTION
### Description of the Change
Fix BUILD_SHARED_LIBS CMake flag, which did not work previously due to cyclic dependencies between libraries.

### Benefits
Possible to build components as shared libraries, which reduces the build directory size on gcc 5.5 from ~27GB to ~4GB.

### Possible Drawbacks 
None?

### Usage Examples or Tests *[optional]*
Configure the project with `-DBUILD_SHARED_LIBS=ON`

