### PR TITLE
PostgresBlockIndexer: split to abstract block indexer & backend entity indexer

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(ametsuchi
     impl/peer_query_wsv.cpp
     impl/postgres_block_query.cpp
     impl/postgres_command_executor.cpp
+    impl/postgres_indexer.cpp
     impl/postgres_block_index.cpp
     impl/wsv_restorer_impl.cpp
     impl/postgres_options.cpp

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -8,6 +8,7 @@
 #include <boost/variant/apply_visitor.hpp>
 #include "ametsuchi/impl/peer_query_wsv.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"
+#include "ametsuchi/impl/postgres_indexer.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/ledger_state.hpp"
@@ -31,7 +32,8 @@ namespace iroha {
               std::make_unique<PeerQueryWsv>(std::make_shared<PostgresWsvQuery>(
                   *sql_, log_manager->getChild("WsvQuery")->getLogger()))),
           block_index_(std::make_unique<PostgresBlockIndex>(
-              *sql_, log_manager->getChild("PostgresBlockIndex")->getLogger())),
+              std::make_unique<PostgresIndexer>(*sql_),
+              log_manager->getChild("PostgresBlockIndex")->getLogger())),
           transaction_executor_(std::move(transaction_executor)),
           block_storage_(std::move(block_storage)),
           committed(false),

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -5,14 +5,20 @@
 
 #include "ametsuchi/impl/postgres_block_index.hpp"
 
+#include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/indexed.hpp>
-
+#include <boost/range/adaptor/transformed.hpp>
 #include "ametsuchi/tx_cache_response.hpp"
 #include "common/visitor.hpp"
 #include "interfaces/commands/command_variant.hpp"
 #include "interfaces/commands/transfer_asset.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "logger/logger.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace shared_model::interface::types;
+
+using TxPosition = iroha::ametsuchi::Indexer::TxPosition;
 
 namespace {
   // Return transfer asset if command contains it
@@ -27,139 +33,54 @@ namespace {
         },
         [](const auto &) -> ReturnType { return boost::none; });
   }
-
-  // make index tx hash -> block where hash is stored
-  std::string makeHashIndex(
-      const shared_model::interface::types::HashType &hash,
-      shared_model::interface::types::HeightType height,
-      size_t index) {
-    boost::format base(
-        "INSERT INTO position_by_hash(hash, height, index) VALUES ('%s', "
-        "'%s', '%s');");
-    return (base % hash.hex() % height % index).str();
-  }
-
-  std::string makeCommittedTxHashIndex(
-      const shared_model::interface::types::HashType &rejected_tx_hash) {
-    boost::format base(
-        "INSERT INTO tx_status_by_hash(hash, status) VALUES ('%s', "
-        "TRUE);");
-    return (base % rejected_tx_hash.hex()).str();
-  }
-
-  std::string makeRejectedTxHashIndex(
-      const shared_model::interface::types::HashType &rejected_tx_hash) {
-    boost::format base(
-        "INSERT INTO tx_status_by_hash(hash, status) VALUES ('%s', "
-        "FALSE);");
-    return (base % rejected_tx_hash.hex()).str();
-  }
-
-  // make index account_id:height -> list of tx indexes
-  // (where tx is placed in the block)
-  std::string makeCreatorHeightIndex(
-      const shared_model::interface::types::AccountIdType creator,
-      shared_model::interface::types::HeightType height,
-      size_t tx_index) {
-    boost::format base(
-        "INSERT INTO index_by_creator_height(creator_id, height, index) VALUES "
-        "('%s', '%s', '%s');");
-    return (base % creator % height % tx_index).str();
-  }
-
-  // Make index account_id -> list of blocks where his txs exist
-  std::string makeAccountHeightIndex(
-      const shared_model::interface::types::AccountIdType &account_id,
-      shared_model::interface::types::HeightType height) {
-    boost::format base(
-        "INSERT INTO height_by_account_set(account_id, "
-        "height) VALUES "
-        "('%s', '%s');");
-    return (base % account_id % height).str();
-  }
-
-  // Collect all assets belonging to creator, sender, and receiver
-  // to make account_id:height:asset_id -> list of tx indexes
-  // for transfer asset in command
-  std::string makeAccountAssetIndex(
-      const shared_model::interface::types::AccountIdType &account_id,
-      shared_model::interface::types::HeightType height,
-      size_t index,
-      const shared_model::interface::Transaction::CommandsType &commands) {
-    return std::accumulate(
-        commands.begin(),
-        commands.end(),
-        std::string{},
-        [&](auto query, const auto &cmd) {
-          auto transfer = getTransferAsset(cmd);
-          if (not transfer) {
-            return query;
-          }
-          const auto &src_id = transfer.value().srcAccountId();
-          const auto &dest_id = transfer.value().destAccountId();
-
-          query += makeAccountHeightIndex(src_id, height);
-          query += makeAccountHeightIndex(dest_id, height);
-
-          const auto ids = {account_id, src_id, dest_id};
-          const auto &asset_id = transfer.value().assetId();
-          // flat map accounts to unindexed keys
-          for (const auto &id : ids) {
-            boost::format base(
-                "INSERT INTO position_by_account_asset(account_id, "
-                "height, asset_id, "
-                "index) "
-                "VALUES ('%s', '%s', '%s', '%s');");
-            query += (base % id % height % asset_id % index).str();
-          }
-          return query;
-        });
-  }
 }  // namespace
 
