### PR TITLE
Ametsuchi: pass dependencies for query executor creation

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -47,6 +47,9 @@ namespace iroha {
         std::shared_ptr<PoolWrapper> pool_wrapper,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
+        std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
+        std::shared_ptr<shared_model::interface::QueryResponseFactory>
+            query_response_factory,
         std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
         size_t pool_size,
         logger::LoggerManagerTreePtr log_manager)
@@ -56,6 +59,8 @@ namespace iroha {
           connection_(pool_wrapper_->connection_pool_),
           notifier_(notifier_lifetime_),
           perm_converter_(std::move(perm_converter)),
+          pending_txs_storage_(std::move(pending_txs_storage)),
+          query_response_factory_(std::move(query_response_factory)),
           temporary_block_storage_factory_(
               std::move(temporary_block_storage_factory)),
           log_manager_(std::move(log_manager)),
@@ -268,6 +273,9 @@ namespace iroha {
         std::shared_ptr<PoolWrapper> pool_wrapper,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
+        std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
+        std::shared_ptr<shared_model::interface::QueryResponseFactory>
+            query_response_factory,
         std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
         std::unique_ptr<BlockStorage> persistent_block_storage,
         logger::LoggerManagerTreePtr log_manager,
@@ -333,6 +341,8 @@ namespace iroha {
                           std::move(persistent_block_storage),
                           std::move(pool_wrapper),
                           perm_converter,
+                          std::move(pending_txs_storage),
+                          std::move(query_response_factory),
                           std::move(temporary_block_storage_factory),
                           pool_size,
                           std::move(log_manager))));

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -24,7 +24,16 @@
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
 
