### PR TITLE
refactoring: reworked PrettyStringBuilder

### DIFF
--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -387,7 +387,7 @@ namespace iroha {
             command_name_(std::move(command_name)),
             perm_converter_(std::move(perm_converter)) {
         arguments_string_builder_.init(command_name_)
-            .append("Validation", std::to_string(enable_validation));
+            .append("Validation", enable_validation);
       }
 
       template <typename T,
@@ -436,7 +436,7 @@ namespace iroha {
       // TODO IR-597 mboldyrev 2019.08.10: build args string on demand
       void addArgumentToString(const std::string &argument_name,
                                const std::string &value) {
-        arguments_string_builder_.append(argument_name, value);
+        arguments_string_builder_.appendNamed(argument_name, value);
       }
 
       void addArgumentToString(const std::string &argument_name,

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -387,7 +387,7 @@ namespace iroha {
             command_name_(std::move(command_name)),
             perm_converter_(std::move(perm_converter)) {
         arguments_string_builder_.init(command_name_)
-            .append("Validation", enable_validation);
+            .appendNamed("Validation", enable_validation);
       }
 
       template <typename T,

--- a/irohad/consensus/impl/round.cpp
+++ b/irohad/consensus/impl/round.cpp
@@ -41,8 +41,8 @@ namespace iroha {
     std::string Round::toString() const {
       return shared_model::detail::PrettyStringBuilder()
           .init("Round")
-          .append("block", std::to_string(block_round))
-          .append("reject", std::to_string(reject_round))
+          .appendNamed("block", block_round)
+          .appendNamed("reject", reject_round)
           .finalize();
     }
   }  // namespace consensus

--- a/irohad/consensus/yac/outcome_messages.hpp
+++ b/irohad/consensus/yac/outcome_messages.hpp
@@ -32,8 +32,7 @@ namespace iroha {
         std::string toString() const {
           return shared_model::detail::PrettyStringBuilder()
               .init(typeName())
-              .appendAll(
-                  "votes", votes, [](auto vote) { return vote.toString(); })
+              .appendNamed("votes", votes)
               .finalize();
         }
 

--- a/irohad/consensus/yac/vote_message.hpp
+++ b/irohad/consensus/yac/vote_message.hpp
@@ -34,7 +34,7 @@ namespace iroha {
         std::string toString() const {
           return shared_model::detail::PrettyStringBuilder()
               .init("VoteMessage")
-              .append("yac hash", hash.toString())
+              .appendNamed("yac hash", hash)
               .appendNamed("signature", signature)
               .finalize();
         }

--- a/irohad/consensus/yac/vote_message.hpp
+++ b/irohad/consensus/yac/vote_message.hpp
@@ -35,8 +35,7 @@ namespace iroha {
           return shared_model::detail::PrettyStringBuilder()
               .init("VoteMessage")
               .append("yac hash", hash.toString())
-              .append("signature",
-                      signature ? signature->toString() : "not set")
+              .appendNamed("signature", signature)
               .finalize();
         }
       };

--- a/irohad/consensus/yac/yac_hash_provider.hpp
+++ b/irohad/consensus/yac/yac_hash_provider.hpp
@@ -59,8 +59,8 @@ namespace iroha {
           std::string toString() const {
             return shared_model::detail::PrettyStringBuilder()
                 .init("VoteHashes")
-                .append("proposal", proposal_hash)
-                .append("block", block_hash)
+                .appendNamed("proposal", proposal_hash)
+                .appendNamed("block", block_hash)
                 .finalize();
           }
         };
@@ -84,8 +84,8 @@ namespace iroha {
         std::string toString() const {
           return shared_model::detail::PrettyStringBuilder()
               .init("YacHash")
-              .append("round", vote_round.toString())
-              .append("hashes", vote_hashes.toString())
+              .appendNamed("round", vote_round)
+              .appendNamed("hashes", vote_hashes)
               .finalize();
         }
       };

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -37,6 +37,13 @@ target_link_libraries(libs_timeout INTERFACE
 
 add_library(irohad_version irohad_version.cpp)
 
+add_library(libs_to_string INTERFACE
+  # to_string.hpp
+  )
+target_link_libraries(libs_to_string INTERFACE
+  Boost::boost
+  )
+
 # Get the git repo data
 set(GIT_REPO_PRETTY_VER "version info unavailable")
 if (EXISTS "${PROJECT_SOURCE_DIR}/.git")

--- a/libs/common/to_string.hpp
+++ b/libs/common/to_string.hpp
@@ -1,0 +1,104 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_LIBS_TO_STRING_HPP
+#define IROHA_LIBS_TO_STRING_HPP
+
+#include <memory>
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace iroha {
+  namespace to_string {
+    namespace detail {
+      const std::string kBeginBlockMarker = "[";
+      const std::string kEndBlockMarker = "]";
+      const std::string kSingleFieldsSeparator = ", ";
+      const std::string kNotSet = "(not set)";
+
+      /// Print pointers and optionals.
+      template <typename T>
+      inline std::string toStringDereferenced(const T &o);
+    }  // namespace detail
+
+    inline std::string toString(const std::string &o) {
+      return o;
+    }
+
+    template <typename T>
+    inline auto toString(const T &o) -> std::enable_if_t<
+        std::is_same<decltype(std::to_string(o)), std::string>::value,
+        std::string> {
+      return std::to_string(o);
+    }
+
+    template <typename T>
+    inline auto toString(const T &o) -> std::enable_if_t<
+        std::is_same<typename std::decay_t<decltype(o.toString())>,
+                     std::string>::value,
+        std::string> {
+      return o.toString();
+    }
+
+    template <typename... T>
+    inline std::string toString(const std::unique_ptr<T...> &o) {
+      return detail::toStringDereferenced(o);
+    }
+
+    template <typename... T>
+    inline std::string toString(const std::shared_ptr<T...> &o) {
+      return detail::toStringDereferenced(o);
+    }
+
+    template <typename T>
+    inline std::string toString(const T *o) {
+      return detail::toStringDereferenced(o);
+    }
+
+    template <typename T>
+    inline auto toString(const T &o) -> std::enable_if_t<
+        boost::optional_detail::is_optional_related<T>::value,
+        std::string> {
+      return detail::toStringDereferenced(o);
+    }
+
+    /// Print a plain collection.
+    template <typename T, typename = decltype(*std::declval<T>().begin())>
+    inline std::string toString(const T &c) {
+      std::string result = detail::kBeginBlockMarker;
+      bool need_field_separator = false;
+      for (auto &o : c) {
+        if (need_field_separator) {
+          result.append(detail::kSingleFieldsSeparator);
+        }
+        result.append(toString(o));
+        need_field_separator = true;
+      }
+      result.append(detail::kEndBlockMarker);
+      return result;
+    }
+
+    namespace detail {
+      /// Print pointers and optionals.
+      template <typename T>
+      inline std::string toStringDereferenced(const T &o) {
+        if (o) {
+          return ::iroha::to_string::toString(*o);
+        } else {
+          return kNotSet;
+        }
+      }
+
+      template <>
+      inline std::string toStringDereferenced<boost::none_t>(
+          const boost::none_t &) {
+        return kNotSet;
+      }
+    }  // namespace detail
+  }    // namespace to_string
+}  // namespace iroha
+
+#endif

--- a/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_role.cpp
@@ -32,9 +32,8 @@ namespace shared_model {
     std::string CreateRole::toString() const {
       return detail::PrettyStringBuilder()
           .init("CreateRole")
-          .append("role_name", roleName())
-          .appendAll(permissions::toString(rolePermissions()),
-                     [](auto p) { return p; })
+          .appendNamed("role_name", roleName())
+          .append(permissions::toString(rolePermissions()))
           .finalize();
     }
 

--- a/shared_model/backend/protobuf/commands/impl/proto_grant_permission.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_grant_permission.cpp
@@ -24,8 +24,8 @@ namespace shared_model {
     std::string GrantPermission::toString() const {
       return detail::PrettyStringBuilder()
           .init("GrantPermission")
-          .append("account_id", accountId())
-          .append("permission", permissions::toString(permissionName()))
+          .appendNamed("account_id", accountId())
+          .appendNamed("permission", permissions::toString(permissionName()))
           .finalize();
     }
 

--- a/shared_model/backend/protobuf/commands/impl/proto_revoke_permission.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_revoke_permission.cpp
@@ -24,8 +24,8 @@ namespace shared_model {
     std::string RevokePermission::toString() const {
       return detail::PrettyStringBuilder()
           .init("RevokePermission")
-          .append("account_id", accountId())
-          .append("permission", permissions::toString(permissionName()))
+          .appendNamed("account_id", accountId())
+          .appendNamed("permission", permissions::toString(permissionName()))
           .finalize();
     }
 

--- a/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_role_permissions_response.cpp
@@ -34,8 +34,7 @@ namespace shared_model {
     std::string RolePermissionsResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("RolePermissionsResponse")
-          .appendAll(permissions::toString(rolePermissions()),
-                     [](auto p) { return p; })
+          .append(permissions::toString(rolePermissions()))
           .finalize();
     }
 

--- a/shared_model/cryptography/model_impl/keypair.cpp
+++ b/shared_model/cryptography/model_impl/keypair.cpp
@@ -26,8 +26,8 @@ namespace shared_model {
     std::string Keypair::toString() const {
       return detail::PrettyStringBuilder()
           .init("Keypair")
-          .append("publicKey", publicKey().toString())
-          .append("privateKey", privateKey().toString())
+          .appendNamed("publicKey", publicKey())
+          .appendNamed("privateKey", privateKey())
           .finalize();
     }
 

--- a/shared_model/interfaces/CMakeLists.txt
+++ b/shared_model/interfaces/CMakeLists.txt
@@ -70,6 +70,7 @@ if (IROHA_ROOT_PROJECT)
       query_responses/impl/pending_transactions_page_response.cpp
       query_responses/impl/peers_response.cpp
       transaction_responses/impl/tx_response.cpp
+      iroha_internal/batch_meta.cpp
       iroha_internal/transaction_sequence.cpp
       iroha_internal/transaction_batch_impl.cpp
       iroha_internal/transaction_batch_parser_impl.cpp

--- a/shared_model/interfaces/base/model_primitive.hpp
+++ b/shared_model/interfaces/base/model_primitive.hpp
@@ -33,7 +33,8 @@ namespace shared_model {
       virtual std::string toString() const {
         return detail::PrettyStringBuilder()
             .init("Primitive")
-            .append("address", std::to_string(reinterpret_cast<uint64_t>(this)))
+            .appendNamed("address",
+                         std::to_string(reinterpret_cast<uint64_t>(this)))
             .finalize();
       }
 

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -91,9 +91,8 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("Signable")
-            .append("created_time", std::to_string(createdTime()))
-            .appendAll(signatures(),
-                       [](auto &signature) { return signature.toString(); })
+            .appendNamed("created_time", std::to_string(createdTime()))
+            .append(signatures())
             .finalize();
       }
 

--- a/shared_model/interfaces/commands/impl/add_asset_quantity.cpp
+++ b/shared_model/interfaces/commands/impl/add_asset_quantity.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string AddAssetQuantity::toString() const {
       return detail::PrettyStringBuilder()
           .init("AddAssetQuantity")
-          .append("asset_id", assetId())
-          .append("amount", amount().toString())
+          .appendNamed("asset_id", assetId())
+          .appendNamed("amount", amount())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/add_peer.cpp
+++ b/shared_model/interfaces/commands/impl/add_peer.cpp
@@ -13,7 +13,7 @@ namespace shared_model {
     std::string AddPeer::toString() const {
       return detail::PrettyStringBuilder()
           .init("AddPeer")
-          .append("peer", peer().toString())
+          .appendNamed("peer", peer())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/add_signatory.cpp
+++ b/shared_model/interfaces/commands/impl/add_signatory.cpp
@@ -13,8 +13,8 @@ namespace shared_model {
     std::string AddSignatory::toString() const {
       return detail::PrettyStringBuilder()
           .init("AddSignatory")
-          .append("pubkey", pubkey().toString())
-          .append("account_id", accountId())
+          .appendNamed("pubkey", pubkey())
+          .appendNamed("account_id", accountId())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/append_role.cpp
+++ b/shared_model/interfaces/commands/impl/append_role.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string AppendRole::toString() const {
       return detail::PrettyStringBuilder()
           .init("AppendRole")
-          .append("role_name", roleName())
-          .append("account_id", accountId())
+          .appendNamed("role_name", roleName())
+          .appendNamed("account_id", accountId())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
+++ b/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
@@ -11,10 +11,10 @@ namespace shared_model {
     std::string CompareAndSetAccountDetail::toString() const {
       return detail::PrettyStringBuilder()
           .init("CompareAndSetAccountDetail")
-          .append("account_id", accountId())
-          .append("key", key())
-          .append("value", value())
-          .append("old_value", oldValue().value_or("(none)"))
+          .appendNamed("account_id", accountId())
+          .appendNamed("key", key())
+          .appendNamed("value", value())
+          .appendNamed("old_value", oldValue())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/create_account.cpp
+++ b/shared_model/interfaces/commands/impl/create_account.cpp
@@ -13,9 +13,9 @@ namespace shared_model {
     std::string CreateAccount::toString() const {
       return detail::PrettyStringBuilder()
           .init("CreateAccount")
-          .append("account_name", accountName())
-          .append("domain_id", domainId())
-          .append(pubkey().toString())
+          .appendNamed("account_name", accountName())
+          .appendNamed("domain_id", domainId())
+          .appendNamed("public_key", pubkey())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/create_asset.cpp
+++ b/shared_model/interfaces/commands/impl/create_asset.cpp
@@ -11,9 +11,9 @@ namespace shared_model {
     std::string CreateAsset::toString() const {
       return detail::PrettyStringBuilder()
           .init("CreateAsset")
-          .append("asset_name", assetName())
-          .append("domain_id", domainId())
-          .append("precision", std::to_string(precision()))
+          .appendNamed("asset_name", assetName())
+          .appendNamed("domain_id", domainId())
+          .appendNamed("precision", precision())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/create_domain.cpp
+++ b/shared_model/interfaces/commands/impl/create_domain.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string CreateDomain::toString() const {
       return detail::PrettyStringBuilder()
           .init("CreateDomain")
-          .append("domain_id", domainId())
-          .append("user_default_role", userDefaultRole())
+          .appendNamed("domain_id", domainId())
+          .appendNamed("user_default_role", userDefaultRole())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/detach_role.cpp
+++ b/shared_model/interfaces/commands/impl/detach_role.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string DetachRole::toString() const {
       return detail::PrettyStringBuilder()
           .init("DetachRole")
-          .append("role_name", roleName())
-          .append("account_id", accountId())
+          .appendNamed("role_name", roleName())
+          .appendNamed("account_id", accountId())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/remove_peer.cpp
+++ b/shared_model/interfaces/commands/impl/remove_peer.cpp
@@ -13,7 +13,7 @@ namespace shared_model {
     std::string RemovePeer::toString() const {
       return detail::PrettyStringBuilder()
           .init("RemovePeer")
-          .append(pubkey().toString())
+          .append(pubkey())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/remove_signatory.cpp
+++ b/shared_model/interfaces/commands/impl/remove_signatory.cpp
@@ -13,8 +13,8 @@ namespace shared_model {
     std::string RemoveSignatory::toString() const {
       return detail::PrettyStringBuilder()
           .init("RemoveSignatory")
-          .append("account_id", accountId())
-          .append(pubkey().toString())
+          .appendNamed("account_id", accountId())
+          .appendNamed("public_key", pubkey())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/set_account_detail.cpp
+++ b/shared_model/interfaces/commands/impl/set_account_detail.cpp
@@ -11,9 +11,9 @@ namespace shared_model {
     std::string SetAccountDetail::toString() const {
       return detail::PrettyStringBuilder()
           .init("SetAccountDetail")
-          .append("account_id", accountId())
-          .append("key", key())
-          .append("value", value())
+          .appendNamed("account_id", accountId())
+          .appendNamed("key", key())
+          .appendNamed("value", value())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/set_quorum.cpp
+++ b/shared_model/interfaces/commands/impl/set_quorum.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string SetQuorum::toString() const {
       return detail::PrettyStringBuilder()
           .init("SetQuorum")
-          .append("account_id", accountId())
-          .append("quorum", std::to_string(newQuorum()))
+          .appendNamed("account_id", accountId())
+          .appendNamed("quorum", newQuorum())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/set_setting_value.cpp
+++ b/shared_model/interfaces/commands/impl/set_setting_value.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string SetSettingValue::toString() const {
       return detail::PrettyStringBuilder()
           .init("SetSettingValue")
-          .append("key", key())
-          .append("value", value())
+          .appendNamed("key", key())
+          .appendNamed("value", value())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/subtract_asset_quantity.cpp
+++ b/shared_model/interfaces/commands/impl/subtract_asset_quantity.cpp
@@ -11,8 +11,8 @@ namespace shared_model {
     std::string SubtractAssetQuantity::toString() const {
       return detail::PrettyStringBuilder()
           .init("SubtractAssetQuantity")
-          .append("asset_id", assetId())
-          .append("amount", amount().toString())
+          .appendNamed("asset_id", assetId())
+          .appendNamed("amount", amount())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/transfer_asset.cpp
+++ b/shared_model/interfaces/commands/impl/transfer_asset.cpp
@@ -11,11 +11,11 @@ namespace shared_model {
     std::string TransferAsset::toString() const {
       return detail::PrettyStringBuilder()
           .init("TransferAsset")
-          .append("src_account_id", srcAccountId())
-          .append("dest_account_id", destAccountId())
-          .append("asset_id", assetId())
-          .append("description", description())
-          .append("amount", amount().toString())
+          .appendNamed("src_account_id", srcAccountId())
+          .appendNamed("dest_account_id", destAccountId())
+          .appendNamed("asset_id", assetId())
+          .appendNamed("description", description())
+          .appendNamed("amount", amount())
           .finalize();
     }
 

--- a/shared_model/interfaces/common_objects/account.hpp
+++ b/shared_model/interfaces/common_objects/account.hpp
@@ -46,10 +46,10 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("Account")
-            .append("accountId", accountId())
-            .append("domainId", domainId())
-            .append("quorum", std::to_string(quorum()))
-            .append("json", jsonData())
+            .appendNamed("accountId", accountId())
+            .appendNamed("domainId", domainId())
+            .appendNamed("quorum", quorum())
+            .appendNamed("json", jsonData())
             .finalize();
       }
 

--- a/shared_model/interfaces/common_objects/account_asset.hpp
+++ b/shared_model/interfaces/common_objects/account_asset.hpp
@@ -41,9 +41,9 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("AccountAsset")
-            .append("accountId", accountId())
-            .append("assetId", assetId())
-            .append("balance", balance().toString())
+            .appendNamed("accountId", accountId())
+            .appendNamed("assetId", assetId())
+            .appendNamed("balance", balance())
             .finalize();
       }
 

--- a/shared_model/interfaces/common_objects/asset.hpp
+++ b/shared_model/interfaces/common_objects/asset.hpp
@@ -40,9 +40,9 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("Asset")
-            .append("assetId", assetId())
-            .append("domainId", domainId())
-            .append("precision", std::to_string(precision()))
+            .appendNamed("assetId", assetId())
+            .appendNamed("domainId", domainId())
+            .appendNamed("precision", precision())
             .finalize();
       }
 

--- a/shared_model/interfaces/common_objects/domain.hpp
+++ b/shared_model/interfaces/common_objects/domain.hpp
@@ -34,8 +34,8 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("Domain")
-            .append("domainId", domainId())
-            .append("defaultRole", defaultRole())
+            .appendNamed("domainId", domainId())
+            .appendNamed("defaultRole", defaultRole())
             .finalize();
       }
 

--- a/shared_model/interfaces/common_objects/impl/peer.cpp
+++ b/shared_model/interfaces/common_objects/impl/peer.cpp
@@ -14,9 +14,9 @@ namespace shared_model {
     std::string Peer::toString() const {
       return detail::PrettyStringBuilder()
           .init("Peer")
-          .append("address", address())
-          .append("pubkey", pubkey().toString())
-          .append("tlsCertificate", bool(tlsCertificate()))
+          .appendNamed("address", address())
+          .appendNamed("pubkey", pubkey())
+          .appendNamed("tlsCertificate", bool(tlsCertificate()))
           .finalize();
     }
 

--- a/shared_model/interfaces/common_objects/impl/signature.cpp
+++ b/shared_model/interfaces/common_objects/impl/signature.cpp
@@ -17,8 +17,8 @@ namespace shared_model {
     std::string Signature::toString() const {
       return detail::PrettyStringBuilder()
           .init("Signature")
-          .append("publicKey", publicKey().hex())
-          .append("signedData", signedData().hex())
+          .appendNamed("publicKey", publicKey().hex())
+          .appendNamed("signedData", signedData().hex())
           .finalize();
     }
   }  // namespace interface

--- a/shared_model/interfaces/impl/transaction.cpp
+++ b/shared_model/interfaces/impl/transaction.cpp
@@ -15,18 +15,14 @@ namespace shared_model {
     std::string Transaction::toString() const {
       return detail::PrettyStringBuilder()
           .init("Transaction")
-          .append("hash", hash().hex())
-          .append("creatorAccountId", creatorAccountId())
-          .append("createdTime", std::to_string(createdTime()))
-          .append("quorum", std::to_string(quorum()))
-          .append("commands")
-          .appendAll(commands(),
-                     [](auto &command) { return command.toString(); })
-          .append("batch_meta",
-                  batchMeta() ? batchMeta()->get()->toString() : "")
-          .append("reducedHash", reducedHash().toString())
-          .append("signatures")
-          .appendAll(signatures(), [](auto &sig) { return sig.toString(); })
+          .appendNamed("hash", hash().hex())
+          .appendNamed("creatorAccountId", creatorAccountId())
+          .appendNamed("createdTime", createdTime())
+          .appendNamed("quorum", quorum())
+          .appendNamed("commands", commands())
+          .appendNamed("batch_meta", batchMeta())
+          .appendNamed("reducedHash", reducedHash())
+          .appendNamed("signatures", signatures())
           .finalize();
     }
 

--- a/shared_model/interfaces/iroha_internal/batch_meta.cpp
+++ b/shared_model/interfaces/iroha_internal/batch_meta.cpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "interfaces/iroha_internal/batch_meta.hpp"
+
+#include <boost/range/algorithm/equal.hpp>
+#include "cryptography/hash.hpp"
+
+using namespace shared_model::interface;
+
+std::string BatchMeta::toString() const {
+  return detail::PrettyStringBuilder()
+      .init("BatchMeta")
+      .appendNamed("Type",
+                   type() == types::BatchType::ATOMIC ? "ATOMIC" : "ORDERED")
+      .append(reducedHashes())
+      .finalize();
+}
+
+bool BatchMeta::operator==(const ModelType &rhs) const {
+  return boost::equal(reducedHashes(), rhs.reducedHashes())
+      and type() == rhs.type();
+}

--- a/shared_model/interfaces/iroha_internal/batch_meta.hpp
+++ b/shared_model/interfaces/iroha_internal/batch_meta.hpp
@@ -19,15 +19,8 @@ namespace shared_model {
      public:
       virtual types::BatchType type() const = 0;
 
-      std::string toString() const override {
-        return detail::PrettyStringBuilder()
-            .init("BatchMeta")
-            .append("Type",
-                    type() == types::BatchType::ATOMIC ? "ATOMIC" : "ORDERED")
-            .appendAll(reducedHashes(),
-                       [](auto &hash) { return hash.toString(); })
-            .finalize();
-      }
+      std::string toString() const override;
+
       /// type of hashes collection
       using ReducedHashesType = std::vector<interface::types::HashType>;
 
@@ -35,15 +28,13 @@ namespace shared_model {
        * @return Hashes of transactions to fetch
        */
       virtual const ReducedHashesType &reducedHashes() const = 0;
+
       /**
        * Checks equality of objects inside
        * @param rhs - other wrapped value
        * @return true, if wrapped objects are same
        */
-      bool operator==(const ModelType &rhs) const override {
-        return boost::equal(reducedHashes(), rhs.reducedHashes())
-            and type() == rhs.type();
-      }
+      bool operator==(const ModelType &rhs) const override;
     };
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/iroha_internal/block.cpp
+++ b/shared_model/interfaces/iroha_internal/block.cpp
@@ -14,18 +14,14 @@ namespace shared_model {
     std::string Block::toString() const {
       return detail::PrettyStringBuilder()
           .init("Block")
-          .append("hash", hash().hex())
-          .append("height", std::to_string(height()))
-          .append("prevHash", prevHash().hex())
-          .append("txsNumber", std::to_string(txsNumber()))
-          .append("createdtime", std::to_string(createdTime()))
-          .append("transactions")
-          .appendAll(transactions(), [](auto &tx) { return tx.toString(); })
-          .append("signatures")
-          .appendAll(signatures(), [](auto &sig) { return sig.toString(); })
-          .appendAll("rejected transactions",
-                     rejected_transactions_hashes(),
-                     [](auto &hash) { return hash.hex(); })
+          .appendNamed("hash", hash().hex())
+          .appendNamed("height", height())
+          .appendNamed("prevHash", prevHash().hex())
+          .appendNamed("txsNumber", txsNumber())
+          .appendNamed("createdtime", createdTime())
+          .appendNamed("transactions", transactions())
+          .appendNamed("signatures", signatures())
+          .appendNamed("rejected transactions", rejected_transactions_hashes())
           .finalize();
     }
 

--- a/shared_model/interfaces/iroha_internal/proposal.hpp
+++ b/shared_model/interfaces/iroha_internal/proposal.hpp
@@ -43,10 +43,8 @@ namespace shared_model {
       std::string toString() const override {
         return detail::PrettyStringBuilder()
             .init("Proposal")
-            .append("height", std::to_string(height()))
-            .append("transactions")
-            .appendAll(transactions(),
-                       [](auto &transaction) { return transaction.toString(); })
+            .appendNamed("height", height())
+            .appendNamed("transactions", transactions())
             .finalize();
       }
     };

--- a/shared_model/interfaces/iroha_internal/transaction_batch.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch.cpp
@@ -14,9 +14,7 @@ namespace shared_model {
     std::string TransactionBatch::toString() const {
       return detail::PrettyStringBuilder()
           .init("TransactionBatch")
-          .appendAll("Transactions",
-                     transactions(),
-                     [](auto &tx) { return tx->toString(); })
+          .appendNamed("Transactions", transactions())
           .finalize();
     }
 

--- a/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
@@ -45,10 +45,9 @@ namespace shared_model {
     std::string TransactionBatchImpl::toString() const {
       return detail::PrettyStringBuilder()
           .init("Batch")
-          .append("reducedHash", reducedHash().toString())
-          .append("hasAllSignatures", hasAllSignatures() ? "true" : "false")
-          .append("transactions")
-          .appendAll(transactions(), [](auto &tx) { return tx->toString(); })
+          .appendNamed("reducedHash", reducedHash())
+          .appendNamed("hasAllSignatures", hasAllSignatures())
+          .appendNamed("transactions", transactions())
           .finalize();
     }
 

--- a/shared_model/interfaces/iroha_internal/transaction_sequence.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_sequence.cpp
@@ -42,8 +42,7 @@ namespace shared_model {
     std::string TransactionSequence::toString() const {
       return detail::PrettyStringBuilder()
           .init("TransactionSequence")
-          .appendAll(batches_,
-                     [](const auto &batch) { return batch->toString(); })
+          .append(batches_)
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/account_detail_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/account_detail_pagination_meta.cpp
@@ -16,9 +16,7 @@ std::string AccountDetailPaginationMeta::toString() const {
   const auto first_record_id = firstRecordId();
   return detail::PrettyStringBuilder()
       .init("AccountDetailPaginationMeta")
-      .append("page_size", std::to_string(pageSize()))
-      .append(
-          "first_record_id",
-          first_record_id ? first_record_id->toString() : std::string("(none)"))
+      .appendNamed("page_size", pageSize())
+      .appendNamed("first_record_id", first_record_id)
       .finalize();
 }

--- a/shared_model/interfaces/queries/impl/account_detail_record_id.cpp
+++ b/shared_model/interfaces/queries/impl/account_detail_record_id.cpp
@@ -14,7 +14,7 @@ bool AccountDetailRecordId::operator==(const ModelType &rhs) const {
 std::string AccountDetailRecordId::toString() const {
   return detail::PrettyStringBuilder()
       .init("AccountDetailRecordId")
-      .append("writer", writer())
-      .append("key", key())
+      .appendNamed("writer", writer())
+      .appendNamed("key", key())
       .finalize();
 }

--- a/shared_model/interfaces/queries/impl/asset_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/asset_pagination_meta.cpp
@@ -14,7 +14,7 @@ bool AssetPaginationMeta::operator==(const ModelType &rhs) const {
 std::string AssetPaginationMeta::toString() const {
   return detail::PrettyStringBuilder()
       .init("AssetPaginationMeta")
-      .append("page_size", std::to_string(pageSize()))
-      .append("first_asset_id", firstAssetId().value_or("(none)"))
+      .appendNamed("page_size", pageSize())
+      .appendNamed("first_asset_id", firstAssetId())
       .finalize();
 }

--- a/shared_model/interfaces/queries/impl/blocks_query.cpp
+++ b/shared_model/interfaces/queries/impl/blocks_query.cpp
@@ -12,8 +12,8 @@ namespace shared_model {
     std::string BlocksQuery::toString() const {
       return detail::PrettyStringBuilder()
           .init("BlocksQuery")
-          .append("creatorId", creatorAccountId())
-          .append("queryCounter", std::to_string(queryCounter()))
+          .appendNamed("creatorId", creatorAccountId())
+          .appendNamed("queryCounter", queryCounter())
           .append(Signable::toString())
           .finalize();
     }

--- a/shared_model/interfaces/queries/impl/get_account.cpp
+++ b/shared_model/interfaces/queries/impl/get_account.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     std::string GetAccount::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAccount")
-          .append("account_id", accountId())
+          .appendNamed("account_id", accountId())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_asset_transactions.cpp
@@ -13,9 +13,9 @@ namespace shared_model {
     std::string GetAccountAssetTransactions::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAccountAssetTransactions")
-          .append("account_id", accountId())
-          .append("asset_id", assetId())
-          .append("pagination_meta", paginationMeta().toString())
+          .appendNamed("account_id", accountId())
+          .appendNamed("asset_id", assetId())
+          .appendNamed("pagination_meta", paginationMeta())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_assets.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_assets.cpp
@@ -13,9 +13,8 @@ namespace shared_model {
     std::string GetAccountAssets::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAccountAssets")
-          .append("account_id", accountId())
-          .append("pagination_meta",
-                  paginationMeta() ? paginationMeta()->toString() : "(not set)")
+          .appendNamed("account_id", accountId())
+          .appendNamed("pagination_meta", paginationMeta())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_detail.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_detail.cpp
@@ -11,11 +11,10 @@ namespace shared_model {
     std::string GetAccountDetail::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAccountDetail")
-          .append("account_id", accountId())
-          .append("key", key() ? *key() : "")
-          .append("writer", writer() ? *writer() : "")
-          .append("pagination_meta",
-                  paginationMeta() ? paginationMeta()->toString() : "(not set)")
+          .appendNamed("account_id", accountId())
+          .appendNamed("key", key())
+          .appendNamed("writer", writer())
+          .appendNamed("pagination_meta", paginationMeta())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_account_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_transactions.cpp
@@ -13,8 +13,8 @@ namespace shared_model {
     std::string GetAccountTransactions::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAccountTransactions")
-          .append("account_id", accountId())
-          .append("pagination_meta", paginationMeta().toString())
+          .appendNamed("account_id", accountId())
+          .appendNamed("pagination_meta", paginationMeta())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_asset_info.cpp
+++ b/shared_model/interfaces/queries/impl/get_asset_info.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     std::string GetAssetInfo::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetAssetInfo")
-          .append("asset_id", assetId())
+          .appendNamed("asset_id", assetId())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_block.cpp
+++ b/shared_model/interfaces/queries/impl/get_block.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     std::string GetBlock::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetBlock")
-          .append("height", std::to_string(height()))
+          .appendNamed("height", height())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
@@ -14,7 +14,7 @@ namespace shared_model {
       auto builder =
           detail::PrettyStringBuilder().init("GetPendingTransactions");
       if (paginationMeta()) {
-        builder.append("pagination_meta", paginationMeta()->toString());
+        builder.appendNamed("pagination_meta", paginationMeta());
       }
       return builder.finalize();
     }

--- a/shared_model/interfaces/queries/impl/get_role_permissions.cpp
+++ b/shared_model/interfaces/queries/impl/get_role_permissions.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     std::string GetRolePermissions::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetRolePermissions")
-          .append("role_id", roleId())
+          .appendNamed("role_id", roleId())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_signatories.cpp
+++ b/shared_model/interfaces/queries/impl/get_signatories.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     std::string GetSignatories::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetSignatories")
-          .append("account_id", accountId())
+          .appendNamed("account_id", accountId())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/get_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_transactions.cpp
@@ -14,8 +14,7 @@ namespace shared_model {
     std::string GetTransactions::toString() const {
       return detail::PrettyStringBuilder()
           .init("GetTransactions")
-          .appendAll(transactionHashes(),
-                     [](const auto &s) { return s.toString(); })
+          .append(transactionHashes())
           .finalize();
     }
 

--- a/shared_model/interfaces/queries/impl/query.cpp
+++ b/shared_model/interfaces/queries/impl/query.cpp
@@ -37,8 +37,8 @@ namespace shared_model {
     std::string Query::toString() const {
       return detail::PrettyStringBuilder()
           .init("Query")
-          .append("creatorId", creatorAccountId())
-          .append("queryCounter", std::to_string(queryCounter()))
+          .appendNamed("creatorId", creatorAccountId())
+          .appendNamed("queryCounter", queryCounter())
           .append(Signable::toString())
           .append(boost::apply_visitor(detail::ToStringVisitor(), get()))
           .finalize();

--- a/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
@@ -16,10 +16,10 @@ bool TxPaginationMeta::operator==(const ModelType &rhs) const {
 std::string TxPaginationMeta::toString() const {
   auto pretty_builder = detail::PrettyStringBuilder()
                             .init("TxPaginationMeta")
-                            .append("page_size", std::to_string(pageSize()));
+                            .appendNamed("page_size", pageSize());
   auto first_tx_hash = firstTxHash();
   if (first_tx_hash) {
-    pretty_builder.append("first_tx_hash", first_tx_hash->toString());
+    pretty_builder.appendNamed("first_tx_hash", first_tx_hash);
   }
   return pretty_builder.finalize();
 }

--- a/shared_model/interfaces/query_responses/impl/account_asset_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/account_asset_response.cpp
@@ -12,11 +12,9 @@ namespace shared_model {
     std::string AccountAssetResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("AccountAssetResponse")
-          .appendAll(
-              "assets", accountAssets(), [](auto &tx) { return tx.toString(); })
-          .append("total assets number",
-                  std::to_string(totalAccountAssetsNumber()))
-          .append("next asset id", nextAssetId().value_or("(none)"))
+          .appendNamed("assets", accountAssets())
+          .appendNamed("total assets number", totalAccountAssetsNumber())
+          .appendNamed("next asset id", nextAssetId())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/account_detail_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/account_detail_response.cpp
@@ -13,10 +13,9 @@ namespace shared_model {
       const auto next_record_id = nextRecordId();
       return detail::PrettyStringBuilder()
           .init("AccountDetailResponse")
-          .append("Details page", detail())
-          .append("Total number", std::to_string(totalNumber()))
-          .append("Next record ID",
-                  next_record_id ? next_record_id->toString() : "(none)")
+          .appendNamed("Details page", detail())
+          .appendNamed("Total number", totalNumber())
+          .appendNamed("Next record ID", next_record_id)
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/account_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/account_response.cpp
@@ -12,9 +12,8 @@ namespace shared_model {
     std::string AccountResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("AccountResponse")
-          .append(account().toString())
-          .append("roles")
-          .appendAll(roles(), [](auto s) { return s; })
+          .append(account())
+          .appendNamed("roles", roles())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/asset_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/asset_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     std::string AssetResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("AssetResponse")
-          .append(asset().toString())
+          .append(asset())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/block_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/block_response.cpp
@@ -13,7 +13,7 @@ namespace shared_model {
     std::string BlockResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("BlockResponse")
-          .append(block().toString())
+          .append(block())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/error_query_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/error_query_response.cpp
@@ -14,7 +14,7 @@ namespace shared_model {
       return detail::PrettyStringBuilder()
           .init("ErrorQueryResponse")
           .append(boost::apply_visitor(detail::ToStringVisitor(), get()))
-          .append("errorMessage", errorMessage())
+          .appendNamed("errorMessage", errorMessage())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/peers_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/peers_response.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "interfaces/query_responses/peers_response.hpp"
+
 #include "interfaces/common_objects/peer.hpp"
 #include "utils/string_builder.hpp"
 
@@ -13,7 +14,7 @@ namespace shared_model {
     std::string PeersResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("PeersResponse")
-          .appendAll(peers(), [](auto &peer) { return peer.toString(); })
+          .append(peers())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/pending_transactions_page_response.cpp
@@ -9,25 +9,21 @@
 
 namespace shared_model {
   namespace interface {
+    std::string PendingTransactionsPageResponse::BatchInfo::toString() const {
+      return detail::PrettyStringBuilder()
+          .init("BatchInfo")
+          .appendNamed("first tx hash", first_tx_hash.hex())
+          .appendNamed("size", batch_size)
+          .finalize();
+    }
 
     std::string PendingTransactionsPageResponse::toString() const {
-      auto builder = detail::PrettyStringBuilder()
-                         .init("PendingTransactionsPageResponse")
-                         .appendAll("transactions",
-                                    transactions(),
-                                    [](auto &tx) { return tx.toString(); })
-                         .append("all transactions size",
-                                 std::to_string(allTransactionsSize()));
-      if (auto next_batch_info = nextBatchInfo()) {
-        builder
-            .append("next batch first tx hash",
-                    next_batch_info->first_tx_hash.hex())
-            .append("next batch size",
-                    std::to_string(next_batch_info->batch_size));
-      } else {
-        builder.append("no next batch info is set");
-      }
-      return builder.finalize();
+      return detail::PrettyStringBuilder()
+          .init("PendingTransactionsPageResponse")
+          .appendNamed("transactions", transactions())
+          .appendNamed("all transactions size", allTransactionsSize())
+          .appendNamed("next batch", nextBatchInfo())
+          .finalize();
     }
 
     bool PendingTransactionsPageResponse::operator==(

--- a/shared_model/interfaces/query_responses/impl/roles_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/roles_response.cpp
@@ -12,7 +12,7 @@ namespace shared_model {
     std::string RolesResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("RolesResponse")
-          .appendAll(roles(), [](auto s) { return s; })
+          .append(roles())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/signatories_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/signatories_response.cpp
@@ -14,7 +14,7 @@ namespace shared_model {
     std::string SignatoriesResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("SignatoriesResponse")
-          .appendAll(keys(), [](auto &key) { return key.toString(); })
+          .append(keys())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/impl/transactions_page_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/transactions_page_response.cpp
@@ -10,17 +10,12 @@ namespace shared_model {
   namespace interface {
 
     std::string TransactionsPageResponse::toString() const {
-      auto builder = detail::PrettyStringBuilder()
-                         .init("TransactionsPageResponse")
-                         .appendAll("transactions",
-                                    transactions(),
-                                    [](auto &tx) { return tx.toString(); })
-                         .append("all transactions size",
-                                 std::to_string(allTransactionsSize()));
-      if (nextTxHash()) {
-        return builder.append("next tx hash", nextTxHash()->hex()).finalize();
-      }
-      return builder.finalize();
+      return detail::PrettyStringBuilder()
+          .init("TransactionsPageResponse")
+          .appendNamed("transactions", transactions())
+          .appendNamed("all transactions size", allTransactionsSize())
+          .appendNamed("next tx", nextTxHash())
+          .finalize();
     }
 
     bool TransactionsPageResponse::operator==(const ModelType &rhs) const {

--- a/shared_model/interfaces/query_responses/impl/transactions_response.cpp
+++ b/shared_model/interfaces/query_responses/impl/transactions_response.cpp
@@ -13,7 +13,7 @@ namespace shared_model {
     std::string TransactionsResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("TransactionsResponse")
-          .appendAll(transactions(), [](auto &tx) { return tx.toString(); })
+          .append(transactions())
           .finalize();
     }
 

--- a/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
@@ -32,6 +32,8 @@ namespace shared_model {
           return first_tx_hash == rhs.first_tx_hash
               and batch_size == rhs.batch_size;
         }
+
+        std::string toString() const;
       };
 
       /**

--- a/shared_model/interfaces/transaction_responses/impl/tx_response.cpp
+++ b/shared_model/interfaces/transaction_responses/impl/tx_response.cpp
@@ -45,11 +45,11 @@ namespace shared_model {
     std::string TransactionResponse::toString() const {
       return detail::PrettyStringBuilder()
           .init("TransactionResponse")
-          .append("transactionHash", transactionHash().hex())
+          .appendNamed("transactionHash", transactionHash().hex())
           .append(boost::apply_visitor(detail::ToStringVisitor(), get()))
-          .append("statelessErrorOrCmdName", statelessErrorOrCommandName())
-          .append("failedCmdIndex", std::to_string(failedCommandIndex()))
-          .append("errorCode", std::to_string(errorCode()))
+          .appendNamed("statelessErrorOrCmdName", statelessErrorOrCommandName())
+          .appendNamed("failedCmdIndex", failedCommandIndex())
+          .appendNamed("errorCode", errorCode())
           .finalize();
     }
 

--- a/shared_model/utils/CMakeLists.txt
+++ b/shared_model/utils/CMakeLists.txt
@@ -4,3 +4,6 @@
 add_library(shared_model_utils
     string_builder.cpp
     )
+target_link_libraries(shared_model_utils
+    libs_to_string
+    )

--- a/shared_model/utils/string_builder.cpp
+++ b/shared_model/utils/string_builder.cpp
@@ -37,7 +37,7 @@ namespace shared_model {
 
     PrettyStringBuilder &PrettyStringBuilder::append(const std::string &value) {
       appendPartial(value);
-      setElementBoundary();
+      need_field_separator_ = true;
       return *this;
     }
 
@@ -47,10 +47,6 @@ namespace shared_model {
         need_field_separator_ = false;
       }
       result_.append(value);
-    }
-
-    void PrettyStringBuilder::setElementBoundary() {
-      need_field_separator_ = true;
     }
 
     std::string PrettyStringBuilder::finalize() {

--- a/shared_model/utils/string_builder.cpp
+++ b/shared_model/utils/string_builder.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     const std::string PrettyStringBuilder::beginBlockMarker = "[";
     const std::string PrettyStringBuilder::endBlockMarker = "]";
     const std::string PrettyStringBuilder::keyValueSeparator = "=";
-    const std::string PrettyStringBuilder::singleFieldsSeparator = ",";
+    const std::string PrettyStringBuilder::singleFieldsSeparator = ", ";
     const std::string PrettyStringBuilder::initSeparator = ":";
     const std::string PrettyStringBuilder::spaceSeparator = " ";
 
@@ -19,47 +19,42 @@ namespace shared_model {
       result_.append(name);
       result_.append(initSeparator);
       result_.append(spaceSeparator);
-      result_.append(beginBlockMarker);
+      insertLevel();
       return *this;
     }
 
     PrettyStringBuilder &PrettyStringBuilder::insertLevel() {
+      need_field_separator_ = false;
       result_.append(beginBlockMarker);
       return *this;
     }
 
     PrettyStringBuilder &PrettyStringBuilder::removeLevel() {
       result_.append(endBlockMarker);
+      need_field_separator_ = true;
       return *this;
-    }
-
-    PrettyStringBuilder &PrettyStringBuilder::append(const std::string &name,
-                                                     const std::string &value) {
-      result_.append(name);
-      result_.append(keyValueSeparator);
-      result_.append(value);
-      result_.append(singleFieldsSeparator);
-      result_.append(spaceSeparator);
-      return *this;
-    }
-
-    PrettyStringBuilder &PrettyStringBuilder::append(const std::string &name,
-                                                     bool value) {
-      if (value) {
-        return append(name, std::string("true"));
-      } else {
-        return append(name, std::string("false"));
-      }
     }
 
     PrettyStringBuilder &PrettyStringBuilder::append(const std::string &value) {
-      result_.append(value);
-      result_.append(spaceSeparator);
+      appendPartial(value);
+      setElementBoundary();
       return *this;
     }
 
+    void PrettyStringBuilder::appendPartial(const std::string &value) {
+      if (need_field_separator_) {
+        result_.append(singleFieldsSeparator);
+        need_field_separator_ = false;
+      }
+      result_.append(value);
+    }
+
+    void PrettyStringBuilder::setElementBoundary() {
+      need_field_separator_ = true;
+    }
+
     std::string PrettyStringBuilder::finalize() {
-      result_.append(endBlockMarker);
+      removeLevel();
       return result_;
     }
 

--- a/shared_model/validators/validation_error.cpp
+++ b/shared_model/validators/validation_error.cpp
@@ -36,11 +36,10 @@ ValidationError &ValidationError::operator|=(ValidationError other) {
 std::string ValidationError::toString() const {
   auto string_builder = detail::PrettyStringBuilder().init(name);
   if (not my_errors.empty()) {
-    string_builder = string_builder.appendAllNamed("Errors", my_errors);
+    string_builder = string_builder.appendNamed("Errors", my_errors);
   }
   if (not child_errors.empty()) {
-    string_builder =
-        string_builder.appendAllNamed("Child errors", child_errors);
+    string_builder = string_builder.appendNamed("Child errors", child_errors);
   }
   return string_builder.finalize();
 }

--- a/test/module/libs/common/CMakeLists.txt
+++ b/test/module/libs/common/CMakeLists.txt
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+addtest(to_string_test to_string_test.cpp)
+target_link_libraries(to_string_test
+        common
+        )
+
 addtest(result_test result_test.cpp)
 target_link_libraries(result_test
         common

--- a/test/module/libs/common/to_string_test.cpp
+++ b/test/module/libs/common/to_string_test.cpp
@@ -1,0 +1,132 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common/to_string.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <boost/optional.hpp>
+#include <boost/range/any_range.hpp>
+
+const std::string kTestString("test");
+
+struct MockToStringable {
+  MOCK_CONST_METHOD0(toString, std::string());
+};
+
+std::unique_ptr<MockToStringable> makeObj(std::string string = kTestString) {
+  auto obj = std::make_unique<MockToStringable>();
+  EXPECT_CALL(*obj, toString()).WillOnce(::testing::Return(string));
+  return obj;
+}
+
+using namespace iroha::to_string;
+
+/**
+ * @given std::string
+ * @when toString is called on it
+ * @then result equals argument
+ */
+TEST(ToStringTest, StdString) {
+  const std::string string("Wake up, Neo...");
+  ASSERT_EQ(toString(string), string);
+}
+
+/**
+ * @given several plain types that std::to_string accepts
+ * @when toString is called on them
+ * @then they are converted as std::to_string does
+ */
+TEST(ToStringTest, PlainValues) {
+  auto test = [](auto o) { EXPECT_EQ(toString(o), std::to_string(o)); };
+  test(404);
+  test(-273);
+  test(15.7f);
+  test(true);
+}
+
+/**
+ * @given ToStringable object
+ * @when toString is called on it
+ * @then result equals expected string
+ */
+TEST(ToStringTest, ToStringMethod) {
+  EXPECT_EQ(toString(*makeObj()), kTestString);
+}
+
+/**
+ * @given ToStringable object wrapped in pointers and optionals
+ * @when toString is called on it
+ * @then result equals expected string
+ */
+TEST(ToStringTest, WrappedDereferenceable) {
+  // start with unique_ptr
+  std::unique_ptr<MockToStringable> o1 = makeObj();
+  MockToStringable *raw_obj = o1.get();
+  EXPECT_EQ(toString(o1), kTestString);
+  // wrap it into optional
+  auto o2 = boost::make_optional(std::move(o1));
+  EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
+  EXPECT_EQ(toString(o2), kTestString);
+  // wrap it into shared_ptr
+  auto o3 = std::make_shared<decltype(o2)>(std::move(o2));
+  EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
+  EXPECT_EQ(toString(o3), kTestString);
+  // wrap it into one more optional
+  auto o4 = boost::make_optional(std::move(o3));
+  EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
+  EXPECT_EQ(toString(o4), kTestString);
+}
+
+/**
+ * @given unset pointers and optional
+ * @when toString is called on them
+ * @then result has "not set"
+ */
+TEST(ToStringTest, UnsetDereferenceable) {
+  auto test = [](const auto &o) { EXPECT_EQ(toString(o), "(not set)"); };
+  test(std::unique_ptr<int>{});
+  test(std::shared_ptr<int>{});
+  test(static_cast<int *>(0));
+  test(boost::optional<int>());
+  test(boost::none);
+}
+
+/**
+ * @given vector of unique_ptr<ToStringable> objects
+ * @when toString is called on it
+ * @then result equals expected string
+ */
+TEST(ToStringTest, VectorOfUniquePointers) {
+  std::vector<std::unique_ptr<MockToStringable>> vec;
+  EXPECT_EQ(toString(vec), "[]");
+  vec.push_back(makeObj("el1"));
+  vec.push_back(makeObj("el2"));
+  vec.push_back(nullptr);
+  EXPECT_EQ(toString(vec), "[el1, el2, (not set)]");
+}
+
+/**
+ * @given vector of unique_ptr<ToStringable> objects
+ * @when toString is called on it
+ * @then result equals expected string
+ */
+TEST(ToStringTest, BoostAnyRangeOfSharedPointers) {
+  std::vector<std::shared_ptr<MockToStringable>> vec;
+  vec.push_back(makeObj("el1"));
+  vec.push_back(makeObj("el2"));
+  vec.push_back(nullptr);
+  boost::any_range<std::shared_ptr<MockToStringable>,
+                   boost::forward_traversal_tag,
+                   const std::shared_ptr<MockToStringable> &>
+      range;
+  EXPECT_EQ(toString(range), "[]");
+  range = vec;
+  EXPECT_EQ(toString(range), "[el1, el2, (not set)]");
+}

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "module/shared_model/mock_objects_factories/mock_command_factory.hpp"
+
 #include "backend/protobuf/permissions.hpp"
 #include "utils/string_builder.hpp"
 
@@ -152,10 +153,9 @@ namespace shared_model {
                 .WillRepeatedly(Return(
                     detail::PrettyStringBuilder()
                         .init("CreateRole")
-                        .append("role_name", role_id)
-                        .appendAll(shared_model::proto::permissions::toString(
-                                       role_permissions),
-                                   [](auto p) { return p; })
+                        .appendNamed("role_name", role_id)
+                        .append(shared_model::proto::permissions::toString(
+                            role_permissions))
                         .finalize()));
             return specific_cmd_mock;
           });
@@ -191,10 +191,10 @@ namespace shared_model {
                 .WillRepeatedly(Return(
                     detail::PrettyStringBuilder()
                         .init("GrantPermission")
-                        .append("account_id", account_id)
-                        .append("permission",
-                                shared_model::proto::permissions::toString(
-                                    permission))
+                        .appendNamed("account_id", account_id)
+                        .appendNamed("permission",
+                                     shared_model::proto::permissions::toString(
+                                         permission))
                         .finalize()));
             return specific_cmd_mock;
           });
@@ -230,10 +230,10 @@ namespace shared_model {
                 .WillRepeatedly(Return(
                     detail::PrettyStringBuilder()
                         .init("RevokePermission")
-                        .append("account_id", account_id)
-                        .append("permission",
-                                shared_model::proto::permissions::toString(
-                                    permission))
+                        .appendNamed("account_id", account_id)
+                        .appendNamed("permission",
+                                     shared_model::proto::permissions::toString(
+                                         permission))
                         .finalize()));
             return specific_cmd_mock;
           });


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

changed string builder interface. added universal printer code.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

made the methods of string builder more uniform and useable. some descriptions in logs & errors look nicer (in whitespaces & commas).
also now we will have a set of functions to print (almost) any object. this is to be used in Result exceptions and tests.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
