### PR TITLE
Introduce cmake target for all fuzzing targets

### DIFF
--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -107,3 +107,15 @@ target_link_libraries(mst_fuzz
   ametsuchi
   ${fuzzing_engine}
   )
+
+add_custom_target(fuzzing DEPENDS
+  torii_fuzz
+  status_fuzz
+  find_fuzz
+  send_batches_fuzz
+  request_proposal_fuzz
+  retrieve_block_fuzz
+  retrieve_blocks_fuzz
+  consensus_fuzz
+  mst_fuzz
+  )


### PR DESCRIPTION
### Description of the Change
Pull request adds a single target for all fuzzing targets.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

It was asked in https://github.com/google/oss-fuzz/pull/2753. 

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Have to maintain target list.

### Usage Examples or Tests 

`cmake -DFUZZING=ON; make fuzzing`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->


