### PR TITLE
P2P TLS: added peer tls certificate providers

### DIFF
--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(application
     )
 target_link_libraries(application
     PRIVATE
+    peer_tls_certificates_providers
     tls_credentials
     yac
     yac_transport

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -41,9 +41,10 @@ namespace iroha {
   namespace network {
     class BlockLoader;
     class ConsensusGate;
-    class PeerCommunicationService;
     class MstTransport;
     class OrderingGate;
+    class PeerCommunicationService;
+    class PeerTlsCertificatesProvider;
     struct TlsCredentials;
   }  // namespace network
   namespace simulator {
@@ -162,6 +163,8 @@ class Irohad {
 
   RunResult initTlsCredentials();
 
+  RunResult initPeerCertProvider();
+
   virtual RunResult initCryptoProvider();
 
   virtual RunResult initBatchParser();
@@ -230,6 +233,9 @@ class Irohad {
       my_inter_peer_tls_creds_;
   boost::optional<std::shared_ptr<const iroha::network::TlsCredentials>>
       torii_tls_creds_;
+  boost::optional<
+      std::shared_ptr<const iroha::network::PeerTlsCertificatesProvider>>
+      peer_tls_certificates_provider_;
 
   std::unique_ptr<iroha::PendingTransactionStorageInit>
       pending_txs_storage_init;

--- a/irohad/main/iroha_conf_literals.cpp
+++ b/irohad/main/iroha_conf_literals.cpp
@@ -10,6 +10,11 @@ namespace config_members {
   const char *ToriiPort = "torii_port";
   const char *ToriiTlsParams = "torii_tls_params";
   const char *InterPeerTls = "inter_peer_tls";
+  const char *PeerCertProvider = "peer_certificates";
+  const char *RootCert = "root_certificate";
+  const char *InLengerCerts = "from_ledger";
+  const char *Type = "type";
+  const char *Path = "path";
   const char *InternalPort = "internal_port";
   const char *KeyPairPath = "key_pair_path";
   const char *PgOpt = "pg_opt";

--- a/irohad/main/iroha_conf_literals.hpp
+++ b/irohad/main/iroha_conf_literals.hpp
@@ -16,6 +16,11 @@ namespace config_members {
   extern const char *ToriiPort;
   extern const char *ToriiTlsParams;
   extern const char *InterPeerTls;
+  extern const char *PeerCertProvider;
+  extern const char *RootCert;
+  extern const char *InLengerCerts;
+  extern const char *Type;
+  extern const char *Path;
   extern const char *InternalPort;
   extern const char *KeyPairPath;
   extern const char *PgOpt;

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -385,6 +385,30 @@ inline void JsonDeserializerImpl::getVal<IrohadConfig::InterPeerTls>(
   assert_fatal(src.IsObject(), path + " must be a dictionary");
   const auto obj = src.GetObject();
   getValByKey(path, dest.my_tls_creds_path, obj, config_members::KeyPairPath);
+  getValByKey(
+      path, dest.peer_certificates, obj, config_members::PeerCertProvider);
+}
+
+template <>
+inline void
+JsonDeserializerImpl::getVal<IrohadConfig::InterPeerTls::PeerCertProvider>(
+    const std::string &path,
+    IrohadConfig::InterPeerTls::PeerCertProvider &dest,
+    const rapidjson::Value &src) {
+  assert_fatal(src.IsObject(), path + " must be a dictionary");
+  const auto obj = src.GetObject();
+  std::string type;
+  getValByKey(path, type, obj, config_members::Type);
+  if (type == config_members::RootCert) {
+    IrohadConfig::InterPeerTls::RootCert root_cert;
+    getValByKey(path, root_cert.path, obj, config_members::Path);
+    dest = std::move(root_cert);
+  } else if (type == config_members::InLengerCerts) {
+    dest = IrohadConfig::InterPeerTls::FromWsv{};
+  } else {
+    throw std::runtime_error{std::string{
+        "Unimplemented peer certificate provider type: '" + type + "'"}};
+  }
 }
 
 template <>

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -25,7 +25,15 @@ struct IrohadConfig {
   };
 
   struct InterPeerTls {
+    struct RootCert {
+      std::string path;
+    };
+    struct FromWsv {};
+    struct None {};
+    using PeerCertProvider = boost::variant<RootCert, FromWsv, None>;
+
     boost::optional<std::string> my_tls_creds_path;
+    PeerCertProvider peer_certificates;
   };
 
   // TODO: block_store_path is now optional, change docs IR-576

--- a/irohad/network/CMakeLists.txt
+++ b/irohad/network/CMakeLists.txt
@@ -47,3 +47,12 @@ add_library(tls_credentials
 target_link_libraries(tls_credentials
     common
     )
+
+add_library(peer_tls_certificates_providers
+    impl/peer_tls_certificates_provider_root.cpp
+    impl/peer_tls_certificates_provider_wsv.cpp
+    )
+target_link_libraries(peer_tls_certificates_providers
+    logger
+    shared_model_interfaces
+    )

--- a/irohad/network/impl/peer_tls_certificates_provider_root.cpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_root.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "network/impl/peer_tls_certificates_provider_root.hpp"
+
+using namespace iroha::network;
+using namespace iroha::expected;
+using namespace shared_model::interface::types;
+
+PeerTlsCertificatesProviderRoot::PeerTlsCertificatesProviderRoot(
+    TLSCertificateType root_certificate)
+    : root_certificate_(std::move(root_certificate)) {}
+
+Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderRoot::get(
+    const shared_model::interface::Peer &) const {
+  return makeValue(root_certificate_);
+}
+
+Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderRoot::get(
+    const PubkeyType &) const {
+  return makeValue(root_certificate_);
+}

--- a/irohad/network/impl/peer_tls_certificates_provider_root.hpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_root.hpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEER_TLS_CERTIFICATES_PROVIDER_ROOT_HPP
+#define IROHA_PEER_TLS_CERTIFICATES_PROVIDER_ROOT_HPP
+
+#include "network/peer_tls_certificates_provider.hpp"
+
+namespace iroha {
+  namespace network {
+
+    class PeerTlsCertificatesProviderRoot : public PeerTlsCertificatesProvider {
+     public:
+      PeerTlsCertificatesProviderRoot(
+          shared_model::interface::types::TLSCertificateType root_certificate);
+
+      iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::Peer &) const override;
+
+      iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::types::PubkeyType &) const override;
+
+     private:
+      shared_model::interface::types::TLSCertificateType root_certificate_;
+    };
+
+  }  // namespace network
+}  // namespace iroha
+
+#endif

--- a/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "network/impl/peer_tls_certificates_provider_wsv.hpp"
+
+#include <mutex>
+
+#include "ametsuchi/peer_query.hpp"
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/peer.hpp"
+
+using namespace iroha::expected;
+using namespace iroha::network;
+using namespace shared_model::interface::types;
+
+class PeerTlsCertificatesProviderWsv::Impl {
+ public:
+  Impl(std::shared_ptr<iroha::ametsuchi::PeerQuery> peer_query)
+      : peer_query_(std::move(peer_query)) {}
+
+  boost::optional<std::shared_ptr<shared_model::interface::Peer>>
+  getPeerFromWsv(
+      const shared_model::interface::types::PubkeyType &public_key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return peer_query_->getLedgerPeerByPublicKey(public_key);
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::shared_ptr<iroha::ametsuchi::PeerQuery> peer_query_;
+};
+
+PeerTlsCertificatesProviderWsv::PeerTlsCertificatesProviderWsv(
+    std::shared_ptr<iroha::ametsuchi::PeerQuery> peer_query)
+    : impl_(std::make_unique<Impl>(std::move(peer_query))) {}
+
+PeerTlsCertificatesProviderWsv::~PeerTlsCertificatesProviderWsv() = default;
+
+Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderWsv::get(
+    const shared_model::interface::Peer &peer) const {
+  if (not peer.tlsCertificate()) {
+    return makeError(peer.toString() + " does not have a certificate.");
+  }
+  return makeValue(peer.tlsCertificate().value());
+}
+
+Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderWsv::get(
+    const shared_model::interface::types::PubkeyType &public_key) const {
+  auto opt_peer = impl_->getPeerFromWsv(public_key);
+  if (not opt_peer) {
+    return makeError(std::string{"Could not find peer by "}
+                     + public_key.toString());
+  }
+  return get(*opt_peer.value());
+}

--- a/irohad/network/impl/peer_tls_certificates_provider_wsv.hpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_wsv.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEER_TLS_CERTIFICATES_PROVIDER_WSV_HPP
+#define IROHA_PEER_TLS_CERTIFICATES_PROVIDER_WSV_HPP
+
+#include "network/peer_tls_certificates_provider.hpp"
+
+#include <memory>
+
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class Peer;
+  }
+}  // namespace shared_model
+
+namespace iroha {
+  namespace ametsuchi {
+    class PeerQuery;
+  }
+  namespace network {
+
+    class PeerTlsCertificatesProviderWsv : public PeerTlsCertificatesProvider {
+     public:
+      PeerTlsCertificatesProviderWsv(
+          std::shared_ptr<iroha::ametsuchi::PeerQuery> peer_query);
+
+      ~PeerTlsCertificatesProviderWsv();
+
+      iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::Peer &peer) const override;
+
+      iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::types::PubkeyType &public_key)
+          const override;
+
+     private:
+      class Impl;
+      std::unique_ptr<Impl> impl_;
+    };
+
+  };  // namespace network
+};    // namespace iroha
+
+#endif

--- a/irohad/network/peer_tls_certificates_provider.hpp
+++ b/irohad/network/peer_tls_certificates_provider.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEER_TLS_CERTIFICATES_PROVIDER_HPP
+#define IROHA_PEER_TLS_CERTIFICATES_PROVIDER_HPP
+
+#include <memory>
+#include <string>
+
+#include "common/result.hpp"
+#include "interfaces/common_objects/types.hpp"
+
+namespace shared_model {
+  namespace interface {
+    class Peer;
+  }
+}  // namespace shared_model
+
+namespace iroha {
+  namespace network {
+
+    class PeerTlsCertificatesProvider {
+     public:
+      virtual ~PeerTlsCertificatesProvider() = default;
+
+      /// Get peer TLS certificate.
+      virtual iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::Peer &peer) const = 0;
+
+      /// Get peer TLS certificate by peer public key.
+      virtual iroha::expected::Result<
+          shared_model::interface::types::TLSCertificateType,
+          std::string>
+      get(const shared_model::interface::types::PubkeyType &public_key)
+          const = 0;
+    };
+
+  }  // namespace network
+}  // namespace iroha
+
+#endif


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This change adds peer certificate provider interface and 2 its implementations: one returns root certificate for every peer, and another gets certificates from WSV. The code to initialize cert provider is also added.

In the cert provider interface, the method accepting `interface::Peer` is required for client side, and is very effective when using both root and WSV impleentations, because all the data is stored in memory. The method accepting `interface::types::PubkeyType` is required for server side, which gets the peer's public key from its sertificate, and is as effetcive as the first only with root certs, because the WSV info has to be queried separately on demand. So it is not reasonable to restrict the interface only to either one of the methods, because it would require excessive work to be done either on client, or on server side. Also see alternative designs section.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

One more step towards p2p tls.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

The interface provides 2 methods to get a cert, that differ in the peer specification method. One takes an `interface::Peer` object, while another takes `interface::types::PubkeyType`. This is in fact combining independent functions and should be split to 2 different interfaces according to single responsibility principle. But that would require writing 2 interfaces: `PeerTlsCertificatesProviderByPeer` and `PeerTlsCertificatesProviderByPublicKey`, with 2 implementations each (root & WSV), which seems too complicated.

<!-- Explain what other alternates were considered and why the proposed version was selected -->
