### PR TITLE
MST: fix propagation of updates from Torii

### DIFF
--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -122,6 +122,10 @@ namespace iroha {
     extractExpiredImpl(current_time, boost::none);
   }
 
+  void MstState::erase(const DataType &batch) {
+    batches_.right.erase(batch);
+  }
+
   // ------------------------------| private api |------------------------------
 
   /**

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -150,6 +150,12 @@ namespace iroha {
     void eraseExpired(const TimeType &current_time);
 
     /**
+     * Erase batch.
+     * @param batch to erase
+     */
+    void erase(const DataType &batch);
+
+    /**
      * Check, if this MST state contains that element
      * @param element to be checked
      * @return true, if state contains the element, false otherwise

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -40,7 +40,7 @@ namespace iroha {
 
   auto MstStorageStateImpl::updateOwnStateImpl(const DataType &tx)
       -> decltype(updateOwnState(tx)) {
-    auto state_update = own_state_ += tx;
+    auto state_update = (own_state_ += tx);
     for (const auto &updated_batch :
          state_update.updated_state_->getBatches()) {
       // assume nobody has the update that we just got

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -40,7 +40,15 @@ namespace iroha {
 
   auto MstStorageStateImpl::updateOwnStateImpl(const DataType &tx)
       -> decltype(updateOwnState(tx)) {
-    return own_state_ += tx;
+    auto state_update = own_state_ += tx;
+    for (const auto &updated_batch :
+         state_update.updated_state_->getBatches()) {
+      // assume nobody has the update that we just got
+      for (auto &peer_and_their_state : peer_states_) {
+        peer_and_their_state.second.erase(updated_batch);
+      }
+    }
+    return state_update;
   }
 
   auto MstStorageStateImpl::extractExpiredTransactionsImpl(

--- a/test/module/irohad/multi_sig_transactions/storage_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/storage_test.cpp
@@ -117,3 +117,60 @@ TEST_F(StorageTest, StorageDoesNotFindNonExistingBatch) {
   auto distinct_batch = makeTestBatch(txBuilder(4, creation_time));
   EXPECT_FALSE(storage->batchInStorage(distinct_batch));
 }
+
+/**
+ * @given storage with a batch from peer A (quorum = 3, 1 signature)
+ * @when the batch gets updated with a new signature from Torii
+ * @then the diff for peer A has the new signature
+ */
+TEST_F(StorageTest, ClearStalledPeerStatesTest) {
+  using namespace testing;
+  using namespace shared_model::interface;
+
+  std::vector<shared_model::crypto::Keypair> keypairs;
+  std::generate_n(std::back_inserter(keypairs), 2, [] {
+    return shared_model::crypto::DefaultCryptoAlgorithmType::generateKeypair();
+  });
+
+  const auto batch =
+      framework::batch::makeTestBatch(txBuilder(1, creation_time));
+
+  const auto peerAKey = shared_model::crypto::PublicKey("A");
+
+  // storage gets a batch from peer A with 1st signature
+  {
+    auto new_state = MstState::empty(getTestLogger("MstState"), completer_);
+    new_state += addSignaturesFromKeyPairs(
+        std::make_unique<TransactionBatchImpl>(batch->transactions()),
+        0,
+        keypairs[0]);
+
+    storage->apply(peerAKey, std::move(new_state));
+  }
+
+  // diff with peer A does not have this batch
+  ASSERT_THAT(storage->getDiffState(peerAKey, creation_time).getBatches(),
+              Not(Contains(Pointee(Property(
+                  &TransactionBatch::transactions,
+                  Contains(Pointee(Property(
+                      &Transaction::reducedHash,
+                      Eq(batch->transactions().front()->reducedHash())))))))));
+
+  // storage gets another signature for the batch from Torii
+  storage->updateOwnState(addSignaturesFromKeyPairs(
+      std::make_unique<TransactionBatchImpl>(batch->transactions()),
+      0,
+      keypairs[1]));
+
+  // diff with peer A now has the batch with the signature that just came Torii
+  EXPECT_THAT(
+      storage->getDiffState(peerAKey, creation_time).getBatches(),
+      Contains(Pointee(Property(
+          &TransactionBatch::transactions,
+          ElementsAre(Pointee(AllOf(
+              Property(&Transaction::reducedHash,
+                       Eq(batch->transactions().front()->reducedHash())),
+              Property(&Transaction::signatures,
+                       Contains(Property(&Signature::publicKey,
+                                         Eq(keypairs[1].publicKey())))))))))));
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Before this change, when a node has received an MST batch from another node, and then an update for it from torii, it would not propagate this update to that node. This PR enables such propagation.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

When parts of MST are sent to different nodes, the chances to gather all signatures are increased.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
