### PR TITLE
Infrastructure: replace gcc5 with gcc9, replace Ubuntu 16.04 with 18.04

### DIFF
--- a/.jenkinsci/text-variables.groovy
+++ b/.jenkinsci/text-variables.groovy
@@ -12,11 +12,11 @@ param_chose_opt = 'Default\nBranch commit\nOn open PR\nCommit in Open PR\nBefore
 param_descriptions = """
 <p>
   <strong>Default</strong> - will automatically chose the correct one based on branch name and build number<br />
-  <strong>Branch commit</strong> - Linux/gcc v5; Test: Smoke, Unit;<br />
-  <strong>On open PR -</strong> Linux/gcc v5, MacOS/appleclang, Windows/msvc; Test: All; Coverage; Analysis: cppcheck, sonar, codestyle;<br />
+  <strong>Branch commit</strong> - Linux/gcc v7; Test: Smoke, Unit;<br />
+  <strong>On open PR -</strong> Linux/gcc v7, MacOS/appleclang, Windows/msvc; Test: All; Coverage; Analysis: cppcheck, sonar, codestyle;<br />
   <strong>Commit in Open PR</strong> - Same as Branch commit<br />
-  <strong>Before merge to trunk</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true<br />
-  <strong>Nightly build</strong> - Linux/gcc v5 v7, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true; sanitize<br />
+  <strong>Before merge to trunk</strong> - Linux/gcc v7 v9, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true<br />
+  <strong>Nightly build</strong> - Linux/gcc v7 v9, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true; sanitize<br />
   <strong>Custom command</strong> - enter command below, Ex: build_type='Release'; testing=false;<br />
 </p>
 """
@@ -40,13 +40,13 @@ cmd_description = """
 </div>
 <ul>
    <li>
-      <p><strong>x64linux_compiler_list</strong> = ['gcc5']&nbsp;</p>
+      <p><strong>x64linux_compiler_list</strong> = ['gcc7']&nbsp;</p>
       <ul>
          <li>
             <p>Linux compiler name to build</p>
          </li>
          <li>
-            <p>Ex:&nbsp;x64linux_compiler_list = ['gcc5','gcc7', 'clang6' , 'clang7']</p>
+            <p>Ex:&nbsp;x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6', 'clang7']</p>
          </li>
       </ul>
    </li>
@@ -174,7 +174,7 @@ cmd_description = """
             <p>Runs Sonar Analysis, runs only on Linux</p>
          </li>
          <li>
-            <p>Ex:&nbsp;sonar = true;x64linux_compiler_list= ['gcc5','gcc7']</p>
+            <p>Ex:&nbsp;sonar = true;x64linux_compiler_list= ['gcc7', 'gcc9']</p>
          </li>
       </ul>
    </li>

