### PR TITLE
network and storage abstraction as traits

### DIFF
--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -14,6 +14,7 @@ futures = { version = "0.3.4", features = ["thread-pool"] }
 parity-scale-codec = { version = "1.3", features = ["derive"] }
 ursa = "0.3.2"
 rand = "0.7.3"
+async-trait = "0.1.30"
 
 [dev-dependencies]
 hex-literal = "0.2.1"

--- a/iroha/src/torii.rs
+++ b/iroha/src/torii.rs
@@ -40,7 +40,7 @@ impl Torii {
             transaction_sender,
             message_sender,
         };
-        Network::listen(Arc::new(Mutex::new(state)), url, handle_connection)
+        TcpNetwork::listen(Arc::new(Mutex::new(state)), url, handle_connection)
             .await
             .expect("Failed to start listening Torii.");
     }
@@ -60,7 +60,7 @@ async fn handle_connection(
     //TODO: Why network can't spawn new task?
     let state22 = Arc::clone(&state);
     state.lock().await.pool.spawn_ok(async move {
-        Network::handle_message_async(state22, stream, handle_request)
+        TcpNetwork::handle_message_async(state22, stream, handle_request)
             .await
             .expect("Failed to handle message.")
     });

--- a/iroha_client/src/client.rs
+++ b/iroha_client/src/client.rs
@@ -38,7 +38,7 @@ impl Client {
     /// Contract API entry point. Submits contracts to `Iroha` peers.
     #[log]
     pub async fn submit(&mut self, command: Contract) -> Result<(), String> {
-        let network = Network::new(&self.torii_url);
+        let network = TcpNetwork::new(&self.torii_url);
         let transaction = Transaction::new(
             vec![command],
             Id::new("account", "domain"),
@@ -66,7 +66,7 @@ impl Client {
     /// Query API entry point. Requests queries from `Iroha` peers.
     #[log]
     pub async fn request(&mut self, request: &QueryRequest) -> Result<QueryResult, String> {
-        let network = Network::new(&self.torii_url);
+        let network = TcpNetwork::new(&self.torii_url);
         match network
             .send_request(Request::new(uri::QUERY_URI.to_string(), request.into()))
             .await

--- a/iroha_network/Cargo.toml
+++ b/iroha_network/Cargo.toml
@@ -11,6 +11,7 @@ iroha_derive = { path = "../iroha_macro/iroha_derive" }
 async-std = { version = "1.5.0", features = ["attributes"] }
 futures = "0.3.4"
 parity-scale-codec = { version = "1.3", features = ["derive"] }
+async-trait = "0.1.30"
 
 [dev-dependencies]
 chashmap = "2.2.2"


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
In order to mock kura and network in sumeragi tests, storage and network traits are introduced. And Sumeragi now uses these traits instead of specififc implementations.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
It was needed to introduce a new dependency crate: `async_trait`. Sadly I don't see a way around this right now. Async traits are still missing in core rust and it is advised to use this crate for this functionality.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
