### PR TITLE
Extract Iroha domain entities for no-std client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "iroha",
   "iroha_client",
+  "iroha_client_no_std",
   "iroha_client_cli",
   "iroha_macro",
   "iroha_macro/iroha_derive",

--- a/iroha_client_no_std/Cargo.toml
+++ b/iroha_client_no_std/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "iroha_client_no_std"
+version = "0.1.0"
+authors = [ "Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov < <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>" ]
+edition = "2018"
+description = "Iroha Client (no-std) is a Rust Library which encapsulates network related logic and gives users an ability to interact with Iroha Peers like they are non-distributed application."
+readme = "README.md"
+homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+repository = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+license = "Apache-2.0"
+keywords = ["crypto", "blockchain", "ledger", "iroha", "client"]
+categories = ["cryptography::cryptocurrencies", "api-bindings"]
+
+[badges]
+is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledger/iroha" }
+is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/iroha" }
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+iroha = { version = "=0.1.0", path = "../iroha" }
+iroha_network = { version = "=0.1.0", path = "../iroha_network" }
+iroha_derive = { version = "=0.1.0", path = "../iroha_macro/iroha_derive" }
+async-std = { version = "1.5", features = ["attributes"] }
+parity-scale-codec = { version = "1.3", features = ["derive"] }
+ursa = "0.3.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/iroha_client_no_std/src/account.rs
+++ b/iroha_client_no_std/src/account.rs
@@ -1,0 +1,157 @@
+//! This module contains `Account` structure and it's implementation.
+
+use crate::prelude::*;
+use iroha::crypto::PublicKey;
+use parity_scale_codec::{Decode, Encode};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display},
+};
+
+/// Account entity is an authority which is used to execute `Iroha Special Insturctions`.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Account {
+    /// An Identification of the `Account`.
+    pub id: Id,
+    /// Asset's in this `Account`.
+    pub assets: BTreeMap<<Asset as Identifiable>::Id, Asset>,
+    signatories: Vec<PublicKey>,
+}
+
+impl Account {
+    /// Constructor of the detached `Account` entity without signatories.
+    ///
+    /// This method can be used to create an `Account` which should be registered in the domain.
+    /// This method should not be used to create an `Account` to work with as a part of the Iroha
+    /// State.
+    pub fn new(account_name: &str, domain_name: &str) -> Self {
+        Account {
+            id: Id::new(account_name, domain_name),
+            assets: BTreeMap::new(),
+            signatories: Vec::new(),
+        }
+    }
+
+    /// Constructor of the detached `Account` entity with one signatory.
+    ///
+    /// This method can be used to create an `Account` which should be registered in the domain.
+    /// This method should not be used to create an `Account` to work with as a part of the Iroha
+    /// State.
+    pub fn with_signatory(account_name: &str, domain_name: &str, public_key: PublicKey) -> Self {
+        Account {
+            id: Id::new(account_name, domain_name),
+            assets: BTreeMap::new(),
+            signatories: vec![public_key],
+        }
+    }
+}
+
+/// Identification of an Account. Consists of Account's name and Domain's name.
+///
+/// # Example
+///
+/// ```
+/// use iroha::account::Id;
+///
+/// let id = Id::new("user", "company");
+/// ```
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, std::hash::Hash, Encode, Decode)]
+pub struct Id {
+    /// Account's name.
+    pub name: String,
+    /// Domain's name.
+    pub domain_name: String,
+}
+
+impl Id {
+    /// `Id` constructor used to easily create an `Id` from two string slices - one for the
+    /// account's name, another one for the container's name.
+    pub fn new(name: &str, domain_name: &str) -> Self {
+        Id {
+            name: name.to_string(),
+            domain_name: domain_name.to_string(),
+        }
+    }
+}
+
+impl From<&str> for Id {
+    fn from(string: &str) -> Id {
+        let vector: Vec<&str> = string.split('@').collect();
+        Id {
+            name: String::from(vector[0]),
+            domain_name: String::from(vector[1]),
+        }
+    }
+}
+
+impl Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.name, self.domain_name)
+    }
+}
+
+impl Identifiable for Account {
+    type Id = Id;
+}
+
+/// Iroha Special Instructions module provides `AccountInstruction` enum with all legal types of
+/// Account related instructions as variants, implementations of generic Iroha Special Instructions
+/// and the `From/Into` implementations to convert `AccountInstruction` variants into generic ISI.
+pub mod isi {
+    use super::*;
+    use iroha_derive::*;
+
+    /// Enumeration of all legal Account related Instructions.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum AccountInstruction {
+        /// Variant of the generic `Transfer` instruction for `Account` --`Asset`--> `Account`.
+        TransferAsset(
+            <Account as Identifiable>::Id,
+            <Account as Identifiable>::Id,
+            Asset,
+        ),
+        /// Variant of the generic `Add` instruction for `PublicKey` --> `Account`.
+        AddSignatory(<Account as Identifiable>::Id, PublicKey),
+        /// Variant of the generic `Remove` instruction for `PublicKey` --> `Account`.
+        RemoveSignatory(<Account as Identifiable>::Id, PublicKey),
+    }
+}
+
+/// Query module provides `IrohaQuery` Account related implementations.
+pub mod query {
+    use super::*;
+    use crate::query::IrohaQuery;
+    use iroha_derive::*;
+    use parity_scale_codec::{Decode, Encode};
+    use std::time::SystemTime;
+
+    /// Get information related to the account with a specified `account_id`.
+    #[derive(Clone, Debug, Io, IntoQuery, Encode, Decode)]
+    pub struct GetAccount {
+        /// Identification of an account to find information about.
+        pub account_id: <Account as Identifiable>::Id,
+    }
+
+    /// Result of the `GetAccount` execution.
+    #[derive(Clone, Debug, Encode, Decode)]
+    pub struct GetAccountResult {
+        /// Account information.
+        pub account: Account,
+    }
+
+    impl GetAccount {
+        /// Build a `GetAccount` query in the form of a `QueryRequest`.
+        pub fn build_request(account_id: <Account as Identifiable>::Id) -> QueryRequest {
+            let query = GetAccount { account_id };
+            QueryRequest {
+                timestamp: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Failed to get System Time.")
+                    .as_millis()
+                    .to_string(),
+                signature: Option::None,
+                query: query.into(),
+            }
+        }
+    }
+}

