### PR TITLE
GetStatus can return Rejected for a tx

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -92,6 +92,13 @@ namespace iroha {
             log_->warn("Asked non-existing tx: {}", request.hex());
             return status_factory_->makeNotReceived(request);
           },
+          [this, &request](
+              const iroha::ametsuchi::tx_cache_status_responses::Rejected &) {
+            std::shared_ptr<shared_model::interface::TransactionResponse>
+                response = status_factory_->makeRejected(request);
+            cache_->addItem(request, response);
+            return response;
+          },
           [this, &request](const auto &) {
             std::shared_ptr<shared_model::interface::TransactionResponse>
                 response = status_factory_->makeCommitted(request);

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -99,7 +99,8 @@ namespace iroha {
             cache_->addItem(request, response);
             return response;
           },
-          [this, &request](const auto &) {
+          [this, &request](
+              const iroha::ametsuchi::tx_cache_status_responses::Committed &) {
             std::shared_ptr<shared_model::interface::TransactionResponse>
                 response = status_factory_->makeCommitted(request);
             cache_->addItem(request, response);

--- a/test/module/irohad/torii/command_service_test.cpp
+++ b/test/module/irohad/torii/command_service_test.cpp
@@ -124,7 +124,7 @@ TEST_F(CommandServiceTest, ProcessBatchOn) {
 /**
  * @given initialized command service
  * @when  status of a transaction is queried
- *        @and im-memory cache does not contain info about the transaction
+ *        @and in-memory cache does not contain info about the transaction
  *        @and the transaction is saved to the ledger as Rejected
  * @then  query response tells that the transaction has been rejected
  */
@@ -148,8 +148,10 @@ TEST_F(CommandServiceTest, RejectedTxStatus) {
 
   initCommandService();
   auto response = command_service_->getStatus(hash);
-  iroha::visit_in_place(
-      response->get(),
-      [](const shared_model::interface::RejectedTxResponse &) {},
-      [](const auto &a) { FAIL() << "Wrong response!"; });
+
+  ASSERT_NO_THROW({
+    boost::get<const shared_model::interface::RejectedTxResponse &>(
+        response->get());
+  }) << "Wrong response. Expected: RejectedTxResponse, Received: "
+     << response->toString();
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

A query for a transaction status could return Committed instead of Rejected for a transaction processed long time ago.

### Benefits

Correct behavior

### Possible Drawbacks 

Miserable code redundancy
