### PR TITLE
ProtoCommandValidator: add precision validation

### DIFF
--- a/shared_model/validators/protobuf/proto_command_validator.cpp
+++ b/shared_model/validators/protobuf/proto_command_validator.cpp
@@ -55,6 +55,20 @@ namespace shared_model {
           return aggregateErrors(
               "CreateAccount", {}, {validatePublicKey(ca.public_key())});
         }
+        case iroha::protocol::Command::kCreateAsset: {
+          const auto &ca = command.create_asset();
+          return aggregateErrors(
+              "CreateAsset",
+              {},
+              {[](auto precision) -> std::optional<ValidationError> {
+                if (precision < 0 or precision > 255) {
+                  return ValidationError(
+                      "Precision",
+                      {"Precision should be within range [0, 255]"});
+                }
+                return std::nullopt;
+              }(ca.precision())});
+        }
         case iroha::protocol::Command::kRemoveSignatory: {
           const auto &rs = command.remove_signatory();
           return aggregateErrors(


### PR DESCRIPTION
### Description of the Change
As precision type in shared model is uint8, uint32 precision in protobuf was not checked for overflows. This PR adds range check before casting it into shared model type.

### Benefits
No precision overflows.

### Possible Drawbacks 
Backward compatibility issues
