### PR TITLE
Shared model: use hex for public key and signature in interface

### DIFF
--- a/irohad/ametsuchi/impl/peer_query_wsv.cpp
+++ b/irohad/ametsuchi/impl/peer_query_wsv.cpp
@@ -21,7 +21,8 @@ namespace iroha {
     }
 
     boost::optional<PeerQuery::wPeer> PeerQueryWsv::getLedgerPeerByPublicKey(
-        const shared_model::interface::types::PubkeyType &public_key) const {
+        shared_model::interface::types::PublicKeyHexStringView public_key)
+        const {
       return wsv_->getPeerByPublicKey(public_key);
     }
 

--- a/irohad/ametsuchi/impl/peer_query_wsv.hpp
+++ b/irohad/ametsuchi/impl/peer_query_wsv.hpp
@@ -36,7 +36,7 @@ namespace iroha {
        * @return the peer if found, none otherwise
        */
       boost::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
-          const shared_model::interface::types::PubkeyType &public_key)
+          shared_model::interface::types::PublicKeyHexStringView public_key)
           const override;
 
      private:

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -34,7 +34,7 @@ namespace iroha {
     bool PostgresQueryExecutor::validateSignatures(const Q &query) {
       auto keys_range =
           query.signatures() | boost::adaptors::transformed([](const auto &s) {
-            return s.publicKey().hex();
+            return s.publicKey();
           });
 
       if (boost::size(keys_range) != 1) {

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
@@ -19,6 +19,7 @@
 #include "backend/plain/peer.hpp"
 #include "common/bind.hpp"
 #include "common/byteutils.hpp"
+#include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/amount.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/permission_to_string.hpp"
@@ -1364,11 +1365,7 @@ namespace iroha {
                     if (peer_key and address) {
                       peers.push_back(
                           std::make_shared<shared_model::plain::Peer>(
-                              *address,
-                              shared_model::interface::types::PubkeyType{
-                                  shared_model::crypto::Blob::fromHexString(
-                                      *peer_key)},
-                              tls_certificate));
+                              *address, *std::move(peer_key), tls_certificate));
                     } else {
                       log_->error(
                           "Address or public key not set for some peer!");

--- a/irohad/ametsuchi/impl/postgres_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.cpp
@@ -23,10 +23,7 @@ namespace {
         [&](auto &public_key, auto &address, auto &tls_certificate) {
           return boost::make_optional(
               std::make_shared<shared_model::plain::Peer>(
-                  address,
-                  shared_model::crypto::PublicKey{
-                      shared_model::crypto::Blob::fromHexString(public_key)},
-                  tls_certificate));
+                  address, std::move(public_key), tls_certificate));
         });
   }
 }  // namespace
@@ -86,15 +83,17 @@ namespace iroha {
     }
 
     boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-    PostgresWsvQuery::getPeerByPublicKey(const PubkeyType &public_key) {
+    PostgresWsvQuery::getPeerByPublicKey(
+        shared_model::interface::types::PublicKeyHexStringView public_key) {
       using T = boost::
           tuple<std::string, AddressType, std::optional<TLSCertificateType>>;
+      std::string target_public_key{public_key};
       auto result = execute<T>([&] {
         return (sql_.prepare << R"(
             SELECT public_key, address, tls_certificate
             FROM peer
             WHERE public_key = :public_key)",
-                soci::use(public_key.hex(), "public_key"));
+                soci::use(target_public_key, "public_key"));
       });
 
       return getPeersFromSociRowSet(result) | [](auto &&peers)

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -29,8 +29,8 @@ namespace iroha {
       getPeers() override;
 
       boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-      getPeerByPublicKey(const shared_model::interface::types::PubkeyType
-                             &public_key) override;
+      getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
+                             public_key) override;
 
      private:
       /**

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -159,7 +159,7 @@ namespace iroha {
 
     expected::Result<void, std::string> StorageImpl::insertPeer(
         const shared_model::interface::Peer &peer) {
-      log_->info("Insert peer {}", peer.pubkey().hex());
+      log_->info("Insert peer {}", peer.pubkey());
       soci::session sql(*connection_);
       PostgresWsvCommand wsv_command(sql);
       return wsv_command.insertPeer(peer);

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -35,7 +35,7 @@ namespace iroha {
         const shared_model::interface::Transaction &transaction) {
       auto keys_range = transaction.signatures()
           | boost::adaptors::transformed(
-                            [](const auto &s) { return s.publicKey().hex(); });
+                            [](const auto &s) { return s.publicKey(); });
       auto keys = boost::algorithm::join(keys_range, "'), ('");
       // not using bool since it is not supported by SOCI
       boost::optional<uint8_t> signatories_valid;

--- a/irohad/ametsuchi/peer_query.hpp
+++ b/irohad/ametsuchi/peer_query.hpp
@@ -6,9 +6,11 @@
 #ifndef IROHA_PEER_QUERY_HPP
 #define IROHA_PEER_QUERY_HPP
 
-#include <boost/optional.hpp>
 #include <memory>
 #include <vector>
+
+#include <boost/optional.hpp>
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -41,7 +43,7 @@ namespace iroha {
        * @return the peer if found, none otherwise
        */
       virtual boost::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
-          const shared_model::interface::types::PubkeyType &public_key)
+          shared_model::interface::types::PublicKeyHexStringView public_key)
           const = 0;
 
       virtual ~PeerQuery() = default;

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/optional.hpp>
 #include "interfaces/common_objects/peer.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 
 namespace iroha {
   namespace ametsuchi {
@@ -43,8 +44,8 @@ namespace iroha {
        * @return the peer if found, none otherwise
        */
       virtual boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-      getPeerByPublicKey(
-          const shared_model::interface::types::PubkeyType &public_key) = 0;
+      getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
+                             public_key) = 0;
     };
 
   }  // namespace ametsuchi

--- a/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_crypto_provider_impl.cpp
@@ -25,9 +25,13 @@ namespace iroha {
               auto blob = shared_model::crypto::Blob(serialized);
 
               return shared_model::crypto::CryptoVerifier<>::verify(
-                  vote.signature->signedData(),
+                  shared_model::crypto::Signed(
+                      shared_model::crypto::Blob::fromHexString(
+                          vote.signature->signedData())),
                   blob,
-                  vote.signature->publicKey());
+                  shared_model::crypto::PublicKey(
+                      shared_model::crypto::Blob::fromHexString(
+                          vote.signature->publicKey())));
             });
       }
 
@@ -44,8 +48,8 @@ namespace iroha {
 
         // TODO 30.08.2018 andrei: IR-1670 Remove optional from YAC
         // CryptoProviderImpl::getVote
-        vote.signature =
-            std::make_shared<shared_model::plain::Signature>(signature, pubkey);
+        vote.signature = std::make_shared<shared_model::plain::Signature>(
+            signature.hex(), pubkey.hex());
 
         return vote;
       }

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -25,7 +25,8 @@ namespace {
     return boost::copy_range<
         shared_model::interface::types::PublicKeyCollectionType>(
         votes | boost::adaptors::transformed([](auto &vote) {
-          return vote.signature->publicKey();
+          return shared_model::crypto::Blob::fromHexString(
+              vote.signature->publicKey());
         }));
   }
 }  // namespace
