### PR TITLE
[DOPS-886] Runtime vcpkg

### DIFF
--- a/.jenkinsci/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci/builders/x64-linux-build-steps.groovy
@@ -44,12 +44,14 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
       boolean testing, String testList, boolean cppcheck, boolean sonar, boolean codestyle, boolean docs, boolean packagebuild,
       boolean sanitize, boolean fuzzing, boolean coredumps, boolean useBTF, boolean forceDockerDevelopBuild, List environment) {
   withEnv(environment) {
+    def build, vars, utils, dockerUtils, doxygen
+    stage('Prepare Linux environment') {
     scmVars = checkout scm
-    def build = load '.jenkinsci/build.groovy'
-    def vars = load ".jenkinsci/utils/vars.groovy"
-    def utils = load ".jenkinsci/utils/utils.groovy"
-    def dockerUtils = load ".jenkinsci/utils/docker-pull-or-build.groovy"
-    def doxygen = load ".jenkinsci/utils/doxygen.groovy"
+    build = load '.jenkinsci/build.groovy'
+    vars = load ".jenkinsci/utils/vars.groovy"
+    utils = load ".jenkinsci/utils/utils.groovy"
+    dockerUtils = load ".jenkinsci/utils/docker-pull-or-build.groovy"
+    doxygen = load ".jenkinsci/utils/doxygen.groovy"
     buildDir = 'build'
     compilers = vars.compilerMapping()
     cmakeBooleanOption = [ (true): 'ON', (false): 'OFF' ]
@@ -86,7 +88,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
         environment,
         forceDockerDevelopBuild,
         ['PARALLELISM': parallelism])
-
+    }
     iC.inside(""
     + " -e IROHA_POSTGRES_HOST=${env.IROHA_POSTGRES_HOST}"
     + " -e IROHA_POSTGRES_PORT=${env.IROHA_POSTGRES_PORT}"

--- a/.jenkinsci/builders/x64-mac-build-steps.groovy
+++ b/.jenkinsci/builders/x64-mac-build-steps.groovy
@@ -37,21 +37,27 @@ def testSteps(scmVars, String buildDir, List environment, String testList) {
 def buildSteps(int parallelism, List compilerVersions, String build_type, boolean coverage, boolean testing, String testList,
        boolean packagebuild, boolean fuzzing, boolean useBTF, List environment) {
   withEnv(environment) {
-    scmVars = checkout scm
-    def build = load '.jenkinsci/build.groovy'
-    def vars = load ".jenkinsci/utils/vars.groovy"
-    def utils = load ".jenkinsci/utils/utils.groovy"
-    buildDir = 'build'
-    compilers = vars.compilerMapping()
-    cmakeBooleanOption = [ (true): 'ON', (false): 'OFF' ]
-    cmakeBuildOptions = ""
+    def build, vars, utils
+    stage('Prepare Mac environment') {
+      scmVars = checkout scm
+      build = load '.jenkinsci/build.groovy'
+      vars = load ".jenkinsci/utils/vars.groovy"
+      utils = load ".jenkinsci/utils/utils.groovy"
+      buildDir = 'build'
+      compilers = vars.compilerMapping()
+      cmakeBooleanOption = [ (true): 'ON', (false): 'OFF' ]
+      cmakeBuildOptions = ""
+      mac_local_vcpkg_hash = sh(script: "python .jenkinsci/helpers/hash.py vcpkg", returnStdout: true).trim()
+      mac_vcpkg_path = "/opt/dependencies/vcpkg-${mac_local_vcpkg_hash}"
+      mac_vcpkg_toolchain_file = "${mac_vcpkg_path}/scripts/buildsystems/vcpkg.cmake"
 
-    if (packagebuild){
-      cmakeBuildOptions = " --target package "
+      if (packagebuild){
+        cmakeBuildOptions = " --target package "
+      }
+
+      utils.ccacheSetup(5)
+      utils.build_vcpkg(mac_vcpkg_path,mac_vcpkg_toolchain_file)
     }
-
-    utils.ccacheSetup(5)
-
     for (compiler in compilerVersions) {
       stage ("build ${compiler}"){
         // Remove artifacts from the previous build
@@ -65,7 +71,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
         -DFUZZING=${cmakeBooleanOption[fuzzing]} \
         -DPACKAGE_TGZ=${cmakeBooleanOption[packagebuild]} \
         -DUSE_BTF=${cmakeBooleanOption[useBTF]} \
-        -DCMAKE_TOOLCHAIN_FILE=/opt/dependencies/vcpkg/scripts/buildsystems/vcpkg.cmake ")
+        -DCMAKE_TOOLCHAIN_FILE=${mac_vcpkg_toolchain_file} ")
 
         build.cmakeBuild(buildDir, cmakeBuildOptions, parallelism)
       }

--- a/.jenkinsci/builders/x64-win-build-steps.groovy
+++ b/.jenkinsci/builders/x64-win-build-steps.groovy
@@ -11,14 +11,24 @@
 def buildSteps(int parallelism, List compilerVersions, String buildType, boolean coverage, boolean testing, String testList,
        boolean packageBuild, boolean useBTF, List environment) {
   withEnv(environment) {
-    scmVars = checkout scm
+    def utils
+    stage('Prepare Windows environment') {
+      scmVars = checkout scm
+      utils = load ".jenkinsci/utils/utils.groovy"
+
+      win_local_vcpkg_hash = bat(script: "python .jenkinsci\\helpers\\hash.py vcpkg", returnStdout: true).trim().readLines()[-1].trim()
+      win_vcpkg_path = "C:\\vcpkg-${win_local_vcpkg_hash}"
+      win_vcpkg_toolchain_file = "${win_vcpkg_path}\\scripts\\buildsystems\\vcpkg.cmake"
+
+      utils.build_vcpkg(win_vcpkg_path,win_vcpkg_toolchain_file)
+    }
     for (compiler in compilerVersions) {
       stage ("build ${compiler}"){
-        bat '''
-cmake -H.\\ -B.\\build -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -G "Visual Studio 16 2019" -A x64 -T host=x64 &&^
+        bat """
+cmake -H.\\ -B.\\build -DCMAKE_TOOLCHAIN_FILE=${win_vcpkg_toolchain_file} -G "Visual Studio 16 2019" -A x64 -T host=x64 &&^
 cmake --build .\\build --target irohad &&^
 cmake --build .\\build --target iroha-cli
-        '''
+        """
       }
     }
   }

--- a/.jenkinsci/helpers/hash.py
+++ b/.jenkinsci/helpers/hash.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import hashlib
+import argparse
+import os
+
+WINDOWS_LINE_ENDING = b'\r\n'
+UNIX_LINE_ENDING = b'\n'
+
+
+def md5_update_from_dir(directory, hash):
+    assert os.path.isdir(directory)
+    for root, dirnames, filenames in os.walk(directory):
+        for file in sorted(filenames, key=lambda p: str(p).lower()):
+            # If you need include file name to hash uncomment this
+            #hash.update(file.encode())
+            with open(os.path.join(root, file), "rb") as f:
+                hash.update(f.read().replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING))
+        for path in sorted(dirnames, key=lambda p: str(p).lower()):
+            hash = md5_update_from_dir(os.path.join(root, path), hash)
+    return hash
+
+
+def md5_dir(directory):
+    return md5_update_from_dir(directory, hashlib.md5()).hexdigest()
+
+
+parser = argparse.ArgumentParser(description='Calculate MD5 hash for given folder')
+parser.add_argument('folder')
+args = parser.parse_args()
+
+print(md5_dir(args.folder))


### PR DESCRIPTION
Currently, it is very difficult to test changes in vcpkg dependencies. For mac and windows, we can use only one dependence in the build agent, which affects all builds. This pr allows to install several vcpkg dependencies on build agent, manage their version and also build vcpkg dependencies if the required version does not exist.

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
1. added stage "Prepare <Platform> environment" to see how long docker or vcpkg builds take.
2. added python script to calculate hash for vcpkg folder, it is universal and return same hash for linux, windows, mac, python2 and python3 
```
./.jenkinsci/helpers/hash.py vcpkg
```
3. added `build_vcpkg()` function to `utils.groovy`, it ensures that host have vcpkg with given hash.
### Benefits
1. No need run manual update for vcpkg dependencies for windows and mac.
2. vcpkg dependencies  do not depend on agent 
### Possible Drawbacks 
1. Build time increase, if  vcpkg  dependencies do not exists.  (~30 min)
2. Mac agent disk will be full in vcpkg dependencies is updated very often. 