--- a/iroha_client_no_std/src/asset.rs
+++ b/iroha_client_no_std/src/asset.rs
@@ -1,0 +1,234 @@
+//! This module contains `Asset` structure and it's implementation.
+
+use crate::prelude::*;
+use parity_scale_codec::{Decode, Encode};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+    hash::Hash,
+};
+
+/// Asset entity represents some sort of commodity or value.
+#[derive(Clone, Debug, Encode, Decode)]
+pub struct AssetDefinition {
+    /// An Identification of the `Asset`.
+    pub id: <AssetDefinition as Identifiable>::Id,
+}
+
+impl AssetDefinition {
+    /// Constructor of the detached and empty `AssetDefinition` entity.
+    ///
+    /// This method can be used to create an `AssetDefinition` which should be registered in the domain.
+    /// This method should not be used to create an `AssetDefinition` to work with as a part of the Iroha
+    /// State.
+    pub fn new(id: <AssetDefinition as Identifiable>::Id) -> Self {
+        AssetDefinition { id }
+    }
+}
+
+/// Represents a sequence of bytes. Used for storing encoded data.
+pub type Bytes = Vec<u8>;
+
+/// All possible variants of `Asset` entity's components.
+#[derive(Clone, Debug, Encode, Decode)]
+pub struct Asset {
+    /// Component Identification.
+    pub id: <Asset as Identifiable>::Id,
+    /// Asset's Quantity associated with an `Account`.
+    pub quantity: u32,
+    /// Asset's Big Quantity associated with an `Account`.
+    pub big_quantity: u128,
+    /// Asset's key-value structured data associated with an `Account`.
+    pub store: BTreeMap<String, Bytes>,
+    /// Asset's key-value  (action, object_id) structured permissions associated with an `Account`.
+    pub permissions: Permissions,
+}
+
+impl Asset {
+    /// Constructor with filled `store` field.
+    pub fn with_parameter(id: <Asset as Identifiable>::Id, parameter: (String, Bytes)) -> Self {
+        let mut store = BTreeMap::new();
+        store.insert(parameter.0, parameter.1);
+        Self {
+            id,
+            quantity: 0,
+            big_quantity: 0,
+            store,
+            permissions: Permissions::new(),
+        }
+    }
+
+    /// Constructor with filled `quantity` field.
+    pub fn with_quantity(id: <Asset as Identifiable>::Id, quantity: u32) -> Self {
+        Self {
+            id,
+            quantity,
+            big_quantity: 0,
+            store: BTreeMap::new(),
+            permissions: Permissions::new(),
+        }
+    }
+
+    /// Constructor with filled `big_quantity` field.
+    pub fn with_big_quantity(id: <Asset as Identifiable>::Id, big_quantity: u128) -> Self {
+        Self {
+            id,
+            quantity: 0,
+            big_quantity,
+            store: BTreeMap::new(),
+            permissions: Permissions::new(),
+        }
+    }
+
+    /// Constructor with filled `permissions` field.
+    pub fn with_permission(id: <Asset as Identifiable>::Id, permission: Permission) -> Self {
+        let permissions = Permissions::single(permission);
+        Self {
+            id,
+            quantity: 0,
+            big_quantity: 0,
+            store: BTreeMap::new(),
+            permissions,
+        }
+    }
+}
+
+/// Identification of an Asset Definition. Consists of Asset's name and Domain's name.
+///
+/// # Example
+///
+/// ```
+/// use iroha::asset::AssetDefinitionId as Id;
+///
+/// let id = Id::new("xor", "soramitsu");
+/// ```
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, std::hash::Hash, Encode, Decode)]
+pub struct AssetDefinitionId {
+    /// Asset's name.
+    pub name: String,
+    /// Domain's name.
+    pub domain_name: String,
+}
+
+impl AssetDefinitionId {
+    /// `Id` constructor used to easily create an `Id` from three string slices - one for the
+    /// asset's name, another one for the domain's name.
+    pub fn new(name: &str, domain_name: &str) -> Self {
+        AssetDefinitionId {
+            name: name.to_string(),
+            domain_name: domain_name.to_string(),
+        }
+    }
+}
+
+/// Asset Identification is represented by `name#domain_name` string.
+impl From<&str> for AssetDefinitionId {
+    fn from(string: &str) -> AssetDefinitionId {
+        let vector: Vec<&str> = string.split('#').collect();
+        AssetDefinitionId {
+            name: String::from(vector[0]),
+            domain_name: String::from(vector[1]),
+        }
+    }
+}
+
+impl Display for AssetDefinitionId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}#{}", self.name, self.domain_name)
+    }
+}
+
+impl Identifiable for AssetDefinition {
+    type Id = AssetDefinitionId;
+}
+
+/// Identification of an Asset's components include Entity Id (`Asset::Id`) and `Account::Id`.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Encode, Decode)]
+pub struct AssetId {
+    /// Entity Identification.
+    pub definition_id: <AssetDefinition as Identifiable>::Id,
+    /// Account Identification.
+    pub account_id: <Account as Identifiable>::Id,
+}
+
+impl AssetId {
+    /// `AssetId` constructor used to easily create an `AssetId` from an `AssetDefinitionId` and
+    /// an `AccountId`.
+    pub fn new(
+        definition_id: <AssetDefinition as Identifiable>::Id,
+        account_id: <Account as Identifiable>::Id,
+    ) -> Self {
+        AssetId {
+            definition_id,
+            account_id,
+        }
+    }
+}
+
+impl Identifiable for Asset {
+    type Id = AssetId;
+}
+
+/// Iroha Special Instructions module provides `AssetInstruction` enum with all legal types of
+/// Asset related instructions as variants, implementations of generic Iroha Special Instructions
+/// and the `From/Into` implementations to convert `AssetInstruction` variants into generic ISI.
+pub mod isi {
+    use super::*;
+    use iroha_derive::*;
+
+    /// Enumeration of all legal Asset related Instructions.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum AssetInstruction {
+        /// Variant of the generic `Mint` instruction for `u32` --> `Asset`.
+        MintAsset(u32, <Asset as Identifiable>::Id),
+        /// Variant of the generic `Mint` instruction for `u128` --> `Asset`.
+        MintBigAsset(u128, <Asset as Identifiable>::Id),
+        /// Variant of the generic `Mint` instruction for `(String, Bytes)` --> `Asset`.
+        MintParameterAsset((String, Bytes), <Asset as Identifiable>::Id),
+        /// Variant of the generic `Demint` instruction for `u32` --> `Asset`.
+        DemintAsset(u32, <Asset as Identifiable>::Id),
+        /// Variant of the generic `Demint` instruction for `u128` --> `Asset`.
+        DemintBigAsset(u128, <Asset as Identifiable>::Id),
+        /// Variant of the generic `Demint` instruction for `String` --> `Asset`.
+        DemintParameterAsset(String, <Asset as Identifiable>::Id),
+    }
+}
+
+/// Query module provides `IrohaQuery` Asset related implementations.
+pub mod query {
+    use super::*;
+    use crate::query::IrohaQuery;
+    use iroha_derive::{IntoQuery, Io};
+    use parity_scale_codec::{Decode, Encode};
+    use std::time::SystemTime;
+
+    /// To get the state of all assets in an account (a balance),
+    /// GetAccountAssets query can be used.
+    #[derive(Clone, Debug, Io, IntoQuery, Encode, Decode)]
+    pub struct GetAccountAssets {
+        account_id: <Account as Identifiable>::Id,
+    }
+
+    /// Result of the `GetAccountAssets` execution.
+    #[derive(Clone, Debug, Encode, Decode)]
+    pub struct GetAccountAssetsResult {
+        /// Assets types which are needed to be included in query result.
+        pub assets: Vec<Asset>,
+    }
+
+    impl GetAccountAssets {
+        /// Build a `GetAccountAssets` query in the form of a `QueryRequest`.
+        pub fn build_request(account_id: <Account as Identifiable>::Id) -> QueryRequest {
+            let query = GetAccountAssets { account_id };
+            QueryRequest {
+                timestamp: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Failed to get System Time.")
+                    .as_millis()
+                    .to_string(),
+                signature: Option::None,
+                query: query.into(),
+            }
+        }
+    }
+}

