### PR TITLE
Refactor rxcpp includes to reduce build time

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -6,6 +6,7 @@
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
 
 #include <boost/variant/apply_visitor.hpp>
+#include <rxcpp/operators/rx-all.hpp>
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/impl/peer_query_wsv.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -13,6 +13,7 @@
 
 #include <soci/soci.h>
 #include <boost/optional.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/impl/pool_wrapper.hpp"
 #include "ametsuchi/impl/postgres_options.hpp"

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -8,7 +8,7 @@
 
 #include <functional>
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/types.hpp"
 

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -8,7 +8,7 @@
 
 #include <functional>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "interfaces/common_objects/types.hpp"
 

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"

--- a/irohad/consensus/yac/impl/timer_impl.hpp
+++ b/irohad/consensus/yac/impl/timer_impl.hpp
@@ -8,8 +8,10 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/yac/timer.hpp"
+
+#include <rxcpp/operators/rx-observe_on.hpp>
 
 namespace iroha {
   namespace consensus {

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -6,6 +6,7 @@
 #include "consensus/yac/impl/yac_gate_impl.hpp"
 
 #include <boost/range/adaptor/transformed.hpp>
+#include <rxcpp/operators/rx-flat_map.hpp>
 #include "common/visitor.hpp"
 #include "consensus/yac/cluster_order.hpp"
 #include "consensus/yac/outcome_messages.hpp"

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/consensus_block_cache.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "logger/logger_fwd.hpp"

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -13,11 +13,13 @@
 #include <mutex>
 
 #include <boost/optional.hpp>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/yac/cluster_order.hpp"     //  for ClusterOrdering
 #include "consensus/yac/outcome_messages.hpp"  // because messages passed by value
 #include "consensus/yac/storage/yac_vote_storage.hpp"  // for VoteStorage
 #include "logger/logger_fwd.hpp"
+
+#include <rxcpp/operators/rx-observe_on.hpp>
 
 namespace iroha {
   namespace consensus {

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_YAC_GATE_HPP
 #define IROHA_YAC_GATE_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/yac/cluster_order.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "network/consensus_gate.hpp"

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_YAC_GATE_HPP
 #define IROHA_YAC_GATE_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "consensus/yac/cluster_order.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "network/consensus_gate.hpp"

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -6,7 +6,7 @@
 #include "main/application.hpp"
 
 #include <boost/filesystem.hpp>
-
+#include <rxcpp/operators/rx-map.hpp>
 #include "ametsuchi/impl/flat_file_block_storage.hpp"
 #include "ametsuchi/impl/k_times_reconnection_strategy.hpp"
 #include "ametsuchi/impl/pool_wrapper.hpp"

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -15,6 +15,7 @@
 #include "consensus/yac/storage/buffered_cleanup_strategy.hpp"
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
+#include "consensus/yac/yac.hpp"
 #include "logger/logger_manager.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -10,10 +10,10 @@
 
 #include "ametsuchi/peer_query_factory.hpp"
 #include "consensus/consensus_block_cache.hpp"
+#include "consensus/yac/consistency_model.hpp"
 #include "consensus/yac/outcome_messages.hpp"
 #include "consensus/yac/timer.hpp"
 #include "consensus/yac/transport/impl/network_impl.hpp"
-#include "consensus/yac/yac.hpp"
 #include "consensus/yac/yac_gate.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "consensus/yac/yac_peer_orderer.hpp"

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -5,6 +5,13 @@
 
 #include "main/impl/on_demand_ordering_init.hpp"
 
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-map.hpp>
+#include <rxcpp/operators/rx-skip.hpp>
+#include <rxcpp/operators/rx-start_with.hpp>
+#include <rxcpp/operators/rx-tap.hpp>
+#include <rxcpp/operators/rx-with_latest_from.hpp>
+#include <rxcpp/operators/rx-zip.hpp>
 #include "common/bind.hpp"
 #include "common/delay.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -8,6 +8,7 @@
 
 #include <random>
 
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/storage.hpp"
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"

--- a/irohad/main/impl/pending_transaction_storage_init.cpp
+++ b/irohad/main/impl/pending_transaction_storage_init.cpp
@@ -5,6 +5,7 @@
 
 #include "main/impl/pending_transaction_storage_init.hpp"
 
+#include <rxcpp/operators/rx-flat_map.hpp>
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "network/peer_communication_service.hpp"

--- a/irohad/main/impl/pending_transaction_storage_init.hpp
+++ b/irohad/main/impl/pending_transaction_storage_init.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {

--- a/irohad/model/commit.hpp
+++ b/irohad/model/commit.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_COMMIT_HPP
 #define IROHA_COMMIT_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 namespace iroha {
   using OldCommit = rxcpp::observable<model::Block>;

--- a/irohad/model/commit.hpp
+++ b/irohad/model/commit.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_COMMIT_HPP
 #define IROHA_COMMIT_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 
 namespace iroha {
   using OldCommit = rxcpp::observable<model::Block>;

--- a/irohad/model/converters/impl/pb_query_response_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_response_factory.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "model/converters/pb_query_response_factory.hpp"
+#include <rxcpp/operators/rx-reduce.hpp>
 #include "common/byteutils.hpp"
 #include "common/instanceof.hpp"
 #include "model/converters/pb_common.hpp"

--- a/irohad/model/queries/responses/transactions_response.hpp
+++ b/irohad/model/queries/responses/transactions_response.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_TRANSACTIONS_RESPONSE_HPP
 #define IROHA_TRANSACTIONS_RESPONSE_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "model/transaction.hpp"
 
 namespace iroha {

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
@@ -10,9 +10,12 @@
 #include <chrono>
 #include <mutex>
 
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/peer_query_factory.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy_params.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"
+
+#include <rxcpp/operators/rx-observe_on.hpp>
 
 namespace iroha {
 

--- a/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
+++ b/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/range/irange.hpp>
+#include <rxcpp/operators/rx-map.hpp>
 #include "common/bind.hpp"
 
 namespace iroha {

--- a/irohad/multi_sig_transactions/impl/mst_processor.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor.cpp
@@ -5,6 +5,8 @@
 
 #include "multi_sig_transactions/mst_processor.hpp"
 
+#include <rxcpp/rx-lite.hpp>
+
 namespace iroha {
 
   MstProcessor::MstProcessor(logger::LoggerPtr log) : log_(std::move(log)) {}

--- a/irohad/multi_sig_transactions/impl/mst_propagation_strategy_stub.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_propagation_strategy_stub.cpp
@@ -5,6 +5,8 @@
 
 #include "multi_sig_transactions/mst_propagation_strategy_stub.hpp"
 
+#include <rxcpp/rx-lite.hpp>
+
 namespace iroha {
   rxcpp::observable<PropagationStrategy::PropagationData>
   PropagationStrategyStub::emitter() {

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 #include <mutex>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 #include <mutex>
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -6,14 +6,17 @@
 #ifndef IROHA_MST_PROCESSOR_IMPL_HPP
 #define IROHA_MST_PROCESSOR_IMPL_HPP
 
+#include "multi_sig_transactions/mst_processor.hpp"
+#include "network/mst_transport.hpp"
+
 #include <memory>
+
+#include <rxcpp/rx-lite.hpp>
 #include "cryptography/public_key.hpp"
 #include "logger/logger_fwd.hpp"
-#include "multi_sig_transactions/mst_processor.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
 #include "multi_sig_transactions/storage/mst_storage.hpp"
-#include "network/mst_transport.hpp"
 
 namespace iroha {
 

--- a/irohad/multi_sig_transactions/mst_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/mst_propagation_strategy.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_MST_PROPAGATION_STRATEGY_HPP
 #define IROHA_MST_PROPAGATION_STRATEGY_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include <vector>
 #include "interfaces/common_objects/peer.hpp"
 

--- a/irohad/multi_sig_transactions/mst_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/mst_propagation_strategy.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_MST_PROPAGATION_STRATEGY_HPP
 #define IROHA_MST_PROPAGATION_STRATEGY_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include <vector>
 #include "interfaces/common_objects/peer.hpp"
 

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -7,7 +7,7 @@
 #define IROHA_BLOCK_LOADER_HPP
 
 #include <memory>
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -7,7 +7,7 @@
 #define IROHA_BLOCK_LOADER_HPP
 
 #include <memory>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_CONSENSUS_GATE_HPP
 #define IROHA_CONSENSUS_GATE_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/gate_object.hpp"
 
 namespace shared_model {

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_CONSENSUS_GATE_HPP
 #define IROHA_CONSENSUS_GATE_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "consensus/gate_object.hpp"
 
 namespace shared_model {

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -5,9 +5,10 @@
 
 #include "network/impl/block_loader_impl.hpp"
 
-#include <grpc++/create_channel.h>
 #include <chrono>
 
+#include <grpc++/create_channel.h>
+#include <rxcpp/rx-lite.hpp>
 #include "backend/protobuf/block.hpp"
 #include "builders/protobuf/transport_builder.hpp"
 #include "common/bind.hpp"

--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -5,6 +5,7 @@
 
 #include "network/impl/peer_communication_service_impl.hpp"
 
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "logger/logger.hpp"
 #include "network/ordering_gate.hpp"

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "network/ordering_gate_common.hpp"
 #include "network/peer_communication_service.hpp"
 

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "network/ordering_gate_common.hpp"
 #include "network/peer_communication_service.hpp"
 

--- a/irohad/network/peer_communication_service.hpp
+++ b/irohad/network/peer_communication_service.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_PEER_COMMUNICATION_SERVICE_HPP
 #define IROHA_PEER_COMMUNICATION_SERVICE_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "network/ordering_gate_common.hpp"
 #include "simulator/verified_proposal_creator_common.hpp"
 #include "synchronizer/synchronizer_common.hpp"

--- a/irohad/network/peer_communication_service.hpp
+++ b/irohad/network/peer_communication_service.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_PEER_COMMUNICATION_SERVICE_HPP
 #define IROHA_PEER_COMMUNICATION_SERVICE_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "network/ordering_gate_common.hpp"
 #include "simulator/verified_proposal_creator_common.hpp"
 #include "synchronizer/synchronizer_common.hpp"

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -10,7 +10,7 @@
 
 #include <shared_mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -11,7 +11,7 @@
 #include <shared_mutex>
 
 #include <boost/variant.hpp>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
@@ -11,7 +11,7 @@
 #include <shared_mutex>
 #include <unordered_map>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "pending_txs_storage/pending_txs_storage.hpp"
 

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -7,7 +7,6 @@
 #define IROHA_PENDING_TXS_STORAGE_HPP
 
 #include <boost/optional.hpp>
-#include <rxcpp/rx-lite.hpp>
 #include "common/result.hpp"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -7,7 +7,7 @@
 #define IROHA_PENDING_TXS_STORAGE_HPP
 
 #include <boost/optional.hpp>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "common/result.hpp"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_BLOCK_CREATOR_HPP
 #define IROHA_BLOCK_CREATOR_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "simulator/block_creator_common.hpp"
 
 namespace iroha {

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_BLOCK_CREATOR_HPP
 #define IROHA_BLOCK_CREATOR_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "simulator/block_creator_common.hpp"
 
 namespace iroha {

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -10,6 +10,7 @@
 #include "simulator/verified_proposal_creator.hpp"
 
 #include <boost/optional.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/temporary_factory.hpp"
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
 #include "interfaces/iroha_internal/unsafe_block_factory.hpp"

--- a/irohad/simulator/verified_proposal_creator.hpp
+++ b/irohad/simulator/verified_proposal_creator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 #define IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "simulator/verified_proposal_creator_common.hpp"
 
 namespace shared_model {

--- a/irohad/simulator/verified_proposal_creator.hpp
+++ b/irohad/simulator/verified_proposal_creator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 #define IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "simulator/verified_proposal_creator_common.hpp"
 
 namespace shared_model {

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include <rxcpp/operators/rx-tap.hpp>
 #include "ametsuchi/block_query_factory.hpp"
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/mutable_storage.hpp"

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -8,6 +8,7 @@
 
 #include "synchronizer/synchronizer.hpp"
 
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/commit_result.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SYNCHRONIZER_HPP
 #define IROHA_SYNCHRONIZER_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 #include "consensus/gate_object.hpp"
 #include "synchronizer/synchronizer_common.hpp"

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SYNCHRONIZER_HPP
 #define IROHA_SYNCHRONIZER_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 
 #include "consensus/gate_object.hpp"
 #include "synchronizer/synchronizer_common.hpp"

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -6,7 +6,7 @@
 #ifndef TORII_COMMAND_SERVICE_HPP
 #define TORII_COMMAND_SERVICE_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {

--- a/irohad/torii/command_service.hpp
+++ b/irohad/torii/command_service.hpp
@@ -6,7 +6,7 @@
 #ifndef TORII_COMMAND_SERVICE_HPP
 #define TORII_COMMAND_SERVICE_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -5,6 +5,8 @@
 
 #include "torii/impl/command_service_impl.hpp"
 
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-start_with.hpp>
 #include "ametsuchi/block_query.hpp"
 #include "common/byteutils.hpp"
 #include "common/is_any.hpp"

--- a/irohad/torii/impl/command_service_impl.hpp
+++ b/irohad/torii/impl/command_service_impl.hpp
@@ -8,6 +8,7 @@
 
 #include "torii/command_service.hpp"
 
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/storage.hpp"
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "cache/cache.hpp"

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -14,6 +14,8 @@
 #include <boost/format.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <rxcpp/operators/rx-start_with.hpp>
+#include <rxcpp/operators/rx-take_while.hpp>
 #include "backend/protobuf/transaction_responses/proto_tx_response.hpp"
 #include "common/combine_latest_until_first_completed.hpp"
 #include "common/run_loop_handler.hpp"

--- a/irohad/torii/impl/command_service_transport_grpc.hpp
+++ b/irohad/torii/impl/command_service_transport_grpc.hpp
@@ -8,6 +8,7 @@
 
 #include "torii/command_service.hpp"
 
+#include <rxcpp/rx-lite.hpp>
 #include "endpoint.grpc.pb.h"
 #include "endpoint.pb.h"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"

--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -5,6 +5,8 @@
 
 #include "torii/query_service.hpp"
 
+#include <rxcpp/operators/rx-observe_on.hpp>
+#include <rxcpp/operators/rx-take_while.hpp>
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "common/run_loop_handler.hpp"

--- a/irohad/torii/impl/status_bus_impl.hpp
+++ b/irohad/torii/impl/status_bus_impl.hpp
@@ -8,6 +8,10 @@
 
 #include "torii/status_bus.hpp"
 
+#include <rxcpp/rx-lite.hpp>
+
+#include <rxcpp/operators/rx-observe_on.hpp>
+
 namespace iroha {
   namespace torii {
     /**

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_QUERY_PROCESSOR_HPP
 #define IROHA_QUERY_PROCESSOR_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 
 #include <memory>
 

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_QUERY_PROCESSOR_HPP
 #define IROHA_QUERY_PROCESSOR_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 #include <memory>
 

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -6,10 +6,12 @@
 #ifndef IROHA_QUERY_PROCESSOR_IMPL_HPP
 #define IROHA_QUERY_PROCESSOR_IMPL_HPP
 
+#include "torii/processor/query_processor.hpp"
+
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/storage.hpp"
 #include "interfaces/iroha_internal/query_response_factory.hpp"
 #include "logger/logger_fwd.hpp"
-#include "torii/processor/query_processor.hpp"
 
 namespace iroha {
   namespace torii {

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
 #include "interfaces/transaction_responses/tx_response.hpp"

--- a/irohad/torii/status_bus.hpp
+++ b/irohad/torii/status_bus.hpp
@@ -6,7 +6,7 @@
 #ifndef TORII_STATUS_BUS
 #define TORII_STATUS_BUS
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "interfaces/transaction_responses/tx_response.hpp"
 
 namespace iroha {

--- a/irohad/torii/status_bus.hpp
+++ b/irohad/torii/status_bus.hpp
@@ -6,7 +6,7 @@
 #ifndef TORII_STATUS_BUS
 #define TORII_STATUS_BUS
 
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "interfaces/transaction_responses/tx_response.hpp"
 
 namespace iroha {

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_CHAIN_VALIDATOR_HPP
 #define IROHA_CHAIN_VALIDATOR_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 namespace shared_model {
   namespace interface {

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -6,7 +6,9 @@
 #ifndef IROHA_CHAIN_VALIDATOR_HPP
 #define IROHA_CHAIN_VALIDATOR_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <memory>
+
+#include <rxcpp/rx-observable-fwd.hpp>
 
 namespace shared_model {
   namespace interface {

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -5,6 +5,7 @@
 
 #include "validation/impl/chain_validator_impl.hpp"
 
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "consensus/yac/supermajority_checker.hpp"

--- a/libs/common/run_loop_handler.hpp
+++ b/libs/common/run_loop_handler.hpp
@@ -7,7 +7,7 @@
 
 #include <condition_variable>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 namespace iroha {
   namespace schedulers {

--- a/test/framework/integration_framework/fake_peer/behaviour/behaviour.hpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/behaviour.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"
 #include "logger/logger_fwd.hpp"

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <boost/core/noncopyable.hpp>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/network/mst_message.hpp"
 #include "framework/integration_framework/fake_peer/proposal_storage.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <boost/core/noncopyable.hpp>
-#include <rxcpp/rx-lite.hpp>
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "framework/integration_framework/fake_peer/network/mst_message.hpp"
 #include "framework/integration_framework/fake_peer/proposal_storage.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.hpp
@@ -6,7 +6,7 @@
 #ifndef INTEGRATION_FRAMEWORK_FAKE_PEER_LOADER_GRPC_HPP_
 #define INTEGRATION_FRAMEWORK_FAKE_PEER_LOADER_GRPC_HPP_
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/types.hpp"
 #include "loader.grpc.pb.h"
 #include "logger/logger_fwd.hpp"

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/network/mst_message.hpp"
 #include "framework/integration_framework/fake_peer/types.hpp"
 

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -6,7 +6,7 @@
 #ifndef FAKE_PEER_ODOS_NETWORK_NOTIFIER_HPP_
 #define FAKE_PEER_ODOS_NETWORK_NOTIFIER_HPP_
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 
 #include <mutex>
 

--- a/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_gate_network_notifier.hpp
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/types.hpp"
 
 namespace integration_framework {

--- a/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/ordering_service_network_notifier.hpp
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/types.hpp"
 
 namespace integration_framework {

--- a/test/framework/integration_framework/fake_peer/network/yac_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/yac_network_notifier.hpp
@@ -10,7 +10,7 @@
 
 #include <mutex>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "framework/integration_framework/fake_peer/types.hpp"
 
 namespace integration_framework {

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -10,6 +10,10 @@
 
 #include <boost/assert.hpp>
 #include <boost/thread/barrier.hpp>
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-flat_map.hpp>
+#include <rxcpp/operators/rx-take.hpp>
+#include <rxcpp/operators/rx-zip.hpp>
 #include "ametsuchi/storage.hpp"
 #include "backend/protobuf/block.hpp"
 #include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_INTEGRATION_FRAMEWORK_HPP
 #define IROHA_INTEGRATION_FRAMEWORK_HPP
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/gate_object.hpp"
 #include "cryptography/keypair.hpp"
 #include "logger/logger_fwd.hpp"

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -6,7 +6,11 @@
 #ifndef IROHA_INTEGRATION_FRAMEWORK_HPP
 #define IROHA_INTEGRATION_FRAMEWORK_HPP
 
-#include <rxcpp/rx-lite.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "consensus/gate_object.hpp"
 #include "cryptography/keypair.hpp"
 #include "logger/logger_fwd.hpp"

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -8,7 +8,7 @@
 
 #include <functional>
 #include <memory>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include <utility>
 
 namespace framework {

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -5,6 +5,11 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-observe_on.hpp>
+#include <rxcpp/operators/rx-replay.hpp>
+#include <rxcpp/operators/rx-take.hpp>
+#include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "consensus/yac/vote_message.hpp"

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -5,6 +5,13 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-flat_map.hpp>
+#include <rxcpp/operators/rx-observe_on.hpp>
+#include <rxcpp/operators/rx-replay.hpp>
+#include <rxcpp/operators/rx-take.hpp>
+#include <rxcpp/operators/rx-tap.hpp>
+#include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"

--- a/test/integration/acceptance/query_test.cpp
+++ b/test/integration/acceptance/query_test.cpp
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "integration/acceptance/acceptance_fixture.hpp"
+
+#include <thread>
+
 #include <boost/variant.hpp>
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "framework/integration_framework/integration_test_framework.hpp"
-#include "integration/acceptance/acceptance_fixture.hpp"
 #include "interfaces/query_responses/transactions_response.hpp"
 
 using namespace integration_framework;

--- a/test/integration/acceptance/remove_peer_test.cpp
+++ b/test/integration/acceptance/remove_peer_test.cpp
@@ -5,6 +5,11 @@
 
 #include "integration/acceptance/fake_peer_fixture.hpp"
 
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-observe_on.hpp>
+#include <rxcpp/operators/rx-replay.hpp>
+#include <rxcpp/operators/rx-take.hpp>
+#include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "consensus/yac/vote_message.hpp"

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -15,6 +15,8 @@
 #include "consensus/yac/yac.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 
+#include <rxcpp/operators/rx-take.hpp>
+#include <rxcpp/operators/rx-timeout.hpp>
 #include "framework/test_logger.hpp"
 #include "framework/test_subscriber.hpp"
 #include "logger/logger_manager.hpp"

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/mutable_storage.hpp"
 
 #include <gmock/gmock.h>
+#include <rxcpp/rx-lite.hpp>
 
 namespace iroha {
   namespace ametsuchi {

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/storage.hpp"
 
 #include <gmock/gmock.h>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "ametsuchi/temporary_wsv.hpp"

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "consensus/consensus_block_cache.hpp"
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"

--- a/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
@@ -16,11 +16,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <boost/range/irange.hpp>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/peer_query_factory.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "module/shared_model/interface_mocks.hpp"
+
+#include <rxcpp/operators/rx-take.hpp>
 
 using namespace iroha;
 

--- a/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/old_pending_txs_storage_test.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "datetime/time.hpp"
 #include "framework/test_logger.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -4,12 +4,14 @@
  */
 
 #include <gtest/gtest.h>
-#include <rxcpp/rx.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "datetime/time.hpp"
 #include "framework/test_logger.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
 #include "pending_txs_storage/impl/pending_txs_storage_impl.hpp"
+
+#include <rxcpp/operators/rx-flat_map.hpp>
 
 // TODO igor-egorov 2019-06-24 IR-573 Refactor pending txs storage tests
 class PendingTxsStorageFixture : public ::testing::Test {

--- a/test/module/irohad/torii/processor/mock_query_processor.hpp
+++ b/test/module/irohad/torii/processor/mock_query_processor.hpp
@@ -9,6 +9,7 @@
 #include "torii/processor/query_processor.hpp"
 
 #include <gmock/gmock.h>
+#include <rxcpp/rx-lite.hpp>
 
 namespace iroha {
   namespace torii {


### PR DESCRIPTION
### Description of the Change
Use `rx-lite` and `rx-observable-fwd` headers to reduce parsing time of compilation. Previous inclusion of all rx operators resulted in significant parsing time increase.

### Benefits
Reduced build time

### Possible Drawbacks 
None