### PR TITLE
Queue tx tx number limit and Iroha initialization fixes

### DIFF
--- a/iroha/src/kura.rs
+++ b/iroha/src/kura.rs
@@ -57,9 +57,6 @@ impl Kura {
         let blocks = self.block_store.read_all().await;
         self.merkle_tree =
             MerkleTree::new().build(&blocks.iter().map(|block| block.hash()).collect::<Vec<_>>());
-        for block in &blocks {
-            self.block_sender.send(block.clone().commit()).await;
-        }
         self.blocks = blocks;
         Ok(())
     }

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -13,6 +13,7 @@ use std::{
 
 /// Temp trait for transaction acceptance.
 //TODO: replace with From.
+//TODO: check the number of ISI in tx and drop if it exceeds the limit. Also drop if it exceeds the byte limit.
 pub trait Accept {
     /// Transform transaction to `AcceptedTransaction`.
     fn accept(self) -> Result<AcceptedTransaction, String>;

--- a/iroha_client/tests/restart_peer.rs
+++ b/iroha_client/tests/restart_peer.rs
@@ -1,0 +1,96 @@
+use async_std::task;
+use iroha::{config::Configuration, prelude::*};
+use iroha_client::{
+    client::{self, Client},
+    config::Configuration as ClientConfiguration,
+};
+use iroha_data_model::prelude::*;
+use std::{path::Path, thread, time::Duration};
+use tempfile::TempDir;
+
+const CONFIGURATION_PATH: &str = "tests/test_config.json";
+
+#[test]
+fn restarted_peer_should_have_the_same_asset_amount() {
+    // Given
+    let temp_dir = TempDir::new().expect("Failed to create TempDir.");
+    let path = temp_dir.path().to_owned();
+    let peer_handle = thread::spawn(move || create_and_start_iroha(path.as_ref()));
+    thread::sleep(std::time::Duration::from_millis(300));
+    let configuration =
+        Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
+    let domain_name = "global";
+    let account_name = "root";
+    let account_id = AccountId::new(account_name, domain_name);
+    let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
+    let create_asset = Register::<Domain, AssetDefinition>::new(
+        AssetDefinition::new(asset_definition_id.clone()),
+        domain_name.to_string(),
+    );
+    let mut iroha_client = Client::new(
+        &ClientConfiguration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration."),
+    );
+    iroha_client
+        .submit(create_asset.into())
+        .expect("Failed to prepare state.");
+    thread::sleep(Duration::from_millis(
+        &configuration.sumeragi_configuration.pipeline_time_ms() * 2,
+    ));
+    //When
+    let quantity: u32 = 200;
+    let mint_asset = Mint::<Asset, u32>::new(
+        quantity,
+        AssetId::new(asset_definition_id, account_id.clone()),
+    );
+    iroha_client
+        .submit(mint_asset.into())
+        .expect("Failed to create asset.");
+    thread::sleep(Duration::from_millis(
+        &configuration.sumeragi_configuration.pipeline_time_ms() * 2,
+    ));
+    //Then
+    let request = client::asset::by_account_id(account_id.clone());
+    let query_result = iroha_client
+        .request(&request)
+        .expect("Failed to execute request.");
+    if let QueryResult::FindAssetsByAccountId(result) = query_result {
+        assert!(!result.assets.is_empty());
+        assert_eq!(
+            quantity,
+            result.assets.last().expect("Asset should exist.").quantity,
+        );
+    } else {
+        panic!("Wrong Query Result Type.");
+    }
+    peer_handle
+        .join()
+        .expect("Failed to wait for the Iroha thread");
+    thread::spawn(move || create_and_start_iroha(temp_dir.path()));
+    thread::sleep(std::time::Duration::from_millis(300));
+    let request = client::asset::by_account_id(account_id);
+    let query_result = iroha_client
+        .request(&request)
+        .expect("Failed to execute request.");
+    if let QueryResult::FindAssetsByAccountId(result) = query_result {
+        assert!(!result.assets.is_empty());
+        assert_eq!(
+            quantity,
+            result.assets.last().expect("Asset should exist.").quantity,
+        );
+    } else {
+        panic!("Wrong Query Result Type.");
+    }
+}
+
+fn create_and_start_iroha(block_store_path: &Path) {
+    let mut configuration =
+        Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
+    configuration
+        .kura_configuration
+        .kura_block_store_path(block_store_path);
+    let iroha = Iroha::new(configuration.clone());
+    let _result = task::block_on(async_std::future::timeout(
+        Duration::from_millis(configuration.sumeragi_configuration.pipeline_time_ms() * 6),
+        iroha.start(),
+    ));
+}


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
- tx queue limit for pending tx introduced
- fixes for initialization logic: sumeragi gets blockhash and height after kura has loaded all the blocks
- test for peer restart
### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


