### PR TITLE
PostgreSQL: reconnect to working database after failure

### DIFF
--- a/irohad/main/impl/pg_connection_init.cpp
+++ b/irohad/main/impl/pg_connection_init.cpp
@@ -188,7 +188,7 @@ PgConnectionInit::prepareConnectionPool(
                                     try_rollback,
                                     *failover_callback_factory,
                                     reconnection_strategy_factory,
-                                    options.maintenanceConnectionString(),
+                                    options_str,
                                     log_manager)
                | [&]() -> iroha::expected::Result<std::shared_ptr<PoolWrapper>,
                                                   std::string> {


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

before this, after a temporary failure in connection to PostgreSQL, the database was changed from working to maintenance, which is wrong and is fixed in this PR.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

hopefully working reconnection

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

lack of autotests

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