--- a/.jenkinsci/utils/vars.groovy
+++ b/.jenkinsci/utils/vars.groovy
@@ -9,8 +9,8 @@
 //
 
 def compilerMapping () {
-  return ['gcc5': ['cxx_compiler':'g++-5', 'cc_compiler':'gcc-5'],
-          'gcc7' : ['cxx_compiler':'g++-7', 'cc_compiler':'gcc-7'],
+  return ['gcc7': ['cxx_compiler':'g++-7', 'cc_compiler':'gcc-7'],
+          'gcc9' : ['cxx_compiler':'g++-9', 'cc_compiler':'gcc-9'],
           'clang6': ['cxx_compiler':'clang++-6.0', 'cc_compiler':'clang-6.0'],
           'clang7': ['cxx_compiler':'clang++-7', 'cc_compiler':'clang-7'],
           'appleclang': ['cxx_compiler':'clang++', 'cc_compiler':'clang'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ node ('master') {
   // Define variable and params
 
   //All variable and Default values
-  x64linux_compiler_list = ['gcc5']
+  x64linux_compiler_list = ['gcc7']
   mac_compiler_list = []
   win_compiler_list = []
 
@@ -216,7 +216,7 @@ node ('master') {
         break;
      case 'Before merge to trunk':
         gitNotify ("Jenkins: Merge to trunk", "Started...", 'PENDING')
-        x64linux_compiler_list = ['gcc5','gcc7', 'clang6' , 'clang7']
+        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6' , 'clang7']
         mac_compiler_list = ['appleclang']
         win_compiler_list = ['msvc']
         testing = true
@@ -228,7 +228,7 @@ node ('master') {
         useBTF = true
         break;
      case 'Nightly build':
-        x64linux_compiler_list = ['gcc5','gcc7', 'clang6' , 'clang7']
+        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6' , 'clang7']
         mac_compiler_list = ['appleclang']
         win_compiler_list = ['msvc']
         testing = true
@@ -301,12 +301,12 @@ node ('master') {
       // TODO 2019-08-14 lebdron: IR-600 Fix integration tests execution when built with shared libraries
       // Build with shared libraries
       x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
-      parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc5'], build_type, true, false, false,
+      parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc7'], build_type, true, false, false,
       false, testList, false, false, false, false, false, false, fuzzing, benchmarking, false, useBTF, use_libursa, false, environmentList)}]
       if (!use_libursa) {
         // Force build with libursa
         x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
-        parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc5'], build_type, build_shared_libs, false, false,
+        parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc7'], build_type, build_shared_libs, false, false,
         testing, testList, false, false, false, false, false, false, fuzzing, benchmarking, coredumps, useBTF, true, false, environmentList)}]
       }
     }

--- a/cmake/Modules/Findursa.cmake
+++ b/cmake/Modules/Findursa.cmake
@@ -1,6 +1,9 @@
 add_library(ursa UNKNOWN IMPORTED)
 find_package(OpenSSL REQUIRED)
 
+get_filename_component(_OPENSSL_INCLUDE_PARENT_DIR ${OPENSSL_INCLUDE_DIR} DIRECTORY)
+set(OPENSSL_ROOT_DIR ${_OPENSSL_INCLUDE_PARENT_DIR})
+
 set(URL     "https://github.com/hyperledger/ursa/")
 set(VERSION "d425dc2f721659f6bdec50a91d3cb9a1d21ec3f3")
 
@@ -17,7 +20,7 @@ externalproject_add(hyperledger_ursa
   GIT_REPOSITORY    ${URL}
   GIT_TAG           ${VERSION}
   BUILD_IN_SOURCE   1
-  BUILD_COMMAND     cargo build --release --no-default-features --features="ffi"
+  BUILD_COMMAND     ${CMAKE_COMMAND} -E env OPENSSL_DIR=${OPENSSL_ROOT_DIR} cargo build --release --no-default-features --features="ffi"
   CONFIGURE_COMMAND "" # remove configure step
   UPDATE_COMMAND    "" # remove update step
   INSTALL_COMMAND   "" # remove install step

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -1,32 +1,28 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # number of concurrent threads during build
 # usage: docker build --build-arg PARALLELISM=8 -t name/name .
 ARG PARALLELISM=1
-ARG CMAKE_BUILD_TYPE=Release
 
 ENV IROHA_HOME /opt/iroha
 ENV IROHA_BUILD /opt/iroha/build
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install apt-utils software-properties-common wget; \
+    apt-get -y --no-install-recommends install apt-utils software-properties-common wget gpg-agent; \
     apt-get -y clean
 
 # add repos
 RUN set -e; \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test; \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
-    echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main' >> /etc/apt/sources.list; \
-    echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main' >> /etc/apt/sources.list; \
+    echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main' >> /etc/apt/sources.list; \
+    echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main' >> /etc/apt/sources.list; \
     apt-get update
 
 RUN set -e; \
-    apt-get -y --no-install-recommends install python-software-properties \
-        automake libtool \
-        # compilers (gcc-5, gcc-7, clang-6)
-        build-essential clang-6.0 lldb-6.0 lld-6.0 g++-7 \
-        # dev dependencies
-        libssl-dev zlib1g-dev libcurl4-openssl-dev libc6-dbg golang \
+    apt-get -y --no-install-recommends install libtool \
+        # compilers (gcc-7, gcc-9, clang-6)
+        build-essential clang-6.0 lldb-6.0 lld-6.0 g++-9 \
         # CI dependencies
         git ssh tar gzip ca-certificates gnupg \
         # Pythons

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-RUN apt-get update; \
-    apt-get install -y libc-ares-dev
+RUN apt-get update
 
 #Install iroha
 COPY iroha.deb /tmp/iroha.deb

--- a/docs/source/build/index.rst
+++ b/docs/source/build/index.rst
@@ -84,7 +84,7 @@ After you execute this script, the following things will happen:
 
 #. The script will check whether you have containers with Iroha already running. Successful completion finishes with the new container shell.
 
-#. The script will download ``hyperledger/iroha:develop-build`` and ``postgres`` images. ``hyperledger/iroha:develop-build`` image contains all development dependencies and is based on top of ``ubuntu:16.04``. ``postgres`` image is required for starting and running Iroha.
+#. The script will download ``hyperledger/iroha:develop-build`` and ``postgres`` images. ``hyperledger/iroha:develop-build`` image contains all development dependencies and is based on top of ``ubuntu:18.04``. ``postgres`` image is required for starting and running Iroha.
 
 #. Two containers are created and launched.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,4 +24,4 @@ sonar.cxx.cppcheck.reportPath=build/reports/cppcheck*.xml
 sonar.cxx.vera.reportPath=build/reports/vera*.xml
 sonar.cxx.xunit.reportPath=build/reports/xunit*.xml
 
-sonar.cxx.includeDirectories=/usr/include/c++/5,/usr/include/x86_64-linux-gnu/c++/5,/usr/include/c++/5/backward,/usr/lib/gcc/x86_64-linux-gnu/5/include,/usr/local/include,/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed,/usr/include/x86_64-linux-gnu,/usr/include,shared_model,libs,irohad,test,iroha-cli
+sonar.cxx.includeDirectories=/usr/include/c++/7,/usr/include/x86_64-linux-gnu/c++/7,/usr/include/c++/7/backward,/usr/lib/gcc/x86_64-linux-gnu/7/include,/usr/local/include,/usr/lib/gcc/x86_64-linux-gnu/7/include-fixed,/usr/include/x86_64-linux-gnu,/usr/include,shared_model,libs,irohad,test,iroha-cli


### PR DESCRIPTION
### Description of the Change
- Bump Ubuntu version to 18.04
- Replace gcc5 with gcc9 to avoid compiler errors and enable C++17 support

### Benefits
Updated environment

### Possible Drawbacks 
Less legacy support?
