### PR TITLE
Ametsuchi: transactions query detects missing transactions

### DIFF
--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.hpp
@@ -9,6 +9,7 @@
 #include "ametsuchi/specific_query_executor.hpp"
 
 #include <soci/soci.h>
+#include "common/result.hpp"
 #include "interfaces/iroha_internal/query_response_factory.hpp"
 #include "logger/logger_fwd.hpp"
 
@@ -133,13 +134,14 @@ namespace iroha {
      private:
       /**
        * Get transactions from block using range from range_gen and filtered by
-       * predicate pred
+       * predicate pred and store them in dest_it
        */
-      template <typename RangeGen, typename Pred>
-      std::vector<std::unique_ptr<shared_model::interface::Transaction>>
-      getTransactionsFromBlock(uint64_t block_id,
-                               RangeGen &&range_gen,
-                               Pred &&pred);
+      template <typename RangeGen, typename Pred, typename OutputIterator>
+      iroha::expected::Result<void, std::string> getTransactionsFromBlock(
+          uint64_t block_id,
+          RangeGen &&range_gen,
+          Pred &&pred,
+          OutputIterator dest_it);
 
       /**
        * Execute query and return its response


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

In case of inconsistency between transaction index and block storage, an unhandled out-of-range exception was thrown. After this change the range violation will result in an internal error response with explanation. also a small refactoring was done.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

less reasons to crash. less objects moving.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
