### PR TITLE
Logger: remove fmt version from exception

### DIFF
--- a/libs/logger/logger.hpp
+++ b/libs/logger/logger.hpp
@@ -87,7 +87,7 @@ namespace logger {
       if (shouldLog(level)) {
         try {
           logInternal(level, fmt::format(format, args...));
-        } catch (const fmt::v5::format_error &error) {
+        } catch (const fmt::format_error &error) {
           std::string error_msg("Exception was thrown while logging: ");
           logInternal(LogLevel::kError, error_msg.append(error.what()));
         }


### PR DESCRIPTION
### Description of the Change
Remove fmt version from exception type to allow building it independent from versions.

### Benefits
No explicit version dependency in code.

### Possible Drawbacks 
None
