### PR TITLE
Fixes coverage job

### DIFF
--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -39,7 +39,7 @@ url = "2.1"
 ursa = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-heim = "0.0.10"
+heim = "0.0.11"
 log = { version = "0.4", features = ["std", "serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

### Background

As you may have noticed our coverage CI job have failed recently, due to compilation errors.

With the new nightly version 1.49 rustc improvements (rust-lang/rust#77638) were introduced, that fail the compilation of our dependencies in nightly rust and our coverage tool uses nightly rust.

### Description of the Change

Therefore it is needed to increment `heim` library version, where the problems are fixed in its dependency `uom` library.

### Benefits
The master branch coverage job should work correctly after this fix.

