### PR TITLE
Ametsuchi: remove sql dependency from VmCaller

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -142,7 +142,6 @@ if(USE_BURROW)
     target_link_libraries(burrow_vm_caller
         burrow_vm_caller_generated
         fmt::fmt
-        postgres_burrow_storage
         proto_command_executor
         proto_specific_query_executor
         )
@@ -162,6 +161,7 @@ target_link_libraries(ametsuchi
     rxcpp
     libs_files
     common
+    postgres_burrow_storage
     postgres_options
     shared_model_interfaces
     shared_model_plain_backend

--- a/irohad/ametsuchi/impl/burrow_vm_caller.cpp
+++ b/irohad/ametsuchi/impl/burrow_vm_caller.cpp
@@ -9,8 +9,6 @@
 #include <soci/session.h>
 #include BURROW_VM_CALL_HEADER
 #include "ametsuchi/command_executor.hpp"
-#include "ametsuchi/impl/postgres_burrow_storage.hpp"
-#include "ametsuchi/query_executor.hpp"
 #include "common/hexutils.hpp"
 #include "common/result.hpp"
 
@@ -18,13 +16,13 @@ using namespace iroha::ametsuchi;
 
 iroha::expected::Result<std::optional<std::string>, std::string>
 BurrowVmCaller::call(
-    soci::session &sql,
     std::string const &tx_hash,
     shared_model::interface::types::CommandIndexType cmd_index,
     shared_model::interface::types::EvmCodeHexStringView input,
     shared_model::interface::types::AccountIdType const &caller,
     std::optional<shared_model::interface::types::EvmCalleeHexStringView>
         callee,
+    BurrowStorage &burrow_storage,
     CommandExecutor &command_executor,
     SpecificQueryExecutor &query_executor) const {
   const char *callee_raw = callee
@@ -35,7 +33,6 @@ BurrowVmCaller::call(
   std::string nonce = tx_hash;
   const char *nonce_raw =
       const_cast<char *>(nonce.append(numToHexstring(cmd_index)).c_str());
-  PostgresBurrowStorage burrow_storage(sql, tx_hash, cmd_index);
   auto raw_result = VmCall(input_raw,
                            caller.c_str(),
                            callee_raw,

--- a/irohad/ametsuchi/impl/burrow_vm_caller.hpp
+++ b/irohad/ametsuchi/impl/burrow_vm_caller.hpp
@@ -12,13 +12,13 @@ namespace iroha::ametsuchi {
   class BurrowVmCaller : public VmCaller {
    public:
     iroha::expected::Result<std::optional<std::string>, std::string> call(
-        soci::session &sql,
         std::string const &tx_hash,
         shared_model::interface::types::CommandIndexType cmd_index,
         shared_model::interface::types::EvmCodeHexStringView input,
         shared_model::interface::types::AccountIdType const &caller,
         std::optional<shared_model::interface::types::EvmCalleeHexStringView>
             callee,
+        BurrowStorage &burrow_storage,
         CommandExecutor &command_executor,
         SpecificQueryExecutor &query_executor) const override;
   };

--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -1542,9 +1542,9 @@ namespace iroha {
           }
 
           using namespace shared_model::interface::types;
+          PostgresBurrowStorage burrow_storage(*sql_, tx_hash, cmd_index);
           return vm_caller_->get()
               .call(
-                  *sql_,
                   tx_hash,
                   cmd_index,
                   EvmCodeHexStringView{command.input()},
@@ -1553,6 +1553,7 @@ namespace iroha {
                       ? std::optional<EvmCalleeHexStringView>{command.callee()
                                                                   ->get()}
                       : std::optional<EvmCalleeHexStringView>{std::nullopt},
+                  burrow_storage,
                   *this,
                   *specific_query_executor_)
               .match(

--- a/irohad/ametsuchi/vm_caller.hpp
+++ b/irohad/ametsuchi/vm_caller.hpp
@@ -15,24 +15,21 @@
 #include "interfaces/common_objects/string_view_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
-namespace soci {
-  class session;
-}
-
 namespace iroha::ametsuchi {
+  class BurrowStorage;
   class CommandExecutor;
   class SpecificQueryExecutor;
 
   class VmCaller {
    public:
     virtual iroha::expected::Result<std::optional<std::string>, std::string>
-    call(soci::session &sql,
-         std::string const &tx_hash,
+    call(std::string const &tx_hash,
          shared_model::interface::types::CommandIndexType cmd_index,
          shared_model::interface::types::EvmCodeHexStringView input,
          shared_model::interface::types::AccountIdType const &caller,
          std::optional<shared_model::interface::types::EvmCalleeHexStringView>
              callee,
+         BurrowStorage &burrow_storage,
          CommandExecutor &command_executor,
          SpecificQueryExecutor &query_executor) const = 0;
   };

--- a/test/integration/executor/call_engine_test.cpp
+++ b/test/integration/executor/call_engine_test.cpp
@@ -71,7 +71,7 @@ using CallEngineBasicTest = BasicExecutorTest<CallEngineTest>;
  */
 TEST_P(CallEngineBasicTest, EngineError) {
   EXPECT_CALL(*getBackendParam().vm_caller_,
-              call(_, _, _, kCode, kAdminId, Optional(kCallee), _, _))
+              call(_, _, kCode, kAdminId, Optional(kCallee), _, _, _))
       .WillOnce(::testing::Return(iroha::expected::makeError("engine error")));
   checkCommandError(callEngine(kAdminId, kAdminId, kCallee, kCode), 3);
 }
@@ -88,7 +88,7 @@ TEST_P(CallEnginePermissionTest, CommandPermissionTest) {
   ASSERT_NO_FATAL_FAILURE(prepareState({}));
 
   EXPECT_CALL(*getBackendParam().vm_caller_,
-              call(_, _, _, kCode, kUserId, Optional(kCallee), _, _))
+              call(_, _, kCode, kUserId, Optional(kCallee), _, _, _))
       .Times(isEnoughPermissions() ? 1 : 0)
       .WillRepeatedly(::testing::Return(iroha::expected::makeValue("success")));
 

--- a/test/integration/executor/get_engine_receipts_test.cpp
+++ b/test/integration/executor/get_engine_receipts_test.cpp
@@ -174,7 +174,7 @@ struct GetEngineReceiptsTest : public ExecutorTestBase {
         set_expectation(
             EXPECT_CALL(
                 *getBackendParam().vm_caller_,
-                call(_, tx_hash, cmd_idx, input, kUserId, callee, _, _)))
+                call(tx_hash, cmd_idx, input, kUserId, callee, _, _, _)))
             .WillOnce(::testing::Return(
                 iroha::expected::makeValue(std::move(engine_response))));
   }

--- a/test/module/irohad/ametsuchi/mock_vm_caller.hpp
+++ b/test/module/irohad/ametsuchi/mock_vm_caller.hpp
@@ -10,7 +10,7 @@
 
 #include <gmock/gmock.h>
 
-#include <soci/soci.h>
+#include "ametsuchi/burrow_storage.hpp"
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/specific_query_executor.hpp"
 #include "common/result.hpp"
@@ -23,13 +23,13 @@ namespace iroha::ametsuchi {
     MOCK_CONST_METHOD8(
         call,
         iroha::expected::Result<std::optional<std::string>, std::string>(
-            soci::session &sql,
             std::string const &tx_hash,
             shared_model::interface::types::CommandIndexType cmd_index,
             shared_model::interface::types::EvmCodeHexStringView input,
             shared_model::interface::types::AccountIdType const &caller,
             std::optional<
                 shared_model::interface::types::EvmCalleeHexStringView> callee,
+            BurrowStorage &burrow_storage,
             CommandExecutor &command_executor,
             SpecificQueryExecutor &query_executor));
   };


### PR DESCRIPTION
### Description of the Change
Remove sql dependency from VmCaller, so that other backends can pass their own BurrowStorage instead.

### Benefits
Other potential backends can use VmCaller

### Possible Drawbacks 
None