### PR TITLE
WsvRestorer: add chain and block object validation

### DIFF
--- a/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.hpp
@@ -11,7 +11,23 @@
 #include "ametsuchi/ledger_state.hpp"
 #include "common/result.hpp"
 
+namespace shared_model {
+  namespace interface {
+    class Block;
+  }
+  namespace validation {
+    template <typename Model>
+    class AbstractValidator;
+  }
+}  // namespace shared_model
+
 namespace iroha {
+  namespace protocol {
+    class Block_v1;
+  }
+  namespace validation {
+    class ChainValidator;
+  }
   namespace ametsuchi {
 
     /**
@@ -20,6 +36,13 @@ namespace iroha {
      */
     class WsvRestorerImpl : public WsvRestorer {
      public:
+      WsvRestorerImpl(
+          std::unique_ptr<shared_model::validation::AbstractValidator<
+              shared_model::interface::Block>> interface_validator,
+          std::unique_ptr<shared_model::validation::AbstractValidator<
+              iroha::protocol::Block_v1>> proto_validator,
+          std::shared_ptr<validation::ChainValidator> validator);
+
       virtual ~WsvRestorerImpl() = default;
       /**
        * Recover WSV (World State View).
@@ -29,6 +52,15 @@ namespace iroha {
        * string
        */
       CommitResult restoreWsv(Storage &storage) override;
+
+     private:
+      std::unique_ptr<shared_model::validation::AbstractValidator<
+          shared_model::interface::Block>>
+          interface_validator_;
+      std::unique_ptr<shared_model::validation::AbstractValidator<
+          iroha::protocol::Block_v1>>
+          proto_validator_;
+      std::shared_ptr<validation::ChainValidator> validator_;
     };
 
   }  // namespace ametsuchi

--- a/shared_model/validators/protobuf/proto_block_validator.cpp
+++ b/shared_model/validators/protobuf/proto_block_validator.cpp
@@ -13,36 +13,40 @@
 #include "validators/validation_error_helpers.hpp"
 #include "validators/validators_common.hpp"
 
-namespace shared_model {
-  namespace validation {
-    std::optional<ValidationError> ProtoBlockValidator::validate(
-        const iroha::protocol::Block &block) const {
-      ValidationErrorCreator error_creator;
+namespace shared_model::validation {
+  std::optional<ValidationError> ProtoBlockValidator::validate(
+      iroha::protocol::Block const &block) const {
+    ValidationErrorCreator error_creator;
 
-      // make sure version one_of field of the Block is set
-      if (block.block_version_case() == iroha::protocol::Block::kBlockV1) {
-        const auto &payload = block.block_v1().payload();
-
-        for (auto hash : payload.rejected_transactions_hashes()
-                 | boost::adaptors::indexed(1)) {
-          if (not validateHexString(hash.value())) {
-            error_creator.addChildError(
-                ValidationError{fmt::format("Rejected transaction hash #{} {}",
-                                            hash.index(),
-                                            hash.value()),
-                                {"Not a hex string."}});
-          }
-        }
-
-        if (not validateHexString(payload.prev_block_hash())) {
-          error_creator.addReason("Prev block hash has incorrect format");
-        }
-
-      } else {
-        error_creator.addReason("Unknown block version.");
-      }
-
-      return std::move(error_creator).getValidationError("Protobuf Block");
+    // make sure version one_of field of the Block is set
+    if (block.block_version_case() == iroha::protocol::Block::kBlockV1) {
+      return validate(block.block_v1());
+    } else {
+      error_creator.addReason("Unknown block version.");
     }
-  }  // namespace validation
-}  // namespace shared_model
+
+    return std::move(error_creator).getValidationError("Protobuf Block");
+  }
+  std::optional<ValidationError> ProtoBlockValidator::validate(
+      iroha::protocol::Block_v1 const &block) const {
+    ValidationErrorCreator error_creator;
+
+    const auto &payload = block.payload();
+
+    for (auto hash :
+         payload.rejected_transactions_hashes() | boost::adaptors::indexed(1)) {
+      if (not validateHexString(hash.value())) {
+        error_creator.addChildError(ValidationError{
+            fmt::format(
+                "Rejected transaction hash #{} {}", hash.index(), hash.value()),
+            {"Not a hex string."}});
+      }
+    }
+
+    if (not validateHexString(payload.prev_block_hash())) {
+      error_creator.addReason("Prev block hash has incorrect format");
+    }
+
+    return std::move(error_creator).getValidationError("Protobuf Block");
+  }
+}  // namespace shared_model::validation

--- a/shared_model/validators/protobuf/proto_block_validator.hpp
+++ b/shared_model/validators/protobuf/proto_block_validator.hpp
@@ -8,21 +8,21 @@
 
 #include "validators/abstract_validator.hpp"
 
-namespace iroha {
-  namespace protocol {
-    class Block;
-  }
-}  // namespace iroha
+namespace iroha::protocol {
+  class Block;
+  class Block_v1;
+}  // namespace iroha::protocol
 
-namespace shared_model {
-  namespace validation {
-    class ProtoBlockValidator
-        : public AbstractValidator<iroha::protocol::Block> {
-     public:
-      std::optional<ValidationError> validate(
-          const iroha::protocol::Block &block) const override;
-    };
-  }  // namespace validation
-}  // namespace shared_model
+namespace shared_model::validation {
+  class ProtoBlockValidator
+      : public AbstractValidator<iroha::protocol::Block>,
+        public AbstractValidator<iroha::protocol::Block_v1> {
+   public:
+    std::optional<ValidationError> validate(
+        iroha::protocol::Block const &block) const override;
+    std::optional<ValidationError> validate(
+        iroha::protocol::Block_v1 const &block) const override;
+  };
+}  // namespace shared_model::validation
 
 #endif  // IROHA_PROTO_BLOCK_VALIDATOR_HPP


### PR DESCRIPTION
### Description of the Change
Add stateless validation for blocks in WsvRestorer

### Benefits
Detect modified block store

### Possible Drawbacks 
None
