### PR TITLE
remove ursa feature build flags

### DIFF
--- a/cmake/Modules/Findursa.cmake
+++ b/cmake/Modules/Findursa.cmake
@@ -37,7 +37,7 @@ if(NOT TARGET hyperledger_ursa_build)
     BUILD_IN_SOURCE   1
     BUILD_COMMAND     ${CMAKE_COMMAND} -E
       env OPENSSL_DIR=${OPENSSL_ROOT_DIR}
-      cargo build --release --no-default-features --features="ffi"
+      cargo build --release
     CONFIGURE_COMMAND "" # remove configure step
     UPDATE_COMMAND    "" # remove update step
     INSTALL_COMMAND   "" # remove install step

--- a/cmake/Modules/Findursa.cmake
+++ b/cmake/Modules/Findursa.cmake
@@ -20,7 +20,12 @@ set_target_properties(ursa PROPERTIES
     INTERFACE_LINK_LIBRARIES "OpenSSL::SSL;OpenSSL::Crypto;dl;pthread"
 )
 
-if(NOT TARGET hyperledger_ursa_build) 
+if(APPLE)
+  find_library(SECURITY_LIBRARY Security)
+  target_link_libraries(ursa ${SECURITY_LIBRARY})
+endif()
+
+if(NOT TARGET hyperledger_ursa_build)
   find_package(OpenSSL REQUIRED)
 
   get_filename_component(OPENSSL_ROOT_DIR ${OPENSSL_INCLUDE_DIR} DIRECTORY)


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

[IR-839](https://jira.hyperledger.org/browse/IR-839)

#649 

### Description of the Change

the flags in question were previously ignored with a warning, and now produce an error to avoid misleading usage. this means, all previous usage and testing was with the default features enabled, and thus it seems reasonable to keep them.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

HL Ursa builds on cargo 1.40+.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
