### PR TITLE
RFC: Compare implementations of sort_peers

### DIFF
--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -13,7 +13,13 @@ async-std = { version = "1.5", features = ["attributes"] }
 futures = { version = "0.3.4", features = ["thread-pool"] }
 parity-scale-codec = { version = "1.3", features = ["derive"] }
 ursa = "0.3.2"
+rand = "0.7.3"
 
 [dev-dependencies]
 hex-literal = "0.2.1"
 tempfile = "3"
+criterion = "0.3"
+
+[[bench]]
+name = "sumeragi"
+harness = false

--- a/iroha/benches/sumeragi.rs
+++ b/iroha/benches/sumeragi.rs
@@ -1,0 +1,30 @@
+use criterion::*;
+use iroha::{peer::PeerId, sumeragi::Sumeragi};
+
+const N_PEERS: usize = 255;
+
+fn get_n_peers(n: usize) -> Vec<PeerId> {
+    (0..n)
+        .map(|i| PeerId {
+            address: format!("127.0.0.{}", i),
+            public_key: [0u8; 32],
+        })
+        .collect()
+}
+
+fn sort_hash_combine(criterion: &mut Criterion) {
+    let mut peers: Vec<PeerId> = get_n_peers(N_PEERS);
+    criterion.bench_function("sort_hash_combine", |b| {
+        b.iter(|| Sumeragi::sort_peers(&mut peers, Some([0u8; 32])));
+    });
+}
+
+fn sort_with_rand(criterion: &mut Criterion) {
+    let mut peers: Vec<PeerId> = get_n_peers(N_PEERS);
+    criterion.bench_function("sort_with_rand", |b| {
+        b.iter(|| Sumeragi::sort_peers_with_rand(&mut peers, Some([0u8; 32])));
+    });
+}
+
+criterion_group!(benches, sort_hash_combine, sort_with_rand);
+criterion_main!(benches);

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -10,7 +10,7 @@ mod merkle;
 pub mod peer;
 pub mod query;
 mod queue;
-mod sumeragi;
+pub mod sumeragi;
 pub mod torii;
 pub mod tx;
 pub mod wsv;

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -6,6 +6,7 @@ use crate::{
 use iroha_derive::*;
 use iroha_network::{Network, Request};
 use parity_scale_codec::{Decode, Encode};
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use std::cmp::Ordering;
 
 pub struct Sumeragi {
@@ -116,7 +117,7 @@ impl Sumeragi {
         }
     }
 
-    fn sort_peers(peers: &mut Vec<PeerId>, block_hash: Option<Hash>) {
+    pub fn sort_peers(peers: &mut Vec<PeerId>, block_hash: Option<Hash>) {
         peers.sort_by(|p1, p2| {
             if let Some(block_hash) = block_hash {
                 let mut bytes_p1 = Vec::<u8>::from(p1);
@@ -135,6 +136,14 @@ impl Sumeragi {
                 p1.address.cmp(&p2.address)
             }
         });
+    }
+
+    pub fn sort_peers_with_rand(peers: &mut Vec<PeerId>, block_hash: Option<Hash>) {
+        peers.sort_by(|p1, p2| p1.address.cmp(&p2.address));
+        if let Some(block_hash) = block_hash {
+            let mut rng = StdRng::from_seed(block_hash);
+            peers.shuffle(&mut rng);
+        }
     }
 
     pub fn sign_block(&self, block: Block) -> Result<Block, String> {
@@ -270,5 +279,49 @@ mod tests {
         let mut peers2 = peers1.clone();
         Sumeragi::sort_peers(&mut peers2, Some([2u8; 32]));
         assert_ne!(peers1, peers2);
+    }
+
+    #[test]
+    fn different_order_rand() {
+        let mut peers1 = vec![
+            PeerId {
+                address: "127.0.0.1:7878".to_string(),
+                public_key: [1u8; 32],
+            },
+            PeerId {
+                address: "127.0.0.1:7879".to_string(),
+                public_key: [2u8; 32],
+            },
+            PeerId {
+                address: "127.0.0.1:7880".to_string(),
+                public_key: [3u8; 32],
+            },
+        ];
+        Sumeragi::sort_peers_with_rand(&mut peers1, Some([1u8; 32]));
+        let mut peers2 = peers1.clone();
+        Sumeragi::sort_peers_with_rand(&mut peers2, Some([2u8; 32]));
+        assert_ne!(peers1, peers2);
+    }
+
+    #[test]
+    fn same_order_rand() {
+        let mut peers1 = vec![
+            PeerId {
+                address: "127.0.0.1:7878".to_string(),
+                public_key: [1u8; 32],
+            },
+            PeerId {
+                address: "127.0.0.1:7879".to_string(),
+                public_key: [2u8; 32],
+            },
+            PeerId {
+                address: "127.0.0.1:7880".to_string(),
+                public_key: [3u8; 32],
+            },
+        ];
+        Sumeragi::sort_peers_with_rand(&mut peers1, Some([1u8; 32]));
+        let mut peers2 = peers1.clone();
+        Sumeragi::sort_peers_with_rand(&mut peers2, Some([1u8; 32]));
+        assert_eq!(peers1, peers2);
     }
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
This PR is not intended to be merged, it is meant to compare different implementations of `sort_peers` function.

Function implementations:
1. Sort by hash of `(peer, block_hash)`
2. Seed rand with `block_hash` and shuffle peers with rand

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
