### PR TITLE
Fix synchronization

### DIFF
--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -83,11 +83,17 @@ namespace iroha {
       using Synchronizable::Synchronizable;
     };
 
+    /// round.block_round > ledger_state->top_block_info.height + 1
+    struct Future : public Synchronizable {
+      using Synchronizable::Synchronizable;
+    };
+
     using GateObject = boost::variant<PairValid,
                                       VoteOther,
                                       ProposalReject,
                                       BlockReject,
-                                      AgreementOnNone>;
+                                      AgreementOnNone,
+                                      Future>;
 
   }  // namespace consensus
 }  // namespace iroha
@@ -96,6 +102,7 @@ extern template class boost::variant<iroha::consensus::PairValid,
                                      iroha::consensus::VoteOther,
                                      iroha::consensus::ProposalReject,
                                      iroha::consensus::BlockReject,
-                                     iroha::consensus::AgreementOnNone>;
+                                     iroha::consensus::AgreementOnNone,
+                                     iroha::consensus::Future>;
 
 #endif  // CONSENSUS_GATE_OBJECT_HPP

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -18,6 +18,17 @@
 #include "logger/logger.hpp"
 #include "simulator/block_creator.hpp"
 
+namespace {
+  auto getPublicKeys(
+      const std::vector<iroha::consensus::yac::VoteMessage> &votes) {
+    return boost::copy_range<
+        shared_model::interface::types::PublicKeyCollectionType>(
+        votes | boost::adaptors::transformed([](auto &vote) {
+          return vote.signature->publicKey();
+        }));
+  }
+}  // namespace
+
 namespace iroha {
   namespace consensus {
     namespace yac {
@@ -43,6 +54,9 @@ namespace iroha {
                                         },
                                         [this](const RejectMessage &msg) {
                                           return this->handleReject(msg);
+                                        },
+                                        [this](const FutureMessage &msg) {
+                                          return this->handleFuture(msg);
                                         });
                                   })
                                   .publish()
@@ -133,11 +147,7 @@ namespace iroha {
               current_hash_.vote_round, current_ledger_state_, block));
         }
 
