### PR TITLE
Yac: store states from future

### DIFF
--- a/irohad/consensus/impl/round.cpp
+++ b/irohad/consensus/impl/round.cpp
@@ -12,38 +12,44 @@
 #include <boost/functional/hash.hpp>
 #include "utils/string_builder.hpp"
 
-namespace iroha {
-  namespace consensus {
-    Round::Round(BlockRoundType block_r, RejectRoundType reject_r)
-        : block_round{block_r}, reject_round{reject_r} {}
+namespace iroha::consensus {
+  Round::Round(BlockRoundType block_r, RejectRoundType reject_r)
+      : block_round{block_r}, reject_round{reject_r} {}
 
-    bool Round::operator<(const Round &rhs) const {
-      return std::tie(block_round, reject_round)
-          < std::tie(rhs.block_round, rhs.reject_round);
-    }
+  bool Round::operator<(const Round &rhs) const {
+    return std::tie(block_round, reject_round)
+        < std::tie(rhs.block_round, rhs.reject_round);
+  }
 
-    bool Round::operator==(const Round &rhs) const {
-      return std::tie(block_round, reject_round)
-          == std::tie(rhs.block_round, rhs.reject_round);
-    }
+  bool Round::operator==(const Round &rhs) const {
+    return std::tie(block_round, reject_round)
+        == std::tie(rhs.block_round, rhs.reject_round);
+  }
 
-    bool Round::operator!=(const Round &rhs) const {
-      return not(*this == rhs);
-    }
+  bool Round::operator!=(const Round &rhs) const {
+    return not(*this == rhs);
+  }
 
-    std::size_t RoundTypeHasher::operator()(const consensus::Round &val) const {
-      size_t seed = 0;
-      boost::hash_combine(seed, val.block_round);
-      boost::hash_combine(seed, val.reject_round);
-      return seed;
-    }
+  std::string Round::toString() const {
+    return shared_model::detail::PrettyStringBuilder()
+        .init("Round")
+        .appendNamed("block", block_round)
+        .appendNamed("reject", reject_round)
+        .finalize();
+  }
 
-    std::string Round::toString() const {
-      return shared_model::detail::PrettyStringBuilder()
-          .init("Round")
-          .appendNamed("block", block_round)
-          .appendNamed("reject", reject_round)
-          .finalize();
-    }
-  }  // namespace consensus
-}  // namespace iroha
+  std::size_t hash_value(Round const &val) {
+    size_t seed = 0;
+    boost::hash_combine(seed, val.block_round);
+    boost::hash_combine(seed, val.reject_round);
+    return seed;
+  }
+
+}  // namespace iroha::consensus
+
+namespace std {
+  std::size_t hash<iroha::consensus::Round>::operator()(
+      iroha::consensus::Round const &val) const noexcept {
+    return hash_value(val);
+  }
+}  // namespace std

--- a/irohad/consensus/round.hpp
+++ b/irohad/consensus/round.hpp
@@ -12,48 +12,47 @@
 
 #include <boost/operators.hpp>
 
