### PR TITLE
YacGateImpl: fix FutureMessage handling

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -211,9 +211,19 @@ namespace iroha {
         auto public_keys = getPublicKeys(msg.votes);
         if (hash.vote_round < current_hash_.vote_round) {
           log_->info(
-              "Current round {} is greater than reject round {}, skipped",
+              "Current round {} is greater than future round {}, skipped",
               current_hash_.vote_round,
               hash.vote_round);
+          return rxcpp::observable<>::empty<GateObject>();
+        }
+
+        if (hash.vote_round.block_round
+            == current_hash_.vote_round.block_round) {
+          log_->info(
+              "Current block round {} is the same as future block round {}, "
+              "skipped",
+              current_hash_.vote_round.block_round,
+              hash.vote_round.block_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -84,6 +84,8 @@ namespace iroha {
         }
 
         current_hash_ = hash_provider_->makeHash(event);
+        assert(current_hash_.vote_round.block_round
+               == current_ledger_state_->top_block_info.height + 1);
 
         if (not event.round_data) {
           current_block_ = boost::none;
@@ -136,6 +138,9 @@ namespace iroha {
           return rxcpp::observable<>::empty<GateObject>();
         }
 
+        assert(hash.vote_round.block_round
+               == current_hash_.vote_round.block_round);
+
         if (hash == current_hash_ and current_block_) {
           // if node has voted for the committed block
           // append signatures of other nodes
@@ -180,6 +185,9 @@ namespace iroha {
           return rxcpp::observable<>::empty<GateObject>();
         }
 
+        assert(hash.vote_round.block_round
+               == current_hash_.vote_round.block_round);
+
         auto has_same_proposals =
             std::all_of(std::next(msg.votes.begin()),
                         msg.votes.end(),
@@ -208,6 +216,9 @@ namespace iroha {
               hash.vote_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
+
+        assert(hash.vote_round.block_round
+               > current_hash_.vote_round.block_round);
 
         log_->info("Message from future, waiting for sync");
         return rxcpp::observable<>::just<GateObject>(Future(

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -306,6 +306,79 @@ TEST_F(YacGateTest, DifferentCommit) {
 }
 
 /**
+ * @given yac gate, in round (i, j) -> last block height is (i - 1)
+ * @when vote for round (i + 1, j) is received
+ * @then peer goes to round (i + 1, j)
+ */
+TEST_F(YacGateTest, Future) {
+  // yac consensus
+  EXPECT_CALL(*hash_gate, vote(expected_hash, _, _)).Times(1);
+
+  // generate order of peers
+  EXPECT_CALL(*peer_orderer, getOrdering(_, _))
+      .WillOnce(Return(ClusterOrdering::create({makePeer("fake_node")})));
+
+  // make hash from block
+  EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
+
+  block_notifier.get_subscriber().on_next(BlockCreatorEvent{
+      RoundData{expected_proposal, expected_block}, round, ledger_state});
+
+  iroha::consensus::Round future_round{round.block_round + 1,
+                                       round.reject_round};
+  PublicKey actual_pubkey("actual_pubkey");
+  auto signature = std::make_shared<MockSignature>();
+  EXPECT_CALL(*signature, publicKey())
+      .WillRepeatedly(ReturnRefOfCopy(actual_pubkey));
+
+  VoteMessage future_message{};
+  future_message.hash =
+      YacHash(future_round, "actual_proposal", "actual_block");
+  future_message.signature = signature;
+
+  // verify that yac gate emit expected block
+  auto gate_wrapper = make_test_subscriber<CallExact>(gate->onOutcome(), 1);
+  gate_wrapper.subscribe([&](auto outcome) {
+    auto concrete_outcome = boost::get<iroha::consensus::Future>(outcome);
+
+    ASSERT_EQ(future_round, concrete_outcome.round);
+  });
+
+  outcome_notifier.get_subscriber().on_next(FutureMessage{future_message});
+
+  ASSERT_TRUE(gate_wrapper.validate());
+}
+
+/**
+ * @given yac gate, in round (i - 1, j)
+ * @when another vote for round (i, j) is received while it is already being
+ * processed
+ * @then vote is ignored
+ */
+TEST_F(YacGateTest, OutdatedFuture) {
+  // yac consensus
+  EXPECT_CALL(*hash_gate, vote(expected_hash, _, _)).Times(1);
+
+  // generate order of peers
+  EXPECT_CALL(*peer_orderer, getOrdering(_, _))
+      .WillOnce(Return(ClusterOrdering::create({makePeer("fake_node")})));
+
+  // make hash from block
+  EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
+
+  block_notifier.get_subscriber().on_next(BlockCreatorEvent{
+      RoundData{expected_proposal, expected_block}, round, ledger_state});
+
+  // verify that yac gate emit expected block
+  auto gate_wrapper = make_test_subscriber<CallExact>(gate->onOutcome(), 0);
+  gate_wrapper.subscribe();
+
+  outcome_notifier.get_subscriber().on_next(FutureMessage{message});
+
+  ASSERT_TRUE(gate_wrapper.validate());
+}
+
+/**
  * The fixture checks the following case for different types of commit messages
  * (VoteOther, AgreementOnNone, BlockReject, ProposalReject):
  * @given yac gate, in round (i, j) -> last block height is (i - 1)


### PR DESCRIPTION
### Description of the Change
Several FutureMessages can be queued up in Yac worker, leading to incorrect synchronization attempt when the same FutureMessage is processed the second time. A conditional is added to ignore the next attempts to process FutureMessage if the node is already synchronized.

### Benefits
Correct behavior

### Possible Drawbacks 
None

### Usage Examples or Tests *[optional]*
YacGateTest.Future, YacGateTest.OutdatedFuture
