### PR TITLE
Build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM debian:stable-slim
-COPY target/release/iroha .
+FROM rust:slim AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
+COPY . iroha/
+WORKDIR iroha
+RUN cargo build --release
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
 COPY iroha/config.json .
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libssl-dev
-RUN ln -s -f /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
-RUN ln -s -f /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 
+COPY --from=builder /iroha/target/release/iroha .
 CMD ["./iroha"]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,8 +1,14 @@
-FROM debian:stable-slim
-COPY target/debug/iroha .
+FROM rust:slim AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
+COPY . iroha/
+WORKDIR iroha
+RUN cargo build
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
 COPY iroha/config.json .
 COPY iroha/genesis.json .
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libssl-dev
-RUN ln -s -f /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
-RUN ln -s -f /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 
+COPY --from=builder /iroha/target/debug/iroha .
 CMD ["./iroha"]

--- a/DockerfileCLI
+++ b/DockerfileCLI
@@ -1,5 +1,13 @@
-FROM debian:stable-slim
-COPY target/release/iroha_client_cli .
-COPY iroha_client_cli/config.json .
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libssl-dev
+FROM rust:slim AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
+COPY . iroha/
+WORKDIR iroha
+RUN cargo build --bin iroha_client_cli
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y upgrade && apt-get install -y apt-utils
+RUN apt-get install -y libssl-dev pkg-config
+COPY iroha_client/config.json .
+COPY --from=builder /iroha/target/debug/iroha_client_cli .
 ENTRYPOINT ["./iroha_client_cli"]

--- a/iroha_client_cli/config.json
+++ b/iroha_client_cli/config.json
@@ -1,9 +1,13 @@
 {
   "TORII_API_URL": "127.0.0.1:8080",
-  "LOGGER_CONFIGURATION": {},
+  "ACCOUNT_ID": {
+    "name": "root",
+    "domain_name": "global"
+  },
   "PUBLIC_KEY": "ed207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0",
   "PRIVATE_KEY": {
     "digest_function": "ed25519",
     "payload": "9ac47abf59b356e0bd7dcbbbb4dec080e302156a48ca907e47cb6aea1d32719e7233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
-  }
+  },
+  "LOGGER_CONFIGURATION": {}
 }


### PR DESCRIPTION
Signed-off-by: Alexey-N-Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Build moved to docker.
Add ACCOUNT_ID to client config.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Can build on different architectures.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Can be simplified with `cargo install --path .` if it is supported in build manifest.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
Alternative docker base can be used, not only Alpine linux.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
