### PR TITLE
Infrastructure: replace MSVC 2017 with MSVC 2019

### DIFF
--- a/.jenkinsci/builders/x64-win-build-steps.groovy
+++ b/.jenkinsci/builders/x64-win-build-steps.groovy
@@ -15,7 +15,7 @@ def buildSteps(int parallelism, List compilerVersions, String buildType, boolean
     for (compiler in compilerVersions) {
       stage ("build ${compiler}"){
         bat '''
-cmake -H.\\ -B.\\build -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -G "Visual Studio 15 2017 Win64" -T host=x64 &&^
+cmake -H.\\ -B.\\build -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -G "Visual Studio 16 2019" -A x64 -T host=x64 &&^
 cmake --build .\\build --target irohad &&^
 cmake --build .\\build --target iroha-cli
         '''

--- a/.packer/win/files/packages.config
+++ b/.packer/win/files/packages.config
@@ -4,5 +4,5 @@
   <package id="curl" />
   <package id="jre8" />
   <package id="cmake" version="3.14.4" installArguments="ADD_CMAKE_TO_PATH=System"/>
-  <package id="visualstudio2017-workload-vctools" packageParameters="--wait" />
+  <package id="visualstudio2019-workload-vctools" packageParameters="--wait" />
 </packages>

--- a/docs/source/build/index.rst
+++ b/docs/source/build/index.rst
@@ -156,7 +156,6 @@ Install CMake, Git, Microsoft compilers via chocolatey being in Administrative m
 .. code-block:: shell
 
   choco install cmake git visualstudio2019-workload-vctools ninja
-  # visualstudio2017-workload-vctools should work as well
 
 
 PostgreSQL is not a build dependency, but it is recommended to install it now for the testing later:


### PR DESCRIPTION
### Description of the Change
Update MSVC version from 2017 to 2019 due to compilation issues of operators inside lambdas.

### Benefits
Standard-conformant code compiles on Windows.

### Possible Drawbacks 
Less compatibility with older compilers.
