### PR TITLE
Documentation push step was deleted

### DIFF
--- a/.jenkinsci/builders/x64-linux-build-steps.groovy
+++ b/.jenkinsci/builders/x64-linux-build-steps.groovy
@@ -154,7 +154,7 @@ def buildSteps(int parallelism, String compiler, String build_type, boolean buil
       }
       stage('Build docs'){
         if (docs) {
-          doxygen.doDoxygen(specialBranch, scmVars.GIT_LOCAL_BRANCH)
+          doxygen.doDoxygen()
         }
       }
     } // end iC.inside

--- a/.jenkinsci/text-variables.groovy
+++ b/.jenkinsci/text-variables.groovy
@@ -205,7 +205,7 @@ cmd_description = """
       <p><strong>doxygen</strong> = false (or = true if master ) </p>
       <ul>
          <li>
-            <p>Build doxygen, if specialBranch== true will publish, if not specialBranch will upload it to jenkins,</p>
+            <p>Build doxygen, docs will be uploaded to jenkins,</p>
          </li>
          <li>
             <p>Ex:&nbsp;doxygen=true</p>

--- a/.jenkinsci/utils/doxygen.groovy
+++ b/.jenkinsci/utils/doxygen.groovy
@@ -8,23 +8,9 @@
 //  Builds and push Doxygen docks
 //
 
-def doDoxygen(boolean specialBranch, String local_branch) {
+def doDoxygen() {
   sh "doxygen Doxyfile"
-  if (specialBranch) {
-    def branch = local_branch == "master" ? local_branch : "develop"
-    sshagent(['jenkins-artifact']) {
-      sh "ssh-agent"
-      sh """
-        rsync \
-        -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
-        -rzcv --delete \
-        docs/doxygen/html/* \
-        ubuntu@docs.iroha.tech:/var/nexus-efs/doxygen/${branch}/
-      """
-    }
-  } else {
-    archiveArtifacts artifacts: 'docs/doxygen/html/*', allowEmptyArchive: true
-  }
+  archiveArtifacts artifacts: 'docs/doxygen/html/*', allowEmptyArchive: true
 }
 
 return this


### PR DESCRIPTION
### Description of the Change

We use `https://iroha.readthedocs.io` instead of `docs.iroha.tech` to store the Iroha documentation.
We don't need the push step anymore. Documentation is built on the `readthedocs.io` side.

Signed-off-by: Roman Gavrilov <gavrilov@soramitsu.co.jp>