### PR TITLE
Commands: added CompareAndSetAccountDetail.need_to_check_empty for legacy compat

### DIFF
--- a/docs/source/develop/api/commands.rst
+++ b/docs/source/develop/api/commands.rst
@@ -905,7 +905,7 @@ Schema
         oneof opt_old_value {
             string old_value = 4;
         }
-        bool need_to_check_empty = 5;
+        bool check_empty = 5;
     }
 
 .. note::
@@ -923,7 +923,7 @@ Structure
     "Key", "key of information being set", "`[A-Za-z0-9_]{1,64}`", "Name"
     "Value", "new value for the corresponding key", "length of value ≤ 4096", "Artyom"
     "Old value", "current value for the corresponding key", "length of value ≤ 4096", "Artem"
-    "need_to_check_empty", "if true, empty old_value in command must match absent value in WSV; if false, any old_value in command matches absent in WSV (legacy)", "bool", "true"
+    "check_empty", "if true, empty old_value in command must match absent value in WSV; if false, any old_value in command matches absent in WSV (legacy)", "bool", "true"
 
 Validation
 ^^^^^^^^^^

--- a/docs/source/develop/api/commands.rst
+++ b/docs/source/develop/api/commands.rst
@@ -905,6 +905,7 @@ Schema
         oneof opt_old_value {
             string old_value = 4;
         }
+        bool need_to_check_empty = 5;
     }
 
 .. note::
@@ -922,6 +923,7 @@ Structure
     "Key", "key of information being set", "`[A-Za-z0-9_]{1,64}`", "Name"
     "Value", "new value for the corresponding key", "length of value ≤ 4096", "Artyom"
     "Old value", "current value for the corresponding key", "length of value ≤ 4096", "Artem"
+    "need_to_check_empty", "if true, empty old_value in command must match absent value in WSV; if false, any old_value in command matches absent in WSV (legacy)", "bool", "true"
 
 Validation
 ^^^^^^^^^^

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -694,7 +694,7 @@ namespace iroha {
                             THEN data->:creator->:key = :expected_value::jsonb
                         ELSE FALSE
                         END
-                    ELSE not :have_expected_value::boolean
+                    ELSE not (:need_to_check_empty::boolean and :have_expected_value::boolean)
                   END
             ),
             inserted AS
