### PR TITLE
Add RejectionReason enum for pipeline events

### DIFF
--- a/iroha/src/block.rs
+++ b/iroha/src/block.rs
@@ -380,9 +380,9 @@ impl From<&CommittedBlock> for Vec<Event> {
                         PipelineEvent::new(
                             PipelineEntityType::Block,
                             //TODO: store rejection reasons for blocks?
-                            PipelineStatus::Rejected(
-                                "Block was rejected during consensus.".to_string(),
-                            ),
+                            PipelineStatus::Rejected(PipelineRejectionReason::Block(
+                                BlockRejectionReason::ConsensusBlockRejection,
+                            )),
                             hash,
                         )
                         .into()

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -563,7 +563,6 @@ impl InitializedNetworkTopology {
     /// Updates it only if the new peers were added, otherwise leaves the order unchanged.
     pub fn update(&mut self, peers: BTreeSet<PeerId>, latest_block_hash: Hash) {
         let current_peers: BTreeSet<_> = self.sorted_peers.iter().cloned().collect();
-        let peers: BTreeSet<_> = peers.into_iter().collect();
         if peers != current_peers {
             self.sorted_peers = peers.iter().cloned().collect();
             self.sort_peers_by_hash(Some(latest_block_hash));

--- a/iroha_client/src/client.rs
+++ b/iroha_client/src/client.rs
@@ -132,7 +132,7 @@ impl Client {
             .recv_timeout(self.transaction_status_timout)
             .map_or_else(
                 |err| Err(format!("Timeout waiting for transaction status: {}", err)),
-                |result| result,
+                |result| result.map_err(|e| e.to_string()),
             )
     }
 

--- a/iroha_client/tests/permissions.rs
+++ b/iroha_client/tests/permissions.rs
@@ -62,7 +62,7 @@ fn permissions_disallow_asset_transfer() {
     //Then
     assert_eq!(
         rejection_reason,
-        "Can't transfer assets of the other account."
+        "Action not permitted: Can\'t transfer assets of the other account."
     );
     let request = client::asset::by_account_id(root_id);
     let query_result = iroha_client
@@ -122,7 +122,10 @@ fn permissions_disallow_asset_burn() {
         .submit_blocking(burn_asset.into())
         .expect_err("Transaction was not rejected.");
     //Then
-    assert_eq!(rejection_reason, "Can't burn assets from another account.");
+    assert_eq!(
+        rejection_reason,
+        "Action not permitted: Can\'t burn assets from another account."
+    );
     let request = client::asset::by_account_id(root_id);
     let query_result = iroha_client
         .request(&request)


### PR DESCRIPTION
Add more type-safety to RejectionReason via enum.

Signed-off-by: i1i1 <vanyarybin1@live.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

It is more typesafe and gives more context to users. Also in future it can allow other implentations of Iroha2.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Some errors are interconnected between several crates and cannot be fully contained in RejectionReason so some variants will always be String.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