-namespace iroha {
-  namespace ametsuchi {
-    PostgresBlockIndex::PostgresBlockIndex(soci::session &sql,
-                                           logger::LoggerPtr log)
-        : sql_(sql), log_(std::move(log)) {}
+// Collect all assets belonging to creator, sender, and receiver
+// to make account_id:height:asset_id -> list of tx indexes
+// for transfer asset in command
+void PostgresBlockIndex::makeAccountAssetIndex(
+    const AccountIdType &account_id,
+    TxPosition position,
+    const shared_model::interface::Transaction::CommandsType &commands) {
+  for (const auto &transfer :
+       commands | boost::adaptors::transformed(getTransferAsset)
+           | boost::adaptors::filtered(
+                 [](const auto &opt_tx) { return static_cast<bool>(opt_tx); })
+           | boost::adaptors::transformed(
+                 [](const auto &opt_tx) -> const auto & { return *opt_tx; })) {
+    const auto &src_id = transfer.srcAccountId();
+    const auto &dest_id = transfer.destAccountId();
 
-    void PostgresBlockIndex::index(
-        const shared_model::interface::Block &block) {
-      auto height = block.height();
-      auto indexed_txs = block.transactions() | boost::adaptors::indexed(0);
-      auto rejected_txs_hashes = block.rejected_transactions_hashes();
-      std::string tx_index_query = std::accumulate(
-          indexed_txs.begin(),
-          indexed_txs.end(),
-          std::string{},
-          [height](auto query, const auto &tx) {
-            const auto &creator_id = tx.value().creatorAccountId();
-            const auto index = tx.index();
-
-            query += makeAccountHeightIndex(creator_id, height);
-            query += makeAccountAssetIndex(
-                creator_id, height, index, tx.value().commands());
-            query += makeHashIndex(tx.value().hash(), height, index);
-            query += makeCommittedTxHashIndex(tx.value().hash());
-            query += makeCreatorHeightIndex(creator_id, height, index);
-            return query;
-          });
-
-      std::string rejected_tx_index_query =
-          std::accumulate(rejected_txs_hashes.begin(),
-                          rejected_txs_hashes.end(),
-                          std::string{},
-                          [](auto query, const auto &rejected_tx_hash) {
-                            query += makeRejectedTxHashIndex(rejected_tx_hash);
-                            return query;
-                          });
-
-      auto index_query = tx_index_query + rejected_tx_index_query;
-      try {
-        sql_ << index_query;
-      } catch (const std::exception &e) {
-        log_->error(e.what());
-      }
+    const auto ids = {account_id, src_id, dest_id};
+    const auto &asset_id = transfer.assetId();
+    // flat map accounts to unindexed keys
+    for (const auto &id : ids) {
+      indexer_->accountAssetTxPosition(id, asset_id, position);
     }
-  }  // namespace ametsuchi
-}  // namespace iroha
+  }
+}
+
+PostgresBlockIndex::PostgresBlockIndex(std::unique_ptr<Indexer> indexer,
+                                       logger::LoggerPtr log)
+    : indexer_(std::move(indexer)), log_(std::move(log)) {}
+
+void PostgresBlockIndex::index(const shared_model::interface::Block &block) {
+  auto height = block.height();
+  for (const auto &tx : block.transactions() | boost::adaptors::indexed(0)) {
+    const auto &creator_id = tx.value().creatorAccountId();
+    const TxPosition position{height, static_cast<size_t>(tx.index())};
+
+    makeAccountAssetIndex(creator_id, position, tx.value().commands());
+    indexer_->txHashPosition(tx.value().hash(), position);
+    indexer_->committedTxHash(tx.value().hash());
+    indexer_->txPositionByCreator(creator_id, position);
+  }
+
+  for (const auto &rejected_tx_hash : block.rejected_transactions_hashes()) {
+    indexer_->rejectedTxHash(rejected_tx_hash);
+  }
+
+  if (auto e = resultToOptionalError(indexer_->flush())) {
+    log_->error(e.value());
+  }
+}

--- a/irohad/ametsuchi/impl/postgres_block_index.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.hpp
@@ -6,36 +6,43 @@
 #ifndef IROHA_POSTGRES_BLOCK_INDEX_HPP
 #define IROHA_POSTGRES_BLOCK_INDEX_HPP
 
-#include <boost/format.hpp>
-
 #include "ametsuchi/impl/block_index.hpp"
-#include "ametsuchi/impl/soci_utils.hpp"
+
+#include "ametsuchi/indexer.hpp"
 #include "interfaces/transaction.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {
   namespace ametsuchi {
+    /**
+     * Creates several indices for passed blocks. Namely:
+     * transaction hash -> block, where this transaction is stored
+     * transaction creator -> block where his transaction is located
+     *
+     * Additionally, for each Transfer Asset command:
+     *   1. (account, asset) -> block for each:
+     *     a. creator of the transaction
+     *     b. source account
+     *     c. destination account
+     *   2. account -> block for source and destination accounts
+     *   3. (account, height) -> list of txes
+     */
     class PostgresBlockIndex : public BlockIndex {
      public:
-      PostgresBlockIndex(soci::session &sql, logger::LoggerPtr log);
+      PostgresBlockIndex(std::unique_ptr<Indexer> indexer,
+                         logger::LoggerPtr log);
 
-      /**
-       * Create several indices for block. Namely:
-       * transaction hash -> block, where this transaction is stored
-       * transaction creator -> block where his transaction is located
-       *
-       * Additionally, for each Transfer Asset command:
-       *   1. (account, asset) -> block for each:
-       *     a. creator of the transaction
-       *     b. source account
-       *     c. destination account
-       *   2. account -> block for source and destination accounts
-       *   3. (account, height) -> list of txes
-       */
+      /// Index a block.
       void index(const shared_model::interface::Block &block) override;
 
      private:
-      soci::session &sql_;
+      /// Index a transaction.
+      void makeAccountAssetIndex(
+          const shared_model::interface::types::AccountIdType &account_id,
+          Indexer::TxPosition position,
+          const shared_model::interface::Transaction::CommandsType &commands);
+
+      std::unique_ptr<Indexer> indexer_;
       logger::LoggerPtr log_;
     };
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/postgres_indexer.cpp
+++ b/irohad/ametsuchi/impl/postgres_indexer.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/postgres_indexer.hpp"
+
+#include <soci/soci.h>
+#include <boost/format.hpp>
+#include "cryptography/hash.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace shared_model::interface::types;
+
+PostgresIndexer::PostgresIndexer(soci::session &sql) : sql_(sql) {}
+
+void PostgresIndexer::txHashPosition(const HashType &hash,
+                                     TxPosition position) {
+  boost::format base(
+      "INSERT INTO position_by_hash"
+      "(hash, height, index) VALUES "
+      "('%s', '%s', '%s');\n");
+  statements_.append(
+      (base % hash.hex() % position.height % position.index).str());
+}
+
+void PostgresIndexer::txHashStatus(const HashType &rejected_tx_hash,
+                                   bool is_committed) {
+  boost::format base(
+      "INSERT INTO tx_status_by_hash"
+      "(hash, status) VALUES "
+      "('%s', '%s');\n");
+  statements_.append(
+      (base % rejected_tx_hash.hex() % (is_committed ? "TRUE" : "FALSE"))
+          .str());
+}
+
+void PostgresIndexer::committedTxHash(const HashType &committed_tx_hash) {
+  txHashStatus(committed_tx_hash, true);
+}
+
+void PostgresIndexer::rejectedTxHash(const HashType &rejected_tx_hash) {
+  txHashStatus(rejected_tx_hash, false);
+}
+
+void PostgresIndexer::txPositionByCreator(const AccountIdType creator,
+                                          TxPosition position) {
+  boost::format base(
+      "INSERT INTO tx_position_by_creator"
+      "(creator_id, height, index) VALUES "
+      "('%s', '%s', '%s');\n");
+  statements_.append((base % creator % position.height % position.index).str());
+}
+
+void PostgresIndexer::accountAssetTxPosition(const AccountIdType &account_id,
+                                             const AssetIdType &asset_id,
+                                             TxPosition position) {
+  boost::format base(
+      "INSERT INTO position_by_account_asset"
+      "(account_id, asset_id, height, index) VALUES "
+      "('%s', '%s', '%s', '%s');\n");
+  statements_.append(
+      (base % account_id % asset_id % position.height % position.index).str());
+}
+
+iroha::expected::Result<void, std::string> PostgresIndexer::flush() {
+  try {
+    sql_ << statements_;
+  } catch (const std::exception &e) {
+    return e.what();
+  }
+  return {};
+}

--- a/irohad/ametsuchi/impl/postgres_indexer.hpp
+++ b/irohad/ametsuchi/impl/postgres_indexer.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AMETSUCHI_POSTGRES_INDEXER_HPP
+#define AMETSUCHI_POSTGRES_INDEXER_HPP
+
+#include "ametsuchi/indexer.hpp"
+
+namespace soci {
+  class session;
+}
+
+namespace iroha {
+  namespace ametsuchi {
+
+    class PostgresIndexer : public Indexer {
+     public:
+      PostgresIndexer(soci::session &sql);
+
+      void txHashPosition(const shared_model::interface::types::HashType &hash,
+                          TxPosition position) override;
+
+      void committedTxHash(const shared_model::interface::types::HashType
+                               &committed_tx_hash) override;
+
+      void rejectedTxHash(const shared_model::interface::types::HashType
+                              &rejected_tx_hash) override;
+
+      void txPositionByCreator(
+          const shared_model::interface::types::AccountIdType creator,
+          TxPosition position) override;
+
+      void accountAssetTxPosition(
+          const shared_model::interface::types::AccountIdType &account_id,
+          const shared_model::interface::types::AssetIdType &asset_id,
+          TxPosition position) override;
+
+      iroha::expected::Result<void, std::string> flush() override;
+
+     private:
+      /// Index tx status by its hash.
+      void txHashStatus(
+          const shared_model::interface::types::HashType &rejected_tx_hash,
+          bool is_committed);
+
+      soci::session &sql_;
+      std::string statements_;  ///< A bunch of SQL to be committed on flush().
+    };
+
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif /* AMETSUCHI_POSTGRES_INDEXER_HPP */

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -704,7 +704,7 @@ namespace iroha {
     QueryExecutorResult PostgresQueryExecutorVisitor::operator()(
         const shared_model::interface::GetAccountTransactions &q) {
       std::string related_txs = R"(SELECT DISTINCT height, index
-      FROM index_by_creator_height
+      FROM tx_position_by_creator
       WHERE creator_id = :account_id
       ORDER BY height, index ASC)";
 
@@ -828,7 +828,7 @@ namespace iroha {
           FROM position_by_account_asset
           WHERE account_id = :account_id
           AND asset_id = :asset_id
-          ORDER BY height, index ASC)";
+          ORDER BY height, index ASC)";  // consider index when changing this
 
       const auto &pagination_info = q.paginationMeta();
       auto first_hash = pagination_info.firstTxHash();

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -18,6 +18,7 @@
 #include "ametsuchi/impl/postgres_block_index.hpp"
 #include "ametsuchi/impl/postgres_block_query.hpp"
 #include "ametsuchi/impl/postgres_command_executor.hpp"
+#include "ametsuchi/impl/postgres_indexer.hpp"
 #include "ametsuchi/impl/postgres_query_executor.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
@@ -407,7 +408,8 @@ namespace iroha {
         soci::session sql(*connection_);
         sql << "COMMIT PREPARED '" + prepared_block_name_ + "';";
         PostgresBlockIndex block_index(
-            sql, log_manager_->getChild("BlockIndex")->getLogger());
+            std::make_unique<PostgresIndexer>(sql),
+            log_manager_->getChild("BlockIndex")->getLogger());
         block_index.index(*block);
         block_is_prepared_ = false;
 

--- a/irohad/ametsuchi/indexer.hpp
+++ b/irohad/ametsuchi/indexer.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AMETSUCHI_INDEXER_HPP
+#define AMETSUCHI_INDEXER_HPP
+
+#include <string>
+
+#include "common/result.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace iroha {
+  namespace ametsuchi {
+
+    /** Stores transaction data in WSV.
+     * \attention The effect of any change only gets into WSV storage after \see
+     * Indexer::flush() is called!
+     */
+    class Indexer {
+     public:
+      virtual ~Indexer() = default;
+
+      /// Position of a transaction in the ledger.
+      struct TxPosition {
+        shared_model::interface::types::HeightType
+            height;    ///< the height of block containing this transaction
+        size_t index;  ///< the number of this transaction in the block
+      };
+
+      /// Index tx position by its hash.
+      virtual void txHashPosition(
+          const shared_model::interface::types::HashType &hash,
+          TxPosition position) = 0;
+
+      /// Store a committed tx hash.
+      virtual void committedTxHash(
+          const shared_model::interface::types::HashType
+              &committed_tx_hash) = 0;
+
+      /// Store a rejected tx hash.
+      virtual void rejectedTxHash(
+          const shared_model::interface::types::HashType &rejected_tx_hash) = 0;
+
+      /// Index tx position by creator account.
+      virtual void txPositionByCreator(
+          const shared_model::interface::types::AccountIdType creator,
+          TxPosition position) = 0;
+
+      /// Index account asset tx position by involved account and asset.
+      virtual void accountAssetTxPosition(
+          const shared_model::interface::types::AccountIdType &account_id,
+          const shared_model::interface::types::AssetIdType &asset_id,
+          TxPosition position) = 0;
+
+      /**
+       * Flush the indices to storage.
+       * Makes the effects of new indices (that were created before this call)
+       * visible to other components.
+       * @return Void Value on success, string Error on failure.
+       */
+      virtual iroha::expected::Result<void, std::string> flush() = 0;
+    };
+
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif /* AMETSUCHI_INDEXER_HPP */

--- a/irohad/main/impl/pg_connection_init.cpp
+++ b/irohad/main/impl/pg_connection_init.cpp
@@ -285,19 +285,15 @@ CREATE TABLE IF NOT EXISTS position_by_hash (
     height bigint,
     index bigint
 );
-
 CREATE TABLE IF NOT EXISTS tx_status_by_hash (
     hash varchar,
     status boolean
 );
-CREATE INDEX IF NOT EXISTS tx_status_by_hash_hash_index ON tx_status_by_hash USING hash (hash);
-
-CREATE TABLE IF NOT EXISTS height_by_account_set (
-    account_id text,
-    height bigint
-);
-CREATE TABLE IF NOT EXISTS index_by_creator_height (
-    id serial,
+CREATE INDEX IF NOT EXISTS tx_status_by_hash_hash_index
+  ON tx_status_by_hash
+  USING hash
+  (hash);
+CREATE TABLE IF NOT EXISTS tx_position_by_creator (
     creator_id text,
     height bigint,
     index bigint
@@ -308,6 +304,10 @@ CREATE TABLE IF NOT EXISTS position_by_account_asset (
     height bigint,
     index bigint
 );
+CREATE INDEX IF NOT EXISTS position_by_account_asset_index
+  ON position_by_account_asset
+  USING btree
+  (account_id, asset_id, height, index ASC);
 )";
 
 iroha::expected::Result<void, std::string> PgConnectionInit::resetWsv(
@@ -327,8 +327,7 @@ iroha::expected::Result<void, std::string> PgConnectionInit::resetWsv(
       TRUNCATE TABLE role RESTART IDENTITY CASCADE;
       TRUNCATE TABLE position_by_hash RESTART IDENTITY CASCADE;
       TRUNCATE TABLE tx_status_by_hash RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE height_by_account_set RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE index_by_creator_height RESTART IDENTITY CASCADE;
+      TRUNCATE TABLE tx_position_by_creator RESTART IDENTITY CASCADE;
       TRUNCATE TABLE position_by_account_asset RESTART IDENTITY CASCADE;
     )";
     sql << reset;

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -219,12 +219,7 @@ CREATE TABLE IF NOT EXISTS tx_status_by_hash (
 );
 CREATE INDEX IF NOT EXISTS tx_status_by_hash_hash_index ON tx_status_by_hash USING hash (hash);
 
-CREATE TABLE IF NOT EXISTS height_by_account_set (
-    account_id text,
-    height bigint
-);
-CREATE TABLE IF NOT EXISTS index_by_creator_height (
-    id serial,
+CREATE TABLE IF NOT EXISTS tx_position_by_creator (
     creator_id text,
     height bigint,
     index bigint

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -9,6 +9,7 @@
 #include <boost/optional.hpp>
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"
+#include "ametsuchi/impl/postgres_indexer.hpp"
 #include "backend/protobuf/proto_block_json_converter.hpp"
 #include "common/byteutils.hpp"
 #include "converters/protobuf/json_proto_converter.hpp"
@@ -34,8 +35,8 @@ class BlockQueryTest : public AmetsuchiTest {
     mock_file = std::make_shared<MockKeyValueStorage>();
     sql = std::make_unique<soci::session>(*soci::factory_postgresql(), pgopt_);
 
-    index =
-        std::make_shared<PostgresBlockIndex>(*sql, getTestLogger("BlockIndex"));
+    index = std::make_shared<PostgresBlockIndex>(
+        std::make_unique<PostgresIndexer>(*sql), getTestLogger("BlockIndex"));
     auto converter =
         std::make_shared<shared_model::proto::ProtoBlockJsonConverter>();
     blocks = std::make_shared<PostgresBlockQuery>(

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -227,8 +227,7 @@ DROP TABLE IF EXISTS signatory;
 DROP TABLE IF EXISTS peer;
 DROP TABLE IF EXISTS role;
 DROP TABLE IF EXISTS position_by_hash;
-DROP TABLE IF EXISTS height_by_account_set;
-DROP TABLE IF EXISTS index_by_creator_height;
+DROP TABLE IF EXISTS tx_position_by_creator;
 DROP TABLE IF EXISTS position_by_account_asset;
 )";
 


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Separate `PostgresBlockIndexer` into block parser & entity indexers (like tx position by hash, by creator, etc.).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Low-level indexers reusable in tests. Decoupled block indexer from PostgreSQL backend.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
