### PR TITLE
Infrastructure: add USE_BURROW option to Jenkins CI

### DIFF
--- a/.jenkinsci/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci/builders/x64-linux-build-steps.groovy
@@ -42,7 +42,8 @@ def testSteps(String buildDir, List environment, String testList) {
 
 def buildSteps(int parallelism, List compilerVersions, String build_type, boolean build_shared_libs, boolean specialBranch, boolean coverage,
       boolean testing, String testList, boolean cppcheck, boolean sonar, boolean codestyle, boolean docs, boolean packagebuild, boolean sanitize,
-      boolean fuzzing, boolean benchmarking, boolean coredumps, boolean useBTF, boolean use_libursa, boolean forceDockerDevelopBuild, List environment) {
+      boolean fuzzing, boolean benchmarking, boolean coredumps, boolean useBTF, boolean use_libursa, boolean use_burrow,
+      boolean forceDockerDevelopBuild, List environment) {
   withEnv(environment) {
     def build, vars, utils, dockerUtils, doxygen
     stage('Prepare Linux environment') {
@@ -116,6 +117,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
             -DPACKAGE_TGZ=${cmakeBooleanOption[packagebuild]} \
             -DUSE_BTF=${cmakeBooleanOption[useBTF]} \
             -DUSE_LIBURSA=${cmakeBooleanOption[use_libursa]} \
+            -DUSE_BURROW=${cmakeBooleanOption[use_burrow]} \
             -DCMAKE_TOOLCHAIN_FILE=/opt/dependencies/scripts/buildsystems/vcpkg.cmake ${cmakeOptions}")
           build.cmakeBuild(buildDir, cmakeBuildOptions, parallelism)
         }

--- a/.jenkinsci/text-variables.groovy
+++ b/.jenkinsci/text-variables.groovy
@@ -279,6 +279,17 @@ cmd_description = """
       </ul>
    </li>
    <li>
+      <p><strong>use_burrow</strong> = false </p>
+      <ul>
+         <li>
+            <p>use Hyperledger Burrow Etherium Virtual Machine integration</p>
+         </li>
+         <li>
+            <p>Ex:use_burrow=true</p>
+         </li>
+      </ul>
+   </li>
+   <li>
       <p><strong>forceDockerDevelopBuild</strong> = false </p>
       <ul>
          <li>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,6 +158,7 @@ node ('master') {
   parallelism = 0
   useBTF = false
   use_libursa = false
+  use_burrow = false
   forceDockerDevelopBuild = false
 
   if (scmVars.GIT_LOCAL_BRANCH in ["master"] || env.TAG_NAME )
@@ -302,25 +303,30 @@ node ('master') {
   if(!x64linux_compiler_list.isEmpty()){
     x64LinuxBuildSteps = [{x64LinuxBuildScript.buildSteps(
       parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, x64linux_compiler_list, build_type, build_shared_libs, specialBranch, coverage,
-      testing, testList, cppcheck, sonar, codestyle, doxygen, packageBuild, sanitize, fuzzing, benchmarking, coredumps, useBTF, use_libursa, forceDockerDevelopBuild, environmentList)}]
+      testing, testList, cppcheck, sonar, codestyle, doxygen, packageBuild, sanitize, fuzzing, benchmarking, coredumps, useBTF, use_libursa, use_burrow,
+      forceDockerDevelopBuild, environmentList)}]
     //If "master" also run Release build
     if(specialBranch && build_type == 'Debug'){
       x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
       parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, x64linux_compiler_list, 'Release', build_shared_libs, specialBranch, false,
-      false, testList, false, false, false, false, true, false, false, false, false, false, use_libursa, false, environmentList)}]
+      false, testList, false, false, false, false, true, false, false, false, false, false, use_libursa, use_burrow, false, environmentList)}]
     }
     if (build_scenario == 'Before merge to trunk') {
       // TODO 2019-08-14 lebdron: IR-600 Fix integration tests execution when built with shared libraries
       // Build with shared libraries
       x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
       parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc7'], build_type, true, false, false,
-      false, testList, false, false, false, false, false, false, fuzzing, benchmarking, false, useBTF, use_libursa, false, environmentList)}]
+      false, testList, false, false, false, false, false, false, fuzzing, benchmarking, false, useBTF, use_libursa, use_burrow, false, environmentList)}]
       if (!use_libursa) {
         // Force build with libursa
         x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
         parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc7'], build_type, build_shared_libs, false, false,
-        testing, testList, false, false, false, false, false, false, fuzzing, benchmarking, coredumps, useBTF, true, false, environmentList)}]
+        testing, testList, false, false, false, false, false, false, fuzzing, benchmarking, coredumps, useBTF, true, use_burrow, false, environmentList)}]
       }
+      // toggle burrow
+      x64LinuxBuildSteps += [{x64LinuxBuildScript.buildSteps(
+      parallelism==0 ?x64LinuxWorker.cpusAvailable : parallelism, ['gcc7'], build_type, build_shared_libs, false, false,
+      testing, testList, false, false, false, false, false, false, fuzzing, benchmarking, coredumps, useBTF, use_libursa, !use_burrow, false, environmentList)}]
     }
     x64LinuxPostSteps = new Builder.PostSteps(
       always: [{x64LinuxBuildScript.alwaysPostSteps(scmVars, environmentList, coredumps)}],

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -42,6 +42,13 @@ RUN set -e; \
       apt-get -y clean; \
     fi
 
+# golang stuff
+RUN curl https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz | tar -C /opt -xz
+ENV GOPATH=/opt/gopath
+RUN mkdir ${GOPATH}
+ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
+RUN go get github.com/golang/protobuf/protoc-gen-go
+
 # install cmake 3.14.0
 RUN set -e; \
     curl -L -o /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.sh; \


### PR DESCRIPTION
### Description of the Change
- Add option to enable Hyperledger Burrow support in CMake for Linux builds
- Add step for "Before merge to trunk" scenario to use Burrow

### Benefits
Catch regressions regarding Burrow support

### Possible Drawbacks 
None