### PR TITLE
Bridge: remove clients

### DIFF
--- a/iroha/src/isi.rs
+++ b/iroha/src/isi.rs
@@ -114,6 +114,30 @@ where
     }
 }
 
+/// Generic instruction for a removal of an object from the identifiable destination.
+pub struct Remove<D, O>
+where
+    D: Identifiable,
+{
+    /// Object which should be removed.
+    pub object: O,
+    /// Destination object `Id`.
+    pub destination_id: D::Id,
+}
+
+impl<D, O> Remove<D, O>
+where
+    D: Identifiable,
+{
+    /// Default `Remove` constructor.
+    pub fn new(object: O, destination_id: D::Id) -> Self {
+        Remove {
+            object,
+            destination_id,
+        }
+    }
+}
+
 /// Generic instruction for a registration of an object to the identifiable destination.
 pub struct Register<D, O>
 where

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -283,7 +283,7 @@ pub mod prelude {
         config::Configuration,
         crypto::{Hash, KeyPair, PrivateKey, PublicKey, Signature},
         domain::Domain,
-        isi::{Add, Demint, Instruction, Mint, Register, Transfer},
+        isi::{Add, Demint, Instruction, Mint, Register, Remove, Transfer},
         peer::{Peer, PeerId},
         query::{IrohaQuery, Query, QueryRequest, QueryResult},
         tx::{AcceptedTransaction, RequestedTransaction, SignedTransaction, ValidTransaction},


### PR DESCRIPTION
Signed-off-by: Maksim Surkov <modbrin@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Added `isi::remove_client` function in `bridge` module in accordance with `UnregisterBridgeClientComponent` function of Bridge Contract. Added required underlying functionality, in particular: Remove ISI, RemoveSignatory ISI, CanRemoveSignatory permission.

### Benefits

<!-- What benefits will be realized by the code change? -->
Possibility to remove bridge client so it will not participate in quorum and therefore have no effect on transaction processing.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
Tests may need to be extended and de-duplicated as of similar fragments with isi::add_client function.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
