### PR TITLE
Bridge registration changes & tests

### DIFF
--- a/iroha/benches/validation.rs
+++ b/iroha/benches/validation.rs
@@ -12,7 +12,7 @@ fn accept_transaction(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, [0; 32]),
+        object: Account::with_signatory(account_name, domain_name, [0; 32]),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -53,7 +53,7 @@ fn sign_transaction(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, [0; 32]),
+        object: Account::with_signatory(account_name, domain_name, [0; 32]),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -102,7 +102,7 @@ fn validate_transaction(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -158,7 +158,7 @@ fn chain_blocks(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -202,7 +202,7 @@ fn sign_blocks(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -248,7 +248,7 @@ fn validate_blocks(criterion: &mut Criterion) {
     };
     let account_name = "account";
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);

--- a/iroha/src/account.rs
+++ b/iroha/src/account.rs
@@ -19,12 +19,25 @@ pub struct Account {
 }
 
 impl Account {
-    /// Constructor of the detached `Account` entity.
+    /// Constructor of the detached `Account` entity without signatories.
     ///
     /// This method can be used to create an `Account` which should be registered in the domain.
     /// This method should not be used to create an `Account` to work with as a part of the Iroha
     /// State.
-    pub fn new(account_name: &str, domain_name: &str, public_key: PublicKey) -> Self {
+    pub fn new(account_name: &str, domain_name: &str) -> Self {
+        Account {
+            id: Id::new(account_name, domain_name),
+            assets: BTreeMap::new(),
+            signatories: Vec::new(),
+        }
+    }
+
+    /// Constructor of the detached `Account` entity with one signatory.
+    ///
+    /// This method can be used to create an `Account` which should be registered in the domain.
+    /// This method should not be used to create an `Account` to work with as a part of the Iroha
+    /// State.
+    pub fn with_signatory(account_name: &str, domain_name: &str, public_key: PublicKey) -> Self {
         Account {
             id: Id::new(account_name, domain_name),
             assets: BTreeMap::new(),

--- a/iroha/src/crypto.rs
+++ b/iroha/src/crypto.rs
@@ -10,7 +10,7 @@ use ursa::{
         digest::{Input, VariableOutput},
         VarBlake2b,
     },
-    keys::{KeyGenOption, PrivateKey as UrsaPrivateKey, PublicKey as UrsaPublicKey},
+    keys::{PrivateKey as UrsaPrivateKey, PublicKey as UrsaPublicKey},
     signatures::{ed25519::Ed25519Sha512, SignatureScheme, Signer},
 };
 
@@ -27,20 +27,6 @@ type Ed25519Signature = [u8; 64];
 pub fn generate_key_pair() -> Result<(PublicKey, PrivateKey), String> {
     let (public_key, ursa_private_key) = Ed25519Sha512
         .keypair(Option::None)
-        .map_err(|e| format!("Failed to generate Ed25519Sha512 key pair: {}", e))?;
-    let public_key = public_key[..]
-        .try_into()
-        .map_err(|e| format!("Public key should be [u8;32]: {}", e))?;
-    let mut private_key = [0; 64];
-    private_key.copy_from_slice(ursa_private_key.as_ref());
-    Ok((public_key, private_key))
-}
-
-/// Generates a determined pair of Public and Private key from the given seed.
-/// Returns `Err(String)` with error message if failed.
-pub fn generate_key_pair_from_seed(seed: Hash) -> Result<(PublicKey, PrivateKey), String> {
-    let (public_key, ursa_private_key) = Ed25519Sha512
-        .keypair(Some(KeyGenOption::UseSeed(seed.to_vec())))
         .map_err(|e| format!("Failed to generate Ed25519Sha512 key pair: {}", e))?;
     let public_key = public_key[..]
         .try_into()
@@ -149,17 +135,5 @@ mod tests {
                 hex!("ba67336efd6a3df3a70eeb757860763036785c182ff4cf587541a0068d09f5b2")[..]
             );
         })
-    }
-
-    #[test]
-    fn create_keypair_from_seed() {
-        let seed = [64u8; 32];
-        let (public_key, private_key) =
-            super::generate_key_pair_from_seed(seed).expect("Failed to generate key pair.");
-        assert_eq!(
-            public_key[..],
-            hex!("2ce0c446f8a2bcd835336f7db9e047e5d391054d7fdcb8cfdb32252445170f7f")
-        );
-        assert_eq!(private_key[..], hex!("3c0a1fabf193da9c1325e9dc918e4824c35682875aefd20afda2ff56bf8e7cad2ce0c446f8a2bcd835336f7db9e047e5d391054d7fdcb8cfdb32252445170f7f")[..]);
     }
 }

--- a/iroha/src/event.rs
+++ b/iroha/src/event.rs
@@ -121,7 +121,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -183,7 +183,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -250,7 +250,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),

--- a/iroha/src/isi.rs
+++ b/iroha/src/isi.rs
@@ -36,6 +36,9 @@ pub enum Instruction {
     /// This variant of Iroha Special Instruction executes the first instruction and if it succeeded
     /// executes the second one, if failed - the third one if presented.
     If(Box<Instruction>, Box<Instruction>, Option<Box<Instruction>>),
+    /// This variant of Iroha Special Instructions explicitly returns an error with the given
+    /// message.
+    Fail(String),
     /// This variant of Iroha Special Instructions sends notifications.
     Notify(String),
 }
@@ -78,6 +81,7 @@ impl Instruction {
                     }
                 }
             }
