### PR TITLE
SpecificQueryExecutor: removed ambiguous setCreatorId and setQueryHash

### DIFF
--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -65,8 +65,6 @@ namespace iroha {
     QueryExecutorResult PostgresQueryExecutor::validateAndExecute(
         const shared_model::interface::Query &query,
         const bool validate_signatories = true) {
-      specific_query_executor_->setCreatorId(query.creatorAccountId());
-      specific_query_executor_->setQueryHash(query.hash());
       if (validate_signatories and not validateSignatures(query)) {
         // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 3
         // with a named constant

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
@@ -184,6 +184,8 @@ namespace iroha {
 
     QueryExecutorResult PostgresSpecificQueryExecutor::execute(
         const shared_model::interface::Query &qry) {
+      query_hash_ = qry.hash();
+      creator_id_ = qry.creatorAccountId();
       return boost::apply_visitor(*this, qry.get());
     }
 
@@ -267,16 +269,6 @@ namespace iroha {
         log_->error("Failed to validate query: {}", e.what());
         return false;
       }
-    }
-
-    void PostgresSpecificQueryExecutor::setCreatorId(
-        const shared_model::interface::types::AccountIdType &creator_id) {
-      creator_id_ = creator_id;
-    }
-
-    void PostgresSpecificQueryExecutor::setQueryHash(
-        const shared_model::interface::types::HashType &query_hash) {
-      query_hash_ = query_hash;
     }
 
     std::unique_ptr<shared_model::interface::QueryResponse>

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.hpp
@@ -61,11 +61,6 @@ namespace iroha {
       QueryExecutorResult execute(
           const shared_model::interface::Query &qry) override;
 
-      void setCreatorId(const shared_model::interface::types::AccountIdType
-                            &creator_id) override;
-
-      void setQueryHash(const shared_model::crypto::Hash &query_hash) override;
-
       bool hasAccountRolePermission(
           shared_model::interface::permissions::Role permission,
           const std::string &account_id) const override;

--- a/irohad/ametsuchi/specific_query_executor.hpp
+++ b/irohad/ametsuchi/specific_query_executor.hpp
@@ -34,12 +34,6 @@ namespace iroha {
       virtual QueryExecutorResult execute(
           const shared_model::interface::Query &qry) = 0;
 
-      virtual void setCreatorId(
-          const shared_model::interface::types::AccountIdType &creator_id) = 0;
-
-      virtual void setQueryHash(
-          const shared_model::crypto::Hash &query_hash) = 0;
-
       virtual bool hasAccountRolePermission(
           shared_model::interface::permissions::Role permission,
           const std::string &account_id) const = 0;

--- a/test/module/irohad/ametsuchi/mock_query_executor_visitor.hpp
+++ b/test/module/irohad/ametsuchi/mock_query_executor_visitor.hpp
@@ -18,11 +18,6 @@ namespace iroha {
       MOCK_METHOD1(execute,
                    QueryExecutorResult(const shared_model::interface::Query &));
 
-      MOCK_METHOD1(setCreatorId,
-                   void(const shared_model::interface::types::AccountIdType &));
-
-      MOCK_METHOD1(setQueryHash, void(const shared_model::crypto::Hash &));
-
       MOCK_CONST_METHOD2(
           hasAccountRolePermission,
           bool(shared_model::interface::permissions::Role permission,


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

`SpecificQueryExecutor` had methods to set internal fields for query hash & creator, while the `Query` object passed for execution provides them as well. This chamge removes the ambiguous side effect methods and sets the fields from `Query` object.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Disambiguation. Less code.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
