### PR TITLE
Replace boost:: optional with std:: in irohad

### DIFF
--- a/iroha-cli/main.cpp
+++ b/iroha-cli/main.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
     auto keysManager =
         iroha::KeysManagerImpl(FLAGS_account_name, keys_manager_log);
     if (not(FLAGS_pass_phrase.size() == 0
-                ? keysManager.createKeys(boost::none)
+                ? keysManager.createKeys(std::nullopt)
                 : keysManager.createKeys(FLAGS_pass_phrase))) {
       logger->error("Keys already exist");
       return EXIT_FAILURE;
@@ -223,7 +223,7 @@ int main(int argc, char *argv[]) {
                                    keys_manager_log);
     auto keypair = FLAGS_pass_phrase.size() != 0
         ? manager.loadKeys(FLAGS_pass_phrase)
-        : manager.loadKeys(boost::none);
+        : manager.loadKeys(std::nullopt);
     if (auto e = iroha::expected::resultToOptionalError(keypair)) {
       logger->error(
           "Keypair error: {}.\n"

--- a/irohad/ametsuchi/block_query_factory.hpp
+++ b/irohad/ametsuchi/block_query_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_BLOCK_QUERY_FACTORY_HPP
 #define IROHA_BLOCK_QUERY_FACTORY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "ametsuchi/block_query.hpp"
 
@@ -18,7 +18,7 @@ namespace iroha {
        * Creates a block query from the current state.
        * @return Created block query
        */
-      virtual boost::optional<std::shared_ptr<BlockQuery>> createBlockQuery()
+      virtual std::optional<std::shared_ptr<BlockQuery>> createBlockQuery()
           const = 0;
 
       virtual ~BlockQueryFactory() = default;

--- a/irohad/ametsuchi/block_storage.hpp
+++ b/irohad/ametsuchi/block_storage.hpp
@@ -9,8 +9,8 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 
-#include <boost/optional.hpp>
 #include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {
@@ -30,9 +30,9 @@ namespace iroha {
 
       /**
        * Get block with given height
-       * @return block if exists, boost::none otherwise
+       * @return block if exists, std::nullopt otherwise
        */
-      virtual boost::optional<std::unique_ptr<shared_model::interface::Block>>
+      virtual std::optional<std::unique_ptr<shared_model::interface::Block>>
       fetch(shared_model::interface::types::HeightType height) const = 0;
 
       /**

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -29,15 +29,15 @@ std::string FlatFile::id_to_name(Identifier id) {
   return os.str();
 }
 
-boost::optional<Identifier> FlatFile::name_to_id(const std::string &name) {
+std::optional<Identifier> FlatFile::name_to_id(const std::string &name) {
   if (name.size() != FlatFile::DIGIT_CAPACITY) {
-    return boost::none;
+    return std::nullopt;
   }
   try {
     Identifier id = std::stoul(name);
-    return boost::make_optional(id);
+    return std::make_optional(id);
   } catch (const std::exception &e) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -92,13 +92,12 @@ bool FlatFile::add(Identifier id, const Bytes &block) {
   available_blocks_.insert(id);
   return true;
 }
-
-boost::optional<FlatFile::Bytes> FlatFile::get(Identifier id) const {
+std::optional<FlatFile::Bytes> FlatFile::get(Identifier id) const {
   const auto filename =
       boost::filesystem::path{dump_dir_} / FlatFile::id_to_name(id);
   if (not boost::filesystem::exists(filename)) {
     log_->info("get({}) file not found", id);
-    return boost::none;
+    return std::nullopt;
   }
   return iroha::expected::resultToOptionalValue(
       iroha::readBinaryFile(filename.string()));

--- a/irohad/ametsuchi/impl/flat_file/flat_file.hpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.hpp
@@ -51,9 +51,9 @@ namespace iroha {
       /**
        * Converts aligned string (see above) to number.
        * @param name - name to convert
-       * @return id or boost::none
+       * @return id or std::nullopt
        */
-      static boost::optional<Identifier> name_to_id(const std::string &name);
+      static std::optional<Identifier> name_to_id(const std::string &name);
 
       /**
        * Create storage in paths
@@ -66,7 +66,7 @@ namespace iroha {
 
       bool add(Identifier id, const Bytes &blob) override;
 
-      boost::optional<Bytes> get(Identifier id) const override;
+      std::optional<Bytes> get(Identifier id) const override;
 
       std::string directory() const override;
 

--- a/irohad/ametsuchi/impl/flat_file_block_storage.cpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.cpp
@@ -34,26 +34,26 @@ bool FlatFileBlockStorage::insert(
       });
 }
 
-boost::optional<std::unique_ptr<shared_model::interface::Block>>
+std::optional<std::unique_ptr<shared_model::interface::Block>>
 FlatFileBlockStorage::fetch(
     shared_model::interface::types::HeightType height) const {
   auto storage_block = flat_file_storage_->get(height);
   if (not storage_block) {
-    return boost::none;
+    return std::nullopt;
   }
 
   return json_converter_->deserialize(bytesToString(*storage_block))
       .match(
           [&](auto &&block) {
-            return boost::make_optional<
+            return std::make_optional<
                 std::unique_ptr<shared_model::interface::Block>>(
                 std::move(block.value));
           },
           [&](const auto &error)
-              -> boost::optional<
+              -> std::optional<
                   std::unique_ptr<shared_model::interface::Block>> {
             log_->warn("Error while block deserialization: {}", error.error);
-            return boost::none;
+            return std::nullopt;
           });
 }
 

--- a/irohad/ametsuchi/impl/flat_file_block_storage.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.hpp
@@ -25,7 +25,7 @@ namespace iroha {
       bool insert(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      boost::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
+      std::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
           shared_model::interface::types::HeightType height) const override;
 
       size_t size() const override;

--- a/irohad/ametsuchi/impl/in_memory_block_storage.cpp
+++ b/irohad/ametsuchi/impl/in_memory_block_storage.cpp
@@ -13,14 +13,14 @@ bool InMemoryBlockStorage::insert(
   return block_store_.emplace(height, std::move(block)).second;
 }
 
-boost::optional<std::unique_ptr<shared_model::interface::Block>>
+std::optional<std::unique_ptr<shared_model::interface::Block>>
 InMemoryBlockStorage::fetch(
     shared_model::interface::types::HeightType height) const {
   auto it = block_store_.find(height);
   if (it != block_store_.end()) {
     return clone(*(it->second));
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/irohad/ametsuchi/impl/in_memory_block_storage.hpp
+++ b/irohad/ametsuchi/impl/in_memory_block_storage.hpp
@@ -21,7 +21,7 @@ namespace iroha {
       bool insert(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      boost::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
+      std::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
           shared_model::interface::types::HeightType height) const override;
 
       size_t size() const override;

--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -26,7 +26,7 @@
 namespace iroha {
   namespace ametsuchi {
     MutableStorageImpl::MutableStorageImpl(
-        boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state,
+        std::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state,
         std::shared_ptr<PostgresCommandExecutor> command_executor,
         std::unique_ptr<BlockStorage> block_storage,
         logger::LoggerManagerTreePtr log_manager)
@@ -137,7 +137,7 @@ namespace iroha {
       }
     }
 
-    boost::optional<std::shared_ptr<const iroha::LedgerState>>
+    std::optional<std::shared_ptr<const iroha::LedgerState>>
     MutableStorageImpl::getLedgerState() const {
       return ledger_state_;
     }

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -28,7 +28,7 @@ namespace iroha {
 
      public:
       MutableStorageImpl(
-          boost::optional<std::shared_ptr<const iroha::LedgerState>>
+          std::optional<std::shared_ptr<const iroha::LedgerState>>
               ledger_state,
           std::shared_ptr<PostgresCommandExecutor> command_executor,
           std::unique_ptr<BlockStorage> block_storage,
@@ -41,7 +41,7 @@ namespace iroha {
                      std::shared_ptr<shared_model::interface::Block>> blocks,
                  MutableStoragePredicate predicate) override;
 
-      boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      std::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const;
 
       expected::Result<CommitResult, std::string> commit() && override;
@@ -64,7 +64,7 @@ namespace iroha {
       bool apply(std::shared_ptr<const shared_model::interface::Block> block,
                  MutableStoragePredicate predicate);
 
-      boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
+      std::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
 
       soci::session &sql_;
       std::unique_ptr<PostgresWsvCommand> wsv_command_;

--- a/irohad/ametsuchi/impl/peer_query_wsv.cpp
+++ b/irohad/ametsuchi/impl/peer_query_wsv.cpp
@@ -15,12 +15,12 @@ namespace iroha {
     PeerQueryWsv::PeerQueryWsv(std::shared_ptr<WsvQuery> wsv)
         : wsv_(std::move(wsv)) {}
 
-    boost::optional<std::vector<PeerQuery::wPeer>>
+    std::optional<std::vector<PeerQuery::wPeer>>
     PeerQueryWsv::getLedgerPeers() {
       return wsv_->getPeers();
     }
 
-    boost::optional<PeerQuery::wPeer> PeerQueryWsv::getLedgerPeerByPublicKey(
+    std::optional<PeerQuery::wPeer> PeerQueryWsv::getLedgerPeerByPublicKey(
         shared_model::interface::types::PublicKeyHexStringView public_key)
         const {
       return wsv_->getPeerByPublicKey(public_key);

--- a/irohad/ametsuchi/impl/peer_query_wsv.hpp
+++ b/irohad/ametsuchi/impl/peer_query_wsv.hpp
@@ -29,13 +29,13 @@ namespace iroha {
        * Fetch peers stored in ledger
        * @return list of peers in insertion to ledger order
        */
-      boost::optional<std::vector<wPeer>> getLedgerPeers() override;
+      std::optional<std::vector<wPeer>> getLedgerPeers() override;
 
       /**
        * Fetch peer with given public key from ledger
        * @return the peer if found, none otherwise
        */
-      boost::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
+      std::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
           shared_model::interface::types::PublicKeyHexStringView public_key)
           const override;
 

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -85,7 +85,7 @@ void PostgresBlockIndex::index(const shared_model::interface::Block &block) {
                           tx.value().commands());
     indexer_->txPositions(creator_id,
                           tx.value().hash(),
-                          boost::none,
+                          std::nullopt,
                           tx.value().createdTime(),
                           position);
   }

--- a/irohad/ametsuchi/impl/postgres_block_index.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_index.cpp
@@ -22,16 +22,16 @@ using TxPosition = iroha::ametsuchi::Indexer::TxPosition;
 
 namespace {
   // Return transfer asset if command contains it
-  boost::optional<const shared_model::interface::TransferAsset &>
+  std::optional<std::reference_wrapper<const shared_model::interface::TransferAsset>>
   getTransferAsset(const shared_model::interface::Command &cmd) noexcept {
     using ReturnType =
-        boost::optional<const shared_model::interface::TransferAsset &>;
+        std::optional<std::reference_wrapper<const shared_model::interface::TransferAsset>>;
     return iroha::visit_in_place(
         cmd.get(),
         [](const shared_model::interface::TransferAsset &c) {
           return ReturnType(c);
         },
-        [](const auto &) -> ReturnType { return boost::none; });
+        [](const auto &) -> ReturnType { return std::nullopt; });
   }
 }  // namespace
 
@@ -51,11 +51,11 @@ void PostgresBlockIndex::makeAccountAssetIndex(
                  [](const auto &opt_tx) { return static_cast<bool>(opt_tx); })
            | boost::adaptors::transformed(
                  [](const auto &opt_tx) -> const auto & { return *opt_tx; })) {
-    const auto &src_id = transfer.srcAccountId();
-    const auto &dest_id = transfer.destAccountId();
+    const auto &src_id = transfer.get().srcAccountId();
+    const auto &dest_id = transfer.get().destAccountId();
 
     const auto ids = {src_id, dest_id};
-    const auto asset_id = transfer.assetId();
+    const auto asset_id = transfer.get().assetId();
     // flat map accounts to unindexed keys
     for (const auto &id : ids) {
       indexer_->txPositions(id, hash, asset_id, ts, position);

--- a/irohad/ametsuchi/impl/postgres_block_storage.cpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.cpp
@@ -37,7 +37,7 @@ PostgresBlockStorage::PostgresBlockStorage(
     std::shared_ptr<BlockTransportFactory> block_factory,
     std::string table_name,
     bool drop_table_at_destruction,
-    boost::optional<HeightRange> height_range,
+    std::optional<HeightRange> height_range,
     logger::LoggerPtr log)
     : block_height_range_(std::move(height_range)),
       pool_wrapper_(std::move(pool_wrapper)),
@@ -151,7 +151,7 @@ void PostgresBlockStorage::clear() {
   soci::statement st = (sql.prepare << "TRUNCATE " << table_name_);
   try {
     st.execute(true);
-    block_height_range_ = boost::none;
+    block_height_range_ = std::nullopt;
   } catch (const std::exception &e) {
     log_->warn("Failed to clear {} table, reason {}", table_name_, e.what());
   }

--- a/irohad/ametsuchi/impl/postgres_block_storage.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.hpp
@@ -7,8 +7,8 @@
 #define IROHA_POSTGRES_BLOCK_STORAGE_HPP
 
 #include "ametsuchi/block_storage.hpp"
-
 #include "ametsuchi/impl/pool_wrapper.hpp"
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include "ametsuchi/impl/soci_utils.hpp"
 #include "backend/protobuf/block.hpp"
 #include "backend/protobuf/proto_block_factory.hpp"
@@ -36,7 +36,7 @@ namespace iroha {
       bool insert(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      boost::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
+      std::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
           shared_model::interface::types::HeightType height) const override;
 
       size_t size() const override;
@@ -58,7 +58,7 @@ namespace iroha {
                            boost::optional<HeightRange> height_range,
                            logger::LoggerPtr log);
 
-      static iroha::expected::Result<boost::optional<HeightRange>, std::string>
+      static iroha::expected::Result<std::optional<HeightRange>, std::string>
       queryBlockHeightsRange(soci::session &sql, const std::string &table_name);
 
       void dropTable();

--- a/irohad/ametsuchi/impl/postgres_block_storage.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.hpp
@@ -55,7 +55,7 @@ namespace iroha {
                            std::shared_ptr<BlockTransportFactory> block_factory,
                            std::string table,
                            bool drop_table_at_destruction,
-                           boost::optional<HeightRange> height_range,
+                           std::optional<HeightRange> height_range,
                            logger::LoggerPtr log);
 
       static iroha::expected::Result<std::optional<HeightRange>, std::string>
@@ -63,7 +63,7 @@ namespace iroha {
 
       void dropTable();
 
-      mutable boost::optional<HeightRange> block_height_range_;
+      mutable std::optional<HeightRange> block_height_range_;
       std::shared_ptr<PoolWrapper> pool_wrapper_;
       std::shared_ptr<BlockTransportFactory> block_factory_;
       std::string table_name_;

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -8,12 +8,15 @@
 #include <exception>
 #include <forward_list>
 #include <memory>
+#include <optional>
 
 #include <fmt/core.h>
 #include <soci/postgresql/soci-postgresql.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/format.hpp>
+
 #include "ametsuchi/impl/executor_common.hpp"
 #include "ametsuchi/impl/postgres_block_storage.hpp"
 #include "ametsuchi/impl/postgres_burrow_storage.hpp"
@@ -127,8 +130,8 @@ namespace {
    * @param command_name of the failed command
    * @return real error code
    */
-  boost::optional<iroha::ametsuchi::CommandError::ErrorCodeType>
-  getRealErrorCode(size_t fake_error_code, const std::string &command_name) {
+  std::optional<iroha::ametsuchi::CommandError::ErrorCodeType> getRealErrorCode(
+      size_t fake_error_code, const std::string &command_name) {
     auto fake_to_real_code = kCmdNameToErrorCode.find(command_name);
     if (fake_to_real_code == kCmdNameToErrorCode.end()) {
       return {};
@@ -450,16 +453,9 @@ namespace iroha {
       }
 
       void addArgumentToString(const std::string &argument_name,
-                               const boost::optional<std::string> &value) {
-        if (value) {
-          addArgumentToString(argument_name, *value);
-        }
-      }
-
-      void addArgumentToString(const std::string &argument_name,
                                const std::optional<std::string> &value) {
         if (value) {
-          addArgumentToString(argument_name, *value);
+          addArgumentToString(argument_name, value.value());
         }
       }
 

--- a/irohad/ametsuchi/impl/postgres_indexer.cpp
+++ b/irohad/ametsuchi/impl/postgres_indexer.cpp
@@ -7,6 +7,7 @@
 
 #include <soci/soci.h>
 #include <boost/format.hpp>
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include "cryptography/hash.hpp"
 
 using namespace iroha::ametsuchi;
@@ -30,7 +31,7 @@ void PostgresIndexer::rejectedTxHash(const HashType &rejected_tx_hash) {
 void PostgresIndexer::txPositions(
     shared_model::interface::types::AccountIdType const &account,
     HashType const &hash,
-    boost::optional<AssetIdType> &&asset_id,
+    std::optional<AssetIdType> &&asset_id,
     TimestampType const ts,
     TxPosition const &position) {
   tx_positions_.account.emplace_back(account);

--- a/irohad/ametsuchi/impl/postgres_indexer.hpp
+++ b/irohad/ametsuchi/impl/postgres_indexer.hpp
@@ -31,7 +31,7 @@ namespace iroha {
       void txPositions(
           shared_model::interface::types::AccountIdType const &account,
           shared_model::interface::types::HashType const &hash,
-          boost::optional<shared_model::interface::types::AssetIdType>
+          std::optional<shared_model::interface::types::AssetIdType>
               &&asset_id,
           shared_model::interface::types::TimestampType const ts,
           TxPosition const &position) override;
@@ -48,7 +48,7 @@ namespace iroha {
         std::vector<shared_model::interface::types::AccountIdType> account;
         std::vector<std::string> hash;
         std::vector<
-            boost::optional<shared_model::interface::types::AssetIdType>>
+            std::optional<shared_model::interface::types::AssetIdType>>
             asset_id;
         std::vector<shared_model::interface::types::TimestampType> ts;
         std::vector<size_t> height;

--- a/irohad/ametsuchi/impl/postgres_options.cpp
+++ b/irohad/ametsuchi/impl/postgres_options.cpp
@@ -18,13 +18,13 @@ using namespace iroha::ametsuchi;
 namespace {
   const std::string kPreparedBlockPrefix{"prepared_block_"};
 
-  boost::optional<std::string> extractOptionalField(
+  std::optional<std::string> extractOptionalField(
       const std::string &connection_string, const std::string &field_name) {
     const std::regex field_regex(
         (boost::format(R"(\b%1%=([^ ]+)\b)") % field_name).str());
     std::smatch m;
     if (not std::regex_search(connection_string, m, field_regex)) {
-      return boost::none;
+      return std::nullopt;
     }
     return std::string{m[1]};
   }

--- a/irohad/ametsuchi/impl/postgres_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.cpp
@@ -41,7 +41,7 @@ namespace iroha {
       }
       std::string keys = *std::begin(keys_range);
       // not using bool since it is not supported by SOCI
-      boost::optional<uint8_t> signatories_valid;
+      std::optional<uint8_t> signatories_valid;
 
       auto qry = R"(
         SELECT count(public_key) = 1

--- a/irohad/ametsuchi/impl/postgres_query_executor.hpp
+++ b/irohad/ametsuchi/impl/postgres_query_executor.hpp
@@ -6,9 +6,10 @@
 #ifndef IROHA_POSTGRES_QUERY_EXECUTOR_HPP
 #define IROHA_POSTGRES_QUERY_EXECUTOR_HPP
 
-#include "ametsuchi/query_executor.hpp"
-
 #include <soci/soci.h>
+
+#include "ametsuchi/impl/soci_std_optional.hpp"
+#include "ametsuchi/query_executor.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace shared_model {

--- a/irohad/ametsuchi/impl/postgres_setting_query.cpp
+++ b/irohad/ametsuchi/impl/postgres_setting_query.cpp
@@ -16,13 +16,13 @@ namespace {
   bool getValueFromDb(soci::session &sql,
                       const shared_model::interface::types::SettingKeyType &key,
                       T &destination) {
-    boost::optional<shared_model::interface::types::SettingValueType> value;
+    std::optional<shared_model::interface::types::SettingValueType> value;
 
     sql << "SELECT setting_value FROM setting WHERE setting_key = :key",
         soci::into(value), soci::use(key, "key");
 
     if (value) {
-      destination = boost::lexical_cast<T>(value.get());
+      destination = boost::lexical_cast<T>(value.value());
       return true;
     }
     return false;

--- a/irohad/ametsuchi/impl/postgres_setting_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_setting_query.hpp
@@ -6,10 +6,12 @@
 #ifndef IROHA_POSTGRES_SETTING_QUERY_HPP
 #define IROHA_POSTGRES_SETTING_QUERY_HPP
 
-#include "ametsuchi/setting_query.hpp"
-
 #include <soci/soci.h>
-#include <boost/optional.hpp>
+
+#include <optional>
+
+#include "ametsuchi/impl/soci_std_optional.hpp"
+#include "ametsuchi/setting_query.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
@@ -1119,9 +1119,9 @@ namespace iroha {
 
       const auto writer = q.writer();
       const auto key = q.key();
-      boost::optional<std::string> first_record_writer;
-      boost::optional<std::string> first_record_key;
-      boost::optional<size_t> page_size;
+      std::optional<std::string> first_record_writer;
+      std::optional<std::string> first_record_key;
+      std::optional<size_t> page_size;
       // TODO 2019.05.29 mboldyrev IR-516 remove when pagination is made
       // mandatory
       q.paginationMeta() | [&](const auto &pagination_meta) {

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -20,15 +20,15 @@ namespace iroha {
       PostgresWsvQuery(std::unique_ptr<soci::session> sql,
                        logger::LoggerPtr log);
 
-      boost::optional<std::vector<std::string>> getSignatories(
+      std::optional<std::vector<std::string>> getSignatories(
           const shared_model::interface::types::AccountIdType &account_id)
           override;
 
-      boost::optional<
+      std::optional<
           std::vector<std::shared_ptr<shared_model::interface::Peer>>>
       getPeers() override;
 
-      boost::optional<std::shared_ptr<shared_model::interface::Peer>>
+      std::optional<std::shared_ptr<shared_model::interface::Peer>>
       getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
                              public_key) override;
 
@@ -41,7 +41,7 @@ namespace iroha {
        * message, and returns an optional rowset<T>
        */
       template <typename T, typename F>
-      auto execute(F &&f) -> boost::optional<soci::rowset<T>>;
+      auto execute(F &&f) -> std::optional<soci::rowset<T>>;
 
       // TODO andrei 24.09.2018: IR-1718 Consistent soci::session fields in
       // storage classes

--- a/irohad/ametsuchi/impl/soci_utils.hpp
+++ b/irohad/ametsuchi/impl/soci_utils.hpp
@@ -7,11 +7,13 @@
 #define IROHA_POSTGRES_WSV_COMMON_HPP
 
 #include <soci/soci.h>
-#include <boost/optional.hpp>
+
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <optional>
+
 #include "common/bind.hpp"
 
 namespace iroha {
@@ -93,7 +95,7 @@ namespace iroha {
             std::forward<T>(t)
                 .template get<Is
                               + length_v<std::decay_t<
-                                    T>> - length_v<std::decay_t<R>>>()...);
+                                  T>> - length_v<std::decay_t<R>>>()...);
       });
     }
 
@@ -104,7 +106,7 @@ namespace iroha {
         return boost::make_tuple(*std::forward<decltype(vals)>(vals)...);
       };
 
-      using ReturnType = decltype(boost::make_optional(
+      using ReturnType = decltype(std::make_optional(
           iroha::ametsuchi::apply(std::forward<T>(t), transform)));
 
       return iroha::ametsuchi::apply(
@@ -116,14 +118,14 @@ namespace iroha {
                                       std::end(temp),
                                       [](auto b) { return b; });
                  })
-          ? boost::make_optional(
-                iroha::ametsuchi::apply(std::forward<T>(t), transform))
+          ? std::make_optional(
+              iroha::ametsuchi::apply(std::forward<T>(t), transform))
           : ReturnType{};
     }
 
     template <typename C, typename T, typename F>
     auto mapValues(T &t, F &&f) {
-      return t | [&](auto &st) -> boost::optional<C> {
+      return t | [&](auto &st) -> std::optional<C> {
         return boost::copy_range<C>(
             st | boost::adaptors::transformed([&](auto &t) {
               return iroha::ametsuchi::apply(t, std::forward<F>(f));
@@ -132,7 +134,7 @@ namespace iroha {
     }
 
     template <typename C, typename T, typename F>
-    boost::optional<C> flatMapValues(T &t, F &&f) {
+    std::optional<C> flatMapValues(T &t, F &&f) {
       if (t) {
         C map_result;
         for (auto &inp_el : *t) {
@@ -143,7 +145,7 @@ namespace iroha {
         }
         return map_result;
       }
-      return boost::none;
+      return std::nullopt;
     }
 
     template <typename R, typename T, typename F>
@@ -152,7 +154,7 @@ namespace iroha {
         auto range = boost::make_iterator_range(st);
 
         if (range.empty()) {
-          return boost::none;
+          return std::nullopt;
         }
 
         return iroha::ametsuchi::apply(range.front(), std::forward<F>(f));

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -221,7 +221,7 @@ namespace iroha {
       return iroha::expected::Value<void>{};
     }
 
-    boost::optional<std::shared_ptr<const iroha::LedgerState>>
+    std::optional<std::shared_ptr<const iroha::LedgerState>>
     StorageImpl::getLedgerState() const {
       return ledger_state_;
     }
@@ -261,7 +261,7 @@ namespace iroha {
         std::optional<std::reference_wrapper<const VmCaller>> vm_caller_ref,
         logger::LoggerManagerTreePtr log_manager,
         size_t pool_size) {
-      boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state;
+      std::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state;
       {
         soci::session sql{*pool_wrapper->connection_pool_};
         PostgresWsvQuery wsv_query(
@@ -272,7 +272,7 @@ namespace iroha {
             [&](auto &&top_block_info) {
               return wsv_query.getPeers() |
                   [&top_block_info](auto &&ledger_peers) {
-                    return boost::make_optional(
+                    return std::make_optional(
                         std::make_shared<const iroha::LedgerState>(
                             std::move(ledger_peers),
                             top_block_info.height,

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -45,7 +45,7 @@ namespace iroha {
     const char *kTmpWsv = "TemporaryWsv";
 
     StorageImpl::StorageImpl(
-        boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state,
+        std::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state,
         const ametsuchi::PostgresOptions &postgres_options,
         std::shared_ptr<BlockStorage> block_store,
         std::shared_ptr<PoolWrapper> pool_wrapper,
@@ -100,23 +100,23 @@ namespace iroha {
                                   *temporary_block_storage_factory_);
     }
 
-    boost::optional<std::shared_ptr<PeerQuery>> StorageImpl::createPeerQuery()
+    std::optional<std::shared_ptr<PeerQuery>> StorageImpl::createPeerQuery()
         const {
       auto wsv = getWsvQuery();
       if (not wsv) {
-        return boost::none;
+        return std::nullopt;
       }
-      return boost::make_optional<std::shared_ptr<PeerQuery>>(
+      return std::make_optional<std::shared_ptr<PeerQuery>>(
           std::make_shared<PeerQueryWsv>(wsv));
     }
 
-    boost::optional<std::shared_ptr<BlockQuery>> StorageImpl::createBlockQuery()
+    std::optional<std::shared_ptr<BlockQuery>> StorageImpl::createBlockQuery()
         const {
       auto block_query = getBlockQuery();
       if (not block_query) {
-        return boost::none;
+        return std::nullopt;
       }
-      return boost::make_optional(block_query);
+      return std::make_optional(block_query);
     }
 
     iroha::expected::Result<std::unique_ptr<QueryExecutor>, std::string>
@@ -393,19 +393,19 @@ namespace iroha {
           log_manager_->getChild("PostgresBlockQuery")->getLogger());
     }
 
-    boost::optional<std::unique_ptr<SettingQuery>>
+    std::optional<std::unique_ptr<SettingQuery>>
     StorageImpl::createSettingQuery() const {
       std::shared_lock<std::shared_timed_mutex> lock(drop_mutex_);
       if (not connection_) {
         log_->info(
             "getSettingQuery: connection to database is not initialised");
-        return boost::none;
+        return std::nullopt;
       }
       std::unique_ptr<SettingQuery> setting_query_ptr =
           std::make_unique<PostgresSettingQuery>(
               std::make_unique<soci::session>(*connection_),
               log_manager_->getChild("PostgresSettingQuery")->getLogger());
-      return boost::make_optional(std::move(setting_query_ptr));
+      return std::make_optional(std::move(setting_query_ptr));
     }
 
     rxcpp::observable<std::shared_ptr<const shared_model::interface::Block>>

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -93,7 +93,7 @@ namespace iroha {
 
       expected::Result<void, std::string> dropBlockStorage() override;
 
-      boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      std::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const override;
 
       void freeConnections() override;

--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -6,19 +6,19 @@
 #ifndef IROHA_STORAGE_IMPL_HPP
 #define IROHA_STORAGE_IMPL_HPP
 
-#include "ametsuchi/storage.hpp"
+#include <soci/soci.h>
 
 #include <atomic>
+#include <optional>
+#include <rxcpp/rx-lite.hpp>
 #include <shared_mutex>
 
-#include <soci/soci.h>
-#include <boost/optional.hpp>
-#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/block_storage_factory.hpp"
 #include "ametsuchi/impl/pool_wrapper.hpp"
 #include "ametsuchi/key_value_storage.hpp"
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/reconnection_strategy.hpp"
+#include "ametsuchi/storage.hpp"
 #include "interfaces/permission_to_string.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
@@ -64,13 +64,13 @@ namespace iroha {
       createMutableStorage(
           std::shared_ptr<CommandExecutor> command_executor) override;
 
-      boost::optional<std::shared_ptr<PeerQuery>> createPeerQuery()
+      std::optional<std::shared_ptr<PeerQuery>> createPeerQuery()
           const override;
 
-      boost::optional<std::shared_ptr<BlockQuery>> createBlockQuery()
+      std::optional<std::shared_ptr<BlockQuery>> createBlockQuery()
           const override;
 
-      boost::optional<std::unique_ptr<SettingQuery>> createSettingQuery()
+      std::optional<std::unique_ptr<SettingQuery>> createSettingQuery()
           const override;
 
       iroha::expected::Result<std::unique_ptr<QueryExecutor>, std::string>
@@ -119,7 +119,7 @@ namespace iroha {
 
      protected:
       StorageImpl(
-          boost::optional<std::shared_ptr<const iroha::LedgerState>>
+          std::optional<std::shared_ptr<const iroha::LedgerState>>
               ledger_state,
           const PostgresOptions &postgres_options,
           std::shared_ptr<BlockStorage> block_store,
@@ -187,7 +187,7 @@ namespace iroha {
 
       std::string prepared_block_name_;
 
-      boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
+      std::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.cpp
@@ -37,7 +37,7 @@ namespace iroha {
                             [](const auto &s) { return s.publicKey(); });
       auto keys = boost::algorithm::join(keys_range, "'), ('");
       // not using bool since it is not supported by SOCI
-      boost::optional<uint8_t> signatories_valid;
+      std::optional<uint8_t> signatories_valid;
 
       boost::format query(R"(SELECT sum(count) = :signatures_count
                           AND sum(quorum) <= :signatures_count

--- a/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
+++ b/irohad/ametsuchi/impl/temporary_wsv_impl.hpp
@@ -7,7 +7,7 @@
 #define IROHA_TEMPORARY_WSV_IMPL_HPP
 
 #include "ametsuchi/temporary_wsv.hpp"
-
+#include "ametsuchi/impl/soci_std_optional.hpp"
 #include <soci/soci.h>
 #include "ametsuchi/command_executor.hpp"
 #include "logger/logger_fwd.hpp"

--- a/irohad/ametsuchi/impl/tx_presence_cache_impl.cpp
+++ b/irohad/ametsuchi/impl/tx_presence_cache_impl.cpp
@@ -15,7 +15,7 @@ namespace iroha {
     TxPresenceCacheImpl::TxPresenceCacheImpl(std::shared_ptr<Storage> storage)
         : storage_(std::move(storage)) {}
 
-    boost::optional<TxCacheStatusType> TxPresenceCacheImpl::check(
+    std::optional<TxCacheStatusType> TxPresenceCacheImpl::check(
         const shared_model::crypto::Hash &hash) const {
       auto res = memory_cache_.findItem(hash);
       if (res) {
@@ -24,7 +24,7 @@ namespace iroha {
       return checkInStorage(hash);
     }
 
-    boost::optional<TxPresenceCache::BatchStatusCollectionType>
+    std::optional<TxPresenceCache::BatchStatusCollectionType>
     TxPresenceCacheImpl::check(
         const shared_model::interface::TransactionBatch &batch) const {
       TxPresenceCache::BatchStatusCollectionType batch_statuses;
@@ -32,17 +32,17 @@ namespace iroha {
         if (auto status = check(tx->hash())) {
           batch_statuses.emplace_back(*status);
         } else {
-          return boost::none;
+          return std::nullopt;
         }
       }
       return batch_statuses;
     }
 
-    boost::optional<TxCacheStatusType> TxPresenceCacheImpl::checkInStorage(
+    std::optional<TxCacheStatusType> TxPresenceCacheImpl::checkInStorage(
         const shared_model::crypto::Hash &hash) const {
       auto block_query = storage_->getBlockQuery();
       if (not block_query) {
-        return boost::none;
+        return std::nullopt;
       }
       return block_query->checkTxPresence(hash) |
           [this, &hash](const auto &status) {

--- a/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
+++ b/irohad/ametsuchi/impl/tx_presence_cache_impl.hpp
@@ -17,10 +17,10 @@ namespace iroha {
      public:
       explicit TxPresenceCacheImpl(std::shared_ptr<Storage> storage);
 
-      boost::optional<TxCacheStatusType> check(
+      std::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const override;
 
-      boost::optional<BatchStatusCollectionType> check(
+      std::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch)
           const override;
 
@@ -28,10 +28,10 @@ namespace iroha {
       /**
        * Performs an actual storage request about hash status
        * @param hash to check
-       * @return hash status if storage query was successful, boost::none
+       * @return hash status if storage query was successful, std::nullopt
        * otherwise
        */
-      boost::optional<TxCacheStatusType> checkInStorage(
+      std::optional<TxCacheStatusType> checkInStorage(
           const shared_model::crypto::Hash &hash) const;
 
       std::shared_ptr<Storage> storage_;

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -35,12 +35,12 @@ namespace {
     }
 
     /**
-     * Returns boost::none - it is not required to fetch individual blocks
+     * Returns std::nullopt - it is not required to fetch individual blocks
      * during WSV reindexing
      */
-    boost::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
+    std::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
         HeightType height) const override {
-      return boost::none;
+      return std::nullopt;
     }
 
     size_t size() const override {

--- a/irohad/ametsuchi/indexer.hpp
+++ b/irohad/ametsuchi/indexer.hpp
@@ -42,7 +42,7 @@ namespace iroha {
       virtual void txPositions(
           shared_model::interface::types::AccountIdType const &creator,
           shared_model::interface::types::HashType const &hash,
-          boost::optional<shared_model::interface::types::AssetIdType>
+          std::optional<shared_model::interface::types::AssetIdType>
               &&asset_id,
           shared_model::interface::types::TimestampType const ts,
           TxPosition const &position) = 0;

--- a/irohad/ametsuchi/key_value_storage.hpp
+++ b/irohad/ametsuchi/key_value_storage.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_KV_STORAGE_HPP
 #define IROHA_KV_STORAGE_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -37,7 +37,7 @@ namespace iroha {
        * @param id - reference key
        * @return - blob, if exists
        */
-      virtual boost::optional<Bytes> get(Identifier id) const = 0;
+      virtual std::optional<Bytes> get(Identifier id) const = 0;
 
       /**
        * @return folder of storage

--- a/irohad/ametsuchi/mutable_factory.hpp
+++ b/irohad/ametsuchi/mutable_factory.hpp
@@ -7,8 +7,8 @@
 #define IROHA_MUTABLE_FACTORY_HPP
 
 #include <memory>
+#include <optional>
 
-#include <boost/optional.hpp>
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/commit_result.hpp"
 #include "common/result_fwd.hpp"

--- a/irohad/ametsuchi/peer_query.hpp
+++ b/irohad/ametsuchi/peer_query.hpp
@@ -7,9 +7,9 @@
 #define IROHA_PEER_QUERY_HPP
 
 #include <memory>
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -36,13 +36,13 @@ namespace iroha {
        * Fetch peers stored in ledger
        * @return list of peers in insertion to ledger order
        */
-      virtual boost::optional<std::vector<wPeer>> getLedgerPeers() = 0;
+      virtual std::optional<std::vector<wPeer>> getLedgerPeers() = 0;
 
       /**
        * Fetch peer with given public key from ledger
        * @return the peer if found, none otherwise
        */
-      virtual boost::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
+      virtual std::optional<PeerQuery::wPeer> getLedgerPeerByPublicKey(
           shared_model::interface::types::PublicKeyHexStringView public_key)
           const = 0;
 

--- a/irohad/ametsuchi/peer_query_factory.hpp
+++ b/irohad/ametsuchi/peer_query_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_PEER_QUERY_FACTORY_HPP
 #define IROHA_PEER_QUERY_FACTORY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "ametsuchi/peer_query.hpp"
 
@@ -18,7 +18,7 @@ namespace iroha {
        * Creates a peer query from the current state.
        * @return Created peer query
        */
-      virtual boost::optional<std::shared_ptr<PeerQuery>> createPeerQuery()
+      virtual std::optional<std::shared_ptr<PeerQuery>> createPeerQuery()
           const = 0;
 
       virtual ~PeerQueryFactory() = default;

--- a/irohad/ametsuchi/query_executor_factory.hpp
+++ b/irohad/ametsuchi/query_executor_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_QUERY_EXECUTOR_FACTORY_HPP
 #define IROHA_QUERY_EXECUTOR_FACTORY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "ametsuchi/query_executor.hpp"
 #include "common/result_fwd.hpp"

--- a/irohad/ametsuchi/setting_query.hpp
+++ b/irohad/ametsuchi/setting_query.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_SETTING_QUERY_HPP
 #define IROHA_SETTING_QUERY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "common/result.hpp"
 #include "validators/settings.hpp"
 

--- a/irohad/ametsuchi/setting_query_factory.hpp
+++ b/irohad/ametsuchi/setting_query_factory.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_SETTING_QUERY_FACTORY_HPP
 #define IROHA_SETTING_QUERY_FACTORY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "ametsuchi/setting_query.hpp"
 
@@ -18,7 +18,7 @@ namespace iroha {
        * Creates a setting query
        * @return Created setting query
        */
-      virtual boost::optional<std::unique_ptr<SettingQuery>>
+      virtual std::optional<std::unique_ptr<SettingQuery>>
       createSettingQuery() const = 0;
 
       virtual ~SettingQueryFactory() = default;

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -98,7 +98,7 @@ namespace iroha {
        */
       virtual expected::Result<void, std::string> dropBlockStorage() = 0;
 
-      virtual boost::optional<std::shared_ptr<const iroha::LedgerState>>
+      virtual std::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const = 0;
 
       virtual void freeConnections() = 0;

--- a/irohad/ametsuchi/tx_presence_cache.hpp
+++ b/irohad/ametsuchi/tx_presence_cache.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_TX_PRESENCE_CACHE_HPP
 #define IROHA_TX_PRESENCE_CACHE_HPP
 
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "ametsuchi/tx_cache_response.hpp"
 
 namespace shared_model {
@@ -31,10 +31,10 @@ namespace iroha {
      public:
       /**
        * Check transaction status by hash
-       * @return transaction status if storage query was successful, boost::none
-       * otherwise
+       * @return transaction status if storage query was successful,
+       * std::nullopt otherwise
        */
-      virtual boost::optional<TxCacheStatusType> check(
+      virtual std::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const = 0;
 
       /// response type which reflects status of each transaction in a batch
@@ -43,9 +43,9 @@ namespace iroha {
       /**
        * Check batch status
        * @return a collection with answers about each transaction in the batch
-       * if storage queries were successful, boost::none otherwise
+       * if storage queries were successful, std::nullopt otherwise
        */
-      virtual boost::optional<BatchStatusCollectionType> check(
+      virtual std::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch) const = 0;
 
       // TODO: 09/11/2018 @muratovv add method for processing collection of

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_WSV_QUERY_HPP
 #define IROHA_WSV_QUERY_HPP
 
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/string_view_types.hpp"
@@ -29,14 +29,14 @@ namespace iroha {
        * @param account_id
        * @return
        */
-      virtual boost::optional<std::vector<std::string>> getSignatories(
+      virtual std::optional<std::vector<std::string>> getSignatories(
           const shared_model::interface::types::AccountIdType &account_id) = 0;
 
       /**
        * Fetch peers stored in ledger
        * @return list of peers in insertion to ledger order
        */
-      virtual boost::optional<
+      virtual std::optional<
           std::vector<std::shared_ptr<shared_model::interface::Peer>>>
       getPeers() = 0;
 
@@ -44,7 +44,7 @@ namespace iroha {
        * Fetch peer with given public key from ledger
        * @return the peer if found, none otherwise
        */
-      virtual boost::optional<std::shared_ptr<shared_model::interface::Peer>>
+      virtual std::optional<std::shared_ptr<shared_model::interface::Peer>>
       getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
                              public_key) = 0;
 

--- a/irohad/consensus/yac/cluster_order.hpp
+++ b/irohad/consensus/yac/cluster_order.hpp
@@ -6,10 +6,11 @@
 #ifndef IROHA_CLUSTER_ORDER_HPP
 #define IROHA_CLUSTER_ORDER_HPP
 
+#include <boost/assert.hpp>
 #include <memory>
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "consensus/yac/yac_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -28,7 +29,7 @@ namespace iroha {
          * @param peer_positions vector of indexes of peer positions
          * @return ClusterOrdering if vectors are not empty, null otherwise
          */
-        static boost::optional<ClusterOrdering> create(
+        static std::optional<ClusterOrdering> create(
             std::vector<std::shared_ptr<shared_model::interface::Peer>> const
                 &order,
             std::vector<size_t> const &peer_positions);
@@ -38,7 +39,7 @@ namespace iroha {
          * @param order vector of peers
          * @return ClusterOrdering if vectors are not empty, null otherwise
          */
-        static boost::optional<ClusterOrdering> create(
+        static std::optional<ClusterOrdering> create(
             std::vector<std::shared_ptr<shared_model::interface::Peer>> const
                 &order);
 

--- a/irohad/consensus/yac/impl/cluster_order.cpp
+++ b/irohad/consensus/yac/impl/cluster_order.cpp
@@ -9,21 +9,21 @@ namespace iroha {
   namespace consensus {
     namespace yac {
 
-      boost::optional<ClusterOrdering> ClusterOrdering::create(
+      std::optional<ClusterOrdering> ClusterOrdering::create(
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &order,
           std::vector<size_t> const &peer_positions) {
         if (order.empty()) {
-          return boost::none;
+          return std::nullopt;
         }
         return ClusterOrdering(order, peer_positions);
       }
 
-      boost::optional<ClusterOrdering> ClusterOrdering::create(
+      std::optional<ClusterOrdering> ClusterOrdering::create(
           const std::vector<std::shared_ptr<shared_model::interface::Peer>>
               &order) {
         if (order.empty()) {
-          return boost::none;
+          return std::nullopt;
         }
         return ClusterOrdering(order);
       }

--- a/irohad/consensus/yac/impl/peer_orderer_impl.cpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.cpp
@@ -20,7 +20,7 @@ namespace iroha {
           std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory)
           : peer_query_factory_(peer_query_factory) {}
 
-      boost::optional<ClusterOrdering> PeerOrdererImpl::getOrdering(
+      std::optional<ClusterOrdering> PeerOrdererImpl::getOrdering(
           const YacHash &hash,
           std::vector<std::shared_ptr<shared_model::interface::Peer>> const
               &peers) {

--- a/irohad/consensus/yac/impl/peer_orderer_impl.hpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.hpp
@@ -25,7 +25,7 @@ namespace iroha {
         explicit PeerOrdererImpl(
             std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory);
 
-        boost::optional<ClusterOrdering> getOrdering(
+        std::optional<ClusterOrdering> getOrdering(
             const YacHash &hash,
             std::vector<std::shared_ptr<shared_model::interface::Peer>> const
                 &peers) override;

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -77,7 +77,7 @@ namespace iroha {
 
       void Yac::vote(YacHash hash,
                      ClusterOrdering order,
-                     boost::optional<ClusterOrdering> alternative_order) {
+                     std::optional<ClusterOrdering> alternative_order) {
         log_->info("Order for voting: [{}]",
                    boost::algorithm::join(
                        order.getPeers()
@@ -211,15 +211,15 @@ namespace iroha {
         return alternative_order_ ? *alternative_order_ : cluster_order_;
       }
 
-      boost::optional<std::shared_ptr<shared_model::interface::Peer>>
+      std::optional<std::shared_ptr<shared_model::interface::Peer>>
       Yac::findPeer(const VoteMessage &vote) {
         auto peers = cluster_order_.getPeers();
         auto it =
             std::find_if(peers.begin(), peers.end(), [&](const auto &peer) {
               return peer->pubkey() == vote.signature->publicKey();
             });
-        return it != peers.end() ? boost::make_optional(std::move(*it))
-                                 : boost::none;
+        return it != peers.end() ? std::make_optional(std::move(*it))
+                                 : std::nullopt;
       }
 
       // ------|Apply data|------

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -38,7 +38,7 @@ namespace iroha {
       YacGateImpl::YacGateImpl(
           std::shared_ptr<HashGate> hash_gate,
           std::shared_ptr<YacPeerOrderer> orderer,
-          boost::optional<ClusterOrdering> alternative_order,
+          std::optional<ClusterOrdering> alternative_order,
           std::shared_ptr<YacHashProvider> hash_provider,
           std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<consensus::ConsensusResultCache>
@@ -111,7 +111,7 @@ namespace iroha {
                == current_ledger_state_->top_block_info.height + 1);
 
         if (not event.round_data) {
-          current_block_ = boost::none;
+          current_block_ = std::nullopt;
           // previous block is committed to block storage, it is safe to clear
           // the cache
           // TODO 2019-03-15 andrei: IR-405 Subscribe BlockLoaderService to
@@ -188,13 +188,13 @@ namespace iroha {
         if (hash.vote_hashes.proposal_hash.empty()) {
           // if consensus agreed on nothing for commit
           log_->info("Consensus skipped round, voted for nothing");
-          current_block_ = boost::none;
+          current_block_ = std::nullopt;
           return rxcpp::observable<>::just<GateObject>(AgreementOnNone(
               hash.vote_round, current_ledger_state_, std::move(public_keys)));
         }
 
         log_->info("Voted for another block, waiting for sync");
-        current_block_ = boost::none;
+        current_block_ = std::nullopt;
         auto model_hash = hash_provider_->toModelHash(hash);
         return rxcpp::observable<>::just<GateObject>(
             VoteOther(hash.vote_round,

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -38,7 +38,7 @@ namespace iroha {
         YacGateImpl(
             std::shared_ptr<HashGate> hash_gate,
             std::shared_ptr<YacPeerOrderer> orderer,
-            boost::optional<ClusterOrdering> alternative_order,
+            std::optional<ClusterOrdering> alternative_order,
             std::shared_ptr<YacHashProvider> hash_provider,
             std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<consensus::ConsensusResultCache>
@@ -66,10 +66,10 @@ namespace iroha {
 
         logger::LoggerPtr log_;
 
-        boost::optional<std::shared_ptr<shared_model::interface::Block>>
+        std::optional<std::shared_ptr<shared_model::interface::Block>>
             current_block_;
         YacHash current_hash_;
-        boost::optional<ClusterOrdering> alternative_order_;
+        std::optional<ClusterOrdering> alternative_order_;
         std::shared_ptr<const LedgerState> current_ledger_state_;
 
         rxcpp::observable<GateObject> published_events_;

--- a/irohad/consensus/yac/storage/buffered_cleanup_strategy.hpp
+++ b/irohad/consensus/yac/storage/buffered_cleanup_strategy.hpp
@@ -6,12 +6,11 @@
 #ifndef IROHA_BUFFERED_CLEANUP_STRATEGY_HPP
 #define IROHA_BUFFERED_CLEANUP_STRATEGY_HPP
 
-#include "consensus/yac/storage/cleanup_strategy.hpp"
-
-#include <boost/optional.hpp>
+#include <optional>
 #include <queue>
 
 #include "consensus/yac/outcome_messages.hpp"
+#include "consensus/yac/storage/cleanup_strategy.hpp"
 
 namespace iroha {
   namespace consensus {
@@ -27,7 +26,7 @@ namespace iroha {
          * @param answer - the output of the round
          * @return rounds to be removed, if any.
          */
-        boost::optional<CleanupStrategy::RoundsType> finalize(
+        std::optional<CleanupStrategy::RoundsType> finalize(
             RoundType consensus_round, Answer answer) override;
 
         bool shouldCreateRound(const RoundType &round) override;
@@ -44,7 +43,7 @@ namespace iroha {
          * @return the lowest round from last committed and last rejected
          * rounds, if the operation can't be applied - returns none
          */
-        boost::optional<RoundType> minimalRound() const;
+        std::optional<RoundType> minimalRound() const;
 
         /**
          * The method creates round into created_rounds_ collection
@@ -66,9 +65,9 @@ namespace iroha {
             created_rounds_;
 
         /// maximal reject round, could empty if commit happened
-        boost::optional<RoundType> last_reject_round_;
+        std::optional<RoundType> last_reject_round_;
         /// maximal commit round
-        boost::optional<RoundType> last_commit_round_;
+        std::optional<RoundType> last_commit_round_;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/storage/cleanup_strategy.hpp
+++ b/irohad/consensus/yac/storage/cleanup_strategy.hpp
@@ -6,9 +6,8 @@
 #ifndef IROHA_CLEANUP_STRATEGY_HPP
 #define IROHA_CLEANUP_STRATEGY_HPP
 
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "consensus/round.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
@@ -29,8 +28,8 @@ namespace iroha {
          * @param answer - outcome of round
          * @return a collection of rounds for removing from the state
          */
-        virtual boost::optional<RoundsType> finalize(Round round,
-                                                     Answer answer) = 0;
+        virtual std::optional<RoundsType> finalize(Round round,
+                                                   Answer answer) = 0;
 
         /**
          * The method checks whether we should add a new round

--- a/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
+++ b/irohad/consensus/yac/storage/impl/buffered_cleanup_strategy.cpp
@@ -10,9 +10,9 @@
 using namespace iroha::consensus;
 using namespace iroha::consensus::yac;
 
-boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
+std::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
     RoundType consensus_round, Answer answer) {
-  using OptRefRoundType = boost::optional<RoundType> &;
+  using OptRefRoundType = std::optional<RoundType> &;
   auto &target_round = iroha::visit_in_place(
       answer,
       [this](const iroha::consensus::yac::CommitMessage &) -> OptRefRoundType {
@@ -20,7 +20,7 @@ boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
         // required anymore for the consensus
         if (last_commit_round_ and last_reject_round_
             and *last_commit_round_ < *last_reject_round_) {
-          last_reject_round_ = boost::none;
+          last_reject_round_ = std::nullopt;
         }
         return last_commit_round_;
       },
@@ -32,7 +32,7 @@ boost::optional<CleanupStrategy::RoundsType> BufferedCleanupStrategy::finalize(
 
   auto removed_rounds = truncateCreatedRounds();
   if (removed_rounds.empty()) {
-    return boost::none;
+    return std::nullopt;
   } else {
     return removed_rounds;
   }
@@ -49,11 +49,11 @@ CleanupStrategy::RoundsType BufferedCleanupStrategy::truncateCreatedRounds() {
   return removed;
 }
 
-boost::optional<BufferedCleanupStrategy::RoundType>
+std::optional<BufferedCleanupStrategy::RoundType>
 BufferedCleanupStrategy::minimalRound() const {
   // both values unavailable
   if (not last_reject_round_ and not last_commit_round_) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // both values present

--- a/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_block_storage.cpp
@@ -23,7 +23,7 @@ namespace iroha {
             supermajority_checker_(std::move(supermajority_checker)),
             log_(std::move(log)) {}
 
-      boost::optional<Answer> YacBlockStorage::insert(VoteMessage msg) {
+      std::optional<Answer> YacBlockStorage::insert(VoteMessage msg) {
         if (validScheme(msg) and uniqueVote(msg)) {
           votes_.push_back(msg);
 
@@ -39,7 +39,7 @@ namespace iroha {
         return getState();
       }
 
-      boost::optional<Answer> YacBlockStorage::insert(
+      std::optional<Answer> YacBlockStorage::insert(
           std::vector<VoteMessage> votes) {
         std::for_each(votes.begin(), votes.end(), [this](auto vote) {
           this->insert(vote);
@@ -55,13 +55,13 @@ namespace iroha {
         return votes_.size();
       }
 
-      boost::optional<Answer> YacBlockStorage::getState() {
+      std::optional<Answer> YacBlockStorage::getState() {
         auto supermajority = supermajority_checker_->hasSupermajority(
             votes_.size(), peers_in_round_);
         if (supermajority) {
           return Answer(CommitMessage(votes_));
         }
-        return boost::none;
+        return std::nullopt;
       }
 
       bool YacBlockStorage::isContains(const VoteMessage &msg) const {

--- a/irohad/consensus/yac/storage/impl/yac_common.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_common.cpp
@@ -25,16 +25,16 @@ namespace iroha {
             });
       }
 
-      boost::optional<Round> getKey(const std::vector<VoteMessage> &votes) {
+      std::optional<Round> getKey(const std::vector<VoteMessage> &votes) {
         if (not sameKeys(votes)) {
-          return boost::none;
+          return std::nullopt;
         }
         return votes[0].hash.vote_round;
       }
 
-      boost::optional<YacHash> getHash(const std::vector<VoteMessage> &votes) {
+      std::optional<YacHash> getHash(const std::vector<VoteMessage> &votes) {
         if (not sameKeys(votes)) {
-          return boost::none;
+          return std::nullopt;
         }
 
         return votes.at(0).hash;

--- a/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_proposal_storage.cpp
@@ -47,14 +47,14 @@ namespace iroha {
           PeersNumberType peers_in_round,
           std::shared_ptr<SupermajorityChecker> supermajority_checker,
           logger::LoggerManagerTreePtr log_manager)
-          : current_state_(boost::none),
+          : current_state_(std::nullopt),
             storage_key_(store_round),
             peers_in_round_(peers_in_round),
             supermajority_checker_(supermajority_checker),
             log_manager_(std::move(log_manager)),
             log_(log_manager_->getLogger()) {}
 
-      boost::optional<Answer> YacProposalStorage::insert(VoteMessage msg) {
+      std::optional<Answer> YacProposalStorage::insert(VoteMessage msg) {
         if (shouldInsert(msg)) {
           // insert to block store
 
@@ -83,7 +83,7 @@ namespace iroha {
         return getState();
       }
 
-      boost::optional<Answer> YacProposalStorage::insert(
+      std::optional<Answer> YacProposalStorage::insert(
           std::vector<VoteMessage> messages) {
         std::for_each(messages.begin(), messages.end(), [this](auto vote) {
           this->insert(std::move(vote));
@@ -95,7 +95,7 @@ namespace iroha {
         return storage_key_;
       }
 
-      boost::optional<Answer> YacProposalStorage::getState() const {
+      std::optional<Answer> YacProposalStorage::getState() const {
         return current_state_;
       }
 
@@ -121,7 +121,7 @@ namespace iroha {
                            });
       }
 
-      boost::optional<Answer> YacProposalStorage::findRejectProof() {
+      std::optional<Answer> YacProposalStorage::findRejectProof() {
         auto is_reject = not supermajority_checker_->canHaveSupermajority(
             block_storages_
                 | boost::adaptors::transformed([](const auto &storage) {
@@ -143,7 +143,7 @@ namespace iroha {
           return Answer(RejectMessage(std::move(result)));
         }
 
-        return boost::none;
+        return std::nullopt;
       }
 
     }  // namespace yac

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -44,7 +44,7 @@ namespace iroha {
         return findStorage(proposal_storages_, round);
       }
 
-      boost::optional<std::vector<YacProposalStorage>::iterator>
+      std::optional<std::vector<YacProposalStorage>::iterator>
       YacVoteStorage::findProposalStorage(const VoteMessage &msg,
                                           PeersNumberType peers_in_round) {
         const auto &round = msg.hash.vote_round;
@@ -60,7 +60,7 @@ namespace iroha {
               supermajority_checker_,
               log_manager_->getChild("ProposalStorage"));
         } else {
-          return boost::none;
+          return std::nullopt;
         }
       }
 
@@ -85,17 +85,17 @@ namespace iroha {
             supermajority_checker_(std::move(supermajority_checker)),
             log_manager_(std::move(log_manager)) {}
 
-      boost::optional<Answer> YacVoteStorage::store(
+      std::optional<Answer> YacVoteStorage::store(
           std::vector<VoteMessage> state, PeersNumberType peers_in_round) {
         if (state.empty()) {
-          return boost::none;
+          return std::nullopt;
         }
         return findProposalStorage(state.at(0), peers_in_round) |
             [this, &state](auto &&storage) {
               const auto &round = storage->getStorageKey();
               return storage->insert(state) |
                          [this, &round](
-                             auto &&insert_outcome) -> boost::optional<Answer> {
+                             auto &&insert_outcome) -> std::optional<Answer> {
                 last_round_ = std::max(last_round_.value_or(round), round);
                 this->strategy_->finalize(round, insert_outcome) |
                     [this](auto &&remove) {
@@ -135,17 +135,17 @@ namespace iroha {
         }
       }
 
-      boost::optional<Round> YacVoteStorage::getLastFinalizedRound() const {
+      std::optional<Round> YacVoteStorage::getLastFinalizedRound() const {
         return last_round_;
       }
 
-      boost::optional<Answer> YacVoteStorage::getState(
+      std::optional<Answer> YacVoteStorage::getState(
           const Round &round) const {
         auto proposal_storage = getProposalStorage(round);
         if (proposal_storage != proposal_storages_.end()) {
           return proposal_storage->getState();
         } else {
-          return boost::none;
+          return std::nullopt;
         }
       }
 

--- a/irohad/consensus/yac/storage/yac_block_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_block_storage.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "consensus/yac/outcome_messages.hpp"
 #include "consensus/yac/storage/storage_result.hpp"
 #include "consensus/yac/supermajority_checker.hpp"
@@ -42,17 +42,17 @@ namespace iroha {
          * Try to insert vote to storage
          * @param msg - vote for insertion
          * @return actual state of storage,
-         * boost::none when storage doesn't have supermajority
+         * std::nullopt when storage doesn't have supermajority
          */
-        boost::optional<Answer> insert(VoteMessage msg);
+        std::optional<Answer> insert(VoteMessage msg);
 
         /**
          * Insert vector of votes to current storage
          * @param votes - bunch of votes for insertion
          * @return state of storage after insertion last vote,
-         * boost::none when storage doesn't have supermajority
+         * std::nullopt when storage doesn't have supermajority
          */
-        boost::optional<Answer> insert(std::vector<VoteMessage> votes);
+        std::optional<Answer> insert(std::vector<VoteMessage> votes);
 
         /**
          * @return votes attached to storage
@@ -67,7 +67,7 @@ namespace iroha {
         /**
          * @return current block store state
          */
-        boost::optional<Answer> getState();
+        std::optional<Answer> getState();
 
         /**
          * Verify that passed vote contains in storage

--- a/irohad/consensus/yac/storage/yac_common.hpp
+++ b/irohad/consensus/yac/storage/yac_common.hpp
@@ -6,9 +6,8 @@
 #ifndef IROHA_YAC_COMMON_HPP
 #define IROHA_YAC_COMMON_HPP
 
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "consensus/round.hpp"
 
@@ -34,17 +33,17 @@ namespace iroha {
        * Provide key common for whole collection
        * @param votes - collection with votes
        * @return vote round, if collection shared the same round,
-       * otherwise boost::none
+       * otherwise std::nullopt
        */
-      boost::optional<Round> getKey(const std::vector<VoteMessage> &votes);
+      std::optional<Round> getKey(const std::vector<VoteMessage> &votes);
 
       /**
        * Get common hash from collection
        * @param votes - collection with votes
        * @return hash, if collection elements have same hash,
-       * otherwise boost::none
+       * otherwise std::nullopt
        */
-      boost::optional<YacHash> getHash(const std::vector<VoteMessage> &votes);
+      std::optional<YacHash> getHash(const std::vector<VoteMessage> &votes);
 
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/consensus/yac/storage/yac_proposal_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_proposal_storage.hpp
@@ -7,9 +7,9 @@
 #define IROHA_YAC_PROPOSAL_STORAGE_HPP
 
 #include <memory>
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "consensus/yac/storage/storage_result.hpp"
 #include "consensus/yac/storage/yac_block_storage.hpp"
 #include "consensus/yac/storage/yac_common.hpp"
@@ -53,10 +53,10 @@ namespace iroha {
          * Try to insert vote to storage
          * @param vote - object for insertion
          * @return result, that contains actual state of storage.
-         * boost::none if not inserted, possible reasons - duplication,
+         * std::nullopt if not inserted, possible reasons - duplication,
          * wrong proposal/block round.
          */
-        boost::optional<Answer> insert(VoteMessage vote);
+        std::optional<Answer> insert(VoteMessage vote);
 
         /**
          * Insert bundle of messages into storage
@@ -64,7 +64,7 @@ namespace iroha {
          * @return result, that contains actual state of storage,
          * after insertion of all votes.
          */
-        boost::optional<Answer> insert(std::vector<VoteMessage> messages);
+        std::optional<Answer> insert(std::vector<VoteMessage> messages);
 
         /**
          * Provides key for storage
@@ -74,7 +74,7 @@ namespace iroha {
         /**
          * @return current state of storage
          */
-        boost::optional<Answer> getState() const;
+        std::optional<Answer> getState() const;
 
        private:
         // --------| private api |--------
@@ -105,14 +105,14 @@ namespace iroha {
          * number of not voted peers + most frequent vote count < supermajority
          * @return answer with proof
          */
-        boost::optional<Answer> findRejectProof();
+        std::optional<Answer> findRejectProof();
 
         // --------| fields |--------
 
         /**
          * Current state of storage
          */
-        boost::optional<Answer> current_state_;
+        std::optional<Answer> current_state_;
 
         /**
          * Vector of block storages based on this proposal

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -7,10 +7,10 @@
 #define IROHA_YAC_VOTE_STORAGE_HPP
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "consensus/yac/consistency_model.hpp"
 #include "consensus/yac/outcome_messages.hpp"  // because messages passed by value
 #include "consensus/yac/storage/cleanup_strategy.hpp"
@@ -80,7 +80,7 @@ namespace iroha {
          * This parameter used on creation of proposal storage
          * @return - iter for required proposal storage
          */
-        boost::optional<std::vector<YacProposalStorage>::iterator>
+        std::optional<std::vector<YacProposalStorage>::iterator>
         findProposalStorage(const VoteMessage &msg,
                             PeersNumberType peers_in_round);
 
@@ -107,10 +107,10 @@ namespace iroha {
          * @param state - current message with votes
          * @param peers_in_round - number of peers participated in round
          * @return structure with result of inserting.
-         * boost::none if msg not valid.
+         * std::nullopt if msg not valid.
          */
-        boost::optional<Answer> store(std::vector<VoteMessage> state,
-                                      PeersNumberType peers_in_round);
+        std::optional<Answer> store(std::vector<VoteMessage> state,
+                                    PeersNumberType peers_in_round);
 
         /**
          * Provide status about closing round of proposal/block
@@ -141,14 +141,14 @@ namespace iroha {
          * Get last by order finalized round
          * @return round if it exists
          */
-        boost::optional<Round> getLastFinalizedRound() const;
+        std::optional<Round> getLastFinalizedRound() const;
 
         /**
          * Get the state attached of a past round
          * @param round - required round
          * @return state if round exists and finalized
          */
-        boost::optional<Answer> getState(const Round &round) const;
+        std::optional<Answer> getState(const Round &round) const;
 
        private:
         // --------| fields |--------
@@ -176,7 +176,7 @@ namespace iroha {
         std::shared_ptr<CleanupStrategy> strategy_;
 
         /// last finalized round
-        boost::optional<Round> last_round_;
+        std::optional<Round> last_round_;
 
         std::shared_ptr<SupermajorityChecker> supermajority_checker_;
 

--- a/irohad/consensus/yac/transport/yac_pb_converters.hpp
+++ b/irohad/consensus/yac/transport/yac_pb_converters.hpp
@@ -91,7 +91,7 @@ namespace iroha {
           return pb_vote;
         }
 
-        static boost::optional<VoteMessage> deserializeVote(
+        static std::optional<VoteMessage> deserializeVote(
             const proto::Vote &pb_vote, logger::LoggerPtr log) {
           // TODO IR-428 igor-egorov refactor PbConverters - do the class
           // instantiable
@@ -117,15 +117,15 @@ namespace iroha {
                 .createSignature(PublicKeyHexStringView{pubkey_hex},
                                  SignedHexStringView{signature_hex})
                 .match(
-                    [&](auto &&sig) -> boost::optional<std::unique_ptr<
+                    [&](auto &&sig) -> std::optional<std::unique_ptr<
                                         shared_model::interface::Signature>> {
                       return std::move(sig).value;
                     },
                     [&](const auto &reason)
-                        -> boost::optional<std::unique_ptr<
+                        -> std::optional<std::unique_ptr<
                             shared_model::interface::Signature>> {
                       log->error(msg, reason.error);
-                      return boost::none;
+                      return std::nullopt;
                     });
           };
 
@@ -136,7 +136,7 @@ namespace iroha {
                                 "Cannot build vote hash block signature: {}")) {
               vote.hash.block_signature = *std::move(block_signature);
             } else {
-              return boost::none;
+              return std::nullopt;
             }
           }
 
@@ -146,7 +146,7 @@ namespace iroha {
                               "Cannot build vote signature: {}")) {
             vote.signature = *std::move(vote_signature);
           } else {
-            return boost::none;
+            return std::nullopt;
           }
 
           return vote;

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -6,20 +6,18 @@
 #ifndef IROHA_YAC_HPP
 #define IROHA_YAC_HPP
 
-#include "consensus/yac/transport/yac_network_interface.hpp"  // for YacNetworkNotifications
-#include "consensus/yac/yac_gate.hpp"                         // for HashGate
-
 #include <memory>
 #include <mutex>
-
-#include <boost/optional.hpp>
+#include <optional>
+#include <rxcpp/operators/rx-observe_on.hpp>
 #include <rxcpp/rx-lite.hpp>
+
 #include "consensus/yac/cluster_order.hpp"     //  for ClusterOrdering
 #include "consensus/yac/outcome_messages.hpp"  // because messages passed by value
 #include "consensus/yac/storage/yac_vote_storage.hpp"  // for VoteStorage
+#include "consensus/yac/transport/yac_network_interface.hpp"  // for YacNetworkNotifications
+#include "consensus/yac/yac_gate.hpp"                         // for HashGate
 #include "logger/logger_fwd.hpp"
-
-#include <rxcpp/operators/rx-observe_on.hpp>
 
 namespace iroha {
   namespace consensus {
@@ -59,8 +57,8 @@ namespace iroha {
 
         void vote(YacHash hash,
                   ClusterOrdering order,
-                  boost::optional<ClusterOrdering> alternative_order =
-                      boost::none) override;
+                  std::optional<ClusterOrdering> alternative_order =
+                      std::nullopt) override;
 
         rxcpp::observable<Answer> onOutcome() override;
 
@@ -90,10 +88,10 @@ namespace iroha {
         /**
          * Find corresponding peer in the ledger from vote message
          * @param vote message containing peer information
-         * @return peer if it is present in the ledger, boost::none otherwise
+         * @return peer if it is present in the ledger, std::nullopt otherwise
          */
-        boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-        findPeer(const VoteMessage &vote);
+        std::optional<std::shared_ptr<shared_model::interface::Peer>> findPeer(
+            const VoteMessage &vote);
 
         /// Remove votes from unknown peers from given vector.
         void removeUnknownPeersVotes(std::vector<VoteMessage> &votes,
@@ -120,7 +118,7 @@ namespace iroha {
 
         // ------|One round|------
         ClusterOrdering cluster_order_;
-        boost::optional<ClusterOrdering> alternative_order_;
+        std::optional<ClusterOrdering> alternative_order_;
         Round round_;
 
         // ------|Fields|------

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -33,8 +33,8 @@ namespace iroha {
          */
         virtual void vote(YacHash hash,
                           ClusterOrdering order,
-                          boost::optional<ClusterOrdering> alternative_order =
-                              boost::none) = 0;
+                          std::optional<ClusterOrdering> alternative_order =
+                              std::nullopt) = 0;
 
         /**
          * Observable with consensus outcomes - commits and rejects - in network

--- a/irohad/consensus/yac/yac_peer_orderer.hpp
+++ b/irohad/consensus/yac/yac_peer_orderer.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_YAC_PEER_ORDERER_HPP
 #define IROHA_YAC_PEER_ORDERER_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "consensus/yac/cluster_order.hpp"
 
@@ -27,7 +27,7 @@ namespace iroha {
          * @param peers - an ordered list of peers
          * @return shuffled cluster order
          */
-        virtual boost::optional<ClusterOrdering> getOrdering(
+        virtual std::optional<ClusterOrdering> getOrdering(
             const YacHash &hash,
             std::vector<std::shared_ptr<shared_model::interface::Peer>> const
                 &peers) = 0;

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -102,7 +102,7 @@ static constexpr iroha::consensus::yac::ConsistencyModel
  * Configuring iroha daemon
  */
 Irohad::Irohad(
-    const boost::optional<std::string> &block_store_dir,
+    const std::optional<std::string> &block_store_dir,
     std::unique_ptr<ametsuchi::PostgresOptions> pg_opt,
     const std::string &listen_ip,
     size_t torii_port,
@@ -114,15 +114,15 @@ Irohad::Irohad(
     const shared_model::crypto::Keypair &keypair,
     std::chrono::milliseconds max_rounds_delay,
     size_t stale_stream_max_rounds,
-    boost::optional<shared_model::interface::types::PeerList>
+    std::optional<shared_model::interface::types::PeerList>
         opt_alternative_peers,
     logger::LoggerManagerTreePtr logger_manager,
     StartupWsvDataPolicy startup_wsv_data_policy,
     std::shared_ptr<const GrpcChannelParams> grpc_channel_params,
-    const boost::optional<GossipPropagationStrategyParams>
+    const std::optional<GossipPropagationStrategyParams>
         &opt_mst_gossip_params,
-    const boost::optional<iroha::torii::TlsParams> &torii_tls_params,
-    boost::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config)
+    const std::optional<iroha::torii::TlsParams> &torii_tls_params,
+    std::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config)
     : block_store_dir_(block_store_dir),
       listen_ip_(listen_ip),
       torii_port_(torii_port),
@@ -233,7 +233,7 @@ Irohad::RunResult Irohad::initSettings() {
     return expected::makeError("Unable to create Settings");
   }
 
-  return settingsQuery.get()->get() | [this](auto &&settings) -> RunResult {
+  return settingsQuery.value()->get() | [this](auto &&settings) -> RunResult {
     this->settings_ = std::move(settings);
 
     log_->info("[Init] => settings");
@@ -333,7 +333,7 @@ Irohad::RunResult Irohad::initTlsCredentials() {
   const auto &p2p_path = inter_peer_tls_config_ |
       [](const auto &p2p_config) { return p2p_config.my_tls_creds_path; };
   const auto &torii_path = torii_tls_params_ | [](const auto &torii_config) {
-    return boost::make_optional(torii_config.key_path);
+    return std::make_optional(torii_config.key_path);
   };
 
   auto load_tls_creds = [this](const auto &opt_path,
@@ -369,7 +369,7 @@ Irohad::RunResult Irohad::initPeerCertProvider() {
   }
 
   using OptionalPeerCertProvider =
-      boost::optional<std::unique_ptr<const PeerTlsCertificatesProvider>>;
+      std::optional<std::unique_ptr<const PeerTlsCertificatesProvider>>;
   using PeerCertProviderResult = Result<OptionalPeerCertProvider, std::string>;
 
   return iroha::visit_in_place(
@@ -392,7 +392,7 @@ Irohad::RunResult Irohad::initPeerCertProvider() {
                  return makeError(std::string{"Failed to get peer query."});
                }
                log_->debug("Prepared WSV peer certificate provider.");
-               return boost::make_optional(
+               return std::make_optional(
                    std::make_unique<PeerTlsCertificatesProviderWsv>(
                        std::move(opt_peer_query).value()));
              },

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -119,7 +119,7 @@ class Irohad {
    * @param inter_peer_tls_config - set up TLS in peer-to-peer communication
    * TODO mboldyrev 03.11.2018 IR-1844 Refactor the constructor.
    */
-  Irohad(const boost::optional<std::string> &block_store_dir,
+  Irohad(const std::optional<std::string> &block_store_dir,
          std::unique_ptr<iroha::ametsuchi::PostgresOptions> pg_opt,
          const std::string &listen_ip,
          size_t torii_port,
@@ -131,18 +131,18 @@ class Irohad {
          const shared_model::crypto::Keypair &keypair,
          std::chrono::milliseconds max_rounds_delay,
          size_t stale_stream_max_rounds,
-         boost::optional<shared_model::interface::types::PeerList>
+         std::optional<shared_model::interface::types::PeerList>
              opt_alternative_peers,
          logger::LoggerManagerTreePtr logger_manager,
          iroha::StartupWsvDataPolicy startup_wsv_data_policy,
          std::shared_ptr<const iroha::network::GrpcChannelParams>
              grpc_channel_params,
-         const boost::optional<iroha::GossipPropagationStrategyParams>
-             &opt_mst_gossip_params = boost::none,
-         const boost::optional<iroha::torii::TlsParams> &torii_tls_params =
-             boost::none,
-         boost::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config =
-             boost::none);
+         const std::optional<iroha::GossipPropagationStrategyParams>
+             &opt_mst_gossip_params = std::nullopt,
+         const std::optional<iroha::torii::TlsParams> &torii_tls_params =
+             std::nullopt,
+         std::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config =
+             std::nullopt);
 
   /**
    * Initialization of whole objects in system
@@ -234,10 +234,10 @@ class Irohad {
   virtual RunResult initWsvRestorer();
 
   // constructor dependencies
-  const boost::optional<std::string> block_store_dir_;
+  const std::optional<std::string> block_store_dir_;
   const std::string listen_ip_;
   size_t torii_port_;
-  boost::optional<iroha::torii::TlsParams> torii_tls_params_;
+  std::optional<iroha::torii::TlsParams> torii_tls_params_;
   size_t internal_port_;
   size_t max_proposal_size_;
   std::chrono::milliseconds proposal_delay_;
@@ -246,18 +246,18 @@ class Irohad {
   std::chrono::minutes mst_expiration_time_;
   std::chrono::milliseconds max_rounds_delay_;
   size_t stale_stream_max_rounds_;
-  const boost::optional<shared_model::interface::types::PeerList>
+  const std::optional<shared_model::interface::types::PeerList>
       opt_alternative_peers_;
   std::shared_ptr<const iroha::network::GrpcChannelParams> grpc_channel_params_;
-  boost::optional<iroha::GossipPropagationStrategyParams>
+  std::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
-  boost::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config_;
+  std::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config_;
 
-  boost::optional<std::shared_ptr<const iroha::network::TlsCredentials>>
+  std::optional<std::shared_ptr<const iroha::network::TlsCredentials>>
       my_inter_peer_tls_creds_;
-  boost::optional<std::shared_ptr<const iroha::network::TlsCredentials>>
+  std::optional<std::shared_ptr<const iroha::network::TlsCredentials>>
       torii_tls_creds_;
-  boost::optional<
+  std::optional<
       std::shared_ptr<const iroha::network::PeerTlsCertificatesProvider>>
       peer_tls_certificates_provider_;
 
@@ -393,8 +393,8 @@ class Irohad {
   rxcpp::composite_subscription consensus_gate_events_subscription;
 
   std::unique_ptr<iroha::network::ServerRunner> torii_server;
-  boost::optional<std::unique_ptr<iroha::network::ServerRunner>>
-      torii_tls_server = boost::none;
+  std::optional<std::unique_ptr<iroha::network::ServerRunner>>
+      torii_tls_server = std::nullopt;
   std::unique_ptr<iroha::network::ServerRunner> internal_server;
 
   logger::LoggerManagerTreePtr log_manager_;  ///< application root log manager

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -87,7 +87,7 @@ namespace iroha {
           Round initial_round,
           std::shared_ptr<iroha::ametsuchi::PeerQueryFactory>
               peer_query_factory,
-          boost::optional<shared_model::interface::types::PeerList>
+          std::optional<shared_model::interface::types::PeerList>
               alternative_peers,
           std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<network::BlockLoader> block_loader,

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -37,7 +37,7 @@ namespace iroha {
             Round initial_round,
             // TODO 30.01.2019 lebdron: IR-262 Remove PeerQueryFactory
             std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
-            boost::optional<shared_model::interface::types::PeerList>
+            std::optional<shared_model::interface::types::PeerList>
                 alternative_peers,
             std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<network::BlockLoader> block_loader,

--- a/irohad/main/impl/storage_init.cpp
+++ b/irohad/main/impl/storage_init.cpp
@@ -83,7 +83,7 @@ iroha::initStorage(
     std::shared_ptr<iroha::PendingTransactionStorage> pending_txs_storage,
     std::shared_ptr<shared_model::interface::QueryResponseFactory>
         query_response_factory,
-    boost::optional<std::string> block_storage_dir,
+    std::optional<std::string> block_storage_dir,
     std::optional<std::reference_wrapper<const iroha::ametsuchi::VmCaller>>
         vm_caller_ref,
     logger::LoggerManagerTreePtr log_manager) {

--- a/irohad/main/impl/storage_init.hpp
+++ b/irohad/main/impl/storage_init.hpp
@@ -11,7 +11,6 @@
 #include <optional>
 #include <string>
 
-#include <boost/optional/optional_fwd.hpp>
 #include "common/result_fwd.hpp"
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
@@ -37,7 +36,7 @@ namespace iroha {
       std::shared_ptr<iroha::PendingTransactionStorage> pending_txs_storage,
       std::shared_ptr<shared_model::interface::QueryResponseFactory>
           query_response_factory,
-      boost::optional<std::string> block_storage_dir,
+      std::optional<std::string> block_storage_dir,
       std::optional<std::reference_wrapper<const iroha::ametsuchi::VmCaller>>
           vm_caller_ref,
       logger::LoggerManagerTreePtr log_manager);

--- a/irohad/main/iroha_conf_loader.cpp
+++ b/irohad/main/iroha_conf_loader.cpp
@@ -55,7 +55,7 @@ class JsonDeserializerImpl {
    */
   template <typename TDest>
   TDest deserialize(const rapidjson::Value &src,
-                    boost::optional<std::string> path = boost::none) {
+                    std::optional<std::string> path = std::nullopt) {
     TDest dest;
     getVal(path.value_or(""), dest, src);
     return dest;
@@ -220,11 +220,11 @@ class JsonDeserializerImpl {
   /// A variant of tryGetValByKey for optional destination
   template <typename TDest, typename TKey>
   bool tryGetValByKey(const std::string &path,
-                      boost::optional<TDest> &dest,
+                      std::optional<TDest> &dest,
                       const rapidjson::Value::ConstObject &obj,
                       const TKey &key) {
     dest = getOptValByKey<TDest>(path, obj, key);
-    return true;  // value loaded any way, either from file or boost::none
+    return true;  // value loaded any way, either from file or std::nullopt
   }
 
   /**
@@ -233,15 +233,15 @@ class JsonDeserializerImpl {
    *    place.
    * @param obj - the source JSON object
    * @param key - the key for the requested value
-   * @return the value if present in the JSON object, otherwise boost::none.
+   * @return the value if present in the JSON object, otherwise std::nullopt.
    */
   template <typename TDest, typename TKey>
-  boost::optional<TDest> getOptValByKey(
+  std::optional<TDest> getOptValByKey(
       const std::string &path,
       const rapidjson::Value::ConstObject &obj,
       const TKey &key) {
     TDest val;
-    return boost::make_optional(tryGetValByKey(path, val, obj, key), val);
+    return tryGetValByKey(path, val, obj, key) ? std::make_optional(val) : std::nullopt;
   }
 
   /**
@@ -368,7 +368,7 @@ JsonDeserializerImpl::getVal<std::unique_ptr<shared_model::interface::Peer>>(
   getValByKey(path, address, obj, config_members::Address);
   std::string public_key_str;
   getValByKey(path, public_key_str, obj, config_members::PublicKey);
-  boost::optional<std::string> tls_certificate_path =
+  std::optional<std::string> tls_certificate_path =
       getOptValByKey<std::string>(
           path, obj, config_members::TlsCertificatePath);
 

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -33,7 +33,7 @@ struct IrohadConfig {
     struct None {};
     using PeerCertProvider = boost::variant<RootCert, FromWsv, None>;
 
-    boost::optional<std::string> my_tls_creds_path;
+    std::optional<std::string> my_tls_creds_path;
     PeerCertProvider peer_certificates;
   };
 
@@ -44,25 +44,25 @@ struct IrohadConfig {
 
   // TODO: block_store_path is now optional, change docs IR-576
   // luckychess 29.06.2019
-  boost::optional<std::string> block_store_path;
+  std::optional<std::string> block_store_path;
   uint16_t torii_port;
-  boost::optional<iroha::torii::TlsParams> torii_tls_params;
-  boost::optional<InterPeerTls> inter_peer_tls;
+  std::optional<iroha::torii::TlsParams> torii_tls_params;
+  std::optional<InterPeerTls> inter_peer_tls;
   uint16_t internal_port;
-  boost::optional<std::string>
+  std::optional<std::string>
       pg_opt;  // TODO 2019.06.26 mboldyrev IR-556 remove
-  boost::optional<DbConfig>
+  std::optional<DbConfig>
       database_config;  // TODO 2019.06.26 mboldyrev IR-556 make required
   uint32_t max_proposal_size;
   uint32_t proposal_delay;
   uint32_t vote_delay;
   bool mst_support;
-  boost::optional<uint32_t> mst_expiration_time;
-  boost::optional<uint32_t> max_round_delay_ms;
-  boost::optional<uint32_t> stale_stream_max_rounds;
-  boost::optional<logger::LoggerManagerTreePtr> logger_manager;
-  boost::optional<shared_model::interface::types::PeerList> initial_peers;
-  boost::optional<UtilityService> utility_service;
+  std::optional<uint32_t> mst_expiration_time;
+  std::optional<uint32_t> max_round_delay_ms;
+  std::optional<uint32_t> stale_stream_max_rounds;
+  std::optional<logger::LoggerManagerTreePtr> logger_manager;
+  std::optional<shared_model::interface::types::PeerList> initial_peers;
+  std::optional<UtilityService> utility_service;
 };
 
 /**

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -228,7 +228,7 @@ int main(int argc, char *argv[]) {
   // Reading public and private key files
   iroha::KeysManagerImpl keysManager(
       FLAGS_keypair_name, log_manager->getChild("KeysManager")->getLogger());
-  auto keypair = keysManager.loadKeys(boost::none);
+  auto keypair = keysManager.loadKeys(std::nullopt);
   // Check if both keys are read properly
   if (auto e = iroha::expected::resultToOptionalError(keypair)) {
     // Abort execution if not
@@ -279,10 +279,10 @@ int main(int argc, char *argv[]) {
       FLAGS_reuse_state ? iroha::StartupWsvDataPolicy::kReuse
                         : iroha::StartupWsvDataPolicy::kDrop,
       ::iroha::network::getDefaultChannelParams(),
-      boost::make_optional(config.mst_support,
+      std::make_optional(config.mst_support,
                            iroha::GossipPropagationStrategyParams{}),
       config.torii_tls_params,
-      boost::none);
+      std::nullopt);
 
   // Check if iroha daemon storage was successfully initialized
   if (not irohad->storage) {

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -257,6 +257,11 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
+  std::optional<iroha::GossipPropagationStrategyParams> opt_mst_gossip_params;
+  if (config.mst_support) {
+    opt_mst_gossip_params = iroha::GossipPropagationStrategyParams{};
+  }
+
   // Configuring iroha daemon
   auto irohad = std::make_unique<Irohad>(
       config.block_store_path,
@@ -279,8 +284,7 @@ int main(int argc, char *argv[]) {
       FLAGS_reuse_state ? iroha::StartupWsvDataPolicy::kReuse
                         : iroha::StartupWsvDataPolicy::kDrop,
       ::iroha::network::getDefaultChannelParams(),
-      std::make_optional(config.mst_support,
-                           iroha::GossipPropagationStrategyParams{}),
+      opt_mst_gossip_params,
       config.torii_tls_params,
       std::nullopt);
 

--- a/irohad/main/server_runner.cpp
+++ b/irohad/main/server_runner.cpp
@@ -19,7 +19,7 @@ namespace {
   const auto kPortBindError = "Cannot bind server to address %s";
 
   std::shared_ptr<grpc::ServerCredentials> createCredentials(
-      const boost::optional<std::shared_ptr<const TlsCredentials>>
+      const std::optional<std::shared_ptr<const TlsCredentials>>
           &my_tls_creds) {
     if (not my_tls_creds) {
       return grpc::InsecureServerCredentials();
@@ -40,7 +40,7 @@ ServerRunner::ServerRunner(
     const std::string &address,
     logger::LoggerPtr log,
     bool reuse,
-    const boost::optional<std::shared_ptr<const TlsCredentials>> &my_tls_creds)
+    const std::optional<std::shared_ptr<const TlsCredentials>> &my_tls_creds)
     : log_(std::move(log)),
       server_address_(address),
       credentials_(createCredentials(my_tls_creds)),

--- a/irohad/main/server_runner.hpp
+++ b/irohad/main/server_runner.hpp
@@ -33,8 +33,8 @@ namespace iroha {
           const std::string &address,
           logger::LoggerPtr log,
           bool reuse = true,
-          const boost::optional<std::shared_ptr<const TlsCredentials>>
-              &my_tls_creds = boost::none);
+          const std::optional<std::shared_ptr<const TlsCredentials>>
+              &my_tls_creds = std::nullopt);
 
       ~ServerRunner();
 

--- a/irohad/model/common.hpp
+++ b/irohad/model/common.hpp
@@ -6,14 +6,14 @@
 #ifndef IROHA_COMMON_HPP
 #define IROHA_COMMON_HPP
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace iroha {
   namespace model {
     // Optional over shared pointer
     template <typename T>
-    using optional_ptr = boost::optional<std::shared_ptr<T>>;
+    using optional_ptr = std::optional<std::shared_ptr<T>>;
 
     template <typename T, typename... Args>
     optional_ptr<T> make_optional_ptr(Args &&... args) {

--- a/irohad/model/converters/impl/json_block_factory.cpp
+++ b/irohad/model/converters/impl/json_block_factory.cpp
@@ -57,7 +57,7 @@ namespace iroha {
         return document;
       }
 
-      boost::optional<Block> JsonBlockFactory::deserialize(
+      std::optional<Block> JsonBlockFactory::deserialize(
           const Document &document) {
         auto des = makeFieldDeserializer(document);
         auto des_transactions = [this](auto array) {
@@ -66,17 +66,17 @@ namespace iroha {
               return factory_.deserialize(x) |
                   [&transactions](auto transaction) {
                     transactions.push_back(transaction);
-                    return boost::make_optional(std::move(transactions));
+                    return std::make_optional(std::move(transactions));
                   };
             };
           };
           return std::accumulate(
               array.begin(),
               array.end(),
-              boost::make_optional(Block::TransactionsType()),
+              std::make_optional(Block::TransactionsType()),
               acc_transactions);
         };
-        return boost::make_optional(model::Block())
+        return std::make_optional(model::Block())
             | des.Uint64(&Block::created_ts, "created_ts")
             | des.Uint64(&Block::height, "height")
             | des.Uint(&Block::txs_number, "txs_number")

--- a/irohad/model/converters/impl/json_command_factory.cpp
+++ b/irohad/model/converters/impl/json_command_factory.cpp
@@ -32,16 +32,16 @@ namespace iroha {
       template <>
       struct Convert<Peer> {
         template <typename T>
-        boost::optional<Peer> operator()(T &&x) const {
+        std::optional<Peer> operator()(T &&x) const {
           auto des = makeFieldDeserializer(std::forward<T>(x));
           auto address = des.String("address");
           auto pubkey = des.String("peer_key");
 
           if (not address or not pubkey) {
-            return boost::none;
+            return std::nullopt;
           }
 
-          return boost::make_optional(Peer(
+          return std::make_optional(Peer(
               address.value(),
               iroha::hexstringToArray<iroha::pubkey_t::size()>(pubkey.value())
                   .value()));
@@ -441,14 +441,14 @@ namespace iroha {
           std::set<std::string> perms;
           for (auto &v : document["permissions"].GetArray()) {
             if (not v.IsString()) {
-              return boost::none;
+              return std::nullopt;
             }
             perms.insert(v.GetString());
           }
           auto role_name = document["role_name"].GetString();
           return make_optional_ptr<CreateRole>(role_name, perms) | toCommand;
         }
-        return boost::none;
+        return std::nullopt;
       }
 
       rapidjson::Document JsonCommandFactory::serializeGrantPermission(

--- a/irohad/model/converters/impl/json_common.cpp
+++ b/irohad/model/converters/impl/json_common.cpp
@@ -23,11 +23,11 @@ namespace iroha {
         return document;
       }
 
-      boost::optional<Document> stringToJson(const std::string &string) {
+      std::optional<Document> stringToJson(const std::string &string) {
         Document document;
         document.Parse(string);
         if (document.HasParseError()) {
-          return boost::none;
+          return std::nullopt;
         }
         return document;
       }

--- a/irohad/model/converters/impl/json_query_factory.cpp
+++ b/irohad/model/converters/impl/json_query_factory.cpp
@@ -74,7 +74,7 @@ namespace iroha {
             | des.String(&Query::creator_account_id, "creator_account_id")
             | des.Uint64(&Query::query_counter, "query_counter")
             | des.Object(&Query::signature, "signature") |
-            [](auto query) { return boost::make_optional(std::move(query)); };
+            [](auto query) { return std::make_optional(std::move(query)); };
       }
 
       optional_ptr<Query> JsonQueryFactory::deserializeGetAccount(

--- a/irohad/model/converters/impl/json_transaction_factory.cpp
+++ b/irohad/model/converters/impl/json_transaction_factory.cpp
@@ -48,7 +48,7 @@ namespace iroha {
         return document;
       }
 
-      boost::optional<Transaction> JsonTransactionFactory::deserialize(
+      std::optional<Transaction> JsonTransactionFactory::deserialize(
           const Value &document) {
         auto des = makeFieldDeserializer(document);
         auto des_commands = [this](auto array) {
@@ -57,17 +57,17 @@ namespace iroha {
               return factory_.deserializeAbstractCommand(x) |
                   [&commands](auto command) {
                     commands.push_back(command);
-                    return boost::make_optional(std::move(commands));
+                    return std::make_optional(std::move(commands));
                   };
             };
           };
           return std::accumulate(
               array.begin(),
               array.end(),
-              boost::make_optional(Transaction::CommandsType()),
+              std::make_optional(Transaction::CommandsType()),
               acc_commands);
         };
-        return boost::make_optional(Transaction())
+        return std::make_optional(Transaction())
             | des.Uint64(&Transaction::created_ts, "created_ts")
             | des.String(&Transaction::creator_account_id, "creator_account_id")
             | des.Array(&Transaction::signatures, "signatures")

--- a/irohad/model/converters/impl/pb_query_factory.cpp
+++ b/irohad/model/converters/impl/pb_query_factory.cpp
@@ -130,7 +130,7 @@ namespace iroha {
             }
             default: {
               // Query not implemented
-              return boost::none;
+              return std::nullopt;
             }
           }
         }
@@ -162,14 +162,14 @@ namespace iroha {
         sig->set_public_key(query->signature.pubkey.to_hexstring());
       }
 
-      boost::optional<protocol::Query> PbQueryFactory::serialize(
+      std::optional<protocol::Query> PbQueryFactory::serialize(
           std::shared_ptr<const Query> query) const {
         auto it = serializers_.find(typeid(*query));
         if (it != serializers_.end()) {
           return (this->*it->second)(query);
         }
         log_->error("Query type not found");
-        return boost::none;
+        return std::nullopt;
       }
 
       protocol::Query PbQueryFactory::serializeGetAccount(

--- a/irohad/model/converters/json_block_factory.hpp
+++ b/irohad/model/converters/json_block_factory.hpp
@@ -19,7 +19,7 @@ namespace iroha {
         explicit JsonBlockFactory(logger::LoggerPtr log);
         rapidjson::Document serialize(const Block &block);
 
-        boost::optional<Block> deserialize(const rapidjson::Document &document);
+        std::optional<Block> deserialize(const rapidjson::Document &document);
 
        private:
         JsonTransactionFactory factory_;

--- a/irohad/model/converters/json_common.hpp
+++ b/irohad/model/converters/json_common.hpp
@@ -39,7 +39,7 @@ namespace iroha {
          */
         template <typename T>
         auto operator()(T &&x) const {
-          return boost::optional<V>(std::forward<T>(x));
+          return std::optional<V>(std::forward<T>(x));
         }
       };
 
@@ -60,13 +60,13 @@ namespace iroha {
        * @return deserialized field on success, nullopt otherwise
        */
       template <typename T, typename D>
-      boost::optional<T> deserializeField(const D &document,
+      std::optional<T> deserializeField(const D &document,
                                           const std::string &field) {
         if (document.HasMember(field.c_str())
             and document[field.c_str()].template Is<T>()) {
           return document[field.c_str()].template Get<T>();
         }
-        return boost::none;
+        return std::nullopt;
       }
 
       /**
@@ -223,7 +223,7 @@ namespace iroha {
         template <typename T>
         auto operator()(T &&x) const {
           auto des = makeFieldDeserializer(std::forward<T>(x));
-          return boost::make_optional(Signature())
+          return std::make_optional(Signature())
               | des.String(&Signature::pubkey, "pubkey")
               | des.String(&Signature::signature, "signature");
         }
@@ -237,13 +237,13 @@ namespace iroha {
             return init | [&x](auto signatures) {
               return Convert<Signature>()(x) | [&signatures](auto signature) {
                 signatures.push_back(signature);
-                return boost::make_optional(std::move(signatures));
+                return std::make_optional(std::move(signatures));
               };
             };
           };
           return std::accumulate(x.begin(),
                                  x.end(),
-                                 boost::make_optional(Block::SignaturesType()),
+                                 std::make_optional(Block::SignaturesType()),
                                  acc_signatures);
         }
       };
@@ -254,28 +254,28 @@ namespace iroha {
         auto operator()(T &&x) const {
           auto acc_hashes = [](auto init, auto &x) {
             return init | [&x](auto tx_hashes)
-                       -> boost::optional<
+                       -> std::optional<
                            GetTransactions::TxHashCollectionType> {
               // If invalid type included, returns nullopt
               if (not x.IsString()) {
-                return boost::none;
+                return std::nullopt;
               }
               auto tx_hash_opt =
                   Convert<GetTransactions::TxHashType>()(x.GetString());
               if (not tx_hash_opt) {
                 // If the the hash is wrong, just skip.
-                return boost::make_optional(std::move(tx_hashes));
+                return std::make_optional(std::move(tx_hashes));
               }
               return tx_hash_opt | [&tx_hashes](auto tx_hash) {
                 tx_hashes.push_back(tx_hash);
-                return boost::make_optional(std::move(tx_hashes));
+                return std::make_optional(std::move(tx_hashes));
               };
             };
           };
           return std::accumulate(
               x.begin(),
               x.end(),
-              boost::make_optional(GetTransactions::TxHashCollectionType()),
+              std::make_optional(GetTransactions::TxHashCollectionType()),
               acc_hashes);
         }
       };
@@ -295,7 +295,7 @@ namespace iroha {
        * @param string - string for parsing
        * @return JSON document on success, nullopt otherwise
        */
-      boost::optional<rapidjson::Document> stringToJson(
+      std::optional<rapidjson::Document> stringToJson(
           const std::string &string);
 
       /**

--- a/irohad/model/converters/json_transaction_factory.hpp
+++ b/irohad/model/converters/json_transaction_factory.hpp
@@ -17,7 +17,7 @@ namespace iroha {
        public:
         rapidjson::Document serialize(const Transaction &transaction);
 
-        boost::optional<Transaction> deserialize(
+        std::optional<Transaction> deserialize(
             const rapidjson::Value &document);
 
        private:

--- a/irohad/model/converters/pb_query_factory.hpp
+++ b/irohad/model/converters/pb_query_factory.hpp
@@ -32,9 +32,9 @@ namespace iroha {
         /**
          * Convert model query to proto query
          * @param query - model query to serialize
-         * @return boost::noneif no query type is found
+         * @return std::nulloptif no query type is found
          */
-        boost::optional<protocol::Query> serialize(
+        std::optional<protocol::Query> serialize(
             std::shared_ptr<const model::Query> query) const;
 
         explicit PbQueryFactory(logger::LoggerPtr log);

--- a/irohad/model/generators/impl/transaction_generator.cpp
+++ b/irohad/model/generators/impl/transaction_generator.cpp
@@ -36,9 +36,9 @@ namespace iroha {
         for (size_t i = 0; i < peers_address.size(); ++i) {
           KeysManagerImpl manager("node" + std::to_string(i),
                                   keys_manager_logger);
-          manager.createKeys(boost::none);
+          manager.createKeys(std::nullopt);
           auto keypair = *std::unique_ptr<iroha::keypair_t>(
-              makeOldModel(manager.loadKeys(boost::none).assumeValue()));
+              makeOldModel(manager.loadKeys(std::nullopt).assumeValue()));
           tx.commands.push_back(command_generator.generateAddPeer(
               Peer(peers_address[i], keypair.pubkey)));
         }
@@ -58,15 +58,15 @@ namespace iroha {
             command_generator.generateCreateAsset("coin", "test", precision));
         // Create accounts
         KeysManagerImpl manager("admin@test", keys_manager_logger);
-        manager.createKeys(boost::none);
+        manager.createKeys(std::nullopt);
         auto keypair = *std::unique_ptr<iroha::keypair_t>(
-            makeOldModel(manager.loadKeys(boost::none).assumeValue()));
+            makeOldModel(manager.loadKeys(std::nullopt).assumeValue()));
         tx.commands.push_back(command_generator.generateCreateAccount(
             "admin", "test", keypair.pubkey));
         manager = KeysManagerImpl("test@test", std::move(keys_manager_logger));
-        manager.createKeys(boost::none);
+        manager.createKeys(std::nullopt);
         keypair = *std::unique_ptr<iroha::keypair_t>(
-            makeOldModel(manager.loadKeys(boost::none).assumeValue()));
+            makeOldModel(manager.loadKeys(std::nullopt).assumeValue()));
         tx.commands.push_back(command_generator.generateCreateAccount(
             "test", "test", keypair.pubkey));
 

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_GOSSIP_PROPAGATION_STRATEGY_HPP
 #define IROHA_GOSSIP_PROPAGATION_STRATEGY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <chrono>
 #include <mutex>
 
@@ -28,7 +28,7 @@ namespace iroha {
   class GossipPropagationStrategy : public PropagationStrategy {
    public:
     using PeerProviderFactory = std::shared_ptr<ametsuchi::PeerQueryFactory>;
-    using OptPeer = boost::optional<PropagationData::value_type>;
+    using OptPeer = std::optional<PropagationData::value_type>;
     /**
      * Initialize strategy with
      * @param peer_factory is a provider of peer list

--- a/irohad/multi_sig_transactions/gossip_propagation_strategy_params.hpp
+++ b/irohad/multi_sig_transactions/gossip_propagation_strategy_params.hpp
@@ -7,8 +7,7 @@
 #define IROHA_GOSSIP_PROPAGATION_STRATEGY_PARAMS_HPP
 
 #include <chrono>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 // TODO: IR-1317 @l4l (02/05/18) magics should be replaced with options via
 // cli parameters

--- a/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
+++ b/irohad/multi_sig_transactions/impl/gossip_propagation_strategy.cpp
@@ -56,7 +56,7 @@ namespace iroha {
   bool GossipPropagationStrategy::initQueue() {
     return peer_factory->createPeerQuery() | [](const auto &query) {
       return query->getLedgerPeers();
-    } | [](auto &&data) -> boost::optional<PropagationData> {
+    } | [](auto &&data) -> std::optional<PropagationData> {
       if (data.size() == 0) {
         return {};
       }

--- a/irohad/multi_sig_transactions/state/impl/mst_state.cpp
+++ b/irohad/multi_sig_transactions/state/impl/mst_state.cpp
@@ -120,7 +120,7 @@ namespace iroha {
   }
 
   void MstState::eraseExpired(const TimeType &current_time) {
-    extractExpiredImpl(current_time, boost::none);
+    extractExpiredImpl(current_time, std::nullopt);
   }
 
   void MstState::eraseByTransactionHash(
@@ -221,11 +221,11 @@ namespace iroha {
   }
 
   void MstState::extractExpiredImpl(const TimeType &current_time,
-                                    boost::optional<MstState &> extracted) {
+                                    std::optional<std::reference_wrapper<MstState>> extracted) {
     for (auto it = batches_.left.begin(); it != batches_.left.end()
          and completer_->isExpired(it->second, current_time);) {
       if (extracted) {
-        *extracted += it->second;
+        extracted->get() += it->second;
       }
       batches_to_hash_.right.erase(it->second);
       it = batches_.left.erase(it);

--- a/irohad/multi_sig_transactions/state/mst_state.hpp
+++ b/irohad/multi_sig_transactions/state/mst_state.hpp
@@ -13,7 +13,6 @@
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/bimap/unordered_multiset_of.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
-#include <boost/optional/optional.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/any_range.hpp>
 #include "cryptography/hash.hpp"
@@ -214,8 +213,9 @@ namespace iroha {
      * @param current_time - current time
      * @param extracted - optional storage for extracted batches.
      */
-    void extractExpiredImpl(const TimeType &current_time,
-                            boost::optional<MstState &> extracted);
+    void extractExpiredImpl(
+        const TimeType &current_time,
+        std::optional<std::reference_wrapper<MstState>> extracted);
 
     // -----------------------------| fields |------------------------------
 

--- a/irohad/network/impl/channel_factory_tls.cpp
+++ b/irohad/network/impl/channel_factory_tls.cpp
@@ -15,9 +15,9 @@ using namespace iroha::network;
 
 ChannelFactoryTls::ChannelFactoryTls(
     std::shared_ptr<const GrpcChannelParams> params,
-    boost::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
+    std::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
         peer_cert_provider,
-    boost::optional<std::shared_ptr<const TlsCredentials>> my_creds)
+    std::optional<std::shared_ptr<const TlsCredentials>> my_creds)
     : ChannelFactory(std::move(params)),
       peer_cert_provider_(std::move(peer_cert_provider)),
       my_creds_(std::move(my_creds)) {}

--- a/irohad/network/impl/channel_factory_tls.hpp
+++ b/irohad/network/impl/channel_factory_tls.hpp
@@ -20,9 +20,9 @@ namespace iroha {
      public:
       ChannelFactoryTls(
           std::shared_ptr<const GrpcChannelParams> params,
-          boost::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
+          std::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
               peer_cert_provider,
-          boost::optional<std::shared_ptr<const TlsCredentials>> my_creds);
+          std::optional<std::shared_ptr<const TlsCredentials>> my_creds);
 
      protected:
       iroha::expected::Result<std::shared_ptr<grpc::ChannelCredentials>,
@@ -31,9 +31,9 @@ namespace iroha {
           const shared_model::interface::Peer &peer) const override;
 
      private:
-      boost::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
+      std::optional<std::shared_ptr<const PeerTlsCertificatesProvider>>
           peer_cert_provider_;
-      boost::optional<std::shared_ptr<const TlsCredentials>> my_creds_;
+      std::optional<std::shared_ptr<const TlsCredentials>> my_creds_;
     };
 
   }  // namespace network

--- a/irohad/network/impl/grpc_channel_params.hpp
+++ b/irohad/network/impl/grpc_channel_params.hpp
@@ -8,8 +8,7 @@
 
 #include <chrono>
 #include <limits>
-
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 namespace iroha {
   namespace network {
@@ -24,7 +23,7 @@ namespace iroha {
       };
       unsigned int max_request_message_bytes;
       unsigned int max_response_message_bytes;
-      boost::optional<RetryPolicy> retry_policy;
+      std::optional<RetryPolicy> retry_policy;
     };
 
   }  // namespace network

--- a/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
+++ b/irohad/network/impl/peer_tls_certificates_provider_wsv.cpp
@@ -19,7 +19,7 @@ class PeerTlsCertificatesProviderWsv::Impl {
   Impl(std::shared_ptr<iroha::ametsuchi::PeerQuery> peer_query)
       : peer_query_(std::move(peer_query)) {}
 
-  boost::optional<std::shared_ptr<shared_model::interface::Peer>>
+  std::optional<std::shared_ptr<shared_model::interface::Peer>>
   getPeerFromWsv(
       shared_model::interface::types::PublicKeyHexStringView public_key) const {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/irohad/network/ordering_gate_common.hpp
+++ b/irohad/network/ordering_gate_common.hpp
@@ -7,8 +7,8 @@
 #define IROHA_ORDERING_GATE_COMMON_HPP
 
 #include <memory>
+#include <optional>
 
-#include <boost/optional.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "consensus/round.hpp"
 
@@ -25,7 +25,7 @@ namespace iroha {
      * Event, which is emitted by ordering gate, when it requests a proposal
      */
     struct OrderingEvent {
-      boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+      std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
           proposal;
       consensus::Round round;
       std::shared_ptr<const LedgerState> ledger_state;

--- a/irohad/ordering/impl/kick_out_proposal_creation_strategy.cpp
+++ b/irohad/ordering/impl/kick_out_proposal_creation_strategy.cpp
@@ -28,12 +28,12 @@ bool KickOutProposalCreationStrategy::shouldCreateRound(RoundType round) {
                                              peers_in_round_);
 }
 
-boost::optional<ProposalCreationStrategy::RoundType>
+std::optional<ProposalCreationStrategy::RoundType>
 KickOutProposalCreationStrategy::onProposalRequest(RoundType requested_round) {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     requested_count_[requested_round]++;
   }
 
-  return boost::none;
+  return std::nullopt;
 }

--- a/irohad/ordering/impl/kick_out_proposal_creation_strategy.hpp
+++ b/irohad/ordering/impl/kick_out_proposal_creation_strategy.hpp
@@ -32,7 +32,7 @@ namespace iroha {
 
       bool shouldCreateRound(RoundType round) override;
 
-      boost::optional<RoundType> onProposalRequest(
+      std::optional<RoundType> onProposalRequest(
           RoundType requested_round) override;
 
      private:

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -78,7 +78,7 @@ std::optional<std::shared_ptr<const OnDemandConnectionManager::ProposalType>>
 OnDemandConnectionManager::onRequestProposal(consensus::Round round) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   if (stop_requested_.load(std::memory_order_relaxed)) {
-    return boost::none;
+    return std::nullopt;
   }
 
   log_->debug("onRequestProposal, {}", round);

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -74,7 +74,7 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
   propagate(kCommitCommitConsumer);
 }
 
-boost::optional<std::shared_ptr<const OnDemandConnectionManager::ProposalType>>
+std::optional<std::shared_ptr<const OnDemandConnectionManager::ProposalType>>
 OnDemandConnectionManager::onRequestProposal(consensus::Round round) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   if (stop_requested_.load(std::memory_order_relaxed)) {

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -76,7 +76,7 @@ namespace iroha {
        */
       struct CurrentConnections {
         PeerCollectionType<
-            boost::optional<std::unique_ptr<transport::OdOsNotification>>>
+            std::optional<std::unique_ptr<transport::OdOsNotification>>>
             peers;
       };
 

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -66,7 +66,7 @@ namespace iroha {
 
       void onBatches(CollectionType batches) override;
 
-      boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
+      std::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
           consensus::Round round) override;
 
      private:

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -113,19 +113,19 @@ void OnDemandOrderingGate::stop() {
   }
 }
 
-boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
 OnDemandOrderingGate::processProposalRequest(
-    boost::optional<
+    std::optional<
         std::shared_ptr<const OnDemandOrderingService::ProposalType>> proposal)
     const {
   if (not proposal) {
-    return boost::none;
+    return std::nullopt;
   }
   auto proposal_without_replays =
       removeReplaysAndDuplicates(*std::move(proposal));
   // no need to check empty proposal
   if (boost::empty(proposal_without_replays->transactions())) {
-    return boost::none;
+    return std::nullopt;
   }
   return proposal_without_replays;
 }

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -74,9 +74,9 @@ namespace iroha {
       /**
        * Handle an incoming proposal from ordering service
        */
-      boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+      std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       processProposalRequest(
-          boost::optional<
+          std::optional<
               std::shared_ptr<const OnDemandOrderingService::ProposalType>>
               proposal) const;
 

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -5,14 +5,14 @@
 
 #include "ordering/impl/on_demand_ordering_service_impl.hpp"
 
-#include <unordered_set>
-
-#include <boost/optional.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/size.hpp>
+#include <optional>
+#include <unordered_set>
+
 #include "ametsuchi/tx_presence_cache.hpp"
 #include "ametsuchi/tx_presence_cache_utils.hpp"
 #include "common/visitor.hpp"
@@ -70,10 +70,9 @@ void OnDemandOrderingServiceImpl::onBatches(CollectionType batches) {
   log_->info("onBatches => collection size = {}", batches.size());
 }
 
-boost::optional<
-    std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>
+std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>
 OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
-  boost::optional<
+  std::optional<
       std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>
       result;
   {
@@ -106,9 +105,10 @@ OnDemandOrderingServiceImpl::onRequestProposal(consensus::Round round) {
  * @return transactions
  */
 static std::vector<std::shared_ptr<shared_model::interface::Transaction>>
-getTransactions(size_t requested_tx_amount,
-                detail::BatchSetType &batch_collection,
-                boost::optional<size_t &> discarded_txs_amount) {
+getTransactions(
+    size_t requested_tx_amount,
+    detail::BatchSetType &batch_collection,
+    std::optional<std::reference_wrapper<size_t>> discarded_txs_amount) {
   std::vector<std::shared_ptr<shared_model::interface::Transaction>> collection;
 
   auto it = batch_collection.begin();
@@ -122,7 +122,7 @@ getTransactions(size_t requested_tx_amount,
   }
 
   if (discarded_txs_amount) {
-    *discarded_txs_amount = 0;
+    discarded_txs_amount->get() = 0;
     for (; it != batch_collection.end(); ++it) {
       *discarded_txs_amount += boost::size((*it)->transactions());
     }

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -66,7 +66,7 @@ namespace iroha {
 
       void onBatches(CollectionType batches) override;
 
-      boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
+      std::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
           consensus::Round round) override;
 
      private:

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -48,7 +48,7 @@ void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
   });
 }
 
-boost::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
+std::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
 OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   grpc::ClientContext context;
   context.set_deadline(time_provider_() + proposal_request_timeout_);
@@ -59,21 +59,21 @@ OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   auto status = stub_->RequestProposal(&context, request, &response);
   if (not status.ok()) {
     log_->warn("RPC failed: {}", status.error_message());
-    return boost::none;
+    return std::nullopt;
   }
   if (not response.has_proposal()) {
-    return boost::none;
+    return std::nullopt;
   }
   return proposal_factory_->build(response.proposal())
       .match(
           [&](auto &&v) {
-            return boost::make_optional(
+            return std::make_optional(
                 std::shared_ptr<const OdOsNotification::ProposalType>(
                     std::move(v).value));
           },
           [this](const auto &error) {
             log_->info("{}", error.error.error);  // error
-            return boost::optional<
+            return std::optional<
                 std::shared_ptr<const OdOsNotification::ProposalType>>();
           });
 }

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -49,7 +49,7 @@ namespace iroha {
 
         void onBatches(CollectionType batches) override;
 
-        boost::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
+        std::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
             consensus::Round round) override;
 
        private:

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -7,10 +7,10 @@
 #define IROHA_ON_DEMAND_OS_TRANSPORT_HPP
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "common/result_fwd.hpp"
 #include "consensus/round.hpp"
 
@@ -59,7 +59,7 @@ namespace iroha {
          * Calculated as block_height + 1
          * @return proposal for requested round
          */
-        virtual boost::optional<std::shared_ptr<const ProposalType>>
+        virtual std::optional<std::shared_ptr<const ProposalType>>
         onRequestProposal(consensus::Round round) = 0;
 
         virtual ~OdOsNotification() = default;

--- a/irohad/ordering/ordering_service_proposal_creation_strategy.hpp
+++ b/irohad/ordering/ordering_service_proposal_creation_strategy.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_ORDERING_SERVICE_PROPOSAL_CREATION_STRATEGY_HPP
 #define IROHA_ORDERING_SERVICE_PROPOSAL_CREATION_STRATEGY_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "consensus/round.hpp"
 
 namespace iroha {
@@ -40,7 +41,7 @@ namespace iroha {
        * @param requested_round - in which round proposal is requested
        * @return round where proposal is required to be created immediately
        */
-      virtual boost::optional<RoundType> onProposalRequest(
+      virtual std::optional<RoundType> onProposalRequest(
           RoundType requested_round) = 0;
 
       virtual ~ProposalCreationStrategy() = default;

--- a/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
+++ b/irohad/pending_txs_storage/impl/pending_txs_storage_impl.cpp
@@ -260,8 +260,8 @@ namespace iroha {
 
   void PendingTransactionStorageImpl::removeBatch(
       const PreparedTransactionDescriptor &prepared_transaction) {
-    boost::optional<std::set<AccountIdType>> creators = boost::none;
-    boost::optional<uint64_t> batch_size = boost::none;
+    std::optional<std::set<AccountIdType>> creators = std::nullopt;
+    std::optional<uint64_t> batch_size = std::nullopt;
     auto &creator_id = prepared_transaction.first;
     auto &first_transaction_hash = prepared_transaction.second;
     {

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -24,7 +24,7 @@ namespace iroha {
       /**
        * Creates a block from given proposal and top block info
        */
-      virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
+      virtual std::optional<std::shared_ptr<shared_model::interface::Block>>
       processVerifiedProposal(
           const std::shared_ptr<validation::VerifiedProposalAndErrors>
               &verified_proposal_and_errors,

--- a/irohad/simulator/block_creator_common.hpp
+++ b/irohad/simulator/block_creator_common.hpp
@@ -7,8 +7,8 @@
 #define IROHA_BLOCK_CREATOR_COMMON_HPP
 
 #include <memory>
+#include <optional>
 
-#include <boost/optional.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "consensus/round.hpp"
 
@@ -32,7 +32,7 @@ namespace iroha {
      * a verified proposal
      */
     struct BlockCreatorEvent {
-      boost::optional<RoundData> round_data;
+      std::optional<RoundData> round_data;
       consensus::Round round;
       std::shared_ptr<const LedgerState> ledger_state;
     };

--- a/irohad/simulator/impl/simulator.cpp
+++ b/irohad/simulator/impl/simulator.cpp
@@ -44,7 +44,7 @@ namespace iroha {
                                                event.ledger_state});
             } else {
               notifier_.get_subscriber().on_next(VerifiedProposalCreatorEvent{
-                  boost::none, event.round, event.ledger_state});
+                  std::nullopt, event.round, event.ledger_state});
             }
           });
 
@@ -63,7 +63,7 @@ namespace iroha {
               }
             } else {
               block_notifier_.get_subscriber().on_next(BlockCreatorEvent{
-                  boost::none, event.round, event.ledger_state});
+                  std::nullopt, event.round, event.ledger_state});
             }
           });
     }
@@ -95,7 +95,7 @@ namespace iroha {
       return validated_proposal_and_errors;
     }
 
-    boost::optional<std::shared_ptr<shared_model::interface::Block>>
+    std::optional<std::shared_ptr<shared_model::interface::Block>>
     Simulator::processVerifiedProposal(
         const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
             &verified_proposal_and_errors,

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -9,7 +9,7 @@
 #include "simulator/block_creator.hpp"
 #include "simulator/verified_proposal_creator.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/temporary_factory.hpp"
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
@@ -50,7 +50,7 @@ namespace iroha {
       rxcpp::observable<VerifiedProposalCreatorEvent> onVerifiedProposal()
           override;
 
-      boost::optional<std::shared_ptr<shared_model::interface::Block>>
+      std::optional<std::shared_ptr<shared_model::interface::Block>>
       processVerifiedProposal(
           const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
               &verified_proposal_and_errors,

--- a/irohad/simulator/verified_proposal_creator_common.hpp
+++ b/irohad/simulator/verified_proposal_creator_common.hpp
@@ -6,7 +6,8 @@
 #ifndef IROHA_VERIFIED_PROPOSAL_CREATOR_COMMON_HPP
 #define IROHA_VERIFIED_PROPOSAL_CREATOR_COMMON_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "ametsuchi/ledger_state.hpp"
 #include "consensus/round.hpp"
 #include "validation/stateful_validator_common.hpp"
@@ -19,7 +20,7 @@ namespace iroha {
      * and processes a proposal
      */
     struct VerifiedProposalCreatorEvent {
-      boost::optional<std::shared_ptr<validation::VerifiedProposalAndErrors>>
+      std::optional<std::shared_ptr<validation::VerifiedProposalAndErrors>>
           verified_proposal_result;
       consensus::Round round;
       std::shared_ptr<const LedgerState> ledger_state;

--- a/irohad/torii/impl/command_service_transport_grpc.cpp
+++ b/irohad/torii/impl/command_service_transport_grpc.cpp
@@ -146,7 +146,7 @@ namespace iroha {
               // on further combine_latest
               .start_with(ConsensusGateEvent{});
 
-      boost::optional<iroha::protocol::TxStatus> last_tx_status;
+      std::optional<iroha::protocol::TxStatus> last_tx_status;
       auto rounds_counter{0};
       makeCombineLatestUntilFirstCompleted(
           status_bus,

--- a/irohad/util/utility_client.cpp
+++ b/irohad/util/utility_client.cpp
@@ -10,7 +10,6 @@
 #include "util/proto_status_tools.hpp"
 
 #include <grpc++/grpc++.h>
-#include <boost/optional.hpp>
 #include "common/bind.hpp"
 #include "logger/logger.hpp"
 #include "network/impl/channel_factory.hpp"

--- a/irohad/util/utility_service.cpp
+++ b/irohad/util/utility_service.cpp
@@ -10,7 +10,6 @@
 
 #include "util/proto_status_tools.hpp"
 
-#include <boost/optional.hpp>
 #include <rxcpp/rx.hpp>
 #include "common/run_loop_handler.hpp"
 #include "logger/logger.hpp"

--- a/libs/cache/abstract_cache.hpp
+++ b/libs/cache/abstract_cache.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_ABSTRACT_CACHE_HPP
 #define IROHA_ABSTRACT_CACHE_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <list>
 #include <shared_mutex>
 #include <string>
@@ -64,7 +64,7 @@ namespace iroha {
        * @param hash - key to find
        * @return Optional of ValueType
        */
-      boost::optional<ValueType> findItem(const KeyType &key) const {
+      std::optional<ValueType> findItem(const KeyType &key) const {
         std::shared_lock<std::shared_timed_mutex> lock(access_mutex_);
         return constUnderlying().findItemImpl(key);
       }

--- a/libs/cache/cache.hpp
+++ b/libs/cache/cache.hpp
@@ -10,6 +10,7 @@
 
 #include <unordered_map>
 
+#include <boost/assert.hpp>
 #include "common/ring_buffer.hpp"
 
 namespace iroha {
@@ -84,12 +85,12 @@ namespace iroha {
         }
       }
 
-      boost::optional<ValueType> findItemImpl(const KeyType &key) const {
+      std::optional<ValueType> findItemImpl(const KeyType &key) const {
         auto const hash = toHash(key);
         auto it = keys_.find(hash);
 
         if (keys_.end() == it) {
-          return boost::none;
+          return std::nullopt;
         } else {
           return values_.getItem(it->second).value;
         }

--- a/libs/common/byteutils.hpp
+++ b/libs/common/byteutils.hpp
@@ -7,10 +7,9 @@
 #define IROHA_BYTEUTILS_H
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "common/bind.hpp"
 #include "common/blob.hpp"
@@ -42,9 +41,9 @@ namespace iroha {
    * @return blob, if conversion was successful, otherwise nullopt
    */
   template <size_t size>
-  boost::optional<blob_t<size>> stringToBlob(const std::string &string) {
+  std::optional<blob_t<size>> stringToBlob(const std::string &string) {
     if (size != string.size()) {
-      return boost::none;
+      return std::nullopt;
     }
     blob_t<size> array;
     std::copy(string.begin(), string.end(), array.begin());
@@ -58,7 +57,7 @@ namespace iroha {
    * @return array of given size if size matches, nullopt otherwise
    */
   template <size_t size>
-  boost::optional<blob_t<size>> hexstringToArray(const std::string &string) {
+  std::optional<blob_t<size>> hexstringToArray(const std::string &string) {
     return hexstringToBytestring(string) | stringToBlob<size>;
   }
 

--- a/libs/common/hexutils.hpp
+++ b/libs/common/hexutils.hpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #include <boost/algorithm/hex.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include "common/result.hpp"
 #include "interfaces/common_objects/byte_range.hpp"
 
@@ -81,7 +81,7 @@ namespace iroha {
     return iroha::expected::makeValue(std::move(result));
   }
 
-  [[deprecated]] inline boost::optional<std::string> hexstringToBytestring(
+  [[deprecated]] inline std::optional<std::string> hexstringToBytestring(
       const std::string &str) {
     return iroha::expected::resultToOptionalValue(
         hexstringToBytestringResult(str));

--- a/libs/common/obj_utils.hpp
+++ b/libs/common/obj_utils.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_COMMON_OBJ_UTILS_HPP
 #define IROHA_COMMON_OBJ_UTILS_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace iroha {
 
@@ -20,12 +20,12 @@ namespace iroha {
    */
   template <typename C>
   auto makeOptionalGet(C map) {
-    return [&map](auto key) -> boost::optional<typename C::mapped_type> {
+    return [&map](auto key) -> std::optional<typename C::mapped_type> {
       auto it = map.find(key);
       if (it != std::end(map)) {
         return it->second;
       }
-      return boost::none;
+      return std::nullopt;
     };
   }
 
@@ -63,7 +63,7 @@ namespace iroha {
   auto assignObjectField(B object, V B::*member) {
     return [=](auto value) mutable {
       object.*member = value;
-      return boost::make_optional(object);
+      return std::make_optional(object);
     };
   }
 
@@ -80,7 +80,7 @@ namespace iroha {
   auto assignObjectField(P<B> object, V B::*member) {
     return [=](auto value) mutable {
       (*object).*member = value;
-      return boost::make_optional(object);
+      return std::make_optional(object);
     };
   }
 }  // namespace iroha

--- a/libs/common/result.hpp
+++ b/libs/common/result.hpp
@@ -9,9 +9,9 @@
 #include "common/result_fwd.hpp"
 
 #include <ciso646>
+#include <optional>
 #include <type_traits>
 
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
 #include "common/visitor.hpp"
@@ -486,7 +486,7 @@ namespace iroha {
     }
 
     /**
-     * Converters from Result to boost::optional. Can be used when only certain
+     * Converters from Result to optional. Can be used when only certain
      * part of result is honored (generally a Value), to smoothly convert it to
      * optional representation.
      */
@@ -494,7 +494,7 @@ namespace iroha {
     /// @return optional with value if present, otherwise none
     template <typename ResultType,
               typename = std::enable_if_t<isResult<ResultType>>>
-    boost::optional<InnerValueOf<ResultType>> resultToOptionalValue(
+    std::optional<InnerValueOf<ResultType>> resultToOptionalValue(
         ResultType &&res) noexcept {
       if (hasValue(res)) {
         return boost::get<ValueOf<ResultType>>(std::forward<ResultType>(res))
@@ -506,7 +506,7 @@ namespace iroha {
     /// @return optional with error if present, otherwise none
     template <typename ResultType,
               typename = std::enable_if_t<isResult<ResultType>>>
-    boost::optional<InnerErrorOf<ResultType>> resultToOptionalError(
+    std::optional<InnerErrorOf<ResultType>> resultToOptionalError(
         ResultType &&res) noexcept {
       if (hasError(res)) {
         return boost::get<ErrorOf<ResultType>>(std::forward<ResultType>(res))

--- a/libs/common/to_string.hpp
+++ b/libs/common/to_string.hpp
@@ -12,8 +12,6 @@
 #include <string>
 #include <string_view>
 
-#include <boost/optional.hpp>
-
 namespace iroha {
   namespace to_string {
     namespace detail {
@@ -79,13 +77,6 @@ namespace iroha {
       return detail::toStringDereferenced(o);
     }
 
-    template <typename T>
-    inline auto toString(const T &o) -> std::enable_if_t<
-        boost::optional_detail::is_optional_related<T>::value,
-        std::string> {
-      return detail::toStringDereferenced(o);
-    }
-
     /// Print a plain collection.
     template <typename T, typename = decltype(*std::declval<T>().begin())>
     inline std::string toString(const T &c) {
@@ -111,12 +102,6 @@ namespace iroha {
         } else {
           return kNotSet;
         }
-      }
-
-      template <>
-      inline std::string toStringDereferenced<boost::none_t>(
-          const boost::none_t &) {
-        return kNotSet;
       }
 
       template <>

--- a/libs/common/to_string.hpp
+++ b/libs/common/to_string.hpp
@@ -60,6 +60,10 @@ namespace iroha {
       return detail::toStringDereferenced(o);
     }
 
+    inline std::string toString(const std::nullopt_t &o) {
+      return detail::kNotSet;
+    }
+
     template <typename... T>
     inline std::string toString(const std::unique_ptr<T...> &o) {
       return detail::toStringDereferenced(o);

--- a/libs/crypto/keys_manager.hpp
+++ b/libs/crypto/keys_manager.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_KEYS_MANAGER_HPP
 #define IROHA_KEYS_MANAGER_HPP
 
+#include<optional>
 #include <string>
 
-#include <boost/optional.hpp>
 #include "common/result_fwd.hpp"
 #include "cryptography/keypair.hpp"
 
@@ -27,7 +27,7 @@ namespace iroha {
      * @return false if keys creation failed
      */
     virtual bool createKeys(
-        const boost::optional<std::string> &pass_phrase) = 0;
+        const std::optional<std::string> &pass_phrase) = 0;
 
     /**
      * Load keys associated with the manager, then validate loaded keypair by
@@ -37,7 +37,7 @@ namespace iroha {
      *         failure. Otherwise - the keypair will be returned
      */
     virtual iroha::expected::Result<shared_model::crypto::Keypair, std::string>
-    loadKeys(const boost::optional<std::string> &pass_phrase) = 0;
+    loadKeys(const std::optional<std::string> &pass_phrase) = 0;
   };
 
 }  // namespace iroha

--- a/libs/crypto/keys_manager_impl.cpp
+++ b/libs/crypto/keys_manager_impl.cpp
@@ -78,7 +78,7 @@ namespace iroha {
       : KeysManagerImpl(account_id, "", std::move(log)) {}
 
   iroha::expected::Result<Keypair, std::string> KeysManagerImpl::loadKeys(
-      const boost::optional<std::string> &pass_phrase) {
+      const std::optional<std::string> &pass_phrase) {
     auto load_from_file = [this](const auto &extension) {
       return iroha::readTextFile(
           (path_to_keypair_ / (account_id_ + extension)).string());
@@ -106,7 +106,7 @@ namespace iroha {
   }
 
   bool KeysManagerImpl::createKeys(
-      const boost::optional<std::string> &pass_phrase) {
+      const std::optional<std::string> &pass_phrase) {
     Keypair keypair = DefaultCryptoAlgorithmType::generateKeypair();
 
     auto pub = keypair.publicKey();

--- a/libs/crypto/keys_manager_impl.hpp
+++ b/libs/crypto/keys_manager_impl.hpp
@@ -9,7 +9,7 @@
 #include "crypto/keys_manager.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include "cryptography/keypair.hpp"
 #include "logger/logger_fwd.hpp"
 
@@ -35,10 +35,10 @@ namespace iroha {
      */
     KeysManagerImpl(const std::string account_id, logger::LoggerPtr log);
 
-    bool createKeys(const boost::optional<std::string> &pass_phrase) override;
+    bool createKeys(const std::optional<std::string> &pass_phrase) override;
 
     iroha::expected::Result<shared_model::crypto::Keypair, std::string>
-    loadKeys(const boost::optional<std::string> &pass_phrase) override;
+    loadKeys(const std::optional<std::string> &pass_phrase) override;
 
     static const std::string kPublicKeyExtension;
     static const std::string kPrivateKeyExtension;

--- a/libs/logger/logger_manager.cpp
+++ b/libs/logger/logger_manager.cpp
@@ -32,8 +32,8 @@ namespace logger {
 
   LoggerManagerTreePtr LoggerManagerTree::registerChild(
       std::string tag,
-      boost::optional<LogLevel> log_level,
-      boost::optional<LogPatterns> patterns) {
+      std::optional<LogLevel> log_level,
+      std::optional<LogPatterns> patterns) {
     LoggerConfig child_config{
         log_level.value_or(config_->log_level),
         patterns ? std::move(patterns)->inherit(config_->patterns)

--- a/libs/logger/logger_manager.hpp
+++ b/libs/logger/logger_manager.hpp
@@ -10,10 +10,10 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
-#include <boost/optional.hpp>
 #include "logger/logger_spdlog.hpp"
 
 namespace logger {
@@ -38,8 +38,8 @@ namespace logger {
      * @param patterns - override the patterns
      */
     LoggerManagerTreePtr registerChild(std::string tag,
-                                       boost::optional<LogLevel> log_level,
-                                       boost::optional<LogPatterns> patterns);
+                                       std::optional<LogLevel> log_level,
+                                       std::optional<LogPatterns> patterns);
 
     /// Get this node's logger. Thread safe.
     LoggerPtr getLogger();

--- a/shared_model/backend/plain/impl/engine_receipt.cpp
+++ b/shared_model/backend/plain/impl/engine_receipt.cpp
@@ -5,6 +5,8 @@
 
 #include "backend/plain/engine_receipt.hpp"
 
+#include <cassert>
+
 using namespace shared_model::interface::types;
 using namespace shared_model::plain;
 

--- a/shared_model/backend/protobuf/queries/impl/proto_ordering.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_ordering.cpp
@@ -77,8 +77,8 @@ void OrderingImpl::copy(OrderingImpl const &src) {
 
 void OrderingImpl::appendUnsafe(ModelType::Field field,
                                 ModelType::Direction direction) {
-  BOOST_ASSERT_MSG(count_ <= (size_t)ModelType::Field::kMaxValueCount,
-                   "Count can not be more than max_count. Check logic.");
+  assert(count_ <= (size_t)ModelType::Field::kMaxValueCount
+         && "Count can not be more than max_count. Check logic.");
 
   if (field >= ModelType::Field::kUnknownValue) {
     return;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_engine_receipt.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_engine_receipt.cpp
@@ -5,9 +5,6 @@
 
 #include "backend/protobuf/query_responses/proto_engine_receipt.hpp"
 
-#include <boost/optional.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "backend/protobuf/query_responses/proto_engine_log.hpp"
 
 using namespace shared_model::proto;

--- a/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
+++ b/shared_model/backend/protobuf/query_responses/impl/proto_query_response.cpp
@@ -85,7 +85,7 @@ namespace shared_model::proto {
     const QueryResponseVariantType ivariant_{variant_};
 
     const crypto::Hash hash_{
-        iroha::hexstringToBytestring(proto_.query_hash()).get()};
+        iroha::hexstringToBytestring(proto_.query_hash()).value()};
   };
 
   QueryResponse::QueryResponse(TransportType &&ref) {

--- a/shared_model/interfaces/commands/impl/call_engine.cpp
+++ b/shared_model/interfaces/commands/impl/call_engine.cpp
@@ -5,6 +5,7 @@
 
 #include "interfaces/commands/call_engine.hpp"
 
+#include <cassert>
 #include <ciso646>
 
 #include "common/optional_reference_equal.hpp"

--- a/shared_model/interfaces/queries/impl/ordering.cpp
+++ b/shared_model/interfaces/queries/impl/ordering.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cassert>
 #include <cstring>
 
 #include "interfaces/queries/ordering.hpp"
@@ -22,14 +23,14 @@ namespace {
                 "String names must be the same size.");
 
   char const *fromField2Str(Ordering::Field const val) {
-    BOOST_ASSERT_MSG(val < Ordering::Field::kMaxValueCount,
-                     "val can not be greater or equal than kMaxValueCount");
+    assert(val < Ordering::Field::kMaxValueCount
+           && "val can not be greater or equal than kMaxValueCount");
     return kFieldStrRepres[(size_t)val];
   }
 
   char const *fromDirection2Str(Ordering::Direction const val) {
-    BOOST_ASSERT_MSG(val < Ordering::Direction::kMaxValueCount,
-                     "val can not be greater or equal than kMaxValueCount");
+    assert(val < Ordering::Direction::kMaxValueCount
+           && "val can not be greater or equal than kMaxValueCount");
     return kDirectionStrRepres[(size_t)val];
   }
 

--- a/shared_model/interfaces/query_responses/engine_log.hpp
+++ b/shared_model/interfaces/query_responses/engine_log.hpp
@@ -6,7 +6,6 @@
 #ifndef IROHA_SHARED_MODEL_INTERFACE_ENGINE_LOG_HPP
 #define IROHA_SHARED_MODEL_INTERFACE_ENGINE_LOG_HPP
 
-#include <boost/optional.hpp>
 #include <vector>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"

--- a/shared_model/interfaces/query_responses/engine_receipt.hpp
+++ b/shared_model/interfaces/query_responses/engine_receipt.hpp
@@ -8,7 +8,6 @@
 
 #include <iosfwd>
 
-#include <boost/optional.hpp>
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/query_responses/engine_log.hpp"

--- a/test/benchmark/bm_pipeline.cpp
+++ b/test/benchmark/bm_pipeline.cpp
@@ -36,7 +36,7 @@ const std::string kAmount = "1.0";
 static void BM_AddAssetQuantity(benchmark::State &state) {
   integration_framework::IntegrationTestFramework itf(
       kProposalSize,
-      boost::none,
+      std::nullopt,
       iroha::StartupWsvDataPolicy::kDrop,
       false,
       false,

--- a/test/framework/config_helper.cpp
+++ b/test/framework/config_helper.cpp
@@ -24,7 +24,7 @@ namespace integration_framework {
     return getPostgresCredsFromEnv().value_or(kDefaultPostgresCreds);
   }
 
-  boost::optional<std::string> getPostgresCredsFromEnv() {
+  std::optional<std::string> getPostgresCredsFromEnv() {
     auto pg_host = std::getenv("IROHA_POSTGRES_HOST");
     auto pg_port = std::getenv("IROHA_POSTGRES_PORT");
     auto pg_user = std::getenv("IROHA_POSTGRES_USER");

--- a/test/framework/config_helper.hpp
+++ b/test/framework/config_helper.hpp
@@ -15,7 +15,7 @@ namespace integration_framework {
 
   std::string getPostgresCredsOrDefault();
 
-  boost::optional<std::string> getPostgresCredsFromEnv();
+  std::optional<std::string> getPostgresCredsFromEnv();
 
   std::string getRandomDbName();
 }  // namespace integration_framework

--- a/test/framework/config_helper.hpp
+++ b/test/framework/config_helper.hpp
@@ -6,9 +6,8 @@
 #ifndef IROHA_CONFIG_HELPER_HPP
 #define IROHA_CONFIG_HELPER_HPP
 
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 namespace integration_framework {
   extern const std::string kDefaultWorkingDatabaseName;

--- a/test/framework/executor_itf/executor_itf.hpp
+++ b/test/framework/executor_itf/executor_itf.hpp
@@ -129,7 +129,7 @@ namespace iroha {
        * @param query The query to execute.
        * @param account_id The issuer account id.
        * @param query_counter The value to set to query counter field. If
-       * boost::none provided, the built-in query counter value will be used.
+       * std::nullopt provided, the built-in query counter value will be used.
        * @return Result of query execution.
        */
       template <typename SpecificQuery,
@@ -138,8 +138,8 @@ namespace iroha {
       iroha::ametsuchi::QueryExecutorResult executeQuery(
           const SpecificQuery &specific_query,
           const std::string &account_id,
-          boost::optional<shared_model::interface::types::CounterType>
-              query_counter = boost::none) {
+          std::optional<shared_model::interface::types::CounterType>
+              query_counter = std::nullopt) {
         shared_model::interface::Query::QueryVariantType variant{
             detail::getInterfaceQueryRef(specific_query)};
         shared_model::interface::MockQuery query;
@@ -199,7 +199,7 @@ namespace iroha {
        * @param query The query to execute.
        * @param account_id The issuer account id.
        * @param query_counter The value to set to query counter field. If
-       * boost::none provided, the built-in query counter value will be used.
+       * std::nullopt provided, the built-in query counter value will be used.
        * @return Result of query execution.
        */
       template <typename T,

--- a/test/framework/executor_itf/executor_itf.hpp
+++ b/test/framework/executor_itf/executor_itf.hpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include <boost/optional.hpp>
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/impl/postgres_options.hpp"
 #include "ametsuchi/query_executor.hpp"

--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -40,7 +40,7 @@ namespace integration_framework {
               "Got a Loader.retrieveBlock call, but have no block storage!");
           return {};
         }
-        const auto block = block_storage->getBlockByHeight(request);
+        const auto block = block_storage->get().getBlockByHeight(request);
         if (!block) {
           getLogger()->debug(
               "Got a Loader.retrieveBlock call for {}, but have no such block!",
@@ -63,7 +63,7 @@ namespace integration_framework {
         BlockStorage::HeightType current_height = request;
         std::shared_ptr<const shared_model::proto::Block> block;
         LoaderBlocksRequestResult blocks;
-        while ((block = block_storage->getBlockByHeight(current_height++))
+        while ((block = block_storage->get().getBlockByHeight(current_height++))
                != nullptr) {
           blocks.emplace_back(block);
         }

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -67,7 +67,7 @@ namespace integration_framework {
     FakePeer::FakePeer(
         const std::string &listen_ip,
         size_t internal_port,
-        const boost::optional<Keypair> &key,
+        const std::optional<Keypair> &key,
         std::shared_ptr<shared_model::interface::Peer> real_peer,
         const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
             &common_objects_factory,
@@ -188,11 +188,12 @@ namespace integration_framework {
       return *this;
     }
 
-    boost::optional<const BlockStorage &> FakePeer::getBlockStorage() const {
+    std::optional<std::reference_wrapper<BlockStorage const>>
+    FakePeer::getBlockStorage() const {
       if (block_storage_) {
         return *block_storage_;
       }
-      return boost::none;
+      return std::nullopt;
     }
 
     ProposalStorage &FakePeer::getProposalStorage() {
@@ -393,7 +394,7 @@ namespace integration_framework {
       };
     }
 
-    boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+    std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
     FakePeer::sendProposalRequest(iroha::consensus::Round round,
                                   std::chrono::milliseconds timeout) const {
       using iroha::ordering::transport::OnDemandOsClientGrpcFactory;

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -61,7 +61,7 @@ namespace integration_framework {
       FakePeer(
           const std::string &listen_ip,
           size_t internal_port,
-          const boost::optional<shared_model::crypto::Keypair> &key,
+          const std::optional<shared_model::crypto::Keypair> &key,
           std::shared_ptr<shared_model::interface::Peer> real_peer,
           const std::shared_ptr<shared_model::interface::CommonObjectsFactory>
               &common_objects_factory,
@@ -96,7 +96,8 @@ namespace integration_framework {
       FakePeer &removeBlockStorage();
 
       /// Get the block storage previously assigned to this peer, if any.
-      boost::optional<const BlockStorage &> getBlockStorage() const;
+      std::optional<std::reference_wrapper<BlockStorage const>>
+      getBlockStorage() const;
 
       ProposalStorage &getProposalStorage();
 
@@ -199,7 +200,7 @@ namespace integration_framework {
        * @param timeout - time to wait for the reply.
        * @return The proposal if it was received
        */
-      boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+      std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       sendProposalRequest(iroha::consensus::Round round,
                           std::chrono::milliseconds timeout) const;
 

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -23,7 +23,7 @@ namespace integration_framework {
           std::make_shared<BatchesCollection>(std::move(batches)));
     }
 
-    boost::optional<
+    std::optional<
         std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>>
     OnDemandOsNetworkNotifier::onRequestProposal(
         iroha::consensus::Round round) {

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -24,7 +24,7 @@ namespace integration_framework {
 
       virtual void onBatches(CollectionType batches);
 
-      virtual boost::optional<std::shared_ptr<const ProposalType>>
+      virtual std::optional<std::shared_ptr<const ProposalType>>
       onRequestProposal(iroha::consensus::Round round);
 
       rxcpp::observable<iroha::consensus::Round>

--- a/test/framework/integration_framework/fake_peer/proposal_storage.cpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.cpp
@@ -24,7 +24,7 @@ namespace integration_framework {
               std::make_unique<shared_model::proto::ProtoProposalFactory<
                   shared_model::validation::DefaultProposalValidator>>(
                   iroha::test::kTestsValidatorsConfig)) {
-      setDefaultProvider([](auto &) { return boost::none; });
+      setDefaultProvider([](auto &) { return std::nullopt; });
     }
 
     OrderingProposalRequestResult ProposalStorage::getProposal(
@@ -37,7 +37,7 @@ namespace integration_framework {
           if (it->second) {
             return it->second;
           } else {
-            return boost::none;
+            return std::nullopt;
           }
         }
       }
@@ -83,12 +83,12 @@ namespace integration_framework {
       }
     }
 
-    boost::optional<std::unique_ptr<shared_model::proto::Proposal>>
+    std::optional<std::unique_ptr<shared_model::proto::Proposal>>
     ProposalStorage::makeProposalFromPendingTxs(
         shared_model::interface::types::HeightType height) {
       std::lock_guard<std::mutex> lock(pending_txs_mutex_);
       if (pending_txs_.empty()) {
-        return boost::none;
+        return std::nullopt;
       }
 
       std::unique_ptr<shared_model::proto::Proposal> proposal{

--- a/test/framework/integration_framework/fake_peer/proposal_storage.hpp
+++ b/test/framework/integration_framework/fake_peer/proposal_storage.hpp
@@ -70,7 +70,7 @@ namespace integration_framework {
 
      private:
       /// Create a proposal from pending transactions, if any.
-      boost::optional<std::unique_ptr<Proposal>> makeProposalFromPendingTxs(
+      std::optional<std::unique_ptr<Proposal>> makeProposalFromPendingTxs(
           shared_model::interface::types::HeightType height);
 
       OrderingProposalRequestResult getDefaultProposal(

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -80,12 +80,12 @@ namespace integration_framework {
     using LoaderBlockRequest = shared_model::interface::types::HeightType;
     using LoaderBlocksRequest = shared_model::interface::types::HeightType;
     using LoaderBlockRequestResult =
-        boost::optional<std::shared_ptr<const shared_model::proto::Block>>;
+        std::optional<std::shared_ptr<const shared_model::proto::Block>>;
     using LoaderBlocksRequestResult =
         std::vector<std::shared_ptr<const shared_model::proto::Block>>;
     using OrderingProposalRequest = iroha::consensus::Round;
     using OrderingProposalRequestResult =
-        boost::optional<std::shared_ptr<const shared_model::proto::Proposal>>;
+        std::optional<std::shared_ptr<const shared_model::proto::Proposal>>;
     using BatchesCollection =
         std::vector<std::shared_ptr<shared_model::interface::TransactionBatch>>;
 

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -122,12 +122,12 @@ namespace integration_framework {
       cv_.notify_one();
     }
 
-    boost::optional<T> try_pop() {
+    std::optional<T> try_pop() {
       std::unique_lock<std::mutex> lock(queue_mutex_);
       if (queue_.empty()) {
         if (not cv_.wait_for(
                 lock, timeout_, [this] { return not queue_.empty(); })) {
-          return boost::none;
+          return std::nullopt;
         }
       }
       T obj(std::move(queue_.front()));
@@ -144,11 +144,11 @@ namespace integration_framework {
 
   IntegrationTestFramework::IntegrationTestFramework(
       size_t maximum_proposal_size,
-      const boost::optional<std::string> &dbname,
+      const std::optional<std::string> &dbname,
       iroha::StartupWsvDataPolicy startup_wsv_data_policy,
       bool cleanup_on_exit,
       bool mst_support,
-      const boost::optional<std::string> block_store_path,
+      const std::optional<std::string> block_store_path,
       milliseconds proposal_waiting,
       milliseconds block_waiting,
       milliseconds tx_response_waiting,
@@ -249,7 +249,7 @@ namespace integration_framework {
   }
 
   std::shared_ptr<FakePeer> IntegrationTestFramework::addFakePeer(
-      const boost::optional<Keypair> &key) {
+      const std::optional<Keypair> &key) {
     BOOST_ASSERT_MSG(this_peer_, "Need to set the ITF peer key first!");
     const auto port = port_guard_->getPort(kDefaultInternalPort);
     auto fake_peer = std::make_shared<FakePeer>(
@@ -691,7 +691,7 @@ namespace integration_framework {
     return *this;
   }
 
-  boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
   IntegrationTestFramework::requestProposal(
       const iroha::consensus::Round &round, std::chrono::milliseconds timeout) {
     auto on_demand_os_transport =
@@ -785,7 +785,7 @@ namespace integration_framework {
       std::function<void(const shared_model::proto::TransactionResponse &)>
           validation) {
     // fetch first response associated with the tx from related queue
-    boost::optional<TxResponseType> opt_response;
+    std::optional<TxResponseType> opt_response;
     const auto it = responses_queues_.find(tx_hash.hex());
     if (it != responses_queues_.end()) {
       opt_response = it->second->try_pop();

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -138,12 +138,12 @@ namespace integration_framework {
      */
     explicit IntegrationTestFramework(
         size_t maximum_proposal_size,
-        const boost::optional<std::string> &dbname = boost::none,
+        const std::optional<std::string> &dbname = std::nullopt,
         iroha::StartupWsvDataPolicy startup_wsv_data_policy =
             iroha::StartupWsvDataPolicy::kDrop,
         bool cleanup_on_exit = true,
         bool mst_support = false,
-        const boost::optional<std::string> block_store_path = boost::none,
+        const std::optional<std::string> block_store_path = std::nullopt,
         milliseconds proposal_waiting = milliseconds(20000),
         milliseconds block_waiting = milliseconds(20000),
         milliseconds tx_response_waiting = milliseconds(10000),
@@ -153,7 +153,7 @@ namespace integration_framework {
 
     /// Add a fake peer with given key.
     std::shared_ptr<fake_peer::FakePeer> addFakePeer(
-        const boost::optional<shared_model::crypto::Keypair> &key);
+        const std::optional<shared_model::crypto::Keypair> &key);
 
     /// Add the given amount of fake peers with generated default keys and
     /// "honest" behaviours.
@@ -335,7 +335,7 @@ namespace integration_framework {
      * @param timeout - the timeout for waiting the proposal
      * @return the proposal if received one
      */
-    boost::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+    std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
     requestProposal(const iroha::consensus::Round &round,
                     std::chrono::milliseconds timeout);
 
@@ -546,7 +546,7 @@ namespace integration_framework {
     std::shared_ptr<iroha::network::MstTransportGrpc> mst_transport_;
     std::shared_ptr<iroha::consensus::yac::YacNetwork> yac_transport_;
 
-    boost::optional<shared_model::crypto::Keypair> my_key_;
+    std::optional<shared_model::crypto::Keypair> my_key_;
     std::shared_ptr<shared_model::interface::Peer> this_peer_;
 
    private:

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -25,15 +25,15 @@ namespace integration_framework {
 
   IrohaInstance::IrohaInstance(
       bool mst_support,
-      const boost::optional<std::string> &block_store_path,
+      const std::optional<std::string> &block_store_path,
       const std::string &listen_ip,
       size_t torii_port,
       size_t internal_port,
       logger::LoggerManagerTreePtr irohad_log_manager,
       logger::LoggerPtr log,
       iroha::StartupWsvDataPolicy startup_wsv_data_policy,
-      const boost::optional<std::string> &dbname,
-      const boost::optional<iroha::torii::TlsParams> &torii_tls_params)
+      const std::optional<std::string> &dbname,
+      const std::optional<iroha::torii::TlsParams> &torii_tls_params)
       : block_store_dir_(block_store_path),
         working_dbname_(dbname.value_or(getRandomDbName())),
         listen_ip_(listen_ip),
@@ -48,13 +48,16 @@ namespace integration_framework {
         vote_delay_(100ms),
         // amount of minutes in a day
         mst_expiration_time_(std::chrono::minutes(24 * 60)),
-        opt_mst_gossip_params_(boost::make_optional(
-            mst_support,
-            [] {
-              iroha::GossipPropagationStrategyParams params;
-              params.emission_period = kMstEmissionPeriod;
-              return params;
-            }())),
+        opt_mst_gossip_params_([mst_support] {
+          std::optional<iroha::GossipPropagationStrategyParams>
+              opt_mst_gossip_params;
+          if (mst_support) {
+            iroha::GossipPropagationStrategyParams params;
+            params.emission_period = kMstEmissionPeriod;
+            opt_mst_gossip_params = params;
+          }
+          return opt_mst_gossip_params;
+        }()),
         max_rounds_delay_(0ms),
         stale_stream_max_rounds_(2),
         irohad_log_manager_(std::move(irohad_log_manager)),
@@ -117,7 +120,7 @@ namespace integration_framework {
         key_pair,
         max_rounds_delay_,
         stale_stream_max_rounds_,
-        boost::none,
+        std::nullopt,
         irohad_log_manager_,
         log_,
         startup_wsv_data_policy_,

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/optional.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "ametsuchi/impl/postgres_options.hpp"

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -49,16 +49,16 @@ namespace integration_framework {
      *   @see iroha::torii::TlsParams
      */
     IrohaInstance(bool mst_support,
-                  const boost::optional<std::string> &block_store_path,
+                  const std::optional<std::string> &block_store_path,
                   const std::string &listen_ip,
                   size_t torii_port,
                   size_t internal_port,
                   logger::LoggerManagerTreePtr irohad_log_manager,
                   logger::LoggerPtr log,
                   iroha::StartupWsvDataPolicy startup_wsv_data_policy,
-                  const boost::optional<std::string> &dbname = boost::none,
-                  const boost::optional<iroha::torii::TlsParams> &tls_params =
-                      boost::none);
+                  const std::optional<std::string> &dbname = std::nullopt,
+                  const std::optional<iroha::torii::TlsParams> &tls_params =
+                      std::nullopt);
 
     /// Initialize Irohad. Throws on error.
     void init();
@@ -86,16 +86,16 @@ namespace integration_framework {
     void terminateAndCleanup();
 
     // config area
-    const boost::optional<std::string> block_store_dir_;
+    const std::optional<std::string> block_store_dir_;
     const std::string working_dbname_;
     const std::string listen_ip_;
     const size_t torii_port_;
-    boost::optional<iroha::torii::TlsParams> torii_tls_params_;
+    std::optional<iroha::torii::TlsParams> torii_tls_params_;
     const size_t internal_port_;
     const std::chrono::milliseconds proposal_delay_;
     const std::chrono::milliseconds vote_delay_;
     const std::chrono::minutes mst_expiration_time_;
-    boost::optional<iroha::GossipPropagationStrategyParams>
+    std::optional<iroha::GossipPropagationStrategyParams>
         opt_mst_gossip_params_;
     const std::chrono::milliseconds max_rounds_delay_;
     const size_t stale_stream_max_rounds_;

--- a/test/framework/integration_framework/port_guard.cpp
+++ b/test/framework/integration_framework/port_guard.cpp
@@ -30,13 +30,13 @@ namespace integration_framework {
     all_used_ports_ &= ~instance_used_ports_;
   }
 
-  boost::optional<PortGuard::PortType> PortGuard::tryGetPort(
+  std::optional<PortGuard::PortType> PortGuard::tryGetPort(
       const PortType min_value, const PortType max_value) {
     std::lock_guard<std::mutex> lock(all_used_ports_mutex_);
     PortType tested_port = min_value;
     while (all_used_ports_.test(tested_port)) {
       if (tested_port == max_value) {
-        return boost::none;
+        return std::nullopt;
       }
       ++tested_port;
     }

--- a/test/framework/integration_framework/port_guard.hpp
+++ b/test/framework/integration_framework/port_guard.hpp
@@ -9,9 +9,9 @@
 #include <bitset>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 
 #include <boost/noncopyable.hpp>
-#include <boost/optional/optional.hpp>
 
 namespace integration_framework {
 

--- a/test/framework/integration_framework/port_guard.hpp
+++ b/test/framework/integration_framework/port_guard.hpp
@@ -39,7 +39,7 @@ namespace integration_framework {
     PortType getPort(PortType min_value, PortType max_value = kMaxPort);
 
     /// Request a port in given boundaries, including them.
-    boost::optional<PortType> tryGetPort(PortType min_value,
+    std::optional<PortType> tryGetPort(PortType min_value,
                                          PortType max_value = kMaxPort);
 
    private:

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -17,7 +17,7 @@ namespace integration_framework {
    */
   class TestIrohad : public Irohad {
    public:
-    TestIrohad(const boost::optional<std::string> &block_store_dir,
+    TestIrohad(const std::optional<std::string> &block_store_dir,
                std::unique_ptr<iroha::ametsuchi::PostgresOptions> pg_opt,
                const std::string &listen_ip,
                size_t torii_port,
@@ -29,15 +29,15 @@ namespace integration_framework {
                const shared_model::crypto::Keypair &keypair,
                std::chrono::milliseconds max_rounds_delay,
                size_t stale_stream_max_rounds,
-               boost::optional<shared_model::interface::types::PeerList>
+               std::optional<shared_model::interface::types::PeerList>
                    opt_alternative_peers,
                logger::LoggerManagerTreePtr irohad_log_manager,
                logger::LoggerPtr log,
                iroha::StartupWsvDataPolicy startup_wsv_data_policy,
-               const boost::optional<iroha::GossipPropagationStrategyParams>
-                   &opt_mst_gossip_params = boost::none,
-               const boost::optional<iroha::torii::TlsParams>
-                   &torii_tls_params = boost::none)
+               const std::optional<iroha::GossipPropagationStrategyParams>
+                   &opt_mst_gossip_params = std::nullopt,
+               const std::optional<iroha::torii::TlsParams>
+                   &torii_tls_params = std::nullopt)
         : Irohad(block_store_dir,
                  std::move(pg_opt),
                  listen_ip,
@@ -56,7 +56,7 @@ namespace integration_framework {
                  iroha::network::getDefaultTestChannelParams(),
                  opt_mst_gossip_params,
                  torii_tls_params,
-                 boost::none),
+                 std::nullopt),
           log_(std::move(log)) {}
 
     auto &getCommandService() {

--- a/test/framework/result_fixture.hpp
+++ b/test/framework/result_fixture.hpp
@@ -19,7 +19,7 @@ namespace framework {
      *         otherwise none
      */
     template <typename ResultType>
-    boost::optional<ValueOf<std::decay_t<ResultType>>> val(
+    std::optional<ValueOf<std::decay_t<ResultType>>> val(
         ResultType &&res) noexcept {
       if (auto *val = boost::get<ValueOf<std::decay_t<ResultType>>>(&res)) {
         return std::move(*val);
@@ -32,7 +32,7 @@ namespace framework {
      *         otherwise none
      */
     template <typename ResultType>
-    boost::optional<ErrorOf<std::decay_t<ResultType>>> err(
+    std::optional<ErrorOf<std::decay_t<ResultType>>> err(
         ResultType &&res) noexcept {
       if (auto *val = boost::get<ErrorOf<std::decay_t<ResultType>>>(&res)) {
         return std::move(*val);

--- a/test/framework/sql_query.hpp
+++ b/test/framework/sql_query.hpp
@@ -9,7 +9,6 @@
 #include <string>
 
 #include <soci/soci.h>
-#include <boost/optional.hpp>
 #include "framework/test_logger.hpp"
 #include "interfaces/common_objects/account.hpp"
 #include "interfaces/common_objects/account_asset.hpp"

--- a/test/framework/sql_query.hpp
+++ b/test/framework/sql_query.hpp
@@ -56,7 +56,7 @@ namespace framework {
        * @param domain_id - id in the system
        * @return Domain if exist, nullopt otherwise
        */
-      boost::optional<std::shared_ptr<shared_model::interface::Domain>>
+      std::optional<std::shared_ptr<shared_model::interface::Domain>>
       getDomain(const shared_model::interface::types::DomainIdType &domain_id);
 
       /**
@@ -64,7 +64,7 @@ namespace framework {
        * @param account_id
        * @return
        */
-      boost::optional<std::vector<shared_model::interface::types::RoleIdType>>
+      std::optional<std::vector<shared_model::interface::types::RoleIdType>>
       getAccountRoles(
           const shared_model::interface::types::AccountIdType &account_id);
       /**
@@ -72,14 +72,14 @@ namespace framework {
        * @param role_name
        * @return
        */
-      boost::optional<shared_model::interface::RolePermissionSet>
+      std::optional<shared_model::interface::RolePermissionSet>
       getRolePermissions(
           const shared_model::interface::types::RoleIdType &role_name);
 
       /**
        * @return All roles currently in the system
        */
-      boost::optional<std::vector<shared_model::interface::types::RoleIdType>>
+      std::optional<std::vector<shared_model::interface::types::RoleIdType>>
       getRoles();
 
       /**
@@ -87,7 +87,7 @@ namespace framework {
        * @param account_id
        * @return
        */
-      boost::optional<std::shared_ptr<shared_model::interface::Account>>
+      std::optional<std::shared_ptr<shared_model::interface::Account>>
       getAccount(
           const shared_model::interface::types::AccountIdType &account_id);
 
@@ -96,7 +96,7 @@ namespace framework {
        * @param asset_id
        * @return
        */
-      boost::optional<std::shared_ptr<shared_model::interface::Asset>> getAsset(
+      std::optional<std::shared_ptr<shared_model::interface::Asset>> getAsset(
           const shared_model::interface::types::AssetIdType &asset_id);
 
       /**
@@ -104,7 +104,7 @@ namespace framework {
        * @param account_id
        * @return
        */
-      boost::optional<
+      std::optional<
           std::vector<std::shared_ptr<shared_model::interface::AccountAsset>>>
       getAccountAssets(
           const shared_model::interface::types::AccountIdType &account_id);
@@ -114,7 +114,7 @@ namespace framework {
        * @param asset_id
        * @return
        */
-      boost::optional<std::shared_ptr<shared_model::interface::AccountAsset>>
+      std::optional<std::shared_ptr<shared_model::interface::AccountAsset>>
       getAccountAsset(
           const shared_model::interface::types::AccountIdType &account_id,
           const shared_model::interface::types::AssetIdType &asset_id);
@@ -128,7 +128,7 @@ namespace framework {
        * returned; default empty
        * @return optional of account details
        */
-      boost::optional<std::string> getAccountDetail(
+      std::optional<std::string> getAccountDetail(
           const shared_model::interface::types::AccountIdType &account_id,
           const shared_model::interface::types::AccountDetailKeyType &key = "",
           const shared_model::interface::types::AccountIdType &writer = "");
@@ -138,7 +138,7 @@ namespace framework {
        * @param setting_key
        * @return if key exist then value otherwise none
        */
-      boost::optional<shared_model::interface::types::SettingValueType>
+      std::optional<shared_model::interface::types::SettingValueType>
       getSettingValue(
           const shared_model::interface::types::SettingKeyType &setting_key);
 
@@ -152,7 +152,7 @@ namespace framework {
        * message, and returns an optional rowset<T>
        */
       template <typename T, typename F>
-      auto execute(F &&f) -> boost::optional<soci::rowset<T>>;
+      auto execute(F &&f) -> std::optional<soci::rowset<T>>;
 
       /**
        * Transforms result to optional
@@ -163,7 +163,7 @@ namespace framework {
        * @return optional<T>
        */
       template <typename T>
-      boost::optional<std::shared_ptr<T>> fromResult(
+      std::optional<std::shared_ptr<T>> fromResult(
           shared_model::interface::CommonObjectsFactory::FactoryResult<
               std::unique_ptr<T>> &&result);
     };

--- a/test/framework/test_client_factory.cpp
+++ b/test/framework/test_client_factory.cpp
@@ -52,9 +52,9 @@ namespace iroha {
     std::shared_ptr<grpc::Channel> createSecureChannel(
         const shared_model::interface::types::AddressType &address,
         const std::string &service_full_name,
-        boost::optional<shared_model::interface::types::TLSCertificateType>
+        std::optional<shared_model::interface::types::TLSCertificateType>
             peer_cert,
-        boost::optional<TlsCredentials> my_creds,
+        std::optional<TlsCredentials> my_creds,
         const GrpcChannelParams &params) {
       auto options = grpc::SslCredentialsOptions();
       if (peer_cert) {

--- a/test/framework/test_client_factory.hpp
+++ b/test/framework/test_client_factory.hpp
@@ -6,7 +6,6 @@
 #ifndef IROHA_TEST_CLIENT_FACTORY_HPP
 #define IROHA_TEST_CLIENT_FACTORY_HPP
 
-#include <boost/optional.hpp>
 #include "interfaces/common_objects/types.hpp"
 #include "network/impl/client_factory_impl.hpp"
 #include "network/impl/generic_client_factory.hpp"

--- a/test/framework/test_client_factory.hpp
+++ b/test/framework/test_client_factory.hpp
@@ -43,9 +43,9 @@ namespace iroha {
     std::unique_ptr<typename Service::StubInterface> createSecureClient(
         const std::string &ip,
         size_t port,
-        boost::optional<shared_model::interface::types::TLSCertificateType>
+        std::optional<shared_model::interface::types::TLSCertificateType>
             peer_cert,
-        boost::optional<TlsCredentials> my_creds,
+        std::optional<TlsCredentials> my_creds,
         const GrpcChannelParams &params) {
       return Service::NewStub(
           createSecureChannel(ip + ":" + std::to_string(port),
@@ -68,9 +68,9 @@ namespace iroha {
     std::shared_ptr<grpc::Channel> createSecureChannel(
         const shared_model::interface::types::AddressType &address,
         const std::string &service_full_name,
-        boost::optional<shared_model::interface::types::TLSCertificateType>
+        std::optional<shared_model::interface::types::TLSCertificateType>
             peer_cert,
-        boost::optional<TlsCredentials> my_creds,
+        std::optional<TlsCredentials> my_creds,
         const GrpcChannelParams &params);
 
   }  // namespace network

--- a/test/fuzzing/block_loader_fixture.hpp
+++ b/test/fuzzing/block_loader_fixture.hpp
@@ -38,7 +38,7 @@ namespace fuzzing {
           std::make_shared<iroha::network::BlockLoaderService>(
               block_query_factory_, block_cache_, logger::getDummyLoggerPtr());
       EXPECT_CALL(*block_query_factory_, createBlockQuery())
-          .WillRepeatedly(Return(boost::make_optional(
+          .WillRepeatedly(Return(std::make_optional(
               std::shared_ptr<iroha::ametsuchi::BlockQuery>(storage_))));
       EXPECT_CALL(*storage_, getBlock(_)).WillRepeatedly(Invoke([](auto) {
         return iroha::expected::makeValue(

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -118,7 +118,7 @@ TEST_F(FakePeerFixture, MstStatePropagtesToNewPeer) {
   auto &itf = prepareState();
 
   // then create a fake peer
-  auto new_peer = itf.addFakePeer(boost::none);
+  auto new_peer = itf.addFakePeer(std::nullopt);
   auto mst_states_observable = new_peer->getMstStatesObservable().replay();
   mst_states_observable.connect();
   auto new_peer_server = new_peer->run();
@@ -162,7 +162,7 @@ TEST_F(FakePeerFixture, MstStatePropagtesToNewPeer) {
 TEST_F(FakePeerFixture, RealPeerIsAdded) {
   // ------------------------ GIVEN ------------------------
   // create the initial fake peer
-  auto initial_peer = itf_->addFakePeer(boost::none);
+  auto initial_peer = itf_->addFakePeer(std::nullopt);
 
   // create a genesis block without only initial fake peer in it
   shared_model::interface::RolePermissionSet all_perms{};

--- a/test/integration/acceptance/fake_peer_fixture.hpp
+++ b/test/integration/acceptance/fake_peer_fixture.hpp
@@ -61,7 +61,7 @@ class FakePeerFixture : public AcceptanceFixture {
  protected:
   void SetUp() override {
     itf_ = std::make_unique<integration_framework::IntegrationTestFramework>(
-        1, boost::none, iroha::StartupWsvDataPolicy::kDrop, true, true);
+        1, std::nullopt, iroha::StartupWsvDataPolicy::kDrop, true, true);
     itf_->initPipeline(common_constants::kAdminKeypair);
   }
 

--- a/test/integration/binary/launchers.hpp
+++ b/test/integration/binary/launchers.hpp
@@ -50,7 +50,7 @@ namespace binary_test {
     bool initialized(const unsigned &transactions_expected = 0,
                      const unsigned &queries_expected = 0);
 
-    boost::optional<shared_model::crypto::Keypair> admin_key;
+    std::optional<shared_model::crypto::Keypair> admin_key;
     std::vector<shared_model::proto::Transaction> transactions;
     std::vector<shared_model::proto::Query> queries;
 

--- a/test/integration/executor/add_asset_qty_test.cpp
+++ b/test/integration/executor/add_asset_qty_test.cpp
@@ -121,5 +121,5 @@ INSTANTIATE_TEST_SUITE_P(
     Common,
     AddAssetQuantityPermissionTest,
     command_permission_test::getParams(
-        boost::none, Role::kAddDomainAssetQty, Role::kAddAssetQty, boost::none),
+        std::nullopt, Role::kAddDomainAssetQty, Role::kAddAssetQty, std::nullopt),
     command_permission_test::paramToString);

--- a/test/integration/executor/add_signatory_test.cpp
+++ b/test/integration/executor/add_signatory_test.cpp
@@ -98,7 +98,7 @@ INSTANTIATE_TEST_SUITE_P(
     Common,
     AddSignatoryPermissionTest,
     command_permission_test::getParams(Role::kAddSignatory,
-                                       boost::none,
-                                       boost::none,
+                                       std::nullopt,
+                                       std::nullopt,
                                        Grantable::kAddMySignatory),
     command_permission_test::paramToString);

--- a/test/integration/executor/call_engine_test.cpp
+++ b/test/integration/executor/call_engine_test.cpp
@@ -100,7 +100,7 @@ INSTANTIATE_TEST_SUITE_P(
     Common,
     CallEnginePermissionTest,
     command_permission_test::getParams(Role::kCallEngine,
-                                       boost::none,
-                                       boost::none,
+                                       std::nullopt,
+                                       std::nullopt,
                                        Grantable::kCallEngineOnMyBehalf),
     command_permission_test::paramToString);

--- a/test/integration/executor/command_permission_test.cpp
+++ b/test/integration/executor/command_permission_test.cpp
@@ -102,10 +102,10 @@ decltype(::testing::Combine(
     ::testing::ValuesIn(
         {command_permission_test::SpecificCommandPermissionTestData{}})))
 command_permission_test::getParams(
-    boost::optional<Role> permission_for_myself,
-    boost::optional<Role> permission_for_my_domain,
-    boost::optional<Role> permission_for_everyone,
-    boost::optional<Grantable> grantable_permission,
+    std::optional<Role> permission_for_myself,
+    std::optional<Role> permission_for_my_domain,
+    std::optional<Role> permission_for_everyone,
+    std::optional<Grantable> grantable_permission,
     bool always_allowed_for_myself) {
   std::vector<SpecificCommandPermissionTestData> perm_params;
   const EnumMap<Actor, std::string> actors_map{
@@ -113,11 +113,11 @@ command_permission_test::getParams(
       {Actor::kSameDomain, kSameDomainUserId},
       {Actor::kSecondDomain, kSecondDomainUserId}};
   const RolePermissionSet kNoRolePerms;
-  const boost::optional<Grantable> kNoGrantablePerm;
+  const std::optional<Grantable> kNoGrantablePerm;
 
   auto add_case = [&](ActorRolePermissions role_perm_type,
                       RolePermissionSet role_permissions,
-                      boost::optional<Grantable> granted_permission,
+                      std::optional<Grantable> granted_permission,
                       Actor actor,
                       bool validation_enabled = true) {
     const bool has_granted_permission{granted_permission};
@@ -146,7 +146,7 @@ command_permission_test::getParams(
 
   auto add_role_cases_if_permission_provided =
       [&](ActorRolePermissions role_perm_type,
-          boost::optional<Role> permission) {
+          std::optional<Role> permission) {
         if (permission) {
           add_role_cases(role_perm_type, RolePermissionSet{permission.value()});
         }

--- a/test/integration/executor/command_permission_test.hpp
+++ b/test/integration/executor/command_permission_test.hpp
@@ -19,7 +19,7 @@ namespace executor_testing {
 
     struct SpecificCommandPermissionTestData {
       shared_model::interface::RolePermissionSet actor_role_permissions;
-      boost::optional<shared_model::interface::permissions::Grantable>
+      std::optional<shared_model::interface::permissions::Grantable>
           actor_grantable_permission;
       bool validation_enabled;
       shared_model::interface::types::AccountIdType actor;
@@ -30,13 +30,13 @@ namespace executor_testing {
     decltype(::testing::Combine(
         executor_testing::getExecutorTestParams(),
         ::testing::ValuesIn({SpecificCommandPermissionTestData{}})))
-    getParams(boost::optional<shared_model::interface::permissions::Role>
+    getParams(std::optional<shared_model::interface::permissions::Role>
                   permission_for_myself,
-              boost::optional<shared_model::interface::permissions::Role>
+              std::optional<shared_model::interface::permissions::Role>
                   permission_for_my_domain,
-              boost::optional<shared_model::interface::permissions::Role>
+              std::optional<shared_model::interface::permissions::Role>
                   permission_for_everyone,
-              boost::optional<shared_model::interface::permissions::Grantable>
+              std::optional<shared_model::interface::permissions::Grantable>
                   grantable_permission,
               bool always_allowed_for_myself = false);
 

--- a/test/integration/executor/create_account_test.cpp
+++ b/test/integration/executor/create_account_test.cpp
@@ -34,14 +34,14 @@ const AccountIdType &getNewId() {
 class CreateAccountTest : public ExecutorTestBase {
  public:
   void checkAccount(
-      const boost::optional<AccountIdType> &account_id = boost::none,
+      const std::optional<AccountIdType> &account_id = std::nullopt,
       PublicKeyHexStringView pubkey = kNewPubkey) {
     auto account_id_val = account_id.value_or(getNewId());
     ASSERT_NO_FATAL_FAILURE(checkSignatories(account_id_val, {pubkey}););
   }
 
   void checkNoSuchAccount(
-      const boost::optional<AccountIdType> &account_id = boost::none) {
+      const std::optional<AccountIdType> &account_id = std::nullopt) {
     auto account_id_val = account_id.value_or(getNewId());
     checkQueryError<shared_model::interface::NoAccountErrorResponse>(
         getItf().executeQuery(
@@ -167,5 +167,5 @@ INSTANTIATE_TEST_SUITE_P(
     Common,
     CreateAccountPermissionTest,
     command_permission_test::getParams(
-        boost::none, boost::none, Role::kCreateAccount, boost::none),
+        std::nullopt, std::nullopt, Role::kCreateAccount, std::nullopt),
     command_permission_test::paramToString);

--- a/test/integration/executor/create_role_test.cpp
+++ b/test/integration/executor/create_role_test.cpp
@@ -111,8 +111,8 @@ TEST_P(CreateRolePermissionTest, CommandPermissionTest) {
 
 INSTANTIATE_TEST_SUITE_P(Common,
                          CreateRolePermissionTest,
-                         command_permission_test::getParams(boost::none,
-                                                            boost::none,
+                         command_permission_test::getParams(std::nullopt,
+                                                            std::nullopt,
                                                             Role::kCreateRole,
-                                                            boost::none),
+                                                            std::nullopt),
                          command_permission_test::paramToString);

--- a/test/integration/executor/get_account_assets_test.cpp
+++ b/test/integration/executor/get_account_assets_test.cpp
@@ -76,7 +76,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
    */
   void validatePageResponse(
       const shared_model::interface::AccountAssetResponse &response,
-      boost::optional<size_t> requested_page_start,
+      std::optional<size_t> requested_page_start,
       size_t page_size) {
     size_t page_start = requested_page_start.value_or(0);
     ASSERT_LE(page_start, assets_added_) << "Bad test.";
@@ -105,7 +105,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
   }
 
   void validatePageResponse(const QueryExecutorResult &response,
-                            boost::optional<size_t> page_start,
+                            std::optional<size_t> page_start,
                             size_t page_size) {
     checkSuccessfulResult<shared_model::interface::AccountAssetResponse>(
         response, [&, this](const auto &response) {
@@ -123,7 +123,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
   /**
    * Query account assets.
    */
-  QueryExecutorResult queryPage(boost::optional<size_t> page_start,
+  QueryExecutorResult queryPage(std::optional<size_t> page_start,
                                 size_t page_size,
                                 AccountIdType command_issuer = kAdminId) {
     std::optional<AssetIdType> first_asset_id;
@@ -141,7 +141,7 @@ struct GetAccountAssetsTest : public ExecutorTestBase {
    * Query account assets and validate the response.
    */
   QueryExecutorResult queryPageAndValidateResponse(
-      boost::optional<size_t> page_start, size_t page_size) {
+      std::optional<size_t> page_start, size_t page_size) {
     auto response = queryPage(page_start, page_size);
     validatePageResponse(response, page_start, page_size);
     return response;
@@ -184,7 +184,7 @@ TEST_P(GetAccountAssetsBasicTest, NoPageMetaData) {
   QueryExecutorResult response = getItf().executeQuery(
       *getItf().getMockQueryFactory()->constructGetAccountAssets(kUserId,
                                                                  std::nullopt));
-  validatePageResponse(response, boost::none, 10);
+  validatePageResponse(response, std::nullopt, 10);
 }
 
 /**
@@ -194,7 +194,7 @@ TEST_P(GetAccountAssetsBasicTest, NoPageMetaData) {
  */
 TEST_P(GetAccountAssetsBasicTest, FirstPage) {
   ASSERT_NO_FATAL_FAILURE(prepareState(10));
-  queryPageAndValidateResponse(boost::none, 5);
+  queryPageAndValidateResponse(std::nullopt, 5);
 }
 
 /**
@@ -252,9 +252,9 @@ TEST_P(GetAccountAssetsPermissionTest, QueryPermissionTest) {
   createAndAddAssets(2);
   auto pagination_meta = makePaginationMeta(assets_added_, std::nullopt);
   checkResponse<shared_model::interface::AccountAssetResponse>(
-      queryPage(boost::none, assets_added_, getSpectator()),
+      queryPage(std::nullopt, assets_added_, getSpectator()),
       [this](const shared_model::interface::AccountAssetResponse &response) {
-        this->validatePageResponse(response, boost::none, assets_added_);
+        this->validatePageResponse(response, std::nullopt, assets_added_);
       });
 }
 

--- a/test/integration/executor/get_asset_info_test.cpp
+++ b/test/integration/executor/get_asset_info_test.cpp
@@ -74,7 +74,7 @@ TEST_P(GetAssetInfoPermissionTest, QueryPermissionTest) {
 
 INSTANTIATE_TEST_SUITE_P(Common,
                          GetAssetInfoPermissionTest,
-                         query_permission_test::getParams({boost::none},
-                                                          {boost::none},
+                         query_permission_test::getParams({std::nullopt},
+                                                          {std::nullopt},
                                                           {Role::kReadAssets}),
                          query_permission_test::paramToString);

--- a/test/integration/executor/query_permission_test.cpp
+++ b/test/integration/executor/query_permission_test.cpp
@@ -82,9 +82,9 @@ decltype(::testing::Combine(
     ::testing::ValuesIn(
         {query_permission_test::SpecificQueryPermissionTestData{}})))
 query_permission_test::getParams(
-    boost::optional<Role> permission_to_query_myself,
-    boost::optional<Role> permission_to_query_my_domain,
-    boost::optional<Role> permission_to_query_everyone) {
+    std::optional<Role> permission_to_query_myself,
+    std::optional<Role> permission_to_query_my_domain,
+    std::optional<Role> permission_to_query_everyone) {
   std::vector<SpecificQueryPermissionTestData> perm_params;
   const EnumMap<Spectator, std::string> spectators_map{
       {Spectator::kMe, kUserId},
@@ -103,7 +103,7 @@ query_permission_test::getParams(
   };
 
   auto add_perm_case_if_provided = [&](SpectatorPermissions perm_type,
-                                       boost::optional<Role> permission) {
+                                       std::optional<Role> permission) {
     if (permission) {
       add_perm_case(perm_type, RolePermissionSet{permission.value()});
     }

--- a/test/integration/executor/query_permission_test.hpp
+++ b/test/integration/executor/query_permission_test.hpp
@@ -27,11 +27,11 @@ namespace executor_testing {
     decltype(::testing::Combine(
         executor_testing::getExecutorTestParams(),
         ::testing::ValuesIn({SpecificQueryPermissionTestData{}})))
-    getParams(boost::optional<shared_model::interface::permissions::Role>
+    getParams(std::optional<shared_model::interface::permissions::Role>
                   permission_to_query_myself,
-              boost::optional<shared_model::interface::permissions::Role>
+              std::optional<shared_model::interface::permissions::Role>
                   permission_to_query_my_domain,
-              boost::optional<shared_model::interface::permissions::Role>
+              std::optional<shared_model::interface::permissions::Role>
                   permission_to_query_everyone);
 
     template <typename SpecificQueryFixture>

--- a/test/integration/executor/remove_signatory_test.cpp
+++ b/test/integration/executor/remove_signatory_test.cpp
@@ -133,7 +133,7 @@ INSTANTIATE_TEST_SUITE_P(
     Common,
     RemoveSignatoryPermissionTest,
     command_permission_test::getParams(Role::kRemoveSignatory,
-                                       boost::none,
-                                       boost::none,
+                                       std::nullopt,
+                                       std::nullopt,
                                        Grantable::kRemoveMySignatory),
     command_permission_test::paramToString);

--- a/test/integration/executor/set_account_detail_test.cpp
+++ b/test/integration/executor/set_account_detail_test.cpp
@@ -188,8 +188,8 @@ TEST_P(SetAccountDetailPermissionTest, CommandPermissionTest) {
 INSTANTIATE_TEST_SUITE_P(
     Common,
     SetAccountDetailPermissionTest,
-    command_permission_test::getParams(boost::none,
-                                       boost::none,
+    command_permission_test::getParams(std::nullopt,
+                                       std::nullopt,
                                        Role::kSetDetail,
                                        Grantable::kSetMyAccountDetail,
                                        true),

--- a/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_mocks.hpp
@@ -9,7 +9,6 @@
 #include "ametsuchi/wsv_command.hpp"
 
 #include <gmock/gmock.h>
-#include <boost/optional.hpp>
 #include "ametsuchi/temporary_wsv.hpp"
 #include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -467,7 +467,7 @@ TEST_F(AmetsuchiTest, TestRestoreWsvFromBlockStorage) {
   initializeStorage();
 
   // block storage should not be altered
-  EXPECT_EQ(storage->getLedgerState(), boost::none);
+  EXPECT_EQ(storage->getLedgerState(), std::nullopt);
   EXPECT_EQ(block_storage_->size(), height);
   EXPECT_EQ(block_storage_->fetch(height).value()->hash(), top_hash);
 

--- a/test/module/irohad/ametsuchi/block_query_test.cpp
+++ b/test/module/irohad/ametsuchi/block_query_test.cpp
@@ -303,7 +303,7 @@ TEST_F(BlockQueryTest, GetTopBlockSuccess) {
  */
 TEST_F(BlockQueryTest, GetTopBlockFail) {
   EXPECT_CALL(*mock_block_storage, size()).WillRepeatedly(Return(0));
-  ASSERT_EQ(mock_block_storage->fetch(mock_block_storage->size()), boost::none);
+  ASSERT_EQ(mock_block_storage->fetch(mock_block_storage->size()), std::nullopt);
 
   auto top_block_error = iroha::expected::resultToOptionalError(
       empty_blocks->getBlock(empty_blocks->getTopBlockHeight()));

--- a/test/module/irohad/ametsuchi/mock_block_query_factory.hpp
+++ b/test/module/irohad/ametsuchi/mock_block_query_factory.hpp
@@ -16,7 +16,7 @@ namespace iroha {
     class MockBlockQueryFactory : public BlockQueryFactory {
      public:
       MOCK_CONST_METHOD0(createBlockQuery,
-                         boost::optional<std::shared_ptr<BlockQuery>>());
+                         std::optional<std::shared_ptr<BlockQuery>>());
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_block_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_block_storage.hpp
@@ -18,7 +18,7 @@ namespace iroha {
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_CONST_METHOD1(
           fetch,
-          boost::optional<std::unique_ptr<shared_model::interface::Block>>(
+          std::optional<std::unique_ptr<shared_model::interface::Block>>(
               shared_model::interface::types::HeightType));
       MOCK_CONST_METHOD0(size, size_t(void));
       MOCK_METHOD0(clear, void(void));

--- a/test/module/irohad/ametsuchi/mock_key_value_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_key_value_storage.hpp
@@ -16,7 +16,7 @@ namespace iroha {
     class MockKeyValueStorage : public KeyValueStorage {
      public:
       MOCK_METHOD2(add, bool(Identifier, const Bytes &));
-      MOCK_CONST_METHOD1(get, boost::optional<Bytes>(Identifier));
+      MOCK_CONST_METHOD1(get, std::optional<Bytes>(Identifier));
       MOCK_CONST_METHOD0(directory, std::string(void));
       MOCK_CONST_METHOD0(last_id, Identifier(void));
       MOCK_METHOD0(dropAll, void(void));

--- a/test/module/irohad/ametsuchi/mock_peer_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_peer_query.hpp
@@ -17,11 +17,11 @@ namespace iroha {
      public:
       MockPeerQuery() = default;
 
-      MOCK_METHOD0(getLedgerPeers, boost::optional<std::vector<wPeer>>());
+      MOCK_METHOD0(getLedgerPeers, std::optional<std::vector<wPeer>>());
 
       MOCK_CONST_METHOD1(
           getLedgerPeerByPublicKey,
-          boost::optional<PeerQuery::wPeer>(
+          std::optional<PeerQuery::wPeer>(
               shared_model::interface::types::PublicKeyHexStringView));
     };
 

--- a/test/module/irohad/ametsuchi/mock_peer_query_factory.hpp
+++ b/test/module/irohad/ametsuchi/mock_peer_query_factory.hpp
@@ -16,7 +16,7 @@ namespace iroha {
     class MockPeerQueryFactory : public PeerQueryFactory {
      public:
       MOCK_CONST_METHOD0(createPeerQuery,
-                         boost::optional<std::shared_ptr<PeerQuery>>());
+                         std::optional<std::shared_ptr<PeerQuery>>());
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/mock_setting_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_setting_query.hpp
@@ -16,7 +16,7 @@ namespace iroha {
     class MockSettingQuery : public SettingQuery {
      public:
       MOCK_METHOD1(getSettingValue,
-                   boost::optional<SettingValueType>(const SettingKeyType &));
+                   std::optional<SettingValueType>(const SettingKeyType &));
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/test/module/irohad/ametsuchi/mock_setting_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_setting_query.hpp
@@ -9,7 +9,6 @@
 #include "ametsuchi/setting_query.hpp"
 
 #include <gmock/gmock.h>
-#include <boost/optional.hpp>
 
 namespace iroha {
   namespace ametsuchi {

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -32,11 +32,11 @@ namespace iroha {
           iroha::expected::Result<std::unique_ptr<MutableStorage>, std::string>(
               std::shared_ptr<CommandExecutor>));
       MOCK_CONST_METHOD0(createPeerQuery,
-                         boost::optional<std::shared_ptr<PeerQuery>>());
+                         std::optional<std::shared_ptr<PeerQuery>>());
       MOCK_CONST_METHOD0(createBlockQuery,
-                         boost::optional<std::shared_ptr<BlockQuery>>());
+                         std::optional<std::shared_ptr<BlockQuery>>());
       MOCK_CONST_METHOD0(createSettingQuery,
-                         boost::optional<std::unique_ptr<SettingQuery>>());
+                         std::optional<std::unique_ptr<SettingQuery>>());
       MOCK_METHOD(
           (iroha::expected::Result<std::unique_ptr<QueryExecutor>,
                                    std::string>),
@@ -64,7 +64,7 @@ namespace iroha {
       MOCK_METHOD0(resetPeers, void());
       MOCK_CONST_METHOD0(
           getLedgerState,
-          boost::optional<std::shared_ptr<const iroha::LedgerState>>());
+          std::optional<std::shared_ptr<const iroha::LedgerState>>());
       MOCK_METHOD0(freeConnections, void());
       MOCK_METHOD1(prepareBlock_, void(std::unique_ptr<TemporaryWsv> &));
 

--- a/test/module/irohad/ametsuchi/mock_tx_presence_cache.hpp
+++ b/test/module/irohad/ametsuchi/mock_tx_presence_cache.hpp
@@ -16,12 +16,12 @@ namespace iroha {
     class MockTxPresenceCache : public TxPresenceCache {
      public:
       MOCK_CONST_METHOD1(check,
-                         boost::optional<TxCacheStatusType>(
+                         std::optional<TxCacheStatusType>(
                              const shared_model::crypto::Hash &hash));
 
       MOCK_CONST_METHOD1(
           check,
-          boost::optional<TxPresenceCache::BatchStatusCollectionType>(
+          std::optional<TxPresenceCache::BatchStatusCollectionType>(
               const shared_model::interface::TransactionBatch &));
     };
 

--- a/test/module/irohad/ametsuchi/mock_wsv_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_wsv_query.hpp
@@ -35,16 +35,16 @@ namespace iroha {
     class MockWsvQuery : public WsvQuery {
      public:
       MOCK_METHOD1(getSignatories,
-                   boost::optional<std::vector<std::string>>(
+                   std::optional<std::vector<std::string>>(
                        const std::string &account_id));
       MOCK_METHOD0(
           getPeers,
-          boost::optional<
+          std::optional<
               std::vector<std::shared_ptr<shared_model::interface::Peer>>>());
 
       MOCK_METHOD1(
           getPeerByPublicKey,
-          boost::optional<std::shared_ptr<shared_model::interface::Peer>>(
+          std::optional<std::shared_ptr<shared_model::interface::Peer>>(
               shared_model::interface::types::PublicKeyHexStringView));
 
       MOCK_CONST_METHOD0(

--- a/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
+++ b/test/module/irohad/ametsuchi/peer_query_wsv_test.cpp
@@ -39,6 +39,6 @@ TEST_F(PeerQueryWSVTest, GetPeers) {
 
   auto result = peer_query_->getLedgerPeers();
   ASSERT_TRUE(result);
-  ASSERT_THAT(result.get(),
+  ASSERT_THAT(result.value(),
               testing::ElementsAreArray(peers.cbegin(), peers.cend()));
 }

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -636,7 +636,7 @@ namespace iroha {
           *mock_command_factory->constructCreateAsset("coin", domain_id, 1)));
       auto asset = sql_query->getAsset(asset_id);
       ASSERT_TRUE(asset);
-      ASSERT_EQ(asset_id, asset.get()->assetId());
+      ASSERT_EQ(asset_id, asset.value()->assetId());
     }
 
     /**
@@ -733,7 +733,7 @@ namespace iroha {
           *mock_command_factory->constructCreateAsset("coin", domain_id, 1)));
       auto asset = sql_query->getAsset(asset_id);
       ASSERT_TRUE(asset);
-      ASSERT_EQ(asset_id, asset.get()->assetId());
+      ASSERT_EQ(asset_id, asset.value()->assetId());
     }
 
     class CreateDomain : public CommandExecutorTest {
@@ -760,7 +760,7 @@ namespace iroha {
           *mock_command_factory->constructCreateDomain(domain2_id, role)));
       auto dom = sql_query->getDomain(domain2_id);
       ASSERT_TRUE(dom);
-      ASSERT_EQ(dom.get()->domainId(), domain2_id);
+      ASSERT_EQ(dom.value()->domainId(), domain2_id);
     }
 
     /**
@@ -819,7 +819,7 @@ namespace iroha {
           *mock_command_factory->constructCreateDomain(domain2_id, role)));
       auto dom = sql_query->getDomain(domain2_id);
       ASSERT_TRUE(dom);
-      ASSERT_EQ(dom.get()->domainId(), domain2_id);
+      ASSERT_EQ(dom.value()->domainId(), domain2_id);
     }
 
     class DetachRole : public CommandExecutorTest {
@@ -1196,20 +1196,20 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
                       asset_id, asset_amount_one_zero),
                   true));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructSubtractAssetQuantity(
               asset_id, asset_amount_one_zero)));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1225,7 +1225,7 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
 
       auto cmd_result =
           execute(*mock_command_factory->constructSubtractAssetQuantity(
@@ -1237,7 +1237,7 @@ namespace iroha {
 
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1257,7 +1257,7 @@ namespace iroha {
 
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
 
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
@@ -1266,7 +1266,7 @@ namespace iroha {
 
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
 
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructSubtractAssetQuantity(
@@ -1275,7 +1275,7 @@ namespace iroha {
 
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1299,7 +1299,7 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset2_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
 
       auto cmd_result =
           execute(*mock_command_factory->constructSubtractAssetQuantity(
@@ -1311,7 +1311,7 @@ namespace iroha {
 
       account_asset = sql_query->getAccountAsset(account_id, asset2_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1380,20 +1380,20 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
                       asset_id, asset_amount_one_zero),
                   true));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructSubtractAssetQuantity(
               asset_id, asset_amount_one_zero)));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     class TransferAccountAssetTest : public CommandExecutorTest {
@@ -1447,14 +1447,14 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
                       asset_id, asset_amount_one_zero),
                   true));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructTransferAsset(
               account_id,
@@ -1464,10 +1464,10 @@ namespace iroha {
               asset_amount_one_zero)));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       account_asset = sql_query->getAccountAsset(account2_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1491,7 +1491,7 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(execute(
           *mock_command_factory->constructTransferAsset(
               account_id, account2_id, asset_id, "desc", asset_amount_one_zero),
@@ -1499,10 +1499,10 @@ namespace iroha {
           account2_id));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       account_asset = sql_query->getAccountAsset(account2_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1518,7 +1518,7 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
 
       auto cmd_result = execute(*mock_command_factory->constructTransferAsset(
           account_id, account2_id, asset_id, "desc", asset_amount_one_zero));
@@ -1647,7 +1647,7 @@ namespace iroha {
 
       auto account_asset = sql_query->getAccountAsset(account2_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(account_asset.get()->balance(),
+      ASSERT_EQ(account_asset.value()->balance(),
                 shared_model::interface::Amount{"1.1"});
     }
 
@@ -1741,14 +1741,14 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
                       asset_id, asset_amount_one_zero),
                   true));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructTransferAsset(
               account_id,
@@ -1758,10 +1758,10 @@ namespace iroha {
               asset_amount_one_zero)));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       account_asset = sql_query->getAccountAsset(account2_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     /**
@@ -1781,14 +1781,14 @@ namespace iroha {
                   true));
       auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructAddAssetQuantity(
                       asset_id, asset_amount_one_zero),
                   true));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ("2.0", account_asset.get()->balance().toStringRepr());
+      ASSERT_EQ("2.0", account_asset.value()->balance().toStringRepr());
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructTransferAsset(
               account_id,
@@ -1798,10 +1798,10 @@ namespace iroha {
               asset_amount_one_zero)));
       account_asset = sql_query->getAccountAsset(account_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
       account_asset = sql_query->getAccountAsset(account2_id, asset_id);
       ASSERT_TRUE(account_asset);
-      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+      ASSERT_EQ(asset_amount_one_zero, account_asset.value()->balance());
     }
 
     class CompareAndSetAccountDetail : public CommandExecutorTest {
@@ -1832,7 +1832,7 @@ namespace iroha {
               account_id, "key", "value", std::nullopt, true)));
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
     }
 
     /**
@@ -1857,7 +1857,7 @@ namespace iroha {
                   account_id));
       auto kv = sql_query->getAccountDetail(account2_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
     }
 
     /**
@@ -1874,7 +1874,7 @@ namespace iroha {
                   account_id));
       auto kv = sql_query->getAccountDetail(account2_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
     }
 
     /**
@@ -1894,7 +1894,7 @@ namespace iroha {
 
       auto kv = sql_query->getAccountDetail(account2_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), "{}");
+      ASSERT_EQ(kv.value(), "{}");
     }
 
     /**
@@ -1927,7 +1927,7 @@ namespace iroha {
 
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
 
       CHECK_SUCCESSFUL_RESULT(
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
@@ -1940,7 +1940,7 @@ namespace iroha {
               true)));
       auto kv1 = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv1);
-      ASSERT_EQ(kv1.get(), R"({"id@domain": {"key": "value1"}})");
+      ASSERT_EQ(kv1.value(), R"({"id@domain": {"key": "value1"}})");
     }
 
     /**
@@ -1956,7 +1956,7 @@ namespace iroha {
 
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
 
       auto cmd_result =
           execute(*mock_command_factory->constructCompareAndSetAccountDetail(
@@ -1990,7 +1990,7 @@ namespace iroha {
 
       auto ad = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(ad);
-      ASSERT_EQ(ad.get(),
+      ASSERT_EQ(ad.value(),
                 R"({"id@domain": {"key": "value", "key1": "value1"}})");
     }
 
@@ -2056,7 +2056,7 @@ namespace iroha {
 
       auto kv1 = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv1);
-      ASSERT_EQ(kv1.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv1.value(), R"({"id@domain": {"key": "value"}})");
     }
 
     /**
@@ -2071,7 +2071,7 @@ namespace iroha {
               account_id, "key", "value", std::nullopt, true)));
       auto kv = sql_query->getAccountDetail(account_id);
       ASSERT_TRUE(kv);
-      ASSERT_EQ(kv.get(), R"({"id@domain": {"key": "value"}})");
+      ASSERT_EQ(kv.value(), R"({"id@domain": {"key": "value"}})");
     }
 
     class SetSettingValueTest : public CommandExecutorTest {};
@@ -2089,7 +2089,7 @@ namespace iroha {
 
       auto setting_value = sql_query->getSettingValue(key);
       ASSERT_TRUE(setting_value);
-      ASSERT_EQ(setting_value.get(), value);
+      ASSERT_EQ(setting_value.value(), value);
     }
 
     /**
@@ -2105,16 +2105,16 @@ namespace iroha {
 
       auto setting_value = sql_query->getSettingValue(key);
       ASSERT_TRUE(setting_value);
-      ASSERT_EQ(setting_value.get(), value);
+      ASSERT_EQ(setting_value.value(), value);
 
       value = "512";
-      ASSERT_NE(setting_value.get(), value);
+      ASSERT_NE(setting_value.value(), value);
       CHECK_SUCCESSFUL_RESULT(execute(
           *mock_command_factory->constructSetSettingValue(key, value), true));
 
       setting_value = sql_query->getSettingValue(key);
       ASSERT_TRUE(setting_value);
-      ASSERT_EQ(setting_value.get(), value);
+      ASSERT_EQ(setting_value.value(), value);
     }
 
   }  // namespace ametsuchi

--- a/test/module/irohad/ametsuchi/tx_presence_cache_stub.hpp
+++ b/test/module/irohad/ametsuchi/tx_presence_cache_stub.hpp
@@ -17,12 +17,12 @@ namespace iroha {
      */
     template <typename T>
     struct TxPresenceCacheStub final : public TxPresenceCache {
-      boost::optional<TxCacheStatusType> check(
+      std::optional<TxCacheStatusType> check(
           const shared_model::crypto::Hash &hash) const override {
-        return boost::make_optional<TxCacheStatusType>(T{hash});
+        return std::make_optional<TxCacheStatusType>(T{hash});
       }
 
-      boost::optional<BatchStatusCollectionType> check(
+      std::optional<BatchStatusCollectionType> check(
           const shared_model::interface::TransactionBatch &batch)
           const override {
         BatchStatusCollectionType result;

--- a/test/module/irohad/ametsuchi/wsv_query_test.cpp
+++ b/test/module/irohad/ametsuchi/wsv_query_test.cpp
@@ -88,7 +88,7 @@ namespace iroha {
 
       auto result = query->getSignatories("account");
       ASSERT_TRUE(result);
-      auto signatories = result.get();
+      auto signatories = result.value();
       ASSERT_THAT(signatories,
                   testing::UnorderedElementsAre(pub_key1, pub_key2));
     }

--- a/test/module/irohad/consensus/yac/buffered_cleanup_strategy_test.cpp
+++ b/test/module/irohad/consensus/yac/buffered_cleanup_strategy_test.cpp
@@ -40,7 +40,7 @@ class BufferedCleanupStrategyTest : public ::testing::Test {
  */
 TEST_F(BufferedCleanupStrategyTest, RejectFirstCase) {
   ASSERT_TRUE(strategy_->shouldCreateRound({1, 1}));
-  ASSERT_EQ(boost::none, strategy_->finalize({1, 1}, makeMockReject()));
+  ASSERT_EQ(std::nullopt, strategy_->finalize({1, 1}, makeMockReject()));
 
   ASSERT_TRUE(strategy_->shouldCreateRound({1, 2}));
 

--- a/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
@@ -19,7 +19,7 @@ namespace iroha {
         MOCK_METHOD3(vote,
                      void(YacHash,
                           ClusterOrdering,
-                          boost::optional<ClusterOrdering>));
+                          std::optional<ClusterOrdering>));
 
         MOCK_METHOD0(onOutcome, rxcpp::observable<Answer>());
 

--- a/test/module/irohad/consensus/yac/mock_yac_peer_orderer.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_peer_orderer.hpp
@@ -18,7 +18,7 @@ namespace iroha {
        public:
         MOCK_METHOD2(
             getOrdering,
-            boost::optional<ClusterOrdering>(
+            std::optional<ClusterOrdering>(
                 const YacHash &,
                 std::vector<
                     std::shared_ptr<shared_model::interface::Peer>> const &));

--- a/test/module/irohad/consensus/yac/peer_orderer_test.cpp
+++ b/test/module/irohad/consensus/yac/peer_orderer_test.cpp
@@ -39,7 +39,7 @@ class YacPeerOrdererTest : public ::testing::Test {
     wsv = make_shared<MockPeerQuery>();
     pbfactory = make_shared<MockPeerQueryFactory>();
     EXPECT_CALL(*pbfactory, createPeerQuery())
-        .WillRepeatedly(testing::Return(boost::make_optional(
+        .WillRepeatedly(testing::Return(std::make_optional(
             std::shared_ptr<iroha::ametsuchi::PeerQuery>(wsv))));
     orderer = PeerOrdererImpl(pbfactory);
   }
@@ -77,7 +77,7 @@ TEST_F(YacPeerOrdererTest, PeerOrdererOrderingWhenInvokeNormalCase) {
 
 TEST_F(YacPeerOrdererTest, PeerOrdererOrderingWhenEmptyPeerList) {
   auto order = orderer.getOrdering(YacHash(), {});
-  ASSERT_EQ(order, boost::none);
+  ASSERT_EQ(order, std::nullopt);
 }
 
 /**

--- a/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_block_storage_test.cpp
@@ -53,12 +53,12 @@ TEST_F(YacBlockStorageTest, YacBlockStorageWhenNormalDataInput) {
   for (size_t num_inserted = 0; num_inserted < number_of_peers;) {
     auto insert_result = storage.insert(valid_votes.at(num_inserted++));
     if (num_inserted < supermajority) {
-      EXPECT_EQ(boost::none, insert_result)
+      EXPECT_EQ(std::nullopt, insert_result)
           << "Got an Answer after inserting " << num_inserted
           << " votes, before the supermajority reached at " << supermajority;
     } else {
       // after supermajority reached we have a CommitMessage
-      ASSERT_NE(boost::none, insert_result)
+      ASSERT_NE(std::nullopt, insert_result)
           << "Did not get an Answer after inserting " << num_inserted
           << " votes and the supermajority reached at " << supermajority;
       ASSERT_EQ(num_inserted,
@@ -72,7 +72,7 @@ TEST_F(YacBlockStorageTest, YacBlockStorageWhenNotCommittedAndCommitAcheive) {
   log_->info("-----------| Insert vote => insert commit |-----------");
 
   auto insert_1 = storage.insert(valid_votes.at(0));
-  ASSERT_EQ(boost::none, insert_1);
+  ASSERT_EQ(std::nullopt, insert_1);
 
   decltype(YacBlockStorageTest::valid_votes) for_insert(valid_votes.begin() + 1,
                                                         valid_votes.end());

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -121,7 +121,7 @@ class YacGateTest : public ::testing::Test {
   }
 
   iroha::consensus::Round round{2, 1};
-  boost::optional<ClusterOrdering> alternative_order;
+  std::optional<ClusterOrdering> alternative_order;
   std::string expected_signed{"expected_signed"};
   Hash prev_hash{"prev hash"};
   YacHash expected_hash;
@@ -215,7 +215,7 @@ TEST_F(YacGateTest, CacheReleased) {
   outcome_notifier.get_subscriber().on_next(expected_commit);
   round.reject_round++;
 
-  gate->vote({boost::none, round, ledger_state});
+  gate->vote({std::nullopt, round, ledger_state});
 
   ASSERT_EQ(block_cache->get(), nullptr);
 }
@@ -230,7 +230,7 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
   EXPECT_CALL(*hash_gate, vote(_, _, _)).Times(0);
 
   // generate order of peers
-  EXPECT_CALL(*peer_orderer, getOrdering(_, _)).WillOnce(Return(boost::none));
+  EXPECT_CALL(*peer_orderer, getOrdering(_, _)).WillOnce(Return(std::nullopt));
 
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
@@ -255,7 +255,7 @@ TEST_F(YacGateTest, AgreementOnNone) {
 
   ASSERT_EQ(block_cache->get(), nullptr);
 
-  gate->vote({boost::none, round, ledger_state});
+  gate->vote({std::nullopt, round, ledger_state});
 
   ASSERT_EQ(block_cache->get(), nullptr);
 }
@@ -520,7 +520,7 @@ TEST_F(YacGateOlderTest, OlderVote) {
   EXPECT_CALL(*hash_provider, makeHash(_)).Times(0);
 
   block_notifier.get_subscriber().on_next(BlockCreatorEvent{
-      boost::none, {round.block_round - 1, round.reject_round}, ledger_state});
+      std::nullopt, {round.block_round - 1, round.reject_round}, ledger_state});
 }
 
 /**
@@ -631,7 +631,7 @@ TEST_F(YacGateAlternativeOrderTest, AlternativeOrderUsedOnce) {
     InSequence s;  // ensures the call order
     EXPECT_CALL(*hash_gate, vote(expected_hash, _, alternative_order)).Times(1);
     EXPECT_CALL(*hash_gate,
-                vote(expected_hash, _, boost::optional<ClusterOrdering>{}))
+                vote(expected_hash, _, std::optional<ClusterOrdering>{}))
         .Times(1);
   }
 

--- a/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_proposal_storage_test.cpp
@@ -61,12 +61,12 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenCommitCase) {
   for (size_t num_inserted = 0; num_inserted < number_of_peers;) {
     auto insert_result = storage.insert(valid_votes.at(num_inserted++));
     if (num_inserted < supermajority) {
-      EXPECT_EQ(boost::none, insert_result)
+      EXPECT_EQ(std::nullopt, insert_result)
           << "Got an Answer after inserting " << num_inserted
           << " votes, before the supermajority reached at " << supermajority;
     } else {
       // after supermajority reached we have a CommitMessage
-      ASSERT_NE(boost::none, insert_result)
+      ASSERT_NE(std::nullopt, insert_result)
           << "Did not get an Answer after inserting " << num_inserted
           << " votes and the supermajority reached at " << supermajority;
       ASSERT_EQ(num_inserted,
@@ -83,7 +83,7 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenInsertNotUnique) {
 
   for (PeersNumberType i = 0; i < number_of_peers; ++i) {
     auto fixed_index = 0;
-    ASSERT_EQ(boost::none, storage.insert(valid_votes.at(fixed_index)));
+    ASSERT_EQ(std::nullopt, storage.insert(valid_votes.at(fixed_index)));
   }
 }
 
@@ -105,13 +105,13 @@ TEST_F(YacProposalStorageTest, YacProposalStorageWhenRejectCase) {
   while (num_inserted < number_of_peers) {
     auto insert_result = storage.insert(valid_votes.at(num_inserted++));
     if (num_inserted < super_reject) {
-      EXPECT_EQ(boost::none, insert_result)
+      EXPECT_EQ(std::nullopt, insert_result)
           << "Got an Answer after inserting " << num_inserted
           << " votes, before the supermajority reject reached at "
           << super_reject;
     } else {
       // after supermajority reached we have a CommitMessage
-      ASSERT_NE(boost::none, insert_result)
+      ASSERT_NE(std::nullopt, insert_result)
           << "Did not get an Answer after inserting " << num_inserted
           << " votes and the supermajority reject reached at " << super_reject;
       ASSERT_EQ(num_inserted,

--- a/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
@@ -57,7 +57,7 @@ class NetworkUtil {
   }
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers_;
-  boost::optional<ClusterOrdering> order_;
+  std::optional<ClusterOrdering> order_;
 };
 
 class YacSynchronizationTest : public YacTest {
@@ -101,7 +101,7 @@ class YacSynchronizationTest : public YacTest {
 
   NetworkUtil network_util_{1};
   const size_t number_of_committed_rounds_ = 10;
-  boost::optional<YacHash> top_hash_;
+  std::optional<YacHash> top_hash_;
   const std::vector<size_t> voters_{{1, 2, 3, 4, 5, 6}};
 };
 

--- a/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/gossip_propagation_strategy_test.cpp
@@ -73,7 +73,7 @@ PropagationData subscribeAndEmit(GossipPropagationStrategy &strategy,
  * @param take is amount taken from the strategy emitter
  * @return emitted data
  */
-PropagationData subscribeAndEmit(boost::optional<PropagationData> data,
+PropagationData subscribeAndEmit(std::optional<PropagationData> data,
                                  std::chrono::milliseconds period,
                                  uint32_t amount,
                                  uint32_t take) {
@@ -81,7 +81,7 @@ PropagationData subscribeAndEmit(boost::optional<PropagationData> data,
   EXPECT_CALL(*query, getLedgerPeers()).WillRepeatedly(testing::Return(data));
   auto pbfactory = std::make_shared<MockPeerQueryFactory>();
   EXPECT_CALL(*pbfactory, createPeerQuery())
-      .WillRepeatedly(testing::Return(boost::make_optional(
+      .WillRepeatedly(testing::Return(std::make_optional(
           std::shared_ptr<iroha::ametsuchi::PeerQuery>(query))));
   iroha::GossipPropagationStrategyParams gossip_params;
   gossip_params.emission_period = period;
@@ -166,7 +166,7 @@ TEST(GossipPropagationStrategyTest, EmptyEmitting) {
  * @then ensure that empty peer list is emitted
  */
 TEST(GossipPropagationStrategyTest, ErrorEmitting) {
-  auto emitted = subscribeAndEmit(boost::none, 1ms, 1, 13);
+  auto emitted = subscribeAndEmit(std::nullopt, 1ms, 1, 13);
   ASSERT_EQ(emitted.size(), 0);
 }
 
@@ -192,7 +192,7 @@ TEST(GossipPropagationStrategyTest, MultipleSubsEmission) {
   auto query = std::make_shared<MockPeerQuery>();
   auto pbfactory = std::make_shared<MockPeerQueryFactory>();
   EXPECT_CALL(*pbfactory, createPeerQuery())
-      .WillRepeatedly(testing::Return(boost::make_optional(
+      .WillRepeatedly(testing::Return(std::make_optional(
           std::shared_ptr<iroha::ametsuchi::PeerQuery>(query))));
   EXPECT_CALL(*query, getLedgerPeers()).WillRepeatedly(testing::Return(peers));
   iroha::GossipPropagationStrategyParams gossip_params;

--- a/test/module/irohad/network/block_loader_test.cpp
+++ b/test/module/irohad/network/block_loader_test.cpp
@@ -51,12 +51,12 @@ class BlockLoaderTest : public testing::Test {
     peer_query = std::make_shared<MockPeerQuery>();
     peer_query_factory = std::make_shared<MockPeerQueryFactory>();
     EXPECT_CALL(*peer_query_factory, createPeerQuery())
-        .WillRepeatedly(testing::Return(boost::make_optional(
+        .WillRepeatedly(testing::Return(std::make_optional(
             std::shared_ptr<iroha::ametsuchi::PeerQuery>(peer_query))));
     storage = std::make_shared<MockBlockQuery>();
     block_query_factory = std::make_shared<MockBlockQueryFactory>();
     EXPECT_CALL(*block_query_factory, createBlockQuery())
-        .WillRepeatedly(testing::Return(boost::make_optional(
+        .WillRepeatedly(testing::Return(std::make_optional(
             std::shared_ptr<iroha::ametsuchi::BlockQuery>(storage))));
     block_cache = std::make_shared<iroha::consensus::ConsensusResultCache>();
     auto validator_ptr =

--- a/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
+++ b/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
@@ -18,7 +18,7 @@ namespace iroha {
         MOCK_METHOD1(onBatches, void(CollectionType));
 
         MOCK_METHOD1(onRequestProposal,
-                     boost::optional<std::shared_ptr<const ProposalType>>(
+                     std::optional<std::shared_ptr<const ProposalType>>(
                          consensus::Round));
       };
 

--- a/test/module/irohad/ordering/mock_proposal_creation_strategy.hpp
+++ b/test/module/irohad/ordering/mock_proposal_creation_strategy.hpp
@@ -16,7 +16,7 @@ namespace iroha {
      public:
       MOCK_METHOD2(onCollaborationOutcome, void(RoundType, size_t));
       MOCK_METHOD1(shouldCreateRound, bool(RoundType));
-      MOCK_METHOD1(onProposalRequest, boost::optional<RoundType>(RoundType));
+      MOCK_METHOD1(onProposalRequest, std::optional<RoundType>(RoundType));
     };
   }  // namespace ordering
 }  // namespace iroha

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -101,7 +101,7 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
  */
 TEST_F(OnDemandConnectionManagerTest, onRequestProposal) {
   consensus::Round round{};
-  auto oproposal = boost::make_optional<
+  auto oproposal = std::make_optional<
       std::shared_ptr<const OnDemandConnectionManager::ProposalType>>({});
   auto proposal = oproposal.value().get();
   EXPECT_CALL(*connections[OnDemandConnectionManager::kIssuer],
@@ -125,7 +125,7 @@ TEST_F(OnDemandConnectionManagerTest, onRequestProposalNone) {
   consensus::Round round{};
   EXPECT_CALL(*connections[OnDemandConnectionManager::kIssuer],
               onRequestProposal(round))
-      .WillOnce(Return(ByMove(std::move(boost::none))));
+      .WillOnce(Return(ByMove(std::move(std::nullopt))));
 
   auto result = manager->onRequestProposal(round);
 

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -51,7 +51,7 @@ class OnDemandOrderingGateTest : public ::testing::Test {
     ON_CALL(*tx_cache,
             check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
         .WillByDefault(
-            Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
+            Return(std::make_optional<ametsuchi::TxCacheStatusType>(
                 iroha::ametsuchi::tx_cache_status_responses::Missing())));
     ordering_gate = std::make_shared<OnDemandOrderingGate>(
         ordering_service,
@@ -134,7 +134,7 @@ TEST_F(OnDemandOrderingGateTest, propagateBatch) {
 TEST_F(OnDemandOrderingGateTest, BlockEvent) {
   auto mproposal = std::make_unique<MockProposal>();
   auto proposal = mproposal.get();
-  boost::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
+  std::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
       oproposal(std::move(mproposal));
   std::vector<std::shared_ptr<MockTransaction>> txs{
       std::make_shared<MockTransaction>()};
@@ -170,7 +170,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
 TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
   auto mproposal = std::make_unique<MockProposal>();
   auto proposal = mproposal.get();
-  boost::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
+  std::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
       oproposal(std::move(mproposal));
   std::vector<std::shared_ptr<MockTransaction>> txs{
       std::make_shared<MockTransaction>()};
@@ -204,7 +204,7 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
  * @then new empty proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
-  boost::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
+  std::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
       proposal;
 
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
@@ -228,7 +228,7 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
  * @then new empty proposal round based on the received height is initiated
  */
 TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
-  boost::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
+  std::optional<std::shared_ptr<const OdOsNotification::ProposalType>>
       proposal;
 
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
@@ -262,7 +262,7 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
   // initialize mock proposal
   auto proposal = std::make_shared<const NiceMock<MockProposal>>();
   ON_CALL(*proposal, transactions()).WillByDefault(Return(tx_range));
-  auto arriving_proposal = boost::make_optional(
+  auto arriving_proposal = std::make_optional(
       std::static_pointer_cast<const shared_model::interface::Proposal>(
           std::move(proposal)));
 
@@ -272,7 +272,7 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
       .WillOnce(Return(ByMove(std::move(arriving_proposal))));
   EXPECT_CALL(*tx_cache,
               check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
-      .WillOnce(Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
+      .WillOnce(Return(std::make_optional<ametsuchi::TxCacheStatusType>(
           iroha::ametsuchi::tx_cache_status_responses::Committed())));
   // expect proposal to be created without any transactions because it was
   // removed by tx cache
@@ -319,7 +319,7 @@ TEST_F(OnDemandOrderingGateTest, RepeatedTransactionInProposal) {
   auto proposal = std::make_shared<MockProposal>();
   ON_CALL(*proposal, transactions()).WillByDefault(Return(txs));
 
-  auto arriving_proposal = boost::make_optional(
+  auto arriving_proposal = std::make_optional(
       std::static_pointer_cast<const shared_model::interface::Proposal>(
           std::move(proposal)));
 
@@ -329,7 +329,7 @@ TEST_F(OnDemandOrderingGateTest, RepeatedTransactionInProposal) {
       .WillOnce(Return(ByMove(std::move(arriving_proposal))));
   EXPECT_CALL(*tx_cache,
               check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
-      .WillRepeatedly(Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
+      .WillRepeatedly(Return(std::make_optional<ametsuchi::TxCacheStatusType>(
           iroha::ametsuchi::tx_cache_status_responses::Missing())));
 
   auto ufactory_proposal = std::make_unique<MockProposal>();

--- a/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
@@ -153,7 +153,7 @@ TEST_F(OnDemandOsServerGrpcTest, RequestProposalNone) {
   request.mutable_round()->set_reject_round(round.reject_round);
   proto::ProposalResponse response;
   EXPECT_CALL(*notification, onRequestProposal(round))
-      .WillOnce(Return(ByMove(std::move(boost::none))));
+      .WillOnce(Return(ByMove(std::move(std::nullopt))));
 
   server->RequestProposal(nullptr, &request, &response);
 

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -40,7 +40,7 @@ namespace iroha {
       MOCK_METHOD1(onBatches, void(CollectionType));
 
       MOCK_METHOD1(onRequestProposal,
-                   boost::optional<std::shared_ptr<const ProposalType>>(
+                   std::optional<std::shared_ptr<const ProposalType>>(
                        consensus::Round));
 
       MOCK_METHOD1(onCollaborationOutcome, void(consensus::Round));

--- a/test/module/irohad/simulator/simulator_mocks.hpp
+++ b/test/module/irohad/simulator/simulator_mocks.hpp
@@ -15,7 +15,7 @@ namespace iroha {
      public:
       MOCK_METHOD2(
           processVerifiedProposal,
-          boost::optional<std::shared_ptr<shared_model::interface::Block>>(
+          std::optional<std::shared_ptr<shared_model::interface::Block>>(
               const std::shared_ptr<
                   iroha::validation::VerifiedProposalAndErrors> &,
               const TopBlockInfo &));

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -97,7 +97,7 @@ class SynchronizerTest : public ::testing::Test {
         .WillOnce(Return(gate_outcome.get_observable()));
 
     ON_CALL(*block_query_factory, createBlockQuery())
-        .WillByDefault(Return(boost::make_optional(
+        .WillByDefault(Return(std::make_optional(
             std::shared_ptr<iroha::ametsuchi::BlockQuery>(block_query))));
     ON_CALL(*block_query, getTopBlockHeight())
         .WillByDefault(Return(kInitTopBlockHeight));

--- a/test/module/libs/cache/cache_test.cpp
+++ b/test/module/libs/cache/cache_test.cpp
@@ -111,7 +111,7 @@ TEST(CacheTest, FindValues) {
     cache.addItem(std::to_string(i), response);
   }
   auto item = cache.findItem("2");
-  ASSERT_NE(item, boost::none);
+  ASSERT_NE(item, std::nullopt);
   ASSERT_EQ(item->tx_status(), TxStatus::STATEFUL_VALIDATION_SUCCESS);
 }
 
@@ -123,7 +123,7 @@ TEST(CacheTest, FindValues) {
 TEST(CacheTest, FindInEmptyCache) {
   Cache<std::string, ToriiResponse> cache;
   auto item = cache.findItem("0");
-  ASSERT_EQ(item, boost::none);
+  ASSERT_EQ(item, std::nullopt);
 }
 
 /**
@@ -143,7 +143,7 @@ TEST(CacheTest, FindVeryOldTransaction) {
     response.set_tx_status(TxStatus::STATEFUL_VALIDATION_FAILED);
     cache.addItem("abcdefg" + std::to_string(i), response);
   }
-  ASSERT_EQ(cache.findItem("0"), boost::none);
+  ASSERT_EQ(cache.findItem("0"), std::nullopt);
 }
 
 /// Custom key type for the test

--- a/test/module/libs/common/to_string_test.cpp
+++ b/test/module/libs/common/to_string_test.cpp
@@ -11,7 +11,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <boost/optional.hpp>
 #include <boost/range/any_range.hpp>
 
 const std::string kTestString("test");

--- a/test/module/libs/common/to_string_test.cpp
+++ b/test/module/libs/common/to_string_test.cpp
@@ -71,7 +71,7 @@ TEST(ToStringTest, WrappedDereferenceable) {
   MockToStringable *raw_obj = o1.get();
   EXPECT_EQ(toString(o1), kTestString);
   // wrap it into optional
-  auto o2 = boost::make_optional(std::move(o1));
+  auto o2 = std::make_optional(std::move(o1));
   EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
   EXPECT_EQ(toString(o2), kTestString);
   // wrap it into shared_ptr
@@ -79,7 +79,7 @@ TEST(ToStringTest, WrappedDereferenceable) {
   EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
   EXPECT_EQ(toString(o3), kTestString);
   // wrap it into one more optional
-  auto o4 = boost::make_optional(std::move(o3));
+  auto o4 = std::make_optional(std::move(o3));
   EXPECT_CALL(*raw_obj, toString()).WillOnce(::testing::Return(kTestString));
   EXPECT_EQ(toString(o4), kTestString);
 }
@@ -94,8 +94,8 @@ TEST(ToStringTest, UnsetDereferenceable) {
   test(std::unique_ptr<int>{});
   test(std::shared_ptr<int>{});
   test(static_cast<int *>(0));
-  test(boost::optional<int>());
-  test(boost::none);
+  test(std::optional<int>());
+  test(std::nullopt);
 }
 
 /**

--- a/test/module/libs/converter/string_converter_test.cpp
+++ b/test/module/libs/converter/string_converter_test.cpp
@@ -23,7 +23,7 @@ TEST(StringConverterTest, ConvertHexToBinary) {
 /**
  * @given invalid hex string
  * @when string is converted to binary string
- * @then boost::none is returned
+ * @then std::nullopt is returned
  */
 TEST(StringConverterTest, InvalidHexToBinary) {
   std::string invalid_hex = "au";

--- a/test/module/libs/crypto/keys_manager_test.cpp
+++ b/test/module/libs/crypto/keys_manager_test.cpp
@@ -74,42 +74,42 @@ using CryptoUsageTestTypes = ::testing::Types<CryptoProviderEd25519Sha3
 TYPED_TEST_CASE(KeyManager, CryptoUsageTestTypes, );
 
 TYPED_TEST(KeyManager, LoadNonExistentKeyFile) {
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadEmptyFilesPubkey) {
   create_file(this->pub_key_path, "");
   create_file(this->pri_key_path, this->prikey);
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadEmptyFilesPrikey) {
   create_file(this->pub_key_path, this->pubkey);
   create_file(this->pri_key_path, "");
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadInvalidPubkey) {
   create_file(this->pub_key_path, std::string(this->pubkey.size() * 2, '1'));
   create_file(this->pri_key_path, this->prikey);
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadInvalidPrikey) {
   create_file(this->pub_key_path, this->pubkey);
   create_file(this->pri_key_path, std::string(this->prikey.size() * 2, '1'));
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadValid) {
   create_file(this->pub_key_path, this->pubkey);
   create_file(this->pri_key_path, this->prikey);
-  IROHA_ASSERT_RESULT_VALUE(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_VALUE(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, CreateAndLoad) {
-  ASSERT_TRUE(this->manager.createKeys(boost::none));
-  IROHA_ASSERT_RESULT_VALUE(this->manager.loadKeys(boost::none));
+  ASSERT_TRUE(this->manager.createKeys(std::nullopt));
+  IROHA_ASSERT_RESULT_VALUE(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, CreateAndLoadEncrypted) {
@@ -131,14 +131,14 @@ TYPED_TEST(KeyManager, LoadInaccessiblePubkey) {
   create_file(this->pub_key_path, this->pubkey);
   create_file(this->pri_key_path, this->prikey);
   remove(this->pub_key_path);
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, LoadInaccessiblePrikey) {
   create_file(this->pub_key_path, this->pubkey);
   create_file(this->pri_key_path, this->prikey);
   remove(this->pri_key_path);
-  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(boost::none));
+  IROHA_ASSERT_RESULT_ERROR(this->manager.loadKeys(std::nullopt));
 }
 
 TYPED_TEST(KeyManager, CreateKeypairInNonexistentDir) {

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -16,7 +16,6 @@
 #include <soci/postgresql/soci-postgresql.h>
 #include <soci/soci.h>
 #include <boost/filesystem.hpp>
-#include <boost/optional.hpp>
 #include <boost/process.hpp>
 #include <boost/variant.hpp>
 

--- a/test/system/irohad_test.cpp
+++ b/test/system/irohad_test.cpp
@@ -63,7 +63,7 @@ static logger::LoggerManagerTreePtr getIrohadTestLoggerManager() {
         std::make_shared<logger::LoggerManagerTree>(logger::LoggerConfig{
             logger::LogLevel::kTrace, logger::getDefaultLogPatterns()});
     irohad_test_logger_manager->registerChild(
-        "UtilityClient", logger::LogLevel::kTrace, boost::none);
+        "UtilityClient", logger::LogLevel::kTrace, std::nullopt);
   }
   return irohad_test_logger_manager->getChild("IrohadTest");
 }
@@ -162,10 +162,10 @@ class IrohadTest : public AcceptanceFixture {
     ASSERT_TRUE(iroha_process_->running());
   }
 
-  void launchIroha(const boost::optional<std::string> &config_path,
-                   const boost::optional<std::string> &genesis_block,
-                   const boost::optional<std::string> &keypair_path,
-                   const boost::optional<std::string> &additional_params) {
+  void launchIroha(const std::optional<std::string> &config_path,
+                   const std::optional<std::string> &genesis_block,
+                   const std::optional<std::string> &keypair_path,
+                   const std::optional<std::string> &additional_params) {
     launchIroha(
         params(config_path, genesis_block, keypair_path, additional_params));
   }
@@ -197,10 +197,10 @@ class IrohadTest : public AcceptanceFixture {
     boost::filesystem::remove(config_copy_);
   }
 
-  std::string params(const boost::optional<std::string> &config_path,
-                     const boost::optional<std::string> &genesis_block,
-                     const boost::optional<std::string> &keypair_path,
-                     const boost::optional<std::string> &additional_params) {
+  std::string params(const std::optional<std::string> &config_path,
+                     const std::optional<std::string> &genesis_block,
+                     const std::optional<std::string> &keypair_path,
+                     const std::optional<std::string> &additional_params) {
     std::string res;
     config_path | [&res](auto &&s) { res += " --config " + s; };
     genesis_block | [&res](auto &&s) { res += " --genesis_block " + s; };
@@ -228,12 +228,12 @@ class IrohadTest : public AcceptanceFixture {
 
   torii::CommandSyncClient createToriiClient(
       bool enable_tls = false,
-      const boost::optional<uint16_t> override_port = {}) {
+      const std::optional<uint16_t> override_port = {}) {
     const auto port = override_port.value_or(enable_tls ? kSecurePort : kPort);
 
     auto client = enable_tls
         ? iroha::network::createSecureClient<torii::CommandSyncClient::Service>(
-              kAddress, port, root_ca_, boost::none, getChannelParams())
+              kAddress, port, root_ca_, std::nullopt, getChannelParams())
         : iroha::network::createInsecureClient<
               torii::CommandSyncClient::Service>(
               kAddress, port, getChannelParams());
@@ -257,19 +257,19 @@ class IrohadTest : public AcceptanceFixture {
     ASSERT_TRUE(boost::filesystem::create_directory(test_data_path_))
         << "Could not create directory " << test_data_path_ << ".";
 
-    ASSERT_TRUE(keys_manager_admin_.createKeys(boost::none));
-    ASSERT_TRUE(keys_manager_node_.createKeys(boost::none));
-    ASSERT_TRUE(keys_manager_testuser_.createKeys(boost::none));
+    ASSERT_TRUE(keys_manager_admin_.createKeys(std::nullopt));
+    ASSERT_TRUE(keys_manager_node_.createKeys(std::nullopt));
+    ASSERT_TRUE(keys_manager_testuser_.createKeys(std::nullopt));
 
-    auto admin_keys_result = keys_manager_admin_.loadKeys(boost::none);
+    auto admin_keys_result = keys_manager_admin_.loadKeys(std::nullopt);
     IROHA_ASSERT_RESULT_VALUE(admin_keys_result);
     auto admin_keys = std::move(admin_keys_result).assumeValue();
 
-    auto node0_keys_result = keys_manager_node_.loadKeys(boost::none);
+    auto node0_keys_result = keys_manager_node_.loadKeys(std::nullopt);
     IROHA_ASSERT_RESULT_VALUE(node0_keys_result);
     auto node0_keys = std::move(node0_keys_result).assumeValue();
 
-    auto user_keys_result = keys_manager_testuser_.loadKeys(boost::none);
+    auto user_keys_result = keys_manager_testuser_.loadKeys(std::nullopt);
     IROHA_ASSERT_RESULT_VALUE(user_keys_result);
     auto user_keys = std::move(user_keys_result).assumeValue();
 
@@ -432,7 +432,7 @@ class IrohadTest : public AcceptanceFixture {
   const uint16_t kPort;
   const uint16_t kSecurePort;
 
-  boost::optional<child> iroha_process_;
+  std::optional<child> iroha_process_;
 
   /**
    * Command client resubscription settings
@@ -486,7 +486,7 @@ TEST_F(IrohadTest, RunIrohad) {
 TEST_F(IrohadTest, SendTx) {
   launchIroha();
 
-  auto key_pair = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair);
 
   SCOPED_TRACE("From send transaction test");
@@ -504,7 +504,7 @@ TEST_F(IrohadTest, SendTx) {
 TEST_F(IrohadTest, SendTxSecure) {
   launchIroha();
 
-  auto key_pair = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair);
 
   SCOPED_TRACE("From secure send transaction test");
@@ -521,7 +521,7 @@ TEST_F(IrohadTest, SendTxSecure) {
 TEST_F(IrohadTest, SendTxInsecureWithTls) {
   launchIroha();
 
-  auto key_pair = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair);
 
   auto tx = createDefaultTx(std::move(key_pair).assumeValue());
@@ -544,7 +544,7 @@ TEST_F(IrohadTest, SendTxInsecureWithTls) {
 TEST_F(IrohadTest, SendQuery) {
   launchIroha();
 
-  auto key_pair = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair);
 
   iroha::protocol::QueryResponse response;
@@ -574,7 +574,7 @@ TEST_F(IrohadTest, SendQuery) {
 TEST_F(IrohadTest, RestartWithOverwriteLedger) {
   launchIroha();
 
-  auto key_pair_result = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair_result = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair_result);
   auto key_pair = std::move(key_pair_result).assumeValue();
 
@@ -606,7 +606,7 @@ TEST_F(IrohadTest, RestartWithOverwriteLedger) {
 TEST_F(IrohadTest, RestartWithoutResetting) {
   launchIroha();
 
-  auto key_pair_result = keys_manager_admin_.loadKeys(boost::none);
+  auto key_pair_result = keys_manager_admin_.loadKeys(std::nullopt);
   IROHA_ASSERT_RESULT_VALUE(key_pair_result);
   auto key_pair = std::move(key_pair_result).assumeValue();
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->
### Description of the Change
Solves task [IR-709](https://jira.hyperledger.org/browse/IR-709)

The replacement was done in multiple step as follows:

automatic replacements through find/sed commands in all .cpp and .hpp files `(#include <boost/optional.hpp> -> #include <optional>, boost::optional -> std::optional, boost::make_optional -> std::make_optional, boost::none -> std::nullopt)`

manual replacements of functions to  get value:  
`boost::optional::get() -> std::optional::value())`

manual replacements for conditional `boost::make_optional()`

Include SOCI support for `std::optional` in irohad with `ametsuchi/impl/soci_std_optional.hpp`

Add `std::optional` support for `libs` functions referenced in `irohad`

### Benefits
Less boost dependencies
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