-namespace iroha {
-  namespace consensus {
+namespace iroha::consensus {
 
-    /**
-     * Type of round indexing by blocks
-     */
-    using BlockRoundType = uint64_t;
+  /**
+   * Type of round indexing by blocks
+   */
+  using BlockRoundType = uint64_t;
 
-    /**
-     * Type of round indexing by reject before new block commit
-     */
-    using RejectRoundType = uint32_t;
+  /**
+   * Type of round indexing by reject before new block commit
+   */
+  using RejectRoundType = uint32_t;
 
-    /**
-     * Type of proposal round
-     */
-    struct Round : public boost::less_than_comparable<Round> {
-      BlockRoundType block_round;
-      RejectRoundType reject_round;
+  /**
+   * Type of proposal round
+   */
+  struct Round : public boost::less_than_comparable<Round> {
+    BlockRoundType block_round;
+    RejectRoundType reject_round;
 
-      Round() = default;
+    Round() = default;
 
-      Round(BlockRoundType block_r, RejectRoundType reject_r);
+    Round(BlockRoundType block_r, RejectRoundType reject_r);
 
-      bool operator<(const Round &rhs) const;
+    bool operator<(const Round &rhs) const;
 
-      bool operator==(const Round &rhs) const;
+    bool operator==(const Round &rhs) const;
 
-      bool operator!=(const Round &rhs) const;
+    bool operator!=(const Round &rhs) const;
 
-      std::string toString() const;
-    };
+    std::string toString() const;
+  };
 
-    /**
-     * Class provides hash function for Round
-     */
-    class RoundTypeHasher {
-     public:
-      std::size_t operator()(const consensus::Round &val) const;
-    };
+  std::size_t hash_value(Round const &val);
 
-  }  // namespace consensus
-}  // namespace iroha
+}  // namespace iroha::consensus
+
+namespace std {
+  template <>
+  struct hash<iroha::consensus::Round> {
+    std::size_t operator()(iroha::consensus::Round const &val) const noexcept;
+  };
+}  // namespace std
 
 #endif  // IROHA_ROUND_HPP

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -24,336 +24,347 @@ auto &getRound(const std::vector<iroha::consensus::yac::VoteMessage> &state) {
   return state.at(0).hash.vote_round;
 }
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
+namespace iroha::consensus::yac {
 
-      std::shared_ptr<Yac> Yac::create(
-          YacVoteStorage vote_storage,
-          std::shared_ptr<YacNetwork> network,
-          std::shared_ptr<YacCryptoProvider> crypto,
-          std::shared_ptr<Timer> timer,
-          ClusterOrdering order,
-          Round round,
-          rxcpp::observe_on_one_worker worker,
-          logger::LoggerPtr log) {
-        return std::make_shared<Yac>(vote_storage,
-                                     network,
-                                     crypto,
-                                     timer,
-                                     order,
-                                     round,
-                                     worker,
-                                     std::move(log));
+  std::shared_ptr<Yac> Yac::create(YacVoteStorage vote_storage,
+                                   std::shared_ptr<YacNetwork> network,
+                                   std::shared_ptr<YacCryptoProvider> crypto,
+                                   std::shared_ptr<Timer> timer,
+                                   ClusterOrdering order,
+                                   Round round,
+                                   rxcpp::observe_on_one_worker worker,
+                                   logger::LoggerPtr log) {
+    return std::make_shared<Yac>(vote_storage,
+                                 network,
+                                 crypto,
+                                 timer,
+                                 order,
+                                 round,
+                                 worker,
+                                 std::move(log));
+  }
+
+  Yac::Yac(YacVoteStorage vote_storage,
+           std::shared_ptr<YacNetwork> network,
+           std::shared_ptr<YacCryptoProvider> crypto,
+           std::shared_ptr<Timer> timer,
+           ClusterOrdering order,
+           Round round,
+           rxcpp::observe_on_one_worker worker,
+           logger::LoggerPtr log)
+      : log_(std::move(log)),
+        cluster_order_(order),
+        round_(round),
+        worker_(worker),
+        notifier_(worker_, notifier_lifetime_),
+        vote_storage_(std::move(vote_storage)),
+        network_(std::move(network)),
+        crypto_(std::move(crypto)),
+        timer_(std::move(timer)) {}
+
+  Yac::~Yac() {
+    notifier_lifetime_.unsubscribe();
+  }
+
+  void Yac::stop() {
+    network_->stop();
+  }
+
+  // ------|Hash gate|------
+
+  void Yac::vote(YacHash hash,
+                 ClusterOrdering order,
+                 boost::optional<ClusterOrdering> alternative_order) {
+    log_->info(
+        "Order for voting: [{}]",
+        boost::algorithm::join(
+            order.getPeers() | boost::adaptors::transformed([](const auto &p) {
+              return p->address();
+            }),
+            ", "));
+
+    std::unordered_set<VoteMessage> state;
+    std::unique_lock<std::mutex> lock(mutex_);
+    cluster_order_ = order;
+    alternative_order_ = std::move(alternative_order);
+    round_ = hash.vote_round;
+    // take states from current round if it was stored, erase older than current
+    auto it = future_states_.lower_bound(round_);
+    if (it->first == round_) {
+      state = std::move(it->second);
+      ++it;
+    }
+    future_states_.erase(future_states_.begin(), it);
+    lock.unlock();
+    if (not state.empty()) {
+      onState(std::vector<VoteMessage>{std::make_move_iterator(state.begin()),
+                                       std::make_move_iterator(state.end())});
+    }
+    auto vote = crypto_->getVote(hash);
+    // TODO 10.06.2018 andrei: IR-1407 move YAC propagation strategy to a
+    // separate entity
+    votingStep(vote);
+  }
+
+  rxcpp::observable<Answer> Yac::onOutcome() {
+    return notifier_.get_observable();
+  }
+
+  // ------|Network notifications|------
+
+  template <typename T, typename P>
+  void removeMatching(std::vector<T> &target, const P &predicate) {
+    target.erase(std::remove_if(target.begin(), target.end(), predicate),
+                 target.end());
+  }
+
+  template <typename CollectionType, typename ElementType>
+  bool contains(const CollectionType &haystack, const ElementType &needle) {
+    return std::find(haystack.begin(), haystack.end(), needle)
+        != haystack.end();
+  }
+
+  /// moves the votes not present in known_keys from votes to return value
+  void Yac::removeUnknownPeersVotes(std::vector<VoteMessage> &votes,
+                                    ClusterOrdering &order) {
+    auto known_keys =
+        order.getPeers() | boost::adaptors::transformed([](const auto &peer) {
+          return peer->pubkey();
+        });
+    removeMatching(
+        votes, [known_keys = std::move(known_keys), this](VoteMessage &vote) {
+          if (not contains(known_keys, vote.signature->publicKey())) {
+            log_->warn("Got a vote from an unknown peer: {}", vote);
+            return true;
+          }
+          return false;
+        });
+  }
+
+  void Yac::onState(std::vector<VoteMessage> state) {
+    std::unique_lock<std::mutex> guard(mutex_);
+    auto &proposal_round = getRound(state);
+
+    if (not crypto_->verify(state)) {
+      log_->warn("Crypto verification failed for message. Votes: [{}]",
+                 boost::algorithm::join(
+                     state | boost::adaptors::transformed([](const auto &v) {
+                       return v.signature->toString();
+                     }),
+                     ", "));
+      return;
+    }
+
+    // TODO lebdron: configurable high water mark (see section 4.4
+    // of https://doi.org/10.1145/571637.571640)
+    if (proposal_round.block_round > round_.block_round) {
+      log_->info("Store state from future for {}", proposal_round);
+      future_states_[proposal_round].insert(state.begin(), state.end());
+    }
+
+    removeUnknownPeersVotes(state, getCurrentOrder());
+    if (state.empty()) {
+      log_->debug("No votes left in the message.");
+      return;
+    }
+
+    // several known peers, commit or reject possible
+    if (proposal_round.block_round > round_.block_round) {
+      guard.unlock();
+      log_->info("Pass state from future for {} to pipeline", proposal_round);
+      notifier_.get_subscriber().on_next(FutureMessage{std::move(state)});
+      return;
+    }
+
+    if (proposal_round.block_round < round_.block_round) {
+      log_->info("Received state from past for {}, try to propagate back",
+                 proposal_round);
+      tryPropagateBack(state);
+      guard.unlock();
+      return;
+    }
+
+    if (alternative_order_) {
+      // filter votes with peers from cluster order to avoid the case when
+      // alternative peer is not present in cluster order
+      removeUnknownPeersVotes(state, cluster_order_);
+      if (state.empty()) {
+        log_->debug("No votes left in the message.");
+        return;
       }
+    }
 
-      Yac::Yac(YacVoteStorage vote_storage,
-               std::shared_ptr<YacNetwork> network,
-               std::shared_ptr<YacCryptoProvider> crypto,
-               std::shared_ptr<Timer> timer,
-               ClusterOrdering order,
-               Round round,
-               rxcpp::observe_on_one_worker worker,
-               logger::LoggerPtr log)
-          : log_(std::move(log)),
-            cluster_order_(order),
-            round_(round),
-            worker_(worker),
-            notifier_(worker_, notifier_lifetime_),
-            vote_storage_(std::move(vote_storage)),
-            network_(std::move(network)),
-            crypto_(std::move(crypto)),
-            timer_(std::move(timer)) {}
+    applyState(state, guard);
+  }
 
-      Yac::~Yac() {
-        notifier_lifetime_.unsubscribe();
-      }
+  // ------|Private interface|------
 
-      void Yac::stop() {
-        network_->stop();
-      }
+  void Yac::votingStep(VoteMessage vote, uint32_t attempt) {
+    log_->info("votingStep got vote: {}, attempt {}", vote, attempt);
+    std::unique_lock<std::mutex> lock(mutex_);
 
-      // ------|Hash gate|------
+    auto committed = vote_storage_.isCommitted(vote.hash.vote_round);
+    if (committed) {
+      return;
+    }
 
-      void Yac::vote(YacHash hash,
-                     ClusterOrdering order,
-                     boost::optional<ClusterOrdering> alternative_order) {
-        log_->info("Order for voting: [{}]",
-                   boost::algorithm::join(
-                       order.getPeers()
-                           | boost::adaptors::transformed(
-                                 [](const auto &p) { return p->address(); }),
-                       ", "));
+    enum { kRotatePeriod = 10 };
 
-        std::unique_lock<std::mutex> lock(mutex_);
-        cluster_order_ = order;
-        alternative_order_ = std::move(alternative_order);
-        round_ = hash.vote_round;
-        lock.unlock();
-        auto vote = crypto_->getVote(hash);
-        // TODO 10.06.2018 andrei: IR-1407 move YAC propagation strategy to a
-        // separate entity
-        votingStep(vote);
-      }
+    if (0 != attempt && 0 == (attempt % kRotatePeriod)) {
+      vote_storage_.remove(vote.hash.vote_round);
+    }
 
-      rxcpp::observable<Answer> Yac::onOutcome() {
-        return notifier_.get_observable();
-      }
+    /**
+     * 3 attempts to build and commit block before we think that round is
+     * freezed
+     */
+    if (attempt == kRotatePeriod) {
+      vote.hash.vote_hashes.proposal_hash.clear();
+      vote.hash.vote_hashes.block_hash.clear();
+      vote.hash.block_signature.reset();
+      vote = crypto_->getVote(vote.hash);
+    }
 
-      // ------|Network notifications|------
+    auto &cluster_order = getCurrentOrder();
 
-      template <typename T, typename P>
-      void removeMatching(std::vector<T> &target, const P &predicate) {
-        target.erase(std::remove_if(target.begin(), target.end(), predicate),
-                     target.end());
-      }
+    const auto &current_leader = cluster_order.currentLeader();
 
-      template <typename CollectionType, typename ElementType>
-      bool contains(const CollectionType &haystack, const ElementType &needle) {
-        return std::find(haystack.begin(), haystack.end(), needle)
-            != haystack.end();
-      }
+    log_->info("Vote {} to peer {}", vote, current_leader);
 
-      /// moves the votes not present in known_keys from votes to return value
-      void Yac::removeUnknownPeersVotes(std::vector<VoteMessage> &votes,
-                                        ClusterOrdering &order) {
-        auto known_keys = order.getPeers()
-            | boost::adaptors::transformed(
-                              [](const auto &peer) { return peer->pubkey(); });
-        removeMatching(
-            votes,
-            [known_keys = std::move(known_keys), this](VoteMessage &vote) {
-              if (not contains(known_keys, vote.signature->publicKey())) {
-                log_->warn("Got a vote from an unknown peer: {}", vote);
-                return true;
-              }
-              return false;
-            });
-      }
+    propagateStateDirectly(current_leader, {vote});
+    cluster_order.switchToNext();
+    lock.unlock();
 
-      void Yac::onState(std::vector<VoteMessage> state) {
-        std::unique_lock<std::mutex> guard(mutex_);
+    timer_->invokeAfterDelay(
+        [this, vote, attempt] { this->votingStep(vote, attempt + 1); });
+  }
 
-        removeUnknownPeersVotes(state, getCurrentOrder());
-        if (state.empty()) {
-          log_->debug("No votes left in the message.");
-          return;
-        }
+  void Yac::closeRound() {
+    timer_->deny();
+  }
 
-        if (crypto_->verify(state)) {
+  ClusterOrdering &Yac::getCurrentOrder() {
+    return alternative_order_ ? *alternative_order_ : cluster_order_;
+  }
+
+  boost::optional<std::shared_ptr<shared_model::interface::Peer>> Yac::findPeer(
+      const VoteMessage &vote) {
+    auto peers = cluster_order_.getPeers();
+    auto it = std::find_if(peers.begin(), peers.end(), [&](const auto &peer) {
+      return peer->pubkey() == vote.signature->publicKey();
+    });
+    return it != peers.end() ? boost::make_optional(std::move(*it))
+                             : boost::none;
+  }
+
+  // ------|Apply data|------
+
+  void Yac::applyState(const std::vector<VoteMessage> &state,
+                       std::unique_lock<std::mutex> &lock) {
+    assert(lock.owns_lock());
+    auto answer = vote_storage_.store(state, cluster_order_.getNumberOfPeers());
+
+    // TODO 10.06.2018 andrei: IR-1407 move YAC propagation strategy to a
+    // separate entity
+
+    iroha::match_in_place(
+        answer,
+        [&](const auto &answer) {
           auto &proposal_round = getRound(state);
+          auto current_round = round_;
 
-          if (proposal_round.block_round > round_.block_round) {
-            guard.unlock();
-            log_->info("Pass state from future for {} to pipeline",
-                       proposal_round);
-            notifier_.get_subscriber().on_next(FutureMessage{std::move(state)});
-            return;
-          }
-
-          if (proposal_round.block_round < round_.block_round) {
-            log_->info("Received state from past for {}, try to propagate back",
-                       proposal_round);
-            tryPropagateBack(state);
-            guard.unlock();
-            return;
-          }
-
-          if (alternative_order_) {
-            // filter votes with peers from cluster order to avoid the case when
-            // alternative peer is not present in cluster order
-            removeUnknownPeersVotes(state, cluster_order_);
-            if (state.empty()) {
-              log_->debug("No votes left in the message.");
-              return;
+          /*
+           * It is possible that a new peer with an outdated peers list may
+           * collect an outcome from a smaller number of peers which are
+           * included in set of `f` peers in the system. The new peer will
+           * not accept our message with valid supermajority because he
+           * cannot apply votes from unknown peers.
+           */
+          if (state.size() > 1
+              or (proposal_round.block_round == current_round.block_round
+                  and cluster_order_.getPeers().size() == 1)) {
+            // some peer has already collected commit/reject, so it is sent
+            if (vote_storage_.getProcessingState(proposal_round)
+                == ProposalState::kNotSentNotProcessed) {
+              vote_storage_.nextProcessingState(proposal_round);
+              log_->info(
+                  "Received supermajority of votes for {}, skip "
+                  "propagation",
+                  proposal_round);
             }
           }
 
-          applyState(state, guard);
-        } else {
-          log_->warn(
-              "Crypto verification failed for message. Votes: [{}]",
-              boost::algorithm::join(
-                  state | boost::adaptors::transformed([](const auto &v) {
-                    return v.signature->toString();
-                  }),
-                  ", "));
-        }
-      }
+          auto processing_state =
+              vote_storage_.getProcessingState(proposal_round);
 
-      // ------|Private interface|------
+          auto votes =
+              [](const auto &state) -> const std::vector<VoteMessage> & {
+            return state.votes;
+          };
 
-      void Yac::votingStep(VoteMessage vote, uint32_t attempt) {
-        log_->info("votingStep got vote: {}, attempt {}", vote, attempt);
-        std::unique_lock<std::mutex> lock(mutex_);
-
-        auto committed = vote_storage_.isCommitted(vote.hash.vote_round);
-        if (committed) {
-          return;
-        }
-
-        enum { kRotatePeriod = 10 };
-
-        if (0 != attempt && 0 == (attempt % kRotatePeriod)) {
-          vote_storage_.remove(vote.hash.vote_round);
-        }
-
-        /**
-         * 3 attempts to build and commit block before we think that round is
-         * freezed
-         */
-        if (attempt == kRotatePeriod) {
-          vote.hash.vote_hashes.proposal_hash.clear();
-          vote.hash.vote_hashes.block_hash.clear();
-          vote.hash.block_signature.reset();
-          vote = crypto_->getVote(vote.hash);
-        }
-
-        auto &cluster_order = getCurrentOrder();
-
-        const auto &current_leader = cluster_order.currentLeader();
-
-        log_->info("Vote {} to peer {}", vote, current_leader);
-
-        propagateStateDirectly(current_leader, {vote});
-        cluster_order.switchToNext();
-        lock.unlock();
-
-        timer_->invokeAfterDelay(
-            [this, vote, attempt] { this->votingStep(vote, attempt + 1); });
-      }
-
-      void Yac::closeRound() {
-        timer_->deny();
-      }
-
-      ClusterOrdering &Yac::getCurrentOrder() {
-        return alternative_order_ ? *alternative_order_ : cluster_order_;
-      }
-
-      boost::optional<std::shared_ptr<shared_model::interface::Peer>>
-      Yac::findPeer(const VoteMessage &vote) {
-        auto peers = cluster_order_.getPeers();
-        auto it =
-            std::find_if(peers.begin(), peers.end(), [&](const auto &peer) {
-              return peer->pubkey() == vote.signature->publicKey();
-            });
-        return it != peers.end() ? boost::make_optional(std::move(*it))
-                                 : boost::none;
-      }
-
-      // ------|Apply data|------
-
-      void Yac::applyState(const std::vector<VoteMessage> &state,
-                           std::unique_lock<std::mutex> &lock) {
-        assert(lock.owns_lock());
-        auto answer =
-            vote_storage_.store(state, cluster_order_.getNumberOfPeers());
-
-        // TODO 10.06.2018 andrei: IR-1407 move YAC propagation strategy to a
-        // separate entity
-
-        iroha::match_in_place(
-            answer,
-            [&](const auto &answer) {
-              auto &proposal_round = getRound(state);
-              auto current_round = round_;
-
-              /*
-               * It is possible that a new peer with an outdated peers list may
-               * collect an outcome from a smaller number of peers which are
-               * included in set of `f` peers in the system. The new peer will
-               * not accept our message with valid supermajority because he
-               * cannot apply votes from unknown peers.
-               */
-              if (state.size() > 1
-                  or (proposal_round.block_round == current_round.block_round
-                      and cluster_order_.getPeers().size() == 1)) {
-                // some peer has already collected commit/reject, so it is sent
-                if (vote_storage_.getProcessingState(proposal_round)
-                    == ProposalState::kNotSentNotProcessed) {
-                  vote_storage_.nextProcessingState(proposal_round);
-                  log_->info(
-                      "Received supermajority of votes for {}, skip "
-                      "propagation",
-                      proposal_round);
-                }
+          switch (processing_state) {
+            case ProposalState::kNotSentNotProcessed:
+              vote_storage_.nextProcessingState(proposal_round);
+              log_->info("Propagate state {} to whole network", proposal_round);
+              this->propagateState(visit_in_place(answer, votes));
+              break;
+            case ProposalState::kSentNotProcessed:
+              vote_storage_.nextProcessingState(proposal_round);
+              log_->info("Pass outcome for {} to pipeline", proposal_round);
+              lock.unlock();
+              if (proposal_round >= current_round) {
+                this->closeRound();
               }
-
-              auto processing_state =
-                  vote_storage_.getProcessingState(proposal_round);
-
-              auto votes =
-                  [](const auto &state) -> const std::vector<VoteMessage> & {
-                return state.votes;
-              };
-
-              switch (processing_state) {
-                case ProposalState::kNotSentNotProcessed:
-                  vote_storage_.nextProcessingState(proposal_round);
-                  log_->info("Propagate state {} to whole network",
-                             proposal_round);
-                  this->propagateState(visit_in_place(answer, votes));
-                  break;
-                case ProposalState::kSentNotProcessed:
-                  vote_storage_.nextProcessingState(proposal_round);
-                  log_->info("Pass outcome for {} to pipeline", proposal_round);
-                  lock.unlock();
-                  if (proposal_round >= current_round) {
-                    this->closeRound();
-                  }
-                  notifier_.get_subscriber().on_next(answer);
-                  break;
-                case ProposalState::kSentProcessed:
-                  if (current_round > proposal_round)
-                    this->tryPropagateBack(state);
-                  break;
-              }
-            },
-            // sent a state which didn't match with current one
-            [&]() { this->tryPropagateBack(state); });
-        if (lock.owns_lock()) {
-          lock.unlock();
-        }
-      }
-
-      void Yac::tryPropagateBack(const std::vector<VoteMessage> &state) {
-        // yac back propagation will work only if another peer is in
-        // propagation stage because if peer sends list of votes this means that
-        // state is already committed
-        if (state.size() != 1) {
-          return;
-        }
-
-        vote_storage_.getLastFinalizedRound() | [&](const auto &last_round) {
-          if (getRound(state) <= last_round) {
-            vote_storage_.getState(last_round) | [&](const auto &last_state) {
-              this->findPeer(state.at(0)) | [&](const auto &from) {
-                log_->info("Propagate state {} directly to {}",
-                           last_round,
-                           from->address());
-                auto votes = [](const auto &state) { return state.votes; };
-                this->propagateStateDirectly(*from,
-                                             visit_in_place(last_state, votes));
-              };
-            };
+              notifier_.get_subscriber().on_next(answer);
+              break;
+            case ProposalState::kSentProcessed:
+              if (current_round > proposal_round)
+                this->tryPropagateBack(state);
+              break;
           }
+        },
+        // sent a state which didn't match with current one
+        [&]() { this->tryPropagateBack(state); });
+    if (lock.owns_lock()) {
+      lock.unlock();
+    }
+  }
+
+  void Yac::tryPropagateBack(const std::vector<VoteMessage> &state) {
+    // yac back propagation will work only if another peer is in
+    // propagation stage because if peer sends list of votes this means that
+    // state is already committed
+    if (state.size() != 1) {
+      return;
+    }
+
+    vote_storage_.getLastFinalizedRound() | [&](const auto &last_round) {
+      if (getRound(state) <= last_round) {
+        vote_storage_.getState(last_round) | [&](const auto &last_state) {
+          this->findPeer(state.at(0)) | [&](const auto &from) {
+            log_->info("Propagate state {} directly to {}",
+                       last_round,
+                       from->address());
+            auto votes = [](const auto &state) { return state.votes; };
+            this->propagateStateDirectly(*from,
+                                         visit_in_place(last_state, votes));
+          };
         };
       }
+    };
+  }
 
-      // ------|Propagation|------
+  // ------|Propagation|------
 
-      void Yac::propagateState(const std::vector<VoteMessage> &msg) {
-        for (const auto &peer : cluster_order_.getPeers()) {
-          propagateStateDirectly(*peer, msg);
-        }
-      }
+  void Yac::propagateState(const std::vector<VoteMessage> &msg) {
+    for (const auto &peer : cluster_order_.getPeers()) {
+      propagateStateDirectly(*peer, msg);
+    }
+  }
 
-      void Yac::propagateStateDirectly(const shared_model::interface::Peer &to,
-                                       const std::vector<VoteMessage> &msg) {
-        network_->sendState(to, msg);
-      }
+  void Yac::propagateStateDirectly(const shared_model::interface::Peer &to,
+                                   const std::vector<VoteMessage> &msg) {
+    network_->sendState(to, msg);
+  }
 
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+}  // namespace iroha::consensus::yac

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -21,170 +21,163 @@
 #include "consensus/yac/yac_types.hpp"
 #include "logger/logger_manager_fwd.hpp"
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
+namespace iroha::consensus::yac {
 
-      /**
-       * Proposal outcome states for multicast propagation strategy
-       *
-       * Outcome is either CommitMessage, which guarantees that supermajority of
-       * votes for the proposal-block hashes is collected, or RejectMessage,
-       * which states that supermajority of votes for a block hash cannot be
-       * achieved
-       *
-       * kNotSentNotProcessed - outcome was not propagated in the network
-       * AND it was not passed to pipeline. Initial state after receiving an
-       * outcome from storage. Outcome with votes is propagated to the network
-       * in this state.
-       *
-       * kSentNotProcessed - outcome was propagated in the network
-       * AND it was not passed to pipeline. State can be set in two cases:
-       * 1. Outcome is received from the network. Some node has already achieved
-       * an outcome and has propagated it to the network, so the first state is
-       * skipped.
-       * 2. Outcome was propagated to the network
-       * Outcome is passed to pipeline in this state.
-       *
-       * kSentProcessed - outcome was propagated in the network
-       * AND it was passed to pipeline. Set after passing proposal to pipeline.
-       * This state is final. Receiving a network message in this state results
-       * in direct propagation of outcome to message sender.
-       */
-      enum class ProposalState {
-        kNotSentNotProcessed,
-        kSentNotProcessed,
-        kSentProcessed
-      };
+  /**
+   * Proposal outcome states for multicast propagation strategy
+   *
+   * Outcome is either CommitMessage, which guarantees that supermajority of
+   * votes for the proposal-block hashes is collected, or RejectMessage,
+   * which states that supermajority of votes for a block hash cannot be
+   * achieved
+   *
+   * kNotSentNotProcessed - outcome was not propagated in the network
+   * AND it was not passed to pipeline. Initial state after receiving an
+   * outcome from storage. Outcome with votes is propagated to the network
+   * in this state.
+   *
+   * kSentNotProcessed - outcome was propagated in the network
+   * AND it was not passed to pipeline. State can be set in two cases:
+   * 1. Outcome is received from the network. Some node has already achieved
+   * an outcome and has propagated it to the network, so the first state is
+   * skipped.
+   * 2. Outcome was propagated to the network
+   * Outcome is passed to pipeline in this state.
+   *
+   * kSentProcessed - outcome was propagated in the network
+   * AND it was passed to pipeline. Set after passing proposal to pipeline.
+   * This state is final. Receiving a network message in this state results
+   * in direct propagation of outcome to message sender.
+   */
+  enum class ProposalState {
+    kNotSentNotProcessed,
+    kSentNotProcessed,
+    kSentProcessed
+  };
 
-      /**
-       * Class provide storage for votes and useful methods for it.
-       */
-      class YacVoteStorage {
-       private:
-        // --------| private api |--------
+  /**
+   * Class provide storage for votes and useful methods for it.
+   */
+  class YacVoteStorage {
+   private:
+    // --------| private api |--------
 
-        /**
-         * Retrieve iterator for storage with specified key
-         * @param round - key of that storage
-         * @return iterator to proposal storage
-         */
-        auto getProposalStorage(const Round &round);
-        auto getProposalStorage(const Round &round) const;
+    /**
+     * Retrieve iterator for storage with specified key
+     * @param round - key of that storage
+     * @return iterator to proposal storage
+     */
+    auto getProposalStorage(const Round &round);
+    auto getProposalStorage(const Round &round) const;
 
-        /**
-         * Find existed proposal storage or create new if required
-         * @param msg - vote for finding
-         * @param peers_in_round - number of peer required
-         * for verify supermajority;
-         * This parameter used on creation of proposal storage
-         * @return - iter for required proposal storage
-         */
-        boost::optional<std::vector<YacProposalStorage>::iterator>
-        findProposalStorage(const VoteMessage &msg,
-                            PeersNumberType peers_in_round);
+    /**
+     * Find existed proposal storage or create new if required
+     * @param msg - vote for finding
+     * @param peers_in_round - number of peer required
+     * for verify supermajority;
+     * This parameter used on creation of proposal storage
+     * @return - iter for required proposal storage
+     */
+    boost::optional<std::vector<YacProposalStorage>::iterator>
+    findProposalStorage(const VoteMessage &msg, PeersNumberType peers_in_round);
 
-       public:
-        // --------| public api |--------
+   public:
+    // --------| public api |--------
 
-        /**
-         * @param cleanup_strategy - strategy for removing elements from storage
-         * @param consistency_model - consensus consistency model (CFT, BFT).
-         * @param log_manager - log manager to create component loggers
-         */
-        YacVoteStorage(
-            std::shared_ptr<CleanupStrategy> cleanup_strategy,
-            std::unique_ptr<SupermajorityChecker> supermajority_checker,
-            logger::LoggerManagerTreePtr log_manager);
+    /**
+     * @param cleanup_strategy - strategy for removing elements from storage
+     * @param consistency_model - consensus consistency model (CFT, BFT).
+     * @param log_manager - log manager to create component loggers
+     */
+    YacVoteStorage(std::shared_ptr<CleanupStrategy> cleanup_strategy,
+                   std::unique_ptr<SupermajorityChecker> supermajority_checker,
+                   logger::LoggerManagerTreePtr log_manager);
 
-        /**
-         * Insert votes in storage
-         * @param state - current message with votes
-         * @param peers_in_round - number of peers participated in round
-         * @return structure with result of inserting.
-         * boost::none if msg not valid.
-         */
-        boost::optional<Answer> store(std::vector<VoteMessage> state,
-                                      PeersNumberType peers_in_round);
+    /**
+     * Insert votes in storage
+     * @param state - current message with votes
+     * @param peers_in_round - number of peers participated in round
+     * @return structure with result of inserting.
+     * boost::none if msg not valid.
+     */
+    boost::optional<Answer> store(std::vector<VoteMessage> state,
+                                  PeersNumberType peers_in_round);
 
-        /**
-         * Provide status about closing round of proposal/block
-         * @param round, in which proposal/block is supposed to be committed
-         * @return true, if round closed
-         */
-        bool isCommitted(const Round &round);
+    /**
+     * Provide status about closing round of proposal/block
+     * @param round, in which proposal/block is supposed to be committed
+     * @return true, if round closed
+     */
+    bool isCommitted(const Round &round);
 
-        /**
-         * Remove proposal storage by round
-         */
-        void remove(const Round &round);
+    /**
+     * Remove proposal storage by round
+     */
+    void remove(const Round &round);
 
-        /**
-         * Method provide state of processing for concrete proposal/block
-         * @param round, in which that proposal/block is being voted
-         * @return value attached to parameter's round. Default is
-         * kNotSentNotProcessed.
-         */
-        ProposalState getProcessingState(const Round &round);
+    /**
+     * Method provide state of processing for concrete proposal/block
+     * @param round, in which that proposal/block is being voted
+     * @return value attached to parameter's round. Default is
+     * kNotSentNotProcessed.
+     */
+    ProposalState getProcessingState(const Round &round);
 
-        /**
-         * Mark round with following transition:
-         * kNotSentNotProcessed -> kSentNotProcessed
-         * kSentNotProcessed -> kSentProcessed
-         * kSentProcessed -> kSentProcessed
-         * @see ProposalState description for transition cases
-         * @param round - target tag
-         */
-        void nextProcessingState(const Round &round);
+    /**
+     * Mark round with following transition:
+     * kNotSentNotProcessed -> kSentNotProcessed
+     * kSentNotProcessed -> kSentProcessed
+     * kSentProcessed -> kSentProcessed
+     * @see ProposalState description for transition cases
+     * @param round - target tag
+     */
+    void nextProcessingState(const Round &round);
 
-        /**
-         * Get last by order finalized round
-         * @return round if it exists
-         */
-        boost::optional<Round> getLastFinalizedRound() const;
+    /**
+     * Get last by order finalized round
+     * @return round if it exists
+     */
+    boost::optional<Round> getLastFinalizedRound() const;
 
-        /**
-         * Get the state attached of a past round
-         * @param round - required round
-         * @return state if round exists and finalized
-         */
-        boost::optional<Answer> getState(const Round &round) const;
+    /**
+     * Get the state attached of a past round
+     * @param round - required round
+     * @return state if round exists and finalized
+     */
+    boost::optional<Answer> getState(const Round &round) const;
 
-       private:
-        // --------| fields |--------
+   private:
+    // --------| fields |--------
 
-        // TODO: 2019-02-28 @muratovv refactor proposal_storages_ &
-        // processing_state_ with separate entity IR-360
+    // TODO: 2019-02-28 @muratovv refactor proposal_storages_ &
+    // processing_state_ with separate entity IR-360
 
-        /**
-         * Active proposal storages
-         */
-        std::vector<YacProposalStorage> proposal_storages_;
+    /**
+     * Active proposal storages
+     */
+    std::vector<YacProposalStorage> proposal_storages_;
 
-        /**
-         * Processing set provide user flags about processing some
-         * proposals/blocks.
-         * If such round exists <=> processed
-         */
-        std::unordered_map<Round, ProposalState, RoundTypeHasher>
-            processing_state_;
+    /**
+     * Processing set provide user flags about processing some
+     * proposals/blocks.
+     * If such round exists <=> processed
+     */
+    std::unordered_map<Round, ProposalState> processing_state_;
 
-        /**
-         * Provides strategy managing rounds (adding and removing) for the
-         * storage
-         */
-        std::shared_ptr<CleanupStrategy> strategy_;
+    /**
+     * Provides strategy managing rounds (adding and removing) for the
+     * storage
+     */
+    std::shared_ptr<CleanupStrategy> strategy_;
 
-        /// last finalized round
-        boost::optional<Round> last_round_;
+    /// last finalized round
+    boost::optional<Round> last_round_;
 
-        std::shared_ptr<SupermajorityChecker> supermajority_checker_;
+    std::shared_ptr<SupermajorityChecker> supermajority_checker_;
 
-        logger::LoggerManagerTreePtr log_manager_;
-      };
+    logger::LoggerManagerTreePtr log_manager_;
+  };
 
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+}  // namespace iroha::consensus::yac
 
 #endif  // IROHA_YAC_VOTE_STORAGE_HPP

--- a/irohad/consensus/yac/vote_message.hpp
+++ b/irohad/consensus/yac/vote_message.hpp
@@ -8,40 +8,53 @@
 
 #include <memory>
 
+#include <boost/functional/hash.hpp>
+
 #include "consensus/yac/yac_hash_provider.hpp"  // for YacHash
 #include "interfaces/common_objects/signature.hpp"
 #include "utils/string_builder.hpp"
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
+namespace iroha::consensus::yac {
 
-      /**
-       * VoteMessage represents voting for some block;
-       */
-      struct VoteMessage {
-        YacHash hash;
-        std::shared_ptr<shared_model::interface::Signature> signature;
+  /**
+   * VoteMessage represents voting for some block;
+   */
+  struct VoteMessage {
+    YacHash hash;
+    std::shared_ptr<shared_model::interface::Signature> signature;
 
-        bool operator==(const VoteMessage &rhs) const {
-          return hash == rhs.hash and *signature == *rhs.signature;
-        }
+    bool operator==(const VoteMessage &rhs) const {
+      return hash == rhs.hash and *signature == *rhs.signature;
+    }
 
-        bool operator!=(const VoteMessage &rhs) const {
-          return not(*this == rhs);
-        }
+    bool operator!=(const VoteMessage &rhs) const {
+      return not(*this == rhs);
+    }
 
-        std::string toString() const {
-          return shared_model::detail::PrettyStringBuilder()
-              .init("VoteMessage")
-              .appendNamed("yac hash", hash)
-              .appendNamed("signature", signature)
-              .finalize();
-        }
-      };
+    std::string toString() const {
+      return shared_model::detail::PrettyStringBuilder()
+          .init("VoteMessage")
+          .appendNamed("yac hash", hash)
+          .appendNamed("signature", signature)
+          .finalize();
+    }
+  };
 
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+}  // namespace iroha::consensus::yac
+
+namespace std {
+  template <>
+  struct hash<iroha::consensus::yac::VoteMessage> {
+    std::size_t operator()(
+        iroha::consensus::yac::VoteMessage const &m) const noexcept {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, m.signature->publicKey());
+      boost::hash_combine(seed, m.hash.vote_round);
+      boost::hash_combine(seed, m.hash.vote_hashes.proposal_hash);
+      boost::hash_combine(seed, m.hash.vote_hashes.block_hash);
+      return seed;
+    }
+  };
+}  // namespace std
 
 #endif  // IROHA_VOTE_MESSAGE_HPP

--- a/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_unknown_peer_test.cpp
@@ -70,7 +70,9 @@ TEST_F(YacTest, UnknownVoteAfterCommit) {
 
   EXPECT_CALL(*timer, deny()).Times(AtLeast(1));
 
-  EXPECT_CALL(*crypto, verify(_)).Times(1).WillRepeatedly(Return(true));
+  EXPECT_CALL(*crypto, verify(_))
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(true));
 
   YacHash my_hash(iroha::consensus::Round{1, 1}, "proposal_hash", "block_hash");
 


### PR DESCRIPTION
### Description of the Change
Reduce transaction latency by storing votes from future and applying them when info about the corresponding round is available.

### Benefits
Improved performance

### Possible Drawbacks 
None?
