### PR TITLE
Support/1.0.x

### DIFF
--- a/.jenkinsci-new/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci-new/builders/x64-linux-build-steps.groovy
@@ -128,7 +128,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
       }
     } // end iC.inside
     stage ('Docker ManifestPush'){
-      if (specialBranch || forceDockerDevelopBuild) {
+      if (specialBranch && !env.TAG_NAME || forceDockerDevelopBuild) {
         utils.dockerPush(iC, "${platform}-develop-build")
         dockerManifestPush(iC, "develop-build", environment)
       }

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -257,7 +257,7 @@ RUN set -e; \
     java -version
 
 RUN set -e; \
-    add-apt-repository -y ppa:jonathonf/python-3.6; \
+    add-apt-repository -y ppa:deadsnakes/ppa; \
     apt-get update; \
     apt-get -y install python3.6-dev
 

--- a/irohad/multi_sig_transactions/mst_processor_impl.hpp
+++ b/irohad/multi_sig_transactions/mst_processor_impl.hpp
@@ -55,7 +55,7 @@ namespace iroha {
     // ------------------| MstTransportNotification override |------------------
 
     void onNewState(const shared_model::crypto::PublicKey &from,
-                    ConstRefState new_state) override;
+                    MstState new_state) override;
 
     // ----------------------------| end override |-----------------------------
 

--- a/irohad/network/mst_transport.hpp
+++ b/irohad/network/mst_transport.hpp
@@ -23,9 +23,8 @@ namespace iroha {
        * @param from - key of the peer emitted the state
        * @param new_state - state propagated from peer
        */
-      virtual void onNewState(
-          const shared_model::crypto::PublicKey &from,
-          const MstState &new_state) = 0;
+      virtual void onNewState(const shared_model::crypto::PublicKey &from,
+                              MstState new_state) = 0;
 
       virtual ~MstTransportNotification() = default;
     };

--- a/test/framework/integration_framework/fake_peer/network/mst_message.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_message.hpp
@@ -12,9 +12,8 @@
 namespace integration_framework {
   namespace fake_peer {
     struct MstMessage final {
-      MstMessage(const shared_model::crypto::PublicKey &f,
-                 const iroha::MstState &s)
-          : from(f), state(s) {}
+      MstMessage(const shared_model::crypto::PublicKey &f, iroha::MstState s)
+          : from(f), state(std::move(s)) {}
       shared_model::crypto::PublicKey from;
       iroha::MstState state;
     };

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.cpp
@@ -10,10 +10,10 @@ namespace integration_framework {
 
     void MstNetworkNotifier::onNewState(
         const shared_model::crypto::PublicKey &from,
-        const iroha::MstState &new_state) {
+        iroha::MstState new_state) {
       std::lock_guard<std::mutex> guard(mst_subject_mutex_);
       mst_subject_.get_subscriber().on_next(
-          std::make_shared<MstMessage>(from, new_state));
+          std::make_shared<MstMessage>(from, std::move(new_state)));
     }
 
     rxcpp::observable<std::shared_ptr<MstMessage>>

--- a/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/mst_network_notifier.hpp
@@ -21,7 +21,7 @@ namespace integration_framework {
         : public iroha::network::MstTransportNotification {
      public:
       void onNewState(const shared_model::crypto::PublicKey &from,
-                      const iroha::MstState &new_state) override;
+                      iroha::MstState new_state) override;
 
       rxcpp::observable<std::shared_ptr<MstMessage>> getObservable();
 

--- a/test/framework/test_subscriber.hpp
+++ b/test/framework/test_subscriber.hpp
@@ -138,6 +138,10 @@ namespace framework {
         subscription_.unsubscribe();
       }
 
+      auto reason() {
+        return strategy_->invalidate_reason_;
+      }
+
      private:
       Observable unwrapped_;
       std::unique_ptr<VerificationStrategy<T>> strategy_;

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -33,7 +33,7 @@ namespace iroha {
    public:
     MOCK_METHOD2(onNewState,
                  void(const shared_model::crypto::PublicKey &from,
-                      const MstState &state));
+                      MstState state));
   };
 
   /**

--- a/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/mst_processor_test.cpp
@@ -93,9 +93,12 @@ auto initObservers(std::shared_ptr<FairMstProcessor> mst_processor,
  */
 template <typename T>
 void check(T &t) {
-  ASSERT_TRUE(std::get<0>(t).validate());
-  ASSERT_TRUE(std::get<1>(t).validate());
-  ASSERT_TRUE(std::get<2>(t).validate());
+  ASSERT_TRUE(std::get<0>(t).validate())
+      << "onStateUpdate" << std::get<0>(t).reason();
+  ASSERT_TRUE(std::get<1>(t).validate())
+      << "onPreparedBatches" << std::get<1>(t).reason();
+  ASSERT_TRUE(std::get<2>(t).validate())
+      << "onExpiredBatches" << std::get<2>(t).reason();
 }
 
 /**
@@ -344,5 +347,30 @@ TEST_F(MstProcessorTest, receivedOutdatedState) {
 
   // ---------------------------------| then |----------------------------------
   EXPECT_FALSE(storage->batchInStorage(expired_batch));
+  check(observers);
+}
+
+/**
+ * @given initialized mst processor with two incomplete transactions in the
+ * state
+ *
+ * @when one of them is received from another peer
+ *
+ * @then no observables are triggered
+ */
+TEST_F(MstProcessorTest, receivedOneOfExistingTxs) {
+  const auto batch = addSignaturesFromKeyPairs(
+      makeTestBatch(txBuilder(1, time_now, 2)), 0, makeKey());
+  mst_processor->propagateBatch(batch);
+  mst_processor->propagateBatch(addSignaturesFromKeyPairs(
+      makeTestBatch(txBuilder(2, time_now, 2)), 0, makeKey()));
+
+  auto received_state = MstState::empty(getTestLogger("MstState"),
+                                        std::make_shared<TestCompleter>());
+  received_state += batch;
+  auto observers = initObservers(mst_processor, 0, 0, 0);
+  shared_model::crypto::PublicKey another_peer_key("another_pubkey");
+  mst_processor->onNewState(another_peer_key, received_state);
+
   check(observers);
 }


### PR DESCRIPTION
#!/usr/bin/env groovy
/**
 * Copyright Soramitsu Co., Ltd. All Rights Reserved.
 * SPDX-License-Identifier: Apache-2.0
 */

//
// Linux Build steps
//

def dockerManifestPush(dockerImageObj, String dockerTag, environment) {
  def manifest = load ".jenkinsci-new/utils/docker-manifest.groovy"
  withEnv(environment) {
    if (manifest.manifestSupportEnabled()) {
      manifest.manifestCreate("${env.DOCKER_REGISTRY_BASENAME}:${dockerTag}",
        ["${env.DOCKER_REGISTRY_BASENAME}:x86_64-${dockerTag}"])
      manifest.manifestAnnotate("${env.DOCKER_REGISTRY_BASENAME}:${dockerTag}",
        [
          [manifest: "${env.DOCKER_REGISTRY_BASENAME}:x86_64-${dockerTag}",
           arch: 'amd64', os: 'linux', osfeatures: [], variant: ''],
        ])
      withCredentials([usernamePassword(credentialsId: 'docker-hub-credentials', usernameVariable: 'login', passwordVariable: 'password')]) {
        manifest.manifestPush("${env.DOCKER_REGISTRY_BASENAME}:${dockerTag}", login, password)
      }
    }
    else {
      echo('[WARNING] Docker CLI does not support manifest management features. Manifest will not be updated')
    }
  }
}

def testSteps(String buildDir, List environment, String testList) {
  withEnv(environment) {
    sh "cd ${buildDir}; ctest --output-on-failure --no-compress-output --tests-regex '${testList}'  --test-action Test || true"
    sh """ python .jenkinsci-new/helpers/platform_tag.py "Linux \$(uname -m)" \$(ls ${buildDir}/Testing/*/Test.xml) """
    // Mark build as UNSTABLE if there are any failed tests (threshold <100%)
    xunit testTimeMargin: '3000', thresholdMode: 2, thresholds: [passed(unstableThreshold: '100')], \
      tools: [CTest(deleteOutputFiles: true, failIfNotNew: false, \
      pattern: "${buildDir}/Testing/**/Test.xml", skipNoTestFiles: false, stopProcessingIfError: true)]
  }
}

def buildSteps(int parallelism, List compilerVersions, String build_type, boolean specialBranch, boolean coverage,
      boolean testing, String testList, boolean cppcheck, boolean sonar, boolean docs, boolean packagebuild,
      boolean sanitize, boolean fuzzing, boolean coredumps, boolean useBTF, boolean forceDockerDevelopBuild, List environment) {
  withEnv(environment) {
    scmVars = checkout scm
    def build = load '.jenkinsci-new/build.groovy'
    def vars = load ".jenkinsci-new/utils/vars.groovy"
    def utils = load ".jenkinsci-new/utils/utils.groovy"
    def dockerUtils = load ".jenkinsci-new/utils/docker-pull-or-build.groovy"
    def doxygen = load ".jenkinsci-new/utils/doxygen.groovy"
    buildDir = 'build'
    compilers = vars.compilerMapping()
    cmakeBooleanOption = [ (true): 'ON', (false): 'OFF' ]
    platform = sh(script: 'uname -m', returnStdout: true).trim()
    cmakeBuildOptions = ""
    cmakeOptions = ""
    if (packagebuild){
      cmakeBuildOptions = " --target package "
    }
    if (sanitize){
      cmakeOptions += " -DSANITIZE='address;leak' "
    }
    // enable coredumps collecting
    if (coredumps) {
      sh "echo %e.%p.coredump > /proc/sys/kernel/core_pattern"
      sh "ulimit -c unlimited"
    }
    // Create postgres
    // enable prepared transactions so that 2 phase commit works
    // we set it to 100 as a safe value
    sh """#!/bin/bash -xe
      if [ ! "\$(docker ps -q -f name=${env.IROHA_POSTGRES_HOST})" ]; then
        docker network create ${env.IROHA_NETWORK}
        docker run -td -e POSTGRES_USER=${env.IROHA_POSTGRES_USER} \
           -e POSTGRES_PASSWORD=${env.IROHA_POSTGRES_PASSWORD} --name ${env.IROHA_POSTGRES_HOST} \
           --network=${env.IROHA_NETWORK} postgres:9.5 -c 'max_prepared_transactions=100'
      fi
    """

    iC = dockerUtils.dockerPullOrBuild("${platform}-develop-build",
        "${env.GIT_RAW_BASE_URL}/${scmVars.GIT_COMMIT}/docker/develop/Dockerfile",
        "${env.GIT_RAW_BASE_URL}/${utils.previousCommitOrCurrent(scmVars)}/docker/develop/Dockerfile",
        "${env.GIT_RAW_BASE_URL}/develop/docker/develop/Dockerfile",
        scmVars,
        environment,
        forceDockerDevelopBuild,
        ['PARALLELISM': parallelism])

    iC.inside(""
    + " -e IROHA_POSTGRES_HOST=${env.IROHA_POSTGRES_HOST}"
    + " -e IROHA_POSTGRES_PORT=${env.IROHA_POSTGRES_PORT}"
    + " -e IROHA_POSTGRES_USER=${env.IROHA_POSTGRES_USER}"
    + " -e IROHA_POSTGRES_PASSWORD=${env.IROHA_POSTGRES_PASSWORD}"
    + " --network=${env.IROHA_NETWORK}"
    + " -v /var/jenkins/ccache:${env.CCACHE_DEBUG_DIR}") {
      utils.ccacheSetup(5)
      for (compiler in compilerVersions) {
        stage ("build ${compiler}"){
          build.cmakeConfigure(buildDir, "-DCMAKE_CXX_COMPILER=${compilers[compiler]['cxx_compiler']} \
            -DCMAKE_C_COMPILER=${compilers[compiler]['cc_compiler']} \
            -DCMAKE_BUILD_TYPE=${build_type} \
            -DCOVERAGE=${cmakeBooleanOption[coverage]} \
            -DTESTING=${cmakeBooleanOption[testing]} \
            -DFUZZING=${cmakeBooleanOption[fuzzing]} \
            -DPACKAGE_DEB=${cmakeBooleanOption[packagebuild]} \
            -DPACKAGE_TGZ=${cmakeBooleanOption[packagebuild]} \
            -DUSE_BTF=${cmakeBooleanOption[useBTF]} ${cmakeOptions}")
          build.cmakeBuild(buildDir, cmakeBuildOptions, parallelism)
        }
        if (testing) {
          stage("Test ${compiler}") {
            coverage ? build.initialCoverage(buildDir) : echo('Skipping initial coverage...')
            testSteps(buildDir, environment, testList)
            coverage ? build.postCoverage(buildDir, '/tmp/lcov_cobertura.py') : echo('Skipping post coverage...')
            // We run coverage once, using the first compiler as it is enough
            coverage = false
          }
        } //end if
      } //end for
      stage("Analysis") {
            cppcheck ? build.cppCheck(buildDir, parallelism) : echo('Skipping Cppcheck...')
            sonar ? build.sonarScanner(scmVars, environment) : echo('Skipping Sonar Scanner...')
      }
      stage('Build docs'){
        docs ? doxygen.doDoxygen(specialBranch, scmVars.GIT_LOCAL_BRANCH) : echo("Skipping Doxygen...")
      }
    } // end iC.inside
    stage ('Docker ManifestPush'){
      if (specialBranch && !env.TAG_NAME || forceDockerDevelopBuild) {
        utils.dockerPush(iC, "${platform}-develop-build")
        dockerManifestPush(iC, "develop-build", environment)
      }
    }
  }
}

def successPostSteps(scmVars, boolean packagePush, String dockerTag, List environment) {
  stage('Linux success PostSteps') {
    withEnv(environment) {
      if (packagePush) {
        def artifacts = load ".jenkinsci-new/artifacts.groovy"
        def utils = load ".jenkinsci-new/utils/utils.groovy"
        platform = sh(script: 'uname -m', returnStdout: true).trim()
        def commit = scmVars.GIT_COMMIT

        // if we use several compilers only the last compiler, used for the build, will be used for iroha.deb and iroha.tar.gz archives
        sh """
          ls -lah ./build
          mv ./build/iroha-*.deb ./build/iroha.deb
          mv ./build/iroha-*.tar.gz ./build/iroha.tar.gz
          cp ./build/iroha.deb docker/release/iroha.deb
          mkdir -p build/artifacts
          mv ./build/iroha.deb ./build/iroha.tar.gz build/artifacts
        """
        // publish docker
        iCRelease = docker.build("${env.DOCKER_REGISTRY_BASENAME}:${commit}-${env.BUILD_NUMBER}-release", "--no-cache -f docker/release/Dockerfile ${WORKSPACE}/docker/release")
        utils.dockerPush(iCRelease, "${platform}-${dockerTag}")
        dockerManifestPush(iCRelease, dockerTag, environment)
        sh "docker rmi ${iCRelease.id}"

        // publish packages
        filePaths = [ './build/artifacts/iroha.deb', './build/artifacts/iroha.tar.gz' ]
        artifacts.uploadArtifacts(filePaths, sprintf('/iroha/linux/%4$s/%1$s-%2$s-%3$s', [scmVars.GIT_LOCAL_BRANCH, sh(script: 'date "+%Y%m%d"', returnStdout: true).trim(), commit.substring(0,6), platform]))
      } else {
        archiveArtifacts artifacts: 'build/iroha*.tar.gz', allowEmptyArchive: true
        archiveArtifacts artifacts: 'build/iroha*.deb', allowEmptyArchive: true
      }
    }
  }
}

def alwaysPostSteps(scmVars, List environment, boolean coredumps) {
  stage('Linux always PostSteps') {
    // handling coredumps (if tests crashed)
    if (currentBuild.currentResult != "SUCCESS" && coredumps) {
      def dumpsFileName = sprintf('coredumps-%1$s.bzip2',
        [scmVars.GIT_COMMIT.substring(0,8)])

      sh(script: "echo 'build/bin' > coredumps.upload")
      sh(script: "find . -type f -name '*.coredump' -exec echo '{}' \\; >> coredumps.upload")
      sh(script: "tar -cjvf ${dumpsFileName} -T coredumps.upload")
      if( fileExists(dumpsFileName)) {
        withCredentials([usernamePassword(credentialsId: 'ci_nexus', passwordVariable: 'NEXUS_PASS', usernameVariable: 'NEXUS_USER')]) {
          sh(script: "curl -u ${NEXUS_USER}:${NEXUS_PASS} --upload-file ${WORKSPACE}/${dumpsFileName} https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}")
        }
        echo "Build is not SUCCESS! Download core dumps at: https://nexus.iroha.tech/repository/artifacts/iroha/coredumps/${dumpsFileName}"
      }
    }
    withEnv(environment) {
      sh "docker rm -f ${env.IROHA_POSTGRES_HOST} || true"
      sh "docker network rm ${env.IROHA_NETWORK}"
      cleanWs()
    }
  }
}

return this