### PR TITLE
Ametsuchi: fixed root permission for account creation

### DIFF
--- a/test/integration/executor/create_account_test.cpp
+++ b/test/integration/executor/create_account_test.cpp
@@ -122,6 +122,30 @@ TEST_P(CreateAccountBasicTest, PrivelegeElevation) {
   checkNoSuchAccount();
 }
 
+/**
+ * Checks that there is no privelege elevation issue via CreateAccount
+ *
+ * @given a user with root permission, but without can_set_detail permission
+ * @and a domain that has a default role that contains can_set_detail permission
+ * @when the user tries to create an account in that domain
+ * @then the command succeeds
+ */
+TEST_P(CreateAccountBasicTest, RootWithNoPermSubset) {
+  ASSERT_NO_FATAL_FAILURE(
+      getItf().createRoleWithPerms("target_role", {Role::kSetDetail}));
+  IROHA_ASSERT_RESULT_VALUE(getItf().executeMaintenanceCommand(
+      *getItf().getMockCommandFactory()->constructCreateDomain(kSecondDomain,
+                                                               "target_role")));
+  ASSERT_NO_FATAL_FAILURE(getItf().createUserWithPerms(
+      kUser,
+      kDomain,
+      PublicKeyHexStringView{kUserKeypair.publicKey()},
+      {Role::kRoot}));
+
+  framework::expected::expectResultValue(createDefaultAccount(kUserId));
+  checkAccount();
+}
+
 INSTANTIATE_TEST_SUITE_P(Base,
                          CreateAccountBasicTest,
                          executor_testing::getExecutorTestParams(),

--- a/test/integration/executor/create_account_test.cpp
+++ b/test/integration/executor/create_account_test.cpp
@@ -98,7 +98,7 @@ TEST_P(CreateAccountBasicTest, NameExists) {
 }
 
 /**
- * Checks that there is no privelege elevation issue via CreateAccount
+ * Checks that there is no privilege elevation issue via CreateAccount
  *
  * @given an account with can_create_account permission, but without
  * can_set_detail permission
@@ -123,8 +123,6 @@ TEST_P(CreateAccountBasicTest, PrivelegeElevation) {
 }
 
 /**
- * Checks that there is no privelege elevation issue via CreateAccount
- *
  * @given a user with root permission, but without can_set_detail permission
  * @and a domain that has a default role that contains can_set_detail permission
  * @when the user tries to create an account in that domain


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

fixed bug:
root permission was not enough when creating an account in a domain with default role that is not a subset of creator's permissions.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

make root great again 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
