### PR TITLE
FIX: Clean up directory with blocks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,3 +21,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose -- --nocapture
+    - name: Run tests with cleanup
+      run:
+        - cargo install --debug cargo-make
+        - cargo make test-flow

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Run tests
       run: cargo test --verbose -- --nocapture
     - name: Run tests with cleanup
-      run:
-        - cargo install --debug cargo-make
-        - cargo make test-flow
+      run: |
+        cargo install --debug cargo-make
+        cargo make test-flow

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,16 @@
+[tasks.test]
+command = "cargo"
+args = ["test", "--verbose", "--", "--nocapture"]
+
+[tasks.cleanup-blocks]
+env = { "BLOCKS_DIR" = "./blocks/" }
+script_runner = "@shell"
+script = [
+    "rm -Rf ${BLOCKS_DIR}"
+]
+
+[tasks.test-flow]
+dependencies = [
+    "test",
+    "cleanup-blocks"
+]

--- a/src/storage/kura.rs
+++ b/src/storage/kura.rs
@@ -315,6 +315,22 @@ impl Disk {
     }
 }
 
+pub mod test_helper_fns {
+    use crate::storage::kura::*;
+
+    /// Cleans up default directory of disk storage.
+    /// Should be used in tests that may potentially read from disk
+    /// to prevent failures due to changes in block structure.
+    pub async fn cleanup_default_block_dir() -> Result<(), String> {
+        use async_std::fs;
+
+        fs::remove_dir_all(DEFAULT_BLOCK_STORE_LOCATION)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::model::block::Blockchain;
@@ -374,7 +390,7 @@ mod tests {
         let account_id = "test@test";
         let mut blockchain = Blockchain::new();
         blockchain.push(Vec::new());
-        //TODO: cleanup blocks dir from previous runs, or the test may fail due to incompatible formats
+        test_helper_fns::cleanup_default_block_dir().await;
         let mut kura = Kura::fast_init().await;
         let _result = kura.store(blockchain.last()).await;
         assert!(kura

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -62,6 +62,8 @@ mod tests {
             Transaction::builder(vec![transfer_asset.into()], "source@domain".to_string()).build(),
         ])
         .build();
+        use kura::test_helper_fns;
+        test_helper_fns::cleanup_default_block_dir().await;
         //TODO: replace with `strict_init` when validation will be ready.
         let mut kura = kura::Kura::fast_init().await;
         assert!(kura.store(&block).await.is_ok());


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
1. Introduces test_helper_fns module with a function to cleanup directory with blocks
2. Calls this function in all of the tests that use default block directory
3. Adds makefile for cargo-make to automatically cleanup blocks folder after test completion

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Fixes bug mentioned in the issue RH2-22. The bug was that the tests might fail if there was already a folder with blocks, which contained blocks with different structure from previous versions of iroha2.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
To run tests with cleanup:
1. Install cargo-make on your machine `cargo install --force cargo-make`
2. Run tests with `cargo make test-flow`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>