### PR TITLE
Fix/db commit order

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -106,6 +106,7 @@ find_package(TBB REQUIRED CONFIG)
 find_package(Boost 1.65.0 REQUIRED
     COMPONENTS
     filesystem
+    iostreams
     thread
     )
 

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(flat_file_storage
     logger
     Boost::boost
     Boost::filesystem
+    Boost::iostreams
     )
 
 add_library(postgres_storage

--- a/irohad/ametsuchi/block_query.hpp
+++ b/irohad/ametsuchi/block_query.hpp
@@ -9,7 +9,7 @@
 #include <optional>
 
 #include "ametsuchi/tx_cache_response.hpp"
-#include "common/result.hpp"
+#include "common/result_fwd.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {

--- a/irohad/ametsuchi/block_storage.hpp
+++ b/irohad/ametsuchi/block_storage.hpp
@@ -10,7 +10,8 @@
 #include <functional>
 #include <memory>
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include "common/result_fwd.hpp"
 #include "interfaces/iroha_internal/block.hpp"
 
 namespace iroha {
@@ -46,13 +47,14 @@ namespace iroha {
       virtual void clear() = 0;
 
       /// type of function which can be applied to the elements of the storage
-      using FunctionType = std::function<void(
+      using FunctionType = std::function<expected::Result<void, std::string>(
           std::shared_ptr<const shared_model::interface::Block>)>;
 
       /**
        * Iterates through all the stored blocks
        */
-      virtual void forEach(FunctionType function) const = 0;
+      virtual expected::Result<void, std::string> forEach(
+          FunctionType function) const = 0;
 
       virtual ~BlockStorage() = default;
     };

--- a/irohad/ametsuchi/impl/flat_file/flat_file.cpp
+++ b/irohad/ametsuchi/impl/flat_file/flat_file.cpp
@@ -86,8 +86,10 @@ bool FlatFile::add(Identifier id, const Bytes &block) {
   auto val_size =
       sizeof(std::remove_reference<decltype(block)>::type::value_type);
 
-  file.write(reinterpret_cast<const char *>(block.data()),
-             block.size() * val_size);
+  if (not file.write(reinterpret_cast<const char *>(block.data()),
+                     block.size() * val_size)) {
+    return false;
+  }
 
   available_blocks_.insert(id);
   return true;

--- a/irohad/ametsuchi/impl/flat_file_block_storage.hpp
+++ b/irohad/ametsuchi/impl/flat_file_block_storage.hpp
@@ -32,7 +32,8 @@ namespace iroha {
 
       void clear() override;
 
-      void forEach(FunctionType function) const override;
+      expected::Result<void, std::string> forEach(
+          FunctionType function) const override;
 
      private:
       std::unique_ptr<FlatFile> flat_file_storage_;

--- a/irohad/ametsuchi/impl/in_memory_block_storage.cpp
+++ b/irohad/ametsuchi/impl/in_memory_block_storage.cpp
@@ -32,8 +32,13 @@ void InMemoryBlockStorage::clear() {
   block_store_.clear();
 }
 
-void InMemoryBlockStorage::forEach(FunctionType function) const {
+iroha::expected::Result<void, std::string> InMemoryBlockStorage::forEach(
+    FunctionType function) const {
   for (const auto &pair : block_store_) {
-    function(pair.second);
+    auto maybe_error = function(pair.second);
+    if (iroha::expected::hasError(maybe_error)) {
+      return maybe_error.assumeError();
+    }
   }
+  return {};
 }

--- a/irohad/ametsuchi/impl/in_memory_block_storage.hpp
+++ b/irohad/ametsuchi/impl/in_memory_block_storage.hpp
@@ -28,7 +28,8 @@ namespace iroha {
 
       void clear() override;
 
-      void forEach(FunctionType function) const override;
+      expected::Result<void, std::string> forEach(
+          FunctionType function) const override;
 
      private:
       std::map<shared_model::interface::types::HeightType,

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -44,7 +44,9 @@ namespace iroha {
       boost::optional<std::shared_ptr<const iroha::LedgerState>>
       getLedgerState() const;
 
-      expected::Result<CommitResult, std::string> commit() && override;
+      expected::Result<CommitResult, std::string> commit(
+          BlockStorage &block_storage)
+          && override;
 
       ~MutableStorageImpl() override;
 

--- a/irohad/ametsuchi/impl/postgres_block_storage.hpp
+++ b/irohad/ametsuchi/impl/postgres_block_storage.hpp
@@ -43,7 +43,8 @@ namespace iroha {
 
       void clear() override;
 
-      void forEach(FunctionType function) const override;
+      expected::Result<void, std::string> forEach(
+          FunctionType function) const override;
 
      private:
       struct HeightRange {

--- a/irohad/ametsuchi/impl/storage_impl.cpp
+++ b/irohad/ametsuchi/impl/storage_impl.cpp
@@ -300,7 +300,14 @@ namespace iroha {
       return std::move(*mutable_storage).commit() |
                  [this](auto commit_result) -> CommitResult {
         commit_result.block_storage->forEach(
-            [this](const auto &block) { this->storeBlock(block); });
+            [this](const auto &block)
+                -> iroha::expected::Result<void, std::string> {
+              auto maybe_error = this->storeBlock(block);
+              if (iroha::expected::hasError(maybe_error)) {
+                return maybe_error.assumeError();
+              }
+              return {};
+            });
 
         ledger_state_ = commit_result.ledger_state;
         return expected::makeValue(std::move(commit_result.ledger_state));

--- a/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
+++ b/irohad/ametsuchi/impl/wsv_restorer_impl.cpp
@@ -57,7 +57,10 @@ namespace {
      * Does not iterate any blocks - it is not required to insert any additional
      * blocks to the existing storage
      */
-    void forEach(FunctionType function) const override {}
+    iroha::expected::Result<void, std::string> forEach(
+        FunctionType function) const override {
+      return {};
+    }
   };
 
   /**

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -68,9 +68,10 @@ namespace iroha {
               blocks,
           MutableStoragePredicate predicate) = 0;
 
-      /// Apply the local changes made to this MutableStorage to the global WSV.
+      /// Apply the local changes made to this MutableStorage to block_storage
+      /// and the global WSV.
       virtual expected::Result<MutableStorage::CommitResult, std::string>
-      commit() && = 0;
+      commit(BlockStorage &block_storage) && = 0;
 
       virtual ~MutableStorage() = default;
     };

--- a/test/module/irohad/ametsuchi/flat_file_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/flat_file_block_storage_test.cpp
@@ -178,9 +178,13 @@ TEST_F(FlatFileBlockStorageTest, ForEach) {
 
   size_t count = 0;
 
-  block_storage->forEach([&count, &raw_block](const auto &block) {
-    ++count;
-    ASSERT_EQ(raw_block, block.get());
+  block_storage->forEach([&count, &raw_block](const auto &block)
+                             -> iroha::expected::Result<void, std::string> {
+    [&] {
+      ++count;
+      ASSERT_EQ(raw_block, block.get());
+    }();
+    return {};
   });
 
   ASSERT_EQ(1, count);

--- a/test/module/irohad/ametsuchi/in_memory_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/in_memory_block_storage_test.cpp
@@ -104,10 +104,14 @@ TEST_F(InMemoryBlockStorageTest, ForEach) {
 
   size_t count = 0;
 
-  block_storage_.forEach([this, &count](const auto &block) {
-    ++count;
-    ASSERT_TRUE(block);
-    ASSERT_EQ(*block_, *block);
+  block_storage_.forEach([this, &count](const auto &block)
+                             -> iroha::expected::Result<void, std::string> {
+    [&] {
+      ++count;
+      ASSERT_TRUE(block);
+      ASSERT_EQ(*block_, *block);
+    }();
+    return {};
   });
 
   ASSERT_EQ(1, count);

--- a/test/module/irohad/ametsuchi/mock_block_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_block_storage.hpp
@@ -22,7 +22,8 @@ namespace iroha {
               shared_model::interface::types::HeightType));
       MOCK_CONST_METHOD0(size, size_t(void));
       MOCK_METHOD0(clear, void(void));
-      MOCK_CONST_METHOD1(forEach, void(FunctionType));
+      MOCK_CONST_METHOD1(forEach,
+                         expected::Result<void, std::string>(FunctionType));
     };
   }  // namespace ametsuchi
 }  // namespace iroha

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -27,13 +27,14 @@ namespace iroha {
                    bool(std::shared_ptr<const shared_model::interface::Block>));
       MOCK_METHOD1(applyPrepared,
                    bool(std::shared_ptr<const shared_model::interface::Block>));
-      MOCK_METHOD0(
-          do_commit,
-          expected::Result<MutableStorage::CommitResult, std::string>());
+      MOCK_METHOD1(do_commit,
+                   expected::Result<MutableStorage::CommitResult, std::string>(
+                       BlockStorage &));
 
-      expected::Result<MutableStorage::CommitResult, std::string> commit()
+      expected::Result<MutableStorage::CommitResult, std::string> commit(
+          BlockStorage &block_storage)
           && override {
-        return do_commit();
+        return do_commit(block_storage);
       }
     };
 

--- a/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_block_storage_test.cpp
@@ -192,15 +192,19 @@ TEST_F(PostgresBlockStorageTest, ForEach) {
 
   size_t count = 0;
 
-  block_storage_->forEach([&count, &block, &another_block](const auto &b) {
-    ++count;
-    if (b->height() == block.height()) {
-      ASSERT_EQ(b->blob(), block.blob());
-    } else if (b->height() == another_block.height()) {
-      ASSERT_EQ(b->blob(), another_block.blob());
-    } else {
-      FAIL() << "Unexpected block height returned: " << b->height();
-    }
+  block_storage_->forEach([&count, &block, &another_block](const auto &b)
+                              -> iroha::expected::Result<void, std::string> {
+    [&] {
+      ++count;
+      if (b->height() == block.height()) {
+        ASSERT_EQ(b->blob(), block.blob());
+      } else if (b->height() == another_block.height()) {
+        ASSERT_EQ(b->blob(), another_block.blob());
+      } else {
+        FAIL() << "Unexpected block height returned: " << b->height();
+      }
+    }();
+    return {};
   });
 
   ASSERT_EQ(2, count);


### PR DESCRIPTION
### Description of the Change
Commit blocks before WSV to prevent failures after node crash when height of WSV is greater than height of block store.

### Benefits
Less cases when it is impossible to start a node after crash without manual external help.

### Possible Drawbacks 
Performance decrease due to additional reads from block store.