### PR TITLE
Simplify Amount interface and IntegrationTestFramework header

### DIFF
--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -8,8 +8,6 @@
 
 #include <utility>
 
-#include <rxcpp/rx.hpp>
-
 #include "ametsuchi/ledger_state.hpp"
 #include "consensus/round.hpp"
 #include "interfaces/iroha_internal/block.hpp"

--- a/shared_model/interfaces/common_objects/amount.hpp
+++ b/shared_model/interfaces/common_objects/amount.hpp
@@ -20,6 +20,10 @@ namespace shared_model {
      public:
       explicit Amount(const std::string &amount);
 
+      /**
+       * Returns a value less than zero if Amount is negative, a value greater
+       * than zero if Amount is positive, and zero if Amount is zero.
+       */
       int sign() const;
 
       /**

--- a/shared_model/interfaces/common_objects/amount.hpp
+++ b/shared_model/interfaces/common_objects/amount.hpp
@@ -8,7 +8,6 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include <boost/multiprecision/cpp_int.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -21,11 +20,7 @@ namespace shared_model {
      public:
       explicit Amount(const std::string &amount);
 
-      /**
-       * Gets integer representation value, which ignores precision
-       * @return amount represented as integer value, which ignores precision
-       */
-      const boost::multiprecision::uint256_t &intValue() const;
+      int sign() const;
 
       /**
        * Gets the position of precision

--- a/shared_model/interfaces/common_objects/impl/amount.cpp
+++ b/shared_model/interfaces/common_objects/impl/amount.cpp
@@ -7,6 +7,7 @@
 
 #include <regex>
 
+#include <boost/multiprecision/cpp_int.hpp>
 #include "utils/string_builder.hpp"
 
 static const char kDecimalSeparator = '.';
@@ -57,8 +58,8 @@ struct Amount::Impl {
 Amount::Amount(const std::string &amount)
     : impl_(std::make_shared<Impl>(amount)) {}
 
-const boost::multiprecision::uint256_t &Amount::intValue() const {
-  return impl_->multiprecision_repr_;
+int Amount::sign() const {
+  return impl_->multiprecision_repr_.sign();
 }
 
 types::PrecisionType Amount::precision() const {

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -106,10 +106,10 @@ namespace shared_model {
 
     void FieldValidator::validateAmount(ReasonsGroupType &reason,
                                         const interface::Amount &amount) const {
-      if (amount.intValue() <= 0) {
+      if (amount.sign() <= 0) {
         auto message =
-            (boost::format("Amount must be greater than 0, passed value: %d")
-             % amount.intValue())
+            (boost::format("Amount must be greater than 0, but got: %d")
+             % amount.toStringRepr())
                 .str();
         reason.second.push_back(message);
       }

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -107,11 +107,8 @@ namespace shared_model {
     void FieldValidator::validateAmount(ReasonsGroupType &reason,
                                         const interface::Amount &amount) const {
       if (amount.sign() <= 0) {
-        auto message =
-            (boost::format("Amount must be greater than 0, but got: %d")
-             % amount.toStringRepr())
-                .str();
-        reason.second.push_back(message);
+        reason.second.push_back(
+            "Invalid number, amount must be greater than 0");
       }
     }
 

--- a/test/benchmark/bm_pipeline.cpp
+++ b/test/benchmark/bm_pipeline.cpp
@@ -6,6 +6,7 @@
 #include <benchmark/benchmark.h>
 #include <string>
 
+#include <boost/filesystem.hpp>
 #include "backend/protobuf/transaction.hpp"
 #include "benchmark/bm_utils.hpp"
 #include "builders/protobuf/unsigned_proto.hpp"

--- a/test/benchmark/bm_query.cpp
+++ b/test/benchmark/bm_query.cpp
@@ -7,6 +7,7 @@
 
 #include <benchmark/benchmark.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "benchmark/bm_utils.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"

--- a/test/framework/executor_itf/executor_itf_helper.hpp
+++ b/test/framework/executor_itf/executor_itf_helper.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include <boost/mpl/at.hpp>
 #include <boost/mpl/contains.hpp>
 #include <boost/mpl/map.hpp>
 #include "common/result.hpp"

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -24,6 +24,7 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "datetime/time.hpp"
+#include "endpoint.grpc.pb.h"
 #include "framework/common_constants.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/honest.hpp"
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
@@ -49,6 +50,8 @@
 #include "network/impl/grpc_channel_builder.hpp"
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
 #include "synchronizer/synchronizer_common.hpp"
+#include "torii/command_client.hpp"
+#include "torii/query_client.hpp"
 #include "torii/status_bus.hpp"
 #include "validators/protobuf/proto_proposal_validator.hpp"
 
@@ -157,11 +160,12 @@ namespace integration_framework {
                                             log_manager_->getChild("Irohad"),
                                             log_,
                                             dbname)),
-        command_client_(
+        command_client_(std::make_unique<torii::CommandSyncClient>(
             iroha::network::createClient<iroha::protocol::CommandService_v1>(
                 format_address(kLocalHost, torii_port_)),
-            log_manager_->getChild("CommandClient")->getLogger()),
-        query_client_(kLocalHost, torii_port_),
+            log_manager_->getChild("CommandClient")->getLogger())),
+        query_client_(std::make_unique<torii_utils::QuerySyncClient>(
+            kLocalHost, torii_port_)),
         async_call_(std::make_shared<AsyncCall>(
             log_manager_->getChild("AsyncCall")->getLogger())),
         tx_response_waiting(tx_response_waiting),
@@ -477,7 +481,7 @@ namespace integration_framework {
     iroha::protocol::TxStatusRequest request;
     request.set_tx_hash(hash.hex());
     iroha::protocol::ToriiResponse response;
-    command_client_.Status(request, response);
+    command_client_->Status(request, response);
     validation(shared_model::proto::TransactionResponse(std::move(response)));
     return *this;
   }
@@ -487,7 +491,7 @@ namespace integration_framework {
     log_->info("sending transaction");
     log_->debug("{}", tx);
 
-    command_client_.Torii(tx.getTransport());
+    command_client_->Torii(tx.getTransport());
     return *this;
   }
 
@@ -601,7 +605,7 @@ namespace integration_framework {
               ->getTransport();
       *tx_list.add_transactions() = proto_tx;
     }
-    command_client_.ListTorii(tx_list);
+    command_client_->ListTorii(tx_list);
 
     std::unique_lock<std::mutex> lk(m);
     cv.wait(lk, [&] { return processed; });
@@ -628,7 +632,7 @@ namespace integration_framework {
     log_->debug("{}", qry);
 
     iroha::protocol::QueryResponse response;
-    query_client_.Find(qry.getTransport(), response);
+    query_client_->Find(qry.getTransport(), response);
     shared_model::proto::QueryResponse query_response{std::move(response)};
 
     validation(query_response);

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -16,11 +16,12 @@
 #include <vector>
 
 #include <boost/filesystem.hpp>
+#include <rxcpp/rx.hpp>
 #include "backend/protobuf/queries/proto_query.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
-#include "framework/integration_framework/iroha_instance.hpp"
-#include "framework/integration_framework/test_irohad.hpp"
+#include "consensus/gate_object.hpp"
+#include "cryptography/keypair.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
 #include "logger/logger.hpp"
@@ -29,6 +30,7 @@
 #include "network/impl/async_grpc_client.hpp"
 #include "network/mst_transport.hpp"
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
+#include "synchronizer/synchronizer_common.hpp"
 #include "torii/command_client.hpp"
 #include "torii/query_client.hpp"
 
@@ -40,12 +42,23 @@ namespace shared_model {
     class CommonObjectsFactory;
     class Block;
     class Proposal;
+    class TransactionBatchFactory;
+    class TransactionBatchParser;
   }  // namespace interface
   namespace proto {
     class Block;
+    class Transaction;
+  }  // namespace proto
+  namespace validation {
+    template <typename Model>
+    class AbstractValidator;
   }
 }  // namespace shared_model
 namespace iroha {
+  namespace ametsuchi {
+    class BlockQuery;
+    class TxPresenceCache;
+  }  // namespace ametsuchi
   namespace consensus {
     namespace yac {
       class YacNetwork;
@@ -62,6 +75,8 @@ namespace iroha {
   }
 }  // namespace iroha
 
+class ServerRunner;
+
 namespace integration_framework {
 
   namespace fake_peer {
@@ -69,6 +84,8 @@ namespace integration_framework {
   }
 
   class PortGuard;
+
+  class IrohaInstance;
 
   using std::chrono::milliseconds;
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -6,48 +6,41 @@
 #ifndef IROHA_INTEGRATION_FRAMEWORK_HPP
 #define IROHA_INTEGRATION_FRAMEWORK_HPP
 
-#include <algorithm>
-#include <chrono>
-#include <exception>
-#include <functional>
-#include <queue>
-#include <string>
-#include <thread>
-#include <vector>
-
-#include <boost/filesystem.hpp>
 #include <rxcpp/rx.hpp>
-#include "backend/protobuf/queries/proto_query.hpp"
-#include "backend/protobuf/query_responses/proto_query_response.hpp"
-#include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 #include "consensus/gate_object.hpp"
 #include "cryptography/keypair.hpp"
-#include "interfaces/common_objects/peer.hpp"
-#include "interfaces/iroha_internal/transaction_sequence.hpp"
-#include "logger/logger.hpp"
+#include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
-#include "multi_sig_transactions/state/mst_state.hpp"
-#include "network/impl/async_grpc_client.hpp"
-#include "network/mst_transport.hpp"
-#include "ordering/impl/on_demand_os_client_grpc.hpp"
 #include "synchronizer/synchronizer_common.hpp"
-#include "torii/command_client.hpp"
-#include "torii/query_client.hpp"
+
+namespace google {
+  namespace protobuf {
+    class Empty;
+  }
+}  // namespace google
 
 namespace shared_model {
   namespace crypto {
     class Keypair;
   }
   namespace interface {
+    template <typename Interface, typename Transport>
+    class AbstractTransportFactory;
     class CommonObjectsFactory;
     class Block;
     class Proposal;
+    class TransactionBatch;
     class TransactionBatchFactory;
     class TransactionBatchParser;
+    class TransactionResponse;
+    class TransactionSequence;
   }  // namespace interface
   namespace proto {
     class Block;
     class Transaction;
+    class TransactionResponse;
+    class Query;
+    class QueryResponse;
   }  // namespace proto
   namespace validation {
     template <typename Model>
@@ -69,11 +62,24 @@ namespace iroha {
   namespace network {
     class MstTransportGrpc;
     class OrderingServiceTransport;
+    template <typename Response>
+    class AsyncGrpcClient;
   }  // namespace network
+  namespace protocol {
+    class Proposal;
+    class Transaction;
+  }  // namespace protocol
   namespace validation {
     struct VerifiedProposalAndErrors;
   }
+  class MstState;
 }  // namespace iroha
+namespace torii {
+  class CommandSyncClient;
+}
+namespace torii_utils {
+  class QuerySyncClient;
+}
 
 class ServerRunner;
 
@@ -400,9 +406,13 @@ namespace integration_framework {
     rxcpp::observable<std::shared_ptr<iroha::MstState>>
     getMstStateUpdateObservable();
 
-    rxcpp::observable<iroha::BatchPtr> getMstPreparedBatchesObservable();
+    rxcpp::observable<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+    getMstPreparedBatchesObservable();
 
-    rxcpp::observable<iroha::BatchPtr> getMstExpiredBatchesObservable();
+    rxcpp::observable<
+        std::shared_ptr<shared_model::interface::TransactionBatch>>
+    getMstExpiredBatchesObservable();
 
     rxcpp::observable<iroha::consensus::GateObject> getYacOnCommitObservable();
 
@@ -492,8 +502,8 @@ namespace integration_framework {
     size_t torii_port_;
     size_t internal_port_;
     std::shared_ptr<IrohaInstance> iroha_instance_;
-    torii::CommandSyncClient command_client_;
-    torii_utils::QuerySyncClient query_client_;
+    std::unique_ptr<torii::CommandSyncClient> command_client_;
+    std::unique_ptr<torii_utils::QuerySyncClient> query_client_;
 
     std::shared_ptr<AsyncCall> async_call_;
 
@@ -517,8 +527,9 @@ namespace integration_framework {
         batch_validator_;
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory_;
-    std::shared_ptr<
-        iroha::ordering::transport::OnDemandOsClientGrpc::TransportFactoryType>
+    std::shared_ptr<shared_model::interface::AbstractTransportFactory<
+        shared_model::interface::Proposal,
+        iroha::protocol::Proposal>>
         proposal_factory_;
     std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache_;
     std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;

--- a/test/integration/acceptance/acceptance_fixture.hpp
+++ b/test/integration/acceptance/acceptance_fixture.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 #include "cryptography/keypair.hpp"
 #include "framework/common_constants.hpp"
 #include "interfaces/permissions.hpp"
@@ -20,14 +21,13 @@
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
 
 namespace {
-  template <typename Type>
-  void checkTransactionResponse(
-      const shared_model::interface::TransactionResponse &resp) {
+  template <typename Type, typename T>
+  void checkTransactionResponse(const T &resp) {
     ASSERT_NO_THROW(boost::get<const Type &>(resp.get())) << resp.toString();
   }
 
 #define BASE_CHECK_RESPONSE(type)                                  \
-  [](const shared_model::interface::TransactionResponse &resp) {   \
+  [](const auto &resp) {                                           \
     SCOPED_TRACE(#type);                                           \
     checkTransactionResponse<shared_model::interface::type>(resp); \
   }

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -5,11 +5,14 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include "ametsuchi/block_query.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/honest.hpp"
 #include "framework/integration_framework/fake_peer/block_storage.hpp"
+#include "framework/integration_framework/iroha_instance.hpp"
+#include "framework/integration_framework/test_irohad.hpp"
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 #include "ordering/impl/on_demand_common.cpp"

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -5,10 +5,13 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include "ametsuchi/block_query.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/honest.hpp"
 #include "framework/integration_framework/fake_peer/block_storage.hpp"
+#include "framework/integration_framework/iroha_instance.hpp"
+#include "framework/integration_framework/test_irohad.hpp"
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 

--- a/test/integration/acceptance/get_account_test.cpp
+++ b/test/integration/acceptance/get_account_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/integration/acceptance/get_asset_info_test.cpp
+++ b/test/integration/acceptance/get_asset_info_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/integration/acceptance/get_role_permissions_test.cpp
+++ b/test/integration/acceptance/get_role_permissions_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"

--- a/test/integration/acceptance/get_roles_test.cpp
+++ b/test/integration/acceptance/get_roles_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"

--- a/test/integration/acceptance/grantable_permissions_fixture.hpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.hpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/integration/acceptance/queries_acceptance_test.cpp
+++ b/test/integration/acceptance/queries_acceptance_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"

--- a/test/integration/acceptance/query_permission_test_base.hpp
+++ b/test/integration/acceptance/query_permission_test_base.hpp
@@ -6,6 +6,7 @@
 #ifndef QUERY_PERMISSION_TEST_BASE_HPP_
 #define QUERY_PERMISSION_TEST_BASE_HPP_
 
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/query_permission_fixture.hpp"
 #include "utils/query_error_response_visitor.hpp"

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/transactions_response.hpp"

--- a/test/integration/acceptance/remove_peer_test.cpp
+++ b/test/integration/acceptance/remove_peer_test.cpp
@@ -5,11 +5,14 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include "ametsuchi/block_query.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/honest.hpp"
 #include "framework/integration_framework/fake_peer/block_storage.hpp"
+#include "framework/integration_framework/iroha_instance.hpp"
+#include "framework/integration_framework/test_irohad.hpp"
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 #include "ordering/impl/on_demand_common.cpp"

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"

--- a/test/integration/acceptance/tx_heavy_data.cpp
+++ b/test/integration/acceptance/tx_heavy_data.cpp
@@ -7,6 +7,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/account_response.hpp"

--- a/test/integration/binary/binaries_test_fixture.hpp
+++ b/test/integration/binary/binaries_test_fixture.hpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
 #include <vector>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
 #include "integration/binary/launchers.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/integration/pipeline/pipeline_test.cpp
+++ b/test/integration/pipeline/pipeline_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"

--- a/test/module/irohad/multi_sig_transactions/mst_net_input_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_net_input_test.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <grpc++/grpc++.h>
 #include <gtest/gtest.h>
 #include "framework/common_constants.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/module/shared_model/interface/common_objects/amount_test.cpp
+++ b/test/module/shared_model/interface/common_objects/amount_test.cpp
@@ -10,43 +10,40 @@
 #include <utility>
 
 #include <gtest/gtest.h>
-#include <boost/multiprecision/cpp_int.hpp>
 
 using namespace shared_model::interface;
 
 struct AmountTest : public ::testing::Test {
-  using int_type = std::decay_t<decltype(std::declval<Amount>().intValue())>;
-
-  /// Check int value, precision and string representation of a valid amount.
+  /// Check sign, precision and string representation of a valid amount.
   void checkValid(const Amount &tested,
-                  int_type ref_int_val,
+                  bool greater_than_zero,
                   types::PrecisionType ref_precision,
                   std::string ref_str) {
-    EXPECT_EQ(tested.intValue(), ref_int_val);
+    EXPECT_EQ(tested.sign() > 0, greater_than_zero);
     EXPECT_EQ(tested.precision(), ref_precision);
     EXPECT_EQ(tested.toStringRepr(), ref_str);
   }
 
-  /// Check int value, precision and string representation of an invalid amount.
+  /// Check sign, precision and string representation of an invalid amount.
   void checkInvalid(const Amount &tested) {
-    EXPECT_EQ(tested.intValue(), 0);
+    EXPECT_EQ(tested.sign(), 0);
     EXPECT_EQ(tested.precision(), 0);
     EXPECT_EQ(tested.toStringRepr(), "NaN");
   }
 };
 
 TEST_F(AmountTest, Basic) {
-  checkValid(Amount{"0"}, 0, 0, "0");
-  checkValid(Amount{"0.1"}, 1, 1, "0.1");
-  checkValid(Amount{"1234"}, 1234, 0, "1234");
-  checkValid(Amount{"23.45"}, 2345, 2, "23.45");
+  checkValid(Amount{"0"}, false, 0, "0");
+  checkValid(Amount{"0.1"}, true, 1, "0.1");
+  checkValid(Amount{"1234"}, true, 0, "1234");
+  checkValid(Amount{"23.45"}, true, 2, "23.45");
 }
 
 TEST_F(AmountTest, Strange) {
-  checkValid(Amount{"000.000"}, 0, 3, "0.000");
-  checkValid(Amount{"000.001"}, 1, 3, "0.001");
-  checkValid(Amount{"0000001"}, 1, 0, "1");
-  checkValid(Amount{"1.00000"}, 100000, 5, "1.00000");
+  checkValid(Amount{"000.000"}, false, 3, "0.000");
+  checkValid(Amount{"000.001"}, true, 3, "0.001");
+  checkValid(Amount{"0000001"}, true, 0, "1");
+  checkValid(Amount{"1.00000"}, true, 5, "1.00000");
 }
 
 TEST_F(AmountTest, Invalid) {

--- a/test/module/shared_model/interface/common_objects/amount_test.cpp
+++ b/test/module/shared_model/interface/common_objects/amount_test.cpp
@@ -10,16 +10,17 @@
 #include <utility>
 
 #include <gtest/gtest.h>
+#include <boost/math/special_functions/sign.hpp>
 
 using namespace shared_model::interface;
 
 struct AmountTest : public ::testing::Test {
   /// Check sign, precision and string representation of a valid amount.
   void checkValid(const Amount &tested,
-                  bool greater_than_zero,
+                  int ref_sign,
                   types::PrecisionType ref_precision,
                   std::string ref_str) {
-    EXPECT_EQ(tested.sign() > 0, greater_than_zero);
+    EXPECT_EQ(boost::math::sign(tested.sign()), boost::math::sign(ref_sign));
     EXPECT_EQ(tested.precision(), ref_precision);
     EXPECT_EQ(tested.toStringRepr(), ref_str);
   }
@@ -33,17 +34,17 @@ struct AmountTest : public ::testing::Test {
 };
 
 TEST_F(AmountTest, Basic) {
-  checkValid(Amount{"0"}, false, 0, "0");
-  checkValid(Amount{"0.1"}, true, 1, "0.1");
-  checkValid(Amount{"1234"}, true, 0, "1234");
-  checkValid(Amount{"23.45"}, true, 2, "23.45");
+  checkValid(Amount{"0"}, 0, 0, "0");
+  checkValid(Amount{"0.1"}, 1, 1, "0.1");
+  checkValid(Amount{"1234"}, 1, 0, "1234");
+  checkValid(Amount{"23.45"}, 1, 2, "23.45");
 }
 
 TEST_F(AmountTest, Strange) {
-  checkValid(Amount{"000.000"}, false, 3, "0.000");
-  checkValid(Amount{"000.001"}, true, 3, "0.001");
-  checkValid(Amount{"0000001"}, true, 0, "1");
-  checkValid(Amount{"1.00000"}, true, 5, "1.00000");
+  checkValid(Amount{"000.000"}, 0, 3, "0.000");
+  checkValid(Amount{"000.001"}, 1, 3, "0.001");
+  checkValid(Amount{"0000001"}, 1, 0, "1");
+  checkValid(Amount{"1.00000"}, 1, 5, "1.00000");
 }
 
 TEST_F(AmountTest, Invalid) {

--- a/test/regression/query_test.cpp
+++ b/test/regression/query_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -4,6 +4,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <boost/variant.hpp>
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -8,6 +8,8 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/variant.hpp>
+#include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 #include "builders/protobuf/queries.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "common/files.hpp"


### PR DESCRIPTION
### Description of the Change
- Remove `boost/multiprecision` from Amount interface, since it was causing significant build time increase, and was not practically used in the code
- Simplify IntegrationTestFramework header to reduce parsing time

### Benefits
Build time reduction

### Possible Drawbacks 
None
