### PR TITLE
Binary-value asset store (first iteration)

### DIFF
--- a/iroha/src/asset.rs
+++ b/iroha/src/asset.rs
@@ -32,6 +32,9 @@ impl AssetDefinition {
     }
 }
 
+/// Represents a sequence of bytes. Used for storing encoded data.
+pub type Bytes = Vec<u8>;
+
 /// All possible variants of `Asset` entity's components.
 #[derive(Clone, Debug, Encode, Decode)]
 pub struct Asset {
@@ -42,14 +45,14 @@ pub struct Asset {
     /// Asset's Big Quantity associated with an `Account`.
     pub big_quantity: u128,
     /// Asset's key-value structured data associated with an `Account`.
-    pub store: BTreeMap<String, String>,
+    pub store: BTreeMap<String, Bytes>,
     /// Asset's key-value  (action, object_id) structured permissions associated with an `Account`.
     pub permissions: Permissions,
 }
 
 impl Asset {
     /// Constructor with filled `store` field.
-    pub fn with_parameter(id: <Asset as Identifiable>::Id, parameter: (String, String)) -> Self {
+    pub fn with_parameter(id: <Asset as Identifiable>::Id, parameter: (String, Bytes)) -> Self {
         let mut store = BTreeMap::new();
         store.insert(parameter.0, parameter.1);
         Self {
@@ -189,8 +192,8 @@ pub mod isi {
         MintAsset(u32, <Asset as Identifiable>::Id),
         /// Variant of the generic `Mint` instruction for `u128` --> `Asset`.
         MintBigAsset(u128, <Asset as Identifiable>::Id),
-        /// Variant of the generic `Mint` instruction for `(String, String)` --> `Asset`.
-        MintParameterAsset((String, String), <Asset as Identifiable>::Id),
+        /// Variant of the generic `Mint` instruction for `(String, Bytes)` --> `Asset`.
+        MintParameterAsset((String, Bytes), <Asset as Identifiable>::Id),
     }
 
     impl AssetInstruction {
@@ -281,7 +284,7 @@ pub mod isi {
         }
     }
 
-    impl Mint<Asset, (String, String)> {
+    impl Mint<Asset, (String, Bytes)> {
         fn execute(
             &self,
             authority: <Account as Identifiable>::Id,
@@ -311,8 +314,8 @@ pub mod isi {
         }
     }
 
-    impl From<Mint<Asset, (String, String)>> for Instruction {
-        fn from(instruction: Mint<Asset, (String, String)>) -> Self {
+    impl From<Mint<Asset, (String, Bytes)>> for Instruction {
+        fn from(instruction: Mint<Asset, (String, Bytes)>) -> Self {
             Instruction::Asset(AssetInstruction::MintParameterAsset(
                 instruction.object,
                 instruction.destination_id,

--- a/iroha/src/bridge.rs
+++ b/iroha/src/bridge.rs
@@ -120,10 +120,7 @@ pub mod isi {
                     }
                     .into(),
                     Mint {
-                        object: (
-                            "bridge_definition".to_string(),
-                            format!("{:?}", bridge_definition.encode()),
-                        ),
+                        object: ("bridge_definition".to_string(), bridge_definition.encode()),
                         destination_id: AssetId {
                             definition_id: bridge_asset_definition_id(),
                             account_id: account.id,
@@ -186,10 +183,6 @@ pub mod isi {
                     bridge_asset_definition_id.clone(),
                     AssetDefinition::new(bridge_asset_definition_id.clone()),
                 );
-                let bridge_asset_id = AssetId {
-                    definition_id: bridge_asset_definition_id,
-                    account_id: account_id.clone(),
-                };
                 let bridge_domain = Domain {
                     name: bridge_domain_name.clone(),
                     accounts: HashMap::new(),


### PR DESCRIPTION
Signed-off-by: Vladislav Markushin <negigic@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Currently, all values in the asset-store are stored as a `String`. This imposes some limitations when storing arbitrary binary data (for example an object serialized with `parity-scale-codec`) due to strong Rust's assumptions that all strings contain valid UTF-8 encoded data. So if one wants to store such data, he will need to use unsafe code.

This PR proposes the first iteration for resolving the issue.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
An ability to store any data in a compact format
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Non-human-readable data
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
