### PR TITLE
Ametsuchi: query executor creator returns result

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -45,7 +45,7 @@ function(addtest test_name SOURCES)
   if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
-    target_compile_options(${test_name} PRIVATE -Wno-inconsistent-missing-override)
+    target_compile_options(${test_name} PRIVATE -Wno-inconsistent-missing-override -Wno-gnu-zero-variadic-macro-arguments)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # do nothing, but also don't spam warning on each test
   else ()

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -20,7 +20,6 @@
 #include "ametsuchi/key_value_storage.hpp"
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/reconnection_strategy.hpp"
-#include "common/result.hpp"
 #include "interfaces/permission_to_string.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
@@ -69,7 +68,8 @@ namespace iroha {
       boost::optional<std::unique_ptr<SettingQuery>> createSettingQuery()
           const override;
 
-      boost::optional<std::shared_ptr<QueryExecutor>> createQueryExecutor(
+      iroha::expected::Result<std::unique_ptr<QueryExecutor>, std::string>
+      createQueryExecutor(
           std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
           std::shared_ptr<shared_model::interface::QueryResponseFactory>
               response_factory) const override;

--- a/irohad/ametsuchi/query_executor_factory.hpp
+++ b/irohad/ametsuchi/query_executor_factory.hpp
@@ -9,6 +9,7 @@
 #include <boost/optional.hpp>
 
 #include "ametsuchi/query_executor.hpp"
+#include "common/result_fwd.hpp"
 #include "interfaces/iroha_internal/query_response_factory.hpp"
 #include "pending_txs_storage/pending_txs_storage.hpp"
 
@@ -19,7 +20,8 @@ namespace iroha {
       /**
        * Creates a query executor from the current state
        */
-      virtual boost::optional<std::shared_ptr<QueryExecutor>>
+      virtual iroha::expected::Result<std::unique_ptr<QueryExecutor>,
+                                      std::string>
       createQueryExecutor(
           std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
           std::shared_ptr<shared_model::interface::QueryResponseFactory>

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -15,7 +15,7 @@
 #include "ametsuchi/query_executor_factory.hpp"
 #include "ametsuchi/setting_query_factory.hpp"
 #include "ametsuchi/temporary_factory.hpp"
-#include "common/result.hpp"
+#include "common/result_fwd.hpp"
 
 namespace shared_model {
   namespace interface {

--- a/irohad/torii/processor/query_processor.hpp
+++ b/irohad/torii/processor/query_processor.hpp
@@ -9,6 +9,9 @@
 #include <rxcpp/rx-observable-fwd.hpp>
 
 #include <memory>
+#include <string>
+
+#include "common/result_fwd.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -32,7 +35,9 @@ namespace iroha {
        * @param qry - client intent
        * @return resulted response
        */
-      virtual std::unique_ptr<shared_model::interface::QueryResponse>
+      virtual iroha::expected::Result<
+          std::unique_ptr<shared_model::interface::QueryResponse>,
+          std::string>
       queryHandle(const shared_model::interface::Query &qry) = 0;
       /**
        * Register client blocks query

--- a/irohad/torii/processor/query_processor_impl.hpp
+++ b/irohad/torii/processor/query_processor_impl.hpp
@@ -30,8 +30,10 @@ namespace iroha {
               response_factory,
           logger::LoggerPtr log);
 
-      std::unique_ptr<shared_model::interface::QueryResponse> queryHandle(
-          const shared_model::interface::Query &qry) override;
+      iroha::expected::Result<
+          std::unique_ptr<shared_model::interface::QueryResponse>,
+          std::string>
+      queryHandle(const shared_model::interface::Query &qry) override;
 
       rxcpp::observable<
           std::shared_ptr<shared_model::interface::BlockQueryResponse>>

--- a/test/framework/result_gtest_checkers.hpp
+++ b/test/framework/result_gtest_checkers.hpp
@@ -62,10 +62,8 @@ namespace framework {
       template <typename V, typename E>
       inline std::string getValueMessage(
           const iroha::expected::Result<V, E> &r) {
-        using iroha::operator|;
-        return iroha::expected::resultToOptionalValue(r) | [](const auto &v) {
-          return ObjectDescription<std::remove_reference_t<V>>::describe(v);
-        };
+        return ObjectDescription<std::remove_reference_t<V>>::describe(
+            r.assumeValue());
       }
 
       template <typename E>
@@ -76,10 +74,8 @@ namespace framework {
 
       template <typename V, typename E>
       inline auto getErrorMessage(const iroha::expected::Result<V, E> &r) {
-        using iroha::operator|;
-        return iroha::expected::resultToOptionalError(r) | [](const auto &e) {
-          return ObjectDescription<std::remove_reference_t<E>>::describe(e);
-        };
+        return ObjectDescription<std::remove_reference_t<E>>::describe(
+            r.assumeError());
       }
 
       template <typename V>

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -36,19 +36,13 @@ namespace iroha {
                          boost::optional<std::shared_ptr<BlockQuery>>());
       MOCK_CONST_METHOD0(createSettingQuery,
                          boost::optional<std::unique_ptr<SettingQuery>>());
-      iroha::expected::Result<std::unique_ptr<QueryExecutor>, std::string>
-      createQueryExecutor(
-          std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
-          std::shared_ptr<shared_model::interface::QueryResponseFactory>
-              response_factory) const override {
-        return createQueryExecutorRaw(std::move(pending_txs_storage),
-                                      std::move(response_factory));
-      }
-      MOCK_CONST_METHOD2(
-          createQueryExecutorRaw,
-          iroha::expected::Result<QueryExecutor *, std::string>(
-              std::shared_ptr<PendingTransactionStorage>,
-              std::shared_ptr<shared_model::interface::QueryResponseFactory>));
+      MOCK_METHOD(
+          (iroha::expected::Result<std::unique_ptr<QueryExecutor>,
+                                   std::string>),
+          createQueryExecutor,
+          (std::shared_ptr<PendingTransactionStorage>,
+           std::shared_ptr<shared_model::interface::QueryResponseFactory>),
+          (const, override));
       MOCK_METHOD1(doCommit, CommitResult(MutableStorage *storage));
       MOCK_CONST_METHOD0(preparedCommitEnabled, bool());
       MOCK_METHOD1(

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -36,9 +36,17 @@ namespace iroha {
                          boost::optional<std::shared_ptr<BlockQuery>>());
       MOCK_CONST_METHOD0(createSettingQuery,
                          boost::optional<std::unique_ptr<SettingQuery>>());
+      iroha::expected::Result<std::unique_ptr<QueryExecutor>, std::string>
+      createQueryExecutor(
+          std::shared_ptr<PendingTransactionStorage> pending_txs_storage,
+          std::shared_ptr<shared_model::interface::QueryResponseFactory>
+              response_factory) const override {
+        return createQueryExecutorRaw(std::move(pending_txs_storage),
+                                      std::move(response_factory));
+      }
       MOCK_CONST_METHOD2(
-          createQueryExecutor,
-          boost::optional<std::shared_ptr<QueryExecutor>>(
+          createQueryExecutorRaw,
+          iroha::expected::Result<QueryExecutor *, std::string>(
               std::shared_ptr<PendingTransactionStorage>,
               std::shared_ptr<shared_model::interface::QueryResponseFactory>));
       MOCK_METHOD1(doCommit, CommitResult(MutableStorage *storage));

--- a/test/module/irohad/torii/processor/mock_query_processor.hpp
+++ b/test/module/irohad/torii/processor/mock_query_processor.hpp
@@ -17,8 +17,9 @@ namespace iroha {
     class MockQueryProcessor : public QueryProcessor {
      public:
       MOCK_METHOD1(queryHandle,
-                   std::unique_ptr<shared_model::interface::QueryResponse>(
-                       const shared_model::interface::Query &));
+                   iroha::expected::Result<
+                       std::unique_ptr<shared_model::interface::QueryResponse>,
+                       std::string>(const shared_model::interface::Query &));
       MOCK_METHOD1(
           blocksQueryHandle,
           rxcpp::observable<

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -10,8 +10,10 @@
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "cryptography/keypair.hpp"
 #include "framework/common_constants.hpp"
+#include "framework/result_gtest_checkers.hpp"
 #include "framework/test_logger.hpp"
 #include "framework/test_subscriber.hpp"
+#include "interfaces/query_responses/block_error_response.hpp"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "module/irohad/ametsuchi/mock_block_query.hpp"
 #include "module/irohad/ametsuchi/mock_query_executor.hpp"
@@ -38,7 +40,7 @@ using ::testing::Return;
 class QueryProcessorTest : public ::testing::Test {
  public:
   void SetUp() override {
-    qry_exec = std::make_shared<MockQueryExecutor>();
+    qry_exec = new MockQueryExecutor();
     storage = std::make_shared<MockStorage>();
     query_response_factory =
         std::make_shared<shared_model::proto::ProtoQueryResponseFactory>();
@@ -50,9 +52,12 @@ class QueryProcessorTest : public ::testing::Test {
         getTestLogger("QueryProcessor"));
     EXPECT_CALL(*storage, getBlockQuery())
         .WillRepeatedly(Return(block_queries));
-    EXPECT_CALL(*storage, createQueryExecutor(_, _))
-        .WillRepeatedly(Return(
-            boost::make_optional(std::shared_ptr<QueryExecutor>(qry_exec))));
+  }
+
+  void provideValidQueryExecutor() {
+    EXPECT_CALL(*storage, createQueryExecutorRaw(_, _))
+        .Times(::testing::AtMost(1))
+        .WillRepeatedly(Return(qry_exec));
   }
 
   auto getBlocksQuery(const std::string &creator_account_id) {
@@ -73,13 +78,36 @@ class QueryProcessorTest : public ::testing::Test {
 
   std::vector<shared_model::interface::types::PubkeyType> signatories = {
       keypair.publicKey()};
-  std::shared_ptr<MockQueryExecutor> qry_exec;
+  MockQueryExecutor *qry_exec;
   std::shared_ptr<MockBlockQuery> block_queries;
   std::shared_ptr<MockStorage> storage;
   std::shared_ptr<shared_model::interface::QueryResponseFactory>
       query_response_factory;
   std::shared_ptr<torii::QueryProcessorImpl> qpi;
 };
+
+/**
+ * @given QueryProcessorImpl and GetAccountDetail query
+ * @when queryHandle called at normal flow, but QueryExecutor fails to create
+ * @then query error response is returned
+ */
+TEST_F(QueryProcessorTest,
+       QueryProcessorWhereInvokeInvalidQueryAndQueryExecutorFailsToCreate) {
+  auto qry = TestUnsignedQueryBuilder()
+                 .creatorAccountId(kAccountId)
+                 .getAccountDetail(kMaxPageSize, kAccountId)
+                 .build()
+                 .signAndAddSignature(keypair)
+                 .finish();
+
+  const std::string error_text{"QueryExecutor fails to create"};
+  EXPECT_CALL(*storage, createQueryExecutorRaw(_, _))
+      .WillRepeatedly(Return(error_text));
+
+  auto response = qpi->queryHandle(qry);
+  IROHA_ASSERT_RESULT_ERROR(response);
+  EXPECT_THAT(response.assumeError(), ::testing::HasSubstr(error_text));
+}
 
 /**
  * @given QueryProcessorImpl and GetAccountDetail query
@@ -98,13 +126,14 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
           ->createAccountDetailResponse("", 1, boost::none, qry.hash())
           .release();
 
+  provideValidQueryExecutor();
   EXPECT_CALL(*qry_exec, validateAndExecute_(_)).WillOnce(Return(qry_resp));
 
   auto response = qpi->queryHandle(qry);
-  ASSERT_TRUE(response);
-  ASSERT_NO_THROW(
-      boost::get<const shared_model::interface::AccountDetailResponse &>(
-          response->get()));
+  IROHA_ASSERT_RESULT_VALUE(response);
+  ASSERT_NE(boost::get<const shared_model::interface::AccountDetailResponse &>(
+                &response.assumeValue()->get()),
+            nullptr);
 }
 
 /**
@@ -130,14 +159,46 @@ TEST_F(QueryProcessorTest, QueryProcessorWithWrongKey) {
                            query.hash())
                        .release();
 
+  provideValidQueryExecutor();
   EXPECT_CALL(*qry_exec, validateAndExecute_(_)).WillOnce(Return(qry_resp));
 
   auto response = qpi->queryHandle(query);
-  ASSERT_TRUE(response);
+  IROHA_ASSERT_RESULT_VALUE(response);
   ASSERT_NO_THROW(boost::apply_visitor(
       shared_model::interface::QueryErrorResponseChecker<
           shared_model::interface::StatefulFailedErrorResponse>(),
-      response->get()));
+      response.assumeValue()->get()));
+}
+
+/**
+ * @given account, ametsuchi queries
+ * @when valid block query is sent, but QueryExecutor fails to create
+ * @then Query Processor should emit an error to the observable
+ */
+TEST_F(QueryProcessorTest, GetBlocksQueryWhenQueryExecutorFailsToCreate) {
+  auto block_number = 5;
+  auto block_query = getBlocksQuery(kAccountId);
+
+  EXPECT_CALL(*storage, createQueryExecutorRaw(_, _))
+      .WillRepeatedly(Return("QueryExecutor fails to create"));
+
+  auto wrapper =
+      make_test_subscriber<CallExact>(qpi->blocksQueryHandle(block_query), 1);
+  wrapper.subscribe([](auto response) {
+    ASSERT_NO_THROW({
+      const auto &error_response =
+          boost::get<const shared_model::interface::BlockErrorResponse &>(
+              response->get());
+      EXPECT_THAT(
+          error_response.message(),
+          ::testing::HasSubstr("Internal error during query validation."));
+    });
+  });
+  for (int i = 0; i < block_number; i++) {
+    storage->notifier.get_subscriber().on_next(
+        clone(TestBlockBuilder().build()));
+  }
+  ASSERT_TRUE(wrapper.validate());
 }
 
 /**
@@ -150,6 +211,7 @@ TEST_F(QueryProcessorTest, GetBlocksQuery) {
   auto block_number = 5;
   auto block_query = getBlocksQuery(kAccountId);
 
+  provideValidQueryExecutor();
   EXPECT_CALL(*qry_exec, validate(_, _)).WillOnce(Return(true));
 
   auto wrapper = make_test_subscriber<CallExact>(
@@ -176,6 +238,7 @@ TEST_F(QueryProcessorTest, GetBlocksQueryNoPerms) {
   auto block_number = 5;
   auto block_query = getBlocksQuery(kAccountId);
 
+  provideValidQueryExecutor();
   EXPECT_CALL(*qry_exec, validate(_, _)).WillOnce(Return(false));
 
   auto wrapper =

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -42,6 +42,7 @@ static constexpr shared_model::interface::types::TransactionsNumberType
 using ::testing::_;
 using ::testing::A;
 using ::testing::AtLeast;
+using ::testing::ByMove;
 using ::testing::Return;
 
 using namespace iroha::ametsuchi;
@@ -61,7 +62,7 @@ class ToriiQueriesTest : public testing::Test {
         ip + ":0", getTestLogger("ServerRunner"));
     wsv_query = std::make_shared<MockWsvQuery>();
     block_query = std::make_shared<MockBlockQuery>();
-    query_executor = new MockQueryExecutor();
+    query_executor = std::make_unique<MockQueryExecutor>();
     storage = std::make_shared<MockStorage>();
     pending_txs_storage =
         std::make_shared<iroha::MockPendingTransactionStorage>();
@@ -72,9 +73,6 @@ class ToriiQueriesTest : public testing::Test {
 
     EXPECT_CALL(*storage, getWsvQuery()).WillRepeatedly(Return(wsv_query));
     EXPECT_CALL(*storage, getBlockQuery()).WillRepeatedly(Return(block_query));
-    EXPECT_CALL(*storage, createQueryExecutorRaw(_, _))
-        .Times(::testing::AtMost(1))
-        .WillRepeatedly(Return(query_executor));
 
     auto qpi = std::make_shared<iroha::torii::QueryProcessorImpl>(
         storage,
@@ -134,7 +132,7 @@ class ToriiQueriesTest : public testing::Test {
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;
-  MockQueryExecutor *query_executor;
+  std::unique_ptr<MockQueryExecutor> query_executor;
   std::shared_ptr<MockStorage> storage;
   std::shared_ptr<iroha::MockPendingTransactionStorage> pending_txs_storage;
   std::shared_ptr<shared_model::interface::QueryResponseFactory>
@@ -229,6 +227,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenNoGrantPermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -275,6 +275,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasReadPermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -322,6 +324,8 @@ TEST_F(ToriiQueriesTest, FindAccountWhenHasRolePermission) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -372,6 +376,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -420,6 +426,8 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -477,6 +485,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesWhenNoGrantPermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -521,6 +531,8 @@ TEST_F(ToriiQueriesTest, FindSignatoriesHasRolePermissions) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);
@@ -588,6 +600,8 @@ TEST_F(ToriiQueriesTest, FindTransactionsWhenValid) {
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))
       .WillRepeatedly(Return(r));
+  EXPECT_CALL(*storage, createQueryExecutor(_, _))
+      .WillOnce(Return(ByMove(std::move(query_executor))));
 
   auto stat = torii_utils::QuerySyncClient(ip, port).Find(
       model_query.getTransport(), response);

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -61,7 +61,7 @@ class ToriiQueriesTest : public testing::Test {
         ip + ":0", getTestLogger("ServerRunner"));
     wsv_query = std::make_shared<MockWsvQuery>();
     block_query = std::make_shared<MockBlockQuery>();
-    query_executor = std::make_shared<MockQueryExecutor>();
+    query_executor = new MockQueryExecutor();
     storage = std::make_shared<MockStorage>();
     pending_txs_storage =
         std::make_shared<iroha::MockPendingTransactionStorage>();
@@ -72,9 +72,9 @@ class ToriiQueriesTest : public testing::Test {
 
     EXPECT_CALL(*storage, getWsvQuery()).WillRepeatedly(Return(wsv_query));
     EXPECT_CALL(*storage, getBlockQuery()).WillRepeatedly(Return(block_query));
-    EXPECT_CALL(*storage, createQueryExecutor(_, _))
-        .WillRepeatedly(Return(boost::make_optional(
-            std::shared_ptr<QueryExecutor>(query_executor))));
+    EXPECT_CALL(*storage, createQueryExecutorRaw(_, _))
+        .Times(::testing::AtMost(1))
+        .WillRepeatedly(Return(query_executor));
 
     auto qpi = std::make_shared<iroha::torii::QueryProcessorImpl>(
         storage,
@@ -134,7 +134,7 @@ class ToriiQueriesTest : public testing::Test {
 
   std::shared_ptr<MockWsvQuery> wsv_query;
   std::shared_ptr<MockBlockQuery> block_query;
-  std::shared_ptr<MockQueryExecutor> query_executor;
+  MockQueryExecutor *query_executor;
   std::shared_ptr<MockStorage> storage;
   std::shared_ptr<iroha::MockPendingTransactionStorage> pending_txs_storage;
   std::shared_ptr<shared_model::interface::QueryResponseFactory>


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

in case of any runtime failure, if a query executor cannot be created, return an `expected::Error` instead of a `nullptr`.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

hopefully fixes a bug discovered by oss fuzzer

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
