### PR TITLE
Introduces World struct

### DIFF
--- a/docs/source/iroha_2_whitepaper.md
+++ b/docs/source/iroha_2_whitepaper.md
@@ -50,29 +50,29 @@ We use [Hyperledger Ursa](https://github.com/hyperledger/ursa).
 
 ### 2.3. Data Model
 
-Iroha uses a simple data model made up of domains, peers, accounts, assets and signatories,
+Iroha uses a simple data model made up of world with domains, accounts, assets and signatories,
 as shown in the figure below:
 
 ```
-                has one
-   +-------------------------------------+
-   |                                     |
-   |     +-----------------+             |
-   |     |Domain           |             |
-   |     +--------------+  |             |
-   |     ||Asset        |  |             |
-+--+-+   ||Definition(s)|  |             |
-|Peer|   +--------------+  |             |
-+--+-+   |                 |             |
-   |     +------------+    |             |
-   |     ||Account(s)||    | has   +-----v-----+
-   |     |------------------------->Signatories|
-   |     +-----------------+       +-----------+
-   |                       |             |
-   |                       |  has  +--------+
-   |                       +------->Asset(s)|
-   |                               +--------+
-   +-------------------------------------+
+                
+   +-----------------------------------------------+
+   |                                               |
+   |     +-----------------+                       |
+   |     |Domain           |                       |
+   |     +--------------+  |                       |
+   |     ||Asset        |  |                       |
++--+--+  ||Definition(s)|  |                       |
+|World|  +--------------+  |                       |
++--+--+  |                 |                       |
+   |     +------------+    |                       |
+   |     ||Account(s)||    | has   +-----------+   |
+   |     |------------------------->Signatories|   |
+   |     +-----------------+       +-----------+   |
+   |                       |                       |
+   |                       |  has  +--------+      |
+   |                       +------->Asset(s)|      |
+   |                               +--------+      |
+   +-----------------------------------------------+
 ```
 
 ### 2.4. Smart Contracts

--- a/iroha/benches/validation.rs
+++ b/iroha/benches/validation.rs
@@ -7,15 +7,7 @@ const TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
 
 fn accept_transaction(criterion: &mut Criterion) {
     let domain_name = "domain";
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new(
-            "127.0.0.1:8080",
-            &KeyPair::generate()
-                .expect("Failed to generate KeyPair.")
-                .public_key,
-        ),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(
@@ -58,15 +50,7 @@ fn accept_transaction(criterion: &mut Criterion) {
 
 fn sign_transaction(criterion: &mut Criterion) {
     let domain_name = "domain";
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new(
-            "127.0.0.1:8080",
-            &KeyPair::generate()
-                .expect("Failed to generate KeyPair.")
-                .public_key,
-        ),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(
@@ -109,10 +93,7 @@ fn sign_transaction(criterion: &mut Criterion) {
 fn validate_transaction(criterion: &mut Criterion) {
     let domain_name = "domain";
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new("127.0.0.1:8080", &key_pair.public_key),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(
@@ -141,10 +122,10 @@ fn validate_transaction(criterion: &mut Criterion) {
     .expect("Failed to accept transaction.");
     let mut success_count = 0;
     let mut failures_count = 0;
-    let mut world_state_view = WorldStateView::new(Peer::new(PeerId::new(
-        "127.0.0.1:8080",
-        &key_pair.public_key,
-    )));
+    let mut world_state_view = WorldStateView::new(
+        Peer::new(PeerId::new("127.0.0.1:8080", &key_pair.public_key)),
+        World::new(),
+    );
     criterion.bench_function("validate", |b| {
         b.iter(|| {
             match transaction
@@ -165,10 +146,7 @@ fn validate_transaction(criterion: &mut Criterion) {
 fn chain_blocks(criterion: &mut Criterion) {
     let domain_name = "domain";
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new("127.0.0.1:8080", &key_pair.public_key),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(
@@ -213,10 +191,7 @@ fn chain_blocks(criterion: &mut Criterion) {
 fn sign_blocks(criterion: &mut Criterion) {
     let domain_name = "domain";
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new("127.0.0.1:8080", &key_pair.public_key),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(
@@ -243,10 +218,10 @@ fn sign_blocks(criterion: &mut Criterion) {
     .expect("Failed to sign.")
     .accept()
     .expect("Failed to accept transaction.");
-    let world_state_view = WorldStateView::new(Peer::new(PeerId::new(
-        "127.0.0.1:8080",
-        &key_pair.public_key,
-    )));
+    let world_state_view = WorldStateView::new(
+        Peer::new(PeerId::new("127.0.0.1:8080", &key_pair.public_key)),
+        World::new(),
+    );
     let block = PendingBlock::new(vec![transaction])
         .chain_first()
         .validate(&world_state_view, &AllowAll.into());
@@ -280,18 +255,14 @@ fn validate_blocks(criterion: &mut Criterion) {
     };
     let mut domains = BTreeMap::new();
     domains.insert(domain_name, domain);
-    let world_state_view = WorldStateView::new(Peer::with(
-        PeerId::new("127.0.0.1:8080", &key_pair.public_key),
-        domains,
-        BTreeSet::new(),
-    ));
+    let world_state_view = WorldStateView::new(
+        Peer::new(PeerId::new("127.0.0.1:8080", &key_pair.public_key)),
+        World::with(domains, BTreeSet::new()),
+    );
     // Pepare test transaction
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
     let domain_name = "domain";
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new("127.0.0.1:8080", &key_pair.public_key),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let create_account = Register::<Domain, Account>::new(
         Account::with_signatory(

--- a/iroha/src/isi.rs
+++ b/iroha/src/isi.rs
@@ -78,12 +78,11 @@ impl Execute for RegisterBox {
                 }
                 _ => Err("Unsupported instruction.".to_string()),
             },
-            IdBox::PeerId(peer_id) => match self.object {
-                IdentifiableBox::Domain(domain) => Register::<Peer, Domain>::new(*domain, peer_id)
+            IdBox::WorldId => match self.object {
+                IdentifiableBox::Domain(domain) => Register::<World, Domain>::new(*domain, WorldId)
                     .execute(authority, world_state_view),
-                IdentifiableBox::Peer(peer) => {
-                    Register::<Peer, Peer>::new(*peer, peer_id).execute(authority, world_state_view)
-                }
+                IdentifiableBox::Peer(peer) => Register::<World, Peer>::new(*peer, WorldId)
+                    .execute(authority, world_state_view),
                 _ => Err("Unsupported instruction.".to_string()),
             },
             _ => Err("Unsupported instruction.".to_string()),
@@ -110,9 +109,9 @@ impl Execute for UnregisterBox {
                 }
                 _ => Err("Unsupported instruction.".to_string()),
             },
-            IdBox::PeerId(peer_id) => match self.object {
+            IdBox::WorldId => match self.object {
                 IdentifiableBox::Domain(domain) => {
-                    Unregister::<Peer, Domain>::new(*domain, peer_id)
+                    Unregister::<World, Domain>::new(*domain, WorldId)
                         .execute(authority, world_state_view)
                 }
                 _ => Err("Unsupported instruction.".to_string()),
@@ -136,8 +135,8 @@ impl Execute for MintBox {
                 }
                 _ => Err("Unsupported instruction.".to_string()),
             },
-            IdBox::PeerId(peer_id) => match self.object {
-                ValueBox::Parameter(parameter) => Mint::<Peer, Parameter>::new(parameter, peer_id)
+            IdBox::WorldId => match self.object {
+                ValueBox::Parameter(parameter) => Mint::<World, Parameter>::new(parameter, WorldId)
                     .execute(authority, world_state_view),
                 _ => Err("Unsupported instruction.".to_string()),
             },
@@ -325,5 +324,5 @@ impl Execute for Not {
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using `Iroha`.
     pub use super::Execute;
-    pub use crate::{account::isi::*, asset::isi::*, domain::isi::*, isi::*, peer::isi::*};
+    pub use crate::{account::isi::*, asset::isi::*, domain::isi::*, isi::*, world::isi::*};
 }

--- a/iroha/src/kura.rs
+++ b/iroha/src/kura.rs
@@ -264,13 +264,7 @@ mod tests {
         let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
         let block = PendingBlock::new(Vec::new())
             .chain_first()
-            .validate(
-                &WorldStateView::new(Peer::new(PeerId {
-                    address: "127.0.0.1:8080".to_string(),
-                    public_key: keypair.public_key.clone(),
-                })),
-                &AllowAll.into(),
-            )
+            .validate(&WorldStateView::new(World::new()), &AllowAll.into())
             .sign(&keypair)
             .expect("Failed to sign blocks.");
         assert!(BlockStore::new(dir.path()).write(&block).await.is_ok());
@@ -282,13 +276,7 @@ mod tests {
         let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
         let block = PendingBlock::new(Vec::new())
             .chain_first()
-            .validate(
-                &WorldStateView::new(Peer::new(PeerId {
-                    address: "127.0.0.1:8080".to_string(),
-                    public_key: keypair.public_key.clone(),
-                })),
-                &AllowAll.into(),
-            )
+            .validate(&WorldStateView::new(World::new()), &AllowAll.into())
             .sign(&keypair)
             .expect("Failed to sign blocks.");
         let block_store = BlockStore::new(dir.path());
@@ -307,13 +295,7 @@ mod tests {
         let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
         let mut block = PendingBlock::new(Vec::new())
             .chain_first()
-            .validate(
-                &WorldStateView::new(Peer::new(PeerId {
-                    address: "127.0.0.1:8080".to_string(),
-                    public_key: keypair.public_key.clone(),
-                })),
-                &AllowAll.into(),
-            )
+            .validate(&WorldStateView::new(World::new()), &AllowAll.into())
             .sign(&keypair)
             .expect("Failed to sign blocks.");
         for height in 0..n {
@@ -323,13 +305,7 @@ mod tests {
                 .expect("Failed to write block to file.");
             block = PendingBlock::new(Vec::new())
                 .chain(height, hash, 0, Vec::new())
-                .validate(
-                    &WorldStateView::new(Peer::new(PeerId {
-                        address: "127.0.0.1:8080".to_string(),
-                        public_key: keypair.public_key.clone(),
-                    })),
-                    &AllowAll.into(),
-                )
+                .validate(&WorldStateView::new(World::new()), &AllowAll.into())
                 .sign(&keypair)
                 .expect("Failed to sign blocks.");
         }
@@ -348,13 +324,7 @@ mod tests {
         let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
         let block = PendingBlock::new(Vec::new())
             .chain_first()
-            .validate(
-                &WorldStateView::new(Peer::new(PeerId {
-                    address: "127.0.0.1:8080".to_string(),
-                    public_key: keypair.public_key.clone(),
-                })),
-                &AllowAll.into(),
-            )
+            .validate(&WorldStateView::new(World::new()), &AllowAll.into())
             .sign(&keypair)
             .expect("Failed to sign blocks.");
         let dir = tempfile::tempdir().unwrap();

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -32,13 +32,13 @@ mod kura;
 pub mod maintenance;
 mod merkle;
 pub mod modules;
-pub mod peer;
 pub mod permissions;
 pub mod query;
 mod queue;
 pub mod sumeragi;
 pub mod torii;
 pub mod tx;
+pub mod world;
 pub mod wsv;
 
 use crate::{
@@ -115,11 +115,7 @@ impl Iroha {
         let (sumeragi_message_sender, sumeragi_message_receiver) = sync::channel(100);
         let (block_sync_message_sender, block_sync_message_receiver) = sync::channel(100);
         let (events_sender, events_receiver) = sync::channel(100);
-        let world_state_view = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-            PeerId::new(
-                &config.torii_configuration.torii_p2p_url,
-                &config.public_key,
-            ),
+        let world_state_view = Arc::new(RwLock::new(WorldStateView::new(World::with(
             init::domains(&config.init_configuration),
             config.sumeragi_configuration.trusted_peers.clone(),
         ))));

--- a/iroha/src/permissions.rs
+++ b/iroha/src/permissions.rs
@@ -232,10 +232,7 @@ mod tests {
         let account_bob = <Account as Identifiable>::Id::new("bob", "test");
         let account_alice = <Account as Identifiable>::Id::new("alice", "test");
         let key_pair = KeyPair::generate().expect("Failed to generate key pair.");
-        let wsv = WorldStateView::new(Peer::new(<Peer as Identifiable>::Id::new(
-            "127.0.0.1:7878",
-            &key_pair.public_key,
-        )));
+        let wsv = WorldStateView::new(World::new());
         assert!(permissions_validator
             .check_instruction(account_bob.clone(), instruction_greater.clone(), &wsv)
             .is_err());
@@ -267,10 +264,7 @@ mod tests {
         }));
         let account_alice = <Account as Identifiable>::Id::new("alice", "test");
         let key_pair = KeyPair::generate().expect("Failed to generate key pair.");
-        let wsv = WorldStateView::new(Peer::new(<Peer as Identifiable>::Id::new(
-            "127.0.0.1:7878",
-            &key_pair.public_key,
-        )));
+        let wsv = WorldStateView::new(World::new());
         assert!(permissions_validator
             .check_instruction(account_alice.clone(), instruction_fail.clone(), &wsv)
             .is_ok());

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -108,7 +108,7 @@ impl Sumeragi {
             .world_state_view
             .read()
             .await
-            .peer
+            .read_world()
             .trusted_peers_ids
             .clone();
         self.network_topology
@@ -1521,8 +1521,7 @@ mod tests {
             let (sumeragi_message_sender, mut sumeragi_message_receiver) = sync::channel(100);
             let (block_sync_message_sender, _) = sync::channel(100);
             let (events_sender, events_receiver) = sync::channel(100);
-            let wsv = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-                ids[i].clone(),
+            let wsv = Arc::new(RwLock::new(WorldStateView::new(World::with(
                 init::domains(&InitConfiguration {
                     root_public_key: root_key_pair.public_key.clone(),
                     genesis_account_public_key: genesis_key_pair.public_key.clone(),
@@ -1650,8 +1649,7 @@ mod tests {
             let (block_sync_message_sender, _) = sync::channel(100);
             let (transactions_sender, _transactions_receiver) = sync::channel(100);
             let (events_sender, events_receiver) = sync::channel(100);
-            let wsv = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-                ids[i].clone(),
+            let wsv = Arc::new(RwLock::new(WorldStateView::new(World::with(
                 init::domains(&InitConfiguration {
                     root_public_key: root_key_pair.public_key.clone(),
                     genesis_account_public_key: genesis_key_pair.public_key.clone(),
@@ -1802,8 +1800,7 @@ mod tests {
             let (block_sync_message_sender, _) = sync::channel(100);
             let (transactions_sender, mut transactions_receiver) = sync::channel(100);
             let (events_sender, events_receiver) = sync::channel(100);
-            let wsv = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-                ids[i].clone(),
+            let wsv = Arc::new(RwLock::new(WorldStateView::new(World::with(
                 init::domains(&InitConfiguration {
                     root_public_key: root_key_pair.public_key.clone(),
                     genesis_account_public_key: genesis_key_pair.public_key.clone(),
@@ -1965,8 +1962,7 @@ mod tests {
             let (block_sync_message_sender, _) = sync::channel(100);
             let (transactions_sender, mut transactions_receiver) = sync::channel(100);
             let (events_sender, events_receiver) = sync::channel(100);
-            let wsv = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-                ids[i].clone(),
+            let wsv = Arc::new(RwLock::new(WorldStateView::new(World::with(
                 init::domains(&InitConfiguration {
                     root_public_key: root_key_pair.public_key.clone(),
                     genesis_account_public_key: genesis_key_pair.public_key.clone(),
@@ -2126,8 +2122,7 @@ mod tests {
             let (transactions_sender, _transactions_receiver) = sync::channel(100);
             let (events_sender, events_receiver) = sync::channel(100);
             let ids_set: BTreeSet<PeerId> = ids.clone().into_iter().collect();
-            let wsv = Arc::new(RwLock::new(WorldStateView::new(Peer::with(
-                ids[i].clone(),
+            let wsv = Arc::new(RwLock::new(WorldStateView::new(World::with(
                 init::domains(&InitConfiguration {
                     root_public_key: root_key_pair.public_key.clone(),
                     genesis_account_public_key: genesis_key_pair.public_key.clone(),

--- a/iroha/src/torii.rs
+++ b/iroha/src/torii.rs
@@ -413,10 +413,7 @@ mod tests {
         let (events_sender, events_receiver) = sync::channel(100);
         let mut torii = Torii::from_configuration(
             &config.torii_configuration,
-            Arc::new(RwLock::new(WorldStateView::new(Peer::new(PeerId::new(
-                &config.torii_configuration.torii_p2p_url,
-                &config.public_key,
-            ))))),
+            Arc::new(RwLock::new(WorldStateView::new(World::new()))),
             tx_tx,
             sumeragi_message_sender,
             block_sync_message_sender,

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -184,13 +184,7 @@ mod tests {
         let accepted_tx_hash = accepted_tx.hash();
         let valid_tx_hash = accepted_tx
             .validate(
-                &WorldStateView::new(Peer::with(
-                    PeerId {
-                        address: "127.0.0.1:8080".to_string(),
-                        public_key: KeyPair::generate()
-                            .expect("Failed to generate KeyPair.")
-                            .public_key,
-                    },
+                &WorldStateView::new(World::with(
                     init::domains(&InitConfiguration {
                         root_public_key: root_key_pair.public_key.clone(),
                         genesis_account_public_key: genesis_key_pair.public_key.clone(),

--- a/iroha/src/world.rs
+++ b/iroha/src/world.rs
@@ -1,16 +1,14 @@
-//! This module contains `Peer` structure and related implementations and traits implementations.
+//! This module contains `World` related ISI implementations.
 
 use crate::{isi::prelude::*, prelude::*};
 use iroha_data_model::*;
 
-/// Iroha Special Instructions module provides `PeerInstruction` enum with all possible types of
-/// Peer related instructions as variants, implementations of generic Iroha Special Instructions
-/// and the `From/Into` implementations to convert `PeerInstruction` variants into generic ISI.
+/// Iroha Special Instructions that have `World` as their target.
 pub mod isi {
     use super::*;
     use iroha_data_model::prelude::*;
 
-    impl Execute for Register<Peer, Peer> {
+    impl Execute for Register<World, Peer> {
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -18,7 +16,7 @@ pub mod isi {
         ) -> Result<WorldStateView, String> {
             let mut world_state_view = world_state_view.clone();
             if world_state_view
-                .peer()
+                .world()
                 .trusted_peers_ids
                 .insert(self.object.id)
             {
@@ -29,7 +27,7 @@ pub mod isi {
         }
     }
 
-    impl Execute for Register<Peer, Domain> {
+    impl Execute for Register<World, Domain> {
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -37,33 +35,33 @@ pub mod isi {
         ) -> Result<WorldStateView, String> {
             let mut world_state_view = world_state_view.clone();
             let _ = world_state_view
-                .peer()
+                .world()
                 .domains
                 .insert(self.object.name.clone(), self.object);
             Ok(world_state_view)
         }
     }
 
-    impl Execute for Unregister<Peer, Domain> {
+    impl Execute for Unregister<World, Domain> {
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
             world_state_view: &WorldStateView,
         ) -> Result<WorldStateView, String> {
             let mut world_state_view = world_state_view.clone();
-            let _ = world_state_view.peer().domains.remove(&self.object.name);
+            let _ = world_state_view.world().domains.remove(&self.object.name);
             Ok(world_state_view)
         }
     }
 
-    impl Execute for Mint<Peer, Parameter> {
+    impl Execute for Mint<World, Parameter> {
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
             world_state_view: &WorldStateView,
         ) -> Result<WorldStateView, String> {
             let mut world_state_view = world_state_view.clone();
-            world_state_view.peer().parameters.push(self.object);
+            world_state_view.world().parameters.push(self.object);
             Ok(world_state_view)
         }
     }
@@ -80,7 +78,7 @@ pub mod query {
         fn execute(&self, world_state_view: &WorldStateView) -> Result<QueryResult, String> {
             Ok(QueryResult::FindAllPeers(Box::new(FindAllPeersResult {
                 peers: world_state_view
-                    .read_peer()
+                    .read_world()
                     .clone()
                     .trusted_peers_ids
                     .into_iter()
@@ -94,7 +92,7 @@ pub mod query {
         fn execute(&self, world_state_view: &WorldStateView) -> Result<QueryResult, String> {
             Ok(QueryResult::FindPeerById(Box::new(FindPeerByIdResult {
                 peer: world_state_view
-                    .read_peer()
+                    .read_world()
                     .clone()
                     .trusted_peers_ids
                     .iter()
@@ -110,7 +108,7 @@ pub mod query {
         fn execute(&self, world_state_view: &WorldStateView) -> Result<QueryResult, String> {
             Ok(QueryResult::FindAllParameters(Box::new(
                 FindAllParametersResult {
-                    parameters: world_state_view.read_peer().parameters.clone(),
+                    parameters: world_state_view.read_world().parameters.clone(),
                 },
             )))
         }

--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -7,16 +7,15 @@ use iroha_data_model::prelude::*;
 /// Current state of the blockchain alligned with `Iroha` module.
 #[derive(Debug, Clone)]
 pub struct WorldStateView {
-    /// The state of this peer.
-    //TODO: Maybe simply move `Peer` contents to WSV?
-    pub peer: Peer,
+    /// The world - contains `domains`, `triggers`, etc..
+    pub world: World,
 }
 
 /// WARNING!!! INTERNAL USE ONLY!!!
 impl WorldStateView {
     /// Default `WorldStateView` constructor.
-    pub fn new(peer: Peer) -> Self {
-        WorldStateView { peer }
+    pub fn new(world: World) -> Self {
+        WorldStateView { world }
     }
 
     /// Initializes WSV with the blocks from block storage.
@@ -35,39 +34,39 @@ impl WorldStateView {
         }
     }
 
-    /// Get `Peer` without an ability to modify it.
-    pub fn read_peer(&self) -> &Peer {
-        &self.peer
+    /// Get `World` without an ability to modify it.
+    pub fn read_world(&self) -> &World {
+        &self.world
     }
 
-    /// Get `Peer` with an ability to modify it.
-    pub fn peer(&mut self) -> &mut Peer {
-        &mut self.peer
+    /// Get `World` with an ability to modify it.
+    pub fn world(&mut self) -> &mut World {
+        &mut self.world
     }
 
     /// Add new `Domain` entity.
     pub fn add_domain(&mut self, domain: Domain) {
-        let _ = self.peer.domains.insert(domain.name.clone(), domain);
+        let _ = self.world.domains.insert(domain.name.clone(), domain);
     }
 
     /// Get `Domain` without an ability to modify it.
     pub fn read_domain(&self, name: &str) -> Option<&Domain> {
-        self.peer.domains.get(name)
+        self.world.domains.get(name)
     }
 
     /// Get `Domain` with an ability to modify it.
     pub fn domain(&mut self, name: &str) -> Option<&mut Domain> {
-        self.peer.domains.get_mut(name)
+        self.world.domains.get_mut(name)
     }
 
     /// Get all `Domain`s without an ability to modify them.
     pub fn read_all_domains(&self) -> Vec<&Domain> {
-        self.peer.domains.values().collect()
+        self.world.domains.values().collect()
     }
 
     /// Get all `Account`s without an ability to modify them.
     pub fn read_all_accounts(&self) -> Vec<&Account> {
-        self.peer
+        self.world
             .domains
             .values()
             .flat_map(|domain| domain.accounts.values())
@@ -86,7 +85,7 @@ impl WorldStateView {
 
     /// Get all `Asset`s without an ability to modify them.
     pub fn read_all_assets(&self) -> Vec<&Asset> {
-        self.peer
+        self.world
             .domains
             .values()
             .flat_map(|domain| domain.accounts.values())
@@ -96,7 +95,7 @@ impl WorldStateView {
 
     /// Get all `Asset Definition`s without an ability to modify them.
     pub fn read_all_assets_definitions(&self) -> Vec<&AssetDefinition> {
-        self.peer
+        self.world
             .domains
             .values()
             .flat_map(|domain| domain.asset_definitions.values())

--- a/iroha_client/benches/torii.rs
+++ b/iroha_client/benches/torii.rs
@@ -20,13 +20,7 @@ fn query_requests(criterion: &mut Criterion) {
     let configuration =
         Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
     let domain_name = "domain";
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new(
-            &configuration.torii_configuration.torii_p2p_url,
-            &configuration.public_key,
-        ),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let account_id = AccountId::new(account_name, domain_name);
     let (public_key, _) = configuration.key_pair();
@@ -96,13 +90,7 @@ fn instruction_submits(criterion: &mut Criterion) {
     let configuration =
         Configuration::from_path(CONFIGURATION_PATH).expect("Failed to load configuration.");
     let domain_name = "domain";
-    let create_domain = Register::<Peer, Domain>::new(
-        Domain::new(domain_name),
-        PeerId::new(
-            &configuration.torii_configuration.torii_p2p_url,
-            &configuration.public_key,
-        ),
-    );
+    let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
     let account_name = "account";
     let account_id = AccountId::new(account_name, domain_name);
     let (public_key, _) = configuration.key_pair();

--- a/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
+++ b/iroha_client/tests/add_asset_should_propagate_to_another_peer.rs
@@ -23,13 +23,7 @@ mod tests {
         let peers = create_and_start_iroha_peers(N_PEERS);
         thread::sleep(std::time::Duration::from_millis(1000));
         let domain_name = "domain";
-        let create_domain = Register::<Peer, Domain>::new(
-            Domain::new(domain_name),
-            PeerId::new(
-                &configuration.torii_configuration.torii_p2p_url,
-                &configuration.public_key,
-            ),
-        );
+        let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
         let account_name = "account";
         let account_id = AccountId::new(account_name, domain_name);
         let (public_key, _) = configuration.key_pair();

--- a/iroha_client/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
+++ b/iroha_client/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
@@ -22,13 +22,7 @@ mod tests {
         let (peer_ids, addresses) = create_and_start_iroha_peers(N_PEERS);
         thread::sleep(std::time::Duration::from_millis(1000));
         let domain_name = "domain";
-        let create_domain = Register::<Peer, Domain>::new(
-            Domain::new(domain_name),
-            PeerId::new(
-                &configuration.torii_configuration.torii_p2p_url,
-                &configuration.public_key,
-            ),
-        );
+        let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
         let account_name = "account";
         let account_id = AccountId::new(account_name, domain_name);
         let (public_key, _) = configuration.key_pair();
@@ -106,7 +100,7 @@ mod tests {
                 .pipeline_time_ms()
                 * 2,
         ));
-        let add_peer = Register::<Peer, Peer>::new(Peer::new(new_peer.clone()), new_peer.clone());
+        let add_peer = Register::<World, Peer>::new(Peer::new(new_peer.clone()), WorldId);
         iroha_client
             .submit(add_peer.into())
             .expect("Failed to add new peer.");

--- a/iroha_client/tests/cucumber.rs
+++ b/iroha_client/tests/cucumber.rs
@@ -1,6 +1,6 @@
 use async_std::task::{self, JoinHandle};
 use async_trait::async_trait;
-use cucumber_rust::{Cucumber, World};
+use cucumber_rust::{Cucumber, World as CucumberWorld};
 use futures::executor;
 use iroha::{config::Configuration, prelude::*};
 use iroha_client::{
@@ -23,7 +23,7 @@ pub struct IrohaWorld {
 }
 
 #[async_trait(?Send)]
-impl World for IrohaWorld {
+impl CucumberWorld for IrohaWorld {
     type Error = Infallible;
     async fn new() -> Result<Self, Infallible> {
         let mut configuration = ClientConfiguration::from_path(CONFIGURATION_PATH)
@@ -293,10 +293,8 @@ mod domain_steps {
                 |mut world, matches, _step| {
                     let domain_name = matches[1].trim();
                     println!("Going to add domain with name: {}", domain_name);
-                    let add_domain = Register::<Peer, Domain>::new(
-                        Domain::new(domain_name),
-                        world.peer_id.clone(),
-                    );
+                    let add_domain =
+                        Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
                     world
                         .client
                         .submit(add_domain.into())
@@ -550,12 +548,12 @@ mod peer_steps {
                     world
                         .client
                         .submit(
-                            Register::<Peer, Peer>::new (
+                            Register::<World, Peer>::new (
                                 Peer::new(
                                     PeerId::new(
                                         trusted_peer_url,
                                         &public_key)),
-                                        world.peer_id.clone()
+                                        WorldId
                                         )
                             .into(),
                             )

--- a/iroha_client/tests/multiple_blocks_created.rs
+++ b/iroha_client/tests/multiple_blocks_created.rs
@@ -26,13 +26,7 @@ mod tests {
         let peers = create_and_start_iroha_peers(N_PEERS);
         thread::sleep(std::time::Duration::from_millis(1000));
         let domain_name = "domain";
-        let create_domain = Register::<Peer, Domain>::new(
-            Domain::new(domain_name),
-            PeerId::new(
-                &configuration.torii_configuration.torii_p2p_url,
-                &configuration.public_key,
-            ),
-        );
+        let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
         let account_name = "account";
         let account_id = AccountId::new(account_name, domain_name);
         let (public_key, _) = configuration.key_pair();

--- a/iroha_client/tests/transfer_asset.rs
+++ b/iroha_client/tests/transfer_asset.rs
@@ -22,10 +22,7 @@ mod tests {
             .expect("Failed to load configuration.");
         let mut iroha_client = Client::new(&configuration);
         let domain_name = "domain";
-        let create_domain = Register::<Peer, Domain>::new(
-            Domain::new(domain_name),
-            PeerId::new(&configuration.torii_api_url, &configuration.public_key),
-        );
+        let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
         let account1_name = "account1";
         let account2_name = "account2";
         let account1_id = AccountId::new(account1_name, domain_name);

--- a/iroha_client_cli/src/main.rs
+++ b/iroha_client_cli/src/main.rs
@@ -84,10 +84,7 @@ mod domain {
 
     fn create_domain(domain_name: &str, configuration: &Configuration) {
         let mut iroha_client = Client::new(configuration);
-        let create_domain = Register::<Peer, Domain>::new(
-            Domain::new(domain_name),
-            PeerId::new(&configuration.torii_api_url, &configuration.public_key),
-        );
+        let create_domain = Register::<World, Domain>::new(Domain::new(domain_name), WorldId);
         iroha_client
             .submit(create_domain.into())
             .expect("Failed to create domain.");

--- a/iroha_dsl/tests/dsl.rs
+++ b/iroha_dsl/tests/dsl.rs
@@ -96,21 +96,9 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
     let mut iroha_client = Client::new(&configuration);
     iroha_client
         .submit_all(vec![
-            Register::<Peer, Domain>::new(
-                Domain::new("exchange"),
-                PeerId::new(&configuration.torii_api_url, &configuration.public_key),
-            )
-            .into(),
-            Register::<Peer, Domain>::new(
-                Domain::new("company"),
-                PeerId::new(&configuration.torii_api_url, &configuration.public_key),
-            )
-            .into(),
-            Register::<Peer, Domain>::new(
-                Domain::new("crypto"),
-                PeerId::new(&configuration.torii_api_url, &configuration.public_key),
-            )
-            .into(),
+            Register::<World, Domain>::new(Domain::new("exchange"), WorldId).into(),
+            Register::<World, Domain>::new(Domain::new("company"), WorldId).into(),
+            Register::<World, Domain>::new(Domain::new("crypto"), WorldId).into(),
             Register::<Domain, Account>::new(
                 Account::new(AccountId::new("seller", "company")),
                 Name::from("company"),

--- a/iroha_permissions_validators/src/lib.rs
+++ b/iroha_permissions_validators/src/lib.rs
@@ -45,14 +45,12 @@ pub mod public_blockchain {
 
         #[test]
         fn transfer_only_owned_assets() {
-            let key_pair = KeyPair::generate().expect("Failed to generate key pair.");
-            let peer_id = <Peer as Identifiable>::Id::new("127.0.0.1:7878", &key_pair.public_key);
             let alice_id = <Account as Identifiable>::Id::new("alice", "test");
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
-            let wsv = WorldStateView::new(Peer::new(peer_id));
+            let wsv = WorldStateView::new(World::new());
             let transfer = InstructionBox::Transfer(TransferBox {
                 source_id: IdBox::AssetId(alice_xor_id),
                 object: ValueBox::U32(10),


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Introduces World struct to improve top level ISI design (e.g. `Register<World, Domain>`). Previously to register the domain for example we had to do the following `Register<Peer, Domain>` and supply `PeerId` in there, but this peer id would be useless and will only confuse users. Instead now this instructions have `World` as their target.

Also this PR removes `Peer` from `WorldStateView` as the peer id is not needed there.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
