### PR TITLE
Infrastructure: use LOCATION Python3 search policy for CMake

### DIFF
--- a/.jenkinsci/builders/x64-mac-build-steps.groovy
+++ b/.jenkinsci/builders/x64-mac-build-steps.groovy
@@ -72,6 +72,7 @@ def buildSteps(int parallelism, List compilerVersions, String build_type, boolea
         -DBENCHMARKING=${cmakeBooleanOption[benchmarking]} \
         -DPACKAGE_TGZ=${cmakeBooleanOption[packagebuild]} \
         -DUSE_BTF=${cmakeBooleanOption[useBTF]} \
+        -DPython3_FIND_STRATEGY=LOCATION \
         -DUSE_LIBURSA=${cmakeBooleanOption[use_libursa]} \
         -DUSE_BURROW=${cmakeBooleanOption[use_burrow]} \
         -DCMAKE_TOOLCHAIN_FILE=${mac_vcpkg_toolchain_file} ")


### PR DESCRIPTION
### Description of the Change
Set LOCATION search policy for Python3 explicitly, so that it uses the first found Python from path instead of searching for the highest available version.

### Benefits
Correct Python is used from the environment.

### Possible Drawbacks 
None
