### PR TITLE
DOPS-967  Update ci, push the right tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,9 +159,8 @@ node ('master') {
   useBTF = false
   use_libursa = false
   forceDockerDevelopBuild = false
-  checkTag = sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStatus: true)
 
-  if (scmVars.GIT_LOCAL_BRANCH in ["master"] || checkTag == 0 )
+  if (scmVars.GIT_LOCAL_BRANCH in ["master"] || env.TAG_NAME )
     specialBranch =  true
   else
     specialBranch = false
@@ -174,8 +173,8 @@ node ('master') {
 
   if (scmVars.GIT_LOCAL_BRANCH == "master")
     pushDockerTag = 'master'
-  else if (checkTag == 0 )
-    pushDockerTag = sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStdout: true).trim().replaceAll('-','_')
+  else if (env.TAG_NAME)
+    pushDockerTag = env.TAG_NAME
   else
     pushDockerTag = 'not-supposed-to-be-pushed'
 
@@ -280,7 +279,7 @@ node ('master') {
        x64linux_compiler_list=${x64linux_compiler_list}, mac_compiler_list=${mac_compiler_list}, win_compiler_list = ${win_compiler_list}"
        sanitize=${sanitize}, cppcheck=${cppcheck}, fuzzing=${fuzzing}, benchmarking=${benchmarking}, coredumps=${coredumps}, sonar=${sonar},
        codestyle=${codestyle},coverage=${coverage}, coverage_mac=${coverage_mac} doxygen=${doxygen}"
-       forceDockerDevelopBuild=${forceDockerDevelopBuild}, checkTag=${checkTag}
+       forceDockerDevelopBuild=${forceDockerDevelopBuild}, env.TAG_NAME=${env.TAG_NAME}
     """
   print scmVars
   print environmentList


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Command `git describe --tags --exact-match 561526112dc2666cdfdbd888984a9fef9b8ed66d` returns only one tag, but we can have situation then 2 tags have same commit (e.g: `latest` and `1.1.3`)
This command will return only first tag `1.1.3`.
This PR uses build in Jenkins variable  `env.TAG_NAME` it contains current building tag or `Null`
### Benefits

Can have multiple tags on single commit. 

### Possible Drawbacks 

Complicated to test, we will test it with next release. 

