### PR TITLE
MST tests: wait for commit before get pending query

### DIFF
--- a/test/integration/pipeline/multisig_tx_pipeline_test.cpp
+++ b/test/integration/pipeline/multisig_tx_pipeline_test.cpp
@@ -299,6 +299,8 @@ TEST_F(MstPipelineTest, OldGetPendingTxsNoSignedTxs) {
         ASSERT_EQ(proposal->transactions().size(), 1);
         ASSERT_EQ(proposal->transactions()[0].hash(), user_tx.hash());
       })
+      .skipVerifiedProposal()
+      .skipBlock()
       .sendQuery(makeGetPendingTxsQuery(kUserId, kUserKeypair), oldNoTxsCheck);
 }
 
@@ -327,6 +329,8 @@ TEST_F(MstPipelineTest, OldReplayViaFullySignedTransaction) {
         ASSERT_EQ(proposal->transactions().size(), 1);
         ASSERT_EQ(proposal->transactions()[0].hash(), fully_signed_tx.hash());
       })
+      .skipVerifiedProposal()
+      .skipBlock()
       .sendQuery(makeGetPendingTxsQuery(kUserId, kUserKeypair), oldNoTxsCheck);
 }
 
@@ -403,6 +407,8 @@ TEST_F(MstPipelineTest, GetPendingTxsNoSignedTxs) {
         ASSERT_EQ(proposal->transactions().size(), 1);
         ASSERT_EQ(proposal->transactions()[0].hash(), user_tx.hash());
       })
+      .skipVerifiedProposal()
+      .skipBlock()
       .sendQuery(makeGetPendingTxsQuery(kUserId, kUserKeypair, kPageSize),
                  noTxsCheck);
 }
@@ -431,6 +437,8 @@ TEST_F(MstPipelineTest, ReplayViaFullySignedTransaction) {
         ASSERT_EQ(proposal->transactions().size(), 1);
         ASSERT_EQ(proposal->transactions()[0].hash(), fully_signed_tx.hash());
       })
+      .skipVerifiedProposal()
+      .skipBlock()
       .sendQuery(makeGetPendingTxsQuery(kUserId, kUserKeypair, kPageSize),
                  noTxsCheck);
 }


### PR DESCRIPTION
### Description of the Change
Pending storage is cleared after commit now. Tests depended on previous logic when pending storage was cleared when proposal was received. Tests now wait for commit before making pending transactions queries.

### Benefits
Less nondeterministic behavior

### Possible Drawbacks 
None