### PR TITLE
Implemented read_all blocks and reorganized storage tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2018"
 chashmap = "2.2.2"
 bincode = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
-async-std = "1.5.0"
+
+[dependencies.async-std]
+version = "1.5.0"
+features = ["attributes"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/storage/kura.rs
+++ b/src/storage/kura.rs
@@ -309,16 +309,14 @@ impl Disk {
         Ok(model::Block::from(buffer))
     }
 
-    /// returns a sorted vector of blocks starting from 0 height to the top block
+    /// Returns a sorted vector of blocks starting from 0 height to the top block.
     async fn read_all(&self) -> Vec<model::Block> {
         let mut height = 0;
         let mut blocks = Vec::new();
-
         while let Ok(block) = self.read(height).await {
             blocks.push(block);
             height += 1;
         }
-
         blocks
     }
 }

--- a/src/storage/kura.rs
+++ b/src/storage/kura.rs
@@ -309,6 +309,7 @@ impl Disk {
         Ok(model::Block::from(buffer))
     }
 
+    /// returns a sorted vector of blocks starting from 0 height to the top block
     async fn read_all(&self) -> Vec<model::Block> {
         let mut height = 0;
         let mut blocks = Vec::new();

--- a/src/storage/kura.rs
+++ b/src/storage/kura.rs
@@ -269,12 +269,12 @@ impl Disk {
         format!("{}", block_height)
     }
 
-    fn get_block_path(&mut self, block_height: u64) -> PathBuf {
+    fn get_block_path(&self, block_height: u64) -> PathBuf {
         self.block_store_location
             .join(Disk::get_block_filename(block_height))
     }
 
-    async fn write(&mut self, block: model::Block) -> Result<model::Hash, String> {
+    async fn write(&self, block: model::Block) -> Result<model::Hash, String> {
         use async_std::fs::File;
         use async_std::prelude::*;
 
@@ -293,7 +293,7 @@ impl Disk {
         }
     }
 
-    async fn read(&mut self, height: u64) -> Result<model::Block, String> {
+    async fn read(&self, height: u64) -> Result<model::Block, String> {
         use async_std::fs::{metadata, File};
         use async_std::prelude::*;
 

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -4,10 +4,8 @@ mod tests {
     use async_std::task;
     use iroha::{model::model, storage::kura};
 
-    #[test]
-    fn transfer_asset_from_account1_to_account2() {
-        //TODO: replace with `strict_init` when validation will be ready.
-        let mut kura = kura::Kura::fast_init();
+    #[async_std::test]
+    async fn transfer_asset_from_account1_to_account2() {
         let create_role_command = model::Command {
             version: 1,
             command_type: 0,
@@ -94,9 +92,9 @@ mod tests {
             previous_block_hash: model::Hash {},
             rejected_transactions_hashes: Option::None,
         };
-        task::block_on(async {
-            assert!(kura.store(block).await.is_ok());
-        });
+        //TODO: replace with `strict_init` when validation will be ready.
+        let mut kura = kura::Kura::fast_init().await;
+        assert!(kura.store(block).await.is_ok());
         assert_eq!(
             kura.world_state_view
                 .get_assets_by_account_id(&account1_id)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

1. implemented read_all
2. reorganized storage tests
3. turned tests with async functions into async tests

Right now read_all assumes that we read blocks starting from `0` and finish when we can't find the block with the next height, meaning there can be no gaps in the sequence. This is an intended behavior.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Read all - implemented
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

What should we do when the sequence on disk is corrupted?

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs *[optional]*

Read all files in a directory and then check and reorder them.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>