### PR TITLE
Shared model: update blob on addSignature

### DIFF
--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -114,6 +114,8 @@ namespace shared_model {
         return SignatureSetType<proto::Signature>(signatures.begin(),
                                                   signatures.end());
       }();
+      impl_->blob_ = makeBlob(impl_->proto_);
+
       return true;
     }
 

--- a/shared_model/backend/protobuf/impl/transaction.cpp
+++ b/shared_model/backend/protobuf/impl/transaction.cpp
@@ -139,6 +139,7 @@ namespace shared_model {
         return SignatureSetType<proto::Signature>(signatures.begin(),
                                                   signatures.end());
       }();
+      impl_->blob_ = makeBlob(*impl_->proto_);
 
       return true;
     }

--- a/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
@@ -58,6 +58,8 @@ namespace shared_model {
       sig->set_public_key(public_key.hex());
       // TODO: nickaleks IR-120 12.12.2018 remove set
       signatures_.emplace(*proto_.mutable_signature());
+      blob_ = makeBlob(proto_);
+
       return true;
     }
 

--- a/shared_model/backend/protobuf/queries/impl/proto_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_query.cpp
@@ -128,6 +128,8 @@ namespace shared_model {
 
       impl_->signatures_ =
           SignatureSetType<proto::Signature>{proto::Signature{*sig}};
+      impl_->blob_ = makeBlob(impl_->proto_);
+
       return true;
     }
 

--- a/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
@@ -44,7 +44,7 @@ namespace shared_model {
       // ------------------------------| fields |-------------------------------
       TransportType proto_;
 
-      const interface::types::BlobType blob_;
+      interface::types::BlobType blob_;
 
       const interface::types::BlobType payload_;
 

--- a/test/module/shared_model/backend_proto/CMakeLists.txt
+++ b/test/module/shared_model/backend_proto/CMakeLists.txt
@@ -113,3 +113,10 @@ if (IROHA_ROOT_PROJECT)
       shared_model_stateless_validation
       )
 endif()
+
+addtest(shared_proto_add_signature_test
+    shared_proto_add_signature_test.cpp
+    )
+target_link_libraries(shared_proto_add_signature_test
+    shared_model_proto_backend
+    )

--- a/test/module/shared_model/backend_proto/shared_proto_add_signature_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_add_signature_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "backend/protobuf/block.hpp"
+#include "backend/protobuf/queries/proto_blocks_query.hpp"
+#include "backend/protobuf/queries/proto_query.hpp"
+#include "backend/protobuf/transaction.hpp"
+
+using namespace shared_model::crypto;
+using namespace shared_model::proto;
+
+template <typename T>
+class SharedProtoAddSignatureTest : public ::testing::Test {};
+
+using ModelTypes = ::testing::Types<Block, BlocksQuery, Transaction, Query>;
+TYPED_TEST_SUITE(SharedProtoAddSignatureTest, ModelTypes, );
+
+/// empty initializer
+template <typename T>
+auto initializeProto(T &proto) {}
+
+/// initializes query with the first specific type
+template <>
+auto initializeProto(Query::TransportType &proto) {
+  auto payload = proto.mutable_payload();
+  auto refl = payload->GetReflection();
+  auto desc = payload->GetDescriptor()->FindOneofByName("query");
+  auto field = desc->field(0);
+  refl->SetAllocatedMessage(
+      payload, refl->GetMessage(*payload, field).New(), field);
+}
+
+/**
+ * @given signable object with its shared model wrapper
+ * @when a signature is added
+ * @then it is reflected in wrapper blob getter result
+ */
+TYPED_TEST(SharedProtoAddSignatureTest, AddSignature) {
+  typename TypeParam::TransportType proto;
+  initializeProto(proto);
+  TypeParam model{proto};
+
+  Signed signature{"signature"};
+  PublicKey public_key{"public_key"};
+
+  model.addSignature(signature, public_key);
+
+  typename TypeParam::TransportType new_proto;
+  new_proto.ParseFromString(toBinaryString(model.blob()));
+  TypeParam new_model{new_proto};
+
+  auto signatures = new_model.signatures();
+  ASSERT_EQ(1, boost::size(signatures));
+  ASSERT_EQ(signature, signatures.front().signedData());
+  ASSERT_EQ(public_key, signatures.front().publicKey());
+}


### PR DESCRIPTION
### Description of the Change
Update blob field of Signable classes when addSignature is called, so that it reflects the updated internal state of the object.

### Benefits
Correct behavior.

### Possible Drawbacks 
None.

### Usage Examples or Tests *[optional]*
SharedProtoAddSignatureTest.AddSignature

### Alternate Designs *[optional]*
Make data objects immutable, and create new ones when they have to be modified.
