### PR TITLE
Ametsuchi: remove ambiguous call to apply

### DIFF
--- a/irohad/ametsuchi/impl/postgres_block_storage.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.cpp
@@ -68,7 +68,7 @@ PostgresBlockStorage::fetch(HeightType height) const {
     return boost::none;
   }
   return rebind(viewQuery<QueryTuple>(row)) | [&, this](auto row) {
-    return apply(row, [&, this](auto &block_data) {
+    return iroha::ametsuchi::apply(row, [&, this](auto &block_data) {
       log_->debug("fetched: {}", block_data);
       return iroha::hexstringToBytestring(block_data) |
           [&, this](auto byte_block) {
@@ -140,7 +140,7 @@ PostgresBlockStorage::getBlockHeightsRange() const {
     return boost::none;
   }
   return rebind(viewQuery<QueryTuple>(row)) | [](auto row) {
-    return apply(row, [](size_t min, size_t max) {
+    return iroha::ametsuchi::apply(row, [](size_t min, size_t max) {
       assert(max >= min);
       return boost::make_optional(HeightRange{min, max});
     });

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
@@ -244,7 +244,7 @@ namespace iroha {
         soci::rowset<T> st = std::forward<QueryExecutor>(query_executor)();
         auto range = boost::make_iterator_range(st.begin(), st.end());
 
-        return apply(
+        return iroha::ametsuchi::apply(
             viewPermissions<PermissionTuple>(range.front()),
             [this, range, &response_creator, &perms_err_response, &query_hash](
                 auto... perms) {
@@ -398,9 +398,10 @@ namespace iroha {
             // unpack results to get map from block height to index of tx in
             // a block
             for (const auto &t : range_without_nulls) {
-              apply(t, [&index](auto &height, auto &idx, auto &) {
-                index[height].push_back(idx);
-              });
+              iroha::ametsuchi::apply(
+                  t, [&index](auto &height, auto &idx, auto &) {
+                    index[height].push_back(idx);
+                  });
             }
 
             std::vector<std::unique_ptr<shared_model::interface::Transaction>>
@@ -513,7 +514,8 @@ namespace iroha {
                   QueryErrorType::kNoAccount, q.accountId(), 0, query_hash);
             }
 
-            return apply(range_without_nulls.front(), query_apply);
+            return iroha::ametsuchi::apply(range_without_nulls.front(),
+                                           query_apply);
           },
           notEnoughPermissionsResponse(perm_converter_,
                                        Role::kGetMyAccount,
@@ -598,7 +600,7 @@ namespace iroha {
             auto pubkeys = boost::copy_range<
                 std::vector<shared_model::interface::types::PubkeyType>>(
                 range_without_nulls | boost::adaptors::transformed([](auto t) {
-                  return apply(t, [&](auto &public_key) {
+                  return iroha::ametsuchi::apply(t, [&](auto &public_key) {
                     return shared_model::interface::types::PubkeyType{
                         shared_model::crypto::Blob::fromHexString(public_key)};
                   });
@@ -712,7 +714,7 @@ namespace iroha {
             }
             std::map<uint64_t, std::unordered_set<std::string>> index;
             for (const auto &t : range_without_nulls) {
-              apply(t, [&index](auto &height, auto &hash) {
+              iroha::ametsuchi::apply(t, [&index](auto &height, auto &hash) {
                 index[height].insert(hash);
               });
             }
@@ -885,17 +887,18 @@ namespace iroha {
                 assets;
             size_t total_number = 0;
             for (const auto &row : range_without_nulls) {
-              apply(row,
-                    [&assets, &total_number](auto &account_id,
-                                             auto &asset_id,
-                                             auto &amount,
-                                             auto &total_number_col) {
-                      total_number = total_number_col;
-                      assets.push_back(std::make_tuple(
-                          std::move(account_id),
-                          std::move(asset_id),
-                          shared_model::interface::Amount(amount)));
-                    });
+              iroha::ametsuchi::apply(
+                  row,
+                  [&assets, &total_number](auto &account_id,
+                                           auto &asset_id,
+                                           auto &amount,
+                                           auto &total_number_col) {
+                    total_number = total_number_col;
+                    assets.push_back(std::make_tuple(
+                        std::move(account_id),
+                        std::move(asset_id),
+                        shared_model::interface::Amount(amount)));
+                  });
             }
             if (assets.empty() and req_first_asset_id) {
               // nonexistent first_asset_id provided in query request
@@ -1055,7 +1058,7 @@ namespace iroha {
                   query_hash);
             }
 
-            return apply(
+            return iroha::ametsuchi::apply(
                 range.front(),
                 [&, this](auto &json,
                           auto &total_number,
@@ -1160,7 +1163,8 @@ namespace iroha {
             auto roles = boost::copy_range<
                 std::vector<shared_model::interface::types::RoleIdType>>(
                 range_without_nulls | boost::adaptors::transformed([](auto t) {
-                  return apply(t, [](auto &role_id) { return role_id; });
+                  return iroha::ametsuchi::apply(
+                      t, [](auto &role_id) { return role_id; });
                 }));
 
             return query_response_factory_->createRolesResponse(roles,
@@ -1202,7 +1206,7 @@ namespace iroha {
                   query_hash);
             }
 
-            return apply(
+            return iroha::ametsuchi::apply(
                 range_without_nulls.front(),
                 [this, &query_hash](auto &permission) {
                   return query_response_factory_->createRolePermissionsResponse(
@@ -1247,7 +1251,7 @@ namespace iroha {
                   query_hash);
             }
 
-            return apply(
+            return iroha::ametsuchi::apply(
                 range_without_nulls.front(),
                 [this, &q, &query_hash](auto &domain_id, auto &precision) {
                   return query_response_factory_->createAssetResponse(
@@ -1348,12 +1352,14 @@ namespace iroha {
             auto range_without_nulls = resultWithoutNulls(std::move(range));
             shared_model::interface::types::PeerList peers;
             for (const auto &row : range_without_nulls) {
-              apply(row, [&peers](auto &peer_key, auto &address) {
-                peers.push_back(std::make_shared<shared_model::plain::Peer>(
-                    address,
-                    shared_model::interface::types::PubkeyType{
-                        shared_model::crypto::Blob::fromHexString(peer_key)}));
-              });
+              iroha::ametsuchi::apply(
+                  row, [&peers](auto &peer_key, auto &address) {
+                    peers.push_back(std::make_shared<shared_model::plain::Peer>(
+                        address,
+                        shared_model::interface::types::PubkeyType{
+                            shared_model::crypto::Blob::fromHexString(
+                                peer_key)}));
+                  });
             }
             return query_response_factory_->createPeersResponse(peers,
                                                                 query_hash);

--- a/irohad/ametsuchi/impl/soci_utils.hpp
+++ b/irohad/ametsuchi/impl/soci_utils.hpp
@@ -104,18 +104,20 @@ namespace iroha {
         return boost::make_tuple(*std::forward<decltype(vals)>(vals)...);
       };
 
-      using ReturnType =
-          decltype(boost::make_optional(apply(std::forward<T>(t), transform)));
+      using ReturnType = decltype(boost::make_optional(
+          iroha::ametsuchi::apply(std::forward<T>(t), transform)));
 
-      return apply(std::forward<T>(t),
-                   [&](auto &&... vals) {
-                     bool temp[] = {static_cast<bool>(
-                         std::forward<decltype(vals)>(vals))...};
-                     return std::all_of(std::begin(temp),
-                                        std::end(temp),
-                                        [](auto b) { return b; });
-                   })
-          ? boost::make_optional(apply(std::forward<T>(t), transform))
+      return iroha::ametsuchi::apply(
+                 std::forward<T>(t),
+                 [&](auto &&... vals) {
+                   bool temp[] = {static_cast<bool>(
+                       std::forward<decltype(vals)>(vals))...};
+                   return std::all_of(std::begin(temp),
+                                      std::end(temp),
+                                      [](auto b) { return b; });
+                 })
+          ? boost::make_optional(
+                iroha::ametsuchi::apply(std::forward<T>(t), transform))
           : ReturnType{};
     }
 
@@ -124,7 +126,7 @@ namespace iroha {
       return t | [&](auto &st) -> boost::optional<C> {
         return boost::copy_range<C>(
             st | boost::adaptors::transformed([&](auto &t) {
-              return apply(t, std::forward<F>(f));
+              return iroha::ametsuchi::apply(t, std::forward<F>(f));
             }));
       };
     }
@@ -134,7 +136,7 @@ namespace iroha {
       if (t) {
         C map_result;
         for (auto &inp_el : *t) {
-          apply(inp_el, std::forward<F>(f)) |
+          iroha::ametsuchi::apply(inp_el, std::forward<F>(f)) |
               [&map_result](auto &&transformed_el) {
                 map_result.emplace_back(std::move(transformed_el));
               };
@@ -153,7 +155,7 @@ namespace iroha {
           return boost::none;
         }
 
-        return apply(range.front(), std::forward<F>(f));
+        return iroha::ametsuchi::apply(range.front(), std::forward<F>(f));
       };
     }
 


### PR DESCRIPTION
### Description of the Change
Disambiguate calls to `iroha::ametsuchi::apply`, because it clashes with `std::apply` if compiled with C++17 standard.

### Benefits
Compilation with C++17 standard

### Possible Drawbacks 
No CI pipeline for C++17 standard yet