+namespace shared_model {
+  namespace interface {
+    class QueryResponseFactory;
+  }  // namespace interface
+}  // namespace shared_model
+
 namespace iroha {
+
+  class PendingTransactionStorage;
+
   namespace ametsuchi {
     class StorageImpl : public Storage {
      public:
@@ -33,6 +42,9 @@ namespace iroha {
           std::shared_ptr<PoolWrapper> pool_wrapper,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
+          std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
+          std::shared_ptr<shared_model::interface::QueryResponseFactory>
+              query_response_factory,
           std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
           std::unique_ptr<BlockStorage> persistent_block_storage,
           logger::LoggerManagerTreePtr log_manager,
@@ -106,6 +118,9 @@ namespace iroha {
           std::shared_ptr<PoolWrapper> pool_wrapper,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
+          std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
+          std::shared_ptr<shared_model::interface::QueryResponseFactory>
+              query_response_factory,
           std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
           size_t pool_size,
           logger::LoggerManagerTreePtr log_manager);
@@ -115,10 +130,6 @@ namespace iroha {
 
      private:
       using StoreBlockResult = iroha::expected::Result<void, std::string>;
-
-      /**
-       * revert prepared transaction
-       */
 
       /**
        * add block to block storage
@@ -145,6 +156,11 @@ namespace iroha {
 
       std::shared_ptr<shared_model::interface::PermissionToString>
           perm_converter_;
+
+      std::shared_ptr<PendingTransactionStorage> pending_txs_storage_;
+
+      std::shared_ptr<shared_model::interface::QueryResponseFactory>
+          query_response_factory_;
 
       std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory_;
 

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -34,6 +34,11 @@ target_link_libraries(pg_connection_init
     logger
     )
 
+add_library(pending_txs_storage_init impl/pending_transaction_storage_init.cpp)
+target_link_libraries(pending_txs_storage_init
+    pending_txs_storage
+    )
+
 add_library(application
     application.cpp
     # TODO andrei 08.11.2018 IR-1851 Create separate targets for initialization
@@ -66,7 +71,7 @@ target_link_libraries(application
     block_loader_service
     mst_processor
     torii_service
-    pending_txs_storage
+    pending_txs_storage_init
     common
     pg_connection_init
     generator

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -278,6 +278,8 @@ Irohad::RunResult Irohad::initStorage(
   return StorageImpl::create(std::move(pg_opt),
                              pool_wrapper_,
                              perm_converter,
+                             pending_txs_storage_,
+                             query_response_factory_,
                              std::move(temporary_block_storage_factory),
                              std::move(persistent_block_storage),
                              log_manager_->getChild("Storage"))

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -22,8 +22,8 @@
 
 namespace iroha {
   class PendingTransactionStorage;
+  class PendingTransactionStorageInit;
   class MstProcessor;
-  class MstState;
   namespace ametsuchi {
     class WsvRestorer;
     class TxPresenceCache;
@@ -222,18 +222,8 @@ class Irohad {
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 
-  rxcpp::composite_subscription pending_storage_lifetime;
-  rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>> updated_batches;
-  rxcpp::subjects::subject<
-      std::shared_ptr<shared_model::interface::TransactionBatch>>
-      prepared_batch;
-  rxcpp::subjects::subject<
-      std::shared_ptr<shared_model::interface::TransactionBatch>>
-      expired_batch;
-  rxcpp::subjects::subject<
-      std::pair<shared_model::interface::types::AccountIdType,
-                shared_model::interface::types::HashType>>
-      prepared_txs;
+  std::unique_ptr<iroha::PendingTransactionStorageInit>
+      pending_txs_storage_init;
 
   // pending transactions storage
   std::shared_ptr<iroha::PendingTransactionStorage> pending_txs_storage_;
@@ -329,7 +319,6 @@ class Irohad {
 
   // pcs
   std::shared_ptr<iroha::network::PeerCommunicationService> pcs;
-  rxcpp::composite_subscription pcs_pending_storage_subscription;
 
   // status bus
   std::shared_ptr<iroha::torii::StatusBus> status_bus_;
@@ -337,7 +326,6 @@ class Irohad {
   // mst
   std::shared_ptr<iroha::network::MstTransport> mst_transport;
   std::shared_ptr<iroha::MstProcessor> mst_processor;
-  rxcpp::composite_subscription mst_pending_storage_subscription;
 
   // transaction service
   std::shared_ptr<iroha::torii::CommandService> command_service;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -23,6 +23,7 @@
 namespace iroha {
   class PendingTransactionStorage;
   class MstProcessor;
+  class MstState;
   namespace ametsuchi {
     class WsvRestorer;
     class TxPresenceCache;
@@ -221,6 +222,26 @@ class Irohad {
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 
+  rxcpp::composite_subscription pending_storage_lifetime;
+  rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>> updated_batches;
+  rxcpp::subjects::subject<
+      std::shared_ptr<shared_model::interface::TransactionBatch>>
+      prepared_batch;
+  rxcpp::subjects::subject<
+      std::shared_ptr<shared_model::interface::TransactionBatch>>
+      expired_batch;
+  rxcpp::subjects::subject<
+      std::pair<shared_model::interface::types::AccountIdType,
+                shared_model::interface::types::HashType>>
+      prepared_txs;
+
+  // pending transactions storage
+  std::shared_ptr<iroha::PendingTransactionStorage> pending_txs_storage_;
+
+  // query response factory
+  std::shared_ptr<shared_model::interface::QueryResponseFactory>
+      query_response_factory_;
+
   // ------------------------| internal dependencies |-------------------------
  public:
   shared_model::crypto::Keypair keypair;
@@ -269,10 +290,6 @@ class Irohad {
       iroha::protocol::Transaction>>
       transaction_factory;
 
-  // query response factory
-  std::shared_ptr<shared_model::interface::QueryResponseFactory>
-      query_response_factory_;
-
   // query factory
   std::shared_ptr<shared_model::interface::AbstractTransportFactory<
       shared_model::interface::Query,
@@ -312,6 +329,7 @@ class Irohad {
 
   // pcs
   std::shared_ptr<iroha::network::PeerCommunicationService> pcs;
+  rxcpp::composite_subscription pcs_pending_storage_subscription;
 
   // status bus
   std::shared_ptr<iroha::torii::StatusBus> status_bus_;
@@ -319,9 +337,7 @@ class Irohad {
   // mst
   std::shared_ptr<iroha::network::MstTransport> mst_transport;
   std::shared_ptr<iroha::MstProcessor> mst_processor;
-
-  // pending transactions storage
-  std::shared_ptr<iroha::PendingTransactionStorage> pending_txs_storage_;
+  rxcpp::composite_subscription mst_pending_storage_subscription;
 
   // transaction service
   std::shared_ptr<iroha::torii::CommandService> command_service;

--- a/irohad/main/impl/pending_transaction_storage_init.cpp
+++ b/irohad/main/impl/pending_transaction_storage_init.cpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "main/impl/pending_transaction_storage_init.hpp"
+
+#include "interfaces/iroha_internal/proposal.hpp"
+#include "multi_sig_transactions/mst_processor.hpp"
+#include "network/peer_communication_service.hpp"
+#include "pending_txs_storage/impl/pending_txs_storage_impl.hpp"
+
+using namespace iroha;
+
+PendingTransactionStorageInit::PendingTransactionStorageInit()
+    : updated_batches(pending_storage_lifetime),
+      prepared_batch(pending_storage_lifetime),
+      expired_batch(pending_storage_lifetime),
+      prepared_txs(pending_storage_lifetime) {}
+
+std::shared_ptr<PendingTransactionStorage>
+PendingTransactionStorageInit::createPendingTransactionsStorage() {
+  return std::make_shared<PendingTransactionStorageImpl>(
+      updated_batches.get_observable(),
+      prepared_batch.get_observable(),
+      expired_batch.get_observable(),
+      prepared_txs.get_observable());
+}
+
+void PendingTransactionStorageInit::setSubscriptions(
+    const MstProcessor &mst_processor) {
+  mst_processor.onStateUpdate().subscribe(pending_storage_lifetime,
+                                          updated_batches.get_subscriber());
+  mst_processor.onPreparedBatches().subscribe(pending_storage_lifetime,
+                                              prepared_batch.get_subscriber());
+  mst_processor.onExpiredBatches().subscribe(pending_storage_lifetime,
+                                             expired_batch.get_subscriber());
+}
+
+void PendingTransactionStorageInit::setSubscriptions(
+    const network::PeerCommunicationService &peer_communication_service) {
+  using PreparedTransactionDescriptor =
+      PendingTransactionStorageImpl::PreparedTransactionDescriptor;
+  peer_communication_service.onProposal()
+      .flat_map([](const auto &event)
+                    -> rxcpp::observable<PreparedTransactionDescriptor> {
+        if (not event.proposal) {
+          return rxcpp::observable<>::empty<PreparedTransactionDescriptor>();
+        }
+        auto prepared_transactions =
+            event.proposal.get()->transactions()
+            | boost::adaptors::transformed(
+                  [](const auto &tx) -> PreparedTransactionDescriptor {
+                    return std::make_pair(tx.creatorAccountId(), tx.hash());
+                  });
+        return rxcpp::observable<>::iterate(prepared_transactions);
+      })
+      .subscribe(pending_storage_lifetime, prepared_txs.get_subscriber());
+}
+
+PendingTransactionStorageInit::~PendingTransactionStorageInit() {
+  pending_storage_lifetime.unsubscribe();
+}

--- a/irohad/main/impl/pending_transaction_storage_init.hpp
+++ b/irohad/main/impl/pending_transaction_storage_init.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PENDING_TRANSACTION_STORAGE_INIT_HPP
+#define IROHA_PENDING_TRANSACTION_STORAGE_INIT_HPP
+
+#include <memory>
+
+#include <rxcpp/rx.hpp>
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class TransactionBatch;
+  }
+}  // namespace shared_model
+
+namespace iroha {
+
+  class MstProcessor;
+  class MstState;
+  class PendingTransactionStorage;
+
+  namespace network {
+    class PeerCommunicationService;
+  }
+
+  class PendingTransactionStorageInit {
+   public:
+    PendingTransactionStorageInit();
+
+    std::shared_ptr<PendingTransactionStorage>
+    createPendingTransactionsStorage();
+
+    void setSubscriptions(const MstProcessor &mst_processor);
+
+    void setSubscriptions(
+        const network::PeerCommunicationService &peer_communication_service);
+
+    ~PendingTransactionStorageInit();
+
+   protected:
+    rxcpp::composite_subscription pending_storage_lifetime;
+    rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>> updated_batches;
+    rxcpp::subjects::subject<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+        prepared_batch;
+    rxcpp::subjects::subject<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+        expired_batch;
+    rxcpp::subjects::subject<
+        std::pair<shared_model::interface::types::AccountIdType,
+                  shared_model::interface::types::HashType>>
+        prepared_txs;
+  };
+}  // namespace iroha
+
+#endif  // IROHA_PENDING_TRANSACTION_STORAGE_INIT_HPP

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -18,6 +18,7 @@
 #include "ametsuchi/mutable_storage.hpp"
 #include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"
 #include "backend/protobuf/proto_permission_to_string.hpp"
+#include "backend/protobuf/proto_query_response_factory.hpp"
 #include "common/files.hpp"
 #include "common/result.hpp"
 #include "framework/config_helper.hpp"
@@ -27,6 +28,7 @@
 #include "logger/logger_manager.hpp"
 #include "main/impl/pg_connection_init.hpp"
 #include "module/irohad/common/validators_config.hpp"
+#include "module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp"
 #include "validators/field_validator.hpp"
 
 namespace iroha {
@@ -47,6 +49,10 @@ namespace iroha {
                 iroha::test::kTestsValidatorsConfig);
         perm_converter_ =
             std::make_shared<shared_model::proto::ProtoPermissionToString>();
+        pending_txs_storage_ =
+            std::make_shared<MockPendingTransactionStorage>();
+        query_response_factory_ =
+            std::make_shared<shared_model::proto::ProtoQueryResponseFactory>();
         auto block_storage_factory =
             std::make_unique<InMemoryBlockStorageFactory>();
         auto block_storage = block_storage_factory->create();
@@ -84,6 +90,8 @@ namespace iroha {
         StorageImpl::create(std::move(options),
                             std::move(pool_wrapper_),
                             perm_converter_,
+                            pending_txs_storage_,
+                            query_response_factory_,
                             std::move(block_storage_factory),
                             std::move(block_storage),
                             getTestLoggerManager()->getChild("Storage"))
@@ -158,6 +166,12 @@ namespace iroha {
       static std::shared_ptr<shared_model::interface::PermissionToString>
           perm_converter_;
 
+      static std::shared_ptr<MockPendingTransactionStorage>
+          pending_txs_storage_;
+
+      static std::shared_ptr<shared_model::interface::QueryResponseFactory>
+          query_response_factory_;
+
       static std::unique_ptr<iroha::ametsuchi::ReconnectionStrategyFactory>
           reconnection_strategy_factory_;
 
@@ -191,6 +205,12 @@ namespace iroha {
 
     std::shared_ptr<shared_model::interface::PermissionToString>
         AmetsuchiTest::perm_converter_ = nullptr;
+
+    std::shared_ptr<MockPendingTransactionStorage>
+        AmetsuchiTest::pending_txs_storage_ = nullptr;
+
+    std::shared_ptr<shared_model::interface::QueryResponseFactory>
+        AmetsuchiTest::query_response_factory_ = nullptr;
 
     std::unique_ptr<iroha::ametsuchi::ReconnectionStrategyFactory>
         AmetsuchiTest::reconnection_strategy_factory_ = nullptr;

--- a/test/module/irohad/ametsuchi/storage_init_test.cpp
+++ b/test/module/irohad/ametsuchi/storage_init_test.cpp
@@ -15,11 +15,13 @@
 #include "ametsuchi/impl/in_memory_block_storage_factory.hpp"
 #include "ametsuchi/impl/k_times_reconnection_strategy.hpp"
 #include "backend/protobuf/proto_permission_to_string.hpp"
+#include "backend/protobuf/proto_query_response_factory.hpp"
 #include "common/result.hpp"
 #include "framework/config_helper.hpp"
 #include "framework/test_logger.hpp"
 #include "logger/logger_manager.hpp"
 #include "main/impl/pg_connection_init.hpp"
+#include "module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp"
 #include "validators/field_validator.hpp"
 
 using namespace iroha::ametsuchi;
@@ -43,6 +45,13 @@ class StorageInitTest : public ::testing::Test {
 
   std::shared_ptr<shared_model::interface::PermissionToString> perm_converter_ =
       std::make_shared<shared_model::proto::ProtoPermissionToString>();
+
+  std::shared_ptr<iroha::MockPendingTransactionStorage> pending_txs_storage_ =
+      std::make_shared<iroha::MockPendingTransactionStorage>();
+
+  std::shared_ptr<shared_model::interface::QueryResponseFactory>
+      query_response_factory_ =
+          std::make_shared<shared_model::proto::ProtoQueryResponseFactory>();
 
   std::unique_ptr<BlockStorageFactory> block_storage_factory_ =
       std::make_unique<InMemoryBlockStorageFactory>();
@@ -101,6 +110,8 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
   StorageImpl::create(std::move(options),
                       std::move(pool_wrapper),
                       perm_converter_,
+                      pending_txs_storage_,
+                      query_response_factory_,
                       std::move(block_storage_factory_),
                       std::move(block_storage_),
                       storage_log_manager_)


### PR DESCRIPTION
### Description of the Change
Pass dependencies for query executor creation in constructor in order to be able to create query executor as a dependency of command executor.

### Benefits
Possible to pass query executor as a dependency to command executor

### Possible Drawbacks 
Even greater coupling

### Alternate Designs *[optional]*
Make storage as a dependency of query executor and create executors outside storage
