### PR TITLE
[Maintenance] Fix/1.1.x python dependencies

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:18.04
 
-RUN apt-get update
+RUN apt-get update; \
+    apt install -y software-properties-common; \
+    add-apt-repository ppa:ubuntu-toolchain-r/test
 
 #Install iroha
 COPY iroha.deb /tmp/iroha.deb
-RUN apt-get install -y /tmp/iroha.deb; \
-    rm -f /tmp/iroha.deb
+RUN set -e; apt-get install -y /tmp/iroha.deb; \
+    rm -f /tmp/iroha.deb; \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/iroha_data
 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update; \
 
 #Install iroha
 COPY iroha.deb /tmp/iroha.deb
-RUN set -e; apt-get install -y /tmp/iroha.deb; \
+RUN set -e; apt-get update; \
+    apt-get install -y /tmp/iroha.deb; \
     rm -f /tmp/iroha.deb; \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Task

[Maintenance]: Fix Iroha release `dockerfile`.

### Description of the Change

The `apt` cache is updated after adding of test PPA repository.

### Benefits

The CI process will work properly.

### Possible Drawbacks 

None

### Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-947]: https://soramitsu.atlassian.net/browse/DOPS-947