### PR TITLE
synchronizer: continue applying blocks after failure on halfway

### DIFF
--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -61,17 +61,17 @@ namespace iroha {
         const shared_model::interface::types::HeightType target_height,
         const PublicKeysRange &public_keys) {
       // TODO mboldyrev 21.03.2019 IR-423 Allow consensus outcome update
+      shared_model::interface::types::HeightType my_height = start_height;
+      auto storage = getStorage().value_or(nullptr);
+      if (not storage) {
+        return iroha::expected::makeError("Could not get mutable storage.");
+      }
+
       while (true) {
         // TODO andrei 17.10.18 IR-1763 Add delay strategy for loading blocks
         for (const auto &public_key : public_keys) {
-          auto storage = getStorage().value_or(nullptr);
-          if (not storage) {
-            return iroha::expected::makeError("Could not get mutable storage.");
-          }
-
-          shared_model::interface::types::HeightType my_height = start_height;
           auto network_chain =
-              block_loader_->retrieveBlocks(start_height, public_key)
+              block_loader_->retrieveBlocks(my_height, public_key)
                   .tap([&my_height](
                            const std::shared_ptr<shared_model::interface::Block>
                                &block) { my_height = block->height(); });

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -52,6 +52,8 @@ createMockMutableStorage() {
 }
 
 static constexpr shared_model::interface::types::HeightType kHeight{5};
+static constexpr shared_model::interface::types::HeightType kInitTopBlockHeight{
+    kHeight - 1};
 
 class SynchronizerTest : public ::testing::Test {
  public:
@@ -87,7 +89,7 @@ class SynchronizerTest : public ::testing::Test {
         .WillByDefault(Return(boost::make_optional(
             std::shared_ptr<iroha::ametsuchi::BlockQuery>(block_query))));
     ON_CALL(*block_query, getTopBlockHeight())
-        .WillByDefault(Return(kHeight - 1));
+        .WillByDefault(Return(kInitTopBlockHeight));
     ON_CALL(*mutable_factory, commit_(_))
         .WillByDefault(Return(ByMove(expected::makeValue(
             std::make_shared<LedgerState>(ledger_peers,
@@ -341,7 +343,7 @@ TEST_F(SynchronizerTest, ValidWhenValidChainMultipleBlocks) {
 TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(3);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
   {
     InSequence s;  // ensures the call order
     EXPECT_CALL(*chain_validator, validateAndApply(ChainEq({}), _))
@@ -370,6 +372,60 @@ TEST_F(SynchronizerTest, ExactlyThreeRetrievals) {
 }
 
 /**
+ * @given A commit from consensus and initialized components
+ * @when gate have voted for other block in the future
+ * @then retrieveBlocks called again after failure in block chain middle
+ */
+TEST_F(SynchronizerTest, FailureInMiddleOfChainThenSuccess) {
+  DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
+      SetFactory(&createMockMutableStorage);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
+
+  const size_t kConsensusHeight = kInitTopBlockHeight + 10;
+  const size_t kBadBlockNumber = 5;  // in the middle
+  const size_t kBadBlockHeight =
+      kInitTopBlockHeight + kBadBlockNumber;  // in the middle
+  std::vector<std::shared_ptr<shared_model::interface::Block>> chain_bad;
+  std::vector<std::shared_ptr<shared_model::interface::Block>> chain_good;
+
+  for (auto height = kInitTopBlockHeight + 1; height <= kConsensusHeight;
+       ++height) {
+    chain_bad.emplace_back(makeCommit(height));
+  }
+  for (auto height = kBadBlockHeight; height <= kConsensusHeight; ++height) {
+    chain_good.emplace_back(makeCommit(height));
+  }
+
+  {
+    InSequence s;  // ensures the call order
+
+    // first attempt: get blocks till kBadBlockHeight, then fail
+    EXPECT_CALL(*block_loader, retrieveBlocks(kInitTopBlockHeight, _))
+        .WillOnce(Return(rxcpp::observable<>::iterate(chain_bad)));
+    EXPECT_CALL(*chain_validator, validateAndApply(_, _))
+        .WillOnce([](auto chain, auto const &) {
+          chain.take(kBadBlockNumber).as_blocking().last();
+          return false;
+        });
+
+    // second attempt: request blocks from kBadBlockHeight and commit
+    EXPECT_CALL(*block_loader, retrieveBlocks(kBadBlockHeight, _))
+        .WillOnce(Return(rxcpp::observable<>::iterate(chain_good)));
+    EXPECT_CALL(*chain_validator, validateAndApply(ChainEq(chain_good), _))
+        .WillOnce(Return(true));
+  }
+
+  auto wrapper =
+      make_test_subscriber<CallExact>(synchronizer->on_commit_chain(), 1);
+  wrapper.subscribe();
+
+  gate_outcome.get_subscriber().on_next(consensus::VoteOther(
+      consensus::Round{kConsensusHeight, 1}, ledger_state, public_keys, hash));
+
+  ASSERT_TRUE(wrapper.validate());
+}
+
+/**
  * @given commit from the consensus and initialized components
  * @when synchronizer fails to download blocks more times than the peers amount
  * @then it will try until success
@@ -378,8 +434,7 @@ TEST_F(SynchronizerTest, RetrieveBlockSeveralFailures) {
   const size_t number_of_failures{ledger_peers.size() + 2};
   DefaultValue<expected::Result<std::unique_ptr<MutableStorage>, std::string>>::
       SetFactory(&createMockMutableStorage);
-  EXPECT_CALL(*mutable_factory, createMutableStorage())
-      .Times(number_of_failures + 1);
+  EXPECT_CALL(*mutable_factory, createMutableStorage()).Times(1);
   EXPECT_CALL(*block_loader, retrieveBlocks(_, _))
       .WillRepeatedly(Return(rxcpp::observable<>::just(commit_message)));
 


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

grpc does not support changing call deadline after the call was started. this means that for long calls, like blocks stream, we either should not use deadline, or be able to split long calls into shorter ones. This implements the second approach for synchronizer.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

when block loader is unable to provide the full chain before the call deadline, we can still apply it in parts with multiple calls, keeping the progress.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
