### PR TITLE
Use the crypto provider corresponding to public key type during runtime

### DIFF
--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
@@ -50,7 +50,7 @@ namespace iroha {
         const auto &pubkey = keypair_.publicKey();
         const auto &privkey = keypair_.privateKey();
         using namespace shared_model::interface::types;
-        auto signature = shared_model::crypto::CryptoSigner<>::sign(
+        auto signature = shared_model::crypto::CryptoSigner::sign(
             blob,
             shared_model::crypto::Keypair(PublicKeyHexStringView{pubkey},
                                           privkey));

--- a/libs/common/hexutils.hpp
+++ b/libs/common/hexutils.hpp
@@ -15,6 +15,18 @@
 
 namespace iroha {
 
+  template <typename Container>
+  inline auto hexstringToBytestringSize(Container const &c)
+      -> decltype(c.size()) {
+    return (c.size() + 1) / 2;
+  }
+
+  template <typename Container>
+  inline auto bytestringToHexstringSize(Container const &c)
+      -> decltype(c.size()) {
+    return c.size() * 2;
+  }
+
   /**
    * Convert string of raw bytes to printable hex string
    * @param str - raw bytes string to convert
@@ -27,7 +39,7 @@ namespace iroha {
     static_assert(sizeof(*input.data()) == sizeof(uint8_t), "type mismatch");
     const auto beg = reinterpret_cast<const uint8_t *>(input.data());
     const auto end = beg + input.size();
-    destination.reserve(destination.size() + input.size() * 2);
+    destination.reserve(destination.size() + bytestringToHexstringSize(input));
     boost::algorithm::hex_lower(beg, end, std::back_inserter(destination));
   }
 
@@ -59,7 +71,7 @@ namespace iroha {
       return makeError("Hex string contains uneven number of characters.");
     }
     std::string result;
-    result.reserve(str.size() / 2);
+    result.reserve(hexstringToBytestringSize(str));
     try {
       boost::algorithm::unhex(
           str.begin(), str.end(), std::back_inserter(result));

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -57,7 +57,7 @@ namespace shared_model {
        * @return signed object
        */
       UnsignedWrapper &signAndAddSignature(const crypto::Keypair &keypair) {
-        auto signature_hex = shared_model::crypto::CryptoSigner<>::sign(
+        auto signature_hex = shared_model::crypto::CryptoSigner::sign(
             shared_model::crypto::Blob(object_.payload()), keypair);
         if (object_finalized_) {
           throw std::runtime_error("object has already been finalized");

--- a/shared_model/cryptography/CMakeLists.txt
+++ b/shared_model/cryptography/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(model_impl)
 add_subdirectory(ed25519_sha3_impl)
 
 add_library(shared_model_cryptography
+  crypto_provider/crypto_signer.cpp
   crypto_provider/crypto_verifier.cpp
   )
 

--- a/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
@@ -14,7 +14,7 @@
 namespace shared_model {
 
   namespace crypto {
-    template <typename Algorithm = CryptoSigner<>>
+    template <typename Algorithm = CryptoSigner>
     class CryptoModelSigner
         : public AbstractCryptoModelSigner<interface::Block> {
      public:

--- a/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
@@ -8,6 +8,7 @@
 
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
 #include "cryptography/crypto_provider/crypto_signer.hpp"
+#include "cryptography/keypair.hpp"
 
 #include "interfaces/iroha_internal/block.hpp"
 

--- a/shared_model/cryptography/crypto_provider/crypto_signer.cpp
+++ b/shared_model/cryptography/crypto_provider/crypto_signer.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cryptography/crypto_provider/crypto_signer.hpp"
+
+#include "common/hexutils.hpp"
+#include "common/result.hpp"
+#include "cryptography/blob.hpp"
+#include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
+#include "cryptography/keypair.hpp"
+#include "interfaces/common_objects/byte_range.hpp"
+#include "multihash/multihash.hpp"
+#include "multihash/type.hpp"
+
+#if defined(USE_LIBURSA)
+#include "cryptography/ed25519_ursa_impl/crypto_provider.hpp"
+#define ED25519_PROVIDER CryptoProviderEd25519Ursa
+#endif
+
+using namespace iroha::expected;
+using namespace shared_model::crypto;
+using namespace shared_model::interface::types;
+
+using DefaultSigner = CryptoProviderEd25519Sha3;
+using iroha::multihash::Multihash;
+
+std::string CryptoSigner::sign(const Blob &blob, const Keypair &keypair) {
+  if (iroha::hexstringToBytestringSize(keypair.publicKey())
+      == DefaultSigner::kPublicKeyLength) {
+    return DefaultSigner::sign(blob, keypair);
+  }
+
+  auto signing_result =
+      iroha::hexstringToBytestringResult(keypair.publicKey()) |
+      [](auto const &public_key) {
+        return iroha::multihash::createFromBuffer(makeByteRange(public_key));
+      }
+      | [&blob, &keypair](
+            const Multihash &public_key) -> Result<std::string, char const *> {
+    // prevent unused warnings when compiling without any additional crypto
+    // engines:
+    (void)blob;
+    (void)keypair;
+
+    using iroha::multihash::Type;
+    switch (public_key.type) {
+#if defined(ED25519_PROVIDER)
+      case Type::ed25519pub:
+        return ED25519_PROVIDER::sign(blob, keypair);
+#endif
+      default:
+        return makeError("Unimplemented signature algorithm.");
+    };
+  };
+
+  return std::move(signing_result)
+      .match([](auto &&signature) { return std::move(signature.value); },
+             [](const auto & /* error */) {
+               assert(false);
+               return "";
+             });
+}

--- a/shared_model/cryptography/crypto_provider/crypto_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_signer.hpp
@@ -6,14 +6,14 @@
 #ifndef IROHA_CRYPTO_SIGNER_HPP
 #define IROHA_CRYPTO_SIGNER_HPP
 
-#include "cryptography/blob.hpp"
-#include "cryptography/ed25519_sha3_impl/crypto_provider.hpp"
-#include "cryptography/keypair.hpp"
-#include "cryptography/signed.hpp"
-#include "multihash/multihash.hpp"
+#include <string>
 
 namespace shared_model {
   namespace crypto {
+
+    class Blob;
+    class Keypair;
+
     /**
      * CryptoSigner - wrapper for generalization signing for different
      * cryptographic algorithms
@@ -27,24 +27,7 @@ namespace shared_model {
        * @param keypair - (public, private) keys for signing
        * @return hex signature
        */
-      static std::string sign(const Blob &blob, const Keypair &keypair) {
-        if (keypair.publicKey().blob().size()
-            == shared_model::crypto::CryptoProviderEd25519Sha3::
-                   kPublicKeyLength) {
-          return CryptoProviderEd25519Sha3::sign(blob, keypair);
-        } else if (auto opt_multihash = iroha::expected::resultToOptionalValue(
-                       libp2p::multi::Multihash::createFromBuffer(
-                           kagome::common::Buffer{
-                               keypair.publicKey().blob()}))) {
-          if (opt_multihash->getType() == libp2p::multi::HashType::ed25519pub
-              && opt_multihash->getHash().size()
-                  == shared_model::crypto::CryptoProviderEd25519Ursa::
-                         kPublicKeyLength) {
-            return CryptoProviderEd25519Ursa::sign(blob, keypair);
-          }
-        }
-        return Signed{""};
-      }
+      static std::string sign(const Blob &blob, const Keypair &keypair);
 
       /// close constructor for forbidding instantiation
       CryptoSigner() = delete;

--- a/test/integration/acceptance/tx_acceptance_test.cpp
+++ b/test/integration/acceptance/tx_acceptance_test.cpp
@@ -168,7 +168,7 @@ TEST_F(AcceptanceTest, TransactionEmptyPubKey) {
   shared_model::proto::Transaction tx =
       baseTx<TestTransactionBuilder>().build();
 
-  auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
+  auto signedBlob = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(tx.payload()), kAdminKeypair);
   tx.addSignature(
       shared_model::interface::types::SignedHexStringView{signedBlob},
@@ -208,7 +208,7 @@ TEST_F(AcceptanceTest, TransactionEmptySignedblob) {
 TEST_F(AcceptanceTest, TransactionInvalidPublicKey) {
   shared_model::proto::Transaction tx =
       baseTx<TestTransactionBuilder>().build();
-  auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
+  auto signedBlob = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(tx.payload()), kAdminKeypair);
   std::string public_key{
       shared_model::crypto::DefaultCryptoAlgorithmType::kPublicKeyLength, 'a'};
@@ -231,7 +231,7 @@ TEST_F(AcceptanceTest, TransactionInvalidSignedBlob) {
   shared_model::proto::Transaction tx =
       baseTx<TestTransactionBuilder>().build();
 
-  auto wrong_signature = shared_model::crypto::CryptoSigner<>::sign(
+  auto wrong_signature = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(tx.payload()), kUserKeypair);
 
   tx.addSignature(

--- a/test/module/irohad/multi_sig_transactions/mst_test_helpers.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_test_helpers.hpp
@@ -73,7 +73,7 @@ auto addSignaturesFromKeyPairs(Batch &&batch,
                                KeyPairs... keypairs) {
   auto create_signature = [&](auto &&key_pair) {
     auto &payload = batch->transactions().at(tx_number)->payload();
-    auto signed_blob = shared_model::crypto::CryptoSigner<>::sign(
+    auto signed_blob = shared_model::crypto::CryptoSigner::sign(
         shared_model::crypto::Blob(payload), key_pair);
     using namespace shared_model::interface::types;
     batch->addSignature(tx_number,

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -97,7 +97,7 @@ class TransactionProcessorTest : public ::testing::Test {
   auto addSignaturesFromKeyPairs(Transaction &&tx, KeyPairs... keypairs) {
     auto create_signature = [&](auto &&key_pair) {
       auto &payload = tx.payload();
-      auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
+      auto signedBlob = shared_model::crypto::CryptoSigner::sign(
           shared_model::crypto::Blob(payload), key_pair);
       using namespace shared_model::interface::types;
       tx.addSignature(SignedHexStringView{signedBlob},

--- a/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_queries_test.cpp
@@ -59,7 +59,7 @@ TEST(ProtoQueryBuilder, Builder) {
 
   auto keypair =
       shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  auto signedProto = shared_model::crypto::CryptoSigner<>::sign(
+  auto signedProto = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(proto_query.payload().SerializeAsString()),
       keypair);
 
@@ -95,7 +95,7 @@ TEST(ProtoQueryBuilder, BlocksQueryBuilder) {
 
   auto keypair =
       shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  auto signedProto = shared_model::crypto::CryptoSigner<>::sign(
+  auto signedProto = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(proto_query.meta().SerializeAsString()),
       keypair);
 

--- a/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_transaction_test.cpp
@@ -62,7 +62,7 @@ TEST(ProtoTransaction, Builder) {
 
   auto keypair =
       shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
-  auto signature_hex = shared_model::crypto::CryptoSigner<>::sign(
+  auto signature_hex = shared_model::crypto::CryptoSigner::sign(
       shared_model::crypto::Blob(proto_tx.payload().SerializeAsString()),
       keypair);
 

--- a/test/module/shared_model/cryptography/crypto_usage_test.cpp
+++ b/test/module/shared_model/cryptography/crypto_usage_test.cpp
@@ -115,10 +115,9 @@ TYPED_TEST_CASE(CryptoUsageTest, CryptoUsageTestTypes, );
  * @then check that siganture valid without clarification of algorithm
  */
 TYPED_TEST(CryptoUsageTest, RawSignAndVerifyTest) {
-  auto signature =
-      iroha::hexstringToBytestringResult(
-          TestFixture::CurrentCryptoProvider::sign(this->data, this->keypair))
-          .assumeValue();
+  auto signature = iroha::hexstringToBytestringResult(
+                       CryptoSigner::sign(this->data, this->keypair))
+                       .assumeValue();
   using namespace shared_model::interface::types;
   auto verified = CryptoVerifier::verify(
       SignedHexStringView{iroha::bytestringToHexstring(signature)},


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Note: This PR is based on the changes in #263, so that should be reviewed before this one. 

This change modifies the `CryptoSigner` to run the correct signing implementation, depending on the input public key type. 

`KeysManagerImpl` also had to be changed so it can correctly load both ursa-keys and iroha-keys from files, depending only on the imported public key. This also assumes Iroha is compiled with the build flag `LIBURSA=ON`.
 
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

During runtime, Iroha can correctly load ursa-generated keys or iroha-generated keys from files, and use them to sign and verify blocks. 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
