### PR TITLE
Backport Short hash

### DIFF
--- a/.jenkinsci/helpers/hash.py
+++ b/.jenkinsci/helpers/hash.py
@@ -29,4 +29,4 @@ parser = argparse.ArgumentParser(description='Calculate MD5 hash for given folde
 parser.add_argument('folder')
 args = parser.parse_args()
 
-print(md5_dir(args.folder))
+print(md5_dir(args.folder)[0:4])


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>
(cherry picked from commit 0ae6b59d18ef5beb1f1e188180fc82f8b2af5b85)

We had problem with windows path(Path is too lobg). In this pr we decries the length of hash https://github.com/hyperledger/iroha/pull/376


### Description of the Change
 1. Backport: Decries the length of hash 


### Benefits
Windows vcpkg builds on master works.

### Possible Drawbacks 

Hash collision.

