### PR TITLE
MST: use response from transport

### DIFF
--- a/irohad/main/impl/pending_transaction_storage_init.cpp
+++ b/irohad/main/impl/pending_transaction_storage_init.cpp
@@ -5,6 +5,7 @@
 
 #include "main/impl/pending_transaction_storage_init.hpp"
 
+#include <boost/range/adaptor/transformed.hpp>
 #include <rxcpp/operators/rx-flat_map.hpp>
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"

--- a/irohad/multi_sig_transactions/mst_processor.hpp
+++ b/irohad/multi_sig_transactions/mst_processor.hpp
@@ -8,10 +8,10 @@
 
 #include <memory>
 #include <mutex>
+
 #include <rxcpp/rx-observable-fwd.hpp>
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
-#include "multi_sig_transactions/state/mst_state.hpp"
 
 namespace iroha {
 

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -112,6 +112,8 @@ namespace iroha {
 
     rxcpp::composite_subscription propagation_subscriber_;
 
+    rxcpp::composite_subscription send_state_subscriber_;
+
     logger::LoggerPtr log_;
   };
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/mst_types.hpp
+++ b/irohad/multi_sig_transactions/mst_types.hpp
@@ -33,6 +33,7 @@ namespace iroha {
   using ConstRefPeer = ConstRefT<shared_model::interface::Peer>;
   using ConstRefTime = ConstRefT<TimeType>;
 
+  class Completer;
   class MstState;
 
   using ConstRefState = ConstRefT<MstState>;

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "backend/protobuf/deserialize_repeated_transactions.hpp"
 #include "backend/protobuf/transaction.hpp"
@@ -16,6 +17,8 @@
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/transaction.hpp"
 #include "logger/logger.hpp"
+#include "multi_sig_transactions/mst_types.hpp"
+#include "multi_sig_transactions/state/mst_state.hpp"
 #include "network/impl/grpc_channel_builder.hpp"
 #include "validators/field_validator.hpp"
 
@@ -24,7 +27,6 @@ using namespace iroha::network;
 
 using shared_model::interface::types::PublicKeyHexStringView;
 
-using iroha::ConstRefState;
 namespace {
   auto default_sender_factory = [](const shared_model::interface::Peer &to) {
     return createClient<transport::MstTransportGrpc>(to.address());
@@ -32,9 +34,11 @@ namespace {
 }
 void sendStateAsyncImpl(
     const shared_model::interface::Peer &to,
-    ConstRefState state,
+    MstState const &state,
     const std::string &sender_key,
     AsyncGrpcClient<google::protobuf::Empty> &async_call,
+    std::function<void(grpc::Status &, google::protobuf::Empty &)> on_response =
+        {},
     MstTransportGrpc::SenderFactory sender_factory = default_sender_factory);
 
 MstTransportGrpc::MstTransportGrpc(
@@ -140,30 +144,43 @@ void MstTransportGrpc::subscribe(
   subscriber_ = notification;
 }
 
-void MstTransportGrpc::sendState(const shared_model::interface::Peer &to,
-                                 ConstRefState providing_state) {
-  log_->info("Propagate MstState to peer {}", to.address());
-  sendStateAsyncImpl(to,
-                     providing_state,
-                     my_key_,
-                     *async_call_,
-                     sender_factory_.value_or(default_sender_factory));
+rxcpp::observable<bool> MstTransportGrpc::sendState(
+    shared_model::interface::Peer const &to, MstState const &providing_state) {
+  return rxcpp::observable<>::create<bool>([&](auto s) {
+    log_->info("Propagate MstState to peer {}", to.address());
+    sendStateAsyncImpl(to,
+                       providing_state,
+                       my_key_,
+                       *async_call_,
+                       [s](auto &status, auto &) {
+                         s.on_next(status.ok());
+                         s.on_completed();
+                       },
+                       sender_factory_.value_or(default_sender_factory));
+  });
 }
 
 void iroha::network::sendStateAsync(
     const shared_model::interface::Peer &to,
-    ConstRefState state,
+    MstState const &state,
     const shared_model::crypto::PublicKey &sender_key,
-    AsyncGrpcClient<google::protobuf::Empty> &async_call) {
-  sendStateAsyncImpl(
-      to, state, shared_model::crypto::toBinaryString(sender_key), async_call);
+    AsyncGrpcClient<google::protobuf::Empty> &async_call,
+    std::function<void(grpc::Status &, google::protobuf::Empty &)>
+        on_response) {
+  sendStateAsyncImpl(to,
+                     state,
+                     shared_model::crypto::toBinaryString(sender_key),
+                     async_call,
+                     std::move(on_response));
 }
 
-void sendStateAsyncImpl(const shared_model::interface::Peer &to,
-                        ConstRefState state,
-                        const std::string &sender_key,
-                        AsyncGrpcClient<google::protobuf::Empty> &async_call,
-                        MstTransportGrpc::SenderFactory sender_factory) {
+void sendStateAsyncImpl(
+    const shared_model::interface::Peer &to,
+    MstState const &state,
+    const std::string &sender_key,
+    AsyncGrpcClient<google::protobuf::Empty> &async_call,
+    std::function<void(grpc::Status &, google::protobuf::Empty &)> on_response,
+    MstTransportGrpc::SenderFactory sender_factory) {
   auto client = sender_factory(to);
   transport::MstState protoState;
   protoState.set_source_peer_key(sender_key);
@@ -173,7 +190,9 @@ void sendStateAsyncImpl(const shared_model::interface::Peer &to,
         std::static_pointer_cast<shared_model::proto::Transaction>(tx)
             ->getTransport();
   });
-  async_call.Call([&](auto context, auto cq) {
-    return client->AsyncSendState(context, protoState, cq);
-  });
+  async_call.Call(
+      [&](auto context, auto cq) {
+        return client->AsyncSendState(context, protoState, cq);
+      },
+      std::move(on_response));
 }

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_stub.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_stub.cpp
@@ -5,13 +5,17 @@
 
 #include "multi_sig_transactions/transport/mst_transport_stub.hpp"
 
+#include <rxcpp/rx-lite.hpp>
+
 namespace iroha {
   namespace network {
 
     void MstTransportStub::subscribe(
         std::shared_ptr<MstTransportNotification>) {}
 
-    void MstTransportStub::sendState(const shared_model::interface::Peer &,
-                                     ConstRefState) {}
+    rxcpp::observable<bool> MstTransportStub::sendState(
+        const shared_model::interface::Peer &, MstState const &) {
+      return rxcpp::observable<>::just(true);
+    }
   }  // namespace network
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -15,7 +15,7 @@
 #include "interfaces/iroha_internal/transaction_batch_factory.hpp"
 #include "interfaces/iroha_internal/transaction_batch_parser.hpp"
 #include "logger/logger_fwd.hpp"
-#include "multi_sig_transactions/state/mst_state.hpp"
+#include "multi_sig_transactions/mst_types.hpp"
 #include "network/impl/async_grpc_client.hpp"
 
 namespace iroha {
@@ -66,8 +66,9 @@ namespace iroha {
       void subscribe(
           std::shared_ptr<MstTransportNotification> notification) override;
 
-      void sendState(const shared_model::interface::Peer &to,
-                     ConstRefState providing_state) override;
+      rxcpp::observable<bool> sendState(
+          shared_model::interface::Peer const &to,
+          MstState const &providing_state) override;
 
      private:
       std::weak_ptr<MstTransportNotification> subscriber_;
@@ -90,10 +91,13 @@ namespace iroha {
       boost::optional<SenderFactory> sender_factory_;
     };
 
-    void sendStateAsync(const shared_model::interface::Peer &to,
-                        iroha::ConstRefState state,
-                        const shared_model::crypto::PublicKey &sender_key,
-                        AsyncGrpcClient<google::protobuf::Empty> &async_call);
+    void sendStateAsync(
+        const shared_model::interface::Peer &to,
+        iroha::ConstRefState state,
+        const shared_model::crypto::PublicKey &sender_key,
+        AsyncGrpcClient<google::protobuf::Empty> &async_call,
+        std::function<void(grpc::Status &, google::protobuf::Empty &)>
+            on_response = {});
 
   }  // namespace network
 }  // namespace iroha

--- a/irohad/multi_sig_transactions/transport/mst_transport_stub.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_stub.hpp
@@ -14,8 +14,8 @@ namespace iroha {
      public:
       void subscribe(std::shared_ptr<MstTransportNotification>) override;
 
-      void sendState(const shared_model::interface::Peer &,
-                     ConstRefState) override;
+      rxcpp::observable<bool> sendState(const shared_model::interface::Peer &,
+                                        MstState const &) override;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/mst_transport.hpp
+++ b/irohad/network/mst_transport.hpp
@@ -7,10 +7,15 @@
 #define IROHA_MST_TRANSPORT_HPP
 
 #include <memory>
+
+#include <rxcpp/rx-observable-fwd.hpp>
 #include "interfaces/common_objects/peer.hpp"
-#include "multi_sig_transactions/state/mst_state.hpp"
+#include "interfaces/common_objects/string_view_types.hpp"
 
 namespace iroha {
+
+  class MstState;
+
   namespace network {
 
     /**
@@ -47,9 +52,11 @@ namespace iroha {
        * Share state with other peer
        * @param to - peer recipient of message
        * @param providing_state - state for transmitting
+       * @return true if transmission was successful, false otherwise
        */
-      virtual void sendState(const shared_model::interface::Peer &to,
-                             const MstState &providing_state) = 0;
+      virtual rxcpp::observable<bool> sendState(
+          shared_model::interface::Peer const &to,
+          MstState const &providing_state) = 0;
 
       virtual ~MstTransport() = default;
     };

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -12,6 +12,7 @@
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
 #include "logger/logger.hpp"
+#include "multi_sig_transactions/state/mst_state.hpp"
 #include "validation/stateful_validator_common.hpp"
 
 namespace iroha {

--- a/test/module/irohad/consensus/yac/peer_orderer_test.cpp
+++ b/test/module/irohad/consensus/yac/peer_orderer_test.cpp
@@ -24,6 +24,7 @@ using namespace iroha::ametsuchi;
 using namespace iroha::consensus::yac;
 
 using namespace std;
+using shared_model::interface::types::PublicKeyHexStringView;
 using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
 
@@ -57,7 +58,8 @@ class YacPeerOrdererTest : public ::testing::Test {
     std::vector<std::shared_ptr<shared_model::interface::Peer>> result;
     for (size_t i = 1; i <= kPeersQuantity; ++i) {
       auto tmp = iroha::consensus::yac::makePeer(std::to_string(i));
-      auto peer = makePeer(tmp->address(), tmp->pubkey());
+      auto peer =
+          makePeer(tmp->address(), PublicKeyHexStringView{tmp->pubkey()});
 
       result.emplace_back(std::move(peer));
     }

--- a/test/module/irohad/multi_sig_transactions/mock_mst_transport.hpp
+++ b/test/module/irohad/multi_sig_transactions/mock_mst_transport.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_MOCK_MST_TRANSPORT_HPP
+#define IROHA_MOCK_MST_TRANSPORT_HPP
+
+#include <gmock/gmock.h>
+#include "network/mst_transport.hpp"
+
+namespace iroha {
+  class MockMstTransport : public network::MstTransport {
+   public:
+    MOCK_METHOD1(subscribe,
+                 void(std::shared_ptr<network::MstTransportNotification>));
+    MOCK_METHOD2(
+        sendState,
+        rxcpp::observable<bool>(const shared_model::interface::Peer &to,
+                                const MstState &providing_state));
+  };
+}  // namespace iroha
+
+#endif  // IROHA_MOCK_MST_TRANSPORT_HPP

--- a/test/module/irohad/multi_sig_transactions/mock_mst_transport_notification.hpp
+++ b/test/module/irohad/multi_sig_transactions/mock_mst_transport_notification.hpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_MOCK_MST_TRANSPORT_NOTIFICATION_HPP
+#define IROHA_MOCK_MST_TRANSPORT_NOTIFICATION_HPP
+
+#include <gmock/gmock.h>
+#include "network/mst_transport.hpp"
+
+namespace iroha {
+  /**
+   * Transport notification mock
+   */
+  class MockMstTransportNotification
+      : public network::MstTransportNotification {
+   public:
+    MOCK_METHOD2(onNewState,
+                 void(shared_model::interface::types::PublicKeyHexStringView,
+                      MstState &&));
+  };
+}  // namespace iroha
+
+#endif  // IROHA_MOCK_MST_TRANSPORT_NOTIFICATION_HPP

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -12,30 +12,8 @@
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_time_provider.hpp"
 #include "multi_sig_transactions/mst_types.hpp"
-#include "network/mst_transport.hpp"
 
 namespace iroha {
-
-  class MockMstTransport : public network::MstTransport {
-   public:
-    MOCK_METHOD1(subscribe,
-                 void(std::shared_ptr<network::MstTransportNotification>));
-    MOCK_METHOD2(sendState,
-                 void(const shared_model::interface::Peer &to,
-                      const MstState &providing_state));
-  };
-
-  /**
-   * Transport notification mock
-   */
-  class MockMstTransportNotification
-      : public network::MstTransportNotification {
-   public:
-    MOCK_METHOD2(onNewState,
-                 void(shared_model::interface::types::PublicKeyHexStringView,
-                      MstState &&));
-  };
-
   /**
    * Propagation strategy mock
    */
@@ -62,4 +40,5 @@ namespace iroha {
     MOCK_CONST_METHOD1(batchInStorageImpl, bool(const DataType &));
   };
 }  // namespace iroha
+
 #endif  // IROHA_MST_MOCKS_HPP

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -14,6 +14,7 @@
 #include "interfaces/iroha_internal/transaction_batch_parser_impl.hpp"
 #include "module/irohad/ametsuchi/ametsuchi_mocks.hpp"
 #include "module/irohad/common/validators_config.hpp"
+#include "module/irohad/multi_sig_transactions/mock_mst_transport_notification.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/multi_sig_transactions/mst_test_helpers.hpp"
 #include "module/shared_model/interface_mocks.hpp"
@@ -174,7 +175,7 @@ TEST_F(TransportTest, SendAndReceive) {
       grpc::testing::MockClientAsyncResponseReader<google::protobuf::Empty>>();
   EXPECT_CALL(*stub, AsyncSendStateRaw(_, _, _))
       .WillOnce(DoAll(SaveArg<1>(&request), Return(r.get())));
-  transport->sendState(*peer, state);
+  transport->sendState(*peer, state).subscribe();
   auto response = transport->SendState(&context, &request, nullptr);
   ASSERT_EQ(response.error_code(), grpc::StatusCode::OK);
 }

--- a/test/module/shared_model/interface_mocks.hpp
+++ b/test/module/shared_model/interface_mocks.hpp
@@ -190,26 +190,28 @@ struct MockPeer : public shared_model::interface::Peer {
 };
 
 inline auto makePeer(
-    const std::string &address,
-    const std::string &pub_key,
+    std::string_view address,
+    shared_model::interface::types::PublicKeyHexStringView pub_key,
     const std::optional<shared_model::interface::types::TLSCertificateType>
         &tls_certificate = std::nullopt) {
   auto peer = std::make_unique<MockPeer>();
   EXPECT_CALL(*peer, address())
-      .WillRepeatedly(testing::ReturnRefOfCopy(address));
+      .WillRepeatedly(testing::ReturnRefOfCopy(std::string{address}));
   EXPECT_CALL(*peer, pubkey())
-      .WillRepeatedly(testing::ReturnRefOfCopy(pub_key));
+      .WillRepeatedly(testing::ReturnRefOfCopy(std::string{pub_key}));
   EXPECT_CALL(*peer, tlsCertificate())
       .WillRepeatedly(testing::ReturnRefOfCopy(tls_certificate));
   return peer;
 }
 
 inline auto makePeer(
-    const std::string &address,
+    std::string_view address,
     const shared_model::crypto::PublicKey &pub_key,
     const std::optional<shared_model::interface::types::TLSCertificateType>
         &tls_certificate = std::nullopt) {
-  return makePeer(address, pub_key.hex(), tls_certificate);
+  using shared_model::interface::types::PublicKeyHexStringView;
+  return makePeer(
+      address, PublicKeyHexStringView{pub_key.hex()}, tls_certificate);
 }
 
 struct MockUnsafeProposalFactory


### PR DESCRIPTION
### Description of the Change
- Add response callback parameter to AsyncGrpcClient. Now it is possible to process responses for asynchronous network calls.
- Add response status handling to MST transport. Allows not to assume that the diff was received as in https://github.com/hyperledger/iroha/pull/362 , but to make a decision based on the status instead.
It is also possible to implement an alternative approach to https://github.com/hyperledger/iroha/pull/364 based on an alternative response structure.

### Benefits
Ability to process responses for asynchronous network calls

### Possible Drawbacks 
None
