### PR TITLE
Windows Packer: allow reboot exit code for chocolatey

### DIFF
--- a/.packer/win/windows-build-server.json
+++ b/.packer/win/windows-build-server.json
@@ -54,7 +54,8 @@
             "type": "powershell",
             "scripts": [
                 "./scripts/SetUpDevTools.ps1"
-            ]
+            ],
+            "valid_exit_codes": [0, 3010]
         },
         {
             "type": "windows-restart"


### PR DESCRIPTION
### Description of the Change
Allow reboot exit code on chocolatey install because dotnet may require reboot after install

### Benefits
Successful Windows image build

### Possible Drawbacks 
None