--- a/iroha_client_no_std/src/client.rs
+++ b/iroha_client_no_std/src/client.rs
@@ -1,0 +1,196 @@
+use crate::config::Configuration;
+use crate::prelude::*;
+use async_std::stream::Stream;
+use iroha::{crypto::KeyPair, torii::uri};
+use iroha_derive::log;
+use iroha_network::{prelude::*, Network};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Debug, Formatter},
+};
+
+pub struct Client {
+    torii_url: String,
+    key_pair: KeyPair,
+    proposed_transaction_ttl_ms: u64,
+}
+
+/// Representation of `Iroha` client.
+impl Client {
+    pub fn new(configuration: &Configuration) -> Self {
+        Client {
+            torii_url: configuration.torii_url.clone(),
+            //TODO: The `public_key` from `configuration` will be different. Fix this inconsistency.
+            key_pair: KeyPair::generate().expect("Failed to generate KeyPair."),
+            proposed_transaction_ttl_ms: configuration.transaction_time_to_live_ms,
+        }
+    }
+
+    /// Instructions API entry point. Submits one Iroha Special Instruction to `Iroha` peers.
+    #[log]
+    pub async fn submit(&mut self, instruction: Instruction) -> Result<(), String> {
+        let network = Network::new(&self.torii_url);
+        let transaction: RequestedTransaction = RequestedTransaction::new(
+            vec![instruction],
+            crate::account::Id::new("root", "global"),
+            self.proposed_transaction_ttl_ms,
+        )
+        .accept()?
+        .sign(&self.key_pair)?
+        .into();
+        if let Response::InternalError = network
+            .send_request(Request::new(
+                uri::INSTRUCTIONS_URI.to_string(),
+                Vec::from(&transaction),
+            ))
+            .await
+            .map_err(|e| {
+                format!(
+                    "Error: {}, Failed to write a transaction request: {:?}",
+                    e, &transaction
+                )
+            })?
+        {
+            return Err("Server error.".to_string());
+        }
+        Ok(())
+    }
+
+    /// Instructions API entry point. Submits several Iroha Special Instructions to `Iroha` peers.
+    pub async fn submit_all(&mut self, instructions: Vec<Instruction>) -> Result<(), String> {
+        let network = Network::new(&self.torii_url);
+        let transaction: RequestedTransaction = RequestedTransaction::new(
+            instructions,
+            crate::account::Id::new("root", "global"),
+            self.proposed_transaction_ttl_ms,
+        )
+        .accept()?
+        .sign(&self.key_pair)?
+        .into();
+        if let Response::InternalError = network
+            .send_request(Request::new(
+                uri::INSTRUCTIONS_URI.to_string(),
+                Vec::from(&transaction),
+            ))
+            .await
+            .map_err(|e| {
+                format!(
+                    "Error: {}, Failed to write a transaction request: {:?}",
+                    e, &transaction
+                )
+            })?
+        {
+            return Err("Server error.".to_string());
+        }
+        Ok(())
+    }
+
+    /// Query API entry point. Requests queries from `Iroha` peers.
+    #[log]
+    pub async fn request(&mut self, request: &QueryRequest) -> Result<QueryResult, String> {
+        let network = Network::new(&self.torii_url);
+        match network
+            .send_request(Request::new(uri::QUERY_URI.to_string(), request.into()))
+            .await
+            .map_err(|e| format!("Failed to write a get request: {}", e))?
+        {
+            Response::Ok(payload) => Ok(
+                QueryResult::try_from(payload).expect("Failed to try Query Result from vector.")
+            ),
+            Response::InternalError => Err("Server error.".to_string()),
+        }
+    }
+}
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("public_key", &self.key_pair.public_key)
+            .field("torii_url", &self.torii_url)
+            .finish()
+    }
+}
+
+pub mod maintenance {
+    use super::*;
+    use iroha::maintenance::*;
+
+    impl Client {
+        pub fn with_maintenance(configuration: &Configuration) -> MaintenanceClient {
+            MaintenanceClient {
+                client: Client::new(configuration),
+                torii_connect_url: configuration.torii_connect_url.clone(),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct MaintenanceClient {
+        client: Client,
+        torii_connect_url: String,
+    }
+
+    impl MaintenanceClient {
+        #[log]
+        pub async fn submit(&mut self, instruction: Instruction) -> Result<(), String> {
+            self.client.submit(instruction).await
+        }
+
+        #[log]
+        pub async fn submit_all(&mut self, instructions: Vec<Instruction>) -> Result<(), String> {
+            self.client.submit_all(instructions).await
+        }
+
+        #[log]
+        pub async fn request(&mut self, request: &QueryRequest) -> Result<QueryResult, String> {
+            self.client.request(request).await
+        }
+
+        #[log]
+        pub async fn health(&mut self) -> Result<Health, String> {
+            let network = Network::new(&self.client.torii_url);
+            match network
+                .send_request(Request::new(uri::HEALTH_URI.to_string(), vec![]))
+                .await
+                .map_err(|e| format!("Failed to write a get request: {}", e))?
+            {
+                Response::Ok(payload) => {
+                    Ok(Health::try_from(payload).expect("Failed to convert Health from vector."))
+                }
+                Response::InternalError => Err("Server error.".to_string()),
+            }
+        }
+
+        #[log]
+        pub async fn scrape_metrics(&mut self) -> Result<Metrics, String> {
+            let network = Network::new(&self.client.torii_url);
+            match network
+                .send_request(Request::new(uri::METRICS_URI.to_string(), vec![]))
+                .await
+                .map_err(|e| format!("Failed to send request to Metrics API: {}", e))?
+            {
+                Response::Ok(payload) => {
+                    Ok(Metrics::try_from(payload).expect("Failed to convert vector to Metrics."))
+                }
+                Response::InternalError => Err("Server error.".to_string()),
+            }
+        }
+
+        pub async fn subscribe_to_block_changes(
+            &mut self,
+        ) -> Result<impl Stream<Item = Vec<u8>>, String> {
+            let network = Network::new(&self.torii_connect_url);
+            let connection = network.connect().await.expect("Failed to connect.");
+            Ok(connection)
+        }
+    }
+}
+
+pub mod assets {
+    use super::*;
+    use crate::asset::query::GetAccountAssets;
+
+    pub fn by_account_id(account_id: <Account as Identifiable>::Id) -> QueryRequest {
+        GetAccountAssets::build_request(account_id)
+    }
+}

--- a/iroha_client_no_std/src/config.rs
+++ b/iroha_client_no_std/src/config.rs
@@ -1,0 +1,92 @@
+use iroha::{config::Configuration as IrohaConfiguration, crypto::PublicKey};
+use iroha_derive::*;
+use serde::Deserialize;
+use std::{env, fmt::Debug, fs::File, io::BufReader, path::Path};
+
+const TORII_URL: &str = "TORII_URL";
+const TORII_CONNECT_URL: &str = "TORII_CONNECT_URL";
+const IROHA_PUBLIC_KEY: &str = "IROHA_PUBLIC_KEY";
+const TRANSACTION_TIME_TO_LIVE_MS: &str = "TRANSACTION_TIME_TO_LIVE_MS";
+const DEFAULT_TORII_URL: &str = "127.0.0.1:1337";
+const DEFAULT_TORII_CONNECT_URL: &str = "127.0.0.1:8888";
+const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
+
+/// `Configuration` provides an ability to define client parameters such as `TORII_URL`.
+#[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+pub struct Configuration {
+    /// Public key of this client.
+    pub public_key: PublicKey,
+    /// Torii URL.
+    #[serde(default = "default_torii_url")]
+    pub torii_url: String,
+    /// Torii connection URL.
+    #[serde(default = "default_torii_connect_url")]
+    pub torii_connect_url: String,
+    /// Proposed transaction TTL in milliseconds.
+    #[serde(default = "default_transaction_time_to_live_ms")]
+    pub transaction_time_to_live_ms: u64,
+}
+
+impl Configuration {
+    /// This method will build `Configuration` from a json *pretty* formatted file (without `:` in
+    /// key names).
+    /// # Panics
+    /// This method will panic if configuration file presented, but has incorrect scheme or format.
+    /// # Errors
+    /// This method will return error if system will fail to find a file or read it's content.
+    #[log]
+    pub fn from_path<P: AsRef<Path> + Debug>(path: P) -> Result<Configuration, String> {
+        let file = File::open(path).map_err(|e| format!("Failed to open a file: {}", e))?;
+        let reader = BufReader::new(file);
+        Ok(serde_json::from_reader(reader)
+            .map_err(|e| format!("Failed to deserialize json from reader: {}", e))?)
+    }
+
+    /// This method will build `Configuration` from existing `IrohaConfiguration`.
+    #[log]
+    pub fn from_iroha_configuration(configuration: &IrohaConfiguration) -> Self {
+        Configuration {
+            torii_url: configuration.torii_configuration.torii_url.clone(),
+            public_key: configuration.public_key,
+            torii_connect_url: default_torii_connect_url(),
+            transaction_time_to_live_ms: configuration
+                .queue_configuration
+                .transaction_time_to_live_ms,
+        }
+    }
+
+    /// Load environment variables and replace predefined parameters with these variables
+    /// values.
+    #[log]
+    pub fn load_environment(&mut self) -> Result<(), String> {
+        if let Ok(torii_url) = env::var(TORII_URL) {
+            self.torii_url = torii_url;
+        }
+        if let Ok(torii_connect_url) = env::var(TORII_CONNECT_URL) {
+            self.torii_connect_url = torii_connect_url;
+        }
+        if let Ok(public_key) = env::var(IROHA_PUBLIC_KEY) {
+            self.public_key = serde_json::from_str(&public_key)
+                .map_err(|e| format!("Failed to parse Public Key: {}", e))?;
+        }
+        if let Ok(proposed_transaction_ttl_ms) = env::var(TRANSACTION_TIME_TO_LIVE_MS) {
+            self.transaction_time_to_live_ms =
+                serde_json::from_str(&proposed_transaction_ttl_ms)
+                    .map_err(|e| format!("Failed to parse proposed transaction ttl: {}", e))?;
+        }
+        Ok(())
+    }
+}
+
+fn default_torii_url() -> String {
+    DEFAULT_TORII_URL.to_string()
+}
+
+fn default_torii_connect_url() -> String {
+    DEFAULT_TORII_CONNECT_URL.to_string()
+}
+
+fn default_transaction_time_to_live_ms() -> u64 {
+    DEFAULT_TRANSACTION_TIME_TO_LIVE_MS
+}

--- a/iroha_client_no_std/src/domain.rs
+++ b/iroha_client_no_std/src/domain.rs
@@ -1,0 +1,52 @@
+//! This module contains `Domain` structure and related implementations.
+
+use crate::prelude::*;
+use iroha_derive::*;
+use parity_scale_codec::{Decode, Encode};
+use std::collections::BTreeMap;
+
+type Name = String;
+
+/// Named group of `Account` and `Asset` entities.
+#[derive(Debug, Clone, Io, Encode, Decode)]
+pub struct Domain {
+    /// Domain name, for example company name.
+    pub name: Name,
+    /// Accounts of the domain.
+    pub accounts: BTreeMap<<Account as Identifiable>::Id, Account>,
+    /// Assets of the domain.
+    pub asset_definitions: BTreeMap<<AssetDefinition as Identifiable>::Id, AssetDefinition>,
+}
+
+impl Domain {
+    /// Creates new detached `Domain`.
+    ///
+    /// Should be used for creation of a new `Domain` or while making queries.
+    pub fn new(name: Name) -> Self {
+        Domain {
+            name,
+            accounts: BTreeMap::new(),
+            asset_definitions: BTreeMap::new(),
+        }
+    }
+}
+
+impl Identifiable for Domain {
+    type Id = Name;
+}
+
+/// Iroha Special Instructions module provides `DomainInstruction` enum with all legal types of
+/// Domain related instructions as variants, implementations of generic Iroha Special Instructions
+/// and the `From/Into` implementations to convert `DomainInstruction` variants into generic ISI.
+pub mod isi {
+    use super::*;
+
+    /// Enumeration of all legal Domain related Instructions.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum DomainInstruction {
+        /// Variant of the generic `Register` instruction for `Account` --> `Domain`.
+        RegisterAccount(Name, Account),
+        /// Variant of the generic `Register` instruction for `AssetDefinition` --> `Domain`.
+        RegisterAsset(Name, AssetDefinition),
+    }
+}

--- a/iroha_client_no_std/src/event.rs
+++ b/iroha_client_no_std/src/event.rs
@@ -1,0 +1,32 @@
+//! Iroha is a quite dynamic system so many events can happen.
+//! This module contains descriptions of such an events and
+//! utilitary Iroha Special Instructions to work with them.
+
+/// Iroha Special Instructions module provides `EventInstruction` enum with all legal types of
+/// events related instructions as variants, implementations of generic Iroha Special Instructions
+/// and the `From/Into` implementations to convert `EventInstruction` variants into generic ISI.
+pub mod isi {
+    use crate::prelude::*;
+    use iroha_derive::*;
+    use parity_scale_codec::{Decode, Encode};
+
+    type Trigger = IrohaQuery;
+
+    /// Instructions related to different type of Iroha events.
+    /// Some of them are time based triggers, another watch the Blockchain and others
+    /// check the World State View.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum EventInstruction {
+        /// This variant of Iroha Special Instruction will execute instruction when new Block
+        /// will be created.
+        OnBlockCreated(Box<Instruction>),
+        /// This variant of Iroha Special Instruction will execute instruction when Blockchain
+        /// will reach predefined height.
+        OnBlockchainHeight(u64, Box<Instruction>),
+        /// This variant of Iroha Special Instruction will execute instruction when World State
+        /// View change will be detected by `Trigger`.
+        OnWorldStateViewChange(Trigger, Box<Instruction>),
+        /// This variant of Iroha Special Instruction will execute instruction regulary.
+        OnTimestamp(u128, Box<Instruction>),
+    }
+}

