### PR TITLE
Fix RST syntax issues in docs

### DIFF
--- a/docs/source/architecture/index.rst
+++ b/docs/source/architecture/index.rst
@@ -1,4 +1,5 @@
-.. _architecture: 
+.. _architecture:
+
 ************
 Architecture
 ************

--- a/docs/source/guides/torii-tls.rst
+++ b/docs/source/guides/torii-tls.rst
@@ -24,6 +24,7 @@ You can use any algorithm you want instead of ``rsa``, as long as your
 To find out which are supported, you can use
 
 .. code:: sh
+
     $ openssl list-public-key-algorithms
 
 If you need to use plain IP addresses to connect to the node, you need to

--- a/docs/source/guides/torii-tls.rst
+++ b/docs/source/guides/torii-tls.rst
@@ -23,7 +23,7 @@ You can use any algorithm you want instead of ``rsa``, as long as your
 ``openssl`` supports it.
 To find out which are supported, you can use
 
-.. code:: sh
+.. code-block:: sh
 
     $ openssl list-public-key-algorithms
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Fix small RST syntax issues in documentation.

Sphinx compiler has been complaining about the following:
```
iroha/docs/source/architecture/index.rst:2: WARNING: Explicit markup ends without a blank line; unexpected unindent.
iroha/docs/source/guides/torii-tls.rst:26: WARNING: Error in "code" directive:
maximum 1 argument(s) allowed, 4 supplied.

.. code:: sh
    $ openssl list-public-key-algorithms
```

### Benefits

No Sphinx compilation issues

### Possible Drawbacks 

None

### Usage Examples or Tests 

```bash
# activate venv with deps installed
cd docs/source
make permissions
make html
```
