### PR TITLE
DOPS-935 Iroha support cli option in docker entrypoint.sh

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /opt/iroha_data
 COPY entrypoint.sh wait-for-it.sh /
 RUN chmod +x /entrypoint.sh /wait-for-it.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/sbin/init"]
+CMD ["irohad"]

--- a/docker/release/entrypoint.sh
+++ b/docker/release/entrypoint.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
+set -e
 
-echo key=$KEY
-echo $PWD
-if [ -n "$IROHA_POSTGRES_HOST" ]; then
-  echo "NOTE: IROHA_POSTGRES_HOST should match 'host' option in config file"
-  PG_PORT=${IROHA_POSTGRES_PORT:-5432}
-  /wait-for-it.sh -h $IROHA_POSTGRES_HOST -p $PG_PORT -t 30 -- true
-else
-  echo "WARNING: IROHA_POSTGRES_HOST is not defined.
-    Do not wait for Postgres to become ready. Iroha may fail to start up"
+# if first arg looks like a flag, assume we want to run irohad server
+if [ "${1:0:1}" = '-' ]; then
+  set -- irohad "$@"
 fi
-irohad --genesis_block genesis.block --config config.docker --keypair_name $KEY
+
+if [ "$1" = 'irohad' ]; then
+  echo key=$KEY
+  echo $PWD
+  if [ -n "$IROHA_POSTGRES_HOST" ]; then
+    echo "NOTE: IROHA_POSTGRES_HOST should match 'host' option in config file"
+    PG_PORT=${IROHA_POSTGRES_PORT:-5432}
+    /wait-for-it.sh -h $IROHA_POSTGRES_HOST -p $PG_PORT -t 30 -- true
+  else
+    echo "WARNING: IROHA_POSTGRES_HOST is not defined.
+      Do not wait for Postgres to become ready. Iroha may fail to start up"
+  fi
+	exec "$@" --genesis_block genesis.block --config config.docker --keypair_name $KEY
+fi
+
+exec "$@"


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
The docker entrypoint was changed, to allow run iroha with custom flags. Also it was changed as recommended in docker best-practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint

### Benefits
1. Run iroha with custom flags 
2. Run iroha tools from container:
```
docker run -it  soramitsu/iroha:PR-425 iroha-cli
```

### Possible Drawbacks 
I did not find information about positional arguments in iroha. If we will have it, we should rewrite docker entrypoint.sh .

### Usage Examples or Tests *[optional]*
```
docker pull soramitsu/iroha:PR-425 
```
### Corresponding PR for Ansible role
https://github.com/hyperledger/iroha-deploy/pull/19
