### PR TITLE
Result: fixes and new constructor

### DIFF
--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -414,25 +414,6 @@ namespace iroha {
     }
 
     /**
-     * Polymorphic Result is simple alias for result type, which can be used to
-     * work with polymorphic objects. It is achieved by wrapping V and E in a
-     * polymorphic container (std::shared_ptr is used by default). This
-     * simplifies declaration of polymorphic result.
-     *
-     * Note: ordinary result itself stores both V and E directly inside itself
-     * (on the stack), polymorphic result stores objects wherever VContainer and
-     * EContainer store them, but since you need polymorphic behavior, it will
-     * probably be on the heap. That is why polymorphic result is generally
-     * slower, and should be used ONLY when polymorphic behaviour is required,
-     * hence the name. For all other use cases, stick to basic Result
-     */
-    template <typename V,
-              typename E,
-              typename VContainer = std::shared_ptr<V>,
-              typename EContainer = std::shared_ptr<E>>
-    using PolymorphicResult = Result<VContainer, EContainer>;
-
-    /**
      * Checkers of the Result type.
      */
 

--- a/test/module/libs/common/result_test.cpp
+++ b/test/module/libs/common/result_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "common/result.hpp"
+
 #include <gtest/gtest.h>
 
 using namespace iroha::expected;
@@ -240,51 +241,4 @@ TEST(ResultTest, MapErrorBlank) {
   map_error<int>(result, [](auto i) { return i * 2; })
       .match([](Value<int> v) { ASSERT_EQ(5, v.value); },
              makeFailCase<Error<int>>(kErrorCaseMessage));
-}
-
-/// Polymorphic result tests
-
-/// Base and Derived are classes, which can be used to test polymorphic behavior
-class Base {
- public:
-  virtual int getNumber() {
-    return 0;
-  }
-  virtual ~Base() = default;
-};
-
-class Derived : public Base {
- public:
-  virtual int getNumber() override {
-    return 1;
-  }
-};
-
-/**
- * @given Polymorphic Result of Base class type with value of derived class
- * @when match function is invoked
- * @then Value case is invoked, and polymorphic behavior persists
- */
-TEST(PolyMorphicResultTest, PolymorphicValueConstruction) {
-  PolymorphicResult<Base, std::string> result =
-      makeValue(std::make_shared<Derived>());
-  result.match(
-      [](Value<std::shared_ptr<Base>> &v) {
-        ASSERT_EQ(1, v.value->getNumber());
-      },
-      makeFailCase<Error<std::shared_ptr<std::string>>>(kErrorCaseMessage));
-}
-
-/**
- * @given Polymorphic Result of Base class type with error
- * @when match function is invoked
- * @then Error case is invoked
- */
-TEST(PolyMorphicResultTest, PolymorphicErrorConstruction) {
-  PolymorphicResult<Base, std::string> result =
-      makeError(std::make_shared<std::string>(kErrorMessage));
-  result.match(makeFailCase<Value<std::shared_ptr<Base>>>(kValueCaseMessage),
-               [](Error<std::shared_ptr<std::string>> &e) {
-                 ASSERT_EQ(kErrorMessage, *e.error);
-               });
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Fixed a bug in `assumeError` (tests added)
- Added `Reslut` construction from another `Result` when possible (with tests)
- Removed unused `PolyMorphicReSult` (with tests)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Casts not needed when returning a `Result` with base type from a function that creates a `Result` with derived type.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

`Result` just got bigger.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
