### PR TITLE
Fixes integration test with asset creation with several peers

### DIFF
--- a/iroha/src/config.rs
+++ b/iroha/src/config.rs
@@ -42,8 +42,10 @@ pub struct Configuration {
     pub trusted_peers: Vec<PeerId>,
     /// Maximum amount of peers to fail and do not compromise the consensus.
     pub max_faulty_peers: usize,
-    public_key: PublicKey,
-    private_key: PrivateKey,
+    /// Public key of this peer. Should be the same as in `peer_id`
+    pub public_key: PublicKey,
+    /// Private key of this peer.
+    pub private_key: PrivateKey,
 }
 
 impl Configuration {

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -598,7 +598,7 @@ mod tests {
             .expect("Failed to accept tx.")])
             .await
             .expect("Round failed.");
-        async_std::task::sleep(Duration::from_millis(1000)).await;
+        async_std::task::sleep(Duration::from_millis(2000)).await;
         for block_counter in block_counters {
             assert_eq!(*block_counter.write().await, 1);
         }
@@ -683,7 +683,7 @@ mod tests {
             .expect("Failed to accept tx.")])
             .await
             .expect("Round failed.");
-        async_std::task::sleep(COMMIT_TIME + Duration::from_millis(1000)).await;
+        async_std::task::sleep(COMMIT_TIME + Duration::from_millis(2000)).await;
         for block_counter in block_counters {
             // No blocks are committed as there was a commit timeout for current block
             assert_eq!(*block_counter.write().await, 0u8);

--- a/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
+++ b/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
@@ -1,16 +1,14 @@
 #[cfg(test)]
 mod tests {
     use async_std::task;
-    use iroha::{isi, peer::PeerId, prelude::*};
+    use iroha::{crypto, isi, peer::PeerId, prelude::*};
     use iroha_client::client::{self, Client};
-    use std::thread;
     use tempfile::TempDir;
 
     const CONFIGURATION_PATH: &str = "tests/test_config.json";
     const N_PEERS: usize = 4;
     const MAX_FAULTS: usize = 1;
 
-    #[ignore]
     #[async_std::test]
     //TODO: use cucumber to write `gherkin` instead of code.
     async fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_another_peer(
@@ -18,8 +16,8 @@ mod tests {
         // Given
         let mut configuration =
             Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
-        let peers = create_and_start_iroha_peers(N_PEERS);
-        thread::sleep(std::time::Duration::from_millis(1000));
+        let peers = create_and_start_iroha_peers(N_PEERS).await;
+        task::sleep(std::time::Duration::from_millis(1000)).await;
         let domain_name = "domain";
         let create_domain = isi::Add {
             object: Domain::new(domain_name.to_string()),
@@ -47,9 +45,10 @@ mod tests {
             ])
             .await
             .expect("Failed to prepare state.");
-        std::thread::sleep(std::time::Duration::from_millis(
-            &configuration.block_build_step_ms * 2,
-        ));
+        task::sleep(std::time::Duration::from_millis(
+            configuration.block_build_step_ms * 20,
+        ))
+        .await;
         //When
         let quantity: u128 = 200;
         let mint_asset = isi::Mint {
@@ -60,9 +59,10 @@ mod tests {
             .submit(mint_asset.into())
             .await
             .expect("Failed to create asset.");
-        std::thread::sleep(std::time::Duration::from_millis(
-            &configuration.block_build_step_ms * 2,
-        ));
+        task::sleep(std::time::Duration::from_millis(
+            configuration.block_build_step_ms * 20,
+        ))
+        .await;
         //Then
         let mut configuration =
             Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
@@ -81,32 +81,37 @@ mod tests {
         );
     }
 
-    fn create_and_start_iroha_peers(n_peers: usize) -> Vec<PeerId> {
-        let peer_ids: Vec<PeerId> = (0..n_peers)
-            .map(|i| PeerId {
+    async fn create_and_start_iroha_peers(n_peers: usize) -> Vec<PeerId> {
+        let peer_keys: Vec<(PublicKey, PrivateKey)> = (0..n_peers)
+            .map(|_| crypto::generate_key_pair().expect("Failed to generate key pair."))
+            .collect();
+        let peer_ids: Vec<PeerId> = peer_keys
+            .iter()
+            .enumerate()
+            .map(|(i, (public_key, _))| PeerId {
                 address: format!("127.0.0.1:{}", 1338 + i),
-                public_key: [
-                    101, 170, 80, 164, 103, 38, 73, 61, 223, 133, 83, 139, 247, 77, 176, 84, 117,
-                    15, 22, 28, 155, 125, 80, 226, 40, 26, 61, 248, 40, 159, 58, 53,
-                ],
+                public_key: public_key.clone(),
             })
             .collect();
-        for peer_id in peer_ids.clone() {
+        for (peer_id, (public_key, private_key)) in peer_ids.iter().zip(peer_keys) {
             let peer_ids = peer_ids.clone();
-            thread::spawn(move || {
+            let peer_id = peer_id.clone();
+            task::spawn(async move {
                 let temp_dir = TempDir::new().expect("Failed to create TempDir.");
                 let mut configuration = Configuration::from_path(CONFIGURATION_PATH)
                     .expect("Failed to load configuration.");
                 configuration.kura_block_store_path(temp_dir.path());
                 configuration.peer_id(peer_id.clone());
+                configuration.public_key = public_key;
+                configuration.private_key = private_key;
                 configuration.trusted_peers(peer_ids.clone());
                 configuration.max_faulty_peers(MAX_FAULTS);
                 let iroha = Iroha::new(configuration);
-                task::block_on(iroha.start()).expect("Failed to start Iroha.");
+                iroha.start().await;
                 //Prevents temp_dir from clean up untill the end of the tests.
                 loop {}
             });
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            task::sleep(std::time::Duration::from_millis(100)).await;
         }
         peer_ids.clone()
     }


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Problems and fixes:
1. task::spawn not executing -> `futures::join`
2. keys were not generated in the test -> are generated now
3. Sumeragi was constantly locked, so handle_message was not called -> introduced time interval

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
