### PR TITLE
Develop Dockerfile: install setuptools and wheel

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -27,7 +27,7 @@ RUN set -e; \
         # CI dependencies
         git ssh tar gzip ca-certificates gnupg \
         # Python3
-        python3-pip python3-setuptools\
+        python3-pip \
         # other
         curl file gdb gdbserver ccache python3.6-dev \
         gcovr cppcheck doxygen rsync graphviz graphviz-dev unzip vim zip pkg-config; \
@@ -87,6 +87,7 @@ RUN set -e; \
 
 # python bindings dependencies
 RUN set -e; \
+    pip3 install setuptools wheel; \
     pip3 install grpcio_tools pysha3 iroha==0.0.5.4
 
 # install lcov


### PR DESCRIPTION
### Description of the Change
Prevent build errors such as here https://jenkins.soramitsu.co.jp/blue/organizations/jenkins/iroha%2Firoha-hyperledger/detail/PR-666/2/pipeline
```
commands.CommandError: We expect a missing `_needs_stub` attribute from older versions of setuptools. Consider upgrading setuptools.
```

### Benefits
Dockerfile build works

### Possible Drawbacks 
None