### PR TITLE
Add other containers for FromVariant derive macro

### DIFF
--- a/iroha_macro/iroha_derive/Cargo.toml
+++ b/iroha_macro/iroha_derive/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 iroha_logger = { version = "=0.1.0", path = "../../iroha_logger"}
+trybuild = "1.0"

--- a/iroha_macro/iroha_derive/tests/from_variant.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+mod tests {
+    use trybuild::TestCases;
+
+    #[test]
+    fn test_from_variant() {
+        let pass = ["01-big-enum", "03-container-enums"];
+        let fail = ["02-double-from", "04-container-from", "05-struct"];
+        let to_test = |test| format!("tests/from_variant/{}.rs", test);
+
+        let t = TestCases::new();
+
+        pass.iter().map(to_test).for_each(|test| t.pass(test));
+        fail.iter()
+            .map(to_test)
+            .for_each(|test| t.compile_fail(test));
+    }
+}

--- a/iroha_macro/iroha_derive/tests/from_variant/01-big-enum.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/01-big-enum.rs
@@ -1,0 +1,24 @@
+struct Variant1;
+struct Variant2;
+struct Variant3;
+struct Variant4;
+struct Variant5;
+struct Variant6;
+struct Variant7;
+struct Variant8;
+struct Variant9;
+
+#[derive(iroha_derive::FromVariant)]
+enum Enum {
+    Variant1(Variant1),
+    Variant2(Variant2),
+    Variant3(Variant3),
+    Variant4(Variant4),
+    Variant5(Variant5),
+    Variant6(Variant6),
+    Variant7(Variant7),
+    Variant8(Variant8),
+    Variant9(Variant9),
+}
+
+fn main() {}

--- a/iroha_macro/iroha_derive/tests/from_variant/02-double-from.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/02-double-from.rs
@@ -1,0 +1,7 @@
+include!("01-big-enum.rs");
+
+impl std::convert::From<Variant1> for Enum {
+    fn from(variant: Variant1) -> Self {
+        Self::Variant1(variant)
+    }
+}

--- a/iroha_macro/iroha_derive/tests/from_variant/03-container-enums.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/03-container-enums.rs
@@ -1,0 +1,26 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex, RwLock};
+
+struct Variant1;
+struct Variant2;
+struct Variant3;
+struct Variant4;
+struct Variant5;
+struct Variant6;
+struct Variant7;
+struct Variant8;
+
+#[derive(iroha_derive::FromVariant)]
+enum Enum {
+    Variant1(Box<Variant1>),
+    Variant2(RefCell<Variant2>),
+    Variant3(Cell<Variant3>),
+    Variant4(Rc<Variant4>),
+    Variant5(Arc<Variant5>),
+    Variant6(Mutex<Variant6>),
+    Variant7(RwLock<Variant7>),
+    Variant8(Variant8),
+}
+
+fn main() {}

--- a/iroha_macro/iroha_derive/tests/from_variant/04-container-from.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/04-container-from.rs
@@ -1,0 +1,7 @@
+include!("03-container-enums.rs");
+
+impl std::convert::From<Variant1> for Enum {
+    fn from(variant: Variant1) -> Self {
+        Self::Variant1(Box::new(variant))
+    }
+}

--- a/iroha_macro/iroha_derive/tests/from_variant/05-struct.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/05-struct.rs
@@ -1,0 +1,4 @@
+#[derive(iroha_derive::FromVariant)]
+struct NotAnEnum;
+
+fn main() {}


### PR DESCRIPTION
Add easy way to add other containers to FromVariant macro. Now it supports deriving from Mutex, Box, Cell, RefCell, RwLock, Rc, Arc.

Signed-off-by: i1i1 <vanyarybin1@live.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