--- a/iroha_client_no_std/src/isi.rs
+++ b/iroha_client_no_std/src/isi.rs
@@ -1,0 +1,45 @@
+//! This module contains enumeration of all legal Iroha Special Instructions `Instruction`
+//! and related implementations.
+
+use super::query::IrohaQuery;
+use iroha_derive::Io;
+use parity_scale_codec::{Decode, Encode};
+
+pub mod prelude {
+    //! Re-exports important traits and types. Meant to be glob imported when using `Iroha`.
+    pub use crate::{account::isi::*, asset::isi::*, domain::isi::*, isi::*, peer::isi::*};
+}
+
+/// Enumeration of all legal Iroha Special Instructions.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+#[allow(clippy::large_enum_variant)]
+pub enum Instruction {
+    /// Variant of instructions related to `Peer`.
+    Peer(crate::peer::isi::PeerInstruction),
+    /// Instruction variants related to `Domain`.
+    Domain(crate::domain::isi::DomainInstruction),
+    /// Instruction variants related to `Asset`.
+    Asset(crate::asset::isi::AssetInstruction),
+    /// Instruction variants related to `Account`.
+    Account(crate::account::isi::AccountInstruction),
+    /// Instruction variants related to `Permission`.
+    Permission(crate::permission::isi::PermissionInstruction),
+    /// Instruction variants connected to different Iroha Events.
+    Event(crate::event::isi::EventInstruction),
+    /// This variant of Iroha Special Instruction composes two other instructions into one, and
+    /// executes them both.
+    Compose(Box<Instruction>, Box<Instruction>),
+    /// This variant of Iroha Special Instruction composes several other instructions into one, and
+    /// executes them one by one. If some instruction fails - the whole sequence will fail.
+    Sequence(Vec<Instruction>),
+    /// This variant of Iroha Special Instruction executes the Iroha Query.
+    ExecuteQuery(IrohaQuery),
+    /// This variant of Iroha Special Instruction executes the first instruction and if it succeeded
+    /// executes the second one, if failed - the third one if presented.
+    If(Box<Instruction>, Box<Instruction>, Option<Box<Instruction>>),
+    /// This variant of Iroha Special Instructions explicitly returns an error with the given
+    /// message.
+    Fail(String),
+    /// This variant of Iroha Special Instructions sends notifications.
+    Notify(String),
+}