-        auto public_keys = boost::copy_range<
-            shared_model::interface::types::PublicKeyCollectionType>(
-            msg.votes | boost::adaptors::transformed([](auto &vote) {
-              return vote.signature->publicKey();
-            }));
+        auto public_keys = getPublicKeys(msg.votes);
 
         if (hash.vote_hashes.proposal_hash.empty()) {
           // if consensus agreed on nothing for commit
@@ -160,11 +170,7 @@ namespace iroha {
       rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleReject(
           const RejectMessage &msg) {
         const auto hash = getHash(msg.votes).value();
-        auto public_keys = boost::copy_range<
-            shared_model::interface::types::PublicKeyCollectionType>(
-            msg.votes | boost::adaptors::transformed([](auto &vote) {
-              return vote.signature->publicKey();
-            }));
+        auto public_keys = getPublicKeys(msg.votes);
         if (hash.vote_round < current_hash_.vote_round) {
           log_->info(
               "Current round {} is greater than reject round {}, skipped",
@@ -187,6 +193,23 @@ namespace iroha {
         }
         log_->info("Block reject since proposal hashes match");
         return rxcpp::observable<>::just<GateObject>(BlockReject(
+            hash.vote_round, current_ledger_state_, std::move(public_keys)));
+      }
+
+      rxcpp::observable<YacGateImpl::GateObject> YacGateImpl::handleFuture(
+          const FutureMessage &msg) {
+        const auto hash = getHash(msg.votes).value();
+        auto public_keys = getPublicKeys(msg.votes);
+        if (hash.vote_round < current_hash_.vote_round) {
+          log_->info(
+              "Current round {} is greater than reject round {}, skipped",
+              current_hash_.vote_round,
+              hash.vote_round);
+          return rxcpp::observable<>::empty<GateObject>();
+        }
+
+        log_->info("Message from future, waiting for sync");
+        return rxcpp::observable<>::just<GateObject>(Future(
             hash.vote_round, current_ledger_state_, std::move(public_keys)));
       }
     }  // namespace yac

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -53,6 +53,7 @@ namespace iroha {
 
         rxcpp::observable<GateObject> handleCommit(const CommitMessage &msg);
         rxcpp::observable<GateObject> handleReject(const RejectMessage &msg);
+        rxcpp::observable<GateObject> handleFuture(const FutureMessage &msg);
 
         logger::LoggerPtr log_;
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -34,6 +34,7 @@ namespace iroha {
        public:
         YacGateImpl(std::shared_ptr<HashGate> hash_gate,
                     std::shared_ptr<YacPeerOrderer> orderer,
+                    boost::optional<ClusterOrdering> alternative_order,
                     std::shared_ptr<YacHashProvider> hash_provider,
                     std::shared_ptr<simulator::BlockCreator> block_creator,
                     std::shared_ptr<consensus::ConsensusResultCache>
@@ -58,6 +59,7 @@ namespace iroha {
         boost::optional<std::shared_ptr<shared_model::interface::Block>>
             current_block_;
         YacHash current_hash_;
+        boost::optional<ClusterOrdering> alternative_order_;
         std::shared_ptr<const LedgerState> current_ledger_state_;
 
         rxcpp::observable<GateObject> published_events_;

--- a/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
+++ b/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
@@ -15,8 +15,7 @@ boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
   using OptRefRoundType = boost::optional<RoundType> &;
   auto &target_round = iroha::visit_in_place(
       answer,
-      [this](
-          const iroha::consensus::yac::CommitMessage &msg) -> OptRefRoundType {
+      [this](const iroha::consensus::yac::CommitMessage &) -> OptRefRoundType {
         // greater commit removes last reject because previous rejects are not
         // required anymore for the consensus
         if (last_commit_round_ and last_reject_round_
@@ -25,8 +24,7 @@ boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
         }
         return last_commit_round_;
       },
-      [this](const iroha::consensus::yac::RejectMessage &msg)
-          -> OptRefRoundType { return last_reject_round_; });
+      [this](const auto &) -> OptRefRoundType { return last_reject_round_; });
 
   if (not target_round or *target_round < consensus_round) {
     target_round = consensus_round;

--- a/irohad/consensus/yac/storage/storage_result.hpp
+++ b/irohad/consensus/yac/storage/storage_result.hpp
@@ -14,11 +14,13 @@ namespace iroha {
 
       struct CommitMessage;
       struct RejectMessage;
+      struct FutureMessage;
 
       /**
        * Contains proof of supermajority for all purposes;
        */
-      using Answer = boost::variant<CommitMessage, RejectMessage>;
+      using Answer =
+          boost::variant<CommitMessage, RejectMessage, FutureMessage>;
 
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -55,7 +55,10 @@ namespace iroha {
 
         // ------|Hash gate|------
 
-        void vote(YacHash hash, ClusterOrdering order) override;
+        void vote(YacHash hash,
+                  ClusterOrdering order,
+                  boost::optional<ClusterOrdering> alternative_order =
+                      boost::none) override;
 
         rxcpp::observable<Answer> onOutcome() override;
 
@@ -77,6 +80,9 @@ namespace iroha {
          */
         void closeRound();
 
+        /// Get cluster_order_ or alternative_order_ if present
+        ClusterOrdering &getCurrentOrder();
+
         /**
          * Find corresponding peer in the ledger from vote message
          * @param vote message containing peer information
@@ -86,7 +92,8 @@ namespace iroha {
         findPeer(const VoteMessage &vote);
 
         /// Remove votes from unknown peers from given vector.
-        void removeUnknownPeersVotes(std::vector<VoteMessage> &votes);
+        void removeUnknownPeersVotes(std::vector<VoteMessage> &votes,
+                                     ClusterOrdering &order);
 
         // ------|Apply data|------
         /**
@@ -109,6 +116,7 @@ namespace iroha {
 
         // ------|One round|------
         ClusterOrdering cluster_order_;
+        boost::optional<ClusterOrdering> alternative_order_;
         Round round_;
 
         // ------|Fields|------

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -28,9 +28,13 @@ namespace iroha {
         /**
          * Proposal new hash in network
          * @param hash - hash for voting
-         * @param order - peer ordering
+         * @param order - peer ordering for round in hash
+         * @param alternative_order - peer order
          */
-        virtual void vote(YacHash hash, ClusterOrdering order) = 0;
+        virtual void vote(YacHash hash,
+                          ClusterOrdering order,
+                          boost::optional<ClusterOrdering> alternative_order =
+                              boost::none) = 0;
 
         /**
          * Observable with consensus outcomes - commits and rejects - in network

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -138,14 +138,6 @@ class Irohad {
   RunResult restoreWsv();
 
   /**
-   * Replaces peers in WSV with an externally provided peers list
-   * @param alternative_peers - the peers to place into WSV
-   * @return void on success, error otherwise
-   */
-  Irohad::RunResult resetPeers(
-      const shared_model::interface::types::PeerList &alternative_peers);
-
-  /**
    * Drop wsv and block store
    */
   virtual void dropStorage();

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -84,6 +84,8 @@ namespace iroha {
           Round initial_round,
           std::shared_ptr<iroha::ametsuchi::PeerQueryFactory>
               peer_query_factory,
+          boost::optional<shared_model::interface::types::PeerList>
+              alternative_peers,
           std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<network::BlockLoader> block_loader,
           const shared_model::crypto::Keypair &keypair,
@@ -123,6 +125,8 @@ namespace iroha {
         return std::make_shared<YacGateImpl>(
             std::move(yac),
             std::move(peer_orderer),
+            alternative_peers |
+                [](auto &peers) { return ClusterOrdering::create(peers); },
             hash_provider,
             block_creator,
             std::move(consensus_result_cache),

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -33,6 +33,8 @@ namespace iroha {
             Round initial_round,
             // TODO 30.01.2019 lebdron: IR-262 Remove PeerQueryFactory
             std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
+            boost::optional<shared_model::interface::types::PeerList>
+                alternative_peers,
             std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<network::BlockLoader> block_loader,
             const shared_model::crypto::Keypair &keypair,

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -64,14 +64,11 @@ namespace iroha {
       /**
        * Performs synchronization on rejects
        * @param msg - consensus gate message with a list of peers and a round
-       * @param alternative_outcome - synchronization outcome when block store
-       * height is equal to expected height after synchronization
+       * @param required_height - minimal top block height to be downloaded
        */
-      void processDifferent(const consensus::Synchronizable &msg,
-                            SynchronizationOutcomeType alternative_outcome);
-
-      boost::optional<shared_model::interface::types::HeightType>
-      getTopBlockHeight() const;
+      void processDifferent(
+          const consensus::Synchronizable &msg,
+          shared_model::interface::types::HeightType required_height);
 
       std::unique_ptr<ametsuchi::MutableStorage> getStorage();
 

--- a/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.cpp
@@ -25,7 +25,8 @@ namespace shared_model {
       if (!ursa_ed25519_sign(&kMessage, &kPrivateKey, &signature, &err)) {
         // handle error
         ursa_ed25519_string_free(err.message);
-      };
+        return Signed{""};
+      }
 
       Signed result(std::string((const std::string::value_type *)signature.data,
                                 signature.len));
@@ -67,7 +68,8 @@ namespace shared_model {
       if (!ursa_ed25519_keypair_new(&public_key, &private_key, &err)) {
         // handle error
         ursa_ed25519_string_free(err.message);
-      };
+        return Keypair{PublicKey{""}, PrivateKey{""}};
+      }
 
       Keypair result(PublicKey(std::string(
                          (const std::string::value_type *)public_key.data,
@@ -94,7 +96,8 @@ namespace shared_model {
               &kSeed, &public_key, &private_key, &err)) {
         // handle error
         ursa_ed25519_string_free(err.message);
-      };
+        return Keypair{PublicKey{""}, PrivateKey{""}};
+      }
 
       Keypair result(PublicKey(std::string(
                          (const std::string::value_type *)public_key.data,

--- a/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
@@ -16,7 +16,10 @@ namespace iroha {
 
       class MockHashGate : public HashGate {
        public:
-        MOCK_METHOD2(vote, void(YacHash, ClusterOrdering));
+        MOCK_METHOD3(vote,
+                     void(YacHash,
+                          ClusterOrdering,
+                          boost::optional<ClusterOrdering>));
 
         MOCK_METHOD0(onOutcome, rxcpp::observable<Answer>());
 

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -212,51 +212,23 @@ TEST_F(YacTest, PropagateCommitBeforeNotifyingSubscribersApplyReject) {
 
 /**
  * @given initialized yac
- * @when receive state with same hashes from future
- * @then commit for synchronization is emitted
+ * @when receive state from future
+ * @then future event for synchronization is emitted
  */
-TEST_F(YacTest, PossibleCommitFromFuture) {
+TEST_F(YacTest, Future) {
   YacHash hash({initial_round.block_round + 1, 0}, "my_proposal", "my_block");
 
   auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
   wrapper.subscribe([hash](auto message) {
-    auto commit_message = boost::get<CommitMessage>(message);
+    auto commit_message = boost::get<FutureMessage>(message);
     ASSERT_EQ(hash, commit_message.votes.at(0).hash);
-    ASSERT_EQ(hash, commit_message.votes.at(1).hash);
   });
 
   EXPECT_CALL(*network, sendState(_, _)).Times(0);
 
   EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
 
-  network->notification->onState(
-      {createVote(hash, "1"), createVote(hash, "2")});
-
-  ASSERT_TRUE(wrapper.validate());
-}
-
-/**
- * @given initialized yac
- * @when receive state with different hashes from future
- * @then reject for synchronization is emitted
- */
-TEST_F(YacTest, PossibleRejectFromFuture) {
-  YacHash hash({initial_round.block_round + 1, 0}, "my_proposal", "my_block"),
-      hash2({initial_round.block_round + 1, 0}, "my_proposal", "my_block2");
-
-  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
-  wrapper.subscribe([hash, hash2](auto message) {
-    auto reject_message = boost::get<RejectMessage>(message);
-    ASSERT_EQ(hash, reject_message.votes.at(0).hash);
-    ASSERT_EQ(hash2, reject_message.votes.at(1).hash);
-  });
-
-  EXPECT_CALL(*network, sendState(_, _)).Times(0);
-
-  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
-
-  network->notification->onState(
-      {createVote(hash, "1"), createVote(hash2, "2")});
+  network->notification->onState({createVote(hash, "1")});
 
   ASSERT_TRUE(wrapper.validate());
 }

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -12,6 +12,7 @@
 #include "consensus/yac/impl/supermajority_checker_bft.hpp"
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 
+#include "backend/plain/peer.hpp"
 #include "framework/test_subscriber.hpp"
 #include "module/irohad/consensus/yac/yac_fixture.hpp"
 
@@ -19,6 +20,7 @@ using ::testing::_;
 using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::Invoke;
+using ::testing::Ref;
 using ::testing::Return;
 
 using namespace iroha::consensus::yac;
@@ -257,4 +259,68 @@ TEST_F(YacTest, PossibleRejectFromFuture) {
       {createVote(hash, "1"), createVote(hash2, "2")});
 
   ASSERT_TRUE(wrapper.validate());
+}
+
+class YacAlternativeOrderTest : public YacTest {
+ public:
+  ClusterOrdering order = *ClusterOrdering::create({makePeer("default_peer")});
+  YacHash my_hash{initial_round, "my_proposal_hash", "my_block_hash"};
+
+  std::string peer_id{"alternative_peer"};
+  std::shared_ptr<shared_model::interface::Peer> peer = makePeer(peer_id);
+  ClusterOrdering alternative_order = *ClusterOrdering::create({peer});
+};
+
+/**
+ * @given yac
+ * @when vote is called with alternative order
+ * @then alternative order is used for sending votes
+ */
+TEST_F(YacAlternativeOrderTest, Voting) {
+  EXPECT_CALL(*network, sendState(Ref(*peer), _)).Times(1);
+
+  yac->vote(my_hash, order, alternative_order);
+}
+
+/**
+ * @given yac, vote called with alternative order
+ * @when alternative peer state with vote from future is received from the
+ *       network
+ * @then peers from alternative order are used to filter out the votes
+ *       and an outcome for synchronization is emitted
+ */
+TEST_F(YacAlternativeOrderTest, OnState) {
+  yac->vote(my_hash, order, alternative_order);
+
+  auto wrapper = make_test_subscriber<CallExact>(yac->onOutcome(), 1);
+  wrapper.subscribe();
+
+  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
+
+  YacHash received_hash(
+      {initial_round.block_round + 1, 0}, "my_proposal", "my_block");
+  // assume that our peer receive message
+  network->notification->onState({createVote(received_hash, peer_id)});
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
+ * @given yac, vote called with alternative order, which does not contain peers
+ *        from cluster order
+ * @when alternative peer state with vote for the same round is received from
+ *       the network
+ * @then peers from cluster order are used to filter out the votes and
+ *       kNotSentNotProcessed action is not executed
+ */
+TEST_F(YacAlternativeOrderTest, OnStateCurrentRoundAlternativePeer) {
+  yac->vote(my_hash, order, alternative_order);
+
+  EXPECT_CALL(*network, sendState(_, _)).Times(0);
+
+  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
+
+  YacHash received_hash(initial_round, "my_proposal", "my_block");
+  // assume that our peer receive message
+  network->notification->onState({createVote(received_hash, peer_id)});
 }

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -349,35 +349,25 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
 
 /**
  * @given commit from the consensus and initialized components
- * @when synchronizer fails to download blocks more times than the peers amount
- * @then it will try until success
+ * @when synchronizer fails to download blocks from all the peers in the list
+ * @then no commit event is emitted
  */
 TEST_F(SynchronizerTest, RetrieveBlockSeveralFailures) {
-  const size_t number_of_failures{ledger_peers.size() + 2};
+  const size_t number_of_failures{ledger_peers.size()};
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
   EXPECT_CALL(*mutable_factory, createMutableStorage(_))
-      .Times(number_of_failures + 1);
+      .Times(number_of_failures);
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
       .WillRepeatedly(Return(rxcpp::observable<>::just(commit_message)));
 
-  // fail the chain validation two times so that synchronizer will try more
-  {
-    InSequence s;  // ensures the call order
-    EXPECT_CALL(*chain_validator,
-                validateAndApply(ChainEq({commit_message}), _))
-        .Times(number_of_failures)
-        .WillRepeatedly(Return(false));
-    EXPECT_CALL(*chain_validator,
-                validateAndApply(ChainEq({commit_message}), _))
-        .WillOnce(Return(true));
-  }
+  EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({commit_message}), _))
+      .Times(number_of_failures)
+      .WillRepeatedly(Return(false));
 
   auto wrapper =
-      make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
-  wrapper.subscribe([](auto commit_event) {
-    ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
-  });
+      make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 0);
+  wrapper.subscribe();
 
   gate_outcome.get_subscriber().on_next(consensus::VoteOther(
       consensus::Round{kHeight, 1}, ledger_state, public_keys, hash));
@@ -601,7 +591,7 @@ TEST_F(SynchronizerTest, OneRoundDifference) {
       make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
   wrapper.subscribe([this](auto commit_event) {
     EXPECT_EQ(this->ledger_peers, commit_event.ledger_state->ledger_peers);
-    ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kNothing);
+    ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
 
   gate_outcome.get_subscriber().on_next(consensus::AgreementOnNone(

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -573,7 +573,7 @@ TEST_F(SynchronizerTest, CommitFailureVoteOther) {
 
 /**
  * @given Peers top block height is kHeight - 1
- * @when arrives AgreementOnNone with kHeight + 1 round
+ * @when arrives Future with kHeight + 1 round
  * @then synchronizer has to download missing block with height = kHeight
  */
 TEST_F(SynchronizerTest, OneRoundDifference) {
@@ -594,7 +594,7 @@ TEST_F(SynchronizerTest, OneRoundDifference) {
     ASSERT_EQ(commit_event.sync_outcome, SynchronizationOutcomeType::kCommit);
   });
 
-  gate_outcome.get_subscriber().on_next(consensus::AgreementOnNone(
+  gate_outcome.get_subscriber().on_next(consensus::Future(
       consensus::Round{kHeight + 1, 1}, ledger_state, public_keys));
 
   ASSERT_TRUE(wrapper.validate());


### PR DESCRIPTION
### Description of the Change
- Fix handling consensus messages from future and past - they are not applied to storage, because the number of peers may not correspond to the current cluster order size.
- Refactor synchronizer to emit commit events due to current logic in OrderingInit class
- Pass optional peers list to consensus instead of WSV, because the state peers list should correspond to the top block in the ledger

### Benefits
Working synchronization on AddPeer commands

### Possible Drawbacks 
Might not be the best or most optimal solution overall, however the changes are localized in Yac and Synchronizer. Please check alternate designs

### Usage Examples or Tests
Please check changed files in test directory

### Alternate Designs
- Pass optional peers list together with corresponding round in config
- Refactor OrderingInit to update hashes on events from storage