### PR TITLE
fixup! synchronizer: continue applying blocks after failure on halfway

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -112,12 +112,12 @@ namespace iroha {
         rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
             blocks,
         MutableStoragePredicate predicate) {
-      return withSavepoint([&] {
-        return blocks
-            .all([&](auto block) { return this->apply(block, predicate); })
-            .as_blocking()
-            .first();
-      });
+      return blocks
+          .all([&](auto block) {
+            return withSavepoint([&] { return this->apply(block, predicate); });
+          })
+          .as_blocking()
+          .first();
     }
 
     boost::optional<std::shared_ptr<const iroha::LedgerState>>

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -76,9 +76,13 @@ namespace iroha {
                            const std::shared_ptr<shared_model::interface::Block>
                                &block) { my_height = block->height(); });
 
-          if (validator_->validateAndApply(network_chain, *storage)
-              and my_height >= target_height) {
-            return mutable_factory_->commit(std::move(storage));
+          if (validator_->validateAndApply(network_chain, *storage)) {
+            if (my_height >= target_height) {
+              return mutable_factory_->commit(std::move(storage));
+            }
+          } else {
+            // last block did not apply - need to ask it again
+            my_height = std::max(my_height - 1, start_height);
           }
         }
       }

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -133,6 +133,17 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
             .build();
       };
 
+  // Add a common block committed before fork but without the real peer:
+  valid_block_storage->storeBlock(std::make_shared<shared_model::proto::Block>(
+      sign_block_by_peers(
+          build_block(
+              valid_block_storage->getTopBlock(),
+              {complete(baseTx(kAdminId).transferAsset(
+                            kAdminId, kUserId, kAssetId, "valid_tx3", "3.0"),
+                        kAdminKeypair)}),
+          good_fake_peers)
+          .finish()));
+
   // Create the malicious fork of the ledger:
   auto bad_block_storage =
       std::make_shared<fake_peer::BlockStorage>(*valid_block_storage);
@@ -141,7 +152,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "bad_tx3", "300.0"),
+                            kAdminId, kUserId, kAssetId, "bad_tx4", "300.0"),
                         kAdminKeypair)}),
           bad_fake_peers)
           .finish()));
@@ -155,7 +166,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "valid_tx3", "3.0"),
+                            kAdminId, kUserId, kAssetId, "valid_tx4", "3.0"),
                         kAdminKeypair)}),
           good_fake_peers)
           .finish()));
@@ -169,7 +180,7 @@ TEST_F(FakePeerFixture, SynchronizeTheRightVersionOfForkedLedger) {
           build_block(
               valid_block_storage->getTopBlock(),
               {complete(baseTx(kAdminId).transferAsset(
-                            kAdminId, kUserId, kAssetId, "valid_tx4", "4.0"),
+                            kAdminId, kUserId, kAssetId, "valid_tx5", "4.0"),
                         kAdminKeypair)})
               .signAndAddSignature(rantipole_peer->getKeypair()),
           good_fake_peers)

--- a/test/module/irohad/synchronizer/synchronizer_test.cpp
+++ b/test/module/irohad/synchronizer/synchronizer_test.cpp
@@ -409,7 +409,10 @@ TEST_F(SynchronizerTest, FailureInMiddleOfChainThenSuccess) {
         });
 
     // second attempt: request blocks from kBadBlockHeight and commit
-    EXPECT_CALL(*block_loader, retrieveBlocks(kBadBlockHeight, _))
+    const auto kRetrieveBlocksArg =
+        kBadBlockHeight - 1;  // for whatever reason, to request blocks starting
+                              // with N, we need to pass N-1...
+    EXPECT_CALL(*block_loader, retrieveBlocks(kRetrieveBlocksArg, _))
         .WillOnce(Return(rxcpp::observable<>::iterate(chain_good)));
     EXPECT_CALL(*chain_validator, validateAndApply(ChainEq(chain_good), _))
         .WillOnce(Return(true));


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

fix of #511 

logical error because of 
- unexpected counterintuitive behaviour of block loader, when it asks blocks after the given value
- mutable storage impl on failure reverting whole sequence of blocks from WSV but keeping in block storage.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
