### PR TITLE
[Maintenance] Fix/python dependencies

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:18.04
 
-RUN apt-get update
+RUN apt-get update; \
+    apt install -y software-properties-common; \
+    add-apt-repository ppa:ubuntu-toolchain-r/test
 
 #Install iroha
 COPY iroha.deb /tmp/iroha.deb
-RUN apt-get install -y /tmp/iroha.deb; \
-    rm -f /tmp/iroha.deb
+RUN set -e; apt-get install -y /tmp/iroha.deb; \
+    rm -f /tmp/iroha.deb; \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/iroha_data
 


### PR DESCRIPTION
## Task

[Maintenance]: Fix Iroha release `dockerfile`.

### Description of the Change

We have got broken CI process for Iroha. The problem was in `iroha.deb` unsatisfied dependency. New PPA repository was added.

### Benefits

The CI process will work properly.

### Possible Drawbacks 

None

### Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-947]: https://soramitsu.atlassian.net/browse/DOPS-947