### PR TITLE
Executor ITF: query permissions common test

### DIFF
--- a/test/integration/executor/CMakeLists.txt
+++ b/test/integration/executor/CMakeLists.txt
@@ -45,6 +45,13 @@ target_link_libraries(create_account_test
     executor_fixture_param_provider
     )
 
+add_library(query_permission_test query_permission_test.cpp)
+target_link_libraries(query_permission_test
+    executor_fixture
+    executor_fixture_param_provider
+    common_test_constants
+    )
+
 addtest(set_account_detail_test set_account_detail_test.cpp)
 target_link_libraries(set_account_detail_test
     account_detail_checker

--- a/test/integration/executor/query_permission_test.cpp
+++ b/test/integration/executor/query_permission_test.cpp
@@ -1,0 +1,121 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "integration/executor/query_permission_test.hpp"
+
+#include "framework/common_constants.hpp"
+
+using namespace common_constants;
+using namespace executor_testing;
+
+using shared_model::interface::RolePermissionSet;
+
+enum class SpectatorPermissions : int {
+  kNone = 0,
+  kMyself,
+  kSameDomain,
+  kEveryone,
+  kRoot,
+
+  LAST,
+  FIRST = kNone
+};
+
+enum class Spectator : int {
+  kMe = 1,
+  kSameDomain,
+  kAnotherDomain,
+
+  LAST,
+  FIRST = kMe
+};
+
+template <typename T>
+struct EnumHasher {
+  std::size_t operator()(T t) const {
+    return static_cast<std::size_t>(t);
+  }
+};
+
+template <typename Key, typename Value>
+using EnumMap = std::unordered_map<Key, Value, EnumHasher<Key>>;
+
+static constexpr bool enoughPermissions(
+    SpectatorPermissions spectator_permissions, Spectator spectator) {
+  return static_cast<int>(spectator_permissions) >= static_cast<int>(spectator);
+}
+
+std::string makeDescription(SpectatorPermissions spectator_permissions,
+                            Spectator spectator) {
+  static const EnumMap<SpectatorPermissions, std::string>
+      kSpectatorPermissionNames{
+          {SpectatorPermissions::kNone, "NoPermissions"},
+          {SpectatorPermissions::kMyself, "PermissionToQueryMyself"},
+          {SpectatorPermissions::kSameDomain, "PermissionToQueryMyDomain"},
+          {SpectatorPermissions::kEveryone, "PermissionToQueryEveryone"},
+          {SpectatorPermissions::kRoot, "RootPermission"}};
+  static const EnumMap<Spectator, std::string> kSpectatorNames{
+      {Spectator::kMe, "Myself"},
+      {Spectator::kSameDomain, "AnAccountFromMyDomain"},
+      {Spectator::kAnotherDomain, "AnAccountFromAnotherDomain"}};
+  std::stringstream ss;
+  ss << "Query" << kSpectatorNames.at(spectator) << "Having"
+     << kSpectatorPermissionNames.at(spectator_permissions);
+  return ss.str();
+}
+
+template <typename TEnum, typename Callable>
+static void iterateEnum(Callable callback) {
+  using IterType = std::underlying_type_t<TEnum>;
+  for (IterType it = static_cast<IterType>(TEnum::FIRST);
+       it < static_cast<IterType>(TEnum::LAST);
+       ++it) {
+    callback(static_cast<TEnum>(it));
+  }
+}
+
+decltype(::testing::Combine(
+    executor_testing::getExecutorTestParams(),
+    ::testing::ValuesIn(
+        {query_permission_test::SpecificQueryPermissionTestData{}})))
+query_permission_test::getParams(
+    RolePermissionSet permission_to_query_myself,
+    RolePermissionSet permission_to_query_my_domain,
+    RolePermissionSet permission_to_query_everyone) {
+  std::vector<SpecificQueryPermissionTestData> perm_params;
+  shared_model::interface::RolePermissionSet no_permissions;
+  static const RolePermissionSet kRootPermission(
+      {shared_model::interface::permissions::Role::kRoot});
+  const EnumMap<SpectatorPermissions, const RolePermissionSet &>
+      spectator_permissions_map{
+          {SpectatorPermissions::kNone, no_permissions},
+          {SpectatorPermissions::kMyself, permission_to_query_myself},
+          {SpectatorPermissions::kSameDomain, permission_to_query_my_domain},
+          {SpectatorPermissions::kEveryone, permission_to_query_everyone},
+          {SpectatorPermissions::kRoot, kRootPermission}};
+  const EnumMap<Spectator, std::string> spectators_map{
+      {Spectator::kMe, kUserId},
+      {Spectator::kSameDomain, kSameDomainUserId},
+      {Spectator::kAnotherDomain, kAnotherDomainUserId}};
+  iterateEnum<SpectatorPermissions>(
+      [&](SpectatorPermissions spectator_permissions) {
+        iterateEnum<Spectator>([&](Spectator spectator) {
+          perm_params.emplace_back(SpecificQueryPermissionTestData{
+              spectator_permissions_map.at(spectator_permissions),
+              spectators_map.at(spectator),
+              enoughPermissions(spectator_permissions, spectator),
+              makeDescription(spectator_permissions, spectator)});
+        });
+      });
+  return ::testing::Combine(getExecutorTestParams(),
+                            ::testing::ValuesIn(std::move(perm_params)));
+}
+
+std::string query_permission_test::paramToString(
+    testing::TestParamInfo<std::tuple<std::shared_ptr<ExecutorTestParam>,
+                                      SpecificQueryPermissionTestData>> param) {
+  return std::get<0>(param.param)->toString()
+      + std::get<1>(param.param).description;
+}

--- a/test/integration/executor/query_permission_test.hpp
+++ b/test/integration/executor/query_permission_test.hpp
@@ -1,0 +1,115 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EXECUTOR_QUERY_PERMISSION_TEST_HPP
+#define EXECUTOR_QUERY_PERMISSION_TEST_HPP
+
+#include "framework/common_constants.hpp"
+#include "framework/executor_itf/executor_itf.hpp"
+#include "framework/result_gtest_checkers.hpp"
+#include "integration/executor/executor_fixture.hpp"
+#include "integration/executor/executor_fixture_param_provider.hpp"
+
+namespace executor_testing {
+  namespace query_permission_test {
+
+    struct SpecificQueryPermissionTestData {
+      shared_model::interface::RolePermissionSet spectator_permissions;
+      shared_model::interface::types::AccountIdType spectator;
+      bool enough_permissions;
+      std::string description;
+    };
+
+    decltype(::testing::Combine(
+        executor_testing::getExecutorTestParams(),
+        ::testing::ValuesIn({SpecificQueryPermissionTestData{}})))
+    getParams(
+        shared_model::interface::RolePermissionSet permission_to_query_myself,
+        shared_model::interface::RolePermissionSet
+            permission_to_query_my_domain,
+        shared_model::interface::RolePermissionSet
+            permission_to_query_everyone);
+
+    template <typename SpecificQueryFixture>
+    struct QueryPermissionTest
+        : public SpecificQueryFixture,
+          public ::testing::WithParamInterface<
+              std::tuple<std::shared_ptr<ExecutorTestParam>,
+                         SpecificQueryPermissionTestData>> {
+      QueryPermissionTest()
+          : backend_param_(std::get<0>(GetParam())),
+            permissions_param_(std::get<1>(GetParam())) {}
+
+      iroha::integration_framework::ExecutorItf &getItf() {
+        return SpecificQueryFixture::getItf();
+      }
+
+      /**
+       * Prepare state of ledger:
+       * - create accounts of target user, close and remote spectators. Close
+       *   spectator is another user from the same domain as the domain of
+       * target user account, remote - a user from domain different to domain
+       * of target user account.
+       *
+       * @param target_permissions - set of permissions for target user
+       */
+      void prepareState(
+          shared_model::interface::RolePermissionSet target_permissions) {
+        using namespace common_constants;
+        using namespace framework::expected;
+        // create target user
+        target_permissions |= permissions_param_.spectator_permissions;
+        assertResultValue(getItf().createUserWithPerms(
+            kUser, kDomain, kUserKeypair.publicKey(), target_permissions));
+        // create spectators
+        assertResultValue(getItf().createUserWithPerms(
+            kAnotherUser,
+            kDomain,
+            kSameDomainUserKeypair.publicKey(),
+            permissions_param_.spectator_permissions));
+        assertResultValue(getItf().createUserWithPerms(
+            kAnotherUser,
+            kSecondDomain,
+            kAnotherDomainUserKeypair.publicKey(),
+            permissions_param_.spectator_permissions));
+      }
+
+      const shared_model::interface::types::AccountIdType &getSpectator()
+          const {
+        return permissions_param_.spectator;
+      }
+
+      /// Check a response.
+      template <typename SpecificQueryResponse,
+                typename SpecificQueryResponseChecker>
+      void checkResponse(const iroha::ametsuchi::QueryExecutorResult &response,
+                         SpecificQueryResponseChecker checker) {
+        if (permissions_param_.enough_permissions) {
+          checkSuccessfulResult<SpecificQueryResponse>(response, checker);
+        } else {
+          checkQueryError<shared_model::interface::StatefulFailedErrorResponse>(
+              response, error_codes::kNoPermissions);
+        }
+      }
+
+     protected:
+      virtual std::shared_ptr<ExecutorTestParam> getBackendParam() {
+        return backend_param_;
+      }
+
+     private:
+      const std::shared_ptr<ExecutorTestParam> &backend_param_;
+      const SpecificQueryPermissionTestData &permissions_param_;
+    };
+
+    std::string paramToString(
+        testing::TestParamInfo<std::tuple<std::shared_ptr<ExecutorTestParam>,
+                                          SpecificQueryPermissionTestData>>
+            param);
+
+  }  // namespace query_permission_test
+}  // namespace executor_testing
+
+#endif /* EXECUTOR_QUERY_PERMISSION_TEST_HPP */


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This adds an implementation of common base fixture - a parametric test class for query permission testing on the new shiny Executor ITF.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

All you need to create a permission test using this class is:
https://github.com/hyperledger/iroha/blob/b01dc38a6a58077a9cd7ee7343a8814da660bb65/test/integration/executor/get_signatories_test.cpp#L94-L112

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