--- a/iroha_client_no_std/src/lib.rs
+++ b/iroha_client_no_std/src/lib.rs
@@ -1,0 +1,25 @@
+pub mod client;
+pub mod config;
+// TODO(vmarkushin): update documentation for the client-side entities (IR-848).
+pub mod account;
+pub mod asset;
+pub mod domain;
+pub mod event;
+pub mod isi;
+pub mod peer;
+pub mod permission;
+pub mod query;
+pub mod tx;
+
+pub mod prelude {
+    pub use super::{
+        account::*, asset::*, domain::*, event::*, isi::*, peer::*, permission::*, query::*, tx::*,
+        Identifiable,
+    };
+}
+
+/// This trait marks entity that implement it as identifiable with an `Id` type to find them by.
+pub trait Identifiable {
+    /// Defines the type of entity's identification.
+    type Id;
+}

--- a/iroha_client_no_std/src/peer.rs
+++ b/iroha_client_no_std/src/peer.rs
@@ -1,0 +1,143 @@
+//! This module contains `Peer` structure and related implementations.
+
+use crate::{
+    account::{Account, Id as AccountId},
+    domain::*,
+    isi::*,
+    Identifiable,
+};
+use iroha::crypto::PublicKey;
+use iroha_derive::*;
+use parity_scale_codec::{Decode, Encode};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Peer's identification.
+#[derive(
+    Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash, Io, Default, Deserialize,
+)]
+pub struct PeerId {
+    /// Address of the Peer's entrypoint.
+    pub address: String,
+    /// Public Key of the Peer.
+    pub public_key: PublicKey,
+}
+
+impl PeerId {
+    /// Default `PeerId` constructor.
+    pub fn new(address: &str, public_key: &PublicKey) -> Self {
+        PeerId {
+            address: address.to_string(),
+            public_key: *public_key,
+        }
+    }
+}
+
+/// Peer represents currently running Iroha instance.
+#[derive(Debug, Clone, Default, Encode, Decode, Io)]
+pub struct Peer {
+    /// Peer Identification.
+    pub id: PeerId,
+    /// All discovered Peers' Ids.
+    pub peers: BTreeSet<PeerId>,
+    /// Address to listen to.
+    pub listen_address: String,
+    /// Registered domains.
+    pub domains: BTreeMap<String, Domain>,
+    /// Events Listeners.
+    pub listeners: Vec<Instruction>,
+}
+
+impl Peer {
+    /// Default `Peer` constructor.
+    pub fn new(id: PeerId, trusted_peers: &[PeerId]) -> Peer {
+        Self::with_domains(id, trusted_peers, BTreeMap::new())
+    }
+
+    /// `Peer` constructor with a predefined domains.
+    pub fn with_domains(
+        id: PeerId,
+        trusted_peers: &[PeerId],
+        domains: BTreeMap<<Domain as Identifiable>::Id, Domain>,
+    ) -> Peer {
+        Peer {
+            id: id.clone(),
+            peers: trusted_peers.iter().cloned().collect(),
+            listen_address: id.address,
+            domains,
+            listeners: Vec::new(),
+        }
+    }
+
+    /// `Peer` constructor with a predefined listeners.
+    pub fn with_listeners(
+        id: PeerId,
+        trusted_peers: &[PeerId],
+        listeners: Vec<Instruction>,
+    ) -> Peer {
+        Peer {
+            id: id.clone(),
+            peers: trusted_peers
+                .iter()
+                .filter(|peer_id| id.address != peer_id.address)
+                .cloned()
+                .collect(),
+            listen_address: id.address,
+            domains: BTreeMap::new(),
+            listeners,
+        }
+    }
+
+    /// `Peer` constructor with a predefined domains and listeners.
+    pub fn with_domains_and_listeners(
+        id: PeerId,
+        trusted_peers: &[PeerId],
+        domains: BTreeMap<<Domain as Identifiable>::Id, Domain>,
+        listeners: Vec<Instruction>,
+    ) -> Peer {
+        Peer {
+            id: id.clone(),
+            peers: trusted_peers
+                .iter()
+                .filter(|peer_id| id.address != peer_id.address)
+                .cloned()
+                .collect(),
+            listen_address: id.address,
+            domains,
+            listeners,
+        }
+    }
+
+    /// Add new Listener to the World.
+    pub fn add_listener(&mut self, listener: Instruction) {
+        self.listeners.push(listener);
+    }
+
+    /// This method should be used to generate Peer's authority.
+    /// For example if you need to execute some Iroha Special Instructions.
+    pub fn authority(&self) -> <Account as Identifiable>::Id {
+        AccountId::new("root", "global")
+    }
+}
+
+impl Identifiable for Peer {
+    type Id = PeerId;
+}
+
+/// Iroha Special Instructions module provides `PeerInstruction` enum with all legal types of
+/// Peer related instructions as variants, implementations of generic Iroha Special Instructions
+/// and the `From/Into` implementations to convert `PeerInstruction` variants into generic ISI.
+pub mod isi {
+    use super::*;
+
+    /// Enumeration of all legal Peer related Instructions.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum PeerInstruction {
+        /// Variant of the generic `Add` instruction for `Domain` --> `Peer`.
+        AddDomain(String, PeerId),
+        /// Variant of the generic `Add` instruction for `Instruction` --> `Peer`.
+        AddListener(Box<Instruction>, PeerId),
+        /// Instruction to add a peer to the network.
+        AddPeer(PeerId),
+    }
+}

