### PR TITLE
Pass state as the param for listen functions in iroha_network

### DIFF
--- a/iroha_network/src/lib.rs
+++ b/iroha_network/src/lib.rs
@@ -56,6 +56,7 @@ impl Network {
     ///
     /// * `server_url` - url of format ip:port (e.g. `127.0.0.1:7878`) on which this server will listen for incoming connections.
     /// * `handler` - callback function which is called when there is an incoming connection, it get's the stream for this connection
+    /// * `state` - the state that you want to capture, place `()` there if don't need the state, use some reference to the state otherwise
     pub fn listen<H, S>(state: S, server_url: &str, mut handler: H) -> Result<(), String>
     where
         H: FnMut(S, Box<dyn Stream>) -> Result<(), String>,
@@ -76,6 +77,8 @@ impl Network {
     ///
     /// * `server_url` - url of format ip:port (e.g. `127.0.0.1:7878`) on which this server will listen for incoming connections.
     /// * `handler` - callback function which is called when there is an incoming connection, it get's the stream for this connection
+    /// * `state` - the state that you want to capture, place `()` there if don't need the state, use some reference to the state otherwise
+    /// As this is an async function, you may consider using `Arc` for `state`.
     pub async fn listen_async<H, F, S>(
         state: S,
         server_url: &str,
@@ -101,6 +104,7 @@ impl Network {
 
     /// Helper function to call inside `listen` `handler` function to parse and send response.
     /// The `handler` specified here will need to generate `Response` from `Request`.
+    /// See `listen` for the description of the `state`.
     pub fn handle_message<H, S>(
         state: S,
         stream: &mut impl Stream,
@@ -125,6 +129,7 @@ impl Network {
 
     /// Helper function to call inside `listen_async` `handler` function to parse and send response.
     /// The `handler` specified here will need to generate `Response` from `Request`.
+    /// See `listen_async` for the description of the `state`.
     pub async fn handle_message_async<H, F, S>(
         state: S,
         mut stream: Box<dyn AsyncStream>,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

1. Pass state as the param for listen functions in iroha_network
2. Errors are represented as `String` instead of `Box<dyn Error>`

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Now it will be possible to capture state in async functions (as async currently does not support closures). Also it in general simplifies work with the shared state.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
Example can be found in `single_threaded_async_stateful` test.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