+            Instruction::Fail(message) => Err(message.into()),
             Instruction::Notify(message) => {
                 println!("Notification: {}", message);
                 Ok(())

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -98,7 +98,7 @@ impl Iroha {
         };
         let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
         let mut account =
-            Account::new(&account_id.name, &account_id.domain_name, config.public_key);
+            Account::with_signatory(&account_id.name, &account_id.domain_name, config.public_key);
         account.assets.insert(asset_id, asset);
         let mut accounts = HashMap::new();
         accounts.insert(account_id, account);
@@ -115,7 +115,7 @@ impl Iroha {
             domains,
         ))));
         let torii = Torii::new(
-            &config.peer_id.address.clone(),
+            &config.peer_id.address,
             Arc::clone(&world_state_view),
             transactions_sender.clone(),
             message_sender,
@@ -150,6 +150,7 @@ impl Iroha {
 
     /// To make `Iroha` peer work it should be started first. After that moment it will listen for
     /// incoming requests and messages.
+    #[allow(clippy::eval_order_dependence)]
     pub async fn start(&self) -> Result<(), String> {
         let kura = Arc::clone(&self.kura);
         kura.write().await.init().await?;

--- a/iroha/src/permission.rs
+++ b/iroha/src/permission.rs
@@ -160,7 +160,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -201,7 +201,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("NOT_ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -262,7 +262,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::AddDomain);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -303,7 +303,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("NOT_ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -364,7 +364,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::AddListener);
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -405,7 +405,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("NOT_ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -466,7 +466,7 @@ pub mod isi {
                 account_id: account_id.clone(),
             };
             let asset = Asset::with_permission(asset_id.clone(), Permission::RegisterAccount(None));
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -516,7 +516,7 @@ pub mod isi {
                 asset_id.clone(),
                 Permission::RegisterAccount(Some(domain_name.clone())),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -558,7 +558,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -621,7 +621,7 @@ pub mod isi {
             };
             let asset =
                 Asset::with_permission(asset_id.clone(), Permission::RegisterAssetDefinition(None));
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -671,7 +671,7 @@ pub mod isi {
                 asset_id.clone(),
                 Permission::RegisterAssetDefinition(Some(domain_name.clone())),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -714,7 +714,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -782,7 +782,7 @@ pub mod isi {
                 asset_id.clone(),
                 Permission::TransferAsset(None, Some(transfer_asset_definition_id.clone())),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -840,7 +840,7 @@ pub mod isi {
                     Some(transfer_asset_definition_id.clone()),
                 ),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -886,7 +886,7 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("ROOT", &domain_name);
-            let account = Account::new(
+            let account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -957,7 +957,7 @@ pub mod isi {
                 asset_id.clone(),
                 Permission::MintAsset(None, Some(mint_asset_definition_id.clone())),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -1011,7 +1011,7 @@ pub mod isi {
                     Some(mint_asset_definition_id.clone()),
                 ),
             );
-            let mut account = Account::new(
+            let mut account = Account::with_signatory(
                 &account_id.name,
                 &account_id.domain_name,
                 public_key.clone(),
@@ -1057,7 +1057,8 @@ pub mod isi {
                 AssetDefinition::new(asset_definition_id.clone()),
             );
             let account_id = AccountId::new("ROOT", &domain_name);
-            let account = Account::new(&account_id.name, &account_id.domain_name, public_key);
+            let account =
+                Account::with_signatory(&account_id.name, &account_id.domain_name, public_key);
             let mut accounts = HashMap::new();
             accounts.insert(account_id.clone(), account);
             let domain = Domain {

--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -142,7 +142,7 @@ mod tests {
             account_id: account_id.clone(),
         };
         let asset = Asset::with_permission(asset_id.clone(), Permission::Anything);
-        let mut account = Account::new(
+        let mut account = Account::with_signatory(
             &account_id.name,
             &account_id.domain_name,
             public_key.clone(),

--- a/iroha_client/benches/torii.rs
+++ b/iroha_client/benches/torii.rs
@@ -23,7 +23,7 @@ fn query_requests(criterion: &mut Criterion) {
     let account_id = AccountId::new(account_name, domain_name);
     let (public_key, _) = configuration.key_pair();
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
@@ -94,7 +94,7 @@ fn instruction_submits(criterion: &mut Criterion) {
     let account_id = AccountId::new(account_name, domain_name);
     let (public_key, _) = configuration.key_pair();
     let create_account = isi::Register {
-        object: Account::new(account_name, domain_name, public_key),
+        object: Account::with_signatory(account_name, domain_name, public_key),
         destination_id: String::from(domain_name),
     };
     let asset_definition_id = AssetDefinitionId::new("xor", domain_name);

--- a/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
+++ b/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
@@ -28,7 +28,7 @@ mod tests {
         let account_id = AccountId::new(account_name, domain_name);
         let (public_key, _) = configuration.key_pair();
         let create_account = isi::Register {
-            object: Account::new(account_name, domain_name, public_key),
+            object: Account::with_signatory(account_name, domain_name, public_key),
             destination_id: String::from(domain_name),
         };
         let asset_id = AssetDefinitionId::new("xor", domain_name);

--- a/iroha_client/tests/high_load_transfer.rs
+++ b/iroha_client/tests/high_load_transfer.rs
@@ -27,11 +27,11 @@ mod tests {
         let account2_id = AccountId::new(account2_name, domain_name);
         let (public_key, _) = configuration.key_pair();
         let create_account1 = isi::Register {
-            object: Account::new(account1_name, domain_name, public_key),
+            object: Account::with_signatory(account1_name, domain_name, public_key),
             destination_id: String::from(domain_name),
         };
         let create_account2 = isi::Register {
-            object: Account::new(account2_name, domain_name, public_key),
+            object: Account::with_signatory(account2_name, domain_name, public_key),
             destination_id: String::from(domain_name),
         };
         let asset_definition_id = AssetDefinitionId::new("xor", domain_name);

--- a/iroha_client/tests/transfer_asset.rs
+++ b/iroha_client/tests/transfer_asset.rs
@@ -28,11 +28,11 @@ mod tests {
         let account2_id = AccountId::new(account2_name, domain_name);
         let (public_key, _) = configuration.key_pair();
         let create_account1 = isi::Register {
-            object: Account::new(account1_name, domain_name, public_key),
+            object: Account::with_signatory(account1_name, domain_name, public_key),
             destination_id: String::from(domain_name),
         };
         let create_account2 = isi::Register {
-            object: Account::new(account2_name, domain_name, public_key),
+            object: Account::with_signatory(account2_name, domain_name, public_key),
             destination_id: String::from(domain_name),
         };
         let asset_definition_id = AssetDefinitionId::new("xor", domain_name);

--- a/iroha_client_cli/src/main.rs
+++ b/iroha_client_cli/src/main.rs
@@ -152,7 +152,7 @@ mod account {
 
     fn create_account(account_name: &str, domain_name: &str, _public_key: &str) {
         let create_account = isi::Register {
-            object: Account::new(account_name, domain_name, [0; 32]),
+            object: Account::with_signatory(account_name, domain_name, [0; 32]),
             destination_id: String::from(domain_name),
         };
         let mut iroha_client = Client::new(


### PR DESCRIPTION
Signed-off-by: Vladislav Markushin <negigic@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Removed keypair generation for a bridge account, keyless accounts are used instead.
Removed `owner_asset` asset, because all bridge-related information is stored in `bridge_asset` already.
Added `Fail` ISI for explicit errors.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
