### PR TITLE
Shared model: simplify proto query backend

### DIFF
--- a/irohad/torii/impl/query_service.cpp
+++ b/irohad/torii/impl/query_service.cpp
@@ -9,6 +9,7 @@
 #include <rxcpp/operators/rx-take_while.hpp>
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
+#include "backend/protobuf/util.hpp"
 #include "common/run_loop_handler.hpp"
 #include "cryptography/default_hash_provider.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -5,6 +5,7 @@
 
 #include "backend/protobuf/proto_query_response_factory.hpp"
 
+#include "backend/protobuf/block.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 #include "backend/protobuf/query_responses/proto_query_response.hpp"

--- a/shared_model/backend/protobuf/permissions.hpp
+++ b/shared_model/backend/protobuf/permissions.hpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "primitive.pb.h"
 
 namespace shared_model {

--- a/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
@@ -5,30 +5,25 @@
 
 #include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
 
+#include <boost/optional.hpp>
+
 namespace types = shared_model::interface::types;
 
 using namespace shared_model::proto;
 
-AssetPaginationMeta::AssetPaginationMeta(const TransportType &query)
-    : TrivialProto(query) {}
-
-AssetPaginationMeta::AssetPaginationMeta(TransportType &&query)
-    : TrivialProto(std::move(query)) {}
-
-AssetPaginationMeta::AssetPaginationMeta(const AssetPaginationMeta &o)
-    : AssetPaginationMeta(*o.proto_) {}
-
-AssetPaginationMeta::AssetPaginationMeta(AssetPaginationMeta &&o) noexcept
-    : TrivialProto(std::move(*o.proto_)) {}
+AssetPaginationMeta::AssetPaginationMeta(
+    iroha::protocol::AssetPaginationMeta &meta)
+    : meta_{meta} {}
 
 types::TransactionsNumberType AssetPaginationMeta::pageSize() const {
-  return proto_->page_size();
+  return meta_.page_size();
 }
 
 boost::optional<types::AssetIdType> AssetPaginationMeta::firstAssetId() const {
-  if (proto_->opt_first_asset_id_case()
-      == TransportType::OptFirstAssetIdCase::OPT_FIRST_ASSET_ID_NOT_SET) {
+  if (meta_.opt_first_asset_id_case()
+      == iroha::protocol::AssetPaginationMeta::OptFirstAssetIdCase::
+             OPT_FIRST_ASSET_ID_NOT_SET) {
     return boost::none;
   }
-  return proto_->first_asset_id();
+  return meta_.first_asset_id();
 }

--- a/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
@@ -4,41 +4,35 @@
  */
 
 #include "backend/protobuf/queries/proto_blocks_query.hpp"
+
 #include "backend/protobuf/util.hpp"
 
 namespace shared_model {
   namespace proto {
 
-    template <typename BlocksQueryType>
-    BlocksQuery::BlocksQuery(BlocksQueryType &&query)
-        : TrivialProto(std::forward<BlocksQueryType>(query)),
-          blob_{makeBlob(*proto_)},
-          payload_{makeBlob(proto_->meta())},
+    BlocksQuery::BlocksQuery(const TransportType &query)
+        : BlocksQuery(TransportType(query)) {}
+
+    BlocksQuery::BlocksQuery(TransportType &&query)
+        : proto_{std::move(query)},
+          blob_{makeBlob(proto_)},
+          payload_{makeBlob(proto_.meta())},
           signatures_{[this] {
             SignatureSetType<proto::Signature> set;
-            if (proto_->has_signature()) {
-              set.emplace(proto_->signature());
+            if (proto_.has_signature()) {
+              set.emplace(*proto_.mutable_signature());
             }
             return set;
           }()},
           hash_(makeHash(payload_)) {}
 
-    template BlocksQuery::BlocksQuery(BlocksQuery::TransportType &);
-    template BlocksQuery::BlocksQuery(const BlocksQuery::TransportType &);
-    template BlocksQuery::BlocksQuery(BlocksQuery::TransportType &&);
-
-    BlocksQuery::BlocksQuery(const BlocksQuery &o) : BlocksQuery(o.proto_) {}
-
-    BlocksQuery::BlocksQuery(BlocksQuery &&o) noexcept
-        : BlocksQuery(std::move(o.proto_)) {}
-
     const interface::types::AccountIdType &BlocksQuery::creatorAccountId()
         const {
-      return proto_->meta().creator_account_id();
+      return proto_.meta().creator_account_id();
     }
 
     interface::types::CounterType BlocksQuery::queryCounter() const {
-      return proto_->meta().query_counter();
+      return proto_.meta().query_counter();
     }
 
     const interface::types::BlobType &BlocksQuery::blob() const {
@@ -55,15 +49,15 @@ namespace shared_model {
 
     bool BlocksQuery::addSignature(const crypto::Signed &signed_blob,
                                    const crypto::PublicKey &public_key) {
-      if (proto_->has_signature()) {
+      if (proto_.has_signature()) {
         return false;
       }
 
-      auto sig = proto_->mutable_signature();
+      auto sig = proto_.mutable_signature();
       sig->set_signature(signed_blob.hex());
       sig->set_public_key(public_key.hex());
       // TODO: nickaleks IR-120 12.12.2018 remove set
-      signatures_.emplace(proto_->signature());
+      signatures_.emplace(*proto_.mutable_signature());
       return true;
     }
 
@@ -72,7 +66,11 @@ namespace shared_model {
     }
 
     interface::types::TimestampType BlocksQuery::createdTime() const {
-      return proto_->meta().created_time();
+      return proto_.meta().created_time();
+    }
+
+    const BlocksQuery::TransportType &BlocksQuery::getTransport() const {
+      return proto_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account.cpp
@@ -8,19 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAccount::GetAccount(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_{proto_->payload().get_account()} {}
-
-    template GetAccount::GetAccount(GetAccount::TransportType &);
-    template GetAccount::GetAccount(const GetAccount::TransportType &);
-    template GetAccount::GetAccount(GetAccount::TransportType &&);
-
-    GetAccount::GetAccount(const GetAccount &o) : GetAccount(o.proto_) {}
-
-    GetAccount::GetAccount(GetAccount &&o) noexcept
-        : GetAccount(std::move(o.proto_)) {}
+    GetAccount::GetAccount(iroha::protocol::Query &query)
+        : account_{query.payload().get_account()} {}
 
     const interface::types::AccountIdType &GetAccount::accountId() const {
       return account_.account_id();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_asset_transactions.cpp
@@ -10,27 +10,13 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAccountAssetTransactions::GetAccountAssetTransactions(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_asset_transactions_{
-              proto_->payload().get_account_asset_transactions()},
-          pagination_meta_{account_asset_transactions_.pagination_meta()} {}
-
-    template GetAccountAssetTransactions::GetAccountAssetTransactions(
-        GetAccountAssetTransactions::TransportType &);
-    template GetAccountAssetTransactions::GetAccountAssetTransactions(
-        const GetAccountAssetTransactions::TransportType &);
-    template GetAccountAssetTransactions::GetAccountAssetTransactions(
-        GetAccountAssetTransactions::TransportType &&);
-
     GetAccountAssetTransactions::GetAccountAssetTransactions(
-        const GetAccountAssetTransactions &o)
-        : GetAccountAssetTransactions(o.proto_) {}
-
-    GetAccountAssetTransactions::GetAccountAssetTransactions(
-        GetAccountAssetTransactions &&o) noexcept
-        : GetAccountAssetTransactions(std::move(o.proto_)) {}
+        iroha::protocol::Query &query)
+        : account_asset_transactions_{query.payload()
+                                          .get_account_asset_transactions()},
+          pagination_meta_{*query.mutable_payload()
+                                ->mutable_get_account_asset_transactions()
+                                ->mutable_pagination_meta()} {}
 
     const interface::types::AccountIdType &
     GetAccountAssetTransactions::accountId() const {

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
@@ -8,32 +8,17 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAccountAssets::GetAccountAssets(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_assets_{proto_->payload().get_account_assets()},
-          pagination_meta_{
-              [this]() -> boost::optional<const AssetPaginationMeta> {
-                if (this->account_assets_.has_pagination_meta()) {
-                  return AssetPaginationMeta{
-                      this->account_assets_.pagination_meta()};
-                } else {
-                  return boost::none;
-                }
-              }()} {}
-
-    template GetAccountAssets::GetAccountAssets(
-        GetAccountAssets::TransportType &);
-    template GetAccountAssets::GetAccountAssets(
-        const GetAccountAssets::TransportType &);
-    template GetAccountAssets::GetAccountAssets(
-        GetAccountAssets::TransportType &&);
-
-    GetAccountAssets::GetAccountAssets(const GetAccountAssets &o)
-        : GetAccountAssets(o.proto_) {}
-
-    GetAccountAssets::GetAccountAssets(GetAccountAssets &&o) noexcept
-        : GetAccountAssets(std::move(o.proto_)) {}
+    GetAccountAssets::GetAccountAssets(iroha::protocol::Query &query)
+        : account_assets_{query.payload().get_account_assets()},
+          pagination_meta_{[&]() -> boost::optional<const AssetPaginationMeta> {
+            if (query.payload().get_account_assets().has_pagination_meta()) {
+              return AssetPaginationMeta{*query.mutable_payload()
+                                              ->mutable_get_account_assets()
+                                              ->mutable_pagination_meta()};
+            } else {
+              return boost::none;
+            }
+          }()} {}
 
     const interface::types::AccountIdType &GetAccountAssets::accountId() const {
       return account_assets_.account_id();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_detail.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_detail.cpp
@@ -8,37 +8,23 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAccountDetail::GetAccountDetail(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_detail_{proto_->payload().get_account_detail()},
-          pagination_meta_{[this]() -> decltype(pagination_meta_) {
-            if (this->account_detail_.has_pagination_meta()) {
+    GetAccountDetail::GetAccountDetail(iroha::protocol::Query &query)
+        : query_{query},
+          account_detail_{query.payload().get_account_detail()},
+          pagination_meta_{[&]() -> decltype(pagination_meta_) {
+            if (query.payload().get_account_detail().has_pagination_meta()) {
               return AccountDetailPaginationMeta{
-                  *this->proto_->mutable_payload()
+                  *query.mutable_payload()
                        ->mutable_get_account_detail()
                        ->mutable_pagination_meta()};
             }
             return boost::none;
           }()} {}
 
-    template GetAccountDetail::GetAccountDetail(
-        GetAccountDetail::TransportType &);
-    template GetAccountDetail::GetAccountDetail(
-        const GetAccountDetail::TransportType &);
-    template GetAccountDetail::GetAccountDetail(
-        GetAccountDetail::TransportType &&);
-
-    GetAccountDetail::GetAccountDetail(const GetAccountDetail &o)
-        : GetAccountDetail(o.proto_) {}
-
-    GetAccountDetail::GetAccountDetail(GetAccountDetail &&o) noexcept
-        : GetAccountDetail(std::move(o.proto_)) {}
-
     const interface::types::AccountIdType &GetAccountDetail::accountId() const {
       return account_detail_.opt_account_id_case()
           ? account_detail_.account_id()
-          : proto_->payload().meta().creator_account_id();
+          : query_.payload().meta().creator_account_id();
     }
 
     boost::optional<interface::types::AccountDetailKeyType>

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_transactions.cpp
@@ -10,26 +10,12 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAccountTransactions::GetAccountTransactions(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_transactions_{proto_->payload().get_account_transactions()},
-          pagination_meta_{account_transactions_.pagination_meta()} {}
-
-    template GetAccountTransactions::GetAccountTransactions(
-        GetAccountTransactions::TransportType &);
-    template GetAccountTransactions::GetAccountTransactions(
-        const GetAccountTransactions::TransportType &);
-    template GetAccountTransactions::GetAccountTransactions(
-        GetAccountTransactions::TransportType &&);
-
     GetAccountTransactions::GetAccountTransactions(
-        const GetAccountTransactions &o)
-        : GetAccountTransactions(o.proto_) {}
-
-    GetAccountTransactions::GetAccountTransactions(
-        GetAccountTransactions &&o) noexcept
-        : GetAccountTransactions(std::move(o.proto_)) {}
+        iroha::protocol::Query &query)
+        : account_transactions_{query.payload().get_account_transactions()},
+          pagination_meta_{*query.mutable_payload()
+                                ->mutable_get_account_transactions()
+                                ->mutable_pagination_meta()} {}
 
     const interface::types::AccountIdType &GetAccountTransactions::accountId()
         const {

--- a/shared_model/backend/protobuf/queries/impl/proto_get_asset_info.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_asset_info.cpp
@@ -8,20 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetAssetInfo::GetAssetInfo(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          asset_info_{proto_->payload().get_asset_info()} {}
-
-    template GetAssetInfo::GetAssetInfo(GetAssetInfo::TransportType &);
-    template GetAssetInfo::GetAssetInfo(const GetAssetInfo::TransportType &);
-    template GetAssetInfo::GetAssetInfo(GetAssetInfo::TransportType &&);
-
-    GetAssetInfo::GetAssetInfo(const GetAssetInfo &o)
-        : GetAssetInfo(o.proto_) {}
-
-    GetAssetInfo::GetAssetInfo(GetAssetInfo &&o) noexcept
-        : GetAssetInfo(std::move(o.proto_)) {}
+    GetAssetInfo::GetAssetInfo(iroha::protocol::Query &query)
+        : asset_info_{query.payload().get_asset_info()} {}
 
     const interface::types::AssetIdType &GetAssetInfo::assetId() const {
       return asset_info_.asset_id();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_block.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_block.cpp
@@ -8,18 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetBlock::GetBlock(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          get_block_{proto_->payload().get_block()} {}
-
-    template GetBlock::GetBlock(GetBlock::TransportType &);
-    template GetBlock::GetBlock(const GetBlock::TransportType &);
-    template GetBlock::GetBlock(GetBlock::TransportType &&);
-
-    GetBlock::GetBlock(const GetBlock &o) : GetBlock(o.proto_) {}
-
-    GetBlock::GetBlock(GetBlock &&o) noexcept : GetBlock(std::move(o.proto_)) {}
+    GetBlock::GetBlock(iroha::protocol::Query &query)
+        : get_block_{query.payload().get_block()} {}
 
     interface::types::HeightType GetBlock::height() const {
       return get_block_.height();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_peers.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_peers.cpp
@@ -8,17 +8,7 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetPeers::GetPeers(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)) {}
-
-    template GetPeers::GetPeers(GetPeers::TransportType &);
-    template GetPeers::GetPeers(const GetPeers::TransportType &);
-    template GetPeers::GetPeers(GetPeers::TransportType &&);
-
-    GetPeers::GetPeers(const GetPeers &o) : GetPeers(o.proto_) {}
-
-    GetPeers::GetPeers(GetPeers &&o) noexcept : GetPeers(std::move(o.proto_)) {}
+    GetPeers::GetPeers(iroha::protocol::Query &query) {}
 
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
@@ -8,31 +8,19 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetPendingTransactions::GetPendingTransactions(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          pending_transactions_{proto_->payload().get_pending_transactions()},
-          pagination_meta_{[this]() -> boost::optional<const TxPaginationMeta> {
-            if (pending_transactions_.has_pagination_meta()) {
-              return TxPaginationMeta{pending_transactions_.pagination_meta()};
+    GetPendingTransactions::GetPendingTransactions(
+        iroha::protocol::Query &query)
+        : pending_transactions_{query.payload().get_pending_transactions()},
+          pagination_meta_{[&]() -> boost::optional<const TxPaginationMeta> {
+            if (query.payload()
+                    .get_pending_transactions()
+                    .has_pagination_meta()) {
+              return TxPaginationMeta{*query.mutable_payload()
+                                           ->mutable_get_pending_transactions()
+                                           ->mutable_pagination_meta()};
             }
             return boost::none;
           }()} {}
-
-    template GetPendingTransactions::GetPendingTransactions(
-        GetPendingTransactions::TransportType &);
-    template GetPendingTransactions::GetPendingTransactions(
-        const GetPendingTransactions::TransportType &);
-    template GetPendingTransactions::GetPendingTransactions(
-        GetPendingTransactions::TransportType &&);
-
-    GetPendingTransactions::GetPendingTransactions(
-        const GetPendingTransactions &o)
-        : GetPendingTransactions(o.proto_) {}
-
-    GetPendingTransactions::GetPendingTransactions(
-        GetPendingTransactions &&o) noexcept
-        : GetPendingTransactions(std::move(o.proto_)) {}
 
     boost::optional<const interface::TxPaginationMeta &>
     GetPendingTransactions::paginationMeta() const {

--- a/shared_model/backend/protobuf/queries/impl/proto_get_role_permissions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_role_permissions.cpp
@@ -8,23 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetRolePermissions::GetRolePermissions(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          role_permissions_{proto_->payload().get_role_permissions()} {}
-
-    template GetRolePermissions::GetRolePermissions(
-        GetRolePermissions::TransportType &);
-    template GetRolePermissions::GetRolePermissions(
-        const GetRolePermissions::TransportType &);
-    template GetRolePermissions::GetRolePermissions(
-        GetRolePermissions::TransportType &&);
-
-    GetRolePermissions::GetRolePermissions(const GetRolePermissions &o)
-        : GetRolePermissions(o.proto_) {}
-
-    GetRolePermissions::GetRolePermissions(GetRolePermissions &&o) noexcept
-        : GetRolePermissions(std::move(o.proto_)) {}
+    GetRolePermissions::GetRolePermissions(iroha::protocol::Query &query)
+        : role_permissions_{query.payload().get_role_permissions()} {}
 
     const interface::types::RoleIdType &GetRolePermissions::roleId() const {
       return role_permissions_.role_id();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_roles.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_roles.cpp
@@ -8,17 +8,7 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetRoles::GetRoles(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)) {}
-
-    template GetRoles::GetRoles(GetRoles::TransportType &);
-    template GetRoles::GetRoles(const GetRoles::TransportType &);
-    template GetRoles::GetRoles(GetRoles::TransportType &&);
-
-    GetRoles::GetRoles(const GetRoles &o) : GetRoles(o.proto_) {}
-
-    GetRoles::GetRoles(GetRoles &&o) noexcept : GetRoles(std::move(o.proto_)) {}
+    GetRoles::GetRoles(iroha::protocol::Query &query) {}
 
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/impl/proto_get_signatories.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_signatories.cpp
@@ -8,21 +8,8 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetSignatories::GetSignatories(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          account_signatories_{proto_->payload().get_signatories()} {}
-
-    template GetSignatories::GetSignatories(GetSignatories::TransportType &);
-    template GetSignatories::GetSignatories(
-        const GetSignatories::TransportType &);
-    template GetSignatories::GetSignatories(GetSignatories::TransportType &&);
-
-    GetSignatories::GetSignatories(const GetSignatories &o)
-        : GetSignatories(o.proto_) {}
-
-    GetSignatories::GetSignatories(GetSignatories &&o) noexcept
-        : GetSignatories(std::move(o.proto_)) {}
+    GetSignatories::GetSignatories(iroha::protocol::Query &query)
+        : account_signatories_{query.payload().get_signatories()} {}
 
     const interface::types::AccountIdType &GetSignatories::accountId() const {
       return account_signatories_.account_id();

--- a/shared_model/backend/protobuf/queries/impl/proto_get_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_transactions.cpp
@@ -4,15 +4,14 @@
  */
 
 #include "backend/protobuf/queries/proto_get_transactions.hpp"
+
 #include <boost/range/numeric.hpp>
 
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryType>
-    GetTransactions::GetTransactions(QueryType &&query)
-        : TrivialProto(std::forward<QueryType>(query)),
-          get_transactions_{proto_->payload().get_transactions()},
+    GetTransactions::GetTransactions(iroha::protocol::Query &query)
+        : get_transactions_{query.payload().get_transactions()},
           transaction_hashes_{boost::accumulate(
               get_transactions_.tx_hashes(),
               TransactionHashesType{},
@@ -20,18 +19,6 @@ namespace shared_model {
                 acc.push_back(crypto::Hash::fromHexString(hash));
                 return std::forward<decltype(acc)>(acc);
               })} {}
-
-    template GetTransactions::GetTransactions(GetTransactions::TransportType &);
-    template GetTransactions::GetTransactions(
-        const GetTransactions::TransportType &);
-    template GetTransactions::GetTransactions(
-        GetTransactions::TransportType &&);
-
-    GetTransactions::GetTransactions(const GetTransactions &o)
-        : GetTransactions(o.proto_) {}
-
-    GetTransactions::GetTransactions(GetTransactions &&o) noexcept
-        : GetTransactions(std::move(o.proto_)) {}
 
     const GetTransactions::TransactionHashesType &
     GetTransactions::transactionHashes() const {

--- a/shared_model/backend/protobuf/queries/impl/proto_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query.cpp
@@ -72,7 +72,7 @@ namespace shared_model {
       SignatureSetType<proto::Signature> signatures_{[this] {
         SignatureSetType<proto::Signature> set;
         if (proto_.has_signature()) {
-          set.emplace(proto_.signature());
+          set.emplace(*proto_.mutable_signature());
         }
         return set;
       }()};

--- a/shared_model/backend/protobuf/queries/impl/proto_query_payload_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query_payload_meta.cpp
@@ -8,34 +8,20 @@
 namespace shared_model {
   namespace proto {
 
-    template <typename QueryPayloadMetaType>
-    QueryPayloadMeta::QueryPayloadMeta(QueryPayloadMetaType &&query)
-        : TrivialProto(std::forward<QueryPayloadMetaType>(query)) {}
-
-    template QueryPayloadMeta::QueryPayloadMeta(
-        QueryPayloadMeta::TransportType &);
-    template QueryPayloadMeta::QueryPayloadMeta(
-        const QueryPayloadMeta::TransportType &);
-    template QueryPayloadMeta::QueryPayloadMeta(
-        QueryPayloadMeta::TransportType &&);
-
-    QueryPayloadMeta::QueryPayloadMeta(const QueryPayloadMeta &o)
-        : QueryPayloadMeta(o.proto_) {}
-
-    QueryPayloadMeta::QueryPayloadMeta(QueryPayloadMeta &&o) noexcept
-        : QueryPayloadMeta(std::move(o.proto_)) {}
+    QueryPayloadMeta::QueryPayloadMeta(iroha::protocol::QueryPayloadMeta &meta)
+        : meta_{meta} {}
 
     const interface::types::AccountIdType &QueryPayloadMeta::creatorAccountId()
         const {
-      return proto_->creator_account_id();
+      return meta_.creator_account_id();
     }
 
     interface::types::CounterType QueryPayloadMeta::queryCounter() const {
-      return proto_->query_counter();
+      return meta_.query_counter();
     }
 
     interface::types::TimestampType QueryPayloadMeta::createdTime() const {
-      return proto_->created_time();
+      return meta_.created_time();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -5,32 +5,25 @@
 
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 
+#include <boost/optional.hpp>
 #include "cryptography/hash.hpp"
 
 namespace types = shared_model::interface::types;
 
 using namespace shared_model::proto;
 
-TxPaginationMeta::TxPaginationMeta(const TransportType &query)
-    : TrivialProto(query) {}
-
-TxPaginationMeta::TxPaginationMeta(TransportType &&query)
-    : TrivialProto(std::move(query)) {}
-
-TxPaginationMeta::TxPaginationMeta(const TxPaginationMeta &o)
-    : TxPaginationMeta(*o.proto_) {}
-
-TxPaginationMeta::TxPaginationMeta(TxPaginationMeta &&o) noexcept
-    : TrivialProto(std::move(*o.proto_)) {}
+TxPaginationMeta::TxPaginationMeta(iroha::protocol::TxPaginationMeta &meta)
+    : meta_{meta} {}
 
 types::TransactionsNumberType TxPaginationMeta::pageSize() const {
-  return proto_->page_size();
+  return meta_.page_size();
 }
 
 boost::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
-  if (proto_->opt_first_tx_hash_case()
-      == TransportType::OptFirstTxHashCase::OPT_FIRST_TX_HASH_NOT_SET) {
+  if (meta_.opt_first_tx_hash_case()
+      == iroha::protocol::TxPaginationMeta::OptFirstTxHashCase::
+             OPT_FIRST_TX_HASH_NOT_SET) {
     return boost::none;
   }
-  return types::HashType::fromHexString(proto_->first_tx_hash());
+  return types::HashType::fromHexString(meta_.first_tx_hash());
 }

--- a/shared_model/backend/protobuf/queries/proto_account_detail_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_account_detail_pagination_meta.hpp
@@ -8,6 +8,7 @@
 
 #include "interfaces/queries/account_detail_pagination_meta.hpp"
 
+#include <boost/optional.hpp>
 #include "backend/protobuf/queries/proto_account_detail_record_id.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/account_detail_record_id.hpp"

--- a/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
@@ -8,7 +8,6 @@
 
 #include "interfaces/queries/asset_pagination_meta.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "queries.pb.h"
 
@@ -16,19 +15,17 @@ namespace shared_model {
   namespace proto {
 
     /// Provides query metadata for AccountAsset list pagination.
-    class AssetPaginationMeta final
-        : public TrivialProto<interface::AssetPaginationMeta,
-                              iroha::protocol::AssetPaginationMeta> {
+    class AssetPaginationMeta final : public interface::AssetPaginationMeta {
      public:
-      explicit AssetPaginationMeta(const TransportType &query);
-      explicit AssetPaginationMeta(TransportType &&query);
-      AssetPaginationMeta(const AssetPaginationMeta &o);
-      AssetPaginationMeta(AssetPaginationMeta &&o) noexcept;
+      explicit AssetPaginationMeta(iroha::protocol::AssetPaginationMeta &meta);
 
       interface::types::TransactionsNumberType pageSize() const override;
 
       boost::optional<interface::types::AssetIdType> firstAssetId()
           const override;
+
+     private:
+      const iroha::protocol::AssetPaginationMeta &meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
@@ -6,23 +6,19 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCKS_QUERY_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCKS_QUERY_HPP
 
-#include "backend/protobuf/common_objects/signature.hpp"
-#include "backend/protobuf/util.hpp"
 #include "interfaces/queries/blocks_query.hpp"
+
+#include "backend/protobuf/common_objects/signature.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class BlocksQuery final
-        : public TrivialProto<interface::BlocksQuery,
-                              iroha::protocol::BlocksQuery> {
+    class BlocksQuery final : public interface::BlocksQuery {
      public:
-      template <typename BlocksQueryType>
-      explicit BlocksQuery(BlocksQueryType &&query);
+      using TransportType = iroha::protocol::BlocksQuery;
 
-      BlocksQuery(const BlocksQuery &o);
-
-      BlocksQuery(BlocksQuery &&o) noexcept;
+      explicit BlocksQuery(const TransportType &query);
+      explicit BlocksQuery(TransportType &&query);
 
       const interface::types::AccountIdType &creatorAccountId() const override;
 
@@ -42,8 +38,12 @@ namespace shared_model {
 
       interface::types::TimestampType createdTime() const override;
 
+      const TransportType &getTransport() const;
+
      private:
       // ------------------------------| fields |-------------------------------
+      TransportType proto_;
+
       const interface::types::BlobType blob_;
 
       const interface::types::BlobType payload_;

--- a/shared_model/backend/protobuf/queries/proto_get_account.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_ACCOUNT_H
 #define IROHA_PROTO_GET_ACCOUNT_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_account.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetAccount final
-        : public TrivialProto<interface::GetAccount, iroha::protocol::Query> {
+    class GetAccount final : public interface::GetAccount {
      public:
-      template <typename QueryType>
-      explicit GetAccount(QueryType &&query);
-
-      GetAccount(const GetAccount &o);
-
-      GetAccount(GetAccount &&o) noexcept;
+      explicit GetAccount(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_asset_transactions.hpp
@@ -6,23 +6,17 @@
 #ifndef IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 #define IROHA_GET_ACCOUNT_ASSET_TRANSACTIONS_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "interfaces/queries/get_account_asset_transactions.hpp"
+
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
     class GetAccountAssetTransactions final
-        : public TrivialProto<interface::GetAccountAssetTransactions,
-                              iroha::protocol::Query> {
+        : public interface::GetAccountAssetTransactions {
      public:
-      template <typename QueryType>
-      explicit GetAccountAssetTransactions(QueryType &&query);
-
-      GetAccountAssetTransactions(const GetAccountAssetTransactions &o);
-
-      GetAccountAssetTransactions(GetAccountAssetTransactions &&o) noexcept;
+      explicit GetAccountAssetTransactions(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
@@ -8,22 +8,15 @@
 
 #include "interfaces/queries/get_account_assets.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include <boost/optional.hpp>
 #include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetAccountAssets final
-        : public TrivialProto<interface::GetAccountAssets,
-                              iroha::protocol::Query> {
+    class GetAccountAssets final : public interface::GetAccountAssets {
      public:
-      template <typename QueryType>
-      explicit GetAccountAssets(QueryType &&query);
-
-      GetAccountAssets(const GetAccountAssets &o);
-
-      GetAccountAssets(GetAccountAssets &&o) noexcept;
+      explicit GetAccountAssets(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
@@ -6,23 +6,17 @@
 #ifndef IROHA_PROTO_GET_ACCOUNT_DETAIL_HPP
 #define IROHA_PROTO_GET_ACCOUNT_DETAIL_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/queries/proto_account_detail_pagination_meta.hpp"
 #include "interfaces/queries/get_account_detail.hpp"
+
+#include <boost/optional.hpp>
+#include "backend/protobuf/queries/proto_account_detail_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetAccountDetail final
-        : public TrivialProto<interface::GetAccountDetail,
-                              iroha::protocol::Query> {
+    class GetAccountDetail final : public interface::GetAccountDetail {
      public:
-      template <typename QueryType>
-      explicit GetAccountDetail(QueryType &&query);
-
-      GetAccountDetail(const GetAccountDetail &o);
-
-      GetAccountDetail(GetAccountDetail &&o) noexcept;
+      explicit GetAccountDetail(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 
@@ -37,6 +31,7 @@ namespace shared_model {
      private:
       // ------------------------------| fields |-------------------------------
 
+      const iroha::protocol::Query &query_;
       const iroha::protocol::GetAccountDetail &account_detail_;
       const boost::optional<const AccountDetailPaginationMeta> pagination_meta_;
     };

--- a/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_transactions.hpp
@@ -6,23 +6,17 @@
 #ifndef IROHA_GET_ACCOUNT_TRANSACTIONS_H
 #define IROHA_GET_ACCOUNT_TRANSACTIONS_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "interfaces/queries/get_account_transactions.hpp"
+
+#include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
     class GetAccountTransactions final
-        : public TrivialProto<interface::GetAccountTransactions,
-                              iroha::protocol::Query> {
+        : public interface::GetAccountTransactions {
      public:
-      template <typename QueryType>
-      explicit GetAccountTransactions(QueryType &&query);
-
-      GetAccountTransactions(const GetAccountTransactions &o);
-
-      GetAccountTransactions(GetAccountTransactions &&o) noexcept;
+      explicit GetAccountTransactions(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_asset_info.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_ASSET_INFO_H
 #define IROHA_PROTO_GET_ASSET_INFO_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_asset_info.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetAssetInfo final
-        : public TrivialProto<interface::GetAssetInfo, iroha::protocol::Query> {
+    class GetAssetInfo final : public interface::GetAssetInfo {
      public:
-      template <typename QueryType>
-      explicit GetAssetInfo(QueryType &&query);
-
-      GetAssetInfo(const GetAssetInfo &o);
-
-      GetAssetInfo(GetAssetInfo &&o) noexcept;
+      explicit GetAssetInfo(iroha::protocol::Query &query);
 
       const interface::types::AssetIdType &assetId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_block.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_block.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_BLOCK_HPP
 #define IROHA_PROTO_GET_BLOCK_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_block.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetBlock final
-        : public TrivialProto<interface::GetBlock, iroha::protocol::Query> {
+    class GetBlock final : public interface::GetBlock {
      public:
-      template <typename QueryType>
-      explicit GetBlock(QueryType &&query);
-
-      GetBlock(const GetBlock &o);
-
-      GetBlock(GetBlock &&o) noexcept;
+      explicit GetBlock(iroha::protocol::Query &query);
 
       interface::types::HeightType height() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_peers.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_peers.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_PEERS_HPP
 #define IROHA_PROTO_GET_PEERS_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_peers.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetPeers final
-        : public TrivialProto<interface::GetPeers, iroha::protocol::Query> {
+    class GetPeers final : public interface::GetPeers {
      public:
-      template <typename QueryType>
-      explicit GetPeers(QueryType &&query);
-
-      GetPeers(const GetPeers &o);
-
-      GetPeers(GetPeers &&o) noexcept;
+      explicit GetPeers(iroha::protocol::Query &query);
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -8,22 +8,16 @@
 
 #include "interfaces/queries/get_pending_transactions.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
+#include <boost/optional.hpp>
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
     class GetPendingTransactions final
-        : public TrivialProto<interface::GetPendingTransactions,
-                              iroha::protocol::Query> {
+        : public interface::GetPendingTransactions {
      public:
-      template <typename QueryType>
-      explicit GetPendingTransactions(QueryType &&query);
-
-      GetPendingTransactions(const GetPendingTransactions &o);
-
-      GetPendingTransactions(GetPendingTransactions &&o) noexcept;
+      explicit GetPendingTransactions(iroha::protocol::Query &query);
 
       boost::optional<const interface::TxPaginationMeta &> paginationMeta()
           const override;

--- a/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_role_permissions.hpp
@@ -6,22 +6,15 @@
 #ifndef IROHA_PROTO_GET_ROLE_PERMISSIONS_H
 #define IROHA_PROTO_GET_ROLE_PERMISSIONS_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_role_permissions.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetRolePermissions final
-        : public TrivialProto<interface::GetRolePermissions,
-                              iroha::protocol::Query> {
+    class GetRolePermissions final : public interface::GetRolePermissions {
      public:
-      template <typename QueryType>
-      explicit GetRolePermissions(QueryType &&query);
-
-      GetRolePermissions(const GetRolePermissions &o);
-
-      GetRolePermissions(GetRolePermissions &&o) noexcept;
+      explicit GetRolePermissions(iroha::protocol::Query &query);
 
       const interface::types::RoleIdType &roleId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_roles.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_roles.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_ROLES_H
 #define IROHA_PROTO_GET_ROLES_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_roles.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetRoles final
-        : public TrivialProto<interface::GetRoles, iroha::protocol::Query> {
+    class GetRoles final : public interface::GetRoles {
      public:
-      template <typename QueryType>
-      explicit GetRoles(QueryType &&query);
-
-      GetRoles(const GetRoles &o);
-
-      GetRoles(GetRoles &&o) noexcept;
+      explicit GetRoles(iroha::protocol::Query &query);
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_signatories.hpp
@@ -6,21 +6,15 @@
 #ifndef IROHA_PROTO_GET_SIGNATORIES_H
 #define IROHA_PROTO_GET_SIGNATORIES_H
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/get_signatories.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetSignatories final : public TrivialProto<interface::GetSignatories,
-                                                     iroha::protocol::Query> {
+    class GetSignatories final : public interface::GetSignatories {
      public:
-      template <typename QueryType>
-      explicit GetSignatories(QueryType &&query);
-
-      GetSignatories(const GetSignatories &o);
-
-      GetSignatories(GetSignatories &&o) noexcept;
+      explicit GetSignatories(iroha::protocol::Query &query);
 
       const interface::types::AccountIdType &accountId() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_transactions.hpp
@@ -8,22 +8,14 @@
 
 #include "interfaces/queries/get_transactions.hpp"
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "cryptography/hash.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class GetTransactions final
-        : public TrivialProto<interface::GetTransactions,
-                              iroha::protocol::Query> {
+    class GetTransactions final : public interface::GetTransactions {
      public:
-      template <typename QueryType>
-      explicit GetTransactions(QueryType &&query);
-
-      GetTransactions(const GetTransactions &o);
-
-      GetTransactions(GetTransactions &&o) noexcept;
+      explicit GetTransactions(iroha::protocol::Query &query);
 
       const TransactionHashesType &transactionHashes() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_query_payload_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query_payload_meta.hpp
@@ -6,28 +6,24 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_QUERY_PAYLOAD_META_HPP
 #define IROHA_SHARED_MODEL_PROTO_QUERY_PAYLOAD_META_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
 #include "interfaces/queries/query_payload_meta.hpp"
+
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
-    class QueryPayloadMeta final
-        : public TrivialProto<interface::QueryPayloadMeta,
-                              iroha::protocol::QueryPayloadMeta> {
+    class QueryPayloadMeta final : public interface::QueryPayloadMeta {
      public:
-      template <typename QueryPayloadMetaType>
-      explicit QueryPayloadMeta(QueryPayloadMetaType &&query);
-
-      QueryPayloadMeta(const QueryPayloadMeta &o);
-
-      QueryPayloadMeta(QueryPayloadMeta &&o) noexcept;
+      explicit QueryPayloadMeta(iroha::protocol::QueryPayloadMeta &meta);
 
       const interface::types::AccountIdType &creatorAccountId() const override;
 
       interface::types::CounterType queryCounter() const override;
 
       interface::types::TimestampType createdTime() const override;
+
+     private:
+      const iroha::protocol::QueryPayloadMeta &meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -6,27 +6,25 @@
 #ifndef IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
 #define IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
 
-#include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
+
+#include "interfaces/common_objects/types.hpp"
 #include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
 
     /// Provides query metadata for any transaction list pagination.
-    class TxPaginationMeta final
-        : public TrivialProto<interface::TxPaginationMeta,
-                              iroha::protocol::TxPaginationMeta> {
+    class TxPaginationMeta final : public interface::TxPaginationMeta {
      public:
-      explicit TxPaginationMeta(const TransportType &query);
-      explicit TxPaginationMeta(TransportType &&query);
-      TxPaginationMeta(const TxPaginationMeta &o);
-      TxPaginationMeta(TxPaginationMeta &&o) noexcept;
+      explicit TxPaginationMeta(iroha::protocol::TxPaginationMeta &meta);
 
       interface::types::TransactionsNumberType pageSize() const override;
 
       boost::optional<interface::types::HashType> firstTxHash() const override;
+
+     private:
+      const iroha::protocol::TxPaginationMeta &meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_block_query_response.cpp
@@ -5,32 +5,52 @@
 
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"
 
+#include "backend/protobuf/query_responses/proto_block_error_response.hpp"
+#include "backend/protobuf/query_responses/proto_block_response.hpp"
+#include "common/hexutils.hpp"
 #include "utils/variant_deserializer.hpp"
+
+namespace {
+  /// type of proto variant
+  using ProtoQueryResponseVariantType =
+      boost::variant<shared_model::proto::BlockResponse,
+                     shared_model::proto::BlockErrorResponse>;
+}  // namespace
 
 namespace shared_model {
   namespace proto {
 
-    BlockQueryResponse::BlockQueryResponse(TransportType &&block_query_response)
-        : proto_(std::move(block_query_response)),
-          variant_{[this] {
-            auto &ar = proto_;
-            int which = ar.GetDescriptor()
-                            ->FindFieldByNumber(ar.response_case())
-                            ->index();
-            return shared_model::detail::variant_impl<
-                ProtoQueryResponseVariantType::types>::
-                template load<ProtoQueryResponseVariantType>(ar, which);
-          }()},
-          ivariant_{variant_} {}
+    struct BlockQueryResponse::Impl {
+      explicit Impl(TransportType &&ref) : proto_{std::move(ref)} {}
+
+      TransportType proto_;
+
+      const ProtoQueryResponseVariantType variant_{[this] {
+        auto &ar = proto_;
+        int which =
+            ar.GetDescriptor()->FindFieldByNumber(ar.response_case())->index();
+        return shared_model::detail::
+            variant_impl<ProtoQueryResponseVariantType::types>::template load<
+                ProtoQueryResponseVariantType>(ar, which);
+      }()};
+
+      const QueryResponseVariantType ivariant_{variant_};
+    };
+
+    BlockQueryResponse::BlockQueryResponse(TransportType &&ref) {
+      impl_ = std::make_unique<Impl>(std::move(ref));
+    }
+
+    BlockQueryResponse::~BlockQueryResponse() = default;
 
     const BlockQueryResponse::QueryResponseVariantType &
     BlockQueryResponse::get() const {
-      return ivariant_;
+      return impl_->ivariant_;
     }
 
     const BlockQueryResponse::TransportType &BlockQueryResponse::getTransport()
         const {
-      return proto_;
+      return impl_->proto_;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_error_query_response.cpp
@@ -4,40 +4,76 @@
  */
 
 #include "backend/protobuf/query_responses/proto_error_query_response.hpp"
+
+#include "backend/protobuf/query_responses/proto_concrete_error_query_response.hpp"
 #include "utils/variant_deserializer.hpp"
+
+namespace {
+  /// type of proto variant
+  using ProtoQueryErrorResponseVariantType =
+      boost::variant<shared_model::proto::StatelessFailedErrorResponse,
+                     shared_model::proto::StatefulFailedErrorResponse,
+                     shared_model::proto::NoAccountErrorResponse,
+                     shared_model::proto::NoAccountAssetsErrorResponse,
+                     shared_model::proto::NoAccountDetailErrorResponse,
+                     shared_model::proto::NoSignatoriesErrorResponse,
+                     shared_model::proto::NotSupportedErrorResponse,
+                     shared_model::proto::NoAssetErrorResponse,
+                     shared_model::proto::NoRolesErrorResponse>;
+
+  /// list of types in proto variant
+  using ProtoQueryErrorResponseListType =
+      ProtoQueryErrorResponseVariantType::types;
+}  // namespace
 
 namespace shared_model {
   namespace proto {
 
+    struct ErrorQueryResponse::Impl {
+      explicit Impl(iroha::protocol::QueryResponse &ref)
+          : error_response_{*ref.mutable_error_response()},
+            variant_{[this] {
+              auto &ar = error_response_;
+
+              unsigned which = ar.GetDescriptor()
+                                   ->FindFieldByName("reason")
+                                   ->enum_type()
+                                   ->FindValueByNumber(ar.reason())
+                                   ->index();
+              return shared_model::detail::
+                  variant_impl<ProtoQueryErrorResponseListType>::template load<
+                      ProtoQueryErrorResponseVariantType>(ar, which);
+            }()},
+            ivariant_{variant_} {}
+
+      iroha::protocol::ErrorResponse &error_response_;
+
+      ProtoQueryErrorResponseVariantType variant_;
+
+      QueryErrorResponseVariantType ivariant_;
+    };
+
     ErrorQueryResponse::ErrorQueryResponse(
         iroha::protocol::QueryResponse &query_response)
-        : error_response_(*query_response.mutable_error_response()),
-          variant_{[this] {
-            auto &ar = error_response_;
+        : impl_{std::make_unique<Impl>(query_response)} {}
 
-            unsigned which = ar.GetDescriptor()
-                                 ->FindFieldByName("reason")
-                                 ->enum_type()
-                                 ->FindValueByNumber(ar.reason())
-                                 ->index();
-            return shared_model::detail::
-                variant_impl<ProtoQueryErrorResponseListType>::template load<
-                    ProtoQueryErrorResponseVariantType>(ar, which);
-          }()},
-          ivariant_{QueryErrorResponseVariantType{variant_}} {}
+    ErrorQueryResponse::ErrorQueryResponse(ErrorQueryResponse &&o) noexcept =
+        default;
+
+    ErrorQueryResponse::~ErrorQueryResponse() = default;
 
     const ErrorQueryResponse::QueryErrorResponseVariantType &
     ErrorQueryResponse::get() const {
-      return ivariant_;
+      return impl_->ivariant_;
     }
 
     const ErrorQueryResponse::ErrorMessageType &
     ErrorQueryResponse::errorMessage() const {
-      return error_response_.message();
+      return impl_->error_response_.message();
     }
 
     ErrorQueryResponse::ErrorCodeType ErrorQueryResponse::errorCode() const {
-      return error_response_.error_code();
+      return impl_->error_response_.error_code();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_block_query_response.hpp
@@ -8,32 +8,25 @@
 
 #include "interfaces/query_responses/block_query_response.hpp"
 
-#include "backend/protobuf/query_responses/proto_block_error_response.hpp"
-#include "backend/protobuf/query_responses/proto_block_response.hpp"
-#include "interfaces/queries/query.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
     class BlockQueryResponse final : public interface::BlockQueryResponse {
-     private:
-      /// type of proto variant
-      using ProtoQueryResponseVariantType =
-          boost::variant<BlockResponse, BlockErrorResponse>;
-
      public:
       using TransportType = iroha::protocol::BlockQueryResponse;
 
       explicit BlockQueryResponse(TransportType &&block_query_response);
+
+      ~BlockQueryResponse() override;
 
       const QueryResponseVariantType &get() const override;
 
       const TransportType &getTransport() const;
 
      private:
-      iroha::protocol::BlockQueryResponse proto_;
-      const ProtoQueryResponseVariantType variant_;
-      const QueryResponseVariantType ivariant_;
+      struct Impl;
+      std::unique_ptr<Impl> impl_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_error_query_response.hpp
@@ -8,31 +8,18 @@
 
 #include "interfaces/query_responses/error_query_response.hpp"
 
-#include "backend/protobuf/query_responses/proto_concrete_error_query_response.hpp"
 #include "qry_responses.pb.h"
 
 namespace shared_model {
   namespace proto {
     class ErrorQueryResponse final : public interface::ErrorQueryResponse {
      public:
-      /// type of proto variant
-      using ProtoQueryErrorResponseVariantType =
-          boost::variant<StatelessFailedErrorResponse,
-                         StatefulFailedErrorResponse,
-                         NoAccountErrorResponse,
-                         NoAccountAssetsErrorResponse,
-                         NoAccountDetailErrorResponse,
-                         NoSignatoriesErrorResponse,
-                         NotSupportedErrorResponse,
-                         NoAssetErrorResponse,
-                         NoRolesErrorResponse>;
-
-      /// list of types in proto variant
-      using ProtoQueryErrorResponseListType =
-          ProtoQueryErrorResponseVariantType::types;
-
       explicit ErrorQueryResponse(
           iroha::protocol::QueryResponse &query_response);
+
+      ErrorQueryResponse(ErrorQueryResponse &&o) noexcept;
+
+      ~ErrorQueryResponse() override;
 
       const QueryErrorResponseVariantType &get() const override;
 
@@ -41,11 +28,8 @@ namespace shared_model {
       ErrorCodeType errorCode() const override;
 
      private:
-      iroha::protocol::ErrorResponse &error_response_;
-
-      ProtoQueryErrorResponseVariantType variant_;
-
-      QueryErrorResponseVariantType ivariant_;
+      struct Impl;
+      std::unique_ptr<Impl> impl_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -6,22 +6,23 @@
 #ifndef IROHA_SHARED_MODEL_QUERY_VALIDATOR_HPP
 #define IROHA_SHARED_MODEL_QUERY_VALIDATOR_HPP
 
+#include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 
-#include "backend/protobuf/queries/proto_get_account.hpp"
-#include "backend/protobuf/queries/proto_get_account_asset_transactions.hpp"
-#include "backend/protobuf/queries/proto_get_account_assets.hpp"
-#include "backend/protobuf/queries/proto_get_account_detail.hpp"
-#include "backend/protobuf/queries/proto_get_account_transactions.hpp"
-#include "backend/protobuf/queries/proto_get_asset_info.hpp"
-#include "backend/protobuf/queries/proto_get_block.hpp"
-#include "backend/protobuf/queries/proto_get_pending_transactions.hpp"
-#include "backend/protobuf/queries/proto_get_role_permissions.hpp"
-#include "backend/protobuf/queries/proto_get_roles.hpp"
-#include "backend/protobuf/queries/proto_get_signatories.hpp"
-#include "backend/protobuf/queries/proto_get_transactions.hpp"
-#include "backend/protobuf/queries/proto_query.hpp"
 #include "common/bind.hpp"
+#include "interfaces/queries/get_account.hpp"
+#include "interfaces/queries/get_account_asset_transactions.hpp"
+#include "interfaces/queries/get_account_assets.hpp"
+#include "interfaces/queries/get_account_detail.hpp"
+#include "interfaces/queries/get_account_transactions.hpp"
+#include "interfaces/queries/get_asset_info.hpp"
+#include "interfaces/queries/get_block.hpp"
+#include "interfaces/queries/get_pending_transactions.hpp"
+#include "interfaces/queries/get_role_permissions.hpp"
+#include "interfaces/queries/get_roles.hpp"
+#include "interfaces/queries/get_signatories.hpp"
+#include "interfaces/queries/get_transactions.hpp"
+#include "interfaces/queries/query.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
 #include "validators/abstract_validator.hpp"
 #include "validators/answer.hpp"

--- a/test/module/irohad/torii/torii_service_query_test.cpp
+++ b/test/module/irohad/torii/torii_service_query_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gmock/gmock.h>
 
+#include "backend/protobuf/block.hpp"
 #include "backend/protobuf/proto_query_response_factory.hpp"
 #include "backend/protobuf/proto_transport_factory.hpp"
 #include "backend/protobuf/query_responses/proto_block_query_response.hpp"


### PR DESCRIPTION
### Description of the Change
- Remove TrivialProto inheritance from classes where it is only required to store a reference, or value, but not both
- Add pimpl to BlockQueryResponse and ErrorQueryResponse to hide proto variant

### Benefits
Simpler code

### Possible Drawbacks 
None