### PR TITLE
Synchronization: fix FutureMessage handling and SynchronizationEvent round numbers

### DIFF
--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -67,10 +67,8 @@ namespace iroha {
             block_creator_(std::move(block_creator)),
             consensus_result_cache_(std::move(consensus_result_cache)),
             hash_gate_(std::move(hash_gate)) {
-        block_creator_->onBlock().subscribe([this](const auto &event) {
-          current_ledger_state_ = event.ledger_state;
-          this->vote(event);
-        });
+        block_creator_->onBlock().subscribe(
+            [this](const auto &event) { this->vote(event); });
       }
 
       void YacGateImpl::vote(const simulator::BlockCreatorEvent &event) {
@@ -83,7 +81,10 @@ namespace iroha {
           return;
         }
 
+        current_ledger_state_ = event.ledger_state;
         current_hash_ = hash_provider_->makeHash(event);
+        assert(current_hash_.vote_round.block_round
+               == current_ledger_state_->top_block_info.height + 1);
 
         if (not event.round_data) {
           current_block_ = boost::none;
@@ -136,6 +137,9 @@ namespace iroha {
           return rxcpp::observable<>::empty<GateObject>();
         }
 
+        assert(hash.vote_round.block_round
+               == current_hash_.vote_round.block_round);
+
         if (hash == current_hash_ and current_block_) {
           // if node has voted for the committed block
           // append signatures of other nodes
@@ -180,6 +184,9 @@ namespace iroha {
           return rxcpp::observable<>::empty<GateObject>();
         }
 
+        assert(hash.vote_round.block_round
+               == current_hash_.vote_round.block_round);
+
         auto has_same_proposals =
             std::all_of(std::next(msg.votes.begin()),
                         msg.votes.end(),
@@ -208,6 +215,9 @@ namespace iroha {
               hash.vote_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
+
+        assert(hash.vote_round.block_round
+               > current_hash_.vote_round.block_round);
 
         log_->info("Message from future, waiting for sync");
         return rxcpp::observable<>::just<GateObject>(Future(

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -208,11 +208,13 @@ namespace iroha {
           const FutureMessage &msg) {
         const auto hash = getHash(msg.votes).value();
         auto public_keys = getPublicKeys(msg.votes);
-        if (hash.vote_round < current_hash_.vote_round) {
+        if (hash.vote_round.block_round
+            <= current_hash_.vote_round.block_round) {
           log_->info(
-              "Current round {} is greater than reject round {}, skipped",
-              current_hash_.vote_round,
-              hash.vote_round);
+              "Current block round {} is not lower than future block round {}, "
+              "skipped",
+              current_hash_.vote_round.block_round,
+              hash.vote_round.block_round);
           return rxcpp::observable<>::empty<GateObject>();
         }
 

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -159,13 +159,15 @@ namespace iroha {
           msg.public_keys);
 
       commit_result.match(
-          [this](auto &value) {
+          [this, &msg](auto &value) {
             auto &ledger_state = value.value;
             assert(ledger_state);
-            auto new_height = ledger_state->top_block_info.height;
+            const auto new_height = ledger_state->top_block_info.height;
             notifier_.get_subscriber().on_next(
                 SynchronizationEvent{SynchronizationOutcomeType::kCommit,
-                                     consensus::Round{new_height, 0},
+                                     new_height != msg.round.block_round
+                                         ? consensus::Round{new_height, 0}
+                                         : msg.round,
                                      std::move(ledger_state)});
           },
           [this](const auto &error) {

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -46,7 +46,7 @@ class YacGateTest : public ::testing::Test {
     EXPECT_CALL(*block, payload())
         .WillRepeatedly(ReturnRefOfCopy(Blob(std::string())));
     EXPECT_CALL(*block, addSignature(_, _)).WillRepeatedly(Return(true));
-    EXPECT_CALL(*block, height()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*block, height()).WillRepeatedly(Return(round.block_round));
     EXPECT_CALL(*block, txsNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*block, createdTime()).WillRepeatedly(Return(1));
     EXPECT_CALL(*block, transactions())
@@ -101,11 +101,11 @@ class YacGateTest : public ::testing::Test {
     auto peer = makePeer("127.0.0.1", shared_model::crypto::PublicKey("111"));
     ledger_state = std::make_shared<iroha::LedgerState>(
         shared_model::interface::types::PeerList{std::move(peer)},
-        block->height(),
-        block->hash());
+        block->height() - 1,
+        block->prevHash());
   }
 
-  iroha::consensus::Round round{1, 1};
+  iroha::consensus::Round round{2, 1};
   boost::optional<ClusterOrdering> alternative_order;
   PublicKey expected_pubkey{"expected_pubkey"};
   Signed expected_signed{"expected_signed"};
@@ -177,7 +177,9 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
  * @then block cache is released
  */
 TEST_F(YacGateTest, CacheReleased) {
-  YacHash empty_hash({}, ProposalHash(""), BlockHash(""));
+  YacHash empty_hash({round.block_round, round.reject_round + 1},
+                     ProposalHash(""),
+                     BlockHash(""));
 
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(expected_hash, _, _)).Times(1);
@@ -233,6 +235,9 @@ TEST_F(YacGateTest, AgreementOnNone) {
 
   EXPECT_CALL(*peer_orderer, getOrdering(_, _))
       .WillOnce(Return(ClusterOrdering::create({makePeer("fake_node")})));
+
+  EXPECT_CALL(*hash_provider, makeHash(_))
+      .WillOnce(Return(YacHash{round, ProposalHash(""), BlockHash("")}));
 
   ASSERT_EQ(block_cache->get(), nullptr);
 


### PR DESCRIPTION
### Description of the Change
- Several FutureMessages can be queued up in Yac worker, leading to incorrect synchronization attempt when the same FutureMessage is processed the second time. A conditional is added to ignore the next attempts to process FutureMessage if the node is already synchronized.
- Fix rounds being incorrectly dropped in OnDemandOrderingInit when commit happened after several reject rounds (e.g. block being committed after round (i, 5), because event contained round (i, 0) instead)
- Generate peer permutations in OnDemandOrderingInit on each event, because it is not known in synchronization events observable whether any blocks were committed.

### Benefits
Correct behavior

### Possible Drawbacks 
None

### Usage Examples or Tests *[optional]*
YacGateTest.Future, YacGateTest.OutdatedFuture
