### PR TITLE
Reduce rxcpp debug symbols size

### DIFF
--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -54,6 +54,10 @@ namespace iroha {
     struct GrpcChannelParams;
     struct TlsCredentials;
   }  // namespace network
+  namespace protocol {
+    class Query;
+    class BlocksQuery;
+  }  // namespace protocol
   namespace simulator {
     class Simulator;
   }
@@ -83,6 +87,9 @@ namespace shared_model {
     class QueryResponseFactory;
     class TransactionBatchFactory;
   }  // namespace interface
+  namespace validation {
+    struct Settings;
+  }
 }  // namespace shared_model
 
 class Irohad {

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -8,11 +8,10 @@
 
 #include <utility>
 
-#include "ametsuchi/ledger_state.hpp"
 #include "consensus/round.hpp"
-#include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {
+  struct LedgerState;
   namespace synchronizer {
 
     /**

--- a/test/integration/acceptance/add_peer_test.cpp
+++ b/test/integration/acceptance/add_peer_test.cpp
@@ -11,6 +11,7 @@
 #include <rxcpp/operators/rx-take.hpp>
 #include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
+#include "ametsuchi/storage.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "common/bind.hpp"
 #include "consensus/yac/vote_message.hpp"

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -13,6 +13,7 @@
 #include <rxcpp/operators/rx-tap.hpp>
 #include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
+#include "ametsuchi/storage.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/honest.hpp"

--- a/test/integration/acceptance/remove_peer_test.cpp
+++ b/test/integration/acceptance/remove_peer_test.cpp
@@ -11,6 +11,7 @@
 #include <rxcpp/operators/rx-take.hpp>
 #include <rxcpp/operators/rx-timeout.hpp>
 #include "ametsuchi/block_query.hpp"
+#include "ametsuchi/storage.hpp"
 #include "builders/protobuf/transaction.hpp"
 #include "consensus/yac/vote_message.hpp"
 #include "consensus/yac/yac_hash_provider.hpp"


### PR DESCRIPTION
### Description of the Change

Before
```
/tmp/bloaty/bloaty /tmp/build/irohad/main/CMakeFiles/application.dir/impl/on_demand_ordering_init.o -d shortsymbols
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  96.3%   380Mi   0.0%       0    [section .debug_str]
   1.7%  6.70Mi  64.7%   618Ki    [5655 Others]
   0.5%  2.03Mi   0.0%       0    [section .rela.debug_info]
   0.4%  1.75Mi   0.0%       0    [section .debug_info]
   0.2%   882Ki   0.0%       0    [section .shstrtab]
   0.2%   614Ki   0.0%       0    [ELF Headers]
   0.1%   318Ki   0.0%       0    [section .symtab]
   0.1%   304Ki   0.0%       0    [section .strtab]
   0.1%   269Ki  28.2%   269Ki    [section .eh_frame]
   0.1%   266Ki   0.0%       0    [section .debug_line]
   0.1%   264Ki   0.0%       0    [section .rela.debug_ranges]
   0.1%   220Ki   0.6%  5.40Ki    std::move<>()
   0.1%   218Ki   0.0%       0    [section .rela.eh_frame]
   0.0%   152Ki   3.8%  36.1Ki    std::_Sp_counted_ptr_inplace<>
   0.0%   139Ki   0.4%  3.57Ki    std::allocator<>::~allocator()
   0.0%   134Ki   0.6%  6.08Ki    rxcpp::observer<>::observer()
   0.0%   133Ki   0.4%  4.25Ki    std::allocator<>::allocator()
   0.0%   132Ki   0.6%  6.15Ki    std::shared_ptr<>::shared_ptr<>()
   0.0%   129Ki   0.3%  2.69Ki    __gnu_cxx::new_allocator<>::new_allocator()
   0.0%   128Ki   0.4%  3.46Ki    std::forward<>()
   0.0%   126Ki   0.0%       0    [section .rela.debug_aranges]
 100.0%   395Mi 100.0%   955Ki    TOTAL
```

After
```
/tmp/bloaty/bloaty /tmp/build/irohad/main/CMakeFiles/application.dir/impl/on_demand_ordering_init.o -d shortsymbols
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  40.3%  8.93Mi   0.0%       0    [section .debug_str]
  18.1%  4.01Mi  64.7%   549Ki    [7072 Others]
   9.3%  2.07Mi   0.0%       0    [section .rela.debug_info]
   7.7%  1.72Mi   0.0%       0    [section .debug_info]
   7.4%  1.63Mi   0.0%       0    [section .shstrtab]
   3.6%   819Ki   0.0%       0    [ELF Headers]
   2.5%   565Ki   0.0%       0    [section .strtab]
   1.9%   422Ki   0.0%       0    [section .symtab]
   1.5%   346Ki   0.0%       0    [section .rela.debug_ranges]
   1.2%   283Ki   0.0%       0    [section .debug_line]
   1.1%   252Ki  29.7%   252Ki    [section .eh_frame]
   0.9%   203Ki   0.0%       0    [section .rela.eh_frame]
   0.7%   167Ki   0.0%       0    [section .rela.debug_aranges]
   0.7%   167Ki   0.0%       0    [section .rela.debug_line]
   0.5%   117Ki   0.0%       0    [section .debug_ranges]
   0.5%   112Ki   0.6%  5.34Ki    std::move<>()
   0.5%   111Ki   0.0%       0    [section .debug_aranges]
   0.4%  99.0Ki   0.3%  2.77Ki    __gnu_cxx::new_allocator<>::new_allocator()
   0.4%  85.9Ki   2.5%  21.1Ki    std::__shared_count<>::__shared_count<>()
   0.4%  83.8Ki   2.2%  18.4Ki    std::_Sp_counted_ptr_inplace<>
   0.4%  80.3Ki   0.0%       0    [section .group]
 100.0%  22.2Mi 100.0%   849Ki    TOTAL
```

Replace rxcpp operator chains with explicit variables to reduce debug symbol size.

### Benefits
Reduced memory usage during link time.

### Possible Drawbacks 
None
