### PR TITLE
synchronizer: continue applying blocks after failure on halfway

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -113,12 +113,12 @@ namespace iroha {
         rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
             blocks,
         MutableStoragePredicate predicate) {
-      return withSavepoint([&] {
-        return blocks
-            .all([&](auto block) { return this->apply(block, predicate); })
-            .as_blocking()
-            .first();
-      });
+      return blocks
+          .all([&](auto block) {
+            return withSavepoint([&] { return this->apply(block, predicate); });
+          })
+          .as_blocking()
+          .first();
     }
 
     boost::optional<std::shared_ptr<const iroha::LedgerState>>

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -51,11 +51,11 @@ namespace iroha {
        * @param public_keys - public keys of peers from which to ask the blocks
        * @return Result of committing the downloaded blocks.
        */
-      template <typename PublicKeysRange>
       ametsuchi::CommitResult downloadAndCommitMissingBlocks(
           const shared_model::interface::types::HeightType start_height,
           const shared_model::interface::types::HeightType target_height,
-          const PublicKeysRange &public_keys);
+          const shared_model::interface::types::PublicKeyCollectionType
+              &public_keys);
 
       void processNext(const consensus::PairValid &msg);
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -254,6 +254,9 @@ namespace integration_framework {
             ->getChild("at " + format_address(kLocalHost, port)));
     fake_peer->initialize();
     fake_peers_.emplace_back(fake_peer);
+    log_->debug("Added a fake peer at {} with {}.",
+                fake_peer->getAddress(),
+                fake_peer->getKeypair().publicKey());
     return fake_peer;
   }
 

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -143,6 +143,17 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
             .build();
       };
 
+  // Add a common block committed before fork but without the real peer:
+  valid_block_storage->storeBlock(std::make_shared<shared_model::proto::Block>(
+      sign_block_by_peers(
+          build_block(
+              valid_block_storage->getTopBlock(),
+              {complete(baseTx(kAdminId).transferAsset(
+                            kAdminId, kUserId, kAssetId, "valid_tx3", "3.0"),
+                        kAdminKeypair)}),
+          good_fake_peers)
+          .finish()));
+
   // Create the malicious fork of the ledger:
   auto bad_block_storage =
       std::make_shared<fake_peer::BlockStorage>(*valid_block_storage);
@@ -151,7 +162,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "bad_tx3", "300.0"),
+                            kAdminId, kUserId, kAssetId, "bad_tx4", "300.0"),
                         kAdminKeypair)}),
           bad_fake_peers)
           .finish()));
@@ -165,7 +176,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "valid_tx3", "3.0"),
+                            kAdminId, kUserId, kAssetId, "valid_tx4", "3.0"),
                         kAdminKeypair)}),
           good_fake_peers)
           .finish()));
@@ -179,7 +190,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "valid_tx4", "4.0"),
+                            kAdminId, kUserId, kAssetId, "valid_tx5", "4.0"),
                         kAdminKeypair)})
               .signAndAddSignature(rantipole_peer->getKeypair()),
           good_fake_peers)


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

this is a port of #511 

### Description of the Change

grpc does not support changing call deadline after the call was started. this means that for long calls, like blocks stream, we either should not use deadline, or be able to split long calls into shorter ones. This implements the second approach for synchronizer.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

when block loader is unable to provide the full chain before the call deadline, we can still apply it in parts with multiple calls, keeping the progress.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