--- a/iroha_client_no_std/src/permission.rs
+++ b/iroha_client_no_std/src/permission.rs
@@ -1,0 +1,141 @@
+use crate::prelude::*;
+use parity_scale_codec::{Decode, Encode};
+
+pub fn permission_asset_definition_id() -> AssetDefinitionId {
+    AssetDefinitionId::new("permissions", "global")
+}
+
+#[derive(Clone, Debug, Default, Encode, Decode)]
+pub struct Permissions {
+    origin: Vec<Permission>,
+}
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq)]
+pub enum Permission {
+    Anything,
+    AddDomain,
+    AddListener,
+    RegisterAssetDefinition(Option<<Domain as Identifiable>::Id>),
+    RegisterAccount(Option<<Domain as Identifiable>::Id>),
+    MintAsset(
+        Option<<Domain as Identifiable>::Id>,
+        Option<<AssetDefinition as Identifiable>::Id>,
+    ),
+    DemintAsset(
+        Option<<Domain as Identifiable>::Id>,
+        Option<<AssetDefinition as Identifiable>::Id>,
+    ),
+    TransferAsset(
+        Option<<Domain as Identifiable>::Id>,
+        Option<<AssetDefinition as Identifiable>::Id>,
+    ),
+    AddSignatory(
+        Option<<Domain as Identifiable>::Id>,
+        Option<<Account as Identifiable>::Id>,
+    ),
+    RemoveSignatory(
+        Option<<Domain as Identifiable>::Id>,
+        Option<<Account as Identifiable>::Id>,
+    ),
+}
+
+impl Permissions {
+    pub fn new() -> Self {
+        Permissions::default()
+    }
+
+    pub fn single(permission: Permission) -> Self {
+        Permissions {
+            origin: vec![permission],
+        }
+    }
+}
+
+pub mod isi {
+    use super::*;
+    use iroha_derive::Io;
+    use parity_scale_codec::{Decode, Encode};
+
+    /// Iroha special instructions related to `Permission`.
+    #[derive(Clone, Debug, Io, Encode, Decode)]
+    pub enum PermissionInstruction {
+        CanAnything(<Account as Identifiable>::Id),
+        CanAddListener(<Account as Identifiable>::Id),
+        CanAddDomain(<Account as Identifiable>::Id),
+        CanRegisterAccount(
+            <Account as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanRegisterAssetDefinition(
+            <Account as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanTransferAsset(
+            <Account as Identifiable>::Id,
+            <AssetDefinition as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanAddSignatory(
+            <Account as Identifiable>::Id,
+            <Account as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanRemoveSignatory(
+            <Account as Identifiable>::Id,
+            <Account as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanMintAsset(
+            <Account as Identifiable>::Id,
+            <AssetDefinition as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+        CanDemintAsset(
+            <Account as Identifiable>::Id,
+            <AssetDefinition as Identifiable>::Id,
+            Option<<Domain as Identifiable>::Id>,
+        ),
+    }
+
+    impl From<&PermissionInstruction> for Permission {
+        fn from(instruction: &PermissionInstruction) -> Self {
+            match instruction {
+                PermissionInstruction::CanAnything(_) => Permission::Anything,
+                PermissionInstruction::CanAddDomain(_) => Permission::AddDomain,
+                PermissionInstruction::CanAddListener(_) => Permission::AddListener,
+                PermissionInstruction::CanRegisterAccount(_, option_domain_id) => {
+                    Permission::RegisterAccount(option_domain_id.clone())
+                }
+                PermissionInstruction::CanRegisterAssetDefinition(_, option_domain_id) => {
+                    Permission::RegisterAssetDefinition(option_domain_id.clone())
+                }
+                PermissionInstruction::CanTransferAsset(
+                    _,
+                    asset_definition_id,
+                    option_domain_id,
+                ) => Permission::TransferAsset(
+                    option_domain_id.clone(),
+                    Some(asset_definition_id.clone()),
+                ),
+                PermissionInstruction::CanAddSignatory(_, account_id, option_domain_id) => {
+                    Permission::AddSignatory(option_domain_id.clone(), Some(account_id.clone()))
+                }
+                PermissionInstruction::CanRemoveSignatory(_, account_id, option_domain_id) => {
+                    Permission::RemoveSignatory(option_domain_id.clone(), Some(account_id.clone()))
+                }
+                PermissionInstruction::CanMintAsset(_, asset_definition_id, option_domain_id) => {
+                    Permission::MintAsset(
+                        option_domain_id.clone(),
+                        Some(asset_definition_id.clone()),
+                    )
+                }
+                PermissionInstruction::CanDemintAsset(_, asset_definition_id, option_domain_id) => {
+                    Permission::DemintAsset(
+                        option_domain_id.clone(),
+                        Some(asset_definition_id.clone()),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/iroha_client_no_std/src/query.rs
+++ b/iroha_client_no_std/src/query.rs
@@ -1,0 +1,35 @@
+//! This module contains query related Iroha functionality.
+
+use crate::{account, asset};
+use iroha::crypto::Signature;
+use iroha_derive::Io;
+use parity_scale_codec::{Decode, Encode};
+
+/// I/O ready structure to send queries.
+#[derive(Debug, Io, Encode, Decode)]
+pub struct QueryRequest {
+    /// Timestamp of the query creation.
+    pub timestamp: String,
+    /// Optional query signature.
+    pub signature: Option<Signature>,
+    /// Query definition.
+    pub query: IrohaQuery,
+}
+
+/// Enumeration of all legal Iroha Queries.
+#[derive(Clone, Debug, Encode, Decode)]
+pub enum IrohaQuery {
+    /// Query all Assets related to the Account.
+    GetAccountAssets(asset::query::GetAccountAssets),
+    /// Query Account information.
+    GetAccount(account::query::GetAccount),
+}
+
+/// Result of queries execution.
+#[derive(Debug, Io, Encode, Decode)]
+pub enum QueryResult {
+    /// Query all Assets related to the Account result.
+    GetAccountAssets(asset::query::GetAccountAssetsResult),
+    /// Query Account information.
+    GetAccount(account::query::GetAccountResult),
+}

--- a/iroha_client_no_std/src/tx.rs
+++ b/iroha_client_no_std/src/tx.rs
@@ -1,0 +1,164 @@
+//! This module contains Transaction related functionality of the Iroha.
+//!
+//! `RequestedTransaction` is the start of the Transaction lifecycle.
+
+use crate::prelude::*;
+use iroha::crypto::{Hash, KeyPair, Signature};
+use iroha_derive::Io;
+use parity_scale_codec::{Decode, Encode};
+use std::time::SystemTime;
+
+/// This structure represents transaction in non-trusted form.
+///
+/// `Iroha` and its' clients use `RequestedTransaction` to send transactions via network.
+/// Direct usage in business logic is strongly prohibited. Before any interactions
+/// `accept`.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct RequestedTransaction {
+    payload: Payload,
+    signatures: Vec<Signature>,
+}
+
+#[derive(Clone, Debug, Io, Encode, Decode)]
+struct Payload {
+    /// Account ID of transaction creator.
+    account_id: <Account as Identifiable>::Id,
+    /// An ordered set of instructions.
+    instructions: Vec<Instruction>,
+    /// Time of creation (unix time, in milliseconds).
+    creation_time: u64,
+    /// The transaction will be dropped after this time if it is still in a `Queue`.
+    time_to_live_ms: u64,
+}
+
+impl RequestedTransaction {
+    /// Default `RequestedTransaction` constructor.
+    pub fn new(
+        instructions: Vec<Instruction>,
+        account_id: <Account as Identifiable>::Id,
+        proposed_ttl_ms: u64,
+    ) -> RequestedTransaction {
+        RequestedTransaction {
+            payload: Payload {
+                instructions,
+                account_id,
+                creation_time: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Failed to get System Time.")
+                    .as_millis() as u64,
+                time_to_live_ms: proposed_ttl_ms,
+            },
+            signatures: Vec::new(),
+        }
+    }
+
+    /// Transaction acceptance will check that transaction signatures are valid and move state one
+    /// step forward.
+    ///
+    /// Returns `Ok(AcceptedTransaction)` if succeeded and `Err(String)` if failed.
+    pub fn accept(self) -> Result<AcceptedTransaction, String> {
+        for signature in &self.signatures {
+            if let Err(e) = signature.verify(&Vec::from(&self.payload)) {
+                return Err(format!("Failed to verify signatures: {}", e));
+            }
+        }
+        Ok(AcceptedTransaction {
+            payload: self.payload,
+            signatures: self.signatures,
+        })
+    }
+}
+
+/// An ordered set of instructions, which is applied to the ledger atomically.
+///
+/// Transactions received by `Iroha` from external resources (clients, peers, etc.)
+/// go through several steps before will be added to the blockchain and stored.
+/// Starting in form of `RequestedTransaction` transaction it changes state based on interactions
+/// with `Iroha` subsystems.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct AcceptedTransaction {
+    payload: Payload,
+    signatures: Vec<Signature>,
+}
+
+impl AcceptedTransaction {
+    /// Sign transaction with the provided key pair.
+    ///
+    /// Returns `Ok(SignedTransaction)` if succeeded and `Err(String)` if failed.
+    pub fn sign(self, key_pair: &KeyPair) -> Result<SignedTransaction, String> {
+        let mut signatures = self.signatures.clone();
+        signatures.push(Signature::new(key_pair.clone(), &Vec::from(&self.payload))?);
+        Ok(SignedTransaction {
+            payload: self.payload,
+            signatures,
+        })
+    }
+
+    /// Calculate transaction `Hash`.
+    pub fn hash(&self) -> Hash {
+        use ursa::blake2::{
+            digest::{Input, VariableOutput},
+            VarBlake2b,
+        };
+        let bytes: Vec<u8> = self.payload.clone().into();
+        let vec_hash = VarBlake2b::new(32)
+            .expect("Failed to initialize variable size hash")
+            .chain(bytes)
+            .vec_result();
+        let mut hash = [0; 32];
+        hash.copy_from_slice(&vec_hash);
+        hash
+    }
+}
+
+/// `SignedTransaction` represents transaction with signatures accumulated from Peer/Peers.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct SignedTransaction {
+    payload: Payload,
+    signatures: Vec<Signature>,
+}
+
+impl SignedTransaction {
+    /// Add additional Signatures.
+    pub fn sign(self, signatures: Vec<Signature>) -> Result<SignedTransaction, String> {
+        Ok(SignedTransaction {
+            payload: self.payload,
+            signatures: vec![self.signatures, signatures]
+                .into_iter()
+                .flatten()
+                .collect(),
+        })
+    }
+
+    /// Calculate transaction `Hash`.
+    pub fn hash(&self) -> Hash {
+        use ursa::blake2::{
+            digest::{Input, VariableOutput},
+            VarBlake2b,
+        };
+        let bytes: Vec<u8> = self.into();
+        let vec_hash = VarBlake2b::new(32)
+            .expect("Failed to initialize variable size hash")
+            .chain(bytes)
+            .vec_result();
+        let mut hash = [0; 32];
+        hash.copy_from_slice(&vec_hash);
+        hash
+    }
+}
+
+impl From<&SignedTransaction> for RequestedTransaction {
+    fn from(transaction: &SignedTransaction) -> RequestedTransaction {
+        let transaction = transaction.clone();
+        RequestedTransaction::from(transaction)
+    }
+}
+
+impl From<SignedTransaction> for RequestedTransaction {
+    fn from(transaction: SignedTransaction) -> RequestedTransaction {
+        RequestedTransaction {
+            payload: transaction.payload,
+            signatures: transaction.signatures,
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces new `iroha_client_no_std` crate with extracted from Iroha basic domain models like `Instruction`, `Peer`, `Domain`, `Account` etc. This should help in porting Iroha to `no_std` and ease client libraries.

Signed-off-by: Vladislav Markushin <negigic@gmail.com>