### PR TITLE
[DOPS-947] Python dependencies have been fixed

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -27,7 +27,7 @@ RUN set -e; \
         # CI dependencies
         git ssh tar gzip ca-certificates gnupg \
         # Pythons
-        python-pip python3-pip python3-setuptools python-dev \
+        python-pip python3-pip python-setuptools python3-setuptools python-dev \
         # other
         curl file gdb gdbserver ccache \
         gcovr cppcheck doxygen rsync graphviz graphviz-dev unzip vim zip pkg-config; \


### PR DESCRIPTION
## Task

[DOPS-947]: Fix Iroha develop `dockerfile`.

### Description of the Change

We have got broken CI process for Iroha. The problem was in `pip` unsatisfied dependency. The problem has been solved. Also, the solution has been tested.

### Benefits

The CI process will work properly.

### Possible Drawbacks 

None

### Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-947]: https://soramitsu.atlassian.net/browse/DOPS-947