@@ -121,8 +122,11 @@ namespace iroha {
       void YacGateImpl::copySignatures(const CommitMessage &commit) {
         for (const auto &vote : commit.votes) {
           auto sig = vote.hash.block_signature;
-          current_block_.value()->addSignature(sig->signedData(),
-                                               sig->publicKey());
+          current_block_.value()->addSignature(
+              shared_model::interface::types::SignedHexStringView{
+                  sig->signedData()},
+              shared_model::interface::types::PublicKeyHexStringView{
+                  sig->publicKey()});
         }
       }
 

--- a/irohad/consensus/yac/transport/yac_pb_converters.hpp
+++ b/irohad/consensus/yac/transport/yac_pb_converters.hpp
@@ -56,10 +56,12 @@ namespace iroha {
           if (vote.hash.block_signature) {
             auto block_signature =
                 pb_vote.mutable_hash()->mutable_block_signature();
-            block_signature->set_signature(shared_model::crypto::toBinaryString(
-                vote.hash.block_signature->signedData()));
-            block_signature->set_pubkey(shared_model::crypto::toBinaryString(
-                vote.hash.block_signature->publicKey()));
+            auto signature = hexstringToBytestringResult(
+                vote.hash.block_signature->signedData());
+            auto public_key = hexstringToBytestringResult(
+                vote.hash.block_signature->publicKey());
+            block_signature->set_signature(std::move(signature).assumeValue());
+            block_signature->set_pubkey(std::move(public_key).assumeValue());
           }
 
           return pb_vote;
@@ -71,18 +73,21 @@ namespace iroha {
           if (vote.hash.block_signature) {
             auto block_signature =
                 pb_vote.mutable_hash()->mutable_block_signature();
-            block_signature->set_signature(shared_model::crypto::toBinaryString(
-                vote.hash.block_signature->signedData()));
-            block_signature->set_pubkey(shared_model::crypto::toBinaryString(
-                vote.hash.block_signature->publicKey()));
+            auto signature = hexstringToBytestringResult(
+                vote.hash.block_signature->signedData());
+            auto public_key = hexstringToBytestringResult(
+                vote.hash.block_signature->publicKey());
+            block_signature->set_signature(std::move(signature).assumeValue());
+            block_signature->set_pubkey(std::move(public_key).assumeValue());
           }
 
-          auto signature = pb_vote.mutable_signature();
-          const auto &sig = *vote.signature;
-          signature->set_signature(
-              shared_model::crypto::toBinaryString(sig.signedData()));
-          signature->set_pubkey(
-              shared_model::crypto::toBinaryString(sig.publicKey()));
+          auto vote_signature = pb_vote.mutable_signature();
+          auto signature =
+              hexstringToBytestringResult(vote.signature->signedData());
+          auto public_key =
+              hexstringToBytestringResult(vote.signature->publicKey());
+          vote_signature->set_signature(std::move(signature).assumeValue());
+          vote_signature->set_pubkey(std::move(public_key).assumeValue());
 
           return pb_vote;
         }
@@ -105,9 +110,13 @@ namespace iroha {
           auto deserialize = [&](auto &pubkey,
                                  auto &signature,
                                  const auto &msg) {
+            auto pubkey_hex = bytestringToHexstring(pubkey);
+            auto signature_hex = bytestringToHexstring(signature);
+            using shared_model::interface::types::PublicKeyHexStringView;
+            using shared_model::interface::types::SignedHexStringView;
             return factory
-                .createSignature(shared_model::crypto::PublicKey(pubkey),
-                                 shared_model::crypto::Signed(signature))
+                .createSignature(PublicKeyHexStringView{pubkey_hex},
+                                 SignedHexStringView{signature_hex})
                 .match(
                     [&](auto &&sig) -> boost::optional<std::unique_ptr<
                                         shared_model::interface::Signature>> {

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -328,7 +328,9 @@ Irohad::RunResult Irohad::restoreWsv() {
 
 Irohad::RunResult Irohad::validateKeypair() {
   auto peers = storage->createPeerQuery() | [this](auto &&peer_query) {
-    return peer_query->getLedgerPeerByPublicKey(keypair.publicKey());
+    return peer_query->getLedgerPeerByPublicKey(
+        shared_model::interface::types::PublicKeyHexStringView{
+            keypair.publicKey().hex()});
   };
   if (not peers) {
     log_->warn("There is no peer in the ledger with my public key!");

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -358,11 +358,10 @@ JsonDeserializerImpl::getVal<std::unique_ptr<shared_model::interface::Peer>>(
   }
 
   common_objects_factory_
-      ->createPeer(
-          address,
-          shared_model::crypto::PublicKey(
-              shared_model::crypto::Blob::fromHexString(public_key_str)),
-          tls_certificate_str)
+      ->createPeer(address,
+                   shared_model::interface::types::PublicKeyHexStringView{
+                       public_key_str},
+                   tls_certificate_str)
       .match([&dest](auto &&v) { dest = std::move(v.value); },
              [&path](const auto &error) {
                throw JsonDeserializerException("Failed to create a peer at '"

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -57,7 +57,7 @@ namespace iroha {
 
     // ------------------| MstTransportNotification override |------------------
 
-    void onNewState(const shared_model::crypto::PublicKey &from,
+    void onNewState(shared_model::interface::types::PublicKeyHexStringView from,
                     MstState &&new_state) override;
 
     // ----------------------------| end override |-----------------------------

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -141,8 +141,11 @@ namespace iroha {
           std::end(donor_tx->signatures()),
           inserted_new_signatures,
           [&target_tx](bool accumulator, const auto &signature) {
-            return target_tx->addSignature(signature.signedData(),
-                                           signature.publicKey())
+            return target_tx->addSignature(
+                       shared_model::interface::types::SignedHexStringView{
+                           signature.signedData()},
+                       shared_model::interface::types::PublicKeyHexStringView{
+                           signature.publicKey()})
                 or accumulator;
           });
     }

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage.cpp
@@ -11,7 +11,7 @@ namespace iroha {
   MstStorage::MstStorage(logger::LoggerPtr log) : log_{std::move(log)} {}
 
   StateUpdateResult MstStorage::apply(
-      const shared_model::crypto::PublicKey &target_peer_key,
+      shared_model::interface::types::PublicKeyHexStringView target_peer_key,
       const MstState &new_state) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return applyImpl(target_peer_key, new_state);
@@ -29,7 +29,7 @@ namespace iroha {
   }
 
   MstState MstStorage::getDiffState(
-      const shared_model::crypto::PublicKey &target_peer_key,
+      shared_model::interface::types::PublicKeyHexStringView target_peer_key,
       const TimeType &current_time) {
     std::lock_guard<std::mutex> lock{this->mutex_};
     return getDiffStateImpl(target_peer_key, current_time);

--- a/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
+++ b/irohad/multi_sig_transactions/storage/impl/mst_storage_impl.cpp
@@ -9,12 +9,13 @@ namespace iroha {
   // ------------------------------| private API |------------------------------
 
   auto MstStorageStateImpl::getState(
-      const shared_model::crypto::PublicKey &target_peer_key) {
-    auto target_state_iter = peer_states_.find(target_peer_key);
+      shared_model::interface::types::PublicKeyHexStringView target_peer_key) {
+    auto target_state_iter =
+        peer_states_.find(StringViewOrString{target_peer_key});
     if (target_state_iter == peer_states_.end()) {
       return peer_states_
-          .insert(
-              {target_peer_key, MstState::empty(mst_state_logger_, completer_)})
+          .emplace(StringViewOrString{std::string{target_peer_key}},
+                   MstState::empty(mst_state_logger_, completer_))
           .first;
     }
     return target_state_iter;
@@ -30,7 +31,7 @@ namespace iroha {
         mst_state_logger_(std::move(mst_state_logger)) {}
 
   auto MstStorageStateImpl::applyImpl(
-      const shared_model::crypto::PublicKey &target_peer_key,
+      shared_model::interface::types::PublicKeyHexStringView target_peer_key,
       const MstState &new_state)
       -> decltype(apply(target_peer_key, new_state)) {
     auto target_state_iter = getState(target_peer_key);
@@ -53,7 +54,7 @@ namespace iroha {
   }
 
   auto MstStorageStateImpl::getDiffStateImpl(
-      const shared_model::crypto::PublicKey &target_peer_key,
+      shared_model::interface::types::PublicKeyHexStringView target_peer_key,
       const TimeType &current_time)
       -> decltype(getDiffState(target_peer_key, current_time)) {
     auto target_current_state_iter = getState(target_peer_key);

--- a/irohad/multi_sig_transactions/storage/mst_storage.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage.hpp
@@ -8,7 +8,7 @@
 
 #include <mutex>
 
-#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
@@ -32,7 +32,7 @@ namespace iroha {
      * General note: implementation of method covered by lock
      */
     StateUpdateResult apply(
-        const shared_model::crypto::PublicKey &target_peer_key,
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
         const MstState &new_state);
 
     /**
@@ -57,7 +57,7 @@ namespace iroha {
      * General note: implementation of method covered by lock
      */
     MstState getDiffState(
-        const shared_model::crypto::PublicKey &target_peer_key,
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
         const TimeType &current_time);
 
     /**
@@ -87,7 +87,7 @@ namespace iroha {
 
    private:
     virtual auto applyImpl(
-        const shared_model::crypto::PublicKey &target_peer_key,
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
         const MstState &new_state)
         -> decltype(apply(target_peer_key, new_state)) = 0;
 
@@ -98,7 +98,7 @@ namespace iroha {
         -> decltype(extractExpiredTransactions(current_time)) = 0;
 
     virtual auto getDiffStateImpl(
-        const shared_model::crypto::PublicKey &target_peer_key,
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
         const TimeType &current_time)
         -> decltype(getDiffState(target_peer_key, current_time)) = 0;
 

--- a/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
+++ b/irohad/multi_sig_transactions/storage/mst_storage_impl.hpp
@@ -7,7 +7,6 @@
 #define IROHA_MST_STORAGE_IMPL_HPP
 
 #include <unordered_map>
-#include "cryptography/blob_hasher.hpp"
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/hash.hpp"
 #include "multi_sig_transactions/storage/mst_storage.hpp"
@@ -23,7 +22,8 @@ namespace iroha {
      * @param target_peer_key - public key of the peer for searching
      * @return valid iterator for state of peer
      */
-    auto getState(const shared_model::crypto::PublicKey &target_peer_key);
+    auto getState(
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key);
 
    public:
     // ----------------------------| interface API |----------------------------
@@ -31,8 +31,9 @@ namespace iroha {
                         logger::LoggerPtr mst_state_logger,
                         logger::LoggerPtr log);
 
-    auto applyImpl(const shared_model::crypto::PublicKey &target_peer_key,
-                   const MstState &new_state)
+    auto applyImpl(
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
+        const MstState &new_state)
         -> decltype(apply(target_peer_key, new_state)) override;
 
     auto updateOwnStateImpl(const DataType &tx)
@@ -42,7 +43,7 @@ namespace iroha {
         -> decltype(extractExpiredTransactions(current_time)) override;
 
     auto getDiffStateImpl(
-        const shared_model::crypto::PublicKey &target_peer_key,
+        shared_model::interface::types::PublicKeyHexStringView target_peer_key,
         const TimeType &current_time)
         -> decltype(getDiffState(target_peer_key, current_time)) override;
 
@@ -55,9 +56,30 @@ namespace iroha {
     // ---------------------------| private fields |----------------------------
 
     const CompleterType completer_;
-    std::unordered_map<shared_model::crypto::PublicKey,
-                       MstState,
-                       shared_model::crypto::BlobHasher>
+    struct StringViewOrString {
+      std::string s;
+      std::string_view v;
+
+      explicit StringViewOrString(std::string_view v) : v(v) {}
+      explicit StringViewOrString(std::string s) : s(s), v(this->s) {}
+
+      StringViewOrString(StringViewOrString const &o)
+          : s(o.s), v(not this->s.empty() ? this->s : o.v) {}
+      StringViewOrString(StringViewOrString &&o) noexcept
+          : s(std::move(o).s),
+            v(not this->s.empty() ? this->s : std::move(o).v) {}
+
+      bool operator==(StringViewOrString const &x) const {
+        return v == x.v;
+      }
+
+      struct Hash {
+        std::size_t operator()(StringViewOrString const &x) const {
+          return std::hash<std::string_view>()(x.v);
+        }
+      };
+    };
+    std::unordered_map<StringViewOrString, MstState, StringViewOrString::Hash>
         peer_states_;
     MstState own_state_;
 

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -119,11 +119,12 @@ BlockLoaderImpl::findPeer(const shared_model::crypto::PublicKey &pubkey) {
     return boost::none;
   }
 
-  auto &blob = pubkey.blob();
-  auto it = std::find_if(
-      peers.value().begin(), peers.value().end(), [&blob](const auto &peer) {
-        return peer->pubkey().blob() == blob;
-      });
+  auto &target_pubkey_hex = pubkey.hex();
+  auto it = std::find_if(peers.value().begin(),
+                         peers.value().end(),
+                         [&target_pubkey_hex](const auto &peer) {
+                           return peer->pubkey() == target_pubkey_hex;
+                         });
   if (it == peers.value().end()) {
     log_->error("{}", kPeerFindFail);
     return boost::none;

--- a/irohad/network/impl/channel_pool.cpp
+++ b/irohad/network/impl/channel_pool.cpp
@@ -8,8 +8,6 @@
 #include <shared_mutex>
 #include <unordered_map>
 
-#include "cryptography/blob_hasher.hpp"
-#include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "network/impl/channel_provider.hpp"
@@ -44,10 +42,7 @@ class ChannelPool::Impl {
   std::unique_ptr<ChannelProvider> channel_provider_;
 
   std::shared_timed_mutex mutex_;
-  std::unordered_map<shared_model::crypto::PublicKey,
-                     std::shared_ptr<grpc::Channel>,
-                     shared_model::crypto::BlobHasher>
-      channels_;
+  std::unordered_map<std::string, std::shared_ptr<grpc::Channel>> channels_;
 };
 
 ChannelPool::ChannelPool(std::unique_ptr<ChannelProvider> channel_provider)

--- a/irohad/network/impl/peer_tls_certificates_provider_root.cpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_root.cpp
@@ -19,6 +19,6 @@ Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderRoot::get(
 }
 
 Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderRoot::get(
-    const PubkeyType &) const {
+    shared_model::interface::types::PublicKeyHexStringView) const {
   return makeValue(root_certificate_);
 }

--- a/irohad/network/impl/peer_tls_certificates_provider_root.hpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_root.hpp
@@ -24,7 +24,8 @@ namespace iroha {
       iroha::expected::Result<
           shared_model::interface::types::TLSCertificateType,
           std::string>
-      get(const shared_model::interface::types::PubkeyType &) const override;
+          get(shared_model::interface::types::PublicKeyHexStringView)
+              const override;
 
      private:
       shared_model::interface::types::TLSCertificateType root_certificate_;

--- a/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
@@ -22,7 +22,7 @@ class PeerTlsCertificatesProviderWsv::Impl {
 
   boost::optional<std::shared_ptr<shared_model::interface::Peer>>
   getPeerFromWsv(
-      const shared_model::interface::types::PubkeyType &public_key) const {
+      shared_model::interface::types::PublicKeyHexStringView public_key) const {
     std::lock_guard<std::mutex> lock(mutex_);
     return peer_query_->getLedgerPeerByPublicKey(public_key);
   }
@@ -47,11 +47,11 @@ Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderWsv::get(
 }
 
 Result<TLSCertificateType, std::string> PeerTlsCertificatesProviderWsv::get(
-    const shared_model::interface::types::PubkeyType &public_key) const {
+    shared_model::interface::types::PublicKeyHexStringView public_key) const {
   auto opt_peer = impl_->getPeerFromWsv(public_key);
   if (not opt_peer) {
     return makeError(std::string{"Could not find peer by "}
-                     + public_key.toString());
+                     + iroha::to_string::toString(public_key));
   }
   return get(*opt_peer.value());
 }

--- a/irohad/network/impl/peer_tls_certificates_provider_wsv.hpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_wsv.hpp
@@ -39,7 +39,7 @@ namespace iroha {
       iroha::expected::Result<
           shared_model::interface::types::TLSCertificateType,
           std::string>
-      get(const shared_model::interface::types::PubkeyType &public_key)
+      get(shared_model::interface::types::PublicKeyHexStringView public_key)
           const override;
 
      private:

--- a/irohad/network/mst_transport.hpp
+++ b/irohad/network/mst_transport.hpp
@@ -23,8 +23,9 @@ namespace iroha {
        * @param from - key of the peer emitted the state
        * @param new_state - state propagated from peer
        */
-      virtual void onNewState(const shared_model::crypto::PublicKey &from,
-                              MstState &&new_state) = 0;
+      virtual void onNewState(
+          shared_model::interface::types::PublicKeyHexStringView from,
+          MstState &&new_state) = 0;
 
       virtual ~MstTransportNotification() = default;
     };

--- a/irohad/network/peer_tls_certificates_provider.hpp
+++ b/irohad/network/peer_tls_certificates_provider.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "common/result.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -35,7 +36,7 @@ namespace iroha {
       virtual iroha::expected::Result<
           shared_model::interface::types::TLSCertificateType,
           std::string>
-      get(const shared_model::interface::types::PubkeyType &public_key)
+      get(shared_model::interface::types::PublicKeyHexStringView public_key)
           const = 0;
     };
 

--- a/irohad/torii/processor/impl/query_processor_impl.cpp
+++ b/irohad/torii/processor/impl/query_processor_impl.cpp
@@ -14,7 +14,6 @@
 #include "interfaces/query_responses/block_response.hpp"
 #include "interfaces/query_responses/query_response.hpp"
 #include "logger/logger.hpp"
-#include "validation/utils.hpp"
 
 namespace iroha {
   namespace torii {

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -84,12 +84,12 @@ namespace iroha {
             "public keys: [{}]",
             boost::algorithm::join(
                 signatures | boost::adaptors::transformed([](const auto &s) {
-                  return s.publicKey().toString();
+                  return s.publicKey();
                 }),
                 ", "),
             boost::algorithm::join(
                 peers | boost::adaptors::transformed([](const auto &p) {
-                  return p->pubkey().toString();
+                  return p->pubkey();
                 }),
                 ", "));
       }

--- a/irohad/validation/impl/stateful_validator_impl.cpp
+++ b/irohad/validation/impl/stateful_validator_impl.cpp
@@ -15,7 +15,6 @@
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/batch_meta.hpp"
 #include "logger/logger.hpp"
-#include "validation/utils.hpp"
 
 namespace iroha {
   namespace validation {

--- a/irohad/validation/utils.hpp
+++ b/irohad/validation/utils.hpp
@@ -24,17 +24,17 @@ namespace iroha {
      * @return true, if all public keys of signatures are present in vector of
      * pubkeys
      */
+    template <typename PublicKeys>
     inline bool signaturesSubset(
         const shared_model::interface::types::SignatureRangeType &signatures,
-        const boost::any_range<shared_model::crypto::PublicKey,
-                               boost::forward_traversal_tag> &public_keys) {
+        const PublicKeys &public_keys) {
       return std::all_of(
           signatures.begin(),
           signatures.end(),
-          [&public_keys](const auto &signature) {
+          [&public_keys](auto const &signature) {
             return std::find_if(public_keys.begin(),
                                 public_keys.end(),
-                                [&signature](const auto &public_key) {
+                                [&signature](auto const &public_key) {
                                   return signature.publicKey() == public_key;
                                 })
                 != public_keys.end();
@@ -51,12 +51,11 @@ namespace iroha {
     inline bool peersSubset(
         const shared_model::interface::types::SignatureRangeType &signatures,
         const Peers &peers) {
-      return signaturesSubset(signatures,
-                              peers
-                                  | boost::adaptors::transformed(
-                                        [](const auto &p) -> decltype(auto) {
-                                          return p->pubkey();
-                                        }));
+      using shared_model::interface::types::PublicKeyHexStringView;
+      return signaturesSubset(
+          signatures, peers | boost::adaptors::transformed([](auto const &p) {
+                        return PublicKeyHexStringView{p->pubkey()};
+                      }));
     }
 
   }  // namespace validation

--- a/libs/common/to_string.hpp
+++ b/libs/common/to_string.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include <boost/optional.hpp>
 
@@ -26,8 +27,12 @@ namespace iroha {
       inline std::string toStringDereferenced(const T &o);
     }  // namespace detail
 
-    inline std::string toString(const std::string &o) {
+    inline std::string toString(std::string const &o) {
       return o;
+    }
+
+    inline std::string toString(std::string_view o) {
+      return std::string{o};
     }
 
     template <typename T>

--- a/shared_model/backend/plain/impl/peer.cpp
+++ b/shared_model/backend/plain/impl/peer.cpp
@@ -10,18 +10,18 @@ using namespace shared_model::plain;
 
 Peer::Peer(
     const interface::types::AddressType &address,
-    const interface::types::PubkeyType &public_key,
+    std::string public_key_hex,
     const std::optional<interface::types::TLSCertificateType> &tls_certificate)
     : address_(address),
-      public_key_(public_key),
+      public_key_hex_(std::move(public_key_hex)),
       tls_certificate_(tls_certificate) {}
 
 const shared_model::interface::types::AddressType &Peer::address() const {
   return address_;
 }
 
-const shared_model::interface::types::PubkeyType &Peer::pubkey() const {
-  return public_key_;
+const std::string &Peer::pubkey() const {
+  return public_key_hex_;
 }
 
 const std::optional<shared_model::interface::types::TLSCertificateType>

--- a/shared_model/backend/plain/impl/signature.cpp
+++ b/shared_model/backend/plain/impl/signature.cpp
@@ -7,18 +7,18 @@
 
 using namespace shared_model::plain;
 
-Signature::Signature(const Signature::SignedType &signedData,
-                     const Signature::PublicKeyType &publicKey)
-    : signed_data_(signedData), public_key_(publicKey) {}
+Signature::Signature(std::string signed_data_hex, std::string public_key_hex)
+    : signed_data_hex_(std::move(signed_data_hex)),
+      public_key_hex_(std::move(public_key_hex)) {}
 
-const Signature::PublicKeyType &Signature::publicKey() const {
-  return public_key_;
+const std::string &Signature::publicKey() const {
+  return public_key_hex_;
 }
 
-const Signature::SignedType &Signature::signedData() const {
-  return signed_data_;
+const std::string &Signature::signedData() const {
+  return signed_data_hex_;
 }
 
 shared_model::interface::Signature *Signature::clone() const {
-  return new Signature(signed_data_, public_key_);
+  return new Signature(signed_data_hex_, public_key_hex_);
 }

--- a/shared_model/backend/plain/peer.hpp
+++ b/shared_model/backend/plain/peer.hpp
@@ -6,7 +6,6 @@
 #ifndef IROHA_SHARED_MODEL_PLAIN_PEER_HPP
 #define IROHA_SHARED_MODEL_PLAIN_PEER_HPP
 
-#include "cryptography/public_key.hpp"
 #include "interfaces/common_objects/peer.hpp"
 
 #include <optional>
@@ -17,20 +16,20 @@ namespace shared_model {
     class Peer final : public interface::Peer {
      public:
       Peer(const interface::types::AddressType &address,
-           const interface::types::PubkeyType &public_key,
+           std::string public_key_hex,
            const std::optional<interface::types::TLSCertificateType>
                &tls_certificate);
 
       const interface::types::AddressType &address() const override;
 
-      const interface::types::PubkeyType &pubkey() const override;
+      const std::string &pubkey() const override;
 
       const std::optional<interface::types::TLSCertificateType>
           &tlsCertificate() const override;
 
      private:
       const interface::types::AddressType address_;
-      const interface::types::PubkeyType public_key_;
+      const std::string public_key_hex_;
       const std::optional<interface::types::TLSCertificateType>
           tls_certificate_;
     };

--- a/shared_model/backend/plain/signature.hpp
+++ b/shared_model/backend/plain/signature.hpp
@@ -6,8 +6,6 @@
 #ifndef IROHA_SHARED_MODEL_PLAIN_SIGNATURE_HPP
 #define IROHA_SHARED_MODEL_PLAIN_SIGNATURE_HPP
 
-#include "cryptography/public_key.hpp"
-#include "cryptography/signed.hpp"
 #include "interfaces/common_objects/signature.hpp"
 
 namespace shared_model {
@@ -16,18 +14,18 @@ namespace shared_model {
 
     class Signature final : public interface::Signature {
      public:
-      Signature(const SignedType &signedData, const PublicKeyType &publicKey);
+      Signature(std::string signed_data_hex, std::string public_key_hex);
 
-      const interface::Signature::PublicKeyType &publicKey() const override;
+      const std::string &publicKey() const override;
 
-      const interface::Signature::SignedType &signedData() const override;
+      const std::string &signedData() const override;
 
      protected:
       interface::Signature *clone() const override;
 
      private:
-      const interface::Signature::SignedType signed_data_;
-      const interface::Signature::PublicKeyType public_key_;
+      const std::string signed_data_hex_;
+      const std::string public_key_hex_;
     };
 
   }  // namespace plain

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -33,8 +33,9 @@ namespace shared_model {
 
       interface::types::SignatureRangeType signatures() const override;
 
-      bool addSignature(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key) override;
+      bool addSignature(
+          interface::types::SignedHexStringView signed_blob,
+          interface::types::PublicKeyHexStringView public_key) override;
 
       const interface::types::HashType &hash() const override;
 

--- a/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_add_signatory.cpp
@@ -11,15 +11,14 @@ namespace shared_model {
   namespace proto {
 
     AddSignatory::AddSignatory(iroha::protocol::Command &command)
-        : add_signatory_{command.add_signatory()},
-          pubkey_{crypto::Hash::fromHexString(add_signatory_.public_key())} {}
+        : add_signatory_{command.add_signatory()} {}
 
     const interface::types::AccountIdType &AddSignatory::accountId() const {
       return add_signatory_.account_id();
     }
 
-    const interface::types::PubkeyType &AddSignatory::pubkey() const {
-      return pubkey_;
+    const std::string &AddSignatory::pubkey() const {
+      return add_signatory_.public_key();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_create_account.cpp
@@ -11,11 +11,10 @@ namespace shared_model {
   namespace proto {
 
     CreateAccount::CreateAccount(iroha::protocol::Command &command)
-        : create_account_{command.create_account()},
-          pubkey_{crypto::Hash::fromHexString(create_account_.public_key())} {}
+        : create_account_{command.create_account()} {}
 
-    const interface::types::PubkeyType &CreateAccount::pubkey() const {
-      return pubkey_;
+    const std::string &CreateAccount::pubkey() const {
+      return create_account_.public_key();
     }
 
     const interface::types::AccountNameType &CreateAccount::accountName()

--- a/shared_model/backend/protobuf/commands/impl/proto_remove_peer.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_remove_peer.cpp
@@ -9,11 +9,10 @@ namespace shared_model {
   namespace proto {
 
     RemovePeer::RemovePeer(iroha::protocol::Command &command)
-        : pubkey_{crypto::Hash::fromHexString(
-              command.remove_peer().public_key())} {}
+        : remove_peer_{command.remove_peer()} {}
 
-    const interface::types::PubkeyType &RemovePeer::pubkey() const {
-      return pubkey_;
+    const std::string &RemovePeer::pubkey() const {
+      return remove_peer_.public_key();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_remove_signatory.cpp
@@ -11,16 +11,14 @@ namespace shared_model {
   namespace proto {
 
     RemoveSignatory::RemoveSignatory(iroha::protocol::Command &command)
-        : remove_signatory_{command.remove_signatory()},
-          pubkey_{crypto::Hash::fromHexString(remove_signatory_.public_key())} {
-    }
+        : remove_signatory_{command.remove_signatory()} {}
 
     const interface::types::AccountIdType &RemoveSignatory::accountId() const {
       return remove_signatory_.account_id();
     }
 
-    const interface::types::PubkeyType &RemoveSignatory::pubkey() const {
-      return pubkey_;
+    const std::string &RemoveSignatory::pubkey() const {
+      return remove_signatory_.public_key();
     }
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_add_signatory.hpp
@@ -19,12 +19,10 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
-      const interface::types::PubkeyType &pubkey() const override;
+      const std::string &pubkey() const override;
 
      private:
       const iroha::protocol::AddSignatory &add_signatory_;
-
-      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_create_account.hpp
+++ b/shared_model/backend/protobuf/commands/proto_create_account.hpp
@@ -18,7 +18,7 @@ namespace shared_model {
      public:
       explicit CreateAccount(iroha::protocol::Command &command);
 
-      const interface::types::PubkeyType &pubkey() const override;
+      const std::string &pubkey() const override;
 
       const interface::types::AccountNameType &accountName() const override;
 
@@ -26,8 +26,6 @@ namespace shared_model {
 
      private:
       const iroha::protocol::CreateAccount &create_account_;
-
-      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/commands/proto_remove_peer.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_peer.hpp
@@ -18,10 +18,10 @@ namespace shared_model {
      public:
       explicit RemovePeer(iroha::protocol::Command &command);
 
-      const interface::types::PubkeyType &pubkey() const override;
+      const std::string &pubkey() const override;
 
      private:
-      const interface::types::PubkeyType pubkey_;
+      const iroha::protocol::RemovePeer &remove_peer_;
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
+++ b/shared_model/backend/protobuf/commands/proto_remove_signatory.hpp
@@ -20,12 +20,10 @@ namespace shared_model {
 
       const interface::types::AccountIdType &accountId() const override;
 
-      const interface::types::PubkeyType &pubkey() const override;
+      const std::string &pubkey() const override;
 
      private:
       const iroha::protocol::RemoveSignatory &remove_signatory_;
-
-      const interface::types::PubkeyType pubkey_;
     };
 
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/peer.hpp
+++ b/shared_model/backend/protobuf/common_objects/peer.hpp
@@ -40,14 +40,12 @@ namespace shared_model {
         return tls_certificate_;
       }
 
-      const interface::types::PubkeyType &pubkey() const override {
-        return public_key_;
+      const std::string &pubkey() const override {
+        return proto_->peer_key();
       }
 
      private:
       detail::ReferenceHolder<iroha::protocol::Peer> proto_;
-      const interface::types::PubkeyType public_key_{
-          crypto::Hash::fromHexString(proto_->peer_key())};
       std::optional<std::string> tls_certificate_;
     };
   }  // namespace proto

--- a/shared_model/backend/protobuf/common_objects/proto_common_objects_factory.hpp
+++ b/shared_model/backend/protobuf/common_objects/proto_common_objects_factory.hpp
@@ -37,12 +37,13 @@ namespace shared_model {
 
       FactoryResult<std::unique_ptr<interface::Peer>> createPeer(
           const interface::types::AddressType &address,
-          const interface::types::PubkeyType &public_key,
+          interface::types::PublicKeyHexStringView public_key,
           const std::optional<interface::types::TLSCertificateType>
               &tls_certificate = std::nullopt) override {
         iroha::protocol::Peer peer;
         peer.set_address(address);
-        peer.set_peer_key(public_key.hex());
+        std::string_view const &public_key_string{public_key};
+        peer.set_peer_key(public_key_string.data(), public_key_string.size());
         if (tls_certificate) {
           peer.set_tls_certificate(*tls_certificate);
         }
@@ -124,11 +125,14 @@ namespace shared_model {
       }
 
       FactoryResult<std::unique_ptr<interface::Signature>> createSignature(
-          const interface::types::PubkeyType &key,
-          const interface::Signature::SignedType &signed_data) override {
+          interface::types::PublicKeyHexStringView key,
+          interface::types::SignedHexStringView signed_data) override {
         iroha::protocol::Signature signature;
-        signature.set_public_key(key.hex());
-        signature.set_signature(signed_data.hex());
+        std::string_view const &public_key_string{key};
+        signature.set_public_key(public_key_string.data(),
+                                 public_key_string.size());
+        std::string_view const &signed_string{signed_data};
+        signature.set_signature(signed_string.data(), signed_string.size());
 
         auto proto_singature =
             std::make_unique<Signature>(std::move(signature));

--- a/shared_model/backend/protobuf/common_objects/signature.hpp
+++ b/shared_model/backend/protobuf/common_objects/signature.hpp
@@ -7,8 +7,6 @@
 #define IROHA_PROTO_SIGNATURE_HPP
 
 #include "backend/protobuf/common_objects/trivial_proto.hpp"
-#include "cryptography/public_key.hpp"
-#include "cryptography/signed.hpp"
 #include "interfaces/common_objects/signature.hpp"
 #include "primitive.pb.h"
 
@@ -25,23 +23,18 @@ namespace shared_model {
 
       Signature(Signature &&o) noexcept : Signature(std::move(o.proto_)) {}
 
-      const PublicKeyType &publicKey() const override {
-        return public_key_;
+      const std::string &publicKey() const override {
+        return proto_->public_key();
       }
 
-      const SignedType &signedData() const override {
-        return signed_;
+      const std::string &signedData() const override {
+        return proto_->signature();
       }
 
      private:
       interface::Signature *clone() const override {
         return new Signature(proto_);
       }
-
-      const PublicKeyType public_key_{
-          PublicKeyType::fromHexString(proto_->public_key())};
-
-      const SignedType signed_{SignedType::fromHexString(proto_->signature())};
     };
   }  // namespace proto
 }  // namespace shared_model

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -10,6 +10,8 @@
 #include "backend/protobuf/transaction.hpp"
 #include "backend/protobuf/util.hpp"
 #include "common/byteutils.hpp"
+#include "cryptography/public_key.hpp"
+#include "cryptography/signed.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -91,8 +93,9 @@ namespace shared_model {
       return impl_->signatures_;
     }
 
-    bool Block::addSignature(const crypto::Signed &signed_blob,
-                             const crypto::PublicKey &public_key) {
+    bool Block::addSignature(
+        interface::types::SignedHexStringView signed_blob,
+        interface::types::PublicKeyHexStringView public_key) {
       // if already has such signature
       if (std::find_if(impl_->signatures_.begin(),
                        impl_->signatures_.end(),
@@ -104,8 +107,10 @@ namespace shared_model {
       }
 
       auto sig = impl_->proto_.add_signatures();
-      sig->set_signature(signed_blob.hex());
-      sig->set_public_key(public_key.hex());
+      std::string_view const &signed_string{signed_blob};
+      sig->set_signature(signed_string.data(), signed_string.size());
+      std::string_view const &public_key_string{public_key};
+      sig->set_public_key(public_key_string.data(), public_key_string.size());
 
       impl_->signatures_ = [this] {
         auto signatures = *impl_->proto_.mutable_signatures()

--- a/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_query_response_factory.cpp
@@ -366,7 +366,7 @@ shared_model::proto::ProtoQueryResponseFactory::createPeersResponse(
         for (const auto &peer : peers) {
           auto *proto_peer = protocol_specific_response->add_peers();
           proto_peer->set_address(peer->address());
-          proto_peer->set_peer_key(peer->pubkey().hex());
+          proto_peer->set_peer_key(peer->pubkey());
         }
       },
       query_hash);

--- a/shared_model/backend/protobuf/impl/transaction.cpp
+++ b/shared_model/backend/protobuf/impl/transaction.cpp
@@ -116,8 +116,9 @@ namespace shared_model {
       return impl_->reduced_hash_;
     }
 
-    bool Transaction::addSignature(const crypto::Signed &signed_blob,
-                                   const crypto::PublicKey &public_key) {
+    bool Transaction::addSignature(
+        interface::types::SignedHexStringView signed_blob,
+        interface::types::PublicKeyHexStringView public_key) {
       // if already has such signature
       if (std::find_if(impl_->signatures_.begin(),
                        impl_->signatures_.end(),
@@ -129,8 +130,10 @@ namespace shared_model {
       }
 
       auto sig = impl_->proto_->add_signatures();
-      sig->set_signature(signed_blob.hex());
-      sig->set_public_key(public_key.hex());
+      std::string_view const &signed_string{signed_blob};
+      sig->set_signature(signed_string.data(), signed_string.size());
+      std::string_view const &public_key_string{public_key};
+      sig->set_public_key(public_key_string.data(), public_key_string.size());
 
       impl_->signatures_ = [this] {
         auto signatures = *impl_->proto_->mutable_signatures()

--- a/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_blocks_query.cpp
@@ -6,6 +6,8 @@
 #include "backend/protobuf/queries/proto_blocks_query.hpp"
 
 #include "backend/protobuf/util.hpp"
+#include "cryptography/public_key.hpp"
+#include "cryptography/signed.hpp"
 
 namespace shared_model {
   namespace proto {
@@ -47,15 +49,18 @@ namespace shared_model {
       return signatures_;
     }
 
-    bool BlocksQuery::addSignature(const crypto::Signed &signed_blob,
-                                   const crypto::PublicKey &public_key) {
+    bool BlocksQuery::addSignature(
+        interface::types::SignedHexStringView signed_blob,
+        interface::types::PublicKeyHexStringView public_key) {
       if (proto_.has_signature()) {
         return false;
       }
 
       auto sig = proto_.mutable_signature();
-      sig->set_signature(signed_blob.hex());
-      sig->set_public_key(public_key.hex());
+      std::string_view const &signed_string{signed_blob};
+      sig->set_signature(signed_string.data(), signed_string.size());
+      std::string_view const &public_key_string{public_key};
+      sig->set_public_key(public_key_string.data(), public_key_string.size());
       // TODO: nickaleks IR-120 12.12.2018 remove set
       signatures_.emplace(*proto_.mutable_signature());
       blob_ = makeBlob(proto_);

--- a/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_blocks_query.hpp
@@ -31,8 +31,9 @@ namespace shared_model {
       // ------------------------| Signable override  |-------------------------
       interface::types::SignatureRangeType signatures() const override;
 
-      bool addSignature(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key) override;
+      bool addSignature(
+          interface::types::SignedHexStringView signed_blob,
+          interface::types::PublicKeyHexStringView public_key) override;
 
       const interface::types::HashType &hash() const override;
 

--- a/shared_model/backend/protobuf/queries/proto_query.hpp
+++ b/shared_model/backend/protobuf/queries/proto_query.hpp
@@ -38,8 +38,9 @@ namespace shared_model {
       // ------------------------| Signable override  |-------------------------
       interface::types::SignatureRangeType signatures() const override;
 
-      bool addSignature(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key) override;
+      bool addSignature(
+          interface::types::SignedHexStringView signed_blob,
+          interface::types::PublicKeyHexStringView public_key) override;
 
       const interface::types::HashType &hash() const override;
 

--- a/shared_model/backend/protobuf/transaction.hpp
+++ b/shared_model/backend/protobuf/transaction.hpp
@@ -41,8 +41,9 @@ namespace shared_model {
 
       const interface::types::HashType &reducedHash() const override;
 
-      bool addSignature(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key) override;
+      bool addSignature(
+          interface::types::SignedHexStringView signed_blob,
+          interface::types::PublicKeyHexStringView public_key) override;
 
       const interface::types::HashType &hash() const override;
 

--- a/shared_model/builders/protobuf/unsigned_proto.hpp
+++ b/shared_model/builders/protobuf/unsigned_proto.hpp
@@ -62,7 +62,11 @@ namespace shared_model {
         if (object_finalized_) {
           throw std::runtime_error("object has already been finalized");
         }
-        object_.addSignature(signedBlob, keypair.publicKey());
+        object_.addSignature(
+            shared_model::interface::types::SignedHexStringView{
+                signedBlob.hex()},
+            shared_model::interface::types::PublicKeyHexStringView{
+                keypair.publicKey().hex()});
         // TODO: 05.12.2017 luckychess think about false case
         return *this;
       }

--- a/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
+++ b/shared_model/cryptography/crypto_provider/crypto_model_signer.hpp
@@ -25,7 +25,11 @@ namespace shared_model {
       template <typename T>
       inline void sign(T &signable) const noexcept {
         auto signedBlob = Algorithm::sign(signable.payload(), keypair_);
-        signable.addSignature(signedBlob, keypair_.publicKey());
+        signable.addSignature(
+            shared_model::interface::types::SignedHexStringView{
+                signedBlob.hex()},
+            shared_model::interface::types::PublicKeyHexStringView{
+                keypair_.publicKey().hex()});
       }
 
       void sign(interface::Block &m) const override {

--- a/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.cpp
+++ b/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.cpp
@@ -110,13 +110,5 @@ namespace shared_model {
       ursa_ed25519_bytebuffer_free(private_key);
       return result;
     }
-
-    // Ursa provides functions for retrieving key lengths, but we use hardcoded
-    // values
-    const size_t CryptoProviderEd25519Ursa::kHashLength = 256 / 8;
-    const size_t CryptoProviderEd25519Ursa::kPublicKeyLength = 256 / 8;
-    const size_t CryptoProviderEd25519Ursa::kPrivateKeyLength = 512 / 8;
-    const size_t CryptoProviderEd25519Ursa::kSignatureLength = 512 / 8;
-
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.hpp
+++ b/shared_model/cryptography/ed25519_ursa_impl/crypto_provider.hpp
@@ -51,10 +51,12 @@ namespace shared_model {
        */
       static Keypair generateKeypair(const Seed &seed);
 
-      static const size_t kHashLength;
-      static const size_t kPublicKeyLength;
-      static const size_t kPrivateKeyLength;
-      static const size_t kSignatureLength;
+      // Ursa provides functions for retrieving key lengths, but we use
+      // hardcoded values
+      static constexpr size_t kHashLength = 256 / 8;
+      static constexpr size_t kPublicKeyLength = 256 / 8;
+      static constexpr size_t kPrivateKeyLength = 512 / 8;
+      static constexpr size_t kSignatureLength = 512 / 8;
     };
   }  // namespace crypto
 }  // namespace shared_model

--- a/shared_model/interfaces/base/signable.hpp
+++ b/shared_model/interfaces/base/signable.hpp
@@ -14,6 +14,7 @@
 #include "cryptography/default_hash_provider.hpp"
 #include "interfaces/common_objects/range_types.hpp"
 #include "interfaces/common_objects/signature.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "utils/string_builder.hpp"
 
@@ -41,11 +42,10 @@ namespace shared_model {
 
       /**
        * Attach signature to object
-       * @param signature - signature object for insertion
        * @return true, if signature was added
        */
-      virtual bool addSignature(const crypto::Signed &signed_blob,
-                                const crypto::PublicKey &public_key) = 0;
+      virtual bool addSignature(types::SignedHexStringView signed_blob,
+                                types::PublicKeyHexStringView public_key) = 0;
 
       /**
        * @return time of creation
@@ -114,7 +114,7 @@ namespace shared_model {
          */
         template <typename T>
         size_t operator()(const T &sig) const {
-          return std::hash<std::string>{}(sig.publicKey().hex());
+          return std::hash<std::string>{}(sig.publicKey());
         }
 
         /**

--- a/shared_model/interfaces/commands/add_signatory.hpp
+++ b/shared_model/interfaces/commands/add_signatory.hpp
@@ -21,7 +21,7 @@ namespace shared_model {
       /**
        * @return New signatory is identified with public key
        */
-      virtual const types::PubkeyType &pubkey() const = 0;
+      virtual const std::string &pubkey() const = 0;
       /**
        * @return Account to which add new signatory
        */

--- a/shared_model/interfaces/commands/create_account.hpp
+++ b/shared_model/interfaces/commands/create_account.hpp
@@ -29,7 +29,7 @@ namespace shared_model {
       /**
        * @return Initial account public key
        */
-      virtual const types::PubkeyType &pubkey() const = 0;
+      virtual const std::string &pubkey() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/commands/remove_peer.hpp
+++ b/shared_model/interfaces/commands/remove_peer.hpp
@@ -8,7 +8,6 @@
 
 #include "interfaces/base/model_primitive.hpp"
 
-#include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -22,7 +21,7 @@ namespace shared_model {
       /**
        * Return public key of peer to be removed by the command.
        */
-      virtual const interface::types::PubkeyType &pubkey() const = 0;
+      virtual const std::string &pubkey() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/commands/remove_signatory.hpp
+++ b/shared_model/interfaces/commands/remove_signatory.hpp
@@ -24,7 +24,7 @@ namespace shared_model {
       /**
        * @return Public key to remove from account
        */
-      virtual const types::PubkeyType &pubkey() const = 0;
+      virtual const std::string &pubkey() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/common_objects/common_objects_factory.hpp
+++ b/shared_model/interfaces/common_objects/common_objects_factory.hpp
@@ -15,6 +15,7 @@
 #include "interfaces/common_objects/domain.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/signature.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -33,7 +34,7 @@ namespace shared_model {
        */
       virtual FactoryResult<std::unique_ptr<Peer>> createPeer(
           const types::AddressType &address,
-          const types::PubkeyType &public_key,
+          types::PublicKeyHexStringView public_key,
           const std::optional<types::TLSCertificateType> &tls_certificate =
               std::nullopt) = 0;
 
@@ -73,8 +74,8 @@ namespace shared_model {
        * Create signature instance
        */
       virtual FactoryResult<std::unique_ptr<Signature>> createSignature(
-          const interface::types::PubkeyType &key,
-          const interface::Signature::SignedType &signed_data) = 0;
+          types::PublicKeyHexStringView key,
+          types::SignedHexStringView signed_data) = 0;
 
       virtual ~CommonObjectsFactory() = default;
     };

--- a/shared_model/interfaces/common_objects/impl/signature.cpp
+++ b/shared_model/interfaces/common_objects/impl/signature.cpp
@@ -5,8 +5,7 @@
 
 #include "interfaces/common_objects/signature.hpp"
 
-#include "cryptography/public_key.hpp"
-#include "cryptography/signed.hpp"
+#include "utils/string_builder.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -17,8 +16,8 @@ namespace shared_model {
     std::string Signature::toString() const {
       return detail::PrettyStringBuilder()
           .init("Signature")
-          .appendNamed("publicKey", publicKey().hex())
-          .appendNamed("signedData", signedData().hex())
+          .appendNamed("publicKey", publicKey())
+          .appendNamed("signedData", signedData())
           .finalize();
     }
   }  // namespace interface

--- a/shared_model/interfaces/common_objects/peer.hpp
+++ b/shared_model/interfaces/common_objects/peer.hpp
@@ -33,7 +33,7 @@ namespace shared_model {
       /**
        * @return Public key, for fetching data
        */
-      virtual const interface::types::PubkeyType &pubkey() const = 0;
+      virtual const std::string &pubkey() const = 0;
 
       std::string toString() const override;
 

--- a/shared_model/interfaces/common_objects/signature.hpp
+++ b/shared_model/interfaces/common_objects/signature.hpp
@@ -8,15 +8,8 @@
 
 #include "common/cloneable.hpp"
 #include "interfaces/base/model_primitive.hpp"
-#include "utils/string_builder.hpp"
 
 namespace shared_model {
-
-  namespace crypto {
-    class PublicKey;
-    class Signed;
-  }  // namespace crypto
-
   namespace interface {
 
     /**
@@ -26,24 +19,14 @@ namespace shared_model {
                       public Cloneable<Signature> {
      public:
       /**
-       * Type of public key
-       */
-      using PublicKeyType = crypto::PublicKey;
-
-      /**
        * @return public key of signatory
        */
-      virtual const PublicKeyType &publicKey() const = 0;
-
-      /**
-       * Type of signed data
-       */
-      using SignedType = crypto::Signed;
+      virtual const std::string &publicKey() const = 0;
 
       /**
        * @return signed data
        */
-      virtual const SignedType &signedData() const = 0;
+      virtual const std::string &signedData() const = 0;
 
       bool operator==(const Signature &rhs) const override;
 

--- a/shared_model/interfaces/common_objects/string_view_types.hpp
+++ b/shared_model/interfaces/common_objects/string_view_types.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SHARED_MODEL_STRING_VIEW_TYPES_HPP
+#define IROHA_SHARED_MODEL_STRING_VIEW_TYPES_HPP
+
+#include <string_view>
+
+#include <boost/serialization/strong_typedef.hpp>
+
+namespace shared_model {
+  namespace interface {
+    namespace types {
+      BOOST_STRONG_TYPEDEF(std::string_view, SignedHexStringView)
+      BOOST_STRONG_TYPEDEF(std::string_view, PublicKeyHexStringView)
+    }  // namespace types
+  }    // namespace interface
+}  // namespace shared_model
+
+#endif  // IROHA_SHARED_MODEL_STRING_VIEW_TYPES_HPP

--- a/shared_model/interfaces/iroha_internal/transaction_batch.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch.hpp
@@ -10,6 +10,7 @@
 
 #include "cryptography/hash.hpp"
 #include "interfaces/base/model_primitive.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -49,10 +50,9 @@ namespace shared_model {
        * @param public_key - public key of inserter
        * @return true if signature has been inserted
        */
-      virtual bool addSignature(
-          size_t number_of_tx,
-          const shared_model::crypto::Signed &signed_blob,
-          const shared_model::crypto::PublicKey &public_key) = 0;
+      virtual bool addSignature(size_t number_of_tx,
+                                types::SignedHexStringView signed_blob,
+                                types::PublicKeyHexStringView public_key) = 0;
 
       /// Pretty print the batch contents.
       std::string toString() const;

--- a/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_impl.cpp
@@ -53,8 +53,8 @@ namespace shared_model {
 
     bool TransactionBatchImpl::addSignature(
         size_t number_of_tx,
-        const shared_model::crypto::Signed &signed_blob,
-        const shared_model::crypto::PublicKey &public_key) {
+        types::SignedHexStringView signed_blob,
+        types::PublicKeyHexStringView public_key) {
       if (number_of_tx >= transactions_.size()) {
         return false;
       } else {

--- a/shared_model/interfaces/iroha_internal/transaction_batch_impl.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch_impl.hpp
@@ -29,10 +29,9 @@ namespace shared_model {
 
       std::string toString() const override;
 
-      bool addSignature(
-          size_t number_of_tx,
-          const shared_model::crypto::Signed &signed_blob,
-          const shared_model::crypto::PublicKey &public_key) override;
+      bool addSignature(size_t number_of_tx,
+                        types::SignedHexStringView signed_blob,
+                        types::PublicKeyHexStringView public_key) override;
 
      private:
       types::SharedTxsCollectionType transactions_;

--- a/shared_model/validators/field_validator.hpp
+++ b/shared_model/validators/field_validator.hpp
@@ -8,6 +8,7 @@
 
 #include <regex>
 
+#include "cryptography/crypto_provider/crypto_defaults.hpp"
 #include "datetime/time.hpp"
 #include "interfaces/base/signable.hpp"
 #include "interfaces/permissions.hpp"
@@ -61,7 +62,7 @@ namespace shared_model {
           const interface::Amount &amount) const;
 
       std::optional<ValidationError> validatePubkey(
-          const interface::types::PubkeyType &pubkey) const;
+          std::string_view pubkey) const;
 
       std::optional<ValidationError> validatePeerAddress(
           const interface::types::AddressType &address) const;
@@ -202,15 +203,21 @@ namespace shared_model {
           std::chrono::minutes(5) / std::chrono::milliseconds(1);
 
       // size of key
-      static const size_t public_key_size;
-      static const size_t signature_size;
-      static const size_t hash_size;
-      static const size_t value_size;
+      static constexpr size_t public_key_size =
+          crypto::DefaultCryptoAlgorithmType::kPublicKeyLength;
+      static constexpr size_t signature_size =
+          crypto::DefaultCryptoAlgorithmType::kSignatureLength;
+      static constexpr size_t hash_size =
+          crypto::DefaultCryptoAlgorithmType::kHashLength;
+      /// limit for the set account detail size in bytes
+      static constexpr size_t value_size = 4 * 1024 * 1024;
       size_t max_description_size;
     };
 
     std::optional<ValidationError> validatePubkey(
         const interface::types::PubkeyType &pubkey);
+
+    std::optional<ValidationError> validatePubkey(std::string_view pubkey);
 
   }  // namespace validation
 }  // namespace shared_model

--- a/test/framework/integration_framework/fake_peer/network/mst_message.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_message.hpp
@@ -6,15 +6,15 @@
 #ifndef INTEGRATION_FRAMEWORK_FAKE_PEER_MST_MESSAGE_HPP_
 #define INTEGRATION_FRAMEWORK_FAKE_PEER_MST_MESSAGE_HPP_
 
-#include "cryptography/public_key.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
 
 namespace integration_framework {
   namespace fake_peer {
     struct MstMessage final {
-      MstMessage(const shared_model::crypto::PublicKey &f, iroha::MstState s)
-          : from(f), state(std::move(s)) {}
-      shared_model::crypto::PublicKey from;
+      MstMessage(shared_model::interface::types::PublicKeyHexStringView f,
+                 iroha::MstState s)
+          : peer_hex_key_from(f), state(std::move(s)) {}
+      std::string peer_hex_key_from;
       iroha::MstState state;
     };
   }  // namespace fake_peer

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
@@ -9,7 +9,7 @@ namespace integration_framework {
   namespace fake_peer {
 
     void MstNetworkNotifier::onNewState(
-        const shared_model::crypto::PublicKey &from,
+        shared_model::interface::types::PublicKeyHexStringView from,
         iroha::MstState &&new_state) {
       std::lock_guard<std::mutex> guard(mst_subject_mutex_);
       mst_subject_.get_subscriber().on_next(

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
@@ -20,8 +20,9 @@ namespace integration_framework {
     class MstNetworkNotifier final
         : public iroha::network::MstTransportNotification {
      public:
-      void onNewState(const shared_model::crypto::PublicKey &from,
-                      iroha::MstState &&new_state) override;
+      void onNewState(
+          shared_model::interface::types::PublicKeyHexStringView from,
+          iroha::MstState &&new_state) override;
 
       rxcpp::observable<std::shared_ptr<MstMessage>> getObservable();
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -357,11 +357,13 @@ namespace integration_framework {
       const shared_model::crypto::Keypair &keypair) {
     log_->info("init state");
     my_key_ = keypair;
-    this_peer_ =
-        framework::expected::val(common_objects_factory_->createPeer(
-                                     getAddress(), keypair.publicKey()))
-            .value()
-            .value;
+    using shared_model::interface::types::PublicKeyHexStringView;
+    this_peer_ = framework::expected::val(
+                     common_objects_factory_->createPeer(
+                         getAddress(),
+                         PublicKeyHexStringView{keypair.publicKey().hex()}))
+                     .value()
+                     .value;
     iroha_instance_->initPipeline(keypair, maximum_proposal_size_);
     log_->info("created pipeline");
   }

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -27,6 +27,8 @@ using namespace shared_model;
 using namespace integration_framework;
 using namespace shared_model::interface::permissions;
 
+using interface::types::PublicKeyHexStringView;
+
 static constexpr std::chrono::seconds kMstStateWaitingTime(20);
 static constexpr std::chrono::seconds kSynchronizerWaitingTime(20);
 
@@ -193,10 +195,11 @@ TEST_F(FakePeerFixture, RealPeerIsAdded) {
 
   auto block_with_add_peer =
       proto::BlockBuilder()
-          .transactions(std::vector<shared_model::proto::Transaction>{
-              complete(baseTx(kAdminId).addPeer(itf_->getAddress(),
-                                                itf_->getThisPeer()->pubkey()),
-                       kAdminKeypair)})
+          .transactions(std::vector<shared_model::proto::Transaction>{complete(
+              baseTx(kAdminId).addPeer(
+                  itf_->getAddress(),
+                  PublicKeyHexStringView{itf_->getThisPeer()->pubkey()}),
+              kAdminKeypair)})
           .height(genesis_block.height() + 1)
           .prevHash(genesis_block.hash())
           .createdTime(iroha::time::now())

--- a/test/integration/acceptance/fake_peer_fixture.hpp
+++ b/test/integration/acceptance/fake_peer_fixture.hpp
@@ -19,12 +19,17 @@ void checkBlockHasNTxs(
 }
 
 auto makePeerPointeeMatcher(shared_model::interface::types::AddressType address,
-                            shared_model::interface::types::PubkeyType pubkey) {
+                            std::string pubkey) {
   return ::testing::Truly(
       [address = std::move(address), pubkey = std::move(pubkey)](
           std::shared_ptr<shared_model::interface::Peer> peer) {
         return peer->address() == address and peer->pubkey() == pubkey;
       });
+}
+
+auto makePeerPointeeMatcher(shared_model::interface::types::AddressType address,
+                            shared_model::interface::types::PubkeyType pubkey) {
+  return makePeerPointeeMatcher(address, pubkey.hex());
 }
 
 auto makePeerPointeeMatcher(

--- a/test/integration/acceptance/grant_permission_test.cpp
+++ b/test/integration/acceptance/grant_permission_test.cpp
@@ -70,11 +70,7 @@ TEST_F(GrantablePermissionsFixture, GrantAddSignatoryPermission) {
                 [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       // Add signatory
       .sendTxAwait(
-          permitteeModifySignatory(
-              &TestUnsignedTransactionBuilder::addSignatory,
-              kAccount2,
-              kAccount2Keypair,
-              kAccount1),
+          permitteeAddSignatory(kAccount2, kAccount2Keypair, kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(querySignatories(kAccount1, kAccount1Keypair),
                  check_if_signatory_is_contained);
@@ -121,18 +117,10 @@ TEST_F(GrantablePermissionsFixture, GrantRemoveSignatoryPermission) {
                           permissions::Grantable::kRemoveMySignatory),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendTxAwait(
-          permitteeModifySignatory(
-              &TestUnsignedTransactionBuilder::addSignatory,
-              kAccount2,
-              kAccount2Keypair,
-              kAccount1),
+          permitteeAddSignatory(kAccount2, kAccount2Keypair, kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendTxAwait(
-          permitteeModifySignatory(
-              &TestUnsignedTransactionBuilder::removeSignatory,
-              kAccount2,
-              kAccount2Keypair,
-              kAccount1),
+          permitteeRemoveSignatory(kAccount2, kAccount2Keypair, kAccount1),
           [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
       .sendQuery(querySignatories(kAccount1, kAccount1Keypair),
                  check_if_signatory_is_not_contained);
@@ -176,11 +164,7 @@ TEST_F(GrantablePermissionsFixture, GrantSetQuorumPermission) {
       .skipProposal()
       .skipVerifiedProposal()
       .skipBlock()
-      .sendTx(permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::addSignatory,
-          kAccount2,
-          kAccount2Keypair,
-          kAccount1))
+      .sendTx(permitteeAddSignatory(kAccount2, kAccount2Keypair, kAccount1))
       .skipProposal()
       .skipVerifiedProposal()
       .skipBlock()

--- a/test/integration/acceptance/grantable_permissions_fixture.cpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.cpp
@@ -66,19 +66,30 @@ shared_model::proto::Transaction GrantablePermissionsFixture::revokePermission(
 }
 
 shared_model::proto::Transaction
-GrantablePermissionsFixture::permitteeModifySignatory(
-    GrantablePermissionsFixture::TxBuilder (
-        GrantablePermissionsFixture::TxBuilder::*f)(
-        const shared_model::interface::types::AccountIdType &,
-        const shared_model::interface::types::PubkeyType &) const,
+GrantablePermissionsFixture::permitteeAddSignatory(
     const shared_model::interface::types::AccountNameType
         &permittee_account_name,
     const shared_model::crypto::Keypair &permittee_key,
     const shared_model::interface::types::AccountNameType &account_name) {
   const auto permittee_account_id = permittee_account_name + "@" + kDomain;
   const auto account_id = account_name + "@" + kDomain;
-  return (baseTx(permittee_account_id).*f)(account_id,
-                                           permittee_key.publicKey())
+  return baseTx(permittee_account_id)
+      .addSignatory(account_id, permittee_key.publicKey())
+      .build()
+      .signAndAddSignature(permittee_key)
+      .finish();
+}
+
+shared_model::proto::Transaction
+GrantablePermissionsFixture::permitteeRemoveSignatory(
+    const shared_model::interface::types::AccountNameType
+        &permittee_account_name,
+    const shared_model::crypto::Keypair &permittee_key,
+    const shared_model::interface::types::AccountNameType &account_name) {
+  const auto permittee_account_id = permittee_account_name + "@" + kDomain;
+  const auto account_id = account_name + "@" + kDomain;
+  return baseTx(permittee_account_id)
+      .removeSignatory(account_id, permittee_key.publicKey())
       .build()
       .signAndAddSignature(permittee_key)
       .finish();

--- a/test/integration/acceptance/grantable_permissions_fixture.hpp
+++ b/test/integration/acceptance/grantable_permissions_fixture.hpp
@@ -88,17 +88,26 @@ class GrantablePermissionsFixture : public AcceptanceFixture {
       const shared_model::interface::permissions::Grantable &revoke_permission);
 
   /**
-   * Forms a transaction that either adds or removes signatory of an account
-   * @param f Add or Remove signatory function
+   * Forms a transaction that adds signatory to an account
    * @param permittee_account_name name of account which is granted permission
    * @param permittee_key key of account which is granted permission
    * @param account_name account name which has granted permission to permittee
    * @return a transaction
    */
-  shared_model::proto::Transaction permitteeModifySignatory(
-      TxBuilder (TxBuilder::*f)(
-          const shared_model::interface::types::AccountIdType &,
-          const shared_model::interface::types::PubkeyType &) const,
+  shared_model::proto::Transaction permitteeAddSignatory(
+      const shared_model::interface::types::AccountNameType
+          &permittee_account_name,
+      const shared_model::crypto::Keypair &permittee_key,
+      const shared_model::interface::types::AccountNameType &account_name);
+
+  /**
+   * Forms a transaction that removes signatory of an account
+   * @param permittee_account_name name of account which is granted permission
+   * @param permittee_key key of account which is granted permission
+   * @param account_name account name which has granted permission to permittee
+   * @return a transaction
+   */
+  shared_model::proto::Transaction permitteeRemoveSignatory(
       const shared_model::interface::types::AccountNameType
           &permittee_account_name,
       const shared_model::crypto::Keypair &permittee_key,

--- a/test/integration/acceptance/remove_peer_test.cpp
+++ b/test/integration/acceptance/remove_peer_test.cpp
@@ -27,6 +27,8 @@ using namespace shared_model;
 using namespace integration_framework;
 using namespace shared_model::interface::permissions;
 
+using interface::types::PublicKeyHexStringView;
+
 static constexpr std::chrono::seconds kSynchronizerWaitingTime(20);
 
 /**
@@ -114,10 +116,10 @@ TEST_F(FakePeerFixture, RealPeerIsRemoved) {
 
   // ------------------------ WHEN -------------------------
   // send removePeer command
-  itf.sendTxAwait(
-      complete(baseTx(kAdminId).removePeer(itf.getThisPeer()->pubkey()),
-               kAdminKeypair),
-      checkBlockHasNTxs<1>);
+  itf.sendTxAwait(complete(baseTx(kAdminId).removePeer(PublicKeyHexStringView{
+                               itf_->getThisPeer()->pubkey()}),
+                           kAdminKeypair),
+                  checkBlockHasNTxs<1>);
 
   // ------------------------ THEN -------------------------
   // check that ledger state contains one peer

--- a/test/integration/acceptance/revoke_permission_test.cpp
+++ b/test/integration/acceptance/revoke_permission_test.cpp
@@ -205,11 +205,8 @@ namespace grantables {
 
     proto::Transaction testTransaction(
         GrantablePermissionsFixture &f) override {
-      return f.permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::addSignatory,
-          f.kAccount2,
-          f.kAccount2Keypair,
-          f.kAccount1);
+      return f.permitteeAddSignatory(
+          f.kAccount2, f.kAccount2Keypair, f.kAccount1);
     }
   };
 
@@ -244,11 +241,8 @@ namespace grantables {
 
     proto::Transaction testTransaction(
         GrantablePermissionsFixture &f) override {
-      return f.permitteeModifySignatory(
-          &TestUnsignedTransactionBuilder::removeSignatory,
-          f.kAccount2,
-          f.kAccount2Keypair,
-          f.kAccount1);
+      return f.permitteeRemoveSignatory(
+          f.kAccount2, f.kAccount2Keypair, f.kAccount1);
     }
   };
 

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -27,7 +27,6 @@
 #include "network/impl/grpc_channel_builder.hpp"
 
 using ::testing::_;
-using ::testing::An;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 
@@ -58,9 +57,9 @@ class FixedCryptoProvider : public MockYacCryptoProvider {
     auto vote = MockYacCryptoProvider::getVote(hash);
     auto signature = std::make_shared<MockSignature>();
     EXPECT_CALL(*signature, publicKey())
-        .WillRepeatedly(testing::ReturnRef(*pubkey));
+        .WillRepeatedly(testing::ReturnRefOfCopy(pubkey->hex()));
     EXPECT_CALL(*signature, signedData())
-        .WillRepeatedly(testing::ReturnRef(*data));
+        .WillRepeatedly(testing::ReturnRefOfCopy(data->hex()));
     vote.signature = signature;
     return vote;
   }
@@ -83,7 +82,8 @@ class ConsensusSunnyDayTest : public ::testing::Test {
 
   ConsensusSunnyDayTest()
       : my_peer(mk_local_peer(port + my_num)),
-        my_pub_key(shared_model::crypto::toBinaryString(my_peer->pubkey())) {
+        my_pub_key(iroha::hexstringToBytestringResult(my_peer->pubkey())
+                       .assumeValue()) {
     for (decltype(num_peers) i = 0; i < num_peers; ++i) {
       default_peers.push_back(mk_local_peer(port + i));
     }

--- a/test/integration/pipeline/batch_pipeline_test.cpp
+++ b/test/integration/pipeline/batch_pipeline_test.cpp
@@ -155,7 +155,10 @@ class BatchPipelineTest
     auto signed_blob =
         crypto::DefaultCryptoAlgorithmType::sign(tx->payload(), keypair);
     auto clone_tx = clone(tx.get());
-    clone_tx->addSignature(signed_blob, keypair.publicKey());
+    clone_tx->addSignature(
+        shared_model::interface::types::SignedHexStringView{signed_blob.hex()},
+        shared_model::interface::types::PublicKeyHexStringView{
+            keypair.publicKey().hex()});
     return std::shared_ptr<interface::Transaction>(std::move(clone_tx));
   }
 

--- a/test/integration/validation/chain_validator_storage_test.cpp
+++ b/test/integration/validation/chain_validator_storage_test.cpp
@@ -16,6 +16,8 @@
 #include "framework/test_logger.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
 
+using shared_model::interface::types::PublicKeyHexStringView;
+
 // TODO mboldyrev 14.02.2019 IR-324 Use supermajority checker mock
 static const iroha::consensus::yac::ConsistencyModel kConsistencyModel =
     iroha::consensus::yac::ConsistencyModel::kBft;

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -163,7 +163,7 @@ TEST_F(AmetsuchiTest, PeerTest) {
   ASSERT_EQ(peers->size(), 1);
   ASSERT_EQ(peers->at(0)->address(), "192.168.9.1:50051");
 
-  ASSERT_EQ(peers->at(0)->pubkey(), fake_pubkey);
+  ASSERT_EQ(peers->at(0)->pubkey(), fake_pubkey.hex());
 }
 
 TEST_F(AmetsuchiTest, AddSignatoryTest) {

--- a/test/module/irohad/ametsuchi/mock_peer_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_peer_query.hpp
@@ -22,7 +22,7 @@ namespace iroha {
       MOCK_CONST_METHOD1(
           getLedgerPeerByPublicKey,
           boost::optional<PeerQuery::wPeer>(
-              const shared_model::interface::types::PubkeyType &));
+              shared_model::interface::types::PublicKeyHexStringView));
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_wsv_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_wsv_query.hpp
@@ -27,7 +27,7 @@ namespace iroha {
       MOCK_METHOD1(
           getPeerByPublicKey,
           boost::optional<std::shared_ptr<shared_model::interface::Peer>>(
-              const shared_model::interface::types::PubkeyType &public_key));
+              shared_model::interface::types::PublicKeyHexStringView));
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
+++ b/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
@@ -6,7 +6,8 @@
 #include "ametsuchi/impl/peer_query_wsv.hpp"
 
 #include <gtest/gtest.h>
-#include <backend/plain/peer.hpp>
+#include "backend/plain/peer.hpp"
+#include "cryptography/public_key.hpp"
 #include "module/irohad/ametsuchi/mock_wsv_query.hpp"
 
 class PeerQueryWSVTest : public ::testing::Test {
@@ -29,14 +30,10 @@ TEST_F(PeerQueryWSVTest, GetPeers) {
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers;
   std::shared_ptr<shared_model::interface::Peer> peer1 =
       std::make_shared<shared_model::plain::Peer>(
-          "some-address",
-          shared_model::crypto::PublicKey("some-public-key"),
-          std::nullopt);
+          "some-address", "0A", std::nullopt);
   std::shared_ptr<shared_model::interface::Peer> peer2 =
       std::make_shared<shared_model::plain::Peer>(
-          "another-address",
-          shared_model::crypto::PublicKey("another-public-key"),
-          std::nullopt);
+          "another-address", "0B", std::nullopt);
   peers.push_back(peer1);
   peers.push_back(peer2);
   EXPECT_CALL(*wsv_query_, getPeers()).WillOnce(::testing::Return(peers));

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -135,11 +135,8 @@ namespace iroha {
      public:
       QueryExecutorTest()
           : peer{"127.0.0.1",
-                 shared_model::interface::types::PubkeyType{
-                     shared_model::crypto::Blob::fromHexString(
-                         "fa6ce0e0c21ce1ceaf4ba38538c1868185e9feefeafff3e42d94f"
-                         "21800"
-                         "0a5533")},
+                 "fa6ce0e0c21ce1ceaf4ba38538c1868185e9feefeafff3e42d94f218000a5"
+                 "533",
                  std::nullopt} {
         role_permissions.set(
             shared_model::interface::permissions::Role::kAddMySignatory);

--- a/test/module/irohad/ametsuchi/wsv_query_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_test.cpp
@@ -49,15 +49,11 @@ namespace iroha {
     TEST_F(WsvQueryTest, GetPeers) {
       std::shared_ptr<shared_model::interface::Peer> peer1 =
           std::make_shared<shared_model::plain::Peer>(
-              "some-address",
-              shared_model::crypto::PublicKey("some-public-key"),
-              std::nullopt);
+              "some-address", "0a", std::nullopt);
       command->insertPeer(*peer1);
       std::shared_ptr<shared_model::interface::Peer> peer2 =
           std::make_shared<shared_model::plain::Peer>(
-              "another-address",
-              shared_model::crypto::PublicKey("another-public-key"),
-              std::nullopt);
+              "another-address", "0b", std::nullopt);
       command->insertPeer(*peer2);
 
       auto result = query->getPeers();

--- a/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_crypto_provider.hpp
@@ -27,11 +27,11 @@ namespace iroha {
         auto sig = std::make_shared<MockSignature>();
         EXPECT_CALL(*sig, publicKey())
             .WillRepeatedly(
-                ::testing::ReturnRefOfCopy(shared_model::crypto::PublicKey(
+                ::testing::ReturnRefOfCopy(iroha::bytestringToHexstring(
                     framework::padPubKeyString(pub_key))));
         EXPECT_CALL(*sig, signedData())
             .WillRepeatedly(
-                ::testing::ReturnRefOfCopy(shared_model::crypto::Signed(
+                ::testing::ReturnRefOfCopy(iroha::bytestringToHexstring(
                     framework::padSignatureString(signature))));
 
         return sig;

--- a/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_crypto_provider_test.cpp
@@ -38,9 +38,9 @@ namespace iroha {
             shared_model::crypto::Signed signed_value) {
           auto sig = std::make_unique<MockSignature>();
           EXPECT_CALL(*sig, publicKey())
-              .WillRepeatedly(ReturnRefOfCopy(public_key));
+              .WillRepeatedly(ReturnRefOfCopy(public_key.hex()));
           EXPECT_CALL(*sig, signedData())
-              .WillRepeatedly(ReturnRefOfCopy(signed_value));
+              .WillRepeatedly(ReturnRefOfCopy(signed_value.hex()));
           return sig;
         }
 

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -29,7 +29,7 @@ using namespace shared_model::crypto;
 using iroha::consensus::ConsensusResultCache;
 
 using ::testing::_;
-using ::testing::An;
+using ::testing::A;
 using ::testing::AtLeast;
 using ::testing::InSequence;
 using ::testing::Return;
@@ -46,7 +46,12 @@ class YacGateTest : public ::testing::Test {
     auto block = std::make_shared<MockBlock>();
     EXPECT_CALL(*block, payload())
         .WillRepeatedly(ReturnRefOfCopy(Blob(std::string())));
-    EXPECT_CALL(*block, addSignature(_, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(
+        *block,
+        addSignature(
+            A<shared_model::interface::types::SignedHexStringView>(),
+            A<shared_model::interface::types::PublicKeyHexStringView>()))
+        .WillRepeatedly(Return(true));
     EXPECT_CALL(*block, height()).WillRepeatedly(Return(round.block_round));
     EXPECT_CALL(*block, txsNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*block, createdTime()).WillRepeatedly(Return(1));
@@ -67,9 +72,9 @@ class YacGateTest : public ::testing::Test {
 
     auto signature = std::make_shared<MockSignature>();
     EXPECT_CALL(*signature, publicKey())
-        .WillRepeatedly(ReturnRefOfCopy(expected_pubkey));
+        .WillRepeatedly(ReturnRefOfCopy(expected_pubkey.hex()));
     EXPECT_CALL(*signature, signedData())
-        .WillRepeatedly(ReturnRefOfCopy(expected_signed));
+        .WillRepeatedly(ReturnRefOfCopy(expected_signed.hex()));
 
     expected_hash.block_signature = signature;
     message.hash = expected_hash;
@@ -272,7 +277,7 @@ TEST_F(YacGateTest, DifferentCommit) {
   PublicKey actual_pubkey("actual_pubkey");
   auto signature = std::make_shared<MockSignature>();
   EXPECT_CALL(*signature, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(actual_pubkey));
+      .WillRepeatedly(ReturnRefOfCopy(actual_pubkey.hex()));
 
   message.hash = YacHash(round, "actual_proposal", "actual_block");
   message.signature = signature;
@@ -401,7 +406,7 @@ class CommitFromTheFuture : public YacGateTest {
     PublicKey actual_pubkey("actual_pubkey");
     auto signature = std::make_shared<MockSignature>();
     EXPECT_CALL(*signature, publicKey())
-        .WillRepeatedly(ReturnRefOfCopy(actual_pubkey));
+        .WillRepeatedly(ReturnRefOfCopy(actual_pubkey.hex()));
 
     future_round =
         iroha::consensus::Round(round.block_round, round.reject_round + 1);
@@ -446,7 +451,7 @@ TEST_F(CommitFromTheFuture, ProposalReject) {
   PublicKey second_actual_pubkey("actual_pubkey_2");
   auto second_signature = std::make_shared<MockSignature>();
   EXPECT_CALL(*second_signature, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(second_actual_pubkey));
+      .WillRepeatedly(ReturnRefOfCopy(second_actual_pubkey.hex()));
 
   VoteMessage second_message;
   second_message.hash =
@@ -522,7 +527,7 @@ TEST_F(YacGateOlderTest, OlderVote) {
 TEST_F(YacGateOlderTest, OlderCommit) {
   auto signature = std::make_shared<MockSignature>();
   EXPECT_CALL(*signature, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey")));
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey").hex()));
 
   VoteMessage message{YacHash({round.block_round - 1, round.reject_round},
                               "actual_proposal",
@@ -547,9 +552,9 @@ TEST_F(YacGateOlderTest, OlderReject) {
   auto signature1 = std::make_shared<MockSignature>(),
        signature2 = std::make_shared<MockSignature>();
   EXPECT_CALL(*signature1, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey1")));
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey1").hex()));
   EXPECT_CALL(*signature2, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey2")));
+      .WillRepeatedly(ReturnRefOfCopy(PublicKey("actual_pubkey2").hex()));
 
   VoteMessage message1{YacHash({round.block_round - 1, round.reject_round},
                                "actual_proposal1",

--- a/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_hash_provider_test.cpp
@@ -24,9 +24,11 @@ using ::testing::ReturnRefOfCopy;
 auto makeSignature() {
   auto signature = std::make_unique<MockSignature>();
   EXPECT_CALL(*signature, publicKey())
-      .WillRepeatedly(ReturnRefOfCopy(shared_model::crypto::PublicKey("key")));
+      .WillRepeatedly(
+          ReturnRefOfCopy(shared_model::crypto::PublicKey("key").hex()));
   EXPECT_CALL(*signature, signedData())
-      .WillRepeatedly(ReturnRefOfCopy(shared_model::crypto::Signed("data")));
+      .WillRepeatedly(
+          ReturnRefOfCopy(shared_model::crypto::Signed("data").hex()));
   return signature;
 }
 

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -10,8 +10,6 @@
 #include "module/irohad/consensus/yac/yac_fixture.hpp"
 
 using ::testing::_;
-using ::testing::An;
-using ::testing::AtLeast;
 using ::testing::Return;
 
 using namespace iroha::consensus::yac;
@@ -127,7 +125,8 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
     ASSERT_LT(i, peers_number) << "Reject must had already happened when "
                                   "all peers have voted for different hashes.";
     auto peer = my_order->getPeers().at(i);
-    auto pubkey = shared_model::crypto::toBinaryString(peer->pubkey());
+    auto pubkey =
+        iroha::hexstringToBytestringResult(peer->pubkey()).assumeValue();
     votes.push_back(createVote(makeYacHash(i), pubkey));
     vote_groups.push_back({1});
   };
@@ -138,6 +137,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
 
   yac->onState(votes);
   auto peer = my_order->getPeers().back();
-  auto pubkey = shared_model::crypto::toBinaryString(peer->pubkey());
+  auto pubkey =
+      iroha::hexstringToBytestringResult(peer->pubkey()).assumeValue();
   yac->onState({createVote(makeYacHash(peers_number), pubkey)});
 }

--- a/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_simple_cold_case_test.cpp
@@ -17,7 +17,6 @@
 #include "module/irohad/consensus/yac/yac_fixture.hpp"
 
 using ::testing::_;
-using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::Invoke;
 using ::testing::Ref;

--- a/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_sunny_day_test.cpp
@@ -12,7 +12,6 @@
 #include "module/irohad/consensus/yac/yac_fixture.hpp"
 
 using ::testing::_;
-using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::Return;
 
@@ -47,7 +46,8 @@ TEST_F(YacTest, ValidCaseWhenReceiveSupermajority) {
 
   for (auto i = 0; i < 3; ++i) {
     auto peer = my_peers.at(i);
-    auto pubkey = shared_model::crypto::toBinaryString(peer->pubkey());
+    auto pubkey =
+        iroha::hexstringToBytestringResult(peer->pubkey()).assumeValue();
     yac->onState({createVote(my_hash, pubkey)});
   };
 }

--- a/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
@@ -35,7 +35,8 @@ class NetworkUtil {
     BOOST_ASSERT_MSG(from < peers_.size(), "Requested unknown index of peer");
     return iroha::consensus::yac::createVote(
         yac_hash,
-        *iroha::hexstringToBytestring(peers_.at(from)->pubkey().hex()));
+        iroha::hexstringToBytestringResult(peers_.at(from)->pubkey())
+            .assumeValue());
   }
   /// create votes of peers by their number
   auto createVotes(

--- a/test/module/irohad/consensus/yac/yac_test_util.hpp
+++ b/test/module/irohad/consensus/yac/yac_test_util.hpp
@@ -24,8 +24,8 @@ namespace iroha {
         EXPECT_CALL(*peer, address())
             .WillRepeatedly(::testing::ReturnRefOfCopy(address));
         EXPECT_CALL(*peer, pubkey())
-            .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::interface::types::PubkeyType(
+            .WillRepeatedly(
+                ::testing::ReturnRefOfCopy(iroha::bytestringToHexstring(
                     framework::padPubKeyString(address))));
         EXPECT_CALL(*peer, tlsCertificate())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
@@ -42,20 +42,20 @@ namespace iroha {
         auto block_signature = std::make_shared<MockSignature>();
         EXPECT_CALL(*block_signature, publicKey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::PublicKey(padded_pub_key)));
+                iroha::bytestringToHexstring(padded_pub_key)));
         EXPECT_CALL(*block_signature, signedData())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::Signed(padded_pub_key)));
+                iroha::bytestringToHexstring(padded_pub_key)));
         hash.block_signature = block_signature;
         vote.hash = std::move(hash);
 
         auto signature = std::make_shared<MockSignature>();
         EXPECT_CALL(*signature, publicKey())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::PublicKey(padded_pub_key)));
+                iroha::bytestringToHexstring(padded_pub_key)));
         EXPECT_CALL(*signature, signedData())
             .WillRepeatedly(::testing::ReturnRefOfCopy(
-                shared_model::crypto::Signed(padded_pub_key)));
+                iroha::bytestringToHexstring(padded_pub_key)));
 
         vote.signature = signature;
         return vote;

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -9,7 +9,6 @@
 #include "module/irohad/consensus/yac/yac_fixture.hpp"
 
 using ::testing::_;
-using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::Return;
 

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -32,8 +32,8 @@ namespace iroha {
       : public network::MstTransportNotification {
    public:
     MOCK_METHOD2(onNewState,
-                 void(const shared_model::crypto::PublicKey &from,
-                      MstState &&state));
+                 void(shared_model::interface::types::PublicKeyHexStringView,
+                      MstState &&));
   };
 
   /**

--- a/test/module/irohad/multi_sig_transactions/mst_test_helpers.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_test_helpers.hpp
@@ -44,7 +44,11 @@ auto addSignatures(Batch &&batch, int tx_number, Signatures... signatures) {
   static logger::LoggerPtr log_ = getTestLogger("addSignatures");
 
   auto insert_signatures = [&](auto &&sig_pair) {
-    batch->addSignature(tx_number, sig_pair.first, sig_pair.second);
+    batch->addSignature(tx_number,
+                        shared_model::interface::types::SignedHexStringView{
+                            sig_pair.first.hex()},
+                        shared_model::interface::types::PublicKeyHexStringView{
+                            sig_pair.second.hex()});
   };
 
   // pack expansion trick:
@@ -68,7 +72,11 @@ auto addSignaturesFromKeyPairs(Batch &&batch,
     auto &payload = batch->transactions().at(tx_number)->payload();
     auto signed_blob = shared_model::crypto::CryptoSigner<>::sign(
         shared_model::crypto::Blob(payload), key_pair);
-    batch->addSignature(tx_number, signed_blob, key_pair.publicKey());
+    batch->addSignature(
+        tx_number,
+        shared_model::interface::types::SignedHexStringView{signed_blob.hex()},
+        shared_model::interface::types::PublicKeyHexStringView{
+            key_pair.publicKey().hex()});
   };
 
   // pack expansion trick:

--- a/test/module/irohad/multi_sig_transactions/storage_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/storage_test.cpp
@@ -16,8 +16,6 @@ auto log_ = getTestLogger("MstStorageTest");
 
 class StorageTest : public testing::Test {
  public:
-  StorageTest() : absent_peer_key("absent") {}
-
   void SetUp() override {
     completer_ = std::make_shared<TestCompleter>();
     storage = std::make_shared<MstStorageStateImpl>(
@@ -32,7 +30,8 @@ class StorageTest : public testing::Test {
   }
 
   std::shared_ptr<MstStorage> storage;
-  const shared_model::crypto::PublicKey absent_peer_key;
+  const shared_model::interface::types::PublicKeyHexStringView absent_peer_key{
+      std::string_view{"0A"}};
 
   const unsigned quorum = 3u;
   const shared_model::interface::types::TimestampType creation_time =
@@ -41,6 +40,7 @@ class StorageTest : public testing::Test {
 };
 
 TEST_F(StorageTest, StorageWhenApplyOtherState) {
+  using namespace std::literals;
   log_->info(
       "create state with default peers and other state => "
       "apply state");
@@ -50,7 +50,8 @@ TEST_F(StorageTest, StorageWhenApplyOtherState) {
   new_state += makeTestBatch(txBuilder(6, creation_time));
   new_state += makeTestBatch(txBuilder(7, creation_time));
 
-  storage->apply(shared_model::crypto::PublicKey("another"), new_state);
+  storage->apply(shared_model::interface::types::PublicKeyHexStringView{"0B"sv},
+                 new_state);
 
   ASSERT_EQ(6,
             storage->getDiffState(absent_peer_key, creation_time)

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -164,7 +164,7 @@ TEST_F(TransportTest, SendAndReceive) {
   EXPECT_CALL(*mst_notification_transport_, onNewState(_, _))
       .WillOnce(Invoke(
           [this, &state](const auto &from_key, auto const &target_state) {
-            EXPECT_EQ(this->my_key_.publicKey(), from_key);
+            EXPECT_EQ(this->my_key_.publicKey().hex(), from_key);
             EXPECT_TRUE(statesEqual(state, target_state));
           }));
 

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -132,8 +132,8 @@ TEST_F(BlockLoaderTest, ValidWhenSameTopBlock) {
       .WillOnce(Return(std::vector<wPeer>{peer}));
   EXPECT_CALL(*storage, getTopBlockHeight()).WillOnce(Return(1));
 
-  auto wrapper = make_test_subscriber<CallExact>(
-      loader->retrieveBlocks(1, peer->pubkey()), 0);
+  auto wrapper =
+      make_test_subscriber<CallExact>(loader->retrieveBlocks(1, peer_key), 0);
   wrapper.subscribe();
 
   ASSERT_TRUE(wrapper.validate());

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -97,7 +97,10 @@ class TransactionProcessorTest : public ::testing::Test {
       auto &payload = tx.payload();
       auto signedBlob = shared_model::crypto::CryptoSigner<>::sign(
           shared_model::crypto::Blob(payload), key_pair);
-      tx.addSignature(signedBlob, key_pair.publicKey());
+      tx.addSignature(
+          shared_model::interface::types::SignedHexStringView{signedBlob.hex()},
+          shared_model::interface::types::PublicKeyHexStringView{
+              key_pair.publicKey().hex()});
     };
 
     int temp[] = {(create_signature(std::forward<KeyPairs>(keypairs)), 0)...};

--- a/test/module/irohad/torii/torii_service_query_test.cpp
+++ b/test/module/irohad/torii/torii_service_query_test.cpp
@@ -21,9 +21,6 @@
 #include "validators/protobuf/proto_query_validator.hpp"
 
 using ::testing::_;
-using ::testing::A;
-using ::testing::An;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::Truly;
 

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -29,20 +29,20 @@ class ChainValidationTest : public ::testing::Test {
  public:
   void SetUp() override {
     validator = std::make_shared<ChainValidatorImpl>(
-        supermajority_checker, getTestLogger("ChainValidato"));
+        supermajority_checker, getTestLogger("ChainValidator"));
     storage = std::make_shared<MockMutableStorage>();
     peers = std::vector<std::shared_ptr<shared_model::interface::Peer>>();
 
     auto peer = std::make_shared<MockPeer>();
     EXPECT_CALL(*peer, pubkey())
         .WillRepeatedly(ReturnRefOfCopy(
-            shared_model::interface::types::PubkeyType(std::string(32, '0'))));
+            iroha::bytestringToHexstring(std::string(32, '0'))));
     peers.push_back(peer);
 
     auto signature = std::make_shared<MockSignature>();
     EXPECT_CALL(*signature, publicKey())
         .WillRepeatedly(ReturnRefOfCopy(
-            shared_model::interface::types::PubkeyType(std::string(32, '0'))));
+            iroha::bytestringToHexstring(std::string(32, '0'))));
     signatures.push_back(signature);
 
     EXPECT_CALL(*block, height()).WillRepeatedly(Return(height));

--- a/test/module/shared_model/backend_proto/proto_batch_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_batch_test.cpp
@@ -171,7 +171,10 @@ TEST_F(TransactionBatchTest, CreateSingleTxBatchWhenValid) {
   auto keypair = crypto::DefaultCryptoAlgorithmType::generateKeypair();
   auto signed_blob =
       crypto::DefaultCryptoAlgorithmType::sign(tx1->payload(), keypair);
-  tx1->addSignature(signed_blob, keypair.publicKey());
+  tx1->addSignature(
+      shared_model::interface::types::SignedHexStringView{signed_blob.hex()},
+      shared_model::interface::types::PublicKeyHexStringView{
+          keypair.publicKey().hex()});
 
   auto transaction_batch = factory_->createTransactionBatch(tx1);
 

--- a/test/module/shared_model/backend_proto/proto_transaction_sequence_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_transaction_sequence_test.cpp
@@ -100,7 +100,10 @@ TEST_F(TransactionSequenceTestFixture, CreateBatches) {
     auto keypair = crypto::DefaultCryptoAlgorithmType::generateKeypair();
     auto signed_blob =
         crypto::DefaultCryptoAlgorithmType::sign(tx->payload(), keypair);
-    tx->addSignature(signed_blob, keypair.publicKey());
+    tx->addSignature(
+        shared_model::interface::types::SignedHexStringView{signed_blob.hex()},
+        shared_model::interface::types::PublicKeyHexStringView{
+            keypair.publicKey().hex()});
 
     tx_collection.emplace_back(tx);
   }

--- a/test/module/shared_model/backend_proto/shared_proto_add_signature_test.cpp
+++ b/test/module/shared_model/backend_proto/shared_proto_add_signature_test.cpp
@@ -39,12 +39,13 @@ auto initializeProto(Query::TransportType &proto) {
  * @then it is reflected in wrapper blob getter result
  */
 TYPED_TEST(SharedProtoAddSignatureTest, AddSignature) {
+  using namespace std::literals;
   typename TypeParam::TransportType proto;
   initializeProto(proto);
   TypeParam model{proto};
 
-  Signed signature{"signature"};
-  PublicKey public_key{"public_key"};
+  shared_model::interface::types::SignedHexStringView signature{"0A"sv};
+  shared_model::interface::types::PublicKeyHexStringView public_key{"0B"sv};
 
   model.addSignature(signature, public_key);
 
@@ -54,6 +55,10 @@ TYPED_TEST(SharedProtoAddSignatureTest, AddSignature) {
 
   auto signatures = new_model.signatures();
   ASSERT_EQ(1, boost::size(signatures));
-  ASSERT_EQ(signature, signatures.front().signedData());
-  ASSERT_EQ(public_key, signatures.front().publicKey());
+  ASSERT_EQ(signature,
+            shared_model::interface::types::SignedHexStringView{
+                signatures.front().signedData()});
+  ASSERT_EQ(public_key,
+            shared_model::interface::types::PublicKeyHexStringView{
+                signatures.front().publicKey()});
 }

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -50,11 +50,11 @@ namespace shared_model {
     };
 
     struct MockRemovePeer : public shared_model::interface::RemovePeer {
-      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(pubkey, const std::string &());
     };
 
     struct MockAddSignatory : public shared_model::interface::AddSignatory {
-      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(pubkey, const std::string &());
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
     };
 
@@ -66,7 +66,7 @@ namespace shared_model {
     struct MockCreateAccount : public shared_model::interface::CreateAccount {
       MOCK_CONST_METHOD0(accountName, const types::AccountNameType &());
       MOCK_CONST_METHOD0(domainId, const types::DomainIdType &());
-      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(pubkey, const std::string &());
     };
 
     struct MockCreateAsset : public shared_model::interface::CreateAsset {
@@ -110,7 +110,7 @@ namespace shared_model {
     struct MockRemoveSignatory
         : public shared_model::interface::RemoveSignatory {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
-      MOCK_CONST_METHOD0(pubkey, const types::PubkeyType &());
+      MOCK_CONST_METHOD0(pubkey, const std::string &());
     };
 
     struct MockRevokePermission

--- a/test/module/shared_model/cryptography/security_signatures_test.cpp
+++ b/test/module/shared_model/cryptography/security_signatures_test.cpp
@@ -22,13 +22,13 @@ TEST(SecuritySignature, SignatureOperatorEqual) {
   auto second_signature = std::make_unique<MockSignature>();
 
   EXPECT_CALL(*first_signature, publicKey())
-      .WillRepeatedly(testing::ReturnRef(pk1));
+      .WillRepeatedly(testing::ReturnRef(pk1.hex()));
   EXPECT_CALL(*second_signature, publicKey())
-      .WillRepeatedly(testing::ReturnRef(pk2));
+      .WillRepeatedly(testing::ReturnRef(pk2.hex()));
   EXPECT_CALL(*first_signature, signedData())
-      .WillRepeatedly(testing::ReturnRef(data1));
+      .WillRepeatedly(testing::ReturnRef(data1.hex()));
   EXPECT_CALL(*second_signature, signedData())
-      .WillRepeatedly(testing::ReturnRef(data2));
+      .WillRepeatedly(testing::ReturnRef(data2.hex()));
 
   ASSERT_TRUE(*first_signature == *second_signature);
 }
@@ -39,11 +39,13 @@ TEST(SecuritySignature, SignatureOperatorEqual) {
  * @then  Expect that second signature wasn't added
  */
 TEST(SecuritySignature, TransactionAddsignature) {
+  using namespace std::literals;
   auto tx = TestTransactionBuilder().build();
-  ASSERT_TRUE(tx.addSignature(shared_model::crypto::Signed("sign_one"),
-                              shared_model::crypto::PublicKey("key_one")));
-  ASSERT_FALSE(tx.addSignature(shared_model::crypto::Signed("sign_two"),
-                               shared_model::crypto::PublicKey("key_one")));
+  shared_model::interface::types::PublicKeyHexStringView public_key{"0B"sv};
+  ASSERT_TRUE(tx.addSignature(
+      shared_model::interface::types::SignedHexStringView{"0A"sv}, public_key));
+  ASSERT_FALSE(tx.addSignature(
+      shared_model::interface::types::SignedHexStringView{"0C"sv}, public_key));
 }
 
 /**
@@ -52,9 +54,11 @@ TEST(SecuritySignature, TransactionAddsignature) {
  * @then  Expect that second signature wasn't added
  */
 TEST(SecuritySignature, BlockAddSignature) {
+  using namespace std::literals;
   auto block = TestBlockBuilder().build();
-  ASSERT_TRUE(block.addSignature(shared_model::crypto::Signed("sign_one"),
-                                 shared_model::crypto::PublicKey("key_one")));
-  ASSERT_FALSE(block.addSignature(shared_model::crypto::Signed("sign_two"),
-                                  shared_model::crypto::PublicKey("key_one")));
+  shared_model::interface::types::PublicKeyHexStringView public_key{"0B"sv};
+  ASSERT_TRUE(block.addSignature(
+      shared_model::interface::types::SignedHexStringView{"0A"sv}, public_key));
+  ASSERT_FALSE(block.addSignature(
+      shared_model::interface::types::SignedHexStringView{"0C"sv}, public_key));
 }

--- a/test/module/shared_model/interface_test.cpp
+++ b/test/module/shared_model/interface_test.cpp
@@ -52,13 +52,14 @@ TEST_F(TransactionFixture, checkEqualsOperatorObvious) {
  * @then  checks that transactions are the same
  */
 TEST_F(TransactionFixture, checkEqualsOperatorSameOrder) {
+  using namespace std::literals;
   auto tx1 = makeTx();
   auto tx2 = makeTx();
+  shared_model::interface::types::SignedHexStringView signature{"0A"sv};
+  shared_model::interface::types::PublicKeyHexStringView public_key{"0B"sv};
 
-  tx1->addSignature(shared_model::crypto::Signed("signed_blob"),
-                    shared_model::crypto::PublicKey("pub_key"));
-  tx2->addSignature(shared_model::crypto::Signed("signed_blob"),
-                    shared_model::crypto::PublicKey("pub_key"));
+  tx1->addSignature(signature, public_key);
+  tx2->addSignature(signature, public_key);
 
   ASSERT_EQ(*tx1, *tx2);
 }
@@ -75,15 +76,19 @@ TEST_F(TransactionFixture, checkEqualsOperatorDifferentOrder) {
   auto N = 5;
 
   for (int i = 0; i < N; ++i) {
-    tx1->addSignature(
-        shared_model::crypto::Signed("signed_blob_" + std::to_string(i)),
-        shared_model::crypto::PublicKey("pub_key_" + std::to_string(i)));
-  }
+    auto signature = "0A0" + std::to_string(i);
+    auto public_key = "0B0" + std::to_string(i);
 
-  for (int i = N - 1; i >= 0; --i) {
+    tx1->addSignature(
+        shared_model::interface::types::SignedHexStringView{signature},
+        shared_model::interface::types::PublicKeyHexStringView{public_key});
+
+    signature = "0A0" + std::to_string(N - 1 - i);
+    public_key = "0B0" + std::to_string(N - 1 - i);
+
     tx2->addSignature(
-        shared_model::crypto::Signed("signed_blob_" + std::to_string(i)),
-        shared_model::crypto::PublicKey("pub_key_" + std::to_string(i)));
+        shared_model::interface::types::SignedHexStringView{signature},
+        shared_model::interface::types::PublicKeyHexStringView{public_key});
   }
 
   ASSERT_EQ(*tx1, *tx2);

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -52,7 +52,7 @@ namespace shared_model {
       return createFactoryResult<MockRemovePeer>(
           [&pubkey](FactoryResult<MockRemovePeer> specific_cmd_mock) {
             ON_CALL(*specific_cmd_mock, pubkey())
-                .WillByDefault(ReturnRefOfCopy(pubkey));
+                .WillByDefault(ReturnRefOfCopy(pubkey.hex()));
             return specific_cmd_mock;
           });
     }
@@ -65,7 +65,7 @@ namespace shared_model {
           [&pubkey,
            &account_id](FactoryResult<MockAddSignatory> specific_cmd_mock) {
             EXPECT_CALL(*specific_cmd_mock, pubkey())
-                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+                .WillRepeatedly(ReturnRefOfCopy(pubkey.hex()));
             EXPECT_CALL(*specific_cmd_mock, accountId())
                 .WillRepeatedly(ReturnRefOfCopy(account_id));
             return specific_cmd_mock;
@@ -100,7 +100,7 @@ namespace shared_model {
             EXPECT_CALL(*specific_cmd_mock, domainId())
                 .WillRepeatedly(ReturnRefOfCopy(domain_id));
             EXPECT_CALL(*specific_cmd_mock, pubkey())
-                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+                .WillRepeatedly(ReturnRefOfCopy(pubkey.hex()));
             return specific_cmd_mock;
           });
     }
@@ -210,7 +210,7 @@ namespace shared_model {
             EXPECT_CALL(*specific_cmd_mock, accountId())
                 .WillRepeatedly(ReturnRefOfCopy(account_id));
             EXPECT_CALL(*specific_cmd_mock, pubkey())
-                .WillRepeatedly(ReturnRefOfCopy(pubkey));
+                .WillRepeatedly(ReturnRefOfCopy(pubkey.hex()));
             return specific_cmd_mock;
           });
     }

--- a/test/module/shared_model/query_mocks.hpp
+++ b/test/module/shared_model/query_mocks.hpp
@@ -34,8 +34,8 @@ namespace shared_model {
       MOCK_CONST_METHOD0(queryCounter, types::CounterType());
       MOCK_CONST_METHOD0(signatures, types::SignatureRangeType());
       MOCK_METHOD2(addSignature,
-                   bool(const crypto::Signed &signed_blob,
-                        const crypto::PublicKey &public_key));
+                   bool(types::SignedHexStringView,
+                        types::PublicKeyHexStringView));
       MOCK_CONST_METHOD0(createdTime, types::TimestampType());
       MOCK_CONST_METHOD0(payload, const types::BlobType &());
       MOCK_CONST_METHOD0(blob, const types::BlobType &());

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -82,12 +82,10 @@ class FieldValidatorTest : public ValidatorsTest {
             std::make_shared<const shared_model::validation::Settings>(
                 std::move(testSettings)));
 
-    field_validators.insert(makeTransformValidator(
-        "public_key",
-        &FieldValidator::validatePubkey,
-        &FieldValidatorTest::public_key,
-        [](auto &&x) { return interface::types::PubkeyType(x); },
-        public_key_test_cases));
+    field_validators.insert(makeValidator("public_key",
+                                          &FieldValidator::validatePubkey,
+                                          &FieldValidatorTest::public_key,
+                                          public_key_test_cases));
 
     for (const auto &field : {"role_name", "default_role", "role_id"}) {
       field_validators.insert(makeValidator(field,
@@ -410,8 +408,8 @@ class FieldValidatorTest : public ValidatorsTest {
   }
 
   std::vector<FieldTestCase> public_key_test_cases{
-      makeValidCase(&FieldValidatorTest::public_key, std::string(32, '0')),
-      invalidPublicKeyTestCase("invalid_key_length", std::string(64, '0')),
+      makeValidCase(&FieldValidatorTest::public_key, std::string(64, '0')),
+      invalidPublicKeyTestCase("invalid_key_length", std::string(128, '0')),
       invalidPublicKeyTestCase("empty_string", "")};
 
   std::vector<FieldTestCase> peer_test_cases{

--- a/test/regression/query_test.cpp
+++ b/test/regression/query_test.cpp
@@ -26,8 +26,11 @@ auto makeQuery() {
 template <typename Query>
 auto createInvalidQuery(Query query,
                         const shared_model::crypto::Keypair &keypair) {
-  query.addSignature(shared_model::crypto::Signed(std::string(32, 'a')),
-                     keypair.publicKey());
+  shared_model::crypto::Signed signature{std::string(32, 'a')};
+  query.addSignature(
+      shared_model::interface::types::SignedHexStringView{signature.hex()},
+      shared_model::interface::types::PublicKeyHexStringView{
+          keypair.publicKey().hex()});
   return query;
 }
 


### PR DESCRIPTION
### Description of the Change
Use hexadecimal representation of public key and signature stored in protobuf implementation directly to avoid multiple blob-hex conversions.

### Benefits
Simpler code, better performance?

### Possible Drawbacks 
None
