### PR TITLE
CI: add option to use BUILD_SHARED_LIBS flag on Linux

### DIFF
--- a/.jenkinsci/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci/builders/x64-linux-build-steps.groovy
@@ -40,7 +40,7 @@ def testSteps(String buildDir, List environment, String testList) {
   }
 }
 
-def buildSteps(int parallelism, List compilerVersions, String build_type, boolean specialBranch, boolean coverage,
+def buildSteps(int parallelism, List compilerVersions, String build_type, boolean build_shared_libs, boolean specialBranch, boolean coverage,
       boolean testing, String testList, boolean cppcheck, boolean sonar, boolean codestyle, boolean docs, boolean packagebuild,
       boolean sanitize, boolean fuzzing, boolean coredumps, boolean useBTF, boolean forceDockerDevelopBuild, List environment) {
   withEnv(environment) {
@@ -102,6 +102,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
           build.cmakeConfigure(buildDir, "-DCMAKE_CXX_COMPILER=${compilers[compiler]['cxx_compiler']} \
             -DCMAKE_C_COMPILER=${compilers[compiler]['cc_compiler']} \
             -DCMAKE_BUILD_TYPE=${build_type} \
+            -DBUILD_SHARED_LIBS=${cmakeBooleanOption[build_shared_libs]} \
             -DCOVERAGE=${cmakeBooleanOption[coverage]} \
             -DTESTING=${cmakeBooleanOption[testing]} \
             -DFUZZING=${cmakeBooleanOption[fuzzing]} \

--- a/.jenkinsci/text-variables.groovy
+++ b/.jenkinsci/text-variables.groovy
@@ -201,6 +201,17 @@ cmd_description = """
       </ul>
    </li>
    <li>
+      <p><span style="color: #ff0000;"><strong>build_shared_libs</strong></span> = false&nbsp;</p>
+      <ul>
+         <li>
+            <p>builds libraries as shared libraries</p>
+         </li>
+         <li>
+            <p>Ex:&nbsp;build_shared_libs = true; testList = '()'</p>
+         </li>
+      </ul>
+   </li>
+   <li>
       <p><span style="color: #ff0000;"><strong>packageBuild</strong></span> = false&nbsp;</p>
       <ul>
          <li>


### PR DESCRIPTION
### Description of the Change
- Add option to use shared libraries in CMake for Linux builds
- Add step for "Before merge to trunk" scenario to use shared libraries

### Benefits
- Can potentially make it default to reduce build time when tests are fixed
- More configurations tested

### Possible Drawbacks 
None
