### PR TITLE
MST: fix rx usage to send state 

### DIFF
--- a/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
+++ b/irohad/multi_sig_transactions/impl/mst_processor_impl.cpp
@@ -3,32 +3,102 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <utility>
-
-#include "logger/logger.hpp"
 #include "multi_sig_transactions/mst_processor_impl.hpp"
 
+#include <utility>
+
+#include <rxcpp/operators/rx-filter.hpp>
+#include <rxcpp/operators/rx-flat_map.hpp>
+#include <rxcpp/operators/rx-map.hpp>
+#include <rxcpp/operators/rx-take.hpp>
+#include "logger/logger.hpp"
+
 using shared_model::interface::types::PublicKeyHexStringView;
+
+namespace {
+  using namespace iroha;
+
+  auto sendState(std::weak_ptr<logger::Logger> log,
+                 std::weak_ptr<network::MstTransport> transport,
+                 std::weak_ptr<MstStorage> storage,
+                 std::weak_ptr<MstTimeProvider> time_provider) {
+    return
+        [log_ = std::move(log),
+         transport_ = std::move(transport),
+         storage_ = std::move(storage),
+         time_provider_ = std::move(time_provider)](auto tpl)
+            -> rxcpp::observable<std::tuple<  // sent successfully
+                std::shared_ptr<shared_model::interface::Peer>,  // to this peer
+                MstState                                         // this state
+                >> {
+          auto &[dst_peer, size] = tpl;
+
+          auto log = log_.lock();
+          auto transport = transport_.lock();
+          auto storage = storage_.lock();
+          auto time_provider = time_provider_.lock();
+
+          if (log and transport and storage and time_provider) {
+            auto current_time = time_provider->getCurrentTime();
+            auto diff = storage->getDiffState(
+                PublicKeyHexStringView{dst_peer->pubkey()}, current_time);
+            if (not diff.isEmpty()) {
+              log->info("Propagate new data[{}]", size);
+              return transport->sendState(dst_peer, diff)
+                  .take(1)
+                  .filter([](auto is_ok) { return is_ok; })
+                  .map([dst_peer = std::move(dst_peer),
+                        diff = std::move(diff)](auto) {
+                    return std::make_tuple(std::move(dst_peer),
+                                           std::move(diff));
+                  });
+            }
+          }
+
+          return rxcpp::observable<>::empty<
+              std::tuple<std::shared_ptr<shared_model::interface::Peer>,
+                         MstState>>();
+        };
+  }
+
+  auto onSendStateResponse(std::weak_ptr<MstStorage> storage) {
+    return [storage_ = std::move(storage)](auto tpl) {
+      auto &[dst_peer, diff] = tpl;
+
+      auto storage = storage_.lock();
+      if (storage) {
+        storage->apply(PublicKeyHexStringView{dst_peer->pubkey()}, diff);
+      }
+    };
+  }
+}  // namespace
 
 namespace iroha {
 
   FairMstProcessor::FairMstProcessor(
-      std::shared_ptr<iroha::network::MstTransport> transport,
+      std::shared_ptr<network::MstTransport> transport,
       std::shared_ptr<MstStorage> storage,
       std::shared_ptr<PropagationStrategy> strategy,
       std::shared_ptr<MstTimeProvider> time_provider,
       logger::LoggerPtr log)
       : MstProcessor(log),  // use the same logger in base class
+        log_(std::move(log)),
         transport_(std::move(transport)),
         storage_(std::move(storage)),
         strategy_(std::move(strategy)),
         time_provider_(std::move(time_provider)),
-        propagation_subscriber_(strategy_->emitter().subscribe(
-            [this](auto data) { this->onPropagate(data); })),
-        log_(std::move(log)) {}
+        propagation_subscriber_(
+            strategy_->emitter()
+                .flat_map([](auto data) {
+                  return rxcpp::observable<>::iterate(data).map(
+                      [size = data.size()](auto dst_peer) {
+                        return std::make_tuple(std::move(dst_peer), size);
+                      });
+                })
+                .flat_map(sendState(log_, transport_, storage_, time_provider_))
+                .subscribe(onSendStateResponse(storage_))) {}
 
   FairMstProcessor::~FairMstProcessor() {
-    send_state_subscriber_.unsubscribe();
     propagation_subscriber_.unsubscribe();
   }
 
@@ -56,30 +126,6 @@ namespace iroha {
   auto FairMstProcessor::onExpiredBatchesImpl() const
       -> decltype(onExpiredBatches()) {
     return expired_subject_.get_observable();
-  }
-
-  // TODO [IR-1687] Akvinikym 10.09.18: three methods below should be one
-  void FairMstProcessor::completedBatchesNotify(ConstRefState state) const {
-    if (not state.isEmpty()) {
-      state.iterateBatches([this](const auto &batch) {
-        batches_subject_.get_subscriber().on_next(batch);
-      });
-    }
-  }
-
-  void FairMstProcessor::updatedBatchesNotify(ConstRefState state) const {
-    if (not state.isEmpty()) {
-      state_subject_.get_subscriber().on_next(
-          std::make_shared<MstState>(state));
-    }
-  }
-
-  void FairMstProcessor::expiredBatchesNotify(ConstRefState state) const {
-    if (not state.isEmpty()) {
-      state.iterateBatches([this](const auto &batch) {
-        expired_subject_.get_subscriber().on_next(batch);
-      });
-    }
   }
 
   bool FairMstProcessor::batchInStorageImpl(const DataType &batch) const {
@@ -112,27 +158,27 @@ namespace iroha {
 
   // -----------------------------| private api |-----------------------------
 
-  void FairMstProcessor::onPropagate(
-      const PropagationStrategy::PropagationData &data) {
-    auto current_time = time_provider_->getCurrentTime();
-    auto size = data.size();
-    for (auto const &dst_peer : data) {
-      auto diff = storage_->getDiffState(
-          PublicKeyHexStringView{dst_peer->pubkey()}, current_time);
-      if (not diff.isEmpty()) {
-        log_->info("Propagate new data[{}]", size);
-        transport_->sendState(*dst_peer, diff)
-            .subscribe(send_state_subscriber_,
-                       [storage = std::weak_ptr<MstStorage>(storage_),
-                        dst_peer,
-                        diff = std::move(diff)](auto is_ok) {
-                         auto s = storage.lock();
-                         if (is_ok and s) {
-                           s->apply(PublicKeyHexStringView{dst_peer->pubkey()},
-                                    diff);
-                         }
-                       });
-      }
+  // TODO [IR-1687] Akvinikym 10.09.18: three methods below should be one
+  void FairMstProcessor::completedBatchesNotify(ConstRefState state) const {
+    if (not state.isEmpty()) {
+      state.iterateBatches([this](const auto &batch) {
+        batches_subject_.get_subscriber().on_next(batch);
+      });
+    }
+  }
+
+  void FairMstProcessor::updatedBatchesNotify(ConstRefState state) const {
+    if (not state.isEmpty()) {
+      state_subject_.get_subscriber().on_next(
+          std::make_shared<MstState>(state));
+    }
+  }
+
+  void FairMstProcessor::expiredBatchesNotify(ConstRefState state) const {
+    if (not state.isEmpty()) {
+      state.iterateBatches([this](const auto &batch) {
+        expired_subject_.get_subscriber().on_next(batch);
+      });
     }
   }
 

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -65,12 +65,6 @@ namespace iroha {
     // -----------------------------| private api |-----------------------------
 
     /**
-     * Invoke when propagation strategy emit new data
-     * @param data - propagated data
-     */
-    void onPropagate(const PropagationStrategy::PropagationData &data);
-
-    /**
      * Notify subscribers when some of the batches received all necessary
      * signatures and ready to move forward
      * @param state with those batches
@@ -91,6 +85,8 @@ namespace iroha {
     void expiredBatchesNotify(ConstRefState state) const;
 
     // -------------------------------| fields |--------------------------------
+    logger::LoggerPtr log_;
+
     std::shared_ptr<iroha::network::MstTransport> transport_;
     std::shared_ptr<MstStorage> storage_;
     std::shared_ptr<PropagationStrategy> strategy_;
@@ -110,10 +106,6 @@ namespace iroha {
     /// use for tracking the propagation subscription
 
     rxcpp::composite_subscription propagation_subscriber_;
-
-    rxcpp::composite_subscription send_state_subscriber_;
-
-    logger::LoggerPtr log_;
   };
 }  // namespace iroha
 

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_stub.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_stub.cpp
@@ -14,7 +14,8 @@ namespace iroha {
         std::shared_ptr<MstTransportNotification>) {}
 
     rxcpp::observable<bool> MstTransportStub::sendState(
-        const shared_model::interface::Peer &, MstState const &) {
+        std::shared_ptr<shared_model::interface::Peer const>,
+        MstState const &) {
       return rxcpp::observable<>::just(true);
     }
   }  // namespace network

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -67,7 +67,7 @@ namespace iroha {
           std::shared_ptr<MstTransportNotification> notification) override;
 
       rxcpp::observable<bool> sendState(
-          shared_model::interface::Peer const &to,
+          std::shared_ptr<shared_model::interface::Peer const> to,
           MstState const &providing_state) override;
 
      private:
@@ -82,7 +82,7 @@ namespace iroha {
       std::shared_ptr<iroha::ametsuchi::TxPresenceCache> tx_presence_cache_;
       /// source peer key for MST propogation messages
       std::shared_ptr<Completer> mst_completer_;
-      const std::string my_key_;
+      std::string const my_key_;
 
       logger::LoggerPtr mst_state_logger_;  ///< Logger for created MstState
                                             ///< objects.
@@ -92,8 +92,8 @@ namespace iroha {
     };
 
     void sendStateAsync(
-        const shared_model::interface::Peer &to,
-        iroha::ConstRefState state,
+        shared_model::interface::Peer const &to,
+        MstState const &state,
         shared_model::interface::types::PublicKeyHexStringView sender_key,
         AsyncGrpcClient<google::protobuf::Empty> &async_call,
         std::function<void(grpc::Status &, google::protobuf::Empty &)>

--- a/irohad/multi_sig_transactions/transport/mst_transport_stub.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_stub.hpp
@@ -14,8 +14,9 @@ namespace iroha {
      public:
       void subscribe(std::shared_ptr<MstTransportNotification>) override;
 
-      rxcpp::observable<bool> sendState(const shared_model::interface::Peer &,
-                                        MstState const &) override;
+      rxcpp::observable<bool> sendState(
+          std::shared_ptr<shared_model::interface::Peer const>,
+          MstState const &) override;
     };
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/mst_transport.hpp
+++ b/irohad/network/mst_transport.hpp
@@ -55,7 +55,7 @@ namespace iroha {
        * @return true if transmission was successful, false otherwise
        */
       virtual rxcpp::observable<bool> sendState(
-          shared_model::interface::Peer const &to,
+          std::shared_ptr<shared_model::interface::Peer const> to,
           MstState const &providing_state) = 0;
 
       virtual ~MstTransport() = default;

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -307,7 +307,7 @@ namespace integration_framework {
     }
 
     void FakePeer::sendMstState(const iroha::MstState &state) {
-      mst_transport_->sendState(*real_peer_, state);
+      mst_transport_->sendState(real_peer_, state);
     }
 
     void FakePeer::sendYacState(

--- a/test/module/irohad/multi_sig_transactions/mock_mst_transport.hpp
+++ b/test/module/irohad/multi_sig_transactions/mock_mst_transport.hpp
@@ -14,10 +14,10 @@ namespace iroha {
    public:
     MOCK_METHOD1(subscribe,
                  void(std::shared_ptr<network::MstTransportNotification>));
-    MOCK_METHOD2(
-        sendState,
-        rxcpp::observable<bool>(const shared_model::interface::Peer &to,
-                                const MstState &providing_state));
+    MOCK_METHOD2(sendState,
+                 rxcpp::observable<bool>(
+                     std::shared_ptr<shared_model::interface::Peer const> to,
+                     const MstState &providing_state));
   };
 }  // namespace iroha
 

--- a/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
@@ -24,6 +24,7 @@ using namespace std::literals;
 using namespace iroha;
 using namespace framework::test_subscriber;
 
+using shared_model::interface::types::PeerList;
 using shared_model::interface::types::PublicKeyHexStringView;
 using testing::_;
 using testing::Return;
@@ -53,8 +54,8 @@ class MstProcessorTest : public testing::Test {
   const shared_model::interface::types::CounterType time_before = time_now - 1;
   const shared_model::interface::types::CounterType time_after = time_now + 1;
 
-  shared_model::interface::types::PublicKeyHexStringView another_peer_key_hex{
-      "another_pubkey"sv};
+  PublicKeyHexStringView another_peer_key_hex{"another_pubkey"sv};
+  PublicKeyHexStringView yet_another_peer_key_hex{"yet_another_pubkey"sv};
 
  protected:
   void SetUp() override {
@@ -325,6 +326,65 @@ TEST_F(MstProcessorTest, SendStateSuccess) {
   // ---------------------------------| then |----------------------------------
   ASSERT_TRUE(
       storage->getDiffState(another_peer_key_hex, time_after).isEmpty());
+}
+
+/**
+ * @given initialised mst processor
+ * AND our state contains one transaction
+ *
+ * @when received notification about new propagation with two peers
+ * AND transport successfully sent the state
+ *
+ * @then same diff is applied to storage
+ */
+TEST_F(MstProcessorTest, SendStateSuccessTwiceSamePropagation) {
+  // ---------------------------------| given |---------------------------------
+  auto quorum = 2u;
+  mst_processor->propagateBatch(addSignaturesFromKeyPairs(
+      makeTestBatch(txBuilder(1, time_after, quorum)), 0, makeKey()));
+  EXPECT_CALL(*transport, sendState(_, _))
+      .WillRepeatedly(Return(rxcpp::observable<>::just(true)));
+
+  // ---------------------------------| when |----------------------------------
+  propagation_subject.get_subscriber().on_next(
+      PeerList{makePeer("one", another_peer_key_hex),
+               makePeer("two", yet_another_peer_key_hex)});
+
+  // ---------------------------------| then |----------------------------------
+  ASSERT_TRUE(
+      storage->getDiffState(another_peer_key_hex, time_after).isEmpty());
+  ASSERT_TRUE(
+      storage->getDiffState(yet_another_peer_key_hex, time_after).isEmpty());
+}
+
+/**
+ * @given initialised mst processor
+ * AND our state contains one transaction
+ *
+ * @when received two notifications about new propagation with different peers
+ * AND transport successfully sent the state
+ *
+ * @then same diff is applied to storage
+ */
+TEST_F(MstProcessorTest, SendStateSuccessTwiceDifferentPropagations) {
+  // ---------------------------------| given |---------------------------------
+  auto quorum = 2u;
+  mst_processor->propagateBatch(addSignaturesFromKeyPairs(
+      makeTestBatch(txBuilder(1, time_after, quorum)), 0, makeKey()));
+  EXPECT_CALL(*transport, sendState(_, _))
+      .WillRepeatedly(Return(rxcpp::observable<>::just(true)));
+
+  // ---------------------------------| when |----------------------------------
+  propagation_subject.get_subscriber().on_next(
+      PeerList{makePeer("one", another_peer_key_hex)});
+  propagation_subject.get_subscriber().on_next(
+      PeerList{makePeer("two", yet_another_peer_key_hex)});
+
+  // ---------------------------------| then |----------------------------------
+  ASSERT_TRUE(
+      storage->getDiffState(another_peer_key_hex, time_after).isEmpty());
+  ASSERT_TRUE(
+      storage->getDiffState(yet_another_peer_key_hex, time_after).isEmpty());
 }
 
 /**

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -174,7 +174,7 @@ TEST_F(TransportTest, SendAndReceive) {
       grpc::testing::MockClientAsyncResponseReader<google::protobuf::Empty>>();
   EXPECT_CALL(*stub, AsyncSendStateRaw(_, _, _))
       .WillOnce(DoAll(SaveArg<1>(&request), Return(r.get())));
-  transport->sendState(*peer, state).subscribe();
+  transport->sendState(peer, state).subscribe();
   auto response = transport->SendState(&context, &request, nullptr);
   ASSERT_EQ(response.error_code(), grpc::StatusCode::OK);
 }


### PR DESCRIPTION
### Description of the Change
Fix the changes done in https://github.com/hyperledger/iroha/pull/442
`composite_subscription` was unsubscribed after the first response, leading to all subsequent calls to `sendState` being not done. A more idiomatic approach with `flat_map` is used now.

### Benefits
MST propagates state more than once...

### Possible Drawbacks 
`MstState` is copied to callback for example, but a more efficient solution will require changes in interfaces