### PR TITLE
Jenkins: fix Docker image build on Linux for master branch

### DIFF
--- a/.jenkinsci/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci/builders/x64-linux-build-steps.groovy
@@ -78,10 +78,13 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
            --network=${env.IROHA_NETWORK} postgres:9.5 -c 'max_prepared_transactions=100'
       fi
     """
-
+    referenceBranchOrCommit = 'master'
+    if (scmVars.GIT_LOCAL_BRANCH == referenceBranchOrCommit && scmVars.GIT_PREVIOUS_COMMIT) {
+      referenceBranchOrCommit = scmVars.GIT_PREVIOUS_COMMIT
+    }
     iC = dockerUtils.dockerPullOrBuild("${platform}-develop-build",
         "${env.GIT_RAW_BASE_URL}/${scmVars.GIT_COMMIT}/docker/develop/Dockerfile",
-        "${env.GIT_RAW_BASE_URL}/master/docker/develop/Dockerfile",
+        "${env.GIT_RAW_BASE_URL}/${referenceBranchOrCommit}/docker/develop/Dockerfile",
         scmVars,
         environment,
         forceDockerDevelopBuild,


### PR DESCRIPTION
### Description of the Change
Docker build could have failed when Dockerfile was changed and committed to master branch because the new Dockerfile was compared to itself instead of previous version.
https://jenkins.soramitsu.co.jp/job/iroha/job/iroha-hyperledger/job/master/218/consoleText

### Benefits
Successful master build on Dockerfile changes

### Possible Drawbacks 
None