### PR TITLE
vcpkg: update tbb to new repository

### DIFF
--- a/.packer/win/scripts/vcpkg.ps1
+++ b/.packer/win/scripts/vcpkg.ps1
@@ -12,7 +12,7 @@ echo "Checkout to commit"
 git -C $vcpkg_path checkout (Get-Content -Path $iroha_vcpkg_path\VCPKG_COMMIT_SHA)
 
 echo "Apply patches to vcpkg"
-foreach($file in Get-ChildItem $iroha_vcpkg_path\patches -Filter *.patch) { git -C $vcpkg_path apply $file.FullName }
+foreach($file in Get-ChildItem $iroha_vcpkg_path\patches -Filter *.patch) { git -C $vcpkg_path apply --ignore-whitespace $file.FullName }
 
 echo "Run bootstrap-vcpkg.bat"
 Invoke-Expression "$vcpkg_path\bootstrap-vcpkg.bat"

--- a/vcpkg/build_iroha_deps.sh
+++ b/vcpkg/build_iroha_deps.sh
@@ -6,7 +6,7 @@ iroha_vcpkg_path="${2:-$(pwd)/iroha/vcpkg}"
 
 git clone https://github.com/microsoft/vcpkg $vcpkg_path
 git -C $vcpkg_path checkout $(cat "$iroha_vcpkg_path"/VCPKG_COMMIT_SHA)
