### PR TITLE
crypto blobs: reworked passthrough

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -69,8 +69,12 @@ namespace fs = boost::filesystem;
 
 iroha::keypair_t *makeOldModel(const shared_model::crypto::Keypair &keypair) {
   return new iroha::keypair_t{
-      iroha::pubkey_t::from_string(toBinaryString(keypair.publicKey())),
-      iroha::privkey_t::from_string(toBinaryString(keypair.privateKey()))};
+      iroha::expected::resultToOptionalValue(
+          iroha::pubkey_t::from_string(toBinaryString(keypair.publicKey())))
+          .value(),
+      iroha::expected::resultToOptionalValue(
+          iroha::privkey_t::from_string(toBinaryString(keypair.privateKey())))
+          .value()};
 }
 
 int main(int argc, char *argv[]) {

--- a/irohad/model/converters/impl/pb_block_factory.cpp
+++ b/irohad/model/converters/impl/pb_block_factory.cpp
@@ -59,13 +59,19 @@ namespace iroha {
 
         block.txs_number = static_cast<uint16_t>(pl.tx_number());
         block.height = pl.height();
-        block.prev_hash = hash256_t::from_string(pl.prev_block_hash());
+        block.prev_hash = iroha::expected::resultToOptionalValue(
+                              hash256_t::from_string(pl.prev_block_hash()))
+                              .value();
         block.created_ts = pl.created_time();
 
         for (const auto &pb_sig : pb_block.block_v1().signatures()) {
           model::Signature sig;
-          sig.signature = sig_t::from_string(pb_sig.signature());
-          sig.pubkey = pubkey_t::from_string(pb_sig.public_key());
+          sig.signature = iroha::expected::resultToOptionalValue(
+                              sig_t::from_string(pb_sig.signature()))
+                              .value();
+          sig.pubkey = iroha::expected::resultToOptionalValue(
+                           pubkey_t::from_string(pb_sig.public_key()))
+                           .value();
           block.sigs.push_back(std::move(sig));
         }
 

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -103,12 +103,15 @@ namespace iroha {
               // Convert to get transactions
               const auto &pb_cast = pl.get_transactions();
               auto query = GetTransactions();
-              std::transform(pb_cast.tx_hashes().begin(),
-                             pb_cast.tx_hashes().end(),
-                             std::back_inserter(query.tx_hashes),
-                             [](auto tx_hash) {
-                               return iroha::hash256_t::from_hexstring(tx_hash);
-                             });
+              std::transform(
+                  pb_cast.tx_hashes().begin(),
+                  pb_cast.tx_hashes().end(),
+                  std::back_inserter(query.tx_hashes),
+                  [](auto tx_hash) {
+                    return iroha::expected::resultToOptionalValue(
+                               iroha::hash256_t::from_hexstring(tx_hash))
+                        .value();
+                  });
               val = std::make_shared<GetTransactions>(query);
               break;
             }
@@ -137,8 +140,12 @@ namespace iroha {
         const auto &pb_sign = pb_query.signature();
 
         Signature sign{};
-        sign.pubkey = pubkey_t::from_hexstring(pb_sign.public_key());
-        sign.signature = sig_t::from_hexstring(pb_sign.signature());
+        sign.pubkey = iroha::expected::resultToOptionalValue(
+                          pubkey_t::from_hexstring(pb_sign.public_key()))
+                          .value();
+        sign.signature = iroha::expected::resultToOptionalValue(
+                             sig_t::from_hexstring(pb_sign.signature()))
+                             .value();
 
         val->query_counter = pl.meta().query_counter();
         val->signature = sign;

--- a/irohad/model/converters/impl/pb_transaction_factory.cpp
+++ b/irohad/model/converters/impl/pb_transaction_factory.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "model/converters/pb_transaction_factory.hpp"
+
 #include "model/commands/add_asset_quantity.hpp"
 #include "model/converters/pb_command_factory.hpp"
 
@@ -47,8 +48,12 @@ namespace iroha {
 
         for (const auto &pb_sig : pb_tx.signatures()) {
           model::Signature sig{};
-          sig.pubkey = pubkey_t::from_hexstring(pb_sig.public_key());
-          sig.signature = sig_t::from_hexstring(pb_sig.signature());
+          sig.pubkey = iroha::expected::resultToOptionalValue(
+                           pubkey_t::from_hexstring(pb_sig.public_key()))
+                           .value();
+          sig.signature = iroha::expected::resultToOptionalValue(
+                              sig_t::from_hexstring(pb_sig.signature()))
+                              .value();
           tx.signatures.push_back(sig);
         }
 

--- a/irohad/model/generators/impl/transaction_generator.cpp
+++ b/irohad/model/generators/impl/transaction_generator.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "model/generators/transaction_generator.hpp"
+
 #include "crypto/keys_manager_impl.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 #include "datetime/time.hpp"
@@ -17,9 +18,14 @@ namespace iroha {
       iroha::keypair_t *makeOldModel(
           const shared_model::crypto::Keypair &keypair) {
         return new iroha::keypair_t{
-            iroha::pubkey_t::from_string(toBinaryString(keypair.publicKey())),
-            iroha::privkey_t::from_string(
-                toBinaryString(keypair.privateKey()))};
+            iroha::expected::resultToOptionalValue(
+                iroha::pubkey_t::from_string(
+                    toBinaryString(keypair.publicKey())))
+                .value(),
+            iroha::expected::resultToOptionalValue(
+                iroha::privkey_t::from_string(
+                    toBinaryString(keypair.privateKey())))
+                .value()};
       }
 
       Transaction TransactionGenerator::generateGenesisTransaction(

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.cpp
@@ -36,16 +36,11 @@ namespace shared_model {
     }
 
     Keypair CryptoProviderEd25519Sha3::generateKeypair(const Seed &seed) {
+      assert(seed.size() == kSeedLength);
       auto keypair = iroha::create_keypair(
-          iroha::blob_t<32>::from_string(toBinaryString(seed)));
+          iroha::blob_t<kSeedLength>::from_raw(seed.blob().data()));
       return Keypair(PublicKey(keypair.pubkey.to_string()),
                      PrivateKey(keypair.privkey.to_string()));
     }
-
-    const size_t CryptoProviderEd25519Sha3::kHashLength = 256 / 8;
-    const size_t CryptoProviderEd25519Sha3::kPublicKeyLength = 256 / 8;
-    const size_t CryptoProviderEd25519Sha3::kPrivateKeyLength = 256 / 8;
-    const size_t CryptoProviderEd25519Sha3::kSignatureLength = 512 / 8;
-    const size_t CryptoProviderEd25519Sha3::kSeedLength = 256 / 8;
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/crypto_provider.hpp
@@ -61,11 +61,11 @@ namespace shared_model {
        */
       static Keypair generateKeypair(const Seed &seed);
 
-      static const size_t kHashLength;
-      static const size_t kPublicKeyLength;
-      static const size_t kPrivateKeyLength;
-      static const size_t kSignatureLength;
-      static const size_t kSeedLength;
+      static constexpr size_t kHashLength = 256 / 8;
+      static constexpr size_t kPublicKeyLength = 256 / 8;
+      static constexpr size_t kPrivateKeyLength = 256 / 8;
+      static constexpr size_t kSignatureLength = 512 / 8;
+      static constexpr size_t kSeedLength = 256 / 8;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/signer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "cryptography/ed25519_sha3_impl/signer.hpp"
+
 #include "crypto/hash_types.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
@@ -11,12 +12,13 @@
 namespace shared_model {
   namespace crypto {
     Signed Signer::sign(const Blob &blob, const Keypair &keypair) {
+      assert(keypair.publicKey().size() == iroha::pubkey_t::size());
+      assert(keypair.privateKey().size() == iroha::privkey_t::size());
       return Signed(
           iroha::sign(
               iroha::sha3_256(crypto::toBinaryString(blob)).to_string(),
-              iroha::pubkey_t::from_string(toBinaryString(keypair.publicKey())),
-              iroha::privkey_t::from_string(
-                  toBinaryString(keypair.privateKey())))
+              iroha::pubkey_t::from_raw(keypair.publicKey().blob().data()),
+              iroha::privkey_t::from_raw(keypair.privateKey().blob().data()))
               .to_string());
     }
   }  // namespace crypto

--- a/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
+++ b/shared_model/cryptography/ed25519_sha3_impl/verifier.cpp
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "verifier.hpp"
+#include "cryptography/ed25519_sha3_impl/verifier.hpp"
+
 #include "cryptography/ed25519_sha3_impl/internal/ed25519_impl.hpp"
 #include "cryptography/ed25519_sha3_impl/internal/sha3_hash.hpp"
 
@@ -12,10 +13,13 @@ namespace shared_model {
     bool Verifier::verify(const Signed &signedData,
                           const Blob &orig,
                           const PublicKey &publicKey) {
-      return iroha::verify(
-          iroha::sha3_256(crypto::toBinaryString(orig)).to_string(),
-          iroha::pubkey_t::from_string(toBinaryString(publicKey)),
-          iroha::sig_t::from_string(toBinaryString(signedData)));
+      auto blob_hash = iroha::sha3_256(orig.blob());
+      return publicKey.size() == iroha::pubkey_t::size()
+          and signedData.size() == iroha::sig_t::size()
+          and iroha::verify(blob_hash.data(),
+                            blob_hash.size(),
+                            iroha::pubkey_t::from_raw(publicKey.blob().data()),
+                            iroha::sig_t::from_raw(signedData.blob().data()));
     }
   }  // namespace crypto
 }  // namespace shared_model


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

[IR-650](https://jira.hyperledger.org/browse/IR-650)

### Description of the Change

This change started as removal of uncaught exception in favour of a `Result` object. Then several optimizations of blobs conversions were also made.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Removed uncaught exception in blob conversion. Optimized conversions.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

The code under old cli and `irohad/model` was fixed fast and dirty, just to keep the old behaviour before it gets purged.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