@@ -1612,6 +1612,7 @@ namespace iroha {
       executor.use("target", command.accountId());
       executor.use("key", command.key());
       executor.use("new_value", new_json_value);
+      executor.use("need_to_check_empty", command.needToCheckEmpty());
       executor.use("have_expected_value",
                    static_cast<bool>(command.oldValue()));
       executor.use("expected_value", expected_json_value);

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -694,7 +694,7 @@ namespace iroha {
                             THEN data->:creator->:key = :expected_value::jsonb
                         ELSE FALSE
                         END
-                    ELSE not (:need_to_check_empty::boolean and :have_expected_value::boolean)
+                    ELSE not (:check_empty::boolean and :have_expected_value::boolean)
                   END
             ),
             inserted AS
@@ -1612,7 +1612,7 @@ namespace iroha {
       executor.use("target", command.accountId());
       executor.use("key", command.key());
       executor.use("new_value", new_json_value);
-      executor.use("need_to_check_empty", command.needToCheckEmpty());
+      executor.use("check_empty", command.checkEmpty());
       executor.use("have_expected_value",
                    static_cast<bool>(command.oldValue()));
       executor.use("expected_value", expected_json_value);

--- a/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
@@ -28,6 +28,10 @@ namespace shared_model {
       return compare_and_set_account_detail_.value();
     }
 
+    bool CompareAndSetAccountDetail::needToCheckEmpty() const {
+      return compare_and_set_account_detail_.need_to_check_empty();
+    }
+
     const std::optional<interface::types::AccountDetailValueType>
     CompareAndSetAccountDetail::oldValue() const {
       if (compare_and_set_account_detail_.opt_old_value_case()

--- a/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
+++ b/shared_model/backend/protobuf/commands/impl/proto_compare_and_set_account_detail.cpp
@@ -28,8 +28,8 @@ namespace shared_model {
       return compare_and_set_account_detail_.value();
     }
 
-    bool CompareAndSetAccountDetail::needToCheckEmpty() const {
-      return compare_and_set_account_detail_.need_to_check_empty();
+    bool CompareAndSetAccountDetail::checkEmpty() const {
+      return compare_and_set_account_detail_.check_empty();
     }
 
     const std::optional<interface::types::AccountDetailValueType>

--- a/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
@@ -23,7 +23,7 @@ namespace shared_model {
 
       const interface::types::AccountDetailValueType &value() const override;
 
-      bool needToCheckEmpty() const override;
+      bool checkEmpty() const override;
 
       const std::optional<interface::types::AccountDetailValueType> oldValue()
           const override;

--- a/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
+++ b/shared_model/backend/protobuf/commands/proto_compare_and_set_account_detail.hpp
@@ -23,6 +23,8 @@ namespace shared_model {
 
       const interface::types::AccountDetailValueType &value() const override;
 
+      bool needToCheckEmpty() const override;
+
       const std::optional<interface::types::AccountDetailValueType> oldValue()
           const override;
 

--- a/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
+++ b/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
@@ -40,7 +40,7 @@ namespace shared_model {
        * @return true, if empty oldValue in command must match absent value in
        * WSV, false if any oldValue in command matches absent in WSV (legacy)
        */
-      virtual bool needToCheckEmpty() const = 0;
+      virtual bool checkEmpty() const = 0;
 
       /**
        * @return the value expected before the change

--- a/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
+++ b/shared_model/interfaces/commands/compare_and_set_account_detail.hpp
@@ -37,6 +37,12 @@ namespace shared_model {
       virtual const types::AccountDetailValueType &value() const = 0;
 
       /**
+       * @return true, if empty oldValue in command must match absent value in
+       * WSV, false if any oldValue in command matches absent in WSV (legacy)
+       */
+      virtual bool needToCheckEmpty() const = 0;
+
+      /**
        * @return the value expected before the change
        */
       virtual const std::optional<types::AccountDetailValueType> oldValue()

--- a/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
+++ b/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
@@ -15,6 +15,7 @@ namespace shared_model {
           .appendNamed("key", key())
           .appendNamed("value", value())
           .appendNamed("old_value", oldValue())
+          .appendNamed("absent previous value is checked: ", needToCheckEmpty())
           .finalize();
     }
 

--- a/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
+++ b/shared_model/interfaces/commands/impl/compare_and_set_account_detail.cpp
@@ -15,7 +15,7 @@ namespace shared_model {
           .appendNamed("key", key())
           .appendNamed("value", value())
           .appendNamed("old_value", oldValue())
-          .appendNamed("absent previous value is checked: ", needToCheckEmpty())
+          .appendNamed("absent previous value is checked: ", checkEmpty())
           .finalize();
     }
 

--- a/shared_model/schema/commands.proto
+++ b/shared_model/schema/commands.proto
@@ -106,6 +106,7 @@ message CompareAndSetAccountDetail {
     oneof opt_old_value {
         string old_value = 4;
     }
+    bool need_to_check_empty = 5;
 }
 
 message SetSettingValue {

--- a/shared_model/schema/commands.proto
+++ b/shared_model/schema/commands.proto
@@ -106,7 +106,7 @@ message CompareAndSetAccountDetail {
     oneof opt_old_value {
         string old_value = 4;
     }
-    bool need_to_check_empty = 5;
+    bool check_empty = 5;
 }
 
 message SetSettingValue {

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -2037,9 +2037,9 @@ namespace iroha {
     }
 
     /**
-     * @given commands
-     * @when trying to set new kv with not empty oldValue
-     * @then corresponding error code is returned
+     * @given no old account detail value
+     * @when trying to set new kv with not empty oldValue in legacy mode
+     * @then the new value is set despite expected old value does not match
      */
     TEST_F(CompareAndSetAccountDetail, NewDetailWithNotEmptyOldValueLegacy) {
       addOnePerm(shared_model::interface::permissions::Role::kGetMyAccDetail);

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -155,7 +155,7 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(key, const types::AccountDetailKeyType &());
       MOCK_CONST_METHOD0(value, const types::AccountDetailValueType &());
-      MOCK_CONST_METHOD0(needToCheckEmpty, bool());
+      MOCK_CONST_METHOD0(checkEmpty, bool());
       MOCK_CONST_METHOD0(oldValue,
                          const std::optional<types::AccountDetailValueType>());
     };

--- a/test/module/shared_model/command_mocks.hpp
+++ b/test/module/shared_model/command_mocks.hpp
@@ -155,6 +155,7 @@ namespace shared_model {
       MOCK_CONST_METHOD0(accountId, const types::AccountIdType &());
       MOCK_CONST_METHOD0(key, const types::AccountDetailKeyType &());
       MOCK_CONST_METHOD0(value, const types::AccountDetailValueType &());
+      MOCK_CONST_METHOD0(needToCheckEmpty, bool());
       MOCK_CONST_METHOD0(oldValue,
                          const std::optional<types::AccountDetailValueType>());
     };

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -321,7 +321,7 @@ namespace shared_model {
         const std::optional<
             shared_model::interface::types::AccountDetailValueType>
             cmd_old_value,
-        bool need_to_check_empty) const {
+        bool check_empty) const {
       return createFactoryResult<MockCompareAndSetAccountDetail>(
           [&](FactoryResult<MockCompareAndSetAccountDetail> specific_cmd_mock) {
             EXPECT_CALL(*specific_cmd_mock, accountId())
@@ -330,8 +330,8 @@ namespace shared_model {
                 .WillRepeatedly(ReturnRefOfCopy(cmd_key));
             EXPECT_CALL(*specific_cmd_mock, value())
                 .WillRepeatedly(ReturnRefOfCopy(cmd_value));
-            EXPECT_CALL(*specific_cmd_mock, needToCheckEmpty())
-                .WillRepeatedly(Return(need_to_check_empty));
+            EXPECT_CALL(*specific_cmd_mock, checkEmpty())
+                .WillRepeatedly(Return(check_empty));
             EXPECT_CALL(*specific_cmd_mock, oldValue())
                 .WillRepeatedly(Return(cmd_old_value));
 

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.cpp
@@ -320,16 +320,18 @@ namespace shared_model {
         const shared_model::interface::types::AccountDetailValueType &cmd_value,
         const std::optional<
             shared_model::interface::types::AccountDetailValueType>
-            cmd_old_value) const {
+            cmd_old_value,
+        bool need_to_check_empty) const {
       return createFactoryResult<MockCompareAndSetAccountDetail>(
-          [&account_id, &cmd_key, &cmd_value, &cmd_old_value](
-              FactoryResult<MockCompareAndSetAccountDetail> specific_cmd_mock) {
+          [&](FactoryResult<MockCompareAndSetAccountDetail> specific_cmd_mock) {
             EXPECT_CALL(*specific_cmd_mock, accountId())
                 .WillRepeatedly(ReturnRefOfCopy(account_id));
             EXPECT_CALL(*specific_cmd_mock, key())
                 .WillRepeatedly(ReturnRefOfCopy(cmd_key));
             EXPECT_CALL(*specific_cmd_mock, value())
                 .WillRepeatedly(ReturnRefOfCopy(cmd_value));
+            EXPECT_CALL(*specific_cmd_mock, needToCheckEmpty())
+                .WillRepeatedly(Return(need_to_check_empty));
             EXPECT_CALL(*specific_cmd_mock, oldValue())
                 .WillRepeatedly(Return(cmd_old_value));
 

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
@@ -197,6 +197,7 @@ namespace shared_model {
        * @param key to be in that command
        * @param value to be in that command
        * @param old_value to be in that command
+       * @param check_empty to be in that command
        * @return pointer to the created command
        */
       FactoryResult<MockCompareAndSetAccountDetail>
@@ -205,7 +206,7 @@ namespace shared_model {
           const types::AccountDetailKeyType &key,
           const types::AccountDetailValueType &value,
           const std::optional<types::AccountDetailValueType> old_value,
-          bool need_to_check_empty) const;
+          bool check_empty) const;
 
       /**
        * Construct a mocked SetSettingValue

--- a/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_command_factory.hpp
@@ -204,7 +204,8 @@ namespace shared_model {
           const types::AccountIdType &account_id,
           const types::AccountDetailKeyType &key,
           const types::AccountDetailValueType &value,
-          const std::optional<types::AccountDetailValueType> old_value) const;
+          const std::optional<types::AccountDetailValueType> old_value,
+          bool need_to_check_empty) const;
 
       /**
        * Construct a mocked SetSettingValue

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -166,7 +166,7 @@ class FieldValidatorTest : public ValidatorsTest {
                               "permissions",
                               "dm_id",
                               "payload",
-                              "need_to_check_empty"}) {
+                              "check_empty"}) {
       field_validators.insert(makeNullValidator(field));
     }
   }

--- a/test/module/shared_model/validators/field_validator_test.cpp
+++ b/test/module/shared_model/validators/field_validator_test.cpp
@@ -165,7 +165,8 @@ class FieldValidatorTest : public ValidatorsTest {
                               // permissions are always valid
                               "permissions",
                               "dm_id",
-                              "payload"}) {
+                              "payload",
+                              "need_to_check_empty"}) {
       field_validators.insert(makeNullValidator(field));
     }
   }

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -42,6 +42,7 @@ class ValidatorsTest : public ::testing::Test {
     auto setUInt64 = setField(&google::protobuf::Reflection::SetUInt64);
     auto addEnum = setField(&google::protobuf::Reflection::AddEnumValue);
     auto setEnum = setField(&google::protobuf::Reflection::SetEnumValue);
+    auto setBool = setField(&google::protobuf::Reflection::SetBool);
     auto setStrongStringView = [](const auto &value) {
       return [&value](auto refl, auto msg, auto field) {
         std::string_view sv{value};
@@ -72,6 +73,8 @@ class ValidatorsTest : public ::testing::Test {
         {"iroha.protocol.SetAccountQuorum.account_id", setString(account_id)},
         {"iroha.protocol.CompareAndSetAccountDetail.account_id",
          setString(account_id)},
+        {"iroha.protocol.CompareAndSetAccountDetail.need_to_check_empty",
+         setBool(true)},
         {"iroha.protocol.AppendRole.role_name", setString(role_name)},
         {"iroha.protocol.DetachRole.role_name", setString(role_name)},
         {"iroha.protocol.CreateRole.role_name", setString(role_name)},

--- a/test/module/shared_model/validators/validators_fixture.hpp
+++ b/test/module/shared_model/validators/validators_fixture.hpp
@@ -73,7 +73,7 @@ class ValidatorsTest : public ::testing::Test {
         {"iroha.protocol.SetAccountQuorum.account_id", setString(account_id)},
         {"iroha.protocol.CompareAndSetAccountDetail.account_id",
          setString(account_id)},
-        {"iroha.protocol.CompareAndSetAccountDetail.need_to_check_empty",
+        {"iroha.protocol.CompareAndSetAccountDetail.check_empty",
          setBool(true)},
         {"iroha.protocol.AppendRole.role_name", setString(role_name)},
         {"iroha.protocol.DetachRole.role_name", setString(role_name)},


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

there was a bug in 1.1.x when `CompareAndSetAccountDetail` was first added it did not check for old_value in command to be empty when the old value in WSV was empty. this was fixed in 1.2, but since it was already part of stable API, we need the the buggy behaviour (sic!) by default. This PR adds a flag that allows to turn this bug off, which should be done explicitly.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

yay a flag to turn bugs off

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

messy API

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
