### PR TITLE
Infrastructure: replace clang-6.0 with clang-9

### DIFF
--- a/.jenkinsci/text-variables.groovy
+++ b/.jenkinsci/text-variables.groovy
@@ -15,8 +15,8 @@ param_descriptions = """
   <strong>Branch commit</strong> - Linux/gcc v7; Test: Smoke, Unit;<br />
   <strong>On open PR -</strong> Linux/gcc v7, MacOS/appleclang, Windows/msvc; Test: All; Coverage; Analysis: cppcheck, sonar, codestyle;<br />
   <strong>Commit in Open PR</strong> - Same as Branch commit<br />
-  <strong>Before merge to trunk</strong> - Linux/gcc v7 v9, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true<br />
-  <strong>Nightly build</strong> - Linux/gcc v7 v9, Linux/clang v6 v7, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true; sanitize<br />
+  <strong>Before merge to trunk</strong> - Linux/gcc v7 v9, Linux/clang v7 v9, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true<br />
+  <strong>Nightly build</strong> - Linux/gcc v7 v9, Linux/clang v7 v9, MacOS/appleclang, Windows/msvc; Test: ALL; Coverage; Analysis: cppcheck, sonar,codestyle; useBTF=true; sanitize<br />
   <strong>Push demo</strong> - Build Release and push to hub.docker.com/r/soramitsu/iroha <br />
   <strong>Custom command</strong> - enter command below, Ex: build_type='Release'; testing=false;<br />
 </p>
@@ -47,7 +47,7 @@ cmd_description = """
             <p>Linux compiler name to build</p>
          </li>
          <li>
-            <p>Ex:&nbsp;x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6', 'clang7']</p>
+            <p>Ex:&nbsp;x64linux_compiler_list = ['gcc7', 'gcc9', 'clang7', 'clang9']</p>
          </li>
       </ul>
    </li>

--- a/.jenkinsci/utils/vars.groovy
+++ b/.jenkinsci/utils/vars.groovy
@@ -11,8 +11,8 @@
 def compilerMapping () {
   return ['gcc7': ['cxx_compiler':'g++-7', 'cc_compiler':'gcc-7'],
           'gcc9' : ['cxx_compiler':'g++-9', 'cc_compiler':'gcc-9'],
-          'clang6': ['cxx_compiler':'clang++-6.0', 'cc_compiler':'clang-6.0'],
           'clang7': ['cxx_compiler':'clang++-7', 'cc_compiler':'clang-7'],
+          'clang9': ['cxx_compiler':'clang++-9', 'cc_compiler':'clang-9'],
           'appleclang': ['cxx_compiler':'clang++', 'cc_compiler':'clang'],
          ]
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ node ('master') {
         break;
      case 'Before merge to trunk':
         gitNotify ("Jenkins: Merge to trunk", "Started...", 'PENDING')
-        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6' , 'clang7']
+        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang7' , 'clang9']
         mac_compiler_list = ['appleclang']
         win_compiler_list = ['msvc']
         testing = true
@@ -225,7 +225,7 @@ node ('master') {
         useBTF = true
         break;
      case 'Nightly build':
-        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang6' , 'clang7']
+        x64linux_compiler_list = ['gcc7', 'gcc9', 'clang7' , 'clang9']
         mac_compiler_list = ['appleclang']
         win_compiler_list = ['msvc']
         testing = true

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -16,14 +16,14 @@ RUN apt-get update && \
 RUN set -e; \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test; \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -; \
-    echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main' >> /etc/apt/sources.list; \
     echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main' >> /etc/apt/sources.list; \
+    echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' >> /etc/apt/sources.list; \
     apt-get update
 
 RUN set -e; \
     apt-get -y --no-install-recommends install libtool \
-        # compilers (gcc-7, gcc-9, clang-6)
-        build-essential clang-6.0 lldb-6.0 lld-6.0 g++-9 ninja-build \
+        # compilers (gcc-7, gcc-9)
+        build-essential g++-9 ninja-build \
         # CI dependencies
         git ssh tar gzip ca-certificates gnupg \
         # Pythons
@@ -33,11 +33,12 @@ RUN set -e; \
         gcovr cppcheck doxygen rsync graphviz graphviz-dev unzip vim zip pkg-config; \
     apt-get -y clean
 
-# compiler clang-7 and libc++ only on x86_64, for debug purpose
+# compiler clang-7, clang-9 and libc++ only on x86_64, for debug purpose
 RUN set -e; \
     if [ `uname -m` = "x86_64" ]; then \
       apt-get -y --no-install-recommends install \
-        clang-7 lldb-7 lld-7 libc++-7-dev libc++abi-7-dev clang-format-7; \
+        clang-7 lldb-7 lld-7 libc++-7-dev libc++abi-7-dev clang-format-7 \
+        clang-9; \
       apt-get -y clean; \
     fi
 


### PR DESCRIPTION
### Description of the Change
- Replace clang-6.0 with clang-9 to avoid compiler errors and enable C++17 support
https://bugs.llvm.org/show_bug.cgi?id=33222

### Benefits
Updated environment

### Possible Drawbacks 
Less legacy support?
