### PR TITLE
Shared model: replace boost optional with std

### DIFF
--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/format.hpp>
 #include "ametsuchi/impl/executor_common.hpp"
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/commands/add_asset_quantity.hpp"
@@ -441,6 +442,13 @@ namespace iroha {
 
       void addArgumentToString(const std::string &argument_name,
                                const boost::optional<std::string> &value) {
+        if (value) {
+          addArgumentToString(argument_name, *value);
+        }
+      }
+
+      void addArgumentToString(const std::string &argument_name,
+                               const std::optional<std::string> &value) {
         if (value) {
           addArgumentToString(argument_name, *value);
         }

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 
 #include <boost/format.hpp>
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/account.hpp"

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -6,6 +6,7 @@
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 
 #include <soci/boost-tuple.h>
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
 #include "backend/plain/peer.hpp"
 #include "common/result.hpp"
@@ -75,7 +76,7 @@ namespace iroha {
     boost::optional<std::vector<std::shared_ptr<shared_model::interface::Peer>>>
     PostgresWsvQuery::getPeers() {
       using T = boost::
-          tuple<std::string, AddressType, boost::optional<TLSCertificateType>>;
+          tuple<std::string, AddressType, std::optional<TLSCertificateType>>;
       auto result = execute<T>([&] {
         return (sql_.prepare
                 << "SELECT public_key, address, tls_certificate FROM peer");
@@ -87,7 +88,7 @@ namespace iroha {
     boost::optional<std::shared_ptr<shared_model::interface::Peer>>
     PostgresWsvQuery::getPeerByPublicKey(const PubkeyType &public_key) {
       using T = boost::
-          tuple<std::string, AddressType, boost::optional<TLSCertificateType>>;
+          tuple<std::string, AddressType, std::optional<TLSCertificateType>>;
       auto result = execute<T>([&] {
         return (sql_.prepare << R"(
             SELECT public_key, address, tls_certificate

--- a/irohad/ametsuchi/impl/soci_std_optional.hpp
+++ b/irohad/ametsuchi/impl/soci_std_optional.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SOCI_STD_OPTIONAL_HPP
+#define IROHA_SOCI_STD_OPTIONAL_HPP
+
+#include <soci/type-conversion-traits.h>
+
+#include <optional>
+
+namespace soci {
+
+  // simple fall-back for std::optional
+  template <typename T>
+  struct type_conversion<std::optional<T>> {
+    typedef typename type_conversion<T>::base_type base_type;
+
+    static void from_base(base_type const &in,
+                          indicator ind,
+                          std::optional<T> &out) {
+      if (ind == i_null) {
+        out.reset();
+      } else {
+        T tmp = T();
+        type_conversion<T>::from_base(in, ind, tmp);
+        out = tmp;
+      }
+    }
+
+    static void to_base(std::optional<T> const &in,
+                        base_type &out,
+                        indicator &ind) {
+      if (in) {
+        type_conversion<T>::to_base(in.value(), out, ind);
+      } else {
+        ind = i_null;
+      }
+    }
+  };
+
+}  // namespace soci
+
+#endif  // IROHA_SOCI_STD_OPTIONAL_HPP

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -345,7 +345,7 @@ JsonDeserializerImpl::getVal<std::unique_ptr<shared_model::interface::Peer>>(
       getOptValByKey<std::string>(
           path, obj, config_members::TlsCertificatePath);
 
-  boost::optional<std::string> tls_certificate_str;
+  std::optional<std::string> tls_certificate_str;
   if (tls_certificate_path) {
     iroha::readTextFile(*tls_certificate_path)
         .match([&tls_certificate_str](

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
@@ -61,7 +61,7 @@ namespace iroha {
   PendingTransactionStorageImpl::getPendingTransactions(
       const shared_model::interface::types::AccountIdType &account_id,
       const shared_model::interface::types::TransactionsNumberType page_size,
-      const boost::optional<shared_model::interface::types::HashType>
+      const std::optional<shared_model::interface::types::HashType>
           &first_tx_hash) const {
     BOOST_ASSERT_MSG(page_size > 0, "Page size has to be positive");
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.hpp
@@ -47,7 +47,7 @@ namespace iroha {
     expected::Result<Response, ErrorCode> getPendingTransactions(
         const shared_model::interface::types::AccountIdType &account_id,
         const shared_model::interface::types::TransactionsNumberType page_size,
-        const boost::optional<shared_model::interface::types::HashType>
+        const std::optional<shared_model::interface::types::HashType>
             &first_tx_hash) const override;
 
    private:

--- a/irohad/pending_txs_storage/pending_txs_storage.hpp
+++ b/irohad/pending_txs_storage/pending_txs_storage.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_PENDING_TXS_STORAGE_HPP
 #define IROHA_PENDING_TXS_STORAGE_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "common/result.hpp"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -35,7 +36,7 @@ namespace iroha {
       shared_model::interface::types::SharedTxsCollectionType transactions;
       shared_model::interface::types::TransactionsNumberType
           all_transactions_size;
-      boost::optional<
+      std::optional<
           shared_model::interface::PendingTransactionsPageResponse::BatchInfo>
           next_batch_info;
 
@@ -69,7 +70,7 @@ namespace iroha {
     virtual expected::Result<Response, ErrorCode> getPendingTransactions(
         const shared_model::interface::types::AccountIdType &account_id,
         const shared_model::interface::types::TransactionsNumberType page_size,
-        const boost::optional<shared_model::interface::types::HashType>
+        const std::optional<shared_model::interface::types::HashType>
             &first_tx_hash) const = 0;
 
     virtual ~PendingTransactionStorage() = default;

--- a/libs/common/optional_reference_equal.hpp
+++ b/libs/common/optional_reference_equal.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_OPTIONAL_REFERENCE_EQUAL_HPP
+#define IROHA_OPTIONAL_REFERENCE_EQUAL_HPP
+
+#include <functional>
+#include <optional>
+
+namespace iroha {
+
+  /**
+   * Compares optional references by accesing the stored reference, if it is
+   * present
+   */
+  template <typename T>
+  constexpr bool optionalReferenceEqual(
+      const std::optional<std::reference_wrapper<T>> &lhs,
+      const std::optional<std::reference_wrapper<T>> &rhs) {
+    return static_cast<bool>(lhs) == static_cast<bool>(rhs)
+        and (not lhs or lhs->get() == rhs->get());
+  }
+}  // namespace iroha
+
+#endif  // IROHA_OPTIONAL_REFERENCE_EQUAL_HPP

--- a/libs/common/to_string.hpp
+++ b/libs/common/to_string.hpp
@@ -6,7 +6,9 @@
 #ifndef IROHA_LIBS_TO_STRING_HPP
 #define IROHA_LIBS_TO_STRING_HPP
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <boost/optional.hpp>
@@ -41,6 +43,16 @@ namespace iroha {
                      std::string>::value,
         std::string> {
       return o.toString();
+    }
+
+    template <typename... T>
+    inline std::string toString(const std::reference_wrapper<T...> &o) {
+      return ::iroha::to_string::toString(o.get());
+    }
+
+    template <typename... T>
+    inline std::string toString(const std::optional<T...> &o) {
+      return detail::toStringDereferenced(o);
     }
 
     template <typename... T>
@@ -95,6 +107,12 @@ namespace iroha {
       template <>
       inline std::string toStringDereferenced<boost::none_t>(
           const boost::none_t &) {
+        return kNotSet;
+      }
+
+      template <>
+      inline std::string toStringDereferenced<std::nullopt_t>(
+          const std::nullopt_t &) {
         return kNotSet;
       }
     }  // namespace detail

--- a/shared_model/backend/plain/impl/peer.cpp
+++ b/shared_model/backend/plain/impl/peer.cpp
@@ -8,10 +8,10 @@
 using namespace shared_model;
 using namespace shared_model::plain;
 
-Peer::Peer(const interface::types::AddressType &address,
-           const interface::types::PubkeyType &public_key,
-           const boost::optional<interface::types::TLSCertificateType>
-               &tls_certificate)
+Peer::Peer(
+    const interface::types::AddressType &address,
+    const interface::types::PubkeyType &public_key,
+    const std::optional<interface::types::TLSCertificateType> &tls_certificate)
     : address_(address),
       public_key_(public_key),
       tls_certificate_(tls_certificate) {}
@@ -24,7 +24,7 @@ const shared_model::interface::types::PubkeyType &Peer::pubkey() const {
   return public_key_;
 }
 
-const boost::optional<shared_model::interface::types::TLSCertificateType>
+const std::optional<shared_model::interface::types::TLSCertificateType>
     &Peer::tlsCertificate() const {
   return tls_certificate_;
 }

--- a/shared_model/backend/plain/peer.hpp
+++ b/shared_model/backend/plain/peer.hpp
@@ -9,7 +9,7 @@
 #include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace shared_model {
   namespace plain {
@@ -18,20 +18,20 @@ namespace shared_model {
      public:
       Peer(const interface::types::AddressType &address,
            const interface::types::PubkeyType &public_key,
-           const boost::optional<interface::types::TLSCertificateType>
+           const std::optional<interface::types::TLSCertificateType>
                &tls_certificate);
 
       const interface::types::AddressType &address() const override;
 
       const interface::types::PubkeyType &pubkey() const override;
 
-      const boost::optional<interface::types::TLSCertificateType>
+      const std::optional<interface::types::TLSCertificateType>
           &tlsCertificate() const override;
 
      private:
       const interface::types::AddressType address_;
       const interface::types::PubkeyType public_key_;
-      const boost::optional<interface::types::TLSCertificateType>
+      const std::optional<interface::types::TLSCertificateType>
           tls_certificate_;
     };
 

--- a/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
@@ -28,12 +28,12 @@ namespace shared_model {
       return compare_and_set_account_detail_.value();
     }
 
-    const boost::optional<interface::types::AccountDetailValueType>
+    const std::optional<interface::types::AccountDetailValueType>
     CompareAndSetAccountDetail::oldValue() const {
       if (compare_and_set_account_detail_.opt_old_value_case()
           == iroha::protocol::CompareAndSetAccountDetail::
                  OPT_OLD_VALUE_NOT_SET) {
-        return boost::none;
+        return std::nullopt;
       }
       return compare_and_set_account_detail_.old_value();
     }

--- a/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
@@ -23,7 +23,7 @@ namespace shared_model {
 
       const interface::types::AccountDetailValueType &value() const override;
 
-      const boost::optional<interface::types::AccountDetailValueType> oldValue()
+      const std::optional<interface::types::AccountDetailValueType> oldValue()
           const override;
 
      private:

--- a/shared_model/backend/protobuf/common_objects/peer.hpp
+++ b/shared_model/backend/protobuf/common_objects/peer.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/common_objects/peer.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "backend/protobuf/util.hpp"
 #include "cryptography/hash.hpp"
@@ -35,7 +35,7 @@ namespace shared_model {
         return proto_->address();
       }
 
-      const boost::optional<interface::types::TLSCertificateType>
+      const std::optional<interface::types::TLSCertificateType>
           &tlsCertificate() const override {
         return tls_certificate_;
       }
@@ -48,7 +48,7 @@ namespace shared_model {
       detail::ReferenceHolder<iroha::protocol::Peer> proto_;
       const interface::types::PubkeyType public_key_{
           crypto::Hash::fromHexString(proto_->peer_key())};
-      boost::optional<std::string> tls_certificate_;
+      std::optional<std::string> tls_certificate_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/common_objects/proto_common_objects_factory.hpp
+++ b/shared_model/backend/protobuf/common_objects/proto_common_objects_factory.hpp
@@ -38,8 +38,8 @@ namespace shared_model {
       FactoryResult<std::unique_ptr<interface::Peer>> createPeer(
           const interface::types::AddressType &address,
           const interface::types::PubkeyType &public_key,
-          const boost::optional<interface::types::TLSCertificateType>
-              &tls_certificate = boost::none) override {
+          const std::optional<interface::types::TLSCertificateType>
+              &tls_certificate = std::nullopt) override {
         iroha::protocol::Peer peer;
         peer.set_address(address);
         peer.set_peer_key(public_key.hex());
@@ -148,7 +148,7 @@ namespace shared_model {
       template <typename ReturnValueType>
       FactoryResult<ReturnValueType> validated(
           ReturnValueType object,
-          const boost::optional<validation::ValidationError> &error) {
+          const std::optional<validation::ValidationError> &error) {
         if (error) {
           return error.value().toString();
         }

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -62,7 +62,7 @@ shared_model::proto::ProtoQueryResponseFactory::createAccountAssetResponse(
                            interface::types::AssetIdType,
                            shared_model::interface::Amount>> assets,
     size_t total_assets_number,
-    boost::optional<shared_model::interface::types::AssetIdType> next_asset_id,
+    std::optional<shared_model::interface::types::AssetIdType> next_asset_id,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
       [assets = std::move(assets),
@@ -89,8 +89,8 @@ std::unique_ptr<shared_model::interface::QueryResponse>
 shared_model::proto::ProtoQueryResponseFactory::createAccountDetailResponse(
     shared_model::interface::types::DetailType account_detail,
     size_t total_number,
-    boost::optional<const shared_model::interface::AccountDetailRecordId &>
-        next_record_id,
+    std::optional<std::reference_wrapper<
+        const shared_model::interface::AccountDetailRecordId>> next_record_id,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
       [&account_detail, total_number, &next_record_id](
@@ -102,8 +102,8 @@ shared_model::proto::ProtoQueryResponseFactory::createAccountDetailResponse(
         if (next_record_id) {
           auto protocol_next_record_id =
               protocol_specific_response->mutable_next_record_id();
-          protocol_next_record_id->set_writer(next_record_id->writer());
-          protocol_next_record_id->set_key(next_record_id->key());
+          protocol_next_record_id->set_writer(next_record_id->get().writer());
+          protocol_next_record_id->set_key(next_record_id->get().key());
         }
       },
       query_hash);
@@ -241,7 +241,7 @@ std::unique_ptr<shared_model::interface::QueryResponse>
 shared_model::proto::ProtoQueryResponseFactory::createTransactionsPageResponse(
     std::vector<std::unique_ptr<shared_model::interface::Transaction>>
         transactions,
-    boost::optional<const crypto::Hash &> next_tx_hash,
+    std::optional<std::reference_wrapper<const crypto::Hash>> next_tx_hash,
     interface::types::TransactionsNumberType all_transactions_size,
     const crypto::Hash &query_hash) const {
   return createQueryResponse(
@@ -258,7 +258,7 @@ shared_model::proto::ProtoQueryResponseFactory::createTransactionsPageResponse(
         }
         if (next_tx_hash) {
           protocol_specific_response->set_next_tx_hash(
-              next_tx_hash.value().hex());
+              next_tx_hash.value().get().hex());
         }
         protocol_specific_response->set_all_transactions_size(
             all_transactions_size);
@@ -271,7 +271,7 @@ std::unique_ptr<shared_model::interface::QueryResponse> shared_model::proto::
         std::vector<std::unique_ptr<shared_model::interface::Transaction>>
             transactions,
         interface::types::TransactionsNumberType all_transactions_size,
-        boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+        std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
             next_batch_info,
         const crypto::Hash &query_hash) const {
   return createQueryResponse(

--- a/shared_model/backend/protobuf/impl/transaction.cpp
+++ b/shared_model/backend/protobuf/impl/transaction.cpp
@@ -44,14 +44,14 @@ namespace shared_model {
           reduced_payload_.mutable_commands()->begin(),
           reduced_payload_.mutable_commands()->end()};
 
-      boost::optional<std::shared_ptr<interface::BatchMeta>> meta_{
-          [this]() -> boost::optional<std::shared_ptr<interface::BatchMeta>> {
+      std::optional<std::shared_ptr<interface::BatchMeta>> meta_{
+          [this]() -> std::optional<std::shared_ptr<interface::BatchMeta>> {
             if (payload_.has_batch()) {
               std::shared_ptr<interface::BatchMeta> b =
                   std::make_shared<proto::BatchMeta>(*payload_.mutable_batch());
               return b;
             }
-            return boost::none;
+            return std::nullopt;
           }()};
 
       SignatureSetType<proto::Signature> signatures_{[this] {
@@ -160,7 +160,7 @@ namespace shared_model {
       return impl_->reduced_payload_.quorum();
     }
 
-    boost::optional<std::shared_ptr<interface::BatchMeta>>
+    std::optional<std::shared_ptr<interface::BatchMeta>>
     Transaction::batchMeta() const {
       return impl_->meta_;
     }

--- a/shared_model/backend/protobuf/proto_query_response_factory.hpp
+++ b/shared_model/backend/protobuf/proto_query_response_factory.hpp
@@ -18,15 +18,16 @@ namespace shared_model {
                                  interface::types::AssetIdType,
                                  shared_model::interface::Amount>> assets,
           size_t total_assets_number,
-          boost::optional<shared_model::interface::types::AssetIdType>
+          std::optional<shared_model::interface::types::AssetIdType>
               next_asset_id,
           const crypto::Hash &query_hash) const override;
 
       std::unique_ptr<interface::QueryResponse> createAccountDetailResponse(
           interface::types::DetailType account_detail,
           size_t total_number,
-          boost::optional<const shared_model::interface::AccountDetailRecordId
-                              &> next_record_id,
+          std::optional<std::reference_wrapper<
+              const shared_model::interface::AccountDetailRecordId>>
+              next_record_id,
           const crypto::Hash &query_hash) const override;
 
       std::unique_ptr<interface::QueryResponse> createAccountResponse(
@@ -59,7 +60,8 @@ namespace shared_model {
       std::unique_ptr<interface::QueryResponse> createTransactionsPageResponse(
           std::vector<std::unique_ptr<shared_model::interface::Transaction>>
               transactions,
-          boost::optional<const crypto::Hash &> next_tx_hash,
+          std::optional<std::reference_wrapper<const crypto::Hash>>
+              next_tx_hash,
           interface::types::TransactionsNumberType all_transactions_size,
           const crypto::Hash &query_hash) const override;
 
@@ -68,7 +70,7 @@ namespace shared_model {
           std::vector<std::unique_ptr<shared_model::interface::Transaction>>
               transactions,
           interface::types::TransactionsNumberType all_transactions_size,
-          boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+          std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
               next_batch_info,
           const crypto::Hash &query_hash) const override;
 

--- a/shared_model/backend/protobuf/queries/impl/proto_account_detail_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_account_detail_pagination_meta.cpp
@@ -10,9 +10,10 @@ using namespace shared_model::proto;
 AccountDetailPaginationMeta::AccountDetailPaginationMeta(TransportType &proto)
     : proto_(proto), first_record_id_{[this]() -> decltype(first_record_id_) {
         if (proto_.has_first_record_id()) {
-          return AccountDetailRecordId{*this->proto_.mutable_first_record_id()};
+          return std::make_optional<const AccountDetailRecordId>(
+              *this->proto_.mutable_first_record_id());
         }
-        return boost::none;
+        return std::nullopt;
       }()} {}
 
 AccountDetailPaginationMeta::AccountDetailPaginationMeta(
@@ -23,10 +24,12 @@ size_t AccountDetailPaginationMeta::pageSize() const {
   return proto_.page_size();
 }
 
-boost::optional<const shared_model::interface::AccountDetailRecordId &>
+std::optional<std::reference_wrapper<
+    const shared_model::interface::AccountDetailRecordId>>
 AccountDetailPaginationMeta::firstRecordId() const {
   if (first_record_id_) {
-    return first_record_id_.value();
+    return std::cref<shared_model::interface::AccountDetailRecordId>(
+        first_record_id_.value());
   }
   return {};
 }

--- a/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_asset_pagination_meta.cpp
@@ -5,7 +5,7 @@
 
 #include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace types = shared_model::interface::types;
 
@@ -19,11 +19,11 @@ types::TransactionsNumberType AssetPaginationMeta::pageSize() const {
   return meta_.page_size();
 }
 
-boost::optional<types::AssetIdType> AssetPaginationMeta::firstAssetId() const {
+std::optional<types::AssetIdType> AssetPaginationMeta::firstAssetId() const {
   if (meta_.opt_first_asset_id_case()
       == iroha::protocol::AssetPaginationMeta::OptFirstAssetIdCase::
              OPT_FIRST_ASSET_ID_NOT_SET) {
-    return boost::none;
+    return std::nullopt;
   }
   return meta_.first_asset_id();
 }

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_assets.cpp
@@ -10,13 +10,13 @@ namespace shared_model {
 
     GetAccountAssets::GetAccountAssets(iroha::protocol::Query &query)
         : account_assets_{query.payload().get_account_assets()},
-          pagination_meta_{[&]() -> boost::optional<const AssetPaginationMeta> {
+          pagination_meta_{[&]() -> std::optional<const AssetPaginationMeta> {
             if (query.payload().get_account_assets().has_pagination_meta()) {
               return AssetPaginationMeta{*query.mutable_payload()
                                               ->mutable_get_account_assets()
                                               ->mutable_pagination_meta()};
             } else {
-              return boost::none;
+              return std::nullopt;
             }
           }()} {}
 
@@ -24,12 +24,13 @@ namespace shared_model {
       return account_assets_.account_id();
     }
 
-    boost::optional<const interface::AssetPaginationMeta &>
+    std::optional<std::reference_wrapper<const interface::AssetPaginationMeta>>
     GetAccountAssets::paginationMeta() const {
       if (pagination_meta_) {
-        return pagination_meta_.value();
+        return std::cref<interface::AssetPaginationMeta>(
+            pagination_meta_.value());
       }
-      return boost::none;
+      return std::nullopt;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_account_detail.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_account_detail.cpp
@@ -18,7 +18,7 @@ namespace shared_model {
                        ->mutable_get_account_detail()
                        ->mutable_pagination_meta()};
             }
-            return boost::none;
+            return std::nullopt;
           }()} {}
 
     const interface::types::AccountIdType &GetAccountDetail::accountId() const {
@@ -27,26 +27,28 @@ namespace shared_model {
           : query_.payload().meta().creator_account_id();
     }
 
-    boost::optional<interface::types::AccountDetailKeyType>
+    std::optional<interface::types::AccountDetailKeyType>
     GetAccountDetail::key() const {
       return account_detail_.opt_key_case()
-          ? boost::make_optional(account_detail_.key())
-          : boost::none;
+          ? std::make_optional(account_detail_.key())
+          : std::nullopt;
     }
 
-    boost::optional<interface::types::AccountIdType> GetAccountDetail::writer()
+    std::optional<interface::types::AccountIdType> GetAccountDetail::writer()
         const {
       return account_detail_.opt_writer_case()
-          ? boost::make_optional(account_detail_.writer())
-          : boost::none;
+          ? std::make_optional(account_detail_.writer())
+          : std::nullopt;
     }
 
-    boost::optional<const interface::AccountDetailPaginationMeta &>
+    std::optional<
+        std::reference_wrapper<const interface::AccountDetailPaginationMeta>>
     GetAccountDetail::paginationMeta() const {
       if (pagination_meta_) {
-        return *pagination_meta_;
+        return std::cref<interface::AccountDetailPaginationMeta>(
+            *pagination_meta_);
       }
-      return boost::none;
+      return std::nullopt;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_get_pending_transactions.cpp
@@ -11,7 +11,7 @@ namespace shared_model {
     GetPendingTransactions::GetPendingTransactions(
         iroha::protocol::Query &query)
         : pending_transactions_{query.payload().get_pending_transactions()},
-          pagination_meta_{[&]() -> boost::optional<const TxPaginationMeta> {
+          pagination_meta_{[&]() -> std::optional<const TxPaginationMeta> {
             if (query.payload()
                     .get_pending_transactions()
                     .has_pagination_meta()) {
@@ -19,15 +19,15 @@ namespace shared_model {
                                            ->mutable_get_pending_transactions()
                                            ->mutable_pagination_meta()};
             }
-            return boost::none;
+            return std::nullopt;
           }()} {}
 
-    boost::optional<const interface::TxPaginationMeta &>
+    std::optional<std::reference_wrapper<const interface::TxPaginationMeta>>
     GetPendingTransactions::paginationMeta() const {
       if (pagination_meta_) {
-        return pagination_meta_.value();
+        return std::cref<interface::TxPaginationMeta>(pagination_meta_.value());
       }
-      return boost::none;
+      return std::nullopt;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -5,7 +5,7 @@
 
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "cryptography/hash.hpp"
 
 namespace types = shared_model::interface::types;
@@ -19,11 +19,11 @@ types::TransactionsNumberType TxPaginationMeta::pageSize() const {
   return meta_.page_size();
 }
 
-boost::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
+std::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
   if (meta_.opt_first_tx_hash_case()
       == iroha::protocol::TxPaginationMeta::OptFirstTxHashCase::
              OPT_FIRST_TX_HASH_NOT_SET) {
-    return boost::none;
+    return std::nullopt;
   }
   return types::HashType::fromHexString(meta_.first_tx_hash());
 }

--- a/shared_model/backend/protobuf/queries/proto_account_detail_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_account_detail_pagination_meta.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/queries/account_detail_pagination_meta.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "backend/protobuf/queries/proto_account_detail_record_id.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/account_detail_record_id.hpp"
@@ -29,12 +29,13 @@ namespace shared_model {
 
       size_t pageSize() const override;
 
-      boost::optional<const interface::AccountDetailRecordId &> firstRecordId()
-          const override;
+      std::optional<
+          std::reference_wrapper<const interface::AccountDetailRecordId>>
+      firstRecordId() const override;
 
      private:
       TransportType &proto_;
-      const boost::optional<const AccountDetailRecordId> first_record_id_;
+      const std::optional<const AccountDetailRecordId> first_record_id_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_asset_pagination_meta.hpp
@@ -21,7 +21,7 @@ namespace shared_model {
 
       interface::types::TransactionsNumberType pageSize() const override;
 
-      boost::optional<interface::types::AssetIdType> firstAssetId()
+      std::optional<interface::types::AssetIdType> firstAssetId()
           const override;
 
      private:

--- a/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_assets.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/queries/get_account_assets.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "backend/protobuf/queries/proto_asset_pagination_meta.hpp"
 #include "queries.pb.h"
 
@@ -20,14 +20,15 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
-      boost::optional<const interface::AssetPaginationMeta &> paginationMeta()
-          const override;
+      std::optional<
+          std::reference_wrapper<const interface::AssetPaginationMeta>>
+      paginationMeta() const override;
 
      private:
       // ------------------------------| fields |-------------------------------
 
       const iroha::protocol::GetAccountAssets &account_assets_;
-      const boost::optional<const AssetPaginationMeta> pagination_meta_;
+      const std::optional<const AssetPaginationMeta> pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_account_detail.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/queries/get_account_detail.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "backend/protobuf/queries/proto_account_detail_pagination_meta.hpp"
 #include "queries.pb.h"
 
@@ -20,12 +20,13 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
-      boost::optional<interface::types::AccountDetailKeyType> key()
+      std::optional<interface::types::AccountDetailKeyType> key()
           const override;
 
-      boost::optional<interface::types::AccountIdType> writer() const override;
+      std::optional<interface::types::AccountIdType> writer() const override;
 
-      boost::optional<const interface::AccountDetailPaginationMeta &>
+      std::optional<
+          std::reference_wrapper<const interface::AccountDetailPaginationMeta>>
       paginationMeta() const override;
 
      private:
@@ -33,7 +34,7 @@ namespace shared_model {
 
       const iroha::protocol::Query &query_;
       const iroha::protocol::GetAccountDetail &account_detail_;
-      const boost::optional<const AccountDetailPaginationMeta> pagination_meta_;
+      const std::optional<const AccountDetailPaginationMeta> pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
+++ b/shared_model/backend/protobuf/queries/proto_get_pending_transactions.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/queries/get_pending_transactions.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 #include "queries.pb.h"
 
@@ -19,12 +19,12 @@ namespace shared_model {
      public:
       explicit GetPendingTransactions(iroha::protocol::Query &query);
 
-      boost::optional<const interface::TxPaginationMeta &> paginationMeta()
-          const override;
+      std::optional<std::reference_wrapper<const interface::TxPaginationMeta>>
+      paginationMeta() const override;
 
      private:
       const iroha::protocol::GetPendingTransactions &pending_transactions_;
-      boost::optional<const TxPaginationMeta> pagination_meta_;
+      std::optional<const TxPaginationMeta> pagination_meta_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -21,7 +21,7 @@ namespace shared_model {
 
       interface::types::TransactionsNumberType pageSize() const override;
 
-      boost::optional<interface::types::HashType> firstTxHash() const override;
+      std::optional<interface::types::HashType> firstTxHash() const override;
 
      private:
       const iroha::protocol::TxPaginationMeta &meta_;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_asset_response.cpp
@@ -22,7 +22,7 @@ namespace shared_model {
                 == iroha::protocol::AccountAssetResponse::kNextAssetId) {
               return this->account_asset_response_.next_asset_id();
             }
-            return boost::none;
+            return std::nullopt;
           }()} {}
 
     const interface::types::AccountAssetCollectionType
@@ -30,7 +30,7 @@ namespace shared_model {
       return account_assets_;
     }
 
-    boost::optional<interface::types::AssetIdType>
+    std::optional<interface::types::AssetIdType>
     AccountAssetResponse::nextAssetId() const {
       return next_asset_id_;
     }

--- a/shared_model/backend/protobuf/query_responses/impl/proto_account_detail_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_account_detail_response.cpp
@@ -14,10 +14,10 @@ namespace shared_model {
           next_record_id_{
               [](auto &query_response) -> decltype(next_record_id_) {
                 if (query_response.has_next_record_id()) {
-                  return AccountDetailRecordId{
-                      *query_response.mutable_next_record_id()};
+                  return std::make_optional<const AccountDetailRecordId>(
+                      *query_response.mutable_next_record_id());
                 }
-                return boost::none;
+                return std::nullopt;
               }(*query_response.mutable_account_detail_response())} {}
 
     const interface::types::DetailType &AccountDetailResponse::detail() const {
@@ -28,12 +28,14 @@ namespace shared_model {
       return account_detail_response_.total_number();
     }
 
-    boost::optional<const shared_model::interface::AccountDetailRecordId &>
+    std::optional<std::reference_wrapper<
+        const shared_model::interface::AccountDetailRecordId>>
     AccountDetailResponse::nextRecordId() const {
       if (next_record_id_) {
-        return next_record_id_.value();
+        return std::cref<shared_model::interface::AccountDetailRecordId>(
+            next_record_id_.value());
       }
-      return boost::none;
+      return std::nullopt;
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_pending_transactions_page_response.cpp
@@ -22,7 +22,7 @@ namespace shared_model {
                   ->end()},
           next_batch_info_{
               [this]()
-                  -> boost::optional<
+                  -> std::optional<
                       interface::PendingTransactionsPageResponse::BatchInfo> {
                 if (pending_transactions_page_response_.has_next_batch_info()) {
                   auto &next =
@@ -34,7 +34,7 @@ namespace shared_model {
                   next_batch.batch_size = next.batch_size();
                   return next_batch;
                 }
-                return boost::none;
+                return std::nullopt;
               }()} {}
 
     interface::types::TransactionsCollectionType
@@ -42,7 +42,7 @@ namespace shared_model {
       return transactions_;
     }
 
-    boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+    std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
     PendingTransactionsPageResponse::nextBatchInfo() const {
       return next_batch_info_;
     }

--- a/shared_model/backend/protobuf/query_responses/impl/proto_transaction_page_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_transaction_page_response.cpp
@@ -14,13 +14,13 @@ namespace shared_model {
         : transactionPageResponse_{query_response.transactions_page_response()},
           transactions_{transactionPageResponse_.transactions().begin(),
                         transactionPageResponse_.transactions().end()},
-          next_hash_{[this]() -> boost::optional<interface::types::HashType> {
+          next_hash_{[this]() -> std::optional<interface::types::HashType> {
             switch (transactionPageResponse_.next_page_tag_case()) {
               case iroha::protocol::TransactionsPageResponse::kNextTxHash:
                 return crypto::Hash::fromHexString(
                     transactionPageResponse_.next_tx_hash());
               default:
-                return boost::none;
+                return std::nullopt;
             }
           }()} {}
 
@@ -29,7 +29,7 @@ namespace shared_model {
       return transactions_;
     }
 
-    boost::optional<interface::types::HashType>
+    std::optional<interface::types::HashType>
     TransactionsPageResponse::nextTxHash() const {
       return next_hash_;
     }

--- a/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_asset_response.hpp
@@ -22,8 +22,7 @@ namespace shared_model {
       const interface::types::AccountAssetCollectionType accountAssets()
           const override;
 
-      boost::optional<interface::types::AssetIdType> nextAssetId()
-          const override;
+      std::optional<interface::types::AssetIdType> nextAssetId() const override;
 
       size_t totalAccountAssetsNumber() const override;
 
@@ -31,7 +30,7 @@ namespace shared_model {
       const iroha::protocol::AccountAssetResponse &account_asset_response_;
 
       std::vector<AccountAsset> account_assets_;
-      const boost::optional<interface::types::AssetIdType> next_asset_id_;
+      const std::optional<interface::types::AssetIdType> next_asset_id_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_account_detail_response.hpp
@@ -24,12 +24,13 @@ namespace shared_model {
 
       size_t totalNumber() const override;
 
-      boost::optional<const shared_model::interface::AccountDetailRecordId &>
+      std::optional<std::reference_wrapper<
+          const shared_model::interface::AccountDetailRecordId>>
       nextRecordId() const override;
 
      private:
       const iroha::protocol::AccountDetailResponse &account_detail_response_;
-      const boost::optional<const AccountDetailRecordId> next_record_id_;
+      const std::optional<const AccountDetailRecordId> next_record_id_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_pending_transactions_page_response.hpp
@@ -23,7 +23,7 @@ namespace shared_model {
       interface::types::TransactionsCollectionType transactions()
           const override;
 
-      boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+      std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
       nextBatchInfo() const override;
 
       interface::types::TransactionsNumberType allTransactionsSize()
@@ -33,7 +33,7 @@ namespace shared_model {
       const iroha::protocol::PendingTransactionsPageResponse
           &pending_transactions_page_response_;
       const std::vector<Transaction> transactions_;
-      boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+      std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
           next_batch_info_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/query_responses/proto_transactions_page_response.hpp
+++ b/shared_model/backend/protobuf/query_responses/proto_transactions_page_response.hpp
@@ -23,7 +23,7 @@ namespace shared_model {
       interface::types::TransactionsCollectionType transactions()
           const override;
 
-      boost::optional<interface::types::HashType> nextTxHash() const override;
+      std::optional<interface::types::HashType> nextTxHash() const override;
 
       interface::types::TransactionsNumberType allTransactionsSize()
           const override;
@@ -31,7 +31,7 @@ namespace shared_model {
      private:
       const iroha::protocol::TransactionsPageResponse &transactionPageResponse_;
       std::vector<proto::Transaction> transactions_;
-      boost::optional<interface::types::HashType> next_hash_;
+      std::optional<interface::types::HashType> next_hash_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -52,7 +52,7 @@ namespace shared_model {
 
       interface::types::QuorumType quorum() const override;
 
-      boost::optional<std::shared_ptr<interface::BatchMeta>> batchMeta()
+      std::optional<std::shared_ptr<interface::BatchMeta>> batchMeta()
           const override;
 
      protected:

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -6,8 +6,8 @@
 #ifndef IROHA_PROTO_QUERY_BUILDER_TEMPLATE_HPP
 #define IROHA_PROTO_QUERY_BUILDER_TEMPLATE_HPP
 
-#include <boost/optional.hpp>
 #include <boost/range/algorithm/for_each.hpp>
+#include <optional>
 
 #include "backend/plain/account_detail_record_id.hpp"
 #include "backend/protobuf/queries/proto_query.hpp"
@@ -85,8 +85,8 @@ namespace shared_model {
       static auto setTxPaginationMeta(
           PageMetaPayload * page_meta_payload,
           interface::types::TransactionsNumberType page_size,
-          const boost::optional<interface::types::HashType> &first_hash =
-              boost::none) {
+          const std::optional<interface::types::HashType> &first_hash =
+              std::nullopt) {
         page_meta_payload->set_page_size(page_size);
         if (first_hash) {
           page_meta_payload->set_first_tx_hash(first_hash->hex());
@@ -141,8 +141,8 @@ namespace shared_model {
       auto getAccountTransactions(
           const interface::types::AccountIdType &account_id,
           interface::types::TransactionsNumberType page_size,
-          const boost::optional<interface::types::HashType> &first_hash =
-              boost::none) const {
+          const std::optional<interface::types::HashType> &first_hash =
+              std::nullopt) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_transactions();
           query->set_account_id(account_id);
@@ -155,8 +155,8 @@ namespace shared_model {
           const interface::types::AccountIdType &account_id,
           const interface::types::AssetIdType &asset_id,
           interface::types::TransactionsNumberType page_size,
-          const boost::optional<interface::types::HashType> &first_hash =
-              boost::none) const {
+          const std::optional<interface::types::HashType> &first_hash =
+              std::nullopt) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_asset_transactions();
           query->set_account_id(account_id);
@@ -169,7 +169,7 @@ namespace shared_model {
       auto getAccountAssets(
           const interface::types::AccountIdType &account_id,
           size_t page_size,
-          boost::optional<shared_model::interface::types::AssetIdType>
+          std::optional<shared_model::interface::types::AssetIdType>
               first_asset_id) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_assets();
@@ -187,8 +187,8 @@ namespace shared_model {
           const interface::types::AccountIdType &account_id = "",
           const interface::types::AccountDetailKeyType &key = "",
           const interface::types::AccountIdType &writer = "",
-          const boost::optional<plain::AccountDetailRecordId> &first_record_id =
-              boost::none) {
+          const std::optional<plain::AccountDetailRecordId> &first_record_id =
+              std::nullopt) {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_detail();
           if (not account_id.empty()) {
@@ -266,8 +266,8 @@ namespace shared_model {
 
       auto getPendingTransactions(
           interface::types::TransactionsNumberType page_size,
-          const boost::optional<interface::types::HashType> &first_hash =
-              boost::none) const {
+          const std::optional<interface::types::HashType> &first_hash =
+              std::nullopt) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_pending_transactions();
           setTxPaginationMeta(

--- a/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/transaction_template.hpp
@@ -142,11 +142,10 @@ namespace shared_model {
         });
       }
 
-      auto addPeerRaw(
-          const interface::types::AddressType &address,
-          const std::string &peer_key,
-          const boost::optional<interface::types::TLSCertificateType>
-              &tls_certificate = boost::none) const {
+      auto addPeerRaw(const interface::types::AddressType &address,
+                      const std::string &peer_key,
+                      const std::optional<interface::types::TLSCertificateType>
+                          &tls_certificate = std::nullopt) const {
         return addCommand([&](auto proto_command) {
           auto command = proto_command->mutable_add_peer();
           auto peer = command->mutable_peer();
@@ -160,8 +159,8 @@ namespace shared_model {
 
       auto addPeer(const interface::types::AddressType &address,
                    const interface::types::PubkeyType &peer_key,
-                   const boost::optional<interface::types::TLSCertificateType>
-                       &tls_certificate = boost::none) const {
+                   const std::optional<interface::types::TLSCertificateType>
+                       &tls_certificate = std::nullopt) const {
         return addPeerRaw(address, peer_key.hex(), tls_certificate);
       }
 

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -9,7 +9,7 @@
 #include "interfaces/base/model_primitive.hpp"
 
 #include <boost/functional/hash.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <unordered_set>
 #include "cryptography/default_hash_provider.hpp"
 #include "interfaces/common_objects/range_types.hpp"

--- a/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
+++ b/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_COMPARE_AND_SET_ACCOUNT_DETAIL_HPP
 #define IROHA_SHARED_MODEL_COMPARE_AND_SET_ACCOUNT_DETAIL_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 
 #include "interfaces/common_objects/types.hpp"
@@ -39,7 +39,7 @@ namespace shared_model {
       /**
        * @return the value expected before the change
        */
-      virtual const boost::optional<types::AccountDetailValueType> oldValue()
+      virtual const std::optional<types::AccountDetailValueType> oldValue()
           const = 0;
 
       std::string toString() const override;

--- a/shared_model/interfaces/common_objects/common_objects_factory.hpp
+++ b/shared_model/interfaces/common_objects/common_objects_factory.hpp
@@ -34,8 +34,8 @@ namespace shared_model {
       virtual FactoryResult<std::unique_ptr<Peer>> createPeer(
           const types::AddressType &address,
           const types::PubkeyType &public_key,
-          const boost::optional<types::TLSCertificateType> &tls_certificate =
-              boost::none) = 0;
+          const std::optional<types::TLSCertificateType> &tls_certificate =
+              std::nullopt) = 0;
 
       /**
        * Create account instance

--- a/shared_model/interfaces/common_objects/impl/peer.cpp
+++ b/shared_model/interfaces/common_objects/impl/peer.cpp
@@ -5,7 +5,7 @@
 
 #include "interfaces/common_objects/peer.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "cryptography/public_key.hpp"
 

--- a/shared_model/interfaces/common_objects/peer.hpp
+++ b/shared_model/interfaces/common_objects/peer.hpp
@@ -9,7 +9,7 @@
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
-#include <boost/optional/optional_fwd.hpp>
+#include <optional>
 
 namespace shared_model {
   namespace interface {
@@ -27,7 +27,7 @@ namespace shared_model {
       /**
        * @return Peer TLS certficate
        */
-      virtual const boost::optional<interface::types::TLSCertificateType>
+      virtual const std::optional<interface::types::TLSCertificateType>
           &tlsCertificate() const = 0;
 
       /**

--- a/shared_model/interfaces/iroha_internal/query_response_factory.hpp
+++ b/shared_model/interfaces/iroha_internal/query_response_factory.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/asset.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -54,7 +54,7 @@ namespace shared_model {
                                  types::AssetIdType,
                                  shared_model::interface::Amount>> assets,
           size_t total_assets_number,
-          boost::optional<shared_model::interface::types::AssetIdType>
+          std::optional<shared_model::interface::types::AssetIdType>
               next_asset_id,
           const crypto::Hash &query_hash) const = 0;
 
@@ -70,8 +70,9 @@ namespace shared_model {
       virtual std::unique_ptr<QueryResponse> createAccountDetailResponse(
           types::DetailType account_detail,
           size_t total_number,
-          boost::optional<const shared_model::interface::AccountDetailRecordId
-                              &> next_record_id,
+          std::optional<std::reference_wrapper<
+              const shared_model::interface::AccountDetailRecordId>>
+              next_record_id,
           const crypto::Hash &query_hash) const = 0;
 
       /**
@@ -164,7 +165,8 @@ namespace shared_model {
       virtual std::unique_ptr<QueryResponse> createTransactionsPageResponse(
           std::vector<std::unique_ptr<shared_model::interface::Transaction>>
               transactions,
-          boost::optional<const crypto::Hash &> next_tx_hash,
+          std::optional<std::reference_wrapper<const crypto::Hash>>
+              next_tx_hash,
           interface::types::TransactionsNumberType all_transactions_size,
           const crypto::Hash &query_hash) const = 0;
 
@@ -181,7 +183,7 @@ namespace shared_model {
       createPendingTransactionsPageResponse(
           std::vector<std::unique_ptr<interface::Transaction>> transactions,
           interface::types::TransactionsNumberType all_transactions_size,
-          boost::optional<interface::PendingTransactionsPageResponse::BatchInfo>
+          std::optional<interface::PendingTransactionsPageResponse::BatchInfo>
               next_batch_info,
           const crypto::Hash &query_hash) const = 0;
 

--- a/shared_model/interfaces/iroha_internal/transaction_batch.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_TRANSACTION_BATCH_HPP
 #define IROHA_TRANSACTION_BATCH_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "cryptography/hash.hpp"
 #include "interfaces/base/model_primitive.hpp"

--- a/shared_model/interfaces/iroha_internal/transaction_sequence.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_sequence.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_TRANSACTION_SEQUENCE_HPP
 #define IROHA_TRANSACTION_SEQUENCE_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 
 namespace shared_model {
@@ -44,7 +44,7 @@ namespace shared_model {
 
      private:
       types::BatchesCollectionType batches_;
-      mutable boost::optional<types::SharedTxsCollectionType> transactions_;
+      mutable std::optional<types::SharedTxsCollectionType> transactions_;
     };
 
   }  // namespace interface

--- a/shared_model/interfaces/iroha_internal/transaction_sequence_factory.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_sequence_factory.cpp
@@ -68,7 +68,7 @@ namespace shared_model {
 
         // if transaction is valid, try to form batch out of it
         if (auto meta = tx.value()->batchMeta()) {
-          auto hashes = meta.get()->reducedHashes();
+          auto hashes = meta.value()->reducedHashes();
           auto batch_hash =
               TransactionBatchHelpers::calculateReducedBatchHash(hashes);
           extracted_batches[batch_hash].push_back(tx.value());

--- a/shared_model/interfaces/queries/account_detail_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/account_detail_pagination_meta.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_DETAIL_PAGINATION_META_HPP
 #define IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_DETAIL_PAGINATION_META_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/account_detail_record_id.hpp"
@@ -22,8 +22,8 @@ namespace shared_model {
       virtual size_t pageSize() const = 0;
 
       /// Get the first requested record id, if provided.
-      virtual boost::optional<const AccountDetailRecordId &> firstRecordId()
-          const = 0;
+      virtual std::optional<std::reference_wrapper<const AccountDetailRecordId>>
+      firstRecordId() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/account_detail_record_id.hpp
+++ b/shared_model/interfaces/queries/account_detail_record_id.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_DETAIL_RECORD_ID_HPP
 #define IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_DETAIL_RECORD_ID_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 

--- a/shared_model/interfaces/queries/asset_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/asset_pagination_meta.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
 #define IROHA_SHARED_INTERFACE_MODEL_QUERY_ACCOUNT_ASSET_PAGINATION_META_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -20,7 +20,7 @@ namespace shared_model {
       virtual types::TransactionsNumberType pageSize() const = 0;
 
       /// Get the first requested asset, if provided.
-      virtual boost::optional<types::AssetIdType> firstAssetId() const = 0;
+      virtual std::optional<types::AssetIdType> firstAssetId() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/get_account_assets.hpp
+++ b/shared_model/interfaces/queries/get_account_assets.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_ASSETS_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_ASSETS_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -26,7 +26,8 @@ namespace shared_model {
 
       /// Get the query pagination metadata.
       // TODO 2019.05.24 mboldyrev IR-516 remove optional
-      virtual boost::optional<const interface::AssetPaginationMeta &>
+      virtual std::optional<
+          std::reference_wrapper<const interface::AssetPaginationMeta>>
       paginationMeta() const = 0;
 
       std::string toString() const override;

--- a/shared_model/interfaces/queries/get_account_detail.hpp
+++ b/shared_model/interfaces/queries/get_account_detail.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_GET_ACCOUNT_DETAIL_HPP
 #define IROHA_SHARED_MODEL_GET_ACCOUNT_DETAIL_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -36,15 +36,16 @@ namespace shared_model {
       /**
        * @return key from key-value storage
        */
-      virtual boost::optional<types::AccountDetailKeyType> key() const = 0;
+      virtual std::optional<types::AccountDetailKeyType> key() const = 0;
 
       /**
        * @return account identifier of writer
        */
-      virtual boost::optional<types::AccountIdType> writer() const = 0;
+      virtual std::optional<types::AccountIdType> writer() const = 0;
 
       /// Get the query pagination metadata.
-      virtual boost::optional<const AccountDetailPaginationMeta &>
+      virtual std::optional<
+          std::reference_wrapper<const AccountDetailPaginationMeta>>
       paginationMeta() const = 0;
 
       std::string toString() const override;

--- a/shared_model/interfaces/queries/get_pending_transactions.hpp
+++ b/shared_model/interfaces/queries/get_pending_transactions.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_MODEL_GET_PENDING_TRANSACTIONS_HPP
 #define IROHA_SHARED_MODEL_GET_PENDING_TRANSACTIONS_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -25,8 +25,8 @@ namespace shared_model {
       /**
        *  Get the query pagination metadata.
        */
-      virtual boost::optional<const TxPaginationMeta &> paginationMeta()
-          const = 0;
+      virtual std::optional<std::reference_wrapper<const TxPaginationMeta>>
+      paginationMeta() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/queries/impl/account_detail_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/account_detail_pagination_meta.cpp
@@ -5,11 +5,13 @@
 
 #include "interfaces/queries/account_detail_pagination_meta.hpp"
 
+#include "common/optional_reference_equal.hpp"
+
 using namespace shared_model::interface;
 
 bool AccountDetailPaginationMeta::operator==(const ModelType &rhs) const {
   return pageSize() == rhs.pageSize()
-      and firstRecordId() == rhs.firstRecordId();
+      and iroha::optionalReferenceEqual(firstRecordId(), rhs.firstRecordId());
 }
 
 std::string AccountDetailPaginationMeta::toString() const {

--- a/shared_model/interfaces/queries/impl/get_account_detail.cpp
+++ b/shared_model/interfaces/queries/impl/get_account_detail.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/queries/get_account_detail.hpp"
 
+#include "common/optional_reference_equal.hpp"
+
 namespace shared_model {
   namespace interface {
 
@@ -21,7 +23,8 @@ namespace shared_model {
     bool GetAccountDetail::operator==(const ModelType &rhs) const {
       return accountId() == rhs.accountId() and key() == rhs.key()
           and writer() == rhs.writer()
-          and paginationMeta() == rhs.paginationMeta();
+          and iroha::optionalReferenceEqual(paginationMeta(),
+                                            rhs.paginationMeta());
     }
 
   }  // namespace interface

--- a/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
+++ b/shared_model/interfaces/queries/impl/get_pending_transactions.cpp
@@ -5,6 +5,7 @@
 
 #include "interfaces/queries/get_pending_transactions.hpp"
 
+#include "common/optional_reference_equal.hpp"
 #include "interfaces/queries/tx_pagination_meta.hpp"
 
 namespace shared_model {
@@ -20,7 +21,8 @@ namespace shared_model {
     }
 
     bool GetPendingTransactions::operator==(const ModelType &rhs) const {
-      return paginationMeta() == rhs.paginationMeta();
+      return iroha::optionalReferenceEqual(paginationMeta(),
+                                           rhs.paginationMeta());
     }
 
   }  // namespace interface

--- a/shared_model/interfaces/queries/tx_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/tx_pagination_meta.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP
 #define IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -20,7 +20,7 @@ namespace shared_model {
       virtual types::TransactionsNumberType pageSize() const = 0;
 
       /// Get the first requested transaction hash, if provided.
-      virtual boost::optional<types::HashType> firstTxHash() const = 0;
+      virtual std::optional<types::HashType> firstTxHash() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/query_responses/account_asset_response.hpp
+++ b/shared_model/interfaces/query_responses/account_asset_response.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/common_objects/account_asset.hpp"
 #include "interfaces/common_objects/range_types.hpp"
 
@@ -24,7 +24,7 @@ namespace shared_model {
        */
       virtual const types::AccountAssetCollectionType accountAssets() const = 0;
 
-      virtual boost::optional<types::AssetIdType> nextAssetId() const = 0;
+      virtual std::optional<types::AssetIdType> nextAssetId() const = 0;
 
       virtual size_t totalAccountAssetsNumber() const = 0;
 

--- a/shared_model/interfaces/query_responses/account_detail_response.hpp
+++ b/shared_model/interfaces/query_responses/account_detail_response.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/queries/account_detail_record_id.hpp"
 
@@ -28,8 +28,8 @@ namespace shared_model {
       virtual size_t totalNumber() const = 0;
 
       /// @return next page starting record, if this page is not last.
-      virtual boost::optional<const AccountDetailRecordId &> nextRecordId()
-          const = 0;
+      virtual std::optional<std::reference_wrapper<const AccountDetailRecordId>>
+      nextRecordId() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/pending_transactions_page_response.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include <boost/optional/optional_fwd.hpp>
+#include <optional>
 #include "cryptography/hash.hpp"
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -44,7 +44,7 @@ namespace shared_model {
       /**
        * @return next batch info to query the following page if exists
        */
-      virtual boost::optional<BatchInfo> nextBatchInfo() const = 0;
+      virtual std::optional<BatchInfo> nextBatchInfo() const = 0;
 
       /**
        * @return total number of transactions for the query

--- a/shared_model/interfaces/query_responses/transactions_page_response.hpp
+++ b/shared_model/interfaces/query_responses/transactions_page_response.hpp
@@ -8,7 +8,7 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include <boost/optional/optional_fwd.hpp>
+#include <optional>
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -28,8 +28,7 @@ namespace shared_model {
       /**
        * @return hash of the first transaction from the next page
        */
-      virtual boost::optional<interface::types::HashType> nextTxHash()
-          const = 0;
+      virtual std::optional<interface::types::HashType> nextTxHash() const = 0;
 
       /**
        * @return total number of transactions for the query

--- a/shared_model/interfaces/transaction.hpp
+++ b/shared_model/interfaces/transaction.hpp
@@ -57,7 +57,7 @@ namespace shared_model {
       /*
        * @return Batch Meta if exists
        */
-      virtual boost::optional<std::shared_ptr<BatchMeta>> batchMeta() const = 0;
+      virtual std::optional<std::shared_ptr<BatchMeta>> batchMeta() const = 0;
 
       std::string toString() const override;
     };

--- a/shared_model/validators/abstract_validator.hpp
+++ b/shared_model/validators/abstract_validator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_ABSTRACT_VALIDATOR_HPP
 #define IROHA_ABSTRACT_VALIDATOR_HPP
 
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include "validators/validation_error.hpp"
 
 namespace shared_model {
@@ -16,8 +16,7 @@ namespace shared_model {
     template <typename Model>
     class AbstractValidator {
      public:
-      virtual boost::optional<ValidationError> validate(
-          const Model &m) const = 0;
+      virtual std::optional<ValidationError> validate(const Model &m) const = 0;
 
       virtual ~AbstractValidator() = default;
     };

--- a/shared_model/validators/always_valid_validator.hpp
+++ b/shared_model/validators/always_valid_validator.hpp
@@ -17,8 +17,8 @@ namespace shared_model {
       AlwaysValidValidator() = default;
       AlwaysValidValidator(
           std::shared_ptr<shared_model::validation::ValidatorsConfig>){};
-      boost::optional<ValidationError> validate(const T &m) const override {
-        return boost::none;
+      std::optional<ValidationError> validate(const T &m) const override {
+        return std::nullopt;
       }
     };
 

--- a/shared_model/validators/block_validator.hpp
+++ b/shared_model/validators/block_validator.hpp
@@ -37,7 +37,7 @@ namespace shared_model {
        * @param block
        * @return found error if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::Block &block) const override {
         ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/blocks_query_validator.hpp
+++ b/shared_model/validators/blocks_query_validator.hpp
@@ -31,7 +31,7 @@ namespace shared_model {
        * @param qry - query to validate
        * @return found error if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::BlocksQuery &qry) const {
         ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/field_validator.cpp
+++ b/shared_model/validators/field_validator.cpp
@@ -38,7 +38,7 @@ namespace {
     RegexValidator(
         std::string name,
         std::string pattern,
-        boost::optional<const char *> format_description = boost::none)
+        std::optional<const char *> format_description = std::nullopt)
         : name_(std::move(name)),
           pattern_(std::move(pattern)),
           regex_(pattern_),
@@ -47,7 +47,7 @@ namespace {
                 return std::string{" "} + std::move(description);
               }) {}
 
-    boost::optional<shared_model::validation::ValidationError> validate(
+    std::optional<shared_model::validation::ValidationError> validate(
         const std::string &value) const {
       if (not std::regex_match(value, regex_)) {
         return shared_model::validation::ValidationError(
@@ -57,7 +57,7 @@ namespace {
                          pattern_,
                          format_description_)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
     std::string getPattern() const {
@@ -123,17 +123,17 @@ namespace shared_model {
           time_provider_(time_provider),
           max_description_size(config->settings->max_description_size) {}
 
-    boost::optional<ValidationError> FieldValidator::validateAccountId(
+    std::optional<ValidationError> FieldValidator::validateAccountId(
         const interface::types::AccountIdType &account_id) const {
       return kAccountIdValidator.validate(account_id);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAssetId(
+    std::optional<ValidationError> FieldValidator::validateAssetId(
         const interface::types::AssetIdType &asset_id) const {
       return kAssetIdValidator.validate(asset_id);
     }
 
-    boost::optional<ValidationError> FieldValidator::validatePeer(
+    std::optional<ValidationError> FieldValidator::validatePeer(
         const interface::Peer &peer) const {
       return aggregateErrors(
           "Peer",
@@ -141,41 +141,41 @@ namespace shared_model {
           {validatePeerAddress(peer.address()), validatePubkey(peer.pubkey())});
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAmount(
+    std::optional<ValidationError> FieldValidator::validateAmount(
         const interface::Amount &amount) const {
       if (amount.sign() <= 0) {
         return ValidationError(
             "Amount", {"Invalid number, amount must be greater than 0"});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validatePubkey(
+    std::optional<ValidationError> FieldValidator::validatePubkey(
         const interface::types::PubkeyType &pubkey) const {
       return shared_model::validation::validatePubkey(pubkey);
     }
 
-    boost::optional<ValidationError> FieldValidator::validatePeerAddress(
+    std::optional<ValidationError> FieldValidator::validatePeerAddress(
         const interface::types::AddressType &address) const {
       return kPeerAddressValidator.validate(address);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateRoleId(
+    std::optional<ValidationError> FieldValidator::validateRoleId(
         const interface::types::RoleIdType &role_id) const {
       return kRoleIdValidator.validate(role_id);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAccountName(
+    std::optional<ValidationError> FieldValidator::validateAccountName(
         const interface::types::AccountNameType &account_name) const {
       return kAccountNameValidator.validate(account_name);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateDomainId(
+    std::optional<ValidationError> FieldValidator::validateDomainId(
         const interface::types::DomainIdType &domain_id) const {
       return kDomainValidator.validate(domain_id);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateDomain(
+    std::optional<ValidationError> FieldValidator::validateDomain(
         const interface::Domain &domain) const {
       return aggregateErrors("Domain",
                              {},
@@ -183,17 +183,17 @@ namespace shared_model {
                               validateRoleId(domain.defaultRole())});
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAssetName(
+    std::optional<ValidationError> FieldValidator::validateAssetName(
         const interface::types::AssetNameType &asset_name) const {
       return kAssetNameValidator.validate(asset_name);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAccountDetailKey(
+    std::optional<ValidationError> FieldValidator::validateAccountDetailKey(
         const interface::types::AccountDetailKeyType &key) const {
       return kAccountDetailKeyValidator.validate(key);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAccountDetailValue(
+    std::optional<ValidationError> FieldValidator::validateAccountDetailValue(
         const interface::types::AccountDetailValueType &value) const {
       if (value.size() > value_size) {
         return ValidationError(
@@ -202,59 +202,58 @@ namespace shared_model {
                 "Detail value size should be less or equal '{}' characters",
                 value_size)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     FieldValidator::validateOldAccountDetailValue(
-        const boost::optional<interface::types::AccountDetailValueType>
+        const std::optional<interface::types::AccountDetailValueType>
             &old_value) const {
       if (old_value) {
         return validateAccountDetailValue(old_value.value());
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validatePrecision(
+    std::optional<ValidationError> FieldValidator::validatePrecision(
         const interface::types::PrecisionType &precision) const {
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateRolePermission(
+    std::optional<ValidationError> FieldValidator::validateRolePermission(
         const interface::permissions::Role &permission) const {
       if (not isValid(permission)) {
         return ValidationError("RolePermission",
                                {"Provided role permission does not exist"});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError>
-    FieldValidator::validateGrantablePermission(
+    std::optional<ValidationError> FieldValidator::validateGrantablePermission(
         const interface::permissions::Grantable &permission) const {
       if (not isValid(permission)) {
         return ValidationError(
             "GrantablePermission",
             {"Provided grantable permission does not exist"});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateQuorum(
+    std::optional<ValidationError> FieldValidator::validateQuorum(
         const interface::types::QuorumType &quorum) const {
       if (quorum < 1 or quorum > 128) {
         return ValidationError("Quorum",
                                {"Quorum should be within range [1, 128]"});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateCreatorAccountId(
+    std::optional<ValidationError> FieldValidator::validateCreatorAccountId(
         const interface::types::AccountIdType &account_id) const {
       return kAccountIdValidator.validate(account_id);
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAccount(
+    std::optional<ValidationError> FieldValidator::validateAccount(
         const interface::Account &account) const {
       return aggregateErrors("Account",
                              {},
@@ -263,7 +262,7 @@ namespace shared_model {
                               validateQuorum(account.quorum())});
     }
 
-    boost::optional<ValidationError> FieldValidator::validateCreatedTime(
+    std::optional<ValidationError> FieldValidator::validateCreatedTime(
         interface::types::TimestampType timestamp,
         interface::types::TimestampType now) const {
       if (now + future_gap_ < timestamp) {
@@ -276,25 +275,25 @@ namespace shared_model {
             "CreatedTime",
             {fmt::format("too old, timestamp: {}, now: {}", timestamp, now)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateCreatedTime(
+    std::optional<ValidationError> FieldValidator::validateCreatedTime(
         interface::types::TimestampType timestamp) const {
       return validateCreatedTime(timestamp, time_provider_());
     }
 
-    boost::optional<ValidationError> FieldValidator::validateCounter(
+    std::optional<ValidationError> FieldValidator::validateCounter(
         const interface::types::CounterType &counter) const {
       if (counter <= 0) {
         return ValidationError(
             "Counter",
             {fmt::format("Counter should be > 0, passed value: {}", counter)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateSignatureForm(
+    std::optional<ValidationError> FieldValidator::validateSignatureForm(
         const interface::Signature &signature) const {
       ValidationErrorCreator error_creator;
       const auto passed_size = signature.signedData().blob().size();
@@ -306,7 +305,7 @@ namespace shared_model {
       return std::move(error_creator).getValidationError("Signature");
     }
 
-    boost::optional<ValidationError> FieldValidator::validateSignatures(
+    std::optional<ValidationError> FieldValidator::validateSignatures(
         const interface::types::SignatureRangeType &signatures,
         const crypto::Blob &source) const {
       ValidationErrorCreator error_creator;
@@ -337,12 +336,12 @@ namespace shared_model {
       return std::move(error_creator).getValidationError("Signatures list");
     }
 
-    boost::optional<ValidationError> FieldValidator::validateQueryPayloadMeta(
+    std::optional<ValidationError> FieldValidator::validateQueryPayloadMeta(
         const interface::QueryPayloadMeta &meta) const {
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateDescription(
+    std::optional<ValidationError> FieldValidator::validateDescription(
         const interface::types::DescriptionType &description) const {
       if (description.size() > max_description_size) {
         return ValidationError(
@@ -350,25 +349,25 @@ namespace shared_model {
             {fmt::format("Size should be less or equal '{}'.",
                          max_description_size)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateBatchMeta(
+    std::optional<ValidationError> FieldValidator::validateBatchMeta(
         const interface::BatchMeta &batch_meta) const {
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateHeight(
+    std::optional<ValidationError> FieldValidator::validateHeight(
         const interface::types::HeightType &height) const {
       if (height <= 0) {
         return ValidationError(
             "Height",
             {fmt::format("Should be > 0, passed value: {}.", height)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateHash(
+    std::optional<ValidationError> FieldValidator::validateHash(
         const crypto::Hash &hash) const {
       if (hash.size() != hash_size) {
         return ValidationError(
@@ -376,10 +375,10 @@ namespace shared_model {
             {fmt::format(
                 "Invalid size: {}, should be {}.", hash.size(), hash_size)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> validatePubkey(
+    std::optional<ValidationError> validatePubkey(
         const interface::types::PubkeyType &pubkey) {
       if (pubkey.blob().size() != FieldValidator::public_key_size) {
         return ValidationError("PublicKey",
@@ -387,10 +386,10 @@ namespace shared_model {
                                             pubkey.blob().size(),
                                             FieldValidator::public_key_size)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> validatePaginationMetaPageSize(
+    std::optional<ValidationError> validatePaginationMetaPageSize(
         const size_t &page_size) {
       if (page_size <= 0) {
         return ValidationError(
@@ -400,10 +399,10 @@ namespace shared_model {
                          (page_size == 0 ? "zero" : "negative"),
                          page_size)});
       }
-      return boost::none;
+      return std::nullopt;
     }
 
-    boost::optional<ValidationError> FieldValidator::validateTxPaginationMeta(
+    std::optional<ValidationError> FieldValidator::validateTxPaginationMeta(
         const interface::TxPaginationMeta &tx_pagination_meta) const {
       using iroha::operator|;
       return aggregateErrors(
@@ -415,7 +414,7 @@ namespace shared_model {
            }});
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAsset(
+    std::optional<ValidationError> FieldValidator::validateAsset(
         const interface::Asset &asset) const {
       return aggregateErrors("Asset",
                              {},
@@ -424,7 +423,7 @@ namespace shared_model {
                               validatePrecision(asset.precision())});
     }
 
-    boost::optional<ValidationError> FieldValidator::validateAccountAsset(
+    std::optional<ValidationError> FieldValidator::validateAccountAsset(
         const interface::AccountAsset &account_asset) const {
       return aggregateErrors("AccountAsset",
                              {},
@@ -433,8 +432,7 @@ namespace shared_model {
                               validateAmount(account_asset.balance())});
     }
 
-    boost::optional<ValidationError>
-    FieldValidator::validateAssetPaginationMeta(
+    std::optional<ValidationError> FieldValidator::validateAssetPaginationMeta(
         const interface::AssetPaginationMeta &asset_pagination_meta) const {
       using iroha::operator|;
       return aggregateErrors(
@@ -447,7 +445,7 @@ namespace shared_model {
                }});
     }
 
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     FieldValidator::validateAccountDetailRecordId(
         const interface::AccountDetailRecordId &record_id) const {
       return aggregateErrors("AccountDetailRecordId",
@@ -456,7 +454,7 @@ namespace shared_model {
                               validateAccountDetailKey(record_id.key())});
     }
 
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     FieldValidator::validateAccountDetailPaginationMeta(
         const interface::AccountDetailPaginationMeta &pagination_meta) const {
       using iroha::operator|;

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -48,28 +48,28 @@ namespace shared_model {
                        return iroha::time::now();
                      });
 
-      boost::optional<ValidationError> validateAccountId(
+      std::optional<ValidationError> validateAccountId(
           const interface::types::AccountIdType &account_id) const;
 
-      boost::optional<ValidationError> validateAssetId(
+      std::optional<ValidationError> validateAssetId(
           const interface::types::AssetIdType &asset_id) const;
 
-      boost::optional<ValidationError> validatePeer(
+      std::optional<ValidationError> validatePeer(
           const interface::Peer &peer) const;
 
-      boost::optional<ValidationError> validateAmount(
+      std::optional<ValidationError> validateAmount(
           const interface::Amount &amount) const;
 
-      boost::optional<ValidationError> validatePubkey(
+      std::optional<ValidationError> validatePubkey(
           const interface::types::PubkeyType &pubkey) const;
 
-      boost::optional<ValidationError> validatePeerAddress(
+      std::optional<ValidationError> validatePeerAddress(
           const interface::types::AddressType &address) const;
 
-      boost::optional<ValidationError> validateRoleId(
+      std::optional<ValidationError> validateRoleId(
           const interface::types::RoleIdType &role_id) const;
 
-      boost::optional<ValidationError> validateAccountName(
+      std::optional<ValidationError> validateAccountName(
           const interface::types::AccountNameType &account_name) const;
 
       // clang-format off
@@ -94,97 +94,97 @@ namespace shared_model {
        * If the validation is not successful reason is updated with corresponding message
        */
       // clang-format on
-      boost::optional<ValidationError> validateDomainId(
+      std::optional<ValidationError> validateDomainId(
           const interface::types::DomainIdType &domain_id) const;
 
-      boost::optional<ValidationError> validateDomain(
+      std::optional<ValidationError> validateDomain(
           const interface::Domain &domain) const;
 
-      boost::optional<ValidationError> validateAssetName(
+      std::optional<ValidationError> validateAssetName(
           const interface::types::AssetNameType &asset_name) const;
 
-      boost::optional<ValidationError> validateAccountDetailKey(
+      std::optional<ValidationError> validateAccountDetailKey(
           const interface::types::AccountDetailKeyType &key) const;
 
-      boost::optional<ValidationError> validateAccountDetailValue(
+      std::optional<ValidationError> validateAccountDetailValue(
           const interface::types::AccountDetailValueType &value) const;
 
-      boost::optional<ValidationError> validateOldAccountDetailValue(
-          const boost::optional<interface::types::AccountDetailValueType>
+      std::optional<ValidationError> validateOldAccountDetailValue(
+          const std::optional<interface::types::AccountDetailValueType>
               &old_value) const;
 
-      boost::optional<ValidationError> validatePrecision(
+      std::optional<ValidationError> validatePrecision(
           const interface::types::PrecisionType &precision) const;
 
-      boost::optional<ValidationError> validateRolePermission(
+      std::optional<ValidationError> validateRolePermission(
           const interface::permissions::Role &permission) const;
 
-      boost::optional<ValidationError> validateGrantablePermission(
+      std::optional<ValidationError> validateGrantablePermission(
           const interface::permissions::Grantable &permission) const;
 
-      boost::optional<ValidationError> validateQuorum(
+      std::optional<ValidationError> validateQuorum(
           const interface::types::QuorumType &quorum) const;
 
-      boost::optional<ValidationError> validateCreatorAccountId(
+      std::optional<ValidationError> validateCreatorAccountId(
           const interface::types::AccountIdType &account_id) const;
 
-      boost::optional<ValidationError> validateAccount(
+      std::optional<ValidationError> validateAccount(
           const interface::Account &account) const;
 
       /**
        * Validate timestamp against now
        */
-      boost::optional<ValidationError> validateCreatedTime(
+      std::optional<ValidationError> validateCreatedTime(
           interface::types::TimestampType timestamp,
           interface::types::TimestampType now) const;
 
       /**
        * Validate timestamp against time_provider_
        */
-      boost::optional<ValidationError> validateCreatedTime(
+      std::optional<ValidationError> validateCreatedTime(
           interface::types::TimestampType timestamp) const;
 
-      boost::optional<ValidationError> validateCounter(
+      std::optional<ValidationError> validateCounter(
           const interface::types::CounterType &counter) const;
 
-      boost::optional<ValidationError> validateSignatureForm(
+      std::optional<ValidationError> validateSignatureForm(
           const interface::Signature &signature) const;
 
-      boost::optional<ValidationError> validateSignatures(
+      std::optional<ValidationError> validateSignatures(
           const interface::types::SignatureRangeType &signatures,
           const crypto::Blob &source) const;
 
-      boost::optional<ValidationError> validateQueryPayloadMeta(
+      std::optional<ValidationError> validateQueryPayloadMeta(
           const interface::QueryPayloadMeta &meta) const;
 
-      boost::optional<ValidationError> validateDescription(
+      std::optional<ValidationError> validateDescription(
           const interface::types::DescriptionType &description) const;
 
-      boost::optional<ValidationError> validateBatchMeta(
+      std::optional<ValidationError> validateBatchMeta(
           const interface::BatchMeta &description) const;
 
-      boost::optional<ValidationError> validateHeight(
+      std::optional<ValidationError> validateHeight(
           const interface::types::HeightType &height) const;
 
-      boost::optional<ValidationError> validateHash(
+      std::optional<ValidationError> validateHash(
           const crypto::Hash &hash) const;
 
-      boost::optional<ValidationError> validateTxPaginationMeta(
+      std::optional<ValidationError> validateTxPaginationMeta(
           const interface::TxPaginationMeta &tx_pagination_meta) const;
 
-      boost::optional<ValidationError> validateAccountAsset(
+      std::optional<ValidationError> validateAccountAsset(
           const interface::AccountAsset &account_asset) const;
 
-      boost::optional<ValidationError> validateAsset(
+      std::optional<ValidationError> validateAsset(
           const interface::Asset &asset) const;
 
-      boost::optional<ValidationError> validateAssetPaginationMeta(
+      std::optional<ValidationError> validateAssetPaginationMeta(
           const interface::AssetPaginationMeta &asset_pagination_meta) const;
 
-      boost::optional<ValidationError> validateAccountDetailRecordId(
+      std::optional<ValidationError> validateAccountDetailRecordId(
           const interface::AccountDetailRecordId &record_id) const;
 
-      boost::optional<ValidationError> validateAccountDetailPaginationMeta(
+      std::optional<ValidationError> validateAccountDetailPaginationMeta(
           const interface::AccountDetailPaginationMeta &pagination_meta) const;
 
      private:
@@ -209,7 +209,7 @@ namespace shared_model {
       size_t max_description_size;
     };
 
-    boost::optional<ValidationError> validatePubkey(
+    std::optional<ValidationError> validatePubkey(
         const interface::types::PubkeyType &pubkey);
 
   }  // namespace validation

--- a/shared_model/validators/proposal_validator.hpp
+++ b/shared_model/validators/proposal_validator.hpp
@@ -33,7 +33,7 @@ namespace shared_model {
        * @param proposal
        * @return found error if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::Proposal &proposal) const {
         ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/protobuf/proto_block_validator.cpp
+++ b/shared_model/validators/protobuf/proto_block_validator.cpp
@@ -13,7 +13,7 @@
 
 namespace shared_model {
   namespace validation {
-    boost::optional<ValidationError> ProtoBlockValidator::validate(
+    std::optional<ValidationError> ProtoBlockValidator::validate(
         const iroha::protocol::Block &block) const {
       ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/protobuf/proto_block_validator.hpp
+++ b/shared_model/validators/protobuf/proto_block_validator.hpp
@@ -19,7 +19,7 @@ namespace shared_model {
     class ProtoBlockValidator
         : public AbstractValidator<iroha::protocol::Block> {
      public:
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::Block &block) const override;
     };
   }  // namespace validation

--- a/shared_model/validators/protobuf/proto_command_validator.cpp
+++ b/shared_model/validators/protobuf/proto_command_validator.cpp
@@ -14,19 +14,19 @@
 using namespace shared_model::validation;
 
 namespace {
-  boost::optional<ValidationError> validatePublicKey(
+  std::optional<ValidationError> validatePublicKey(
       const std::string &public_key) {
     if (not validateHexString(public_key)) {
       return ValidationError{"Public key", {"Not in hex format"}};
     }
-    return boost::none;
+    return std::nullopt;
   }
 }  // namespace
 
 namespace shared_model {
   namespace validation {
 
-    boost::optional<ValidationError> ProtoCommandValidator::validate(
+    std::optional<ValidationError> ProtoCommandValidator::validate(
         const iroha::protocol::Command &command) const {
       switch (command.command_case()) {
         case iroha::protocol::Command::COMMAND_NOT_SET: {
@@ -70,7 +70,7 @@ namespace shared_model {
             return ValidationError{"GrantPermission",
                                    {"Invalid grantable permission."}};
           }
-          return boost::none;
+          return std::nullopt;
         }
         case iroha::protocol::Command::kRevokePermission: {
           if (not iroha::protocol::GrantablePermission_IsValid(
@@ -78,10 +78,10 @@ namespace shared_model {
             return ValidationError{"RevokePermission",
                                    {"Invalid grantable permission."}};
           }
-          return boost::none;
+          return std::nullopt;
         }
         default:
-          return boost::none;
+          return std::nullopt;
       }
     }
   }  // namespace validation

--- a/shared_model/validators/protobuf/proto_command_validator.hpp
+++ b/shared_model/validators/protobuf/proto_command_validator.hpp
@@ -20,7 +20,7 @@ namespace shared_model {
     class ProtoCommandValidator
         : public AbstractValidator<iroha::protocol::Command> {
      public:
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::Command &command) const override;
     };
   }  // namespace validation

--- a/shared_model/validators/protobuf/proto_proposal_validator.cpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.cpp
@@ -16,7 +16,7 @@ namespace shared_model {
         ProtoValidatorType transaction_validator)
         : transaction_validator_(std::move(transaction_validator)) {}
 
-    boost::optional<ValidationError> ProtoProposalValidator::validate(
+    std::optional<ValidationError> ProtoProposalValidator::validate(
         const iroha::protocol::Proposal &proposal) const {
       ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/protobuf/proto_proposal_validator.hpp
+++ b/shared_model/validators/protobuf/proto_proposal_validator.hpp
@@ -27,7 +27,7 @@ namespace shared_model {
 
       ProtoProposalValidator(ProtoValidatorType transaction_validator);
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::Proposal &proposal) const override;
 
      private:

--- a/shared_model/validators/protobuf/proto_query_validator.cpp
+++ b/shared_model/validators/protobuf/proto_query_validator.cpp
@@ -11,7 +11,7 @@
 using namespace shared_model::validation;
 
 namespace {
-  boost::optional<ValidationError> validateTxPaginationMeta(
+  std::optional<ValidationError> validateTxPaginationMeta(
       const iroha::protocol::TxPaginationMeta &paginationMeta) {
     if (paginationMeta.opt_first_tx_hash_case()
         != iroha::protocol::TxPaginationMeta::OPT_FIRST_TX_HASH_NOT_SET) {
@@ -21,14 +21,14 @@ namespace {
             {"First tx hash from pagination meta is not a hex string."}};
       }
     }
-    return boost::none;
+    return std::nullopt;
   }
 }  // namespace
 
 namespace shared_model {
   namespace validation {
 
-    boost::optional<ValidationError> validateProtoQuery(
+    std::optional<ValidationError> validateProtoQuery(
         const iroha::protocol::Query &qry) {
       ValidationErrorCreator error_creator;
 
@@ -54,14 +54,14 @@ namespace shared_model {
       return std::move(error_creator).getValidationError("Protobuf Query");
     }
 
-    boost::optional<ValidationError> ProtoQueryValidator::validate(
+    std::optional<ValidationError> ProtoQueryValidator::validate(
         const iroha::protocol::Query &query) const {
       return validateProtoQuery(query);
     }
 
-    boost::optional<ValidationError> ProtoBlocksQueryValidator::validate(
+    std::optional<ValidationError> ProtoBlocksQueryValidator::validate(
         const iroha::protocol::BlocksQuery &) const {
-      return boost::none;
+      return std::nullopt;
     }
 
   }  // namespace validation

--- a/shared_model/validators/protobuf/proto_query_validator.hpp
+++ b/shared_model/validators/protobuf/proto_query_validator.hpp
@@ -16,14 +16,14 @@ namespace shared_model {
     class ProtoQueryValidator
         : public AbstractValidator<iroha::protocol::Query> {
      public:
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::Query &query) const override;
     };
 
     class ProtoBlocksQueryValidator
         : public AbstractValidator<iroha::protocol::BlocksQuery> {
      public:
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::BlocksQuery &) const override;
     };
 

--- a/shared_model/validators/protobuf/proto_transaction_validator.cpp
+++ b/shared_model/validators/protobuf/proto_transaction_validator.cpp
@@ -12,7 +12,7 @@
 namespace shared_model {
   namespace validation {
 
-    boost::optional<ValidationError> ProtoTransactionValidator::validate(
+    std::optional<ValidationError> ProtoTransactionValidator::validate(
         const iroha::protocol::Transaction &tx) const {
       ValidationErrorCreator error_creator;
       for (const auto &command : tx.payload().reduced_payload().commands()) {

--- a/shared_model/validators/protobuf/proto_transaction_validator.hpp
+++ b/shared_model/validators/protobuf/proto_transaction_validator.hpp
@@ -22,7 +22,7 @@ namespace shared_model {
     class ProtoTransactionValidator
         : public AbstractValidator<iroha::protocol::Transaction> {
      public:
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const iroha::protocol::Transaction &tx) const override;
 
      private:

--- a/shared_model/validators/query_validator.hpp
+++ b/shared_model/validators/query_validator.hpp
@@ -36,7 +36,7 @@ namespace shared_model {
      */
     template <typename FieldValidator>
     class QueryValidatorVisitor
-        : public boost::static_visitor<boost::optional<ValidationError>> {
+        : public boost::static_visitor<std::optional<ValidationError>> {
       QueryValidatorVisitor(FieldValidator validator)
           : validator_(std::move(validator)) {}
 
@@ -46,7 +46,7 @@ namespace shared_model {
       QueryValidatorVisitor(std::shared_ptr<ValidatorsConfig> config)
           : QueryValidatorVisitor(FieldValidator{std::move(config)}) {}
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAccount &get_account) const {
         return aggregateErrors(
             "GetAccount",
@@ -54,13 +54,13 @@ namespace shared_model {
             {validator_.validateAccountId(get_account.accountId())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetBlock &get_block) const {
         return aggregateErrors(
             "GetBlock", {}, {validator_.validateHeight(get_block.height())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetSignatories &get_signatories) const {
         return aggregateErrors(
             "GetSignatories",
@@ -68,7 +68,7 @@ namespace shared_model {
             {validator_.validateAccountId(get_signatories.accountId())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAccountTransactions &get_account_transactions)
           const {
         return aggregateErrors(
@@ -79,7 +79,7 @@ namespace shared_model {
                  get_account_transactions.paginationMeta())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAccountAssetTransactions
               &get_account_asset_transactions) const {
         return aggregateErrors(
@@ -93,7 +93,7 @@ namespace shared_model {
                  get_account_asset_transactions.paginationMeta())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetTransactions &get_transactions) const {
         ValidationErrorCreator error_creator;
 
@@ -109,7 +109,7 @@ namespace shared_model {
         return std::move(error_creator).getValidationError("GetTransactions");
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAccountAssets &get_account_assets) const {
         using iroha::operator|;
         return aggregateErrors(
@@ -123,7 +123,7 @@ namespace shared_model {
                  }});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAccountDetail &get_account_detail) const {
         using iroha::operator|;
         return aggregateErrors(
@@ -145,12 +145,12 @@ namespace shared_model {
                  }});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetRoles &get_roles) const {
-        return boost::none;
+        return std::nullopt;
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetRolePermissions &get_role_permissions) const {
         return aggregateErrors(
             "GetRolePermissions",
@@ -158,7 +158,7 @@ namespace shared_model {
             {validator_.validateRoleId(get_role_permissions.roleId())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetAssetInfo &get_asset_info) const {
         return aggregateErrors(
             "GetAssetInfo",
@@ -166,7 +166,7 @@ namespace shared_model {
             {validator_.validateAssetId(get_asset_info.assetId())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetPendingTransactions &get_pending_transactions)
           const {
         using iroha::operator|;
@@ -180,9 +180,9 @@ namespace shared_model {
              }});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GetPeers &get_peers) const {
-        return boost::none;
+        return std::nullopt;
       }
 
      private:
@@ -211,7 +211,7 @@ namespace shared_model {
        * @param qry - query to validate
        * @return found error if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::Query &qry) const override {
         ValidationErrorCreator error_creator;
 

--- a/shared_model/validators/signable_validator.hpp
+++ b/shared_model/validators/signable_validator.hpp
@@ -18,8 +18,8 @@ namespace shared_model {
     class SignableModelValidator : public ModelValidator {
      private:
       template <typename Validator>
-      boost::optional<ValidationError> validateImpl(
-          const Model &model, Validator &&validator) const {
+      std::optional<ValidationError> validateImpl(const Model &model,
+                                                  Validator &&validator) const {
         ValidationErrorCreator error_creator;
 
         error_creator |= std::forward<Validator>(validator)(model);
@@ -39,7 +39,7 @@ namespace shared_model {
       explicit SignableModelValidator(std::shared_ptr<ValidatorsConfig> config)
           : SignableModelValidator(config, FieldValidator{config}) {}
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const Model &model,
           interface::types::TimestampType current_timestamp) const {
         return validateImpl(model, [&, current_timestamp](const Model &m) {
@@ -47,7 +47,7 @@ namespace shared_model {
         });
       }
 
-      boost::optional<ValidationError> validate(const Model &model) const {
+      std::optional<ValidationError> validate(const Model &model) const {
         return validateImpl(
             model, [&](const Model &m) { return ModelValidator::validate(m); });
       }

--- a/shared_model/validators/transaction_batch_validator.cpp
+++ b/shared_model/validators/transaction_batch_validator.cpp
@@ -17,7 +17,7 @@ BatchValidator<BatchOrderValidator>::BatchValidator(
     : batch_order_validator_(BatchOrderValidator{std::move(config)}) {}
 
 template <typename BatchOrderValidator>
-boost::optional<ValidationError> BatchValidator<BatchOrderValidator>::validate(
+std::optional<ValidationError> BatchValidator<BatchOrderValidator>::validate(
     const shared_model::interface::TransactionBatch &batch) const {
   return batch_order_validator_.validate(batch.transactions()
                                          | boost::adaptors::indirected);

--- a/shared_model/validators/transaction_batch_validator.hpp
+++ b/shared_model/validators/transaction_batch_validator.hpp
@@ -21,7 +21,7 @@ namespace shared_model {
      public:
       BatchValidator(std::shared_ptr<ValidatorsConfig> config);
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::TransactionBatch &batch) const override;
 
      private:

--- a/shared_model/validators/transaction_validator.hpp
+++ b/shared_model/validators/transaction_validator.hpp
@@ -45,7 +45,7 @@ namespace shared_model {
      */
     template <typename FieldValidator>
     class CommandValidatorVisitor
-        : public boost::static_visitor<boost::optional<ValidationError>> {
+        : public boost::static_visitor<std::optional<ValidationError>> {
       CommandValidatorVisitor(FieldValidator validator)
           : validator_(std::move(validator)) {}
 
@@ -53,7 +53,7 @@ namespace shared_model {
       CommandValidatorVisitor(std::shared_ptr<ValidatorsConfig> config)
           : CommandValidatorVisitor(FieldValidator{std::move(config)}) {}
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::AddAssetQuantity &add_asset_quantity) const {
         return aggregateErrors(
             "AddAssetQuantity",
@@ -62,13 +62,13 @@ namespace shared_model {
              validator_.validateAmount(add_asset_quantity.amount())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::AddPeer &add_peer) const {
         return aggregateErrors(
             "AddPeer", {}, {validator_.validatePeer(add_peer.peer())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::AddSignatory &add_signatory) const {
         return aggregateErrors(
             "AddSignatory",
@@ -77,7 +77,7 @@ namespace shared_model {
              validator_.validatePubkey(add_signatory.pubkey())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::AppendRole &append_role) const {
         return aggregateErrors(
             "AppendRole",
@@ -86,7 +86,7 @@ namespace shared_model {
              validator_.validateRoleId(append_role.roleName())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::CreateAccount &create_account) const {
         return aggregateErrors(
             "CreateAccount",
@@ -96,7 +96,7 @@ namespace shared_model {
              validator_.validateDomainId(create_account.domainId())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::CreateAsset &create_asset) const {
         return aggregateErrors(
             "CreateAsset",
@@ -106,7 +106,7 @@ namespace shared_model {
              validator_.validatePrecision(create_asset.precision())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::CreateDomain &create_domain) const {
         return aggregateErrors(
             "CreateDomain",
@@ -115,7 +115,7 @@ namespace shared_model {
              validator_.validateRoleId(create_domain.userDefaultRole())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::CreateRole &create_role) const {
         ValidationErrorCreator error_creator;
         error_creator |= validator_.validateRoleId(create_role.roleName());
@@ -126,7 +126,7 @@ namespace shared_model {
         return std::move(error_creator).getValidationError("CreateRole");
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::DetachRole &detach_role) const {
         return aggregateErrors(
             "DetachRole",
@@ -135,7 +135,7 @@ namespace shared_model {
              validator_.validateRoleId(detach_role.roleName())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::GrantPermission &grant_permission) const {
         return aggregateErrors(
             "GrantPermission",
@@ -145,7 +145,7 @@ namespace shared_model {
                  grant_permission.permissionName())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::RemovePeer &remove_peer) const {
         return aggregateErrors(
             "RemovePeer",
@@ -153,7 +153,7 @@ namespace shared_model {
             {validator_.validatePubkey(remove_peer.pubkey())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::RemoveSignatory &remove_signatory) const {
         return aggregateErrors(
             "RemoveSignatory",
@@ -162,7 +162,7 @@ namespace shared_model {
              validator_.validatePubkey(remove_signatory.pubkey())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::RevokePermission &revoke_permission) const {
         return aggregateErrors(
             "RevokePermission",
@@ -172,7 +172,7 @@ namespace shared_model {
                  revoke_permission.permissionName())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::SetAccountDetail &set_account_detail) const {
         return aggregateErrors(
             "SetAccountDetail",
@@ -183,7 +183,7 @@ namespace shared_model {
                  set_account_detail.value())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::SetQuorum &set_quorum) const {
         return aggregateErrors(
             "SetQuorum",
@@ -192,7 +192,7 @@ namespace shared_model {
              validator_.validateQuorum(set_quorum.newQuorum())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::SubtractAssetQuantity &subtract_asset_quantity)
           const {
         return aggregateErrors(
@@ -202,17 +202,17 @@ namespace shared_model {
              validator_.validateAmount(subtract_asset_quantity.amount())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::TransferAsset &transfer_asset) const {
         return aggregateErrors(
             "TransferAsset",
-            {[&]() -> boost::optional<std::string> {
+            {[&]() -> std::optional<std::string> {
               if (transfer_asset.srcAccountId()
                   == transfer_asset.destAccountId()) {
                 return std::string{
                     "Source and destination accounts are the same."};
               }
-              return boost::none;
+              return std::nullopt;
             }()},
             {validator_.validateAccountId(transfer_asset.srcAccountId()),
              validator_.validateAccountId(transfer_asset.destAccountId()),
@@ -221,7 +221,7 @@ namespace shared_model {
              validator_.validateDescription(transfer_asset.description())});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::CompareAndSetAccountDetail
               &compare_and_set_account_detail) const {
         using iroha::operator|;
@@ -236,12 +236,12 @@ namespace shared_model {
                  compare_and_set_account_detail.value()),
              compare_and_set_account_detail.oldValue() |
                  [this](
-                     const auto &oldValue) -> boost::optional<ValidationError> {
+                     const auto &oldValue) -> std::optional<ValidationError> {
                return this->validator_.validateOldAccountDetailValue(oldValue);
              }});
       }
 
-      boost::optional<ValidationError> operator()(
+      std::optional<ValidationError> operator()(
           const interface::SetSettingValue &set_setting_value) const {
         // genesis block does not undergo stateless validation
         return ValidationError(
@@ -263,7 +263,7 @@ namespace shared_model {
         : public AbstractValidator<interface::Transaction> {
      private:
       template <typename CreatedTimeValidator>
-      boost::optional<ValidationError> validateImpl(
+      std::optional<ValidationError> validateImpl(
           const interface::Transaction &tx,
           CreatedTimeValidator &&validator) const {
         using iroha::operator|;
@@ -307,7 +307,7 @@ namespace shared_model {
        * @param tx - transaction to validate
        * @return found error if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::Transaction &tx) const override {
         return validateImpl(tx, [this](auto time) {
           return field_validator_.validateCreatedTime(time);
@@ -318,7 +318,7 @@ namespace shared_model {
        * Validates transaction against current_timestamp instead of time
        * provider
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::Transaction &tx,
           interface::types::TimestampType current_timestamp) const {
         return validateImpl(tx, [this, current_timestamp](auto time) {

--- a/shared_model/validators/transactions_collection/batch_order_validator.cpp
+++ b/shared_model/validators/transactions_collection/batch_order_validator.cpp
@@ -23,7 +23,7 @@ BatchOrderValidator::BatchOrderValidator(
       partial_ordered_batches_are_valid_(
           config->partial_ordered_batches_are_valid) {}
 
-boost::optional<ValidationError> BatchOrderValidator::validate(
+std::optional<ValidationError> BatchOrderValidator::validate(
     const shared_model::interface::types::TransactionsForwardCollectionType
         &transactions) const {
   ValidationErrorCreator error_creator;

--- a/shared_model/validators/transactions_collection/batch_order_validator.hpp
+++ b/shared_model/validators/transactions_collection/batch_order_validator.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_BATCH_ORDER_VALIDATOR_HPP
 #define IROHA_BATCH_ORDER_VALIDATOR_HPP
 
-#include <boost/optional/optional_fwd.hpp>
+#include <optional>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "validators/validators_common.hpp"
 
@@ -18,7 +18,7 @@ namespace shared_model {
      public:
       BatchOrderValidator(std::shared_ptr<ValidatorsConfig> config);
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::types::TransactionsForwardCollectionType
               &transactions) const;
 

--- a/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
+++ b/shared_model/validators/transactions_collection/transactions_collection_validator.cpp
@@ -39,7 +39,7 @@ namespace shared_model {
               typename OrderValidator,
               bool CollectionCanBeEmpty>
     template <typename Validator>
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     TransactionsCollectionValidator<TransactionValidator,
                                     OrderValidator,
                                     CollectionCanBeEmpty>::
@@ -90,7 +90,7 @@ namespace shared_model {
     template <typename TransactionValidator,
               typename OrderValidator,
               bool CollectionCanBeEmpty>
-    boost::optional<ValidationError> TransactionsCollectionValidator<
+    std::optional<ValidationError> TransactionsCollectionValidator<
         TransactionValidator,
         OrderValidator,
         CollectionCanBeEmpty>::validate(const shared_model::interface::types::
@@ -104,7 +104,7 @@ namespace shared_model {
     template <typename TransactionValidator,
               typename OrderValidator,
               bool CollectionCanBeEmpty>
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     TransactionsCollectionValidator<TransactionValidator,
                                     OrderValidator,
                                     CollectionCanBeEmpty>::
@@ -116,7 +116,7 @@ namespace shared_model {
     template <typename TransactionValidator,
               typename OrderValidator,
               bool CollectionCanBeEmpty>
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     TransactionsCollectionValidator<TransactionValidator,
                                     OrderValidator,
                                     CollectionCanBeEmpty>::
@@ -132,7 +132,7 @@ namespace shared_model {
     template <typename TransactionValidator,
               typename OrderValidator,
               bool CollectionCanBeEmpty>
-    boost::optional<ValidationError>
+    std::optional<ValidationError>
     TransactionsCollectionValidator<TransactionValidator,
                                     OrderValidator,
                                     CollectionCanBeEmpty>::

--- a/shared_model/validators/transactions_collection/transactions_collection_validator.hpp
+++ b/shared_model/validators/transactions_collection/transactions_collection_validator.hpp
@@ -29,7 +29,7 @@ namespace shared_model {
 
      private:
       template <typename Validator>
-      boost::optional<ValidationError> validateImpl(
+      std::optional<ValidationError> validateImpl(
           const interface::types::TransactionsForwardCollectionType
               &transactions,
           Validator &&validator) const;
@@ -44,19 +44,19 @@ namespace shared_model {
        * @param transactions collection of transactions
        * @return validation error, if any
        */
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::types::TransactionsForwardCollectionType
               &transactions) const;
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::types::SharedTxsCollectionType &transactions) const;
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::types::TransactionsForwardCollectionType
               &transactions,
           interface::types::TimestampType current_timestamp) const;
 
-      boost::optional<ValidationError> validate(
+      std::optional<ValidationError> validate(
           const interface::types::SharedTxsCollectionType &transactions,
           interface::types::TimestampType current_timestamp) const;
 

--- a/shared_model/validators/validation_error_helpers.cpp
+++ b/shared_model/validators/validation_error_helpers.cpp
@@ -12,7 +12,7 @@
 
 using namespace shared_model::validation;
 
-boost::optional<ValidationError> ValidationErrorCreator::getValidationError(
+std::optional<ValidationError> ValidationErrorCreator::getValidationError(
     const ReasonName &name) && {
   if (optional_error_) {
     optional_error_->name = name;
@@ -32,7 +32,7 @@ ValidationErrorCreator &ValidationErrorCreator::addChildError(
 }
 
 ValidationErrorCreator &ValidationErrorCreator::operator|=(
-    boost::optional<ReasonType> optional_reason) {
+    std::optional<ReasonType> optional_reason) {
   if (optional_reason) {
     return addReason(std::move(optional_reason).value());
   }
@@ -40,7 +40,7 @@ ValidationErrorCreator &ValidationErrorCreator::operator|=(
 }
 
 ValidationErrorCreator &ValidationErrorCreator::operator|=(
-    boost::optional<ValidationError> optional_error) {
+    std::optional<ValidationError> optional_error) {
   if (optional_error) {
     return addChildError(std::move(optional_error).value());
   }
@@ -54,10 +54,10 @@ ValidationError &ValidationErrorCreator::getOrCreateValidationError() {
   return optional_error_.value();
 }
 
-boost::optional<ValidationError> shared_model::validation::aggregateErrors(
+std::optional<ValidationError> shared_model::validation::aggregateErrors(
     const ReasonName &name,
-    std::vector<boost::optional<ReasonType>> optional_reasons,
-    std::vector<boost::optional<ValidationError>> optional_child_errors) {
+    std::vector<std::optional<ReasonType>> optional_reasons,
+    std::vector<std::optional<ValidationError>> optional_child_errors) {
   ValidationErrorCreator error_creator;
   for (auto &optional_reason : optional_reasons) {
     error_creator |= std::move(optional_reason);
@@ -68,9 +68,8 @@ boost::optional<ValidationError> shared_model::validation::aggregateErrors(
   return std::move(error_creator).getValidationError(name);
 }
 
-boost::optional<ValidationError> operator|(
-    boost::optional<ValidationError> oe1,
-    boost::optional<ValidationError> oe2) {
+std::optional<ValidationError> operator|(std::optional<ValidationError> oe1,
+                                         std::optional<ValidationError> oe2) {
   if (oe1) {
     if (oe2) {
       return oe1.value() |= std::move(oe2).value();

--- a/shared_model/validators/validation_error_helpers.hpp
+++ b/shared_model/validators/validation_error_helpers.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_VALIDATION_ERROR_HELPERS_HPP
 #define IROHA_VALIDATION_ERROR_HELPERS_HPP
 
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include "validators/validation_error.hpp"
 
 namespace shared_model {
@@ -19,7 +19,7 @@ namespace shared_model {
        * Extract the error, if any.
        * @param name - the name of resulting error, if any.
        */
-      boost::optional<ValidationError> getValidationError(
+      std::optional<ValidationError> getValidationError(
           const ReasonName &name) &&;
 
       /**
@@ -28,7 +28,7 @@ namespace shared_model {
        * error, if any.
        */
       template <typename NameProvider>
-      boost::optional<ValidationError> getValidationErrorWithGeneratedName(
+      std::optional<ValidationError> getValidationErrorWithGeneratedName(
           NameProvider &&name_provider) && {
         if (optional_error_) {
           optional_error_->name = std::forward<NameProvider>(name_provider)();
@@ -44,21 +44,20 @@ namespace shared_model {
 
       /// Add a reason, if any.
       ValidationErrorCreator &operator|=(
-          boost::optional<ReasonType> optional_reason);
+          std::optional<ReasonType> optional_reason);
 
       /// Add a child error, if any.
       ValidationErrorCreator &operator|=(
-          boost::optional<ValidationError> optional_error);
+          std::optional<ValidationError> optional_error);
 
      private:
       ValidationError &getOrCreateValidationError();
 
-      boost::optional<ValidationError> optional_error_;
+      std::optional<ValidationError> optional_error_;
     };
 
-    boost::optional<ValidationError> operator|(
-        boost::optional<ValidationError> oe1,
-        boost::optional<ValidationError> oe2);
+    std::optional<ValidationError> operator|(
+        std::optional<ValidationError> oe1, std::optional<ValidationError> oe2);
 
     /**
      * Create an error if provided some reasons or child errors.
@@ -66,12 +65,13 @@ namespace shared_model {
      * @param optional_reasons - a collection of optional error reasons
      * @param optional_child_errors - optional child errors
      * @return an error with all present reasons and child errors from
-     * parameters, if any, or boost::none, if not any reason nor error provided.
+     * parameters, if any, or std::nullopt, if not any reason nor error
+     * provided.
      */
-    boost::optional<ValidationError> aggregateErrors(
+    std::optional<ValidationError> aggregateErrors(
         const ReasonName &name,
-        std::vector<boost::optional<ReasonType>> optional_reasons,
-        std::vector<boost::optional<ValidationError>> optional_child_errors);
+        std::vector<std::optional<ReasonType>> optional_reasons,
+        std::vector<std::optional<ValidationError>> optional_child_errors);
 
   }  // namespace validation
 }  // namespace shared_model

--- a/test/integration/acceptance/transfer_asset_test.cpp
+++ b/test/integration/acceptance/transfer_asset_test.cpp
@@ -386,7 +386,7 @@ TEST_F(TransferAsset, BigPrecision) {
   auto make_query = [this](std::string account_id) {
     return baseQry()
         .creatorAccountId(kAdminId)
-        .getAccountAssets(account_id, kMaxPageSize, boost::none)
+        .getAccountAssets(account_id, kMaxPageSize, std::nullopt)
         .build()
         .signAndAddSignature(kAdminKeypair)
         .finish();

--- a/test/integration/executor/executor_fixture.cpp
+++ b/test/integration/executor/executor_fixture.cpp
@@ -121,7 +121,7 @@ void ExecutorTestBase::checkAssetQuantities(
     const std::vector<AssetQuantity> &quantities) {
   auto pagination_meta =
       getItf().getMockQueryFactory()->constructAssetPaginationMeta(
-          quantities.size(), boost::none);
+          quantities.size(), std::nullopt);
   getItf()
       .executeQueryAndConvertResult(
           *getItf().getMockQueryFactory()->constructGetAccountAssets(

--- a/test/integration/executor/get_account_assets_test.cpp
+++ b/test/integration/executor/get_account_assets_test.cpp
@@ -112,7 +112,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
 
   std::unique_ptr<shared_model::interface::MockAssetPaginationMeta>
   makePaginationMeta(TransactionsNumberType page_size,
-                     boost::optional<AssetIdType> first_asset_id) {
+                     std::optional<AssetIdType> first_asset_id) {
     return getItf().getMockQueryFactory()->constructAssetPaginationMeta(
         page_size, std::move(first_asset_id));
   }
@@ -123,7 +123,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
   QueryExecutorResult queryPage(boost::optional<size_t> page_start,
                                 size_t page_size,
                                 AccountIdType command_issuer = kAdminId) {
-    boost::optional<AssetIdType> first_asset_id;
+    std::optional<AssetIdType> first_asset_id;
     if (page_start) {
       first_asset_id = makeAssetId(page_start.value());
     }
@@ -180,7 +180,7 @@ TEST_P(GetAccountAssetsBasicTest, NoPageMetaData) {
   prepareState(10);
   QueryExecutorResult response = getItf().executeQuery(
       *getItf().getMockQueryFactory()->constructGetAccountAssets(kUserId,
-                                                                 boost::none));
+                                                                 std::nullopt));
   validatePageResponse(response, boost::none, 10);
 }
 
@@ -247,7 +247,7 @@ using GetAccountAssetsPermissionTest =
 TEST_P(GetAccountAssetsPermissionTest, QueryPermissionTest) {
   ASSERT_NO_FATAL_FAILURE(prepareState({Role::kReceive}));
   createAndAddAssets(2);
-  auto pagination_meta = makePaginationMeta(assets_added_, boost::none);
+  auto pagination_meta = makePaginationMeta(assets_added_, std::nullopt);
   checkResponse<shared_model::interface::AccountAssetResponse>(
       queryPage(boost::none, assets_added_, getSpectator()),
       [this](const shared_model::interface::AccountAssetResponse &response) {

--- a/test/integration/executor/get_account_detail_test.cpp
+++ b/test/integration/executor/get_account_detail_test.cpp
@@ -7,8 +7,8 @@
 
 #include <map>
 
+#include <fmt/core.h>
 #include <gtest/gtest.h>
-#include <boost/format.hpp>
 #include "backend/plain/account_detail_record_id.hpp"
 #include "framework/common_constants.hpp"
 #include "integration/executor/account_detail_checker.hpp"
@@ -30,7 +30,7 @@ using shared_model::plain::AccountDetailRecordId;
 
 struct GetAccountDetailTest : public ExecutorTestBase {
   std::string makeAccountName(size_t i) const {
-    return (boost::format("account_%02d") % i).str();
+    return fmt::format("account_{:02}", i);
   }
 
   AccountIdType makeAccountId(size_t i) const {
@@ -38,11 +38,11 @@ struct GetAccountDetailTest : public ExecutorTestBase {
   }
 
   std::string makeKey(size_t i) const {
-    return (boost::format("key_%02d") % i).str();
+    return fmt::format("key_{:02}", i);
   }
 
   std::string makeValue(size_t writer, size_t key) const {
-    return (boost::format("value_w%02d_k%02d") % writer % key).str();
+    return fmt::format("value_w{:02}_k{:02}", writer, key);
   }
 
   /**
@@ -79,21 +79,24 @@ struct GetAccountDetailTest : public ExecutorTestBase {
   std::unique_ptr<shared_model::interface::MockAccountDetailPaginationMeta>
   makePaginationMeta(
       TransactionsNumberType page_size,
-      const boost::optional<AccountDetailRecordId> &requested_first_record_id) {
-    boost::optional<const shared_model::interface::AccountDetailRecordId &>
+      const std::optional<AccountDetailRecordId> &requested_first_record_id) {
+    std::optional<std::reference_wrapper<
+        const shared_model::interface::AccountDetailRecordId>>
         first_record_id;
     if (requested_first_record_id) {
-      first_record_id = requested_first_record_id.value();
-    }  // convert to boost::optional ctor?
+      first_record_id =
+          std::cref<shared_model::interface::AccountDetailRecordId>(
+              requested_first_record_id.value());
+    }  // convert to optional ctor?
     return getItf().getMockQueryFactory()->constructAccountDetailPaginationMeta(
         page_size, first_record_id);
   }
 
   /// Query account details.
   QueryExecutorResult queryPage(
-      boost::optional<std::string> writer,
-      boost::optional<std::string> key,
-      boost::optional<AccountDetailRecordId> first_record_id,
+      std::optional<std::string> writer,
+      std::optional<std::string> key,
+      std::optional<AccountDetailRecordId> first_record_id,
       size_t page_size,
       const AccountIdType &command_issuer = kAdminId) {
     auto page_meta = makePaginationMeta(page_size, first_record_id);
@@ -114,10 +117,9 @@ struct GetAccountDetailTest : public ExecutorTestBase {
 
   void validatePageResponse(
       const QueryExecutorResult &response,
-      boost::optional<std::string> writer,
-      boost::optional<std::string> key,
-      boost::optional<shared_model::plain::AccountDetailRecordId>
-          first_record_id,
+      std::optional<std::string> writer,
+      std::optional<std::string> key,
+      std::optional<shared_model::plain::AccountDetailRecordId> first_record_id,
       size_t page_size) {
     checkSuccessfulResult<shared_model::interface::AccountDetailResponse>(
         response, [&, this](const auto &response) {
@@ -139,7 +141,7 @@ struct GetAccountDetailTest : public ExecutorTestBase {
  protected:
   struct Response {
     size_t total_number{0};
-    boost::optional<shared_model::plain::AccountDetailRecordId> next_record;
+    std::optional<shared_model::plain::AccountDetailRecordId> next_record;
     DetailsByKeyByWriter details;
   };
 
@@ -155,9 +157,9 @@ struct GetAccountDetailTest : public ExecutorTestBase {
       if (not response.nextRecordId()) {
         ADD_FAILURE() << "nextRecordId not set!";
       } else {
-        EXPECT_EQ(response.nextRecordId()->writer(),
+        EXPECT_EQ(response.nextRecordId()->get().writer(),
                   expected_response.next_record->writer());
-        EXPECT_EQ(response.nextRecordId()->key(),
+        EXPECT_EQ(response.nextRecordId()->get().key(),
                   expected_response.next_record->key());
       }
     } else {
@@ -176,9 +178,9 @@ struct GetAccountDetailTest : public ExecutorTestBase {
    */
   void validatePageResponse(
       const AccountDetailResponse &response,
-      boost::optional<std::string> writer,
-      boost::optional<std::string> key,
-      boost::optional<AccountDetailRecordId> first_record_id,
+      std::optional<std::string> writer,
+      std::optional<std::string> key,
+      std::optional<AccountDetailRecordId> first_record_id,
       size_t page_size) {
     Response expected_response = this->getExpectedResponse(
         writer, key, std::move(first_record_id), page_size);
@@ -190,9 +192,9 @@ struct GetAccountDetailTest : public ExecutorTestBase {
    * given parameters.
    */
   Response getExpectedResponse(
-      const boost::optional<std::string> &req_writer,
-      const boost::optional<std::string> &req_key,
-      const boost::optional<shared_model::plain::AccountDetailRecordId>
+      const std::optional<std::string> &req_writer,
+      const std::optional<std::string> &req_key,
+      const std::optional<shared_model::plain::AccountDetailRecordId>
           &first_record_id,
       size_t page_size) {
     auto optional_match = [](const auto &opt, const auto &val) {
@@ -269,20 +271,20 @@ struct GetAccountDetailRecordIdTest
         + record_id_param_names.at(std::get<1>(param.param));
   }
 
-  boost::optional<std::string> requestedWriter() const {
+  std::optional<std::string> requestedWriter() const {
     if (record_id_param_ == kDetailsByWriter
         or record_id_param_ == kSingleDetail) {
       return makeAccountId(0);
     }
-    return boost::none;
+    return std::nullopt;
   }
 
-  boost::optional<std::string> requestedKey() const {
+  std::optional<std::string> requestedKey() const {
     if (record_id_param_ == kDetailsByKey
         or record_id_param_ == kSingleDetail) {
       return makeKey(0);
     }
-    return boost::none;
+    return std::nullopt;
   }
 
   shared_model::plain::AccountDetailRecordId makeFirstRecordId(
@@ -293,8 +295,7 @@ struct GetAccountDetailRecordIdTest
   }
 
   QueryExecutorResult queryPage(
-      boost::optional<shared_model::plain::AccountDetailRecordId>
-          first_record_id,
+      std::optional<shared_model::plain::AccountDetailRecordId> first_record_id,
       size_t page_size) {
     return GetAccountDetailTest::queryPage(requestedWriter(),
                                            requestedKey(),
@@ -304,13 +305,12 @@ struct GetAccountDetailRecordIdTest
 
   QueryExecutorResult queryPage(size_t page_size) {
     return GetAccountDetailTest::queryPage(
-        requestedWriter(), requestedKey(), boost::none, page_size);
+        requestedWriter(), requestedKey(), std::nullopt, page_size);
   }
 
   void validatePageResponse(
       const QueryExecutorResult &response,
-      boost::optional<shared_model::plain::AccountDetailRecordId>
-          first_record_id,
+      std::optional<shared_model::plain::AccountDetailRecordId> first_record_id,
       size_t page_size) {
     checkSuccessfulResult<shared_model::interface::AccountDetailResponse>(
         response, [&, this](const auto &response) {
@@ -367,7 +367,7 @@ TEST_P(GetAccountDetailRecordIdTest, NoDetail) {
 TEST_P(GetAccountDetailRecordIdTest, InvalidNoAccount) {
   checkQueryError<shared_model::interface::NoAccountDetailErrorResponse>(
       GetAccountDetailTest::queryPage(
-          makeAccountId(1), makeKey(1), boost::none, 1),
+          makeAccountId(1), makeKey(1), std::nullopt, 1),
       error_codes::kNoStatefulError);
 }
 
@@ -380,8 +380,8 @@ TEST_P(GetAccountDetailRecordIdTest, NoPageMetaData) {
   ASSERT_NO_FATAL_FAILURE(prepareState(3, 3));
   QueryExecutorResult response = getItf().executeQuery(
       *getItf().getMockQueryFactory()->constructGetAccountDetail(
-          kUserId, requestedKey(), requestedWriter(), boost::none));
-  validatePageResponse(response, boost::none, 9);
+          kUserId, requestedKey(), requestedWriter(), std::nullopt));
+  validatePageResponse(response, std::nullopt, 9);
 }
 
 /**
@@ -405,7 +405,7 @@ TEST_P(GetAccountDetailRecordIdTest, NonexistentFirstRecordId) {
  */
 TEST_P(GetAccountDetailRecordIdTest, FirstPage) {
   ASSERT_NO_FATAL_FAILURE(prepareState(3, 3));
-  queryPageAndValidateResponse(boost::none, 2);
+  queryPageAndValidateResponse(std::nullopt, 2);
 }
 
 /**
@@ -463,10 +463,10 @@ TEST_P(GetAccountDetailPermissionTest, QueryPermissionTest) {
   ASSERT_NO_FATAL_FAILURE(prepareState({Role::kSetMyAccountDetail}));
   addDetails(1, 1);
   checkResponse<shared_model::interface::AccountDetailResponse>(
-      queryPage(makeAccountId(0), makeKey(0), boost::none, 1, getSpectator()),
+      queryPage(makeAccountId(0), makeKey(0), std::nullopt, 1, getSpectator()),
       [this](const shared_model::interface::AccountDetailResponse &response) {
         this->validatePageResponse(
-            response, makeAccountId(0), makeKey(0), boost::none, 1);
+            response, makeAccountId(0), makeKey(0), std::nullopt, 1);
       });
 }
 

--- a/test/integration/executor/set_account_detail_test.cpp
+++ b/test/integration/executor/set_account_detail_test.cpp
@@ -50,7 +50,7 @@ class SetAccountDetailTest : public ExecutorTestBase {
         getItf()
             .executeQueryAndConvertResult(
                 *getItf().getMockQueryFactory()->constructGetAccountDetail(
-                    account, boost::none, boost::none, boost::none))
+                    account, std::nullopt, std::nullopt, std::nullopt))
             .specific_response
         | [&reference_details](const auto &response) {
             checkJsonData(response.detail(), reference_details);

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -106,8 +106,8 @@ class MstPipelineTest : public AcceptanceFixture {
       const std::string &creator,
       const crypto::Keypair &key,
       const interface::types::TransactionsNumberType &page_size,
-      const boost::optional<interface::types::HashType> &first_tx_hash =
-          boost::none) {
+      const std::optional<interface::types::HashType> &first_tx_hash =
+          std::nullopt) {
     return shared_model::proto::QueryBuilder()
         .createdTime(getUniqueTime())
         .creatorAccountId(creator)

--- a/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
+++ b/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
@@ -31,12 +31,12 @@ TEST_F(PeerQueryWSVTest, GetPeers) {
       std::make_shared<shared_model::plain::Peer>(
           "some-address",
           shared_model::crypto::PublicKey("some-public-key"),
-          boost::none);
+          std::nullopt);
   std::shared_ptr<shared_model::interface::Peer> peer2 =
       std::make_shared<shared_model::plain::Peer>(
           "another-address",
           shared_model::crypto::PublicKey("another-public-key"),
-          boost::none);
+          std::nullopt);
   peers.push_back(peer1);
   peers.push_back(peer2);
   EXPECT_CALL(*wsv_query_, getPeers()).WillOnce(::testing::Return(peers));

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -223,9 +223,10 @@ namespace iroha {
         address =
             std::make_unique<shared_model::interface::types::AddressType>("");
         pk = std::make_unique<shared_model::interface::types::PubkeyType>("");
-        tls_certificate = std::make_unique<boost::optional<
-            shared_model::interface::types::TLSCertificateType>>("");
-        blank_tls_certificate = std::make_unique<boost::optional<
+        tls_certificate = std::make_unique<
+            std::optional<shared_model::interface::types::TLSCertificateType>>(
+            "");
+        blank_tls_certificate = std::make_unique<std::optional<
             shared_model::interface::types::TLSCertificateType>>();
         peer = std::make_unique<MockPeer>();
         EXPECT_CALL(*peer, address())
@@ -248,10 +249,10 @@ namespace iroha {
       std::unique_ptr<shared_model::interface::types::AddressType> address;
       std::unique_ptr<shared_model::interface::types::PubkeyType> pk;
       std::unique_ptr<
-          boost::optional<shared_model::interface::types::TLSCertificateType>>
+          std::optional<shared_model::interface::types::TLSCertificateType>>
           blank_tls_certificate;
       std::unique_ptr<
-          boost::optional<shared_model::interface::types::TLSCertificateType>>
+          std::optional<shared_model::interface::types::TLSCertificateType>>
           tls_certificate;
       std::unique_ptr<MockPeer> peer;
       std::unique_ptr<MockPeer> peer_with_cert;
@@ -1842,7 +1843,7 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none)));
+              account_id, "key", "value", std::nullopt)));
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
       ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
@@ -1865,7 +1866,7 @@ namespace iroha {
 
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-                      account2_id, "key", "value", boost::none),
+                      account2_id, "key", "value", std::nullopt),
                   false,
                   account_id));
       auto kv = sql_query->getAccountDetail(account2_id);
@@ -1882,7 +1883,7 @@ namespace iroha {
       addAllPermsWithoutRoot();
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-                      account2_id, "key", "value", boost::none),
+                      account2_id, "key", "value", std::nullopt),
                   false,
                   account_id));
       auto kv = sql_query->getAccountDetail(account2_id);
@@ -1898,7 +1899,7 @@ namespace iroha {
     TEST_F(CompareAndSetAccountDetail, NoPerms) {
       auto cmd_result =
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-                      account2_id, "key", "value", boost::none),
+                      account2_id, "key", "value", std::nullopt),
                   false,
                   account_id);
 
@@ -1919,7 +1920,7 @@ namespace iroha {
       addAllPermsWithoutRoot();
       auto cmd_result =
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-                      "doge@noaccount", "key", "value", boost::none),
+                      "doge@noaccount", "key", "value", std::nullopt),
                   false,
                   account_id);
 
@@ -1936,7 +1937,7 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none)));
+              account_id, "key", "value", std::nullopt)));
 
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
@@ -1947,7 +1948,7 @@ namespace iroha {
               account_id,
               "key",
               "value1",
-              boost::optional<
+              std::optional<
                   shared_model::interface::types::AccountDetailValueType>(
                   "value"))));
       auto kv1 = sql_query->getAccountDetail(account_id);
@@ -1964,7 +1965,7 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none)));
+              account_id, "key", "value", std::nullopt)));
 
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
@@ -1975,7 +1976,7 @@ namespace iroha {
               account_id,
               "key",
               "value1",
-              boost::optional<
+              std::optional<
                   shared_model::interface::types::AccountDetailValueType>(
                   "oldValue")));
 
@@ -1993,11 +1994,11 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none)));
+              account_id, "key", "value", std::nullopt)));
 
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key1", "value1", boost::none)));
+              account_id, "key1", "value1", std::nullopt)));
 
       auto ad = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(ad);
@@ -2014,11 +2015,11 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "", boost::none)));
+              account_id, "key", "", std::nullopt)));
 
       auto cmd_result =
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none));
+              account_id, "key", "value", std::nullopt));
 
       std::vector<std::string> query_args{account_id, "key", "value"};
       CHECK_ERROR_CODE_AND_MESSAGE(cmd_result, 4, query_args);
@@ -2037,7 +2038,7 @@ namespace iroha {
               account_id,
               "key",
               "value",
-              boost::optional<
+              std::optional<
                   shared_model::interface::types::AccountDetailValueType>(
                   "notEmptyOldValue")));
 
@@ -2055,7 +2056,7 @@ namespace iroha {
       addOnePerm(shared_model::interface::permissions::Role::kRoot);
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
-              account_id, "key", "value", boost::none)));
+              account_id, "key", "value", std::nullopt)));
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
       ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -140,7 +140,7 @@ namespace iroha {
                          "fa6ce0e0c21ce1ceaf4ba38538c1868185e9feefeafff3e42d94f"
                          "21800"
                          "0a5533")},
-                 boost::none} {
+                 std::nullopt} {
         role_permissions.set(
             shared_model::interface::permissions::Role::kAddMySignatory);
         grantable_permission =
@@ -713,7 +713,7 @@ namespace iroha {
 
       auto queryPage(
           types::TransactionsNumberType page_size,
-          const boost::optional<types::HashType> &first_hash = boost::none) {
+          const std::optional<types::HashType> &first_hash = std::nullopt) {
         auto query = Impl::makeQuery(page_size, first_hash);
         return executeQuery(query);
       }
@@ -731,8 +731,8 @@ namespace iroha {
       void generalTransactionsPageResponseCheck(
           const TransactionsPageResponse &tx_page_response,
           types::TransactionsNumberType page_size,
-          const boost::optional<types::HashType> &first_hash =
-              boost::none) const {
+          const std::optional<types::HashType> &first_hash =
+              std::nullopt) const {
         EXPECT_EQ(tx_page_response.allTransactionsSize(), tx_hashes_.size())
             << "Wrong `total transactions' number.";
         auto resp_tx_hashes = tx_page_response.transactions()
@@ -765,7 +765,7 @@ namespace iroha {
               << "Wrong transaction returned.";
         }
         if (page_end == tx_hashes_.cend()) {
-          EXPECT_EQ(tx_page_response.nextTxHash(), boost::none)
+          EXPECT_EQ(tx_page_response.nextTxHash(), std::nullopt)
               << "Next transaction hash value must be unset.";
         } else {
           EXPECT_TRUE(tx_page_response.nextTxHash());
@@ -807,7 +807,7 @@ namespace iroha {
 
       static shared_model::proto::Query makeQuery(
           types::TransactionsNumberType page_size,
-          const boost::optional<types::HashType> &first_hash = boost::none) {
+          const std::optional<types::HashType> &first_hash = std::nullopt) {
         return TestQueryBuilder()
             .creatorAccountId(account_id)
             .createdTime(iroha::time::now())
@@ -860,7 +860,7 @@ namespace iroha {
 
       static shared_model::proto::Query makeQuery(
           types::TransactionsNumberType page_size,
-          const boost::optional<types::HashType> &first_hash = boost::none) {
+          const std::optional<types::HashType> &first_hash = std::nullopt) {
         return TestQueryBuilder()
             .creatorAccountId(account_id)
             .createdTime(iroha::time::now())

--- a/test/module/irohad/ametsuchi/wsv_query_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_test.cpp
@@ -51,13 +51,13 @@ namespace iroha {
           std::make_shared<shared_model::plain::Peer>(
               "some-address",
               shared_model::crypto::PublicKey("some-public-key"),
-              boost::none);
+              std::nullopt);
       command->insertPeer(*peer1);
       std::shared_ptr<shared_model::interface::Peer> peer2 =
           std::make_shared<shared_model::plain::Peer>(
               "another-address",
               shared_model::crypto::PublicKey("another-public-key"),
-              boost::none);
+              std::nullopt);
       command->insertPeer(*peer2);
 
       auto result = query->getPeers();

--- a/test/module/irohad/consensus/yac/yac_test_util.hpp
+++ b/test/module/irohad/consensus/yac/yac_test_util.hpp
@@ -29,7 +29,7 @@ namespace iroha {
                     framework::padPubKeyString(address))));
         EXPECT_CALL(*peer, tlsCertificate())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                boost::optional<
+                std::optional<
                     shared_model::interface::types::TLSCertificateType>()));
 
         return peer;

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -236,7 +236,7 @@ TEST_F(BlockLoaderTest, ValidWhenBlockPresent) {
   EXPECT_CALL(*peer_query, getLedgerPeers())
       .WillOnce(Return(std::vector<wPeer>{peer}));
   EXPECT_CALL(*validator, validate(RefAndPointerEq(block)))
-      .WillOnce(Return(boost::none));
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*storage, getBlock(_)).Times(0);
   auto retrieved_block = loader->retrieveBlock(peer_key, block->height());
 

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp
@@ -23,7 +23,7 @@ namespace iroha {
             const shared_model::interface::types::AccountIdType &account_id,
             const shared_model::interface::types::TransactionsNumberType
                 page_size,
-            const boost::optional<shared_model::interface::types::HashType>
+            const std::optional<shared_model::interface::types::HashType>
                 &first_tx_hash));
   };
 

--- a/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
+++ b/test/module/irohad/pending_txs_storage/pending_txs_storage_test.cpp
@@ -103,7 +103,7 @@ TEST_F(PendingTxsStorageFixture, InsertionTest) {
                                                dummyPreparedTxsObservable());
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
     auto pending =
-        storage.getPendingTransactions(creator, kPageSize, boost::none);
+        storage.getPendingTransactions(creator, kPageSize, std::nullopt);
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
@@ -144,7 +144,7 @@ TEST_F(PendingTxsStorageFixture, ExactSize) {
                                                dummyPreparedTxsObservable());
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
     auto pending =
-        storage.getPendingTransactions(creator, kPageSize, boost::none);
+        storage.getPendingTransactions(creator, kPageSize, std::nullopt);
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
@@ -192,7 +192,7 @@ TEST_F(PendingTxsStorageFixture, CompletedTransactionsAreRemoved) {
       updates, dummyObservable(), dummyObservable(), prepared);
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
     auto pending =
-        storage.getPendingTransactions(creator, kPageSize, boost::none);
+        storage.getPendingTransactions(creator, kPageSize, std::nullopt);
     pending.match(
         [](const auto &response) {
           auto &pending_txs = response.value.transactions;
@@ -229,7 +229,7 @@ TEST_F(PendingTxsStorageFixture, InsufficientSize) {
                                                dummyPreparedTxsObservable());
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
     auto pending =
-        storage.getPendingTransactions(creator, kPageSize, boost::none);
+        storage.getPendingTransactions(creator, kPageSize, std::nullopt);
     pending.match(
         [&txs = transactions](const auto &response) {
           auto &pending_txs = response.value.transactions;
@@ -272,7 +272,7 @@ TEST_F(PendingTxsStorageFixture, BatchAndAHalfPageSize) {
                                                dummyPreparedTxsObservable());
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
     auto pending =
-        storage.getPendingTransactions(creator, kPageSize, boost::none);
+        storage.getPendingTransactions(creator, kPageSize, std::nullopt);
     pending.match(
         [&](const auto &response) {
           auto &pending_txs = response.value.transactions;
@@ -358,7 +358,7 @@ TEST_F(PendingTxsStorageFixture, NoPendingBatches) {
                                                dummyPreparedTxsObservable());
 
   auto response =
-      storage.getPendingTransactions(kThirdAccount, kPageSize, boost::none);
+      storage.getPendingTransactions(kThirdAccount, kPageSize, std::nullopt);
   response.match(
       [](const auto &response) {
         auto &pending_txs = response.value.transactions;
@@ -396,7 +396,7 @@ TEST_F(PendingTxsStorageFixture, SignaturesUpdate) {
                                                dummyObservable(),
                                                dummyPreparedTxsObservable());
   auto pending =
-      storage.getPendingTransactions("alice@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("alice@iroha", kPageSize, std::nullopt);
   pending.match(
       [&txs = transactions](const auto &response) {
         const auto &resp = response.value;
@@ -439,7 +439,7 @@ TEST_F(PendingTxsStorageFixture, SeveralBatches) {
                                                dummyObservable(),
                                                dummyPreparedTxsObservable());
   auto alice_pending =
-      storage.getPendingTransactions("alice@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("alice@iroha", kPageSize, std::nullopt);
   alice_pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 4);
@@ -450,7 +450,7 @@ TEST_F(PendingTxsStorageFixture, SeveralBatches) {
       });
 
   auto bob_pending =
-      storage.getPendingTransactions("bob@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("bob@iroha", kPageSize, std::nullopt);
   bob_pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 3);
@@ -489,7 +489,7 @@ TEST_F(PendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
                                                dummyPreparedTxsObservable());
 
   auto alice_pending =
-      storage.getPendingTransactions("alice@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("alice@iroha", kPageSize, std::nullopt);
   alice_pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 4);
@@ -500,7 +500,7 @@ TEST_F(PendingTxsStorageFixture, SeparateBatchesDoNotOverwriteStorage) {
       });
 
   auto bob_pending =
-      storage.getPendingTransactions("bob@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("bob@iroha", kPageSize, std::nullopt);
   bob_pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 2);
@@ -544,7 +544,7 @@ TEST_F(PendingTxsStorageFixture, PreparedBatch) {
   prepared_batches_subject.get_subscriber().on_completed();
   const auto kPageSize = 100u;
   auto pending =
-      storage.getPendingTransactions("alice@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("alice@iroha", kPageSize, std::nullopt);
   pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 0);
@@ -583,7 +583,7 @@ TEST_F(PendingTxsStorageFixture, ExpiredBatch) {
   expired_batches_subject.get_subscriber().on_completed();
   const auto kPageSize = 100u;
   auto pending =
-      storage.getPendingTransactions("alice@iroha", kPageSize, boost::none);
+      storage.getPendingTransactions("alice@iroha", kPageSize, std::nullopt);
   pending.match(
       [](const auto &response) {
         ASSERT_EQ(response.value.transactions.size(), 0);
@@ -654,8 +654,8 @@ TEST_F(PendingTxsStorageFixture, QueryAllTheBatches) {
                                                dummyObservable(),
                                                dummyPreparedTxsObservable());
   for (const auto &creator : {"alice@iroha", "bob@iroha"}) {
-    auto first_page =
-        storage.getPendingTransactions(creator, batchSize(batch1), boost::none);
+    auto first_page = storage.getPendingTransactions(
+        creator, batchSize(batch1), std::nullopt);
     first_page.match(
         [&](const auto &first_response) {
           const auto &resp1 = first_response.value;

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -119,7 +119,7 @@ TEST_F(QueryProcessorTest, QueryProcessorWhereInvokeInvalidQuery) {
                  .finish();
   auto *qry_resp =
       query_response_factory
-          ->createAccountDetailResponse("", 1, boost::none, qry.hash())
+          ->createAccountDetailResponse("", 1, std::nullopt, qry.hash())
           .release();
 
   EXPECT_CALL(*qry_exec, validateAndExecute_(_)).WillOnce(Return(qry_resp));

--- a/test/module/irohad/torii/torii_queries_test.cpp
+++ b/test/module/irohad/torii/torii_queries_test.cpp
@@ -364,7 +364,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenNoGrantPermissions) {
           .creatorAccountId(creator)
           .queryCounter(1)
           .createdTime(iroha::time::now())
-          .getAccountAssets(accountb_id, kMaxPageSize, boost::none)
+          .getAccountAssets(accountb_id, kMaxPageSize, std::nullopt)
           .build()
           .signAndAddSignature(pair)
           .finish();
@@ -409,7 +409,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
                          .creatorAccountId(creator)
                          .queryCounter(1)
                          .createdTime(iroha::time::now())
-                         .getAccountAssets(creator, kMaxPageSize, boost::none)
+                         .getAccountAssets(creator, kMaxPageSize, std::nullopt)
                          .build()
                          .signAndAddSignature(pair)
                          .finish();
@@ -421,7 +421,7 @@ TEST_F(ToriiQueriesTest, FindAccountAssetWhenHasRolePermissions) {
   assets.push_back(std::make_tuple(account_id, asset_id, amount));
   auto *r = query_response_factory
                 ->createAccountAssetResponse(
-                    assets, assets.size(), boost::none, model_query.hash())
+                    assets, assets.size(), std::nullopt, model_query.hash())
                 .release();
 
   EXPECT_CALL(*query_executor, validateAndExecute_(_))

--- a/test/module/irohad/torii/torii_transport_command_test.cpp
+++ b/test/module/irohad/torii/torii_transport_command_test.cpp
@@ -157,10 +157,10 @@ TEST_F(CommandServiceTransportGrpcTest, ListTorii) {
 
   EXPECT_CALL(*proto_tx_validator, validate(_))
       .Times(kTimes)
-      .WillRepeatedly(Return(boost::none));
+      .WillRepeatedly(Return(std::nullopt));
   EXPECT_CALL(*tx_validator, validate(_))
       .Times(kTimes)
-      .WillRepeatedly(Return(boost::none));
+      .WillRepeatedly(Return(std::nullopt));
   EXPECT_CALL(
       *batch_factory,
       createTransactionBatch(
@@ -189,7 +189,7 @@ TEST_F(CommandServiceTransportGrpcTest, ListToriiInvalid) {
   shared_model::validation::ValidationError error{"some error", {}};
   EXPECT_CALL(*proto_tx_validator, validate(_))
       .Times(AtLeast(1))
-      .WillRepeatedly(Return(boost::none));
+      .WillRepeatedly(Return(std::nullopt));
   EXPECT_CALL(*tx_validator, validate(_))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(error));
@@ -220,16 +220,16 @@ TEST_F(CommandServiceTransportGrpcTest, ListToriiPartialInvalid) {
   size_t counter = 0;
   EXPECT_CALL(*proto_tx_validator, validate(_))
       .Times(kTimes)
-      .WillRepeatedly(Return(boost::none));
+      .WillRepeatedly(Return(std::nullopt));
   EXPECT_CALL(*tx_validator, validate(_))
       .Times(kTimes)
       .WillRepeatedly(
           Invoke([this, &counter, kError](const auto &) mutable
-                 -> boost::optional<shared_model::validation::ValidationError> {
+                 -> std::optional<shared_model::validation::ValidationError> {
             if (counter++ == kTimes - 1) {
               return shared_model::validation::ValidationError{kError, {}};
             }
-            return boost::none;
+            return std::nullopt;
           }));
   EXPECT_CALL(
       *batch_factory,

--- a/test/module/shared_model/backend_proto/common_objects/proto_common_objects_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/common_objects/proto_common_objects_factory_test.cpp
@@ -31,7 +31,7 @@ class PeerTest : public ProtoFixture {
 
   void testValidPeerCreation(const std::string &address,
                              const crypto::PublicKey &pubkey,
-                             const boost::optional<std::string> &tls_cert) {
+                             const std::optional<std::string> &tls_cert) {
     factory.createPeer(address, pubkey, tls_cert)
         .match(
             [&](const auto &v) {
@@ -58,7 +58,7 @@ TEST_F(PeerTest, ValidPeerInitializationWithTlsCert) {
  * @then peer is successfully initialized
  */
 TEST_F(PeerTest, ValidPeerInitializationWithoutTlsCert) {
-  testValidPeerCreation(valid_address, valid_pubkey, boost::none);
+  testValidPeerCreation(valid_address, valid_pubkey, std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
@@ -5,7 +5,7 @@
 
 #include "backend/protobuf/proto_query_response_factory.hpp"
 #include <gtest/gtest.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include "backend/plain/account_detail_record_id.hpp"
 #include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"
 #include "cryptography/crypto_provider/crypto_defaults.hpp"
@@ -94,7 +94,7 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateAccountAssetResponse) {
   }
 
   query_responses.push_back(response_factory->createAccountAssetResponse(
-      assets, assets.size(), boost::none, kQueryHash));
+      assets, assets.size(), std::nullopt, kQueryHash));
 
   for (auto &query_response : query_responses) {
     ASSERT_TRUE(query_response);
@@ -138,7 +138,7 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateAccountDetailResponse) {
     EXPECT_EQ(response.detail(), account_details);
     EXPECT_EQ(response.totalNumber(), total_number);
     ASSERT_TRUE(response.nextRecordId());
-    EXPECT_EQ(response.nextRecordId().value(), next_record_id);
+    EXPECT_EQ(response.nextRecordId().value().get(), next_record_id);
   });
 }
 
@@ -376,7 +376,7 @@ TEST_F(ProtoQueryResponseFactoryTest,
     transactions_test_copy.push_back(std::move(tx_copy));
   }
   auto query_response = response_factory->createTransactionsPageResponse(
-      std::move(transactions), boost::none, kTransactionsNumber, kQueryHash);
+      std::move(transactions), std::nullopt, kTransactionsNumber, kQueryHash);
 
   ASSERT_TRUE(query_response);
   EXPECT_EQ(query_response->queryHash(), kQueryHash);

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -7,8 +7,8 @@
 #define IROHA_COMMAND_MOCKS_HPP
 
 #include <gmock/gmock.h>
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <optional>
 #include "cryptography/public_key.hpp"
 #include "interfaces/commands/add_asset_quantity.hpp"
 #include "interfaces/commands/add_peer.hpp"
@@ -156,8 +156,8 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(key, const types::AccountDetailKeyType &());
       MOCK_CONST_METHOD0(value, const types::AccountDetailValueType &());
-      MOCK_CONST_METHOD0(
-          oldValue, const boost::optional<types::AccountDetailValueType>());
+      MOCK_CONST_METHOD0(oldValue,
+                         const std::optional<types::AccountDetailValueType>());
     };
 
     struct MockSetSettingValue

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -55,7 +55,7 @@ struct MockTransaction : public shared_model::interface::Transaction {
   MOCK_CONST_METHOD0(hash, const shared_model::interface::types::HashType &());
   MOCK_CONST_METHOD0(
       batch_meta,
-      boost::optional<std::shared_ptr<shared_model::interface::BatchMeta>>());
+      std::optional<std::shared_ptr<shared_model::interface::BatchMeta>>());
   MOCK_CONST_METHOD0(signatures,
                      shared_model::interface::types::SignatureRangeType());
   MOCK_CONST_METHOD0(createdTime,
@@ -71,7 +71,7 @@ struct MockTransaction : public shared_model::interface::Transaction {
                      const shared_model::interface::types::BlobType &());
   MOCK_CONST_METHOD0(
       batchMeta,
-      boost::optional<std::shared_ptr<shared_model::interface::BatchMeta>>());
+      std::optional<std::shared_ptr<shared_model::interface::BatchMeta>>());
 };
 
 /**
@@ -185,7 +185,7 @@ struct MockPeer : public shared_model::interface::Peer {
                      const shared_model::interface::types::PubkeyType &());
   MOCK_CONST_METHOD0(
       tlsCertificate,
-      const boost::optional<shared_model::interface::types::TLSCertificateType>
+      const std::optional<shared_model::interface::types::TLSCertificateType>
           &());
   MOCK_CONST_METHOD0(clone, MockPeer *());
 };
@@ -193,8 +193,8 @@ struct MockPeer : public shared_model::interface::Peer {
 inline auto makePeer(
     const std::string &address,
     const shared_model::crypto::PublicKey &pub_key,
-    const boost::optional<shared_model::interface::types::TLSCertificateType>
-        &tls_certificate = boost::none) {
+    const std::optional<shared_model::interface::types::TLSCertificateType>
+        &tls_certificate = std::nullopt) {
   auto peer = std::make_unique<MockPeer>();
   EXPECT_CALL(*peer, address())
       .WillRepeatedly(testing::ReturnRefOfCopy(address));
@@ -220,7 +220,7 @@ struct MockCommonObjectsFactory
                FactoryResult<std::unique_ptr<shared_model::interface::Peer>>(
                    const shared_model::interface::types::AddressType &,
                    const shared_model::interface::types::PubkeyType &,
-                   const boost::optional<
+                   const std::optional<
                        shared_model::interface::types::TLSCertificateType> &));
 
   MOCK_METHOD4(createAccount,

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -318,7 +318,7 @@ namespace shared_model {
         const shared_model::interface::types::AccountIdType &account_id,
         const shared_model::interface::types::AccountDetailKeyType &cmd_key,
         const shared_model::interface::types::AccountDetailValueType &cmd_value,
-        const boost::optional<
+        const std::optional<
             shared_model::interface::types::AccountDetailValueType>
             cmd_old_value) const {
       return createFactoryResult<MockCompareAndSetAccountDetail>(

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
@@ -203,7 +203,7 @@ namespace shared_model {
           const types::AccountIdType &account_id,
           const types::AccountDetailKeyType &key,
           const types::AccountDetailValueType &value,
-          const boost::optional<types::AccountDetailValueType> old_value) const;
+          const std::optional<types::AccountDetailValueType> old_value) const;
 
       /**
        * Construct a mocked SetSettingValue

--- a/test/module/shared_model/mock_objects_factories/mock_query_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_query_factory.cpp
@@ -23,7 +23,7 @@ MockQueryFactory::createFactoryResult(
 MockQueryFactory::FactoryResult<MockAssetPaginationMeta>
 MockQueryFactory::constructAssetPaginationMeta(
     types::TransactionsNumberType page_size,
-    boost::optional<types::AssetIdType> first_asset_id) const {
+    std::optional<types::AssetIdType> first_asset_id) const {
   return createFactoryResult<MockAssetPaginationMeta>(
       [&page_size, &first_asset_id](MockAssetPaginationMeta &mock) {
         EXPECT_CALL(mock, pageSize()).WillRepeatedly(Return(page_size));
@@ -35,8 +35,8 @@ MockQueryFactory::constructAssetPaginationMeta(
 MockQueryFactory::FactoryResult<MockGetAccountAssets>
 MockQueryFactory::constructGetAccountAssets(
     const types::AccountIdType &account_id,
-    boost::optional<const interface::AssetPaginationMeta &> pagination_meta)
-    const {
+    std::optional<std::reference_wrapper<const interface::AssetPaginationMeta>>
+        pagination_meta) const {
   return createFactoryResult<MockGetAccountAssets>(
       [&account_id, &pagination_meta](MockGetAccountAssets &mock) {
         EXPECT_CALL(mock, accountId()).WillRepeatedly(ReturnRef(account_id));
@@ -63,7 +63,8 @@ MockQueryFactory::constructGetAccountAssetTransactions(
 MockQueryFactory::FactoryResult<MockAccountDetailPaginationMeta>
 MockQueryFactory::constructAccountDetailPaginationMeta(
     size_t page_size,
-    boost::optional<const AccountDetailRecordId &> first_record_id) const {
+    std::optional<std::reference_wrapper<const AccountDetailRecordId>>
+        first_record_id) const {
   return createFactoryResult<MockAccountDetailPaginationMeta>(
       [&page_size, &first_record_id](MockAccountDetailPaginationMeta &mock) {
         EXPECT_CALL(mock, pageSize()).WillRepeatedly(Return(page_size));
@@ -75,10 +76,10 @@ MockQueryFactory::constructAccountDetailPaginationMeta(
 MockQueryFactory::FactoryResult<MockGetAccountDetail>
 MockQueryFactory::constructGetAccountDetail(
     const types::AccountIdType &account_id,
-    boost::optional<types::AccountDetailKeyType> key,
-    boost::optional<types::AccountIdType> writer,
-    boost::optional<const AccountDetailPaginationMeta &> pagination_meta)
-    const {
+    std::optional<types::AccountDetailKeyType> key,
+    std::optional<types::AccountIdType> writer,
+    std::optional<std::reference_wrapper<const AccountDetailPaginationMeta>>
+        pagination_meta) const {
   return createFactoryResult<MockGetAccountDetail>(
       [&account_id, &key, &writer, &pagination_meta](
           MockGetAccountDetail &mock) {
@@ -163,7 +164,7 @@ MockQueryFactory::constructGetPeers() const {
 MockQueryFactory::FactoryResult<MockTxPaginationMeta>
 MockQueryFactory::constructTxPaginationMeta(
     types::TransactionsNumberType page_size,
-    boost::optional<types::HashType> first_tx_hash) const {
+    std::optional<types::HashType> first_tx_hash) const {
   return createFactoryResult<MockTxPaginationMeta>(
       [&page_size, &first_tx_hash](MockTxPaginationMeta &mock) {
         EXPECT_CALL(mock, pageSize()).WillRepeatedly(Return(page_size));

--- a/test/module/shared_model/mock_objects_factories/mock_query_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_query_factory.hpp
@@ -17,11 +17,12 @@ namespace shared_model {
      public:
       FactoryResult<MockAssetPaginationMeta> constructAssetPaginationMeta(
           types::TransactionsNumberType page_size,
-          boost::optional<types::AssetIdType> first_asset_id) const;
+          std::optional<types::AssetIdType> first_asset_id) const;
 
       FactoryResult<MockGetAccountAssets> constructGetAccountAssets(
           const types::AccountIdType &account_id,
-          boost::optional<const interface::AssetPaginationMeta &>
+          std::optional<
+              std::reference_wrapper<const interface::AssetPaginationMeta>>
               pagination_meta) const;
 
       FactoryResult<MockGetAccountAssetTransactions>
@@ -33,14 +34,16 @@ namespace shared_model {
       FactoryResult<MockAccountDetailPaginationMeta>
       constructAccountDetailPaginationMeta(
           size_t page_size,
-          boost::optional<const AccountDetailRecordId &> first_record_id) const;
+          std::optional<std::reference_wrapper<const AccountDetailRecordId>>
+              first_record_id) const;
 
       FactoryResult<MockGetAccountDetail> constructGetAccountDetail(
           const types::AccountIdType &account_id,
-          boost::optional<types::AccountDetailKeyType> key,
-          boost::optional<types::AccountIdType> writer,
-          boost::optional<const AccountDetailPaginationMeta &> pagination_meta)
-          const;
+          std::optional<types::AccountDetailKeyType> key,
+          std::optional<types::AccountIdType> writer,
+          std::optional<
+              std::reference_wrapper<const AccountDetailPaginationMeta>>
+              pagination_meta) const;
 
       FactoryResult<MockGetAccount> constructGetAccount(
           const types::AccountIdType &account_id) const;
@@ -69,7 +72,7 @@ namespace shared_model {
 
       FactoryResult<MockTxPaginationMeta> constructTxPaginationMeta(
           types::TransactionsNumberType page_size,
-          boost::optional<types::HashType> first_tx_hash) const;
+          std::optional<types::HashType> first_tx_hash) const;
 
      private:
       /**

--- a/test/module/shared_model/query_mocks.hpp
+++ b/test/module/shared_model/query_mocks.hpp
@@ -53,7 +53,7 @@ namespace shared_model {
     struct MockAssetPaginationMeta
         : public SpecificMockQuery<AssetPaginationMeta> {
       MOCK_CONST_METHOD0(pageSize, types::TransactionsNumberType());
-      MOCK_CONST_METHOD0(firstAssetId, boost::optional<types::AssetIdType>());
+      MOCK_CONST_METHOD0(firstAssetId, std::optional<types::AssetIdType>());
       MOCK_CONST_METHOD0(clone, AssetPaginationMeta *());
     };
 
@@ -61,7 +61,8 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(
           paginationMeta,
-          boost::optional<const interface::AssetPaginationMeta &>());
+          std::optional<
+              std::reference_wrapper<const interface::AssetPaginationMeta>>());
       MOCK_CONST_METHOD0(clone, GetAccountAssets *());
     };
 
@@ -76,19 +77,21 @@ namespace shared_model {
     struct MockAccountDetailPaginationMeta
         : public AccountDetailPaginationMeta {
       MOCK_CONST_METHOD0(pageSize, size_t());
-      MOCK_CONST_METHOD0(firstRecordId,
-                         boost::optional<const AccountDetailRecordId &>());
+      MOCK_CONST_METHOD0(
+          firstRecordId,
+          std::optional<std::reference_wrapper<const AccountDetailRecordId>>());
       MOCK_CONST_METHOD0(clone, AccountDetailPaginationMeta *());
     };
 
     struct MockGetAccountDetail : public GetAccountDetail {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
-      MOCK_CONST_METHOD0(key, boost::optional<types::AccountDetailKeyType>());
-      MOCK_CONST_METHOD0(writer, boost::optional<types::AccountIdType>());
+      MOCK_CONST_METHOD0(key, std::optional<types::AccountDetailKeyType>());
+      MOCK_CONST_METHOD0(writer, std::optional<types::AccountIdType>());
       MOCK_CONST_METHOD0(clone, GetAccountDetail *());
       MOCK_CONST_METHOD0(
           paginationMeta,
-          boost::optional<const AccountDetailPaginationMeta &>());
+          std::optional<
+              std::reference_wrapper<const AccountDetailPaginationMeta>>());
     };
 
     struct MockGetAccount : public SpecificMockQuery<GetAccount> {
@@ -135,7 +138,7 @@ namespace shared_model {
 
     struct MockTxPaginationMeta : public TxPaginationMeta {
       MOCK_CONST_METHOD0(pageSize, types::TransactionsNumberType());
-      MOCK_CONST_METHOD0(firstTxHash, boost::optional<types::HashType>());
+      MOCK_CONST_METHOD0(firstTxHash, std::optional<types::HashType>());
       MOCK_CONST_METHOD0(clone, TxPaginationMeta *());
     };
 

--- a/test/module/shared_model/validators/always_valid_validators.hpp
+++ b/test/module/shared_model/validators/always_valid_validators.hpp
@@ -20,148 +20,147 @@ namespace shared_model {
       AlwaysValidFieldValidator(std::shared_ptr<ValidatorsConfig>) {}
 
       template <typename... Args>
-      boost::optional<ValidationError> validateAccountId(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAccountId(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAssetId(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAssetId(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validatePeer(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validatePeer(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAmount(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAmount(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validatePubkey(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validatePubkey(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validatePeerAddress(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validatePeerAddress(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateRoleId(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateRoleId(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAccountName(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAccountName(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateDomainId(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateDomainId(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateDomain(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateDomain(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAssetName(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAssetName(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAccountDetailKey(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateAccountDetailKey(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateAccountDetailValue(
+      std::optional<ValidationError> validateAccountDetailValue(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validatePrecision(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateRolePermission(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateGrantablePermission(
           Args...) const {
-        return boost::none;
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validatePrecision(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateQuorum(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateRolePermission(Args...) const {
-        return boost::none;
+      std::optional<ValidationError> validateCreatorAccountId(Args...) const {
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateGrantablePermission(
+      std::optional<ValidationError> validateAccount(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateCreatedTime(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateCounter(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateSignatureForm(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateSignatures(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateQueryPayloadMeta(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateDescription(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateBatchMeta(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateHeight(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateHash(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateTxPaginationMeta(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateAccountAsset(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateAsset(Args...) const {
+        return std::nullopt;
+      }
+      template <typename... Args>
+      std::optional<ValidationError> validateAccountDetailRecordId(
           Args...) const {
-        return boost::none;
+        return std::nullopt;
       }
       template <typename... Args>
-      boost::optional<ValidationError> validateQuorum(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateCreatorAccountId(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateAccount(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateCreatedTime(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateCounter(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateSignatureForm(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateSignatures(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateQueryPayloadMeta(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateDescription(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateBatchMeta(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateHeight(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateHash(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateTxPaginationMeta(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateAccountAsset(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateAsset(Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateAccountDetailRecordId(
+      std::optional<ValidationError> validateAccountDetailPaginationMeta(
           Args...) const {
-        return boost::none;
-      }
-      template <typename... Args>
-      boost::optional<ValidationError> validateAccountDetailPaginationMeta(
-          Args...) const {
-        return boost::none;
+        return std::nullopt;
       }
     };
 
     template <typename Model>
     struct AlwaysValidModelValidator final : public AbstractValidator<Model> {
      public:
-      boost::optional<ValidationError> validate(const Model &m) const override {
-        return boost::none;
+      std::optional<ValidationError> validate(const Model &m) const override {
+        return std::nullopt;
       };
     };
 

--- a/test/module/shared_model/validators/batch_validator_test.cpp
+++ b/test/module/shared_model/validators/batch_validator_test.cpp
@@ -6,7 +6,7 @@
 #include "validators/transaction_batch_validator.hpp"
 
 #include <gtest/gtest.h>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "framework/batch_helper.hpp"
 #include "interfaces/iroha_internal/transaction_batch_impl.hpp"
 #include "module/irohad/common/validators_config.hpp"
@@ -39,7 +39,7 @@ TEST_F(BatchValidatorFixture, PartialOrderedWhenPartialsAllowed) {
   txs.pop_back();
   auto batch =
       std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
-  ASSERT_EQ(validator->validate(*batch), boost::none);
+  ASSERT_EQ(validator->validate(*batch), std::nullopt);
 }
 
 /**
@@ -75,7 +75,7 @@ TEST_F(BatchValidatorFixture, ComleteOrderedWhenPartialsDisallowed) {
       {"alice@iroha", "bob@iroha", "donna@iroha"});
   auto batch =
       std::make_unique<shared_model::interface::TransactionBatchImpl>(txs);
-  ASSERT_EQ(validator->validate(*batch), boost::none);
+  ASSERT_EQ(validator->validate(*batch), std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/block_validator_test.cpp
+++ b/test/module/shared_model/validators/block_validator_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
@@ -84,7 +84,7 @@ TEST_F(BlockValidatorTest, ValidBlock) {
   auto valid_block =
       generateBlock(txs, std::vector<shared_model::crypto::Hash>{});
 
-  ASSERT_EQ(validator_.validate(valid_block), boost::none);
+  ASSERT_EQ(validator_.validate(valid_block), std::nullopt);
 }
 
 /**
@@ -97,7 +97,7 @@ TEST_F(BlockValidatorTest, EmptyBlock) {
       generateBlock(std::vector<shared_model::proto::Transaction>{},
                     std::vector<shared_model::crypto::Hash>{});
 
-  ASSERT_EQ(validator_.validate(empty_block), boost::none);
+  ASSERT_EQ(validator_.validate(empty_block), std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/container_validator_test.cpp
+++ b/test/module/shared_model/validators/container_validator_test.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "cryptography/default_hash_provider.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
@@ -75,7 +75,7 @@ TEST_F(ContainerValidatorTest, OldProposal) {
       iroha::test::kTestsValidatorsConfig);
   auto proposal = makeProposal(old_timestamp, makeTransaction(old_timestamp));
 
-  ASSERT_EQ(validator.validate(proposal), boost::none);
+  ASSERT_EQ(validator.validate(proposal), std::nullopt);
 }
 
 /**
@@ -88,7 +88,7 @@ TEST_F(ContainerValidatorTest, OldBlock) {
       iroha::test::kTestsValidatorsConfig);
   auto block = makeBlock(old_timestamp, makeTransaction(old_timestamp));
 
-  ASSERT_EQ(validator.validate(block), boost::none);
+  ASSERT_EQ(validator.validate(block), std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -11,9 +11,9 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/dynamic_message.h>
 #include <boost/format.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/join.hpp>
+#include <optional>
 #include "block.pb.h"
 
 #include "backend/protobuf/batch_meta.hpp"
@@ -36,7 +36,7 @@ class FieldValidatorTest : public ValidatorsTest {
  protected:
   // Function which performs validation
   using ValidationFunction =
-      std::function<boost::optional<validation::ValidationError>()>;
+      std::function<std::optional<validation::ValidationError>()>;
   // Function which initializes field, allows to have one type when dealing
   // with various types of fields
   using InitFieldFunction = std::function<void()>;
@@ -196,7 +196,7 @@ class FieldValidatorTest : public ValidatorsTest {
         ASSERT_TRUE(error) << testFailMessage(field_name, testcase.name);
         // TODO IR-1183 add returned message check 29.03.2018
       } else {
-        EXPECT_EQ(error, boost::none)
+        EXPECT_EQ(error, std::nullopt)
             << testFailMessage(field_name, testcase.name);
       }
     }
@@ -572,7 +572,7 @@ class FieldValidatorTest : public ValidatorsTest {
           std::string(5 * 1024 * 1024, '0'))};
 
   std::vector<FieldTestCase> detail_old_value_test_cases{
-      makeValidCase(&FieldValidatorTest::detail_old_value, boost::none),
+      makeValidCase(&FieldValidatorTest::detail_old_value, std::nullopt),
       makeValidCase(&FieldValidatorTest::detail_old_value, "valid old value"),
       makeValidCase(&FieldValidatorTest::detail_old_value,
                     std::string(4096, '0')),
@@ -750,7 +750,7 @@ class FieldValidatorTest : public ValidatorsTest {
                     counter_test_cases),
       makeValidator(
           "created_time",
-          static_cast<boost::optional<validation::ValidationError> (
+          static_cast<std::optional<validation::ValidationError> (
               FieldValidator::*)(interface::types::TimestampType) const>(
               &FieldValidator::validateCreatedTime),
           &FieldValidatorTest::created_time,
@@ -880,7 +880,7 @@ TEST_F(FieldValidatorTest, TryReachDefaultLimit) {
 
   auto error = custom_field_validator.validateDescription(
       std::string(shared_model::validation::kDefaultDescriptionSize + 1, 0));
-  ASSERT_EQ(error, boost::none);
+  ASSERT_EQ(error, std::nullopt);
 }
 
 /**
@@ -893,7 +893,7 @@ TEST_F(FieldValidatorTest, TryReachNewMaxSize) {
 
   auto error = custom_field_validator.validateDescription(
       std::string(kCustomMaxDescriptionSize, 0));
-  ASSERT_EQ(error, boost::none);
+  ASSERT_EQ(error, std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/proposal_validator_test.cpp
+++ b/test/module/shared_model/validators/proposal_validator_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "builders/protobuf/transaction.hpp"
 #include "framework/batch_helper.hpp"
 #include "module/irohad/common/validators_config.hpp"
@@ -101,7 +101,7 @@ TEST_F(ProposalValidatorTest, TransportProposalWithDuplicateTransactions) {
   shared_model::validation::DefaultProposalValidator validator(
       iroha::test::kProposalTestsValidatorsConfig);
 
-  ASSERT_EQ(validator.validate(proposal), boost::none);
+  ASSERT_EQ(validator.validate(proposal), std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/protobuf/proto_block_validator_test.cpp
+++ b/test/module/shared_model/validators/protobuf/proto_block_validator_test.cpp
@@ -6,7 +6,7 @@
 #include "validators/protobuf/proto_block_validator.hpp"
 
 #include <gmock/gmock-matchers.h>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "block.pb.h"
 #include "module/shared_model/validators/validators_fixture.hpp"
 #include "validators/validation_error_output.hpp"
@@ -42,7 +42,7 @@ TEST_F(ProtoBlockValidatorTest, ValidBlock) {
   iroha::protocol::Block_v1 versioned_block;
   *valid_block.mutable_block_v1() = versioned_block;
 
-  ASSERT_EQ(validator.validate(valid_block), boost::none);
+  ASSERT_EQ(validator.validate(valid_block), std::nullopt);
 }
 
 /**
@@ -74,7 +74,7 @@ TEST_F(ProtoBlockValidatorTest, BlockWithValidRejectedHash) {
       std::string("123abc");
   *valid_block.mutable_block_v1() = versioned_block;
 
-  ASSERT_EQ(validator.validate(valid_block), boost::none);
+  ASSERT_EQ(validator.validate(valid_block), std::nullopt);
 }
 
 /**
@@ -89,7 +89,7 @@ TEST_F(ProtoBlockValidatorTest, BlockWithValidPrevHash) {
   versioned_block.mutable_payload()->set_prev_block_hash("123abc");
   *valid_block.mutable_block_v1() = versioned_block;
 
-  ASSERT_EQ(validator.validate(valid_block), boost::none);
+  ASSERT_EQ(validator.validate(valid_block), std::nullopt);
 }
 
 /**

--- a/test/module/shared_model/validators/protobuf/proto_query_validator_test.cpp
+++ b/test/module/shared_model/validators/protobuf/proto_query_validator_test.cpp
@@ -6,7 +6,7 @@
 #include "validators/protobuf/proto_query_validator.hpp"
 
 #include <gmock/gmock-matchers.h>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "module/shared_model/validators/validators_fixture.hpp"
 #include "queries.pb.h"
 #include "validators/validation_error_output.hpp"
@@ -43,7 +43,7 @@ TEST_F(ProtoQueryValidatorTest, SetQuery) {
   iroha::protocol::Query qry;
   qry.mutable_payload()->mutable_get_account()->set_account_id(account_id);
 
-  ASSERT_EQ(validator.validate(qry), boost::none);
+  ASSERT_EQ(validator.validate(qry), std::nullopt);
 }
 
 iroha::protocol::Query generateGetAccountAssetTransactionsQuery(
@@ -76,7 +76,7 @@ class ValidProtoPaginationQueryValidatorTest
       public ::testing::WithParamInterface<iroha::protocol::Query> {};
 
 TEST_P(ValidProtoPaginationQueryValidatorTest, ValidPaginationQuery) {
-  ASSERT_EQ(validator.validate(GetParam()), boost::none)
+  ASSERT_EQ(validator.validate(GetParam()), std::nullopt)
       << GetParam().DebugString();
 }
 

--- a/test/module/shared_model/validators/protobuf/proto_tx_validator_test.cpp
+++ b/test/module/shared_model/validators/protobuf/proto_tx_validator_test.cpp
@@ -6,7 +6,7 @@
 #include "validators/protobuf/proto_transaction_validator.hpp"
 
 #include <gtest/gtest.h>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "module/shared_model/validators/validators_fixture.hpp"
 #include "validators/validation_error_output.hpp"
 
@@ -135,7 +135,7 @@ class ValidProtoTxValidatorTest
  */
 TEST_P(ValidProtoTxValidatorTest, ValidTxsTest) {
   auto tx = GetParam();
-  ASSERT_EQ(validator.validate(tx), boost::none) << tx.DebugString();
+  ASSERT_EQ(validator.validate(tx), std::nullopt) << tx.DebugString();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/module/shared_model/validators/query_validator_test.cpp
+++ b/test/module/shared_model/validators/query_validator_test.cpp
@@ -5,7 +5,7 @@
 
 #include "module/shared_model/validators/validators_fixture.hpp"
 
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include "builders/protobuf/queries.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "validators/validation_error_output.hpp"
@@ -56,7 +56,7 @@ TEST_F(QueryValidatorTest, StatelessValidTest) {
         auto result = proto::Query(iroha::protocol::Query(qry));
         auto error = query_validator.validate(result);
 
-        ASSERT_EQ(error, boost::none);
+        ASSERT_EQ(error, std::nullopt);
       });
 }
 

--- a/test/module/shared_model/validators/transaction_validator_test.cpp
+++ b/test/module/shared_model/validators/transaction_validator_test.cpp
@@ -8,8 +8,8 @@
 #include <type_traits>
 
 #include <gtest/gtest.h>
-#include <boost/optional/optional_io.hpp>
 #include <boost/range/irange.hpp>
+#include <optional>
 #include "builders/protobuf/transaction.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/test_transaction_builder.hpp"
@@ -93,7 +93,7 @@ TEST_F(TransactionValidatorTest, StatelessValidTest) {
       [] {});
 
   auto result = proto::Transaction(iroha::protocol::Transaction(tx));
-  ASSERT_EQ(transaction_validator.validate(result), boost::none);
+  ASSERT_EQ(transaction_validator.validate(result), std::nullopt);
 }
 
 /**
@@ -170,7 +170,7 @@ TEST_F(TransactionValidatorTest, BatchValidTest) {
       transaction_validator(iroha::test::kTestsValidatorsConfig);
   auto result = proto::Transaction(iroha::protocol::Transaction(tx));
 
-  ASSERT_EQ(transaction_validator.validate(result), boost::none);
+  ASSERT_EQ(transaction_validator.validate(result), std::nullopt);
   ASSERT_EQ(tx.payload().batch().type(),
             static_cast<int>(interface::types::BatchType::ATOMIC));
 }

--- a/test/module/shared_model/validators/validators.hpp
+++ b/test/module/shared_model/validators/validators.hpp
@@ -21,8 +21,8 @@ namespace shared_model {
       AlwaysValidValidator(std::shared_ptr<ValidatorsConfig>) {}
 
       template <typename T>
-      boost::optional<ValidationError> validate(const T &) const {
-        return boost::none;
+      std::optional<ValidationError> validate(const T &) const {
+        return std::nullopt;
       }
     };
 
@@ -31,8 +31,7 @@ namespace shared_model {
      public:
       MockValidator() = default;
       MockValidator(std::shared_ptr<ValidatorsConfig>){};
-      MOCK_CONST_METHOD1_T(validate,
-                           boost::optional<ValidationError>(const T &));
+      MOCK_CONST_METHOD1_T(validate, std::optional<ValidationError>(const T &));
     };
 
   }  // namespace validation

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -274,7 +274,7 @@ class ValidatorsTest : public ::testing::Test {
   std::string domain_id;
   std::string detail_key;
   std::string detail_value;
-  boost::optional<std::string> detail_old_value;
+  std::optional<std::string> detail_old_value;
   std::string description;
   std::string public_key;
   std::string hash;


### PR DESCRIPTION
### Description of the Change
As C++17 was enabled in master branch, it is possible to replace several boost components with standard library, such as optional. This pull request replaces boost optional in shared model.
- Enable SOCI support for `std::optional`

Major replacements:
- `boost::optional` -> `std::optional`
- `boost::make_optional` -> `std::make_optional`
- `boost::optional<T&>` -> `std::optional<std::reference_wrapper<T>>`
- `boost::none` -> `std::nullopt`
- `#include <boost.*optional.*>` -> `#include <optional>`

### Benefits
Less boost dependencies

### Possible Drawbacks 
None