### PR TITLE
option to reuse WSV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ if(CCACHE_PROGRAM)
   message(STATUS "ccache enabled (${CCACHE_PROGRAM})")
 endif()
 
-PROJECT(iroha C CXX)
+PROJECT(iroha
+  VERSION 1.2.0
+  LANGUAGES C CXX)
 
 SET(CMAKE_CXX_STANDARD 17)
 

--- a/docs/source/maintenance/index.rst
+++ b/docs/source/maintenance/index.rst
@@ -8,5 +8,6 @@ Hardware requirements, deployment process in details, aspects related to securit
     :maxdepth: 3
     :caption: Table of contents
 
+    restarting_node.rst
     sec-install.rst
     shepherd.rst

--- a/docs/source/maintenance/restarting_node.rst
+++ b/docs/source/maintenance/restarting_node.rst
@@ -1,0 +1,51 @@
+Starting Iroha node with existing WSV
+=====================================
+This will explain some details about reusing existing world state view (aka WSV) database when starting a node in order to minimize the startup.
+
+Please consider the following specifics of reusing WSV, compared to restoring it from block storage:
+
+// table or whatever
+trust point
+reuse: we need to rely on both blockstorage and WSV.
+restore: we trust only the genesis block.
+
+integrity
+reuse: blockstorage and WSV must match each other! iroha will not verify that.
+restore: iroha will check every block while restoring WSV. any error in blockstorage will be found (except genesis block, of course). WSV is guaranteed to match the blockstorage.
+
+time
+reuse: iroha is almost immediately ready to operate in the network.
+restore: the larger blockstorage - the longer time to restore and begin operation.
+
+
+
+Enabling WSV Reuse
+^^^^^^^^^^^^^^^^^^
+
+If you want to reuse WSV state, start Iroha with `--reuse_state` flag.
+Given this flag, Iroha will not reset or overwrite the state database if it fails to start for whatever reason.
+
+State Database Schema version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When reusing existing WSV, iroha performs a schema version compatibility check.
+It will not start or somehow alter a database if its schema is not compatible with the binary.
+
+If your schema was created by iroha of version v1.1.1 or lower, most probably it does not include the version information.
+In this case you need to add it manually.
+You are encouraged to use our script for this purpose, it is located `here <https://github.com/hyperledger/iroha-state-migration-tool/blob/master/state_migration.py>`__.
+To forcefully (i.e. without any `migration process <#changing-iroha-version-migration>`__) set your schema version, launch the script with `--force_schema_version` flag and pass the version of Iroha binary that was used to create your schema.
+
+.. warning::
+  Before forcefully writing the schema version numbers, double check the version of irohad that created the schema.
+  No checks are performed when you force schema numbers, hence it is easy to break the state database in the future (during the next migration).
+
+Changing Iroha version. Migration.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In case you want to change Iroha version while keeping the WSV, you are encouraged to perform a migration.
+Although it might be not necessary (Iroha will refuse to start if the schema is incompatible), generally, we improve the schema and migration will help Iroha perform better and the sun shine brighter blah blah.
+You are encouraged to perform a database backup before migration using standard PostgreSQL guidelines for that.
+
+To perform migration, please use our `script <https://github.com/hyperledger/iroha-state-migration-tool/blob/master/state_migration.py>`__.
+It will load the schema information from the database and match it with migration steps (by default, migration scenarios are defined in ``migration_data`` directory in the same folder as the script).
+Then it will find all migration paths that will transition your database to the desired version and ask you to choose one.

--- a/docs/source/maintenance/restarting_node.rst
+++ b/docs/source/maintenance/restarting_node.rst
@@ -1,22 +1,48 @@
-Starting Iroha node with existing WSV
-=====================================
-This will explain some details about reusing existing world state view (aka WSV) database when starting a node in order to minimize the startup.
+.. raw:: html
 
-Please consider the following specifics of reusing WSV, compared to restoring it from block storage:
+    <style> .red {color:#aa0060; font-weight:bold; font-size:16px} </style>
 
-// table or whatever
-trust point
-reuse: we need to rely on both blockstorage and WSV.
-restore: we trust only the genesis block.
+.. role:: red
 
-integrity
-reuse: blockstorage and WSV must match each other! iroha will not verify that.
-restore: iroha will check every block while restoring WSV. any error in blockstorage will be found (except genesis block, of course). WSV is guaranteed to match the blockstorage.
+Restarting Iroha node with existing WSV
+=======================================
 
-time
-reuse: iroha is almost immediately ready to operate in the network.
-restore: the larger blockstorage - the longer time to restore and begin operation.
+Previously, in cases when you had to update a node or it shut down for some reason, there was only one option of re-reading all of the blocks to recreate consistent `world state view (aka WSV) <../concepts_architecture/architecture.html#world-state-view>`__.
+To start up a node quicker, it is now possible to reuse an existing WSV database after a quick check.
+For that, ``hash`` of the top block and the ``height`` of the blockstorage are included in the WSV.
 
+.. warning::
+	It is up to Administrators of the node to make sure the WSV is not edited manually – only by Iroha or the `migration script <#changing-iroha-version-migration>`__.
+	Manual editing or editing of the migration script not following a trustworthy guideline can lead to inconsistent network.
+	Only do so at your own risk (we warned you).
+
+Although it can be a great idea for some of the cases, but please consider that there are certain specifics of reusing WSV, compared to restoring it from blockstorage:
+
+| :red:`Trust point`
+| **Reusing WSV:** we need to rely on both blockstorage and WSV.
+| **Restore WSV from block storage:** we trust only the genesis block.
+
+
+| :red:`Integrity`
+| **Reusing WSV:** blockstorage and WSV must match each other! Iroha will not check for that.
+| **Restore WSV from block storage:** Iroha will check every block, while restoring WSV.
+	Any error in blockstorage will be found (except genesis block, of course).
+	WSV is guaranteed to match the blockstorage.
+
+| :red:`Time`
+| **Reusing WSV:** Iroha is almost immediately ready to operate in the network.
+| **Restore WSV from block storage:** the larger blockstorage - the longer it takes to restore it and begin operation.
+
+.. note:: If the local ledger that shut down has more blocks than it should and the correct WSV is among them - it is ok, Iroha will take the WSV of the correct block.
+	If blocks are less than should be – the option of reusing WSV will not work for you.
+	Please, restore it from blocks.
+
+
+Enabling WSV Reuse
+^^^^^^^^^^^^^^^^^^
+
+If you want to reuse WSV state, start Iroha with `--reuse_state` flag.
+Given this flag, Iroha will not reset or overwrite the state database if it fails to start for whatever reason.
 
 
 Enabling WSV Reuse
@@ -28,10 +54,10 @@ Given this flag, Iroha will not reset or overwrite the state database if it fail
 State Database Schema version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When reusing existing WSV, iroha performs a schema version compatibility check.
-It will not start or somehow alter a database if its schema is not compatible with the binary.
+When reusing existing WSV, Iroha performs a schema version compatibility check.
+It will not start or somehow alter the database, if its schema is not compatible with the Iroha in use.
 
-If your schema was created by iroha of version v1.1.1 or lower, most probably it does not include the version information.
+If your schema was created by Iroha of version v1.1.1 or lower, most likely it does not include the version information.
 In this case you need to add it manually.
 You are encouraged to use our script for this purpose, it is located `here <https://github.com/hyperledger/iroha-state-migration-tool/blob/master/state_migration.py>`__.
 To forcefully (i.e. without any `migration process <#changing-iroha-version-migration>`__) set your schema version, launch the script with `--force_schema_version` flag and pass the version of Iroha binary that was used to create your schema.
@@ -43,8 +69,8 @@ To forcefully (i.e. without any `migration process <#changing-iroha-version-migr
 Changing Iroha version. Migration.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In case you want to change Iroha version while keeping the WSV, you are encouraged to perform a migration.
-Although it might be not necessary (Iroha will refuse to start if the schema is incompatible), generally, we improve the schema and migration will help Iroha perform better and the sun shine brighter blah blah.
-You are encouraged to perform a database backup before migration using standard PostgreSQL guidelines for that.
+Although it might be unnecessary (Iroha will refuse to start if the schema is incompatible), as a general rule, we improve the schema with each version and migration might be a good idea for a better performance.
+You are encouraged to perform a database backup before migration using standard `PostgreSQL guidelines <https://www.postgresql.org/docs/current/backup.html>`__ for that.
 
 To perform migration, please use our `script <https://github.com/hyperledger/iroha-state-migration-tool/blob/master/state_migration.py>`__.
 It will load the schema information from the database and match it with migration steps (by default, migration scenarios are defined in ``migration_data`` directory in the same folder as the script).

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -137,7 +137,10 @@ namespace iroha {
 
     expected::Result<MutableStorage::CommitResult, std::string>
     MutableStorageImpl::commit() && {
-      assert(not committed);
+      if (committed) {
+        assert(not committed);
+        return "Tried to commit mutable storage twice.";
+      }
       assert(ledger_state_);
       try {
         sql_ << "COMMIT";

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -135,17 +135,18 @@ namespace iroha {
       return ledger_state_;
     }
 
-    expected::Result<void, std::string> MutableStorageImpl::commit() {
-      if (committed) {
-        return "Tried to commit mutable storage twice.";
-      }
+    expected::Result<MutableStorage::CommitResult, std::string>
+    MutableStorageImpl::commit() && {
+      assert(not committed);
+      assert(ledger_state_);
       try {
         sql_ << "COMMIT";
         committed = true;
       } catch (std::exception &e) {
         return expected::makeError(e.what());
       }
-      return expected::Value<void>{};
+      return MutableStorage::CommitResult{ledger_state_.value(),
+                                          std::move(block_storage_)};
     }
 
     MutableStorageImpl::~MutableStorageImpl() {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -141,7 +141,10 @@ namespace iroha {
         assert(not committed);
         return "Tried to commit mutable storage twice.";
       }
-      assert(ledger_state_);
+      if (not ledger_state_) {
+        assert(ledger_state_);
+        return "Tried to commit mutable storage with no blocks applied.";
+      }
       try {
         sql_ << "COMMIT";
         committed = true;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -5,6 +5,7 @@
 
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
 
+#include <fmt/core.h>
 #include <boost/variant/apply_visitor.hpp>
 #include <rxcpp/operators/rx-all.hpp>
 #include "ametsuchi/command_executor.hpp"
@@ -30,6 +31,7 @@ namespace iroha {
         logger::LoggerManagerTreePtr log_manager)
         : ledger_state_(std::move(ledger_state)),
           sql_(command_executor->getSession()),
+          wsv_command_(std::make_unique<PostgresWsvCommand>(sql_)),
           peer_query_(
               std::make_unique<PeerQueryWsv>(std::make_shared<PostgresWsvQuery>(
                   sql_, log_manager->getChild("WsvQuery")->getLogger()))),
@@ -67,6 +69,13 @@ namespace iroha {
                           block->transactions().end(),
                           execute_transaction);
       if (block_applied) {
+        if (auto e =
+                expected::resultToOptionalError(wsv_command_->setTopBlockInfo(
+                    TopBlockInfo{block->height(), block->hash()}))) {
+          log_->error("{}", e.value());
+          return false;
+        }
+
         block_storage_->insert(block);
         block_index_->index(*block);
 
@@ -124,6 +133,19 @@ namespace iroha {
     boost::optional<std::shared_ptr<const iroha::LedgerState>>
     MutableStorageImpl::getLedgerState() const {
       return ledger_state_;
+    }
+
+    expected::Result<void, std::string> MutableStorageImpl::commit() {
+      if (committed) {
+        return "Tried to commit mutable storage twice.";
+      }
+      try {
+        sql_ << "COMMIT";
+        committed = true;
+      } catch (std::exception &e) {
+        return expected::makeError(e.what());
+      }
+      return expected::Value<void>{};
     }
 
     MutableStorageImpl::~MutableStorageImpl() {

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <soci/soci.h>
 #include "ametsuchi/block_storage.hpp"
+#include "common/result.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
@@ -19,6 +20,7 @@ namespace iroha {
     class BlockIndex;
     class PeerQuery;
     class PostgresCommandExecutor;
+    class PostgresWsvCommand;
     class TransactionExecutor;
 
     class MutableStorageImpl : public MutableStorage {
@@ -42,6 +44,8 @@ namespace iroha {
       boost::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const;
 
+      expected::Result<void, std::string> commit() override;
+
       ~MutableStorageImpl() override;
 
      private:
@@ -63,6 +67,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
 
       soci::session &sql_;
+      std::unique_ptr<PostgresWsvCommand> wsv_command_;
       std::unique_ptr<PeerQuery> peer_query_;
       std::unique_ptr<BlockIndex> block_index_;
       std::shared_ptr<TransactionExecutor> transaction_executor_;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -44,7 +44,7 @@ namespace iroha {
       boost::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const;
 
-      expected::Result<void, std::string> commit() override;
+      expected::Result<CommitResult, std::string> commit() && override;
 
       ~MutableStorageImpl() override;
 

--- a/irohad/ametsuchi/impl/postgres_wsv_command.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.cpp
@@ -11,6 +11,7 @@
 #include <boost/format.hpp>
 #include "ametsuchi/impl/soci_std_optional.hpp"
 #include "ametsuchi/impl/soci_string_view.hpp"
+#include "ametsuchi/ledger_state.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/account_asset.hpp"
@@ -406,6 +407,21 @@ namespace iroha {
       };
 
       return execute(st, msg);
+    }
+
+    WsvCommandResult PostgresWsvCommand::setTopBlockInfo(
+        const TopBlockInfo &top_block_info) const {
+      try {
+        sql_ << "insert into top_block_info (height, hash) "
+                "values (:height, :hash) "
+                "on conflict (lock) do update "
+                "set height = :height, hash = :hash;",
+            soci::use(top_block_info.height, "height"),
+            soci::use(top_block_info.top_hash.hex(), "hash");
+        return expected::Value<void>{};
+      } catch (std::exception &e) {
+        return fmt::format("Failed to set top_block_info: {}.", e.what());
+      }
     }
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_wsv_command.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_command.hpp
@@ -78,6 +78,9 @@ namespace iroha {
           const shared_model::interface::types::AccountIdType &account_id,
           shared_model::interface::permissions::Grantable permission) override;
 
+      WsvCommandResult setTopBlockInfo(
+          const TopBlockInfo &top_block_info) const override;
+
      private:
       soci::session &sql_;
     };

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -8,6 +8,7 @@
 #include <soci/boost-tuple.h>
 #include "ametsuchi/impl/soci_std_optional.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
+#include "ametsuchi/ledger_state.hpp"
 #include "backend/plain/peer.hpp"
 #include "common/result.hpp"
 #include "logger/logger.hpp"
@@ -102,5 +103,27 @@ namespace iroha {
         return boost::none;
       };
     }
+
+    iroha::expected::Result<iroha::TopBlockInfo, std::string>
+    PostgresWsvQuery::getTopBlockInfo() const {
+      try {
+        soci::rowset<boost::tuple<size_t, std::string>> rowset(
+            sql_.prepare << "select height, hash from top_block_info;");
+        auto range = boost::make_iterator_range(rowset.begin(), rowset.end());
+        if (range.empty()) {
+          return "No top block information in WSV.";
+        }
+        shared_model::interface::types::HeightType height = 0;
+        std::string hex_hash;
+        boost::tie(height, hex_hash) = range.front();
+        shared_model::crypto::Hash hash(
+            shared_model::crypto::Blob::fromHexString(hex_hash));
+        assert(not hash.blob().empty());
+        return iroha::TopBlockInfo{height, hash};
+      } catch (std::exception &e) {
+        return e.what();
+      }
+    }
+
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -32,6 +32,9 @@ namespace iroha {
       getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
                              public_key) override;
 
+      iroha::expected::Result<iroha::TopBlockInfo, std::string>
+      getTopBlockInfo() const override;
+
      private:
       /**
        * Executes given lambda of type F, catches exceptions if any, logs the

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <boost/range/algorithm/replace_if.hpp>
+#include <boost/tuple/tuple.hpp>
 #include "ametsuchi/impl/mutable_storage_impl.hpp"
 #include "ametsuchi/impl/peer_query_wsv.hpp"
 #include "ametsuchi/impl/postgres_block_index.hpp"
@@ -19,12 +20,14 @@
 #include "ametsuchi/impl/postgres_block_storage_factory.hpp"
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_indexer.hpp"
+#include "ametsuchi/impl/postgres_options.hpp"
 #include "ametsuchi/impl/postgres_query_executor.hpp"
 #include "ametsuchi/impl/postgres_setting_query.hpp"
 #include "ametsuchi/impl/postgres_specific_query_executor.hpp"
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
 #include "ametsuchi/impl/temporary_wsv_impl.hpp"
+#include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/tx_executor.hpp"
 #include "backend/protobuf/permissions.hpp"
 #include "common/bind.hpp"
@@ -43,8 +46,8 @@ namespace iroha {
 
     StorageImpl::StorageImpl(
         boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state,
-        std::unique_ptr<ametsuchi::PostgresOptions> postgres_options,
-        std::unique_ptr<BlockStorage> block_store,
+        const ametsuchi::PostgresOptions &postgres_options,
+        std::shared_ptr<BlockStorage> block_store,
         std::shared_ptr<PoolWrapper> pool_wrapper,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
@@ -54,8 +57,7 @@ namespace iroha {
         std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
         size_t pool_size,
         logger::LoggerManagerTreePtr log_manager)
-        : postgres_options_(std::move(postgres_options)),
-          block_store_(std::move(block_store)),
+        : block_store_(std::move(block_store)),
           pool_wrapper_(std::move(pool_wrapper)),
           connection_(pool_wrapper_->connection_pool_),
           notifier_(notifier_lifetime_),
@@ -70,7 +72,7 @@ namespace iroha {
           prepared_blocks_enabled_(
               pool_wrapper_->enable_prepared_transactions_),
           block_is_prepared_(false),
-          prepared_block_name_(postgres_options_->preparedBlockName()),
+          prepared_block_name_(postgres_options.preparedBlockName()),
           ledger_state_(std::move(ledger_state)) {}
 
     std::unique_ptr<TemporaryWsv> StorageImpl::createTemporaryWsv(
@@ -194,29 +196,6 @@ namespace iroha {
           log_manager_->getChild("MutableStorageImpl"));
     }
 
-    void StorageImpl::reset() {
-      resetWsv().match(
-          [this](auto &&v) {
-            log_->debug("drop blocks from disk");
-            block_store_->clear();
-          },
-          [this](auto &&e) {
-            log_->warn("Failed to drop WSV. Reason: {}", e.error);
-          });
-    }
-
-    expected::Result<void, std::string> StorageImpl::resetWsv() {
-      log_->debug("drop wsv records from db tables");
-      try {
-        soci::session sql(*connection_);
-        // rollback possible prepared transaction
-        tryRollback(sql);
-        return PgConnectionInit::resetWsv(sql);
-      } catch (std::exception &e) {
-        return expected::makeError(e.what());
-      }
-    }
-
     void StorageImpl::resetPeers() {
       log_->info("Remove everything from peers table");
       soci::session sql(*connection_);
@@ -224,28 +203,19 @@ namespace iroha {
           [this](const auto &e) { this->log_->error("{}", e); };
     }
 
-    void StorageImpl::dropStorage() {
-      log_->info("drop storage");
-      if (connection_ == nullptr) {
-        log_->warn("Tried to drop storage without active connection");
-        return;
-      }
-
-      std::unique_lock<std::shared_timed_mutex> lock(drop_mutex_);
-
-      // erase blocks
-      log_->info("drop block store");
+    expected::Result<void, std::string> StorageImpl::dropBlockStorage() {
+      log_->info("drop block storage");
       block_store_->clear();
+      return iroha::expected::Value<void>{};
+    }
 
-      freeConnections();
-      log_->info("Drop database {}", postgres_options_->workingDbName());
-      if (auto e = expected::resultToOptionalError(
-              PgConnectionInit::dropWorkingDatabase(*postgres_options_))) {
-        log_->warn(e.value());
-      }
+    boost::optional<std::shared_ptr<const iroha::LedgerState>>
+    StorageImpl::getLedgerState() const {
+      return ledger_state_;
     }
 
     void StorageImpl::freeConnections() {
+      std::unique_lock<std::shared_timed_mutex> lock(drop_mutex_);
       if (connection_ == nullptr) {
         log_->warn("Tried to free connections without active connection");
         return;
@@ -267,7 +237,7 @@ namespace iroha {
 
     expected::Result<std::shared_ptr<StorageImpl>, std::string>
     StorageImpl::create(
-        std::unique_ptr<ametsuchi::PostgresOptions> postgres_options,
+        const ametsuchi::PostgresOptions &postgres_options,
         std::shared_ptr<PoolWrapper> pool_wrapper,
         std::shared_ptr<shared_model::interface::PermissionToString>
             perm_converter,
@@ -275,63 +245,31 @@ namespace iroha {
         std::shared_ptr<shared_model::interface::QueryResponseFactory>
             query_response_factory,
         std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
-        std::unique_ptr<BlockStorage> persistent_block_storage,
+        std::shared_ptr<BlockStorage> persistent_block_storage,
         logger::LoggerManagerTreePtr log_manager,
         size_t pool_size) {
-      auto opt_ledger_state = [&] {
+      boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state;
+      {
         soci::session sql{*pool_wrapper->connection_pool_};
+        PostgresWsvQuery wsv_query(
+            sql, log_manager->getChild("WsvQuery")->getLogger());
 
-        using BlockInfoResult =
-            expected::Result<iroha::TopBlockInfo, std::string>;
-        auto get_top_block_info = [&]() -> BlockInfoResult {
-          PostgresBlockQuery block_query(
-              sql,
-              *persistent_block_storage,
-              log_manager->getChild("PostgresBlockQuery")->getLogger());
-          const auto ledger_height = block_query.getTopBlockHeight();
-          return block_query.getBlock(ledger_height)
-              .match(
-                  [&ledger_height](const auto &block) -> BlockInfoResult {
-                    return expected::makeValue(iroha::TopBlockInfo{
-                        ledger_height, block.value->hash()});
-                  },
-                  [](auto &&err) -> BlockInfoResult {
-                    return std::move(err).error.message;
-                  });
-        };
-
-        auto get_ledger_peers = [&]()
-            -> expected::Result<
-                std::vector<std::shared_ptr<shared_model::interface::Peer>>,
-                std::string> {
-          PostgresWsvQuery peer_query(
-              sql, log_manager->getChild("WsvQuery")->getLogger());
-          return expected::optionalValueToResult(
-              peer_query.getPeers(),
-              std::string{"Failed to get ledger peers!"});
-        };
-
-        return expected::resultToOptionalValue(
-            get_top_block_info() | [&](auto &&top_block_info) {
-              return get_ledger_peers().match(
-                  [&top_block_info](auto &&ledger_peers_value)
-                      -> expected::Result<
-                          std::shared_ptr<const iroha::LedgerState>,
-                          std::string> {
-                    return expected::makeValue(
+        ledger_state =
+            expected::resultToOptionalValue(wsv_query.getTopBlockInfo()) |
+            [&](auto &&top_block_info) {
+              return wsv_query.getPeers() |
+                  [&top_block_info](auto &&ledger_peers) {
+                    return boost::make_optional(
                         std::make_shared<const iroha::LedgerState>(
-                            std::move(ledger_peers_value).value,
+                            std::move(ledger_peers),
                             top_block_info.height,
                             top_block_info.top_hash));
-                  },
-                  [](auto &&e) -> expected::Result<
-                                   std::shared_ptr<const iroha::LedgerState>,
-                                   std::string> { return std::move(e); });
-            });
-      }();
+                  };
+            };
+      }
 
       return expected::makeValue(std::shared_ptr<StorageImpl>(
-          new StorageImpl(std::move(opt_ledger_state),
+          new StorageImpl(std::move(ledger_state),
                           std::move(postgres_options),
                           std::move(persistent_block_storage),
                           std::move(pool_wrapper),
@@ -347,25 +285,19 @@ namespace iroha {
         std::unique_ptr<MutableStorage> mutable_storage) {
       auto storage = static_cast<MutableStorageImpl *>(mutable_storage.get());
 
-      try {
-        storage->sql_ << "COMMIT";
-      } catch (std::exception &e) {
-        storage->committed = false;
-        return expected::makeError(e.what());
-      }
-      storage->committed = true;
+      return storage->commit() | [&storage, this]() -> CommitResult {
+        storage->block_storage_->forEach(
+            [this](const auto &block) { this->storeBlock(block); });
 
-      storage->block_storage_->forEach(
-          [this](const auto &block) { this->storeBlock(block); });
-
-      ledger_state_ = storage->getLedgerState();
-      if (ledger_state_) {
-        return expected::makeValue(ledger_state_.value());
-      } else {
-        return expected::makeError(
-            "This should never happen - a missing ledger state after a "
-            "successful commit!");
-      }
+        ledger_state_ = storage->getLedgerState();
+        if (ledger_state_) {
+          return expected::makeValue(ledger_state_.value());
+        } else {
+          return expected::makeError(
+              "This should never happen - a missing ledger state after a "
+              "successful commit!");
+        }
+      };
     }
 
     bool StorageImpl::preparedCommitEnabled() const {
@@ -399,6 +331,12 @@ namespace iroha {
             log_manager_->getChild("BlockIndex")->getLogger());
         block_index.index(*block);
         block_is_prepared_ = false;
+
+        if (auto e = expected::resultToOptionalError(
+                PostgresWsvCommand{sql}.setTopBlockInfo(
+                    TopBlockInfo{block->height(), block->hash()}))) {
+          throw std::runtime_error(e.value());
+        }
 
         return storeBlock(block) | [this, &sql, &block]() -> CommitResult {
           decltype(

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -16,7 +16,6 @@
 #include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/impl/pool_wrapper.hpp"
-#include "ametsuchi/impl/postgres_options.hpp"
 #include "ametsuchi/key_value_storage.hpp"
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/reconnection_strategy.hpp"
@@ -29,16 +28,19 @@ namespace shared_model {
     class QueryResponseFactory;
   }  // namespace interface
 }  // namespace shared_model
-
 namespace iroha {
 
   class PendingTransactionStorage;
 
   namespace ametsuchi {
+
+    class AmetsuchiTest;
+    class PostgresOptions;
+
     class StorageImpl : public Storage {
      public:
       static expected::Result<std::shared_ptr<StorageImpl>, std::string> create(
-          std::unique_ptr<ametsuchi::PostgresOptions> postgres_options,
+          const PostgresOptions &postgres_options,
           std::shared_ptr<PoolWrapper> pool_wrapper,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
@@ -46,7 +48,7 @@ namespace iroha {
           std::shared_ptr<shared_model::interface::QueryResponseFactory>
               query_response_factory,
           std::unique_ptr<BlockStorageFactory> temporary_block_storage_factory,
-          std::unique_ptr<BlockStorage> persistent_block_storage,
+          std::shared_ptr<BlockStorage> persistent_block_storage,
           logger::LoggerManagerTreePtr log_manager,
           size_t pool_size = 10);
 
@@ -84,13 +86,12 @@ namespace iroha {
           std::shared_ptr<CommandExecutor> command_executor,
           BlockStorageFactory &storage_factory) override;
 
-      void reset() override;
-
-      expected::Result<void, std::string> resetWsv() override;
-
       void resetPeers() override;
 
-      void dropStorage() override;
+      expected::Result<void, std::string> dropBlockStorage() override;
+
+      boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      getLedgerState() const override;
 
       void freeConnections() override;
 
@@ -117,8 +118,8 @@ namespace iroha {
       StorageImpl(
           boost::optional<std::shared_ptr<const iroha::LedgerState>>
               ledger_state,
-          std::unique_ptr<ametsuchi::PostgresOptions> postgres_options,
-          std::unique_ptr<BlockStorage> block_store,
+          const PostgresOptions &postgres_options,
+          std::shared_ptr<BlockStorage> block_store,
           std::shared_ptr<PoolWrapper> pool_wrapper,
           std::shared_ptr<shared_model::interface::PermissionToString>
               perm_converter,
@@ -129,11 +130,10 @@ namespace iroha {
           size_t pool_size,
           logger::LoggerManagerTreePtr log_manager);
 
-      // db info
-      const std::unique_ptr<ametsuchi::PostgresOptions> postgres_options_;
-
      private:
       using StoreBlockResult = iroha::expected::Result<void, std::string>;
+
+      friend class ::iroha::ametsuchi::AmetsuchiTest;
 
       /**
        * add block to block storage
@@ -146,7 +146,7 @@ namespace iroha {
        */
       void tryRollback(soci::session &session);
 
-      std::unique_ptr<BlockStorage> block_store_;
+      std::shared_ptr<BlockStorage> block_store_;
 
       std::shared_ptr<PoolWrapper> pool_wrapper_;
 

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -11,7 +11,11 @@
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "ametsuchi/storage.hpp"
+#include "common/bind.hpp"
 #include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger.hpp"
+
+using shared_model::interface::types::HeightType;
 
 namespace {
   /**
@@ -34,7 +38,7 @@ namespace {
      * during WSV reindexing
      */
     boost::optional<std::shared_ptr<const shared_model::interface::Block>>
-    fetch(shared_model::interface::types::HeightType height) const override {
+    fetch(HeightType height) const override {
       return boost::none;
     }
 
@@ -66,15 +70,17 @@ namespace {
    * @param storage - current storage
    * @param mutable_storage - mutable storage without blocks
    * @param block_query - current block storage
+   * @param starting_height - the first block to apply
+   * @param ending_height - the last block to apply (inclusive)
    * @return commit status after applying the blocks
    */
   iroha::ametsuchi::CommitResult reindexBlocks(
       iroha::ametsuchi::Storage &storage,
       std::unique_ptr<iroha::ametsuchi::MutableStorage> &mutable_storage,
-      std::shared_ptr<iroha::ametsuchi::BlockQuery> &block_query) {
-    // apply all blocks starting from the genesis
-    auto top_height = block_query->getTopBlockHeight();
-    for (decltype(top_height) i = 1; i <= top_height; ++i) {
+      std::shared_ptr<iroha::ametsuchi::BlockQuery> &block_query,
+      HeightType starting_height,
+      HeightType ending_height) {
+    for (auto i = starting_height; i <= ending_height; ++i) {
       auto result = block_query->getBlock(i).match(
           [&mutable_storage](
               auto &&block) -> iroha::expected::Result<void, std::string> {
@@ -110,10 +116,61 @@ namespace iroha {
           return expected::makeError("Cannot create BlockQuery");
         }
 
-        return storage.resetWsv() |
-            [&storage, &mutable_storage, &block_query]() {
-              return reindexBlocks(storage, mutable_storage, block_query);
-            };
+        const auto last_block_in_storage = block_query->getTopBlockHeight();
+        const auto wsv_ledger_state = storage.getLedgerState();
+
+        shared_model::interface::types::HeightType wsv_ledger_height;
+        if (wsv_ledger_state) {
+          const auto &wsv_top_block_info =
+              wsv_ledger_state.value()->top_block_info;
+          wsv_ledger_height = wsv_top_block_info.height;
+          if (wsv_ledger_height > last_block_in_storage) {
+            return fmt::format(
+                "WSV state (height {}) is more recent "
+                "than block storage (height {}).",
+                wsv_ledger_height,
+                last_block_in_storage);
+          }
+          // check that a block with that height is present in the block storage
+          // and that its hash matches
+          auto check_top_block =
+              block_query->getBlock(wsv_top_block_info.height)
+                  .match(
+                      [&wsv_top_block_info](
+                          const auto &block_from_block_storage)
+                          -> expected::Result<void, std::string> {
+                        if (block_from_block_storage.value->hash()
+                            != wsv_top_block_info.top_hash) {
+                          return fmt::format(
+                              "The hash of block applied to WSV ({}) "
+                              "does not match the hash of the block "
+                              "from block storage ({}).",
+                              wsv_top_block_info.top_hash,
+                              block_from_block_storage.value->hash());
+                        }
+                        return expected::Value<void>{};
+                      },
+                      [](expected::Error<BlockQuery::GetBlockError> &&error)
+                          -> expected::Result<void, std::string> {
+                        return std::move(error).error.message;
+                      });
+          if (auto e = expected::resultToOptionalError(check_top_block)) {
+            return fmt::format(
+                "WSV top block (height {}) check failed: {} "
+                "Please check that WSV matches block storage "
+                "or avoid reusing WSV.",
+                wsv_ledger_height,
+                e.value());
+          }
+        } else {
+          wsv_ledger_height = 0;
+        }
+
+        return reindexBlocks(storage,
+                             mutable_storage,
+                             block_query,
+                             wsv_ledger_height + 1,
+                             last_block_in_storage);
       };
     }
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
@@ -6,8 +6,9 @@
 #ifndef IROHA_WSVRESTORERIMPL_HPP
 #define IROHA_WSVRESTORERIMPL_HPP
 
-#include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/wsv_restorer.hpp"
+
+#include "ametsuchi/ledger_state.hpp"
 #include "common/result.hpp"
 
 namespace iroha {

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -10,6 +10,7 @@
 
 #include <rxcpp/rx-observable-fwd.hpp>
 #include "ametsuchi/ledger_state.hpp"
+#include "common/result.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -58,6 +59,9 @@ namespace iroha {
           rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
               blocks,
           MutableStoragePredicate predicate) = 0;
+
+      /// Apply the local changes made to this MutableStorage to the global WSV.
+      virtual expected::Result<void, std::string> commit() = 0;
 
       virtual ~MutableStorage() = default;
     };

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include <rxcpp/rx-observable-fwd.hpp>
+#include "ametsuchi/block_storage.hpp"
 #include "ametsuchi/ledger_state.hpp"
 #include "common/result.hpp"
 #include "interfaces/common_objects/types.hpp"
@@ -20,6 +21,8 @@ namespace shared_model {
 }  // namespace shared_model
 
 namespace iroha {
+  struct LedgerState;
+
   namespace ametsuchi {
 
     class WsvQuery;
@@ -39,6 +42,11 @@ namespace iroha {
       using MutableStoragePredicate = std::function<bool(
           std::shared_ptr<const shared_model::interface::Block>,
           const LedgerState &)>;
+
+      struct CommitResult {
+        std::shared_ptr<const LedgerState> ledger_state;
+        std::unique_ptr<BlockStorage> block_storage;
+      };
 
       /**
        * Applies block without additional validation function
@@ -61,7 +69,8 @@ namespace iroha {
           MutableStoragePredicate predicate) = 0;
 
       /// Apply the local changes made to this MutableStorage to the global WSV.
-      virtual expected::Result<void, std::string> commit() = 0;
+      virtual expected::Result<MutableStorage::CommitResult, std::string>
+      commit() && = 0;
 
       virtual ~MutableStorage() = default;
     };

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -88,27 +88,17 @@ namespace iroha {
       on_commit() = 0;
 
       /**
-       * Remove all records from the tables and remove all the blocks
-       */
-      virtual void reset() = 0;
-
-      /*
-       * Remove all records from the tables
-       * @return error message if reset has failed
-       */
-      virtual expected::Result<void, std::string> resetWsv() = 0;
-
-      /**
        * Removes all peers from WSV
        */
       virtual void resetPeers() = 0;
 
       /**
-       * Remove all information from ledger
-       * Tables and the database will be removed too
-       * TODO: 2019-05-22 @muratovv move method to TestStorage IR-493
+       * Remove all blocks from block storage.
        */
-      virtual void dropStorage() = 0;
+      virtual expected::Result<void, std::string> dropBlockStorage() = 0;
+
+      virtual boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      getLedgerState() const = 0;
 
       virtual void freeConnections() = 0;
 

--- a/irohad/ametsuchi/wsv_command.hpp
+++ b/irohad/ametsuchi/wsv_command.hpp
@@ -25,6 +25,8 @@ namespace shared_model {
 }  // namespace shared_model
 
 namespace iroha {
+  struct TopBlockInfo;
+
   namespace ametsuchi {
 
     /**
@@ -220,6 +222,14 @@ namespace iroha {
        */
       virtual WsvCommandResult insertDomain(
           const shared_model::interface::Domain &domain) = 0;
+
+      /**
+       * Set the top block info in ledger state.
+       * @param top_block_info the info to be written to wsv
+       * @return WsvCommandResult, which will contain error in case of failure
+       */
+      virtual WsvCommandResult setTopBlockInfo(
+          const TopBlockInfo &top_block_info) const = 0;
     };
 
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -9,10 +9,13 @@
 #include <vector>
 
 #include <boost/optional.hpp>
+#include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/string_view_types.hpp"
 
 namespace iroha {
+  struct TopBlockInfo;
+
   namespace ametsuchi {
     /**
      *  Public interface for world state view queries
@@ -44,6 +47,10 @@ namespace iroha {
       virtual boost::optional<std::shared_ptr<shared_model::interface::Peer>>
       getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
                              public_key) = 0;
+
+      /// Get top block info from ledger state.
+      virtual iroha::expected::Result<iroha::TopBlockInfo, std::string>
+      getTopBlockInfo() const = 0;
     };
 
   }  // namespace ametsuchi

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -69,6 +69,10 @@ namespace iroha {
         notifier_lifetime_.unsubscribe();
       }
 
+      void Yac::stop() {
+        network_->stop();
+      }
+
       // ------|Hash gate|------
 
       void Yac::vote(YacHash hash,
@@ -193,7 +197,7 @@ namespace iroha {
 
         log_->info("Vote {} to peer {}", vote, current_leader);
 
-        network_->sendState(current_leader, {vote});
+        propagateStateDirectly(current_leader, {vote});
         cluster_order.switchToNext();
         lock.unlock();
         timer_->invokeAfterDelay([this, vote] { this->votingStep(vote); });

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -117,6 +117,10 @@ namespace iroha {
         return published_events_;
       }
 
+      void YacGateImpl::stop() {
+        hash_gate_->stop();
+      }
+
       void YacGateImpl::copySignatures(const CommitMessage &commit) {
         for (const auto &vote : commit.votes) {
           auto sig = vote.hash.block_signature;

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -45,6 +45,8 @@ namespace iroha {
 
         rxcpp::observable<GateObject> onOutcome() override;
 
+        void stop() override;
+
        private:
         /**
          * Update current block with signatures from commit message

--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -35,8 +35,19 @@ namespace iroha {
         handler_ = handler;
       }
 
+      void NetworkImpl::stop() {
+        std::lock_guard<std::mutex> stop_lock(stop_mutex_);
+        stop_requested_ = true;
+      }
+
       void NetworkImpl::sendState(const shared_model::interface::Peer &to,
                                   const std::vector<VoteMessage> &state) {
+        std::lock_guard<std::mutex> stop_lock(stop_mutex_);
+        if (stop_requested_) {
+          log_->warn("Not sending state to {} because stop was requested.", to);
+          return;
+        }
+
         createPeerConnection(to);
 
         proto::State request;

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -10,6 +10,7 @@
 #include "yac.grpc.pb.h"
 
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 #include "consensus/yac/outcome_messages.hpp"
@@ -52,6 +53,8 @@ namespace iroha {
             const ::iroha::consensus::yac::proto::State *request,
             ::google::protobuf::Empty *response) override;
 
+        void stop() override;
+
        private:
         /**
          * Create GRPC connection for given peer if it does not exist in
@@ -84,6 +87,9 @@ namespace iroha {
         std::function<std::unique_ptr<proto::Yac::StubInterface>(
             const shared_model::interface::Peer &)>
             client_creator_;
+
+        std::mutex stop_mutex_;
+        bool stop_requested_{false};
 
         logger::LoggerPtr log_;
       };

--- a/irohad/consensus/yac/transport/yac_network_interface.hpp
+++ b/irohad/consensus/yac/transport/yac_network_interface.hpp
@@ -45,6 +45,9 @@ namespace iroha {
         virtual void sendState(const shared_model::interface::Peer &to,
                                const std::vector<VoteMessage> &state) = 0;
 
+        /// Prevent any new outgoing network activity. Be passive.
+        virtual void stop() = 0;
+
         /**
          * Virtual destructor required for inheritance
          */

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -68,6 +68,8 @@ namespace iroha {
 
         void onState(std::vector<VoteMessage> state) override;
 
+        void stop() override;
+
        private:
         // ------|Private interface|------
 

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -42,6 +42,9 @@ namespace iroha {
          */
         virtual rxcpp::observable<Answer> onOutcome() = 0;
 
+        /// Prevent any new outgoing network activity. Be passive.
+        virtual void stop() = 0;
+
         virtual ~HashGate() = default;
       };
     }  // namespace yac

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(pg_connection_init
     SOCI::postgresql
     SOCI::core
     failover_callback
+    irohad_version
     pool_wrapper
     logger
     )

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -153,6 +153,12 @@ Irohad::Irohad(
 }
 
 Irohad::~Irohad() {
+  if (consensus_gate) {
+    consensus_gate->stop();
+  }
+  if (ordering_gate) {
+    ordering_gate->stop();
+  }
   consensus_gate_objects_lifetime.unsubscribe();
   consensus_gate_events_subscription.unsubscribe();
 }

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -170,7 +170,7 @@ namespace iroha {
                        .with_latest_from(latest_hashes)
                        .map(map_peers);
 
-      return std::make_shared<ordering::OnDemandConnectionManager>(
+      return std::make_unique<ordering::OnDemandConnectionManager>(
           createNotificationFactory(std::move(async_call),
                                     std::move(proposal_transport_factory),
                                     delay,
@@ -181,7 +181,7 @@ namespace iroha {
 
     auto OnDemandOrderingInit::createGate(
         std::shared_ptr<ordering::OnDemandOrderingService> ordering_service,
-        std::shared_ptr<ordering::transport::OdOsNotification> network_client,
+        std::unique_ptr<ordering::transport::OdOsNotification> network_client,
         std::shared_ptr<ordering::cache::OrderingGateCache> cache,
         std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
             proposal_factory,

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -65,7 +65,7 @@ namespace iroha {
        */
       auto createGate(
           std::shared_ptr<ordering::OnDemandOrderingService> ordering_service,
-          std::shared_ptr<ordering::transport::OdOsNotification> network_client,
+          std::unique_ptr<ordering::transport::OdOsNotification> network_client,
           std::shared_ptr<ordering::cache::OrderingGateCache> cache,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,

--- a/irohad/main/impl/pg_connection_init.cpp
+++ b/irohad/main/impl/pg_connection_init.cpp
@@ -5,15 +5,63 @@
 
 #include "main/impl/pg_connection_init.hpp"
 
+#include <boost/functional/hash.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include "ametsuchi/impl/pool_wrapper.hpp"
+#include "common/irohad_version.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
+
+using namespace iroha::ametsuchi;
 
 namespace {
   std::string formatPostgresMessage(const char *message) {
     std::string formatted_message(message);
     boost::replace_if(formatted_message, boost::is_any_of("\r\n"), ' ');
     return formatted_message;
+  }
+
+  /// WSV schema version is identified by compatibile irohad version.
+  using SchemaVersion = iroha::IrohadVersion;
+
+  /**
+   * Get the version of database.
+   * @param sql a connection to working database
+   * @return result of schema version or error.
+   */
+  iroha::expected::Result<SchemaVersion, std::string> getDbSchemaVersion(
+      soci::session &sql) {
+    SchemaVersion version;
+    try {
+      int test = 0;
+      sql << "select "
+             "1 test, iroha_major, iroha_minor, iroha_patch "
+             "from schema_version;",
+          soci::into(test), soci::into(version.major),
+          soci::into(version.minor), soci::into(version.patch);
+      if (test == 0) {
+        return "Database contains no schema version information.";
+      }
+    } catch (std::exception &e) {
+      return iroha::expected::makeError(formatPostgresMessage(e.what()));
+    }
+    return version;
+  }
+
+  /**
+   * Checks schema compatibility.
+   * @return value of true if the schema in the provided sql connection is
+   * compatibile with this code, false if not and an error message if the
+   * check could not be performed.
+   */
+  iroha::expected::Result<bool, std::string> isSchemaCompatible(
+      const PostgresOptions &postgres_options) {
+    return getWorkingDbSession(postgres_options) | [](auto sql) {
+      return getDbSchemaVersion(*sql) |
+          [](const SchemaVersion &db_schema_version) {
+            return db_schema_version == iroha::getIrohadVersion();
+          };
+    };
   }
 
   void processPqNotice(void *arg, const char *message) {
@@ -216,7 +264,27 @@ void PgConnectionInit::initializeConnectionPool(
 
 void PgConnectionInit::prepareTables(soci::session &session) {
   static const std::string prepare_tables_sql = R"(
-CREATE TABLE IF NOT EXISTS role (
+CREATE TABLE schema_version (
+    lock CHAR(1) DEFAULT 'X' NOT NULL PRIMARY KEY,
+    iroha_major int not null,
+    iroha_minor int not null,
+    iroha_patch int not null
+);
+insert into schema_version
+    (iroha_major, iroha_minor, iroha_patch)
+    values ()"
+      +
+      [] {
+        auto v = iroha::getIrohadVersion();
+        return fmt::format("{}, {}, {}", v.major, v.minor, v.patch);
+      }()
+      + R"();
+CREATE TABLE top_block_info (
+    lock CHAR(1) DEFAULT 'X' NOT NULL PRIMARY KEY,
+    height int,
+    hash character varying(128)
+);
+CREATE TABLE role (
     role_id character varying(32),
     PRIMARY KEY (role_id)
 );
@@ -352,40 +420,6 @@ CREATE INDEX IF NOT EXISTS burrow_tx_logs_topics_log_idx
     (log_idx ASC);
 )";
   session << prepare_tables_sql;
-}
-
-iroha::expected::Result<void, std::string> PgConnectionInit::resetWsv(
-    soci::session &sql) {
-  try {
-    static const std::string reset = R"(
-      TRUNCATE TABLE account_has_signatory RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE account_has_asset RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE role_has_permissions RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE account_has_roles RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE account_has_grantable_permissions RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE account RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE asset RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE domain RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE signatory RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE role RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE position_by_hash RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE tx_status_by_hash RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE tx_position_by_creator RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE position_by_account_asset RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE setting RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE engine_calls RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE burrow_account_data;
-      TRUNCATE TABLE burrow_account_key_value;
-      TRUNCATE TABLE burrow_tx_logs RESTART IDENTITY CASCADE;
-      TRUNCATE TABLE burrow_tx_logs_topics;
-    )";
-    sql << reset;
-  } catch (std::exception &e) {
-    return iroha::expected::makeError(std::string{"Failed to reset WSV: "}
-                                      + formatPostgresMessage(e.what()));
-  }
-  return expected::Value<void>();
 }
 
 iroha::expected::Result<void, std::string>

--- a/irohad/main/impl/pg_connection_init.hpp
+++ b/irohad/main/impl/pg_connection_init.hpp
@@ -88,6 +88,13 @@ namespace iroha {
       /// Create tables in the given session. Left public for tests.
       static void prepareTables(soci::session &session);
 
+      /**
+       * Creates schema. Working database must not exist when calling this.
+       * @return void value in case of success or an error message otherwise.
+       */
+      static expected::Result<void, std::string> createSchema(
+          const PostgresOptions &postgres_options);
+
      private:
       /**
        * Function initializes existing connection pool

--- a/irohad/main/impl/pg_connection_init.hpp
+++ b/irohad/main/impl/pg_connection_init.hpp
@@ -21,6 +21,7 @@
 #include "interfaces/permissions.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
+#include "main/startup_params.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -29,9 +30,9 @@ namespace iroha {
 
     class PgConnectionInit {
      public:
-      static expected::Result<std::shared_ptr<soci::connection_pool>,
-                              std::string>
-      initPostgresConnection(std::string &options_str, size_t pool_size);
+      static expected::Result<void, std::string> prepareWorkingDatabase(
+          StartupWsvDataPolicy startup_wsv_data_policy,
+          const PostgresOptions &options);
 
       static expected::Result<std::shared_ptr<PoolWrapper>, std::string>
       prepareConnectionPool(
@@ -47,30 +48,6 @@ namespace iroha {
 
       static iroha::expected::Result<void, std::string> rollbackPrepared(
           soci::session &sql, const std::string &prepared_block_name);
-
-      /*
-       * Check whether working database exists.
-       * @param pg_opt Database options.
-       * @return Result of bool that is true if the database exists and false
-       * otherwise, or error message if check has failed.
-       */
-      static expected::Result<bool, std::string> checkIfWorkingDatabaseExists(
-          const PostgresOptions &pg_opt);
-
-      /*
-       * Create working database if it does not exist.
-       * @param pg_opt Database options.
-       * @return Result of bool that is true if the database was creates and
-       * false otherwise, or error message if something has gone wrong.
-       */
-      static expected::Result<bool, std::string> createDatabaseIfNotExist(
-          const PostgresOptions &pg_opt);
-
-      /*
-       * Remove all records from the tables
-       * @return error message if reset has failed
-       */
-      static expected::Result<void, std::string> resetWsv(soci::session &sql);
 
       /*
        * Drop working database.
@@ -109,9 +86,10 @@ namespace iroha {
        * reconnect
        * @param log_manager - log manager of storage
        * @tparam RollbackFunction - type of rollback function
+       * @return void value on success or string error
        */
       template <typename RollbackFunction>
-      static void initializeConnectionPool(
+      static expected::Result<void, std::string> initializeConnectionPool(
           soci::connection_pool &connection_pool,
           size_t pool_size,
           RollbackFunction try_rollback,

--- a/irohad/main/startup_params.hpp
+++ b/irohad/main/startup_params.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_STARTUP_PARAMS_HPP
+#define IROHA_STARTUP_PARAMS_HPP
+
+namespace iroha {
+  /// Policy regarging possible existing WSV data at startup
+  enum class StartupWsvDataPolicy {
+    kReuse,  //!< try to reuse existing data in the
+    kDrop,   //!< drop any existing state data
+  };
+}  // namespace iroha
+
+#endif

--- a/irohad/network/consensus_gate.hpp
+++ b/irohad/network/consensus_gate.hpp
@@ -43,6 +43,9 @@ namespace iroha {
        */
       virtual rxcpp::observable<consensus::GateObject> onOutcome() = 0;
 
+      /// Prevent any new outgoing network activity. Be passive.
+      virtual void stop() = 0;
+
       virtual ~ConsensusGate() = default;
     };
 

--- a/irohad/network/ordering_gate.hpp
+++ b/irohad/network/ordering_gate.hpp
@@ -41,6 +41,9 @@ namespace iroha {
       virtual rxcpp::observable<OrderingEvent> onProposal() = 0;
 
       virtual ~OrderingGate() = default;
+
+      /// Prevent any new outgoing network activity. Be passive.
+      virtual void stop() = 0;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -8,6 +8,7 @@
 
 #include "ordering/on_demand_os_transport.hpp"
 
+#include <atomic>
 #include <shared_mutex>
 
 #include <rxcpp/rx-lite.hpp>
@@ -90,6 +91,7 @@ namespace iroha {
       CurrentConnections connections_;
 
       std::shared_timed_mutex mutex_;
+      std::atomic_bool stop_requested_{false};
     };
 
   }  // namespace ordering

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -24,7 +24,7 @@ using namespace iroha::ordering;
 
 OnDemandOrderingGate::OnDemandOrderingGate(
     std::shared_ptr<OnDemandOrderingService> ordering_service,
-    std::shared_ptr<transport::OdOsNotification> network_client,
+    std::unique_ptr<transport::OdOsNotification> network_client,
     rxcpp::observable<
         std::shared_ptr<const cache::OrderingGateCache::HashesSetType>>
         processed_tx_hashes,
@@ -52,6 +52,12 @@ OnDemandOrderingGate::OnDemandOrderingGate(
                std::move(proposal_creation_strategy)](auto event) {
             log_->debug("Current: {}", event.next_round);
 
+            std::shared_lock<std::shared_timed_mutex> stop_lock(stop_mutex_);
+            if (stop_requested_) {
+              log_->warn("Not doing anything because stop was requested.");
+              return;
+            }
+
             // notify our ordering service about new round
             proposal_creation_strategy->onCollaborationOutcome(
                 event.next_round, event.ledger_state->ledger_peers.size());
@@ -74,13 +80,17 @@ OnDemandOrderingGate::OnDemandOrderingGate(
       proposal_notifier_(proposal_notifier_lifetime_) {}
 
 OnDemandOrderingGate::~OnDemandOrderingGate() {
-  proposal_notifier_lifetime_.unsubscribe();
-  processed_tx_hashes_subscription_.unsubscribe();
-  round_switch_subscription_.unsubscribe();
+  stop();
 }
 
 void OnDemandOrderingGate::propagateBatch(
     std::shared_ptr<shared_model::interface::TransactionBatch> batch) {
+  std::shared_lock<std::shared_timed_mutex> stop_lock(stop_mutex_);
+  if (stop_requested_) {
+    log_->warn("Not propagating {} because stop was requested.", *batch);
+    return;
+  }
+
   cache_->addToBack({batch});
 
   network_client_->onBatches(
@@ -89,6 +99,18 @@ void OnDemandOrderingGate::propagateBatch(
 
 rxcpp::observable<network::OrderingEvent> OnDemandOrderingGate::onProposal() {
   return proposal_notifier_.get_observable();
+}
+
+void OnDemandOrderingGate::stop() {
+  std::lock_guard<std::shared_timed_mutex> stop_lock(stop_mutex_);
+  if (not stop_requested_) {
+    stop_requested_ = true;
+    log_->info("Stopping.");
+    proposal_notifier_lifetime_.unsubscribe();
+    processed_tx_hashes_subscription_.unsubscribe();
+    round_switch_subscription_.unsubscribe();
+    network_client_.reset();
+  }
 }
 
 boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
@@ -109,6 +131,7 @@ OnDemandOrderingGate::processProposalRequest(
 }
 
 void OnDemandOrderingGate::sendCachedTransactions() {
+  assert(not stop_mutex_.try_lock());  // lock must be taken before
   // TODO mboldyrev 22.03.2019 IR-425
   // make cache_->getBatchesForRound(current_round) that respects sync
   auto batches = cache_->pop();

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -45,7 +45,7 @@ namespace iroha {
 
       OnDemandOrderingGate(
           std::shared_ptr<OnDemandOrderingService> ordering_service,
-          std::shared_ptr<transport::OdOsNotification> network_client,
+          std::unique_ptr<transport::OdOsNotification> network_client,
           rxcpp::observable<
               std::shared_ptr<const cache::OrderingGateCache::HashesSetType>>
               processed_tx_hashes,
@@ -67,6 +67,8 @@ namespace iroha {
           override;
 
       rxcpp::observable<network::OrderingEvent> onProposal() override;
+
+      void stop() override;
 
      private:
       /**
@@ -93,13 +95,16 @@ namespace iroha {
       /// max number of transactions passed to one ordering service
       size_t transaction_limit_;
       std::shared_ptr<OnDemandOrderingService> ordering_service_;
-      std::shared_ptr<transport::OdOsNotification> network_client_;
+      std::unique_ptr<transport::OdOsNotification> network_client_;
       rxcpp::composite_subscription processed_tx_hashes_subscription_;
       rxcpp::composite_subscription round_switch_subscription_;
       std::shared_ptr<cache::OrderingGateCache> cache_;
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;
       std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache_;
+
+      std::shared_timed_mutex stop_mutex_;
+      bool stop_requested_{false};
 
       rxcpp::composite_subscription proposal_notifier_lifetime_;
       rxcpp::subjects::subject<network::OrderingEvent> proposal_notifier_;

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -75,4 +75,10 @@ if (EXISTS "${PROJECT_SOURCE_DIR}/.git")
   endif()
 endif()
 
-target_compile_definitions(irohad_version PRIVATE -DGIT_REPO_PRETTY_VER="${GIT_REPO_PRETTY_VER}")
+target_compile_definitions(irohad_version
+  PRIVATE
+    -DGIT_REPO_PRETTY_VER="${GIT_REPO_PRETTY_VER}"
+    -DIROHA_MAJOR_VERSION=${PROJECT_VERSION_MAJOR}
+    -DIROHA_MINOR_VERSION=${PROJECT_VERSION_MINOR}
+    -DIROHA_PATCH_VERSION=${PROJECT_VERSION_PATCH}
+  )

--- a/libs/common/irohad_version.cpp
+++ b/libs/common/irohad_version.cpp
@@ -5,8 +5,19 @@
 
 #include "common/irohad_version.hpp"
 
+#include <ciso646>
+
 namespace iroha {
 
   const char *kGitPrettyVersion = GIT_REPO_PRETTY_VER;
+
+  IrohadVersion getIrohadVersion() {
+    return IrohadVersion{
+        IROHA_MAJOR_VERSION, IROHA_MINOR_VERSION, IROHA_PATCH_VERSION};
+  }
+
+  bool IrohadVersion::operator==(const IrohadVersion &rhs) const {
+    return major == rhs.major and minor == rhs.minor and patch == rhs.patch;
+  }
 
 }  // namespace iroha

--- a/libs/common/irohad_version.hpp
+++ b/libs/common/irohad_version.hpp
@@ -6,10 +6,29 @@
 #ifndef LIBS_COMMON_IROHAD_VERSION_HPP
 #define LIBS_COMMON_IROHAD_VERSION_HPP
 
+// disabling GNU macros
+#ifdef major
+#undef major
+#endif
+
+#ifdef minor
+#undef minor
+#endif
+
 namespace iroha {
 
   /// A string describing current git repository version in a human-readable way
   extern const char *kGitPrettyVersion;
+
+  struct IrohadVersion {
+    unsigned int major;
+    unsigned int minor;
+    unsigned int patch;
+
+    bool operator==(const IrohadVersion &) const;
+  };
+
+  IrohadVersion getIrohadVersion();
 
 }  // namespace iroha
 

--- a/test/benchmark/bm_pipeline.cpp
+++ b/test/benchmark/bm_pipeline.cpp
@@ -37,6 +37,7 @@ static void BM_AddAssetQuantity(benchmark::State &state) {
   integration_framework::IntegrationTestFramework itf(
       kProposalSize,
       boost::none,
+      iroha::StartupWsvDataPolicy::kDrop,
       false,
       false,
       (boost::filesystem::temp_directory_path()

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -41,6 +41,7 @@
 #include "interfaces/permissions.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
+#include "main/impl/pg_connection_init.hpp"
 #include "module/irohad/ametsuchi/tx_presence_cache_stub.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
@@ -137,6 +138,7 @@ namespace integration_framework {
   IntegrationTestFramework::IntegrationTestFramework(
       size_t maximum_proposal_size,
       const boost::optional<std::string> &dbname,
+      iroha::StartupWsvDataPolicy startup_wsv_data_policy,
       bool cleanup_on_exit,
       bool mst_support,
       const boost::optional<std::string> block_store_path,
@@ -165,6 +167,7 @@ namespace integration_framework {
                                             internal_port_,
                                             log_manager_->getChild("Irohad"),
                                             log_,
+                                            startup_wsv_data_policy,
                                             dbname)),
         command_client_(std::make_unique<torii::CommandSyncClient>(
             iroha::network::createClient<iroha::protocol::CommandService_v1>(

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -41,7 +41,6 @@
 #include "interfaces/permissions.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
-#include "main/impl/pg_connection_init.hpp"
 #include "module/irohad/ametsuchi/tx_presence_cache_stub.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -16,6 +16,7 @@
 #include "interfaces/common_objects/string_view_types.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
+#include "main/startup_params.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 namespace google {
@@ -124,6 +125,7 @@ namespace integration_framework {
      * @param maximum_proposal_size - Maximum number of transactions per
      * proposal
      * @param dbname - override database name to use (optional)
+     * @param startup_wsv_data_policy - @see StartupWsvDataPolicy
      * @param cleanup_on_exit - whether to clean resources on exit
      * @param mst_support - enables multisignature tx support
      * @param block_store_path - specifies path where blocks will be stored
@@ -136,6 +138,8 @@ namespace integration_framework {
     explicit IntegrationTestFramework(
         size_t maximum_proposal_size,
         const boost::optional<std::string> &dbname = boost::none,
+        iroha::StartupWsvDataPolicy startup_wsv_data_policy =
+            iroha::StartupWsvDataPolicy::kDrop,
         bool cleanup_on_exit = true,
         bool mst_support = false,
         const boost::optional<std::string> block_store_path = boost::none,

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -73,7 +73,10 @@ namespace integration_framework {
 
   void IrohaInstance::makeGenesis(
       std::shared_ptr<const shared_model::interface::Block> block) {
-    instance_->dropStorage();
+    if (auto e =
+            iroha::expected::resultToOptionalError(instance_->dropStorage())) {
+      throw std::runtime_error(e.value());
+    }
     rawInsertBlock(block);
   }
 

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -31,6 +31,7 @@ namespace integration_framework {
       size_t internal_port,
       logger::LoggerManagerTreePtr irohad_log_manager,
       logger::LoggerPtr log,
+      iroha::StartupWsvDataPolicy startup_wsv_data_policy,
       const boost::optional<std::string> &dbname,
       const boost::optional<iroha::torii::TlsParams> &torii_tls_params)
       : block_store_dir_(block_store_path),
@@ -56,7 +57,8 @@ namespace integration_framework {
         max_rounds_delay_(0ms),
         stale_stream_max_rounds_(2),
         irohad_log_manager_(std::move(irohad_log_manager)),
-        log_(std::move(log)) {}
+        log_(std::move(log)),
+        startup_wsv_data_policy_(startup_wsv_data_policy) {}
 
   void IrohaInstance::init() {
     auto init_result = instance_->init();
@@ -71,7 +73,7 @@ namespace integration_framework {
 
   void IrohaInstance::makeGenesis(
       std::shared_ptr<const shared_model::interface::Block> block) {
-    instance_->storage->reset();
+    instance_->dropStorage();
     rawInsertBlock(block);
   }
 
@@ -113,6 +115,7 @@ namespace integration_framework {
         boost::none,
         irohad_log_manager_,
         log_,
+        startup_wsv_data_policy_,
         opt_mst_gossip_params_,
         torii_tls_params_);
   }
@@ -134,13 +137,11 @@ namespace integration_framework {
       log_->warn("Iroha instance or its storage are not initialized");
       return;
     }
-    auto storage = instance_->storage;
+    const auto pg_opt = *instance_->pg_opt_;
     log_->info("stopping irohad");
     instance_.reset();
     log_->info("removing storage");
-    storage->dropStorage();  // dropStorage must be called after Synchronizer
-                             // and Simulator are destroyed, because they hold
-                             // database sessions
+    iroha::ametsuchi::PgConnectionInit::dropWorkingDatabase(pg_opt);
     if (block_store_dir_) {
       boost::filesystem::remove_all(block_store_dir_.value());
     }

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -16,6 +16,7 @@
 #include "ametsuchi/impl/postgres_options.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
+#include "main/startup_params.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy_params.hpp"
 #include "torii/tls_params.hpp"
 
@@ -42,6 +43,7 @@ namespace integration_framework {
      * @param internal_port - port for internal irohad communication
      * @param irohad_log_manager - the log manager for irohad
      * @param log - the log for internal messages
+     * @param startup_wsv_data_policy - @see StartupWsvDataPolicy
      * @param dbname is a name of postgres database
      * @param tls_params - optional tls parameters for torii
      *   @see iroha::torii::TlsParams
@@ -53,6 +55,7 @@ namespace integration_framework {
                   size_t internal_port,
                   logger::LoggerManagerTreePtr irohad_log_manager,
                   logger::LoggerPtr log,
+                  iroha::StartupWsvDataPolicy startup_wsv_data_policy,
                   const boost::optional<std::string> &dbname = boost::none,
                   const boost::optional<iroha::torii::TlsParams> &tls_params =
                       boost::none);
@@ -102,6 +105,8 @@ namespace integration_framework {
     logger::LoggerManagerTreePtr irohad_log_manager_;
 
     logger::LoggerPtr log_;
+
+    const iroha::StartupWsvDataPolicy startup_wsv_data_policy_;
   };
 }  // namespace integration_framework
 #endif  // IROHA_IROHA_INSTANCE_HPP

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -32,6 +32,7 @@ namespace integration_framework {
                    opt_alternative_peers,
                logger::LoggerManagerTreePtr irohad_log_manager,
                logger::LoggerPtr log,
+               iroha::StartupWsvDataPolicy startup_wsv_data_policy,
                const boost::optional<iroha::GossipPropagationStrategyParams>
                    &opt_mst_gossip_params = boost::none,
                const boost::optional<iroha::torii::TlsParams>
@@ -50,8 +51,10 @@ namespace integration_framework {
                  stale_stream_max_rounds,
                  std::move(opt_alternative_peers),
                  std::move(irohad_log_manager),
+                 startup_wsv_data_policy,
                  opt_mst_gossip_params,
-                 torii_tls_params),
+                 torii_tls_params,
+                 boost::none),
           log_(std::move(log)) {}
 
     auto &getCommandService() {

--- a/test/integration/acceptance/fake_peer_fixture.hpp
+++ b/test/integration/acceptance/fake_peer_fixture.hpp
@@ -78,7 +78,7 @@ class FakePeerFixture : public AcceptanceFixture {
  protected:
   void SetUp() override {
     itf_ = std::make_unique<integration_framework::IntegrationTestFramework>(
-        1, boost::none, true, true);
+        1, boost::none, iroha::StartupWsvDataPolicy::kDrop, true, true);
     itf_->initPipeline(common_constants::kAdminKeypair);
   }
 

--- a/test/integration/executor/executor_fixture_param_postgres.cpp
+++ b/test/integration/executor/executor_fixture_param_postgres.cpp
@@ -18,6 +18,7 @@
 #include "logger/logger_manager.hpp"
 #include "main/impl/pg_connection_init.hpp"
 #include "module/irohad/ametsuchi/mock_block_storage.hpp"
+#include "module/irohad/ametsuchi/truncate_postgres_wsv.hpp"
 #include "module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp"
 #include "module/shared_model/interface_mocks.hpp"
 
@@ -52,7 +53,8 @@ PostgresExecutorTestParam::~PostgresExecutorTestParam() = default;
 
 void PostgresExecutorTestParam::clearBackendState() {
   auto session = db_manager_->getSession();
-  IROHA_ASSERT_RESULT_VALUE(PgConnectionInit::resetWsv(*session));
+  assert(session);
+  iroha::ametsuchi::truncateWsv(*session);
 }
 
 ExecutorItfTarget PostgresExecutorTestParam::getExecutorItfParam() const {

--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -22,7 +22,8 @@ using shared_model::interface::types::PublicKeyHexStringView;
 
 class MstPipelineTest : public AcceptanceFixture {
  public:
-  MstPipelineTest() : mst_itf_{1, {}, true, true} {}
+  MstPipelineTest()
+      : mst_itf_{1, {}, iroha::StartupWsvDataPolicy::kDrop, true, true} {}
 
   /**
    * Creates a mst user

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -7,6 +7,8 @@ addtest(ametsuchi_test ametsuchi_test.cpp)
 target_link_libraries(ametsuchi_test
     ametsuchi
     ametsuchi_fixture
+    common_test_constants
+    flat_file_storage
     shared_model_stateless_validation
     test_logger
     )

--- a/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_fixture.hpp
@@ -28,6 +28,7 @@
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
 #include "main/impl/pg_connection_init.hpp"
+#include "module/irohad/ametsuchi/truncate_postgres_wsv.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp"
 #include "validators/field_validator.hpp"
@@ -54,77 +55,111 @@ namespace iroha {
             std::make_shared<MockPendingTransactionStorage>();
         query_response_factory_ =
             std::make_shared<shared_model::proto::ProtoQueryResponseFactory>();
-        auto block_storage_factory =
-            std::make_unique<InMemoryBlockStorageFactory>();
-        auto block_storage = block_storage_factory->create();
 
         reconnection_strategy_factory_ = std::make_unique<
             iroha::ametsuchi::KTimesReconnectionStrategyFactory>(0);
 
-        auto options = std::make_unique<PostgresOptions>(
+        options_ = std::make_unique<PostgresOptions>(
             pgopt_,
             integration_framework::kDefaultWorkingDatabaseName,
             storage_logger_);
 
-        PgConnectionInit::createDatabaseIfNotExist(*options).match(
-            [](auto &&val) {},
-            [&](auto &&error) {
-              storage_logger_->error("Database creation error: {}",
-                                     error.error);
-              std::terminate();
-            });
+        block_storage_ = InMemoryBlockStorageFactory{}.create();
 
-        auto pool = PgConnectionInit::prepareConnectionPool(
-            *reconnection_strategy_factory_,
-            *options,
-            pool_size_,
-            getTestLoggerManager()->getChild("Storage"));
+        initializeStorage();
+      }
 
-        if (auto error = resultToOptionalError(pool)) {
-          storage_logger_->error("Pool initialization error: {}", *error);
-          std::terminate();
+      static void initializeStorage(bool keep_wsv_data = false) {
+        bool wsv_is_dirty = true;
+        auto db_result = PgConnectionInit::prepareWorkingDatabase(
+            iroha::StartupWsvDataPolicy::kReuse, *options_);
+        if (iroha::expected::hasError(db_result)) {
+          db_result = db_result.or_res(PgConnectionInit::prepareWorkingDatabase(
+              iroha::StartupWsvDataPolicy::kDrop, *options_));
+          wsv_is_dirty = false;
         }
 
-        pool_wrapper_ = std::move(pool).assumeValue();
+        (std::move(db_result) |
+         [&] {
+           return PgConnectionInit::prepareConnectionPool(
+               *reconnection_strategy_factory_,
+               *options_,
+               pool_size_,
+               getTestLoggerManager()->getChild("Storage"));
+         }
+         |
+         [&](auto &&pool_wrapper) {
+           sql = std::make_shared<soci::session>(*soci::factory_postgresql(),
+                                                 pgopt_);
+           sql_query =
+               std::make_unique<framework::ametsuchi::SqlQuery>(*sql, factory);
 
-        StorageImpl::create(std::move(options),
-                            std::move(pool_wrapper_),
-                            perm_converter_,
-                            pending_txs_storage_,
-                            query_response_factory_,
-                            std::move(block_storage_factory),
-                            std::move(block_storage),
-                            getTestLoggerManager()->getChild("Storage"))
-            .match([&](const auto &_storage) { storage = _storage.value; },
+           if (wsv_is_dirty and not keep_wsv_data) {
+             truncateWsv();
+           }
+
+           return StorageImpl::create(
+               *options_,
+               std::move(pool_wrapper),
+               perm_converter_,
+               pending_txs_storage_,
+               query_response_factory_,
+               std::make_unique<InMemoryBlockStorageFactory>(),
+               block_storage_,
+               getTestLoggerManager()->getChild("Storage"));
+         }
+         |
+         [&](auto &&_storage) {
+           storage = std::move(_storage);
+           return storage->createCommandExecutor();
+         }
+         |
+         [&](auto &&_command_executor) {
+           command_executor = std::move(_command_executor);
+           return iroha::expected::Value<void>{};
+         })
+            .match([&](const auto &) {},
                    [](const auto &error) {
                      storage_logger_->error(
                          "Storage initialization has failed: {}", error.error);
                      // TODO: 2019-05-29 @muratovv find assert workaround IR-522
                      std::terminate();
                    });
-        sql = std::make_shared<soci::session>(*soci::factory_postgresql(),
-                                              pgopt_);
-        sql_query =
-            std::make_unique<framework::ametsuchi::SqlQuery>(*sql, factory);
+        assert(sql);
+        assert(sql_query);
+        assert(storage);
+        assert(command_executor);
+      }
 
-        storage->createCommandExecutor().match(
-            [](auto &&value) { command_executor = std::move(value).value; },
-            [](const auto &error) {
-              FAIL()
-                  << "Could not create command executor to apply genesis block!"
-                  << error.error;
-            });
+      static void destroyWsvStorage() {
+        command_executor.reset();
+        sql_query.reset();
+        sql->close();
+        sql.reset();
+        storage.reset();
       }
 
       static void TearDownTestCase() {
-        command_executor.reset();
-        sql->close();
-        storage->dropStorage();
+        storage_logger_->info("TearDownTestCase()");
+        storage->dropBlockStorage();
+        destroyWsvStorage();
+        PgConnectionInit::dropWorkingDatabase(*options_);
         boost::filesystem::remove_all(block_store_path);
       }
 
+      static void truncateWsv() {
+        storage_logger_->info("truncateWsv()");
+        assert(sql);
+        ::iroha::ametsuchi::truncateWsv(*sql);
+      }
+
       void TearDown() override {
-        storage->reset();
+        storage_logger_->info("TearDown()");
+        block_storage_->clear();
+        assert(sql);
+        storage->tryRollback(*sql);
+        destroyWsvStorage();
+        initializeStorage();
       }
 
       /**
@@ -144,6 +179,20 @@ namespace iroha {
         return storage->createMutableStorage(command_executor);
       }
 
+      // this is for resolving private visibility issues
+#define PROXY_STORAGE_IMPL_FUNCTION(function)                               \
+  template <typename... T>                                                  \
+  auto function(T &&... args)                                               \
+      ->decltype(                                                           \
+          std::declval<StorageImpl>().function(std::forward<T>(args)...)) { \
+    return storage->function(std::forward<T>(args)...);                     \
+  }
+
+      PROXY_STORAGE_IMPL_FUNCTION(storeBlock)
+      PROXY_STORAGE_IMPL_FUNCTION(tryRollback)
+
+#undef PROXY_STORAGE_IMPL_FUNCTION
+
      protected:
       static std::shared_ptr<soci::session> sql;
 
@@ -158,6 +207,7 @@ namespace iroha {
        *  static storage
        */
       static logger::LoggerPtr storage_logger_;
+      static std::shared_ptr<BlockStorage> block_storage_;
       static std::shared_ptr<StorageImpl> storage;
       static std::shared_ptr<CommandExecutor> command_executor;
       static std::unique_ptr<framework::ametsuchi::SqlQuery> sql_query;
@@ -180,10 +230,9 @@ namespace iroha {
       static std::string dbname_;
 
       static std::string pgopt_;
+      static std::unique_ptr<PostgresOptions> options_;
 
       static std::string block_store_path;
-
-      static std::shared_ptr<iroha::ametsuchi::PoolWrapper> pool_wrapper_;
     };
 
     std::shared_ptr<shared_model::proto::ProtoCommonObjectsFactory<
@@ -198,9 +247,7 @@ namespace iroha {
               .substr(0, 8);
     std::string AmetsuchiTest::pgopt_ = "dbname=" + AmetsuchiTest::dbname_ + " "
         + integration_framework::getPostgresCredsOrDefault();
-
-    std::shared_ptr<iroha::ametsuchi::PoolWrapper>
-        AmetsuchiTest::pool_wrapper_ = nullptr;
+    std::unique_ptr<PostgresOptions> AmetsuchiTest::options_ = nullptr;
 
     std::shared_ptr<shared_model::interface::PermissionToString>
         AmetsuchiTest::perm_converter_ = nullptr;
@@ -219,6 +266,7 @@ namespace iroha {
     logger::LoggerPtr AmetsuchiTest::storage_logger_ =
         getTestLoggerManager()->getChild("Storage")->getLogger();
     std::shared_ptr<StorageImpl> AmetsuchiTest::storage = nullptr;
+    std::shared_ptr<BlockStorage> AmetsuchiTest::block_storage_ = nullptr;
     std::shared_ptr<CommandExecutor> AmetsuchiTest::command_executor = nullptr;
     std::unique_ptr<framework::ametsuchi::SqlQuery> AmetsuchiTest::sql_query =
         nullptr;

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -6,10 +6,11 @@
 #ifndef IROHA_AMETSUCHI_MOCKS_HPP
 #define IROHA_AMETSUCHI_MOCKS_HPP
 
+#include "ametsuchi/wsv_command.hpp"
+
 #include <gmock/gmock.h>
 #include <boost/optional.hpp>
 #include "ametsuchi/temporary_wsv.hpp"
-#include "ametsuchi/wsv_command.hpp"
 #include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "module/irohad/ametsuchi/mock_block_query.hpp"
@@ -94,6 +95,8 @@ namespace iroha {
                                     const std::string &,
                                     const std::string &,
                                     const std::string &));
+      MOCK_CONST_METHOD1(setTopBlockInfo,
+                         WsvCommandResult(const TopBlockInfo &top_block_info));
     };
 
     class MockTemporaryWsv : public TemporaryWsv {

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -27,6 +27,14 @@ namespace iroha {
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(applyPrepared,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
+      MOCK_METHOD0(
+          do_commit,
+          expected::Result<MutableStorage::CommitResult, std::string>());
+
+      expected::Result<MutableStorage::CommitResult, std::string> commit()
+          && override {
+        return do_commit();
+      }
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -58,10 +58,11 @@ namespace iroha {
       MOCK_METHOD1(insertPeer,
                    expected::Result<void, std::string>(
                        const shared_model::interface::Peer &));
-      MOCK_METHOD0(reset, void());
-      MOCK_METHOD0(resetWsv, expected::Result<void, std::string>());
+      MOCK_METHOD0(dropBlockStorage, expected::Result<void, std::string>());
       MOCK_METHOD0(resetPeers, void());
-      MOCK_METHOD0(dropStorage, void());
+      MOCK_CONST_METHOD0(
+          getLedgerState,
+          boost::optional<std::shared_ptr<const iroha::LedgerState>>());
       MOCK_METHOD0(freeConnections, void());
       MOCK_METHOD1(prepareBlock_, void(std::unique_ptr<TemporaryWsv> &));
 

--- a/test/module/irohad/ametsuchi/mock_wsv_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_wsv_query.hpp
@@ -9,6 +9,25 @@
 #include "ametsuchi/wsv_query.hpp"
 
 #include <gmock/gmock.h>
+#include "ametsuchi/ledger_state.hpp"
+
+namespace testing {
+  // iroha::TopBlockInfo is not default-constructible, so this provides a
+  // default for getTopBlockInfo mock
+  template <>
+  class DefaultValue<
+      iroha::expected::Result<iroha::TopBlockInfo, std::string>> {
+   public:
+    using ValueType = iroha::expected::Result<iroha::TopBlockInfo, std::string>;
+    static bool Exists() {
+      return true;
+    }
+    static ValueType &Get() {
+      static ValueType val("default error value");
+      return val;
+    }
+  };
+}  // namespace testing
 
 namespace iroha {
   namespace ametsuchi {
@@ -27,6 +46,10 @@ namespace iroha {
           getPeerByPublicKey,
           boost::optional<std::shared_ptr<shared_model::interface::Peer>>(
               shared_model::interface::types::PublicKeyHexStringView));
+
+      MOCK_CONST_METHOD0(
+          getTopBlockInfo,
+          iroha::expected::Result<iroha::TopBlockInfo, std::string>());
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
@@ -42,12 +42,8 @@ class PostgresBlockStorageTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
-    PgConnectionInit::createDatabaseIfNotExist(options_).match(
-        [](auto &&val) {},
-        [&](auto &&error) {
-          storage_logger_->error("Database creation error: {}", error.error);
-          std::terminate();
-        });
+    IROHA_ASSERT_RESULT_VALUE(PgConnectionInit::prepareWorkingDatabase(
+        iroha::StartupWsvDataPolicy::kDrop, options_));
 
     auto reconnection_strategy_factory =
         std::make_unique<iroha::ametsuchi::KTimesReconnectionStrategyFactory>(

--- a/test/module/irohad/ametsuchi/storage_init_test.cpp
+++ b/test/module/irohad/ametsuchi/storage_init_test.cpp
@@ -21,6 +21,7 @@
 #include "framework/test_logger.hpp"
 #include "logger/logger_manager.hpp"
 #include "main/impl/pg_connection_init.hpp"
+#include "module/irohad/ametsuchi/truncate_postgres_wsv.hpp"
 #include "module/irohad/pending_txs_storage/pending_txs_storage_mock.hpp"
 #include "validators/field_validator.hpp"
 
@@ -90,8 +91,9 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
       integration_framework::kDefaultWorkingDatabaseName,
       storage_log_manager_->getLogger());
 
-  PgConnectionInit::createDatabaseIfNotExist(*options).match(
-      [](auto &&val) {}, [&](auto &&error) { FAIL() << error.error; });
+  PgConnectionInit::prepareWorkingDatabase(iroha::StartupWsvDataPolicy::kDrop,
+                                           *options)
+      .match([](auto &&val) {}, [&](auto &&error) { FAIL() << error.error; });
   auto pool = PgConnectionInit::prepareConnectionPool(
       *reconnection_strategy_factory_,
       *options,
@@ -107,7 +109,7 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
           .value);
 
   std::shared_ptr<StorageImpl> storage;
-  StorageImpl::create(std::move(options),
+  StorageImpl::create(*options,
                       std::move(pool_wrapper),
                       perm_converter_,
                       pending_txs_storage_,
@@ -128,7 +130,8 @@ TEST_F(StorageInitTest, CreateStorageWithDatabase) {
          ":dbname",
       soci::into(size), soci::use(dbname_);
   ASSERT_EQ(size, 1);
-  storage->dropStorage();
+  storage->dropBlockStorage();
+  PgConnectionInit::dropWorkingDatabase(*options);
 }
 
 /**
@@ -145,12 +148,6 @@ TEST_F(StorageInitTest, CreateStorageWithInvalidPgOpt) {
                           integration_framework::kDefaultWorkingDatabaseName,
                           storage_log_manager_->getLogger());
 
-  PgConnectionInit::createDatabaseIfNotExist(options).match(
-      [](auto &&val) {},
-      [&](auto &&error) {
-        storage_log_manager_->getLogger()->error("Database creation error: {}",
-                                                 error.error);
-      });
   auto pool = PgConnectionInit::prepareConnectionPool(
       *reconnection_strategy_factory_,
       options,

--- a/test/module/irohad/ametsuchi/truncate_postgres_wsv.hpp
+++ b/test/module/irohad/ametsuchi/truncate_postgres_wsv.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_TEST_TRUNCATE_POSTGRES_WSV_HPP
+#define IROHA_TEST_TRUNCATE_POSTGRES_WSV_HPP
+
+#include <soci/soci.h>
+
+namespace iroha {
+  namespace ametsuchi {
+    inline void truncateWsv(soci::session &sql) {
+      sql <<
+          R"(
+        TRUNCATE TABLE top_block_info;
+        TRUNCATE TABLE account_has_signatory RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE account_has_asset RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE role_has_permissions RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE account_has_roles RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE account_has_grantable_permissions RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE account RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE asset RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE domain RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE signatory RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE peer RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE role RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE position_by_hash RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE tx_status_by_hash RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE tx_position_by_creator RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE position_by_account_asset RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE setting RESTART IDENTITY CASCADE;
+            )";
+    }
+  }  // namespace ametsuchi
+}  // namespace iroha
+
+#endif

--- a/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_command_test.cpp
@@ -7,7 +7,10 @@
 
 #include "ametsuchi/impl/postgres_wsv_command.hpp"
 #include "ametsuchi/impl/postgres_wsv_query.hpp"
+#include "ametsuchi/ledger_state.hpp"
+#include "cryptography/hash.hpp"
 #include "framework/result_fixture.hpp"
+#include "framework/result_gtest_checkers.hpp"
 #include "framework/test_logger.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_fixture.hpp"
 #include "module/shared_model/interface_mocks.hpp"
@@ -47,6 +50,24 @@ namespace iroha {
     TEST_F(RoleTest, InsertTwoRole) {
       ASSERT_TRUE(val(command->insertRole("role")));
       ASSERT_TRUE(err(command->insertRole("role")));
+    }
+
+    /**
+     * @given WSV state
+     * @when we set top block info with wsv command
+     * @then we get same top block info with wsv query
+     */
+    TEST_F(WsvQueryCommandTest, SetAndGetTopBlockInfo) {
+      iroha::TopBlockInfo top_block_info_set{
+          1234, shared_model::crypto::Hash{"hash"}};
+      framework::expected::expectResultValue(
+          command->setTopBlockInfo(top_block_info_set));
+      auto top_block_info_read = query->getTopBlockInfo();
+      IROHA_ASSERT_RESULT_VALUE(top_block_info_read);
+      EXPECT_EQ(top_block_info_set.top_hash,
+                top_block_info_read.assumeValue().top_hash);
+      EXPECT_EQ(top_block_info_set.height,
+                top_block_info_read.assumeValue().height);
     }
 
     class DeletePeerTest : public WsvQueryCommandTest {

--- a/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
@@ -23,6 +23,8 @@ namespace iroha {
 
         MOCK_METHOD0(onOutcome, rxcpp::observable<Answer>());
 
+        MOCK_METHOD0(stop, void());
+
         MockHashGate() = default;
 
         MockHashGate(const MockHashGate &rhs) {}

--- a/test/module/irohad/consensus/yac/mock_yac_network.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_network.hpp
@@ -29,6 +29,8 @@ namespace iroha {
                      void(const shared_model::interface::Peer &,
                           const std::vector<VoteMessage> &));
 
+        MOCK_METHOD0(stop, void());
+
         MockYacNetwork() = default;
 
         MockYacNetwork(const MockYacNetwork &rhs)

--- a/test/module/irohad/multi_sig_transactions/mst_net_input_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_net_input_test.cpp
@@ -21,7 +21,8 @@ using namespace iroha::network;
  */
 TEST(MstNetInteraction, TypelessCommand) {
   bool enable_mst = true;
-  IntegrationTestFramework itf(1, {}, true, enable_mst);
+  IntegrationTestFramework itf(
+      1, {}, iroha::StartupWsvDataPolicy::kDrop, true, enable_mst);
   itf.setInitialState(kAdminKeypair);
   auto internal_port = itf.internalPort();
 

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -72,6 +72,8 @@ namespace iroha {
       MOCK_METHOD0(onProposal, rxcpp::observable<OrderingEvent>());
 
       MOCK_METHOD1(setPcs, void(const PeerCommunicationService &));
+
+      MOCK_METHOD0(stop, void());
     };
 
     class MockConsensusGate : public ConsensusGate {
@@ -79,6 +81,8 @@ namespace iroha {
       MOCK_METHOD1(vote, void(const simulator::BlockCreatorEvent &));
 
       MOCK_METHOD0(onOutcome, rxcpp::observable<GateObject>());
+
+      MOCK_METHOD0(stop, void());
     };
 
   }  // namespace network

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -41,7 +41,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
  public:
   void SetUp() override {
     ordering_service = std::make_shared<MockOnDemandOrderingService>();
-    notification = std::make_shared<MockOdOsNotification>();
+    notification = new MockOdOsNotification();
     cache = std::make_shared<cache::MockOrderingGateCache>();
     auto ufactory = std::make_unique<NiceMock<MockUnsafeProposalFactory>>();
     factory = ufactory.get();
@@ -55,7 +55,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
                 iroha::ametsuchi::tx_cache_status_responses::Missing())));
     ordering_gate = std::make_shared<OnDemandOrderingGate>(
         ordering_service,
-        notification,
+        std::unique_ptr<OdOsNotification>(notification),
         processed_tx_hashes.get_observable(),
         rounds.get_observable(),
         cache,
@@ -96,7 +96,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
       processed_tx_hashes;
   rxcpp::subjects::subject<OnDemandOrderingGate::RoundSwitch> rounds;
   std::shared_ptr<MockOnDemandOrderingService> ordering_service;
-  std::shared_ptr<MockOdOsNotification> notification;
+  MockOdOsNotification *notification;
   NiceMock<MockUnsafeProposalFactory> *factory;
   std::shared_ptr<ametsuchi::MockTxPresenceCache> tx_cache;
   std::shared_ptr<MockProposalCreationStrategy> proposal_creation_strategy;

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -55,7 +55,8 @@ TEST(RegressionTest, SequentialInitialization) {
       + boost::uuids::to_string(boost::uuids::random_generator()())
             .substr(0, 8);
   {
-    integration_framework::IntegrationTestFramework(1, dbname, false, false)
+    integration_framework::IntegrationTestFramework(
+        1, dbname, iroha::StartupWsvDataPolicy::kDrop, false, false)
         .setInitialState(kAdminKeypair)
         .sendTx(tx, check_stateless_valid_status)
         .skipProposal()
@@ -66,7 +67,8 @@ TEST(RegressionTest, SequentialInitialization) {
             [](auto block) { ASSERT_EQ(block->transactions().size(), 0); });
   }
   {
-    integration_framework::IntegrationTestFramework(1, dbname, true, false)
+    integration_framework::IntegrationTestFramework(
+        1, dbname, iroha::StartupWsvDataPolicy::kReuse, true, false)
         .setInitialState(kAdminKeypair)
         .sendTx(tx, check_stateless_valid_status)
         .checkProposal(checkProposal)
@@ -126,7 +128,8 @@ TEST(RegressionTest, StateRecovery) {
             .substr(0, 8);
 
   {
-    integration_framework::IntegrationTestFramework(1, dbname, false, false)
+    integration_framework::IntegrationTestFramework(
+        1, dbname, iroha::StartupWsvDataPolicy::kDrop, false)
         .setInitialState(kAdminKeypair)
         .sendTx(tx)
         .checkProposal(checkOne)
@@ -135,7 +138,8 @@ TEST(RegressionTest, StateRecovery) {
         .sendQuery(makeQuery(1, kAdminKeypair), checkQuery);
   }
   {
-    integration_framework::IntegrationTestFramework(1, dbname, true, false)
+    integration_framework::IntegrationTestFramework(
+        1, dbname, iroha::StartupWsvDataPolicy::kReuse, false)
         .recoverState(kAdminKeypair)
         .sendQuery(makeQuery(2, kAdminKeypair), checkQuery);
   }
@@ -158,5 +162,6 @@ TEST(RegressionTest, DoubleCallOfDone) {
  * @then no exceptions are risen
  */
 TEST(RegressionTest, DestructionOfNonInitializedItf) {
-  integration_framework::IntegrationTestFramework itf(1, {}, true);
+  integration_framework::IntegrationTestFramework itf(
+      1, {}, iroha::StartupWsvDataPolicy::kDrop, true);
 }

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -607,7 +607,10 @@ TEST_F(IrohadTest, RestartWithoutResetting) {
 
   terminateIroha();
 
-  launchIroha(config_copy_, {}, path_keypair_node_.string(), {});
+  launchIroha(config_copy_,
+              {},
+              path_keypair_node_.string(),
+              std::string{"--reuse_state"});
 
   ASSERT_EQ(getBlockCount(), height);
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

port of #335

This change adds WSV schema versioning and an option to reuse existing WSV state at startup via `--reuse_state` flag.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

fast restart

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

see RestoreWsvTest in `ametsuchi_test`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

- move in-database block storage to seRestoreWsvTestparate database from WSV
- rework `Irohad` constructor with either strongly-typed arguments or a structure of these (to pass through ITF&Co seamlessly)

<!-- Explain what other alternates were considered and why the proposed version was selected -->