-for i in "$iroha_vcpkg_path"/patches/*.patch; do git -C $vcpkg_path apply $i; done;
+for i in "$iroha_vcpkg_path"/patches/*.patch; do git -C $vcpkg_path apply --ignore-whitespace $i; done;
 $vcpkg_path/bootstrap-vcpkg.sh
 $vcpkg_path/vcpkg install $(cat "$iroha_vcpkg_path"/VCPKG_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')
 $vcpkg_path/vcpkg install --head $(cat "$iroha_vcpkg_path"/VCPKG_HEAD_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')

--- a/vcpkg/patches/0001-iroha-ed25519-Initial-port.patch
+++ b/vcpkg/patches/0001-iroha-ed25519-Initial-port.patch
@@ -1,27 +1,27 @@
-From 0ff426a760fbb749f5d59aca029b2f74a45857ad Mon Sep 17 00:00:00 2001
+From f4c07b52668b03f33ff460053f95230169d4e4ec Mon Sep 17 00:00:00 2001
 From: Andrei Lebedev <lebdron@gmail.com>
-Date: Sat, 22 Jun 2019 07:45:34 +0000
+Date: Wed, 11 Mar 2020 10:38:21 +0300
 Subject: [PATCH] [iroha-ed25519] Initial port
 
 Signed-off-by: Andrei Lebedev <lebdron@gmail.com>
 ---
- ...001-Add-check-for-amd64-64-24k-pic-target.patch | 27 +++++++++++++++++++
- ports/iroha-ed25519/CONTROL                        |  4 +++
- ports/iroha-ed25519/portfile.cmake                 | 31 ++++++++++++++++++++++
- 3 files changed, 62 insertions(+)
+ ...dd-check-for-amd64-64-24k-pic-target.patch | 26 ++++++++++++++++
+ ports/iroha-ed25519/CONTROL                   |  3 ++
+ ports/iroha-ed25519/portfile.cmake            | 30 +++++++++++++++++++
+ 3 files changed, 59 insertions(+)
  create mode 100644 ports/iroha-ed25519/0001-Add-check-for-amd64-64-24k-pic-target.patch
  create mode 100644 ports/iroha-ed25519/CONTROL
  create mode 100644 ports/iroha-ed25519/portfile.cmake
 
 diff --git a/ports/iroha-ed25519/0001-Add-check-for-amd64-64-24k-pic-target.patch b/ports/iroha-ed25519/0001-Add-check-for-amd64-64-24k-pic-target.patch
 new file mode 100644
-index 0000000..1051437
+index 000000000..70d3edcc0
 --- /dev/null
 +++ b/ports/iroha-ed25519/0001-Add-check-for-amd64-64-24k-pic-target.patch
-@@ -0,0 +1,27 @@
-+From 3ce523b1f003d074d29f21674fdd1bee8c0a884f Mon Sep 17 00:00:00 2001
+@@ -0,0 +1,26 @@
++From 6afefd3224c2ab3da80564ef2be2259a4b0c620c Mon Sep 17 00:00:00 2001
 +From: Andrei Lebedev <lebdron@gmail.com>
-+Date: Wed, 12 Jun 2019 16:18:45 +0300
++Date: Wed, 11 Mar 2020 10:18:14 +0300
 +Subject: [PATCH] Add check for amd64-64-24k-pic target
 +
 +Signed-off-by: Andrei Lebedev <lebdron@gmail.com>
@@ -34,7 +34,7 @@ index 0000000..1051437
 +--- a/cmake/ed25519_merge_libraries.cmake
 ++++ b/cmake/ed25519_merge_libraries.cmake
 +@@ -46,7 +46,7 @@ function(ed25519_merge_libraries TARGET LIBTYPE)
-+
++ 
 +       else()
 +         # it is shared library
 +-        if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -42,26 +42,24 @@ index 0000000..1051437
 +           ed25519_target_link_libraries(amd64-64-24k-pic
 +             "-Wl,--version-script=${CMAKE_SOURCE_DIR}/linker_exportmap"
 +             )
-+--
-+2.20.1.windows.1
-+
++-- 
++2.25.1
 +
 diff --git a/ports/iroha-ed25519/CONTROL b/ports/iroha-ed25519/CONTROL
 new file mode 100644
-index 0000000..b7a3d23
+index 000000000..1313b8ccc
 --- /dev/null
 +++ b/ports/iroha-ed25519/CONTROL
-@@ -0,0 +1,4 @@
+@@ -0,0 +1,3 @@
 +Source: iroha-ed25519
 +Version: 2.0.1
 +Description: RFC8032 compatible Ed25519 implementation with pluggable hash (sha2-512, sha3-512).
-+
 diff --git a/ports/iroha-ed25519/portfile.cmake b/ports/iroha-ed25519/portfile.cmake
 new file mode 100644
-index 0000000..9158510
+index 000000000..675b9226d
 --- /dev/null
 +++ b/ports/iroha-ed25519/portfile.cmake
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +include(vcpkg_common_functions)
 +
 +vcpkg_from_github(
@@ -92,7 +90,6 @@ index 0000000..9158510
 +#vcpkg_copy_pdbs()
 +
 +file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/iroha-ed25519 RENAME copyright)
-+
---
-2.7.4
+-- 
+2.25.1
 

--- a/vcpkg/patches/0003-tbb-Update-to-new-repository.patch
+++ b/vcpkg/patches/0003-tbb-Update-to-new-repository.patch
@@ -1,0 +1,29 @@
+From ca140b140343700bb8a38fd89e946170a8926120 Mon Sep 17 00:00:00 2001
+From: Andrei Lebedev <lebdron@gmail.com>
+Date: Mon, 23 Mar 2020 14:27:34 +0300
+Subject: [PATCH] [tbb] Update to new repository
+
+Signed-off-by: Andrei Lebedev <lebdron@gmail.com>
+---
+ ports/tbb/portfile.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ports/tbb/portfile.cmake b/ports/tbb/portfile.cmake
+index 119916757..09c2a98d8 100644
+--- a/ports/tbb/portfile.cmake
++++ b/ports/tbb/portfile.cmake
+@@ -6,9 +6,9 @@ endif()
+ 
+ vcpkg_from_github(
+     OUT_SOURCE_PATH SOURCE_PATH
+-    REPO intel/tbb
++    REPO oneapi-src/oneTBB
+     REF 4233fef583b4f8cbf9f781311717600feaaa0694
+-    SHA512 6eb239f16e0ecacb825264869aafad7fb39aa1b1f8a3c03c92344c4255d1c1a34ca0a47a366c471fd2da808f3be14262c7e2305294677f2f490c1a48f6f76ec3
++    SHA512 e7b73d7d72d945d69f67fb1d24aa4e9b114223bb23aa9af08df063fb4f63bd3e740104cd2d6866ba521c12d3d8c36cb30e5f4ca38887b32353da1795b95136a4
+     HEAD_REF tbb_2019
+ )
+ 
+-- 
+2.26.0.rc2
+


### PR DESCRIPTION
### Description of the Change
- `tbb` repository has been changed to https://github.com/oneapi-src/oneTBB from https://github.com/intel/tbb, causing the related hash to be modified. This patch allows to successfully build vcpkg considering the change.
- Backport changes for ignoring whitespaces to successfully apply patches on Linux and Windows.

### Benefits
Build works

### Possible Drawbacks 
None