### PR TITLE
CMakeLists: removed circular dependency between ametsuchi & pg_connection_init

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(raw_block_loader
 
 add_library(pg_connection_init impl/pg_connection_init.cpp)
 target_link_libraries(pg_connection_init
-    ametsuchi
     SOCI::postgresql
     SOCI::core
     failover_callback

--- a/irohad/main/impl/pg_connection_init.cpp
+++ b/irohad/main/impl/pg_connection_init.cpp
@@ -5,6 +5,7 @@
 
 #include "main/impl/pg_connection_init.hpp"
 
+#include "ametsuchi/impl/pool_wrapper.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
 

--- a/irohad/main/impl/pg_connection_init.hpp
+++ b/irohad/main/impl/pg_connection_init.hpp
@@ -14,7 +14,6 @@
 #include <boost/range/algorithm/replace_if.hpp>
 
 #include "ametsuchi/impl/failover_callback_holder.hpp"
-#include "ametsuchi/impl/pool_wrapper.hpp"
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_options.hpp"
 #include "ametsuchi/reconnection_strategy.hpp"
@@ -25,6 +24,9 @@
 
 namespace iroha {
   namespace ametsuchi {
+
+    struct PoolWrapper;
+
     class PgConnectionInit {
      public:
       static expected::Result<std::shared_ptr<soci::connection_pool>,

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 addtest(irohad_test irohad_test.cpp)
 target_link_libraries(irohad_test
+        ametsuchi
         boost
         SOCI::postgresql
         SOCI::core

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -18,6 +18,7 @@
 #include <boost/process.hpp>
 #include <boost/variant.hpp>
 
+#include "ametsuchi/impl/postgres_options.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "common/bind.hpp"
 #include "common/files.hpp"


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

`libpg_connection_init` depends from `libametsuchi` and vice versa. Though the first dependency seems odd and thus is removed. Also one include is substituted with forward declaration.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Now the project can be configured with shared libs.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
