### PR TITLE
AsyncGrpcClient: move class template to Call method

### DIFF
--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -23,8 +23,7 @@ namespace iroha {
       // ----------| Public API |----------
 
       NetworkImpl::NetworkImpl(
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
+          std::shared_ptr<network::AsyncGrpcClient> async_call,
           std::unique_ptr<ClientFactory> client_factory,
           logger::LoggerPtr log)
           : async_call_(async_call),
@@ -66,7 +65,9 @@ namespace iroha {
                       auto context, auto cq) {
                     log->info(log_sending_msg);
                     return client->AsyncSendState(context, request, cq);
-                  });
+                  },
+                  std::function<void(grpc::Status &,
+                                     google::protobuf::Empty &)>{});
             },
             [&](const auto &error) {
               log_->error("Could not send state to {}: {}", to, error.error);

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -35,8 +35,7 @@ namespace iroha {
         using ClientFactory = iroha::network::ClientFactory<Service>;
 
         explicit NetworkImpl(
-            std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
+            std::shared_ptr<network::AsyncGrpcClient> async_call,
             std::unique_ptr<iroha::network::ClientFactory<
                 ::iroha::consensus::yac::proto::Yac>> client_factory,
             logger::LoggerPtr log);
@@ -68,8 +67,7 @@ namespace iroha {
         /**
          * Rpc call to provide an ability to perform call grpc endpoints
          */
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call_;
+        std::shared_ptr<network::AsyncGrpcClient> async_call_;
 
         /**
          * Yac stub creator

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -458,9 +458,8 @@ Irohad::RunResult Irohad::initValidators() {
  * Initializing network client
  */
 Irohad::RunResult Irohad::initNetworkClient() {
-  async_call_ =
-      std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>(
-          log_manager_->getChild("AsyncNetworkClient")->getLogger());
+  async_call_ = std::make_shared<network::AsyncGrpcClient>(
+      log_manager_->getChild("AsyncNetworkClient")->getLogger());
   return {};
 }
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -288,8 +288,7 @@ class Irohad {
   std::shared_ptr<iroha::validation::ChainValidator> chain_validator;
 
   // async call
-  std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-      async_call_;
+  std::shared_ptr<iroha::network::AsyncGrpcClient> async_call_;
 
   // transaction batch factory
   std::shared_ptr<shared_model::interface::TransactionBatchFactory>

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -96,9 +96,7 @@ namespace iroha {
           std::shared_ptr<consensus::ConsensusResultCache>
               consensus_result_cache,
           std::chrono::milliseconds vote_delay_milliseconds,
-          std::shared_ptr<
-              iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
+          std::shared_ptr<iroha::network::AsyncGrpcClient> async_call,
           ConsistencyModel consistency_model,
           const logger::LoggerManagerTreePtr &consensus_log_manager,
           std::chrono::milliseconds delay,

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -45,9 +45,7 @@ namespace iroha {
             const shared_model::crypto::Keypair &keypair,
             std::shared_ptr<consensus::ConsensusResultCache> block_cache,
             std::chrono::milliseconds vote_delay_milliseconds,
-            std::shared_ptr<
-                iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
+            std::shared_ptr<iroha::network::AsyncGrpcClient> async_call,
             ConsistencyModel consistency_model,
             const logger::LoggerManagerTreePtr &consensus_log_manager,
             std::chrono::milliseconds delay,

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -45,8 +45,7 @@ OnDemandOrderingInit::OnDemandOrderingInit(logger::LoggerPtr log)
  * gRPC backend. \see initOrderingGate for parameters
  */
 auto createNotificationFactory(
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
+    std::shared_ptr<iroha::network::AsyncGrpcClient> async_call,
     std::shared_ptr<OnDemandOrderingInit::TransportFactoryType>
         proposal_transport_factory,
     std::chrono::milliseconds delay,
@@ -64,8 +63,7 @@ auto createNotificationFactory(
 }
 
 auto OnDemandOrderingInit::createConnectionManager(
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
+    std::shared_ptr<iroha::network::AsyncGrpcClient> async_call,
     std::shared_ptr<TransportFactoryType> proposal_transport_factory,
     std::chrono::milliseconds delay,
     std::vector<shared_model::interface::types::HashType> initial_hashes,
@@ -302,8 +300,7 @@ OnDemandOrderingInit::initOrderingGate(
         batch_parser,
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory,
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
+    std::shared_ptr<iroha::network::AsyncGrpcClient> async_call,
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
         proposal_factory,
     std::shared_ptr<TransportFactoryType> proposal_transport_factory,

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -40,7 +40,6 @@ namespace shared_model {
 namespace iroha {
   namespace network {
     class GenericClientFactory;
-    template <typename Response>
     class AsyncGrpcClient;
     class OrderingGate;
   }  // namespace network
@@ -81,8 +80,7 @@ namespace iroha {
        * parameters
        */
       auto createConnectionManager(
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
+          std::shared_ptr<network::AsyncGrpcClient> async_call,
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,
           std::chrono::milliseconds delay,
           std::vector<shared_model::interface::types::HashType> initial_hashes,
@@ -159,8 +157,7 @@ namespace iroha {
               batch_parser,
           std::shared_ptr<shared_model::interface::TransactionBatchFactory>
               transaction_batch_factory,
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
+          std::shared_ptr<network::AsyncGrpcClient> async_call,
           std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
               proposal_factory,
           std::shared_ptr<TransportFactoryType> proposal_transport_factory,

--- a/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
+++ b/irohad/multi_sig_transactions/transport/impl/mst_transport_grpc.cpp
@@ -31,7 +31,7 @@ using namespace iroha::network;
 using shared_model::interface::types::PublicKeyHexStringView;
 
 MstTransportGrpc::MstTransportGrpc(
-    std::shared_ptr<AsyncGrpcClient<google::protobuf::Empty>> async_call,
+    std::shared_ptr<AsyncGrpcClient> async_call,
     std::shared_ptr<TransportFactoryType> transaction_factory,
     std::shared_ptr<shared_model::interface::TransactionBatchParser>
         batch_parser,
@@ -139,9 +139,8 @@ rxcpp::observable<bool> MstTransportGrpc::sendState(
              to = std::move(to),
              providing_state,
              my_key = my_key_,
-             async_call_ = std::weak_ptr<
-                 network::AsyncGrpcClient<google::protobuf::Empty>>(
-                 async_call_)](auto s) {
+             async_call_ =
+                 std::weak_ptr<network::AsyncGrpcClient>(async_call_)](auto s) {
               auto log = log_.lock();
               auto async_call = async_call_.lock();
 
@@ -168,7 +167,7 @@ void iroha::network::sendStateAsync(
     MstState const &state,
     PublicKeyHexStringView sender_key,
     transport::MstTransportGrpc::StubInterface &client_stub,
-    AsyncGrpcClient<google::protobuf::Empty> &async_call,
+    AsyncGrpcClient &async_call,
     std::function<void(grpc::Status &, google::protobuf::Empty &)>
         on_response) {
   transport::MstState proto_state;

--- a/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
+++ b/irohad/multi_sig_transactions/transport/mst_transport_grpc.hpp
@@ -40,8 +40,7 @@ namespace iroha {
       using MstClientFactory = ClientFactory<Service>;
 
       MstTransportGrpc(
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
+          std::shared_ptr<network::AsyncGrpcClient> async_call,
           std::shared_ptr<TransportFactoryType> transaction_factory,
           std::shared_ptr<shared_model::interface::TransactionBatchParser>
               batch_parser,
@@ -75,8 +74,7 @@ namespace iroha {
 
      private:
       std::weak_ptr<MstTransportNotification> subscriber_;
-      std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-          async_call_;
+      std::shared_ptr<network::AsyncGrpcClient> async_call_;
       std::shared_ptr<TransportFactoryType> transaction_factory_;
       std::shared_ptr<shared_model::interface::TransactionBatchParser>
           batch_parser_;
@@ -98,7 +96,7 @@ namespace iroha {
         MstState const &state,
         shared_model::interface::types::PublicKeyHexStringView sender_key,
         transport::MstTransportGrpc::StubInterface &client_stub,
-        AsyncGrpcClient<google::protobuf::Empty> &async_call,
+        AsyncGrpcClient &async_call,
         std::function<void(grpc::Status &, google::protobuf::Empty &)>
             on_response = {});
 

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -40,8 +40,7 @@ namespace iroha {
          */
         OnDemandOsClientGrpc(
             std::shared_ptr<proto::OnDemandOrdering::StubInterface> stub,
-            std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
+            std::shared_ptr<network::AsyncGrpcClient> async_call,
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
@@ -55,8 +54,7 @@ namespace iroha {
        private:
         logger::LoggerPtr log_;
         std::shared_ptr<proto::OnDemandOrdering::StubInterface> stub_;
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call_;
+        std::shared_ptr<network::AsyncGrpcClient> async_call_;
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
@@ -69,8 +67,7 @@ namespace iroha {
 
         using TransportFactoryType = OnDemandOsClientGrpc::TransportFactoryType;
         OnDemandOsClientGrpcFactory(
-            std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
+            std::shared_ptr<network::AsyncGrpcClient> async_call,
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
             OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
@@ -81,8 +78,7 @@ namespace iroha {
         create(const shared_model::interface::Peer &to) override;
 
        private:
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call_;
+        std::shared_ptr<network::AsyncGrpcClient> async_call_;
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -209,8 +209,7 @@ namespace integration_framework {
       using OsTransport = iroha::ordering::OrderingServiceTransportGrpc;
       using OgTransport = iroha::ordering::OrderingGateTransportGrpc;
       using OdOsTransport = iroha::ordering::transport::OnDemandOsServerGrpc;
-      using AsyncCall =
-          iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
+      using AsyncCall = iroha::network::AsyncGrpcClient;
 
       /// Ensure the initialize() method was called.
       void ensureInitialized();

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -72,7 +72,6 @@ namespace iroha {
     class MstTransportGrpc;
     class OrderingServiceTransport;
     class ServerRunner;
-    template <typename Response>
     class AsyncGrpcClient;
   }  // namespace network
   namespace protocol {
@@ -470,7 +469,7 @@ namespace integration_framework {
     std::string getAddress() const;
 
    protected:
-    using AsyncCall = iroha::network::AsyncGrpcClient<google::protobuf::Empty>;
+    using AsyncCall = iroha::network::AsyncGrpcClient;
 
     /**
      * A wrapper over a queue that provides thread safety and blocking pop

--- a/test/fuzzing/consensus_fuzz.cpp
+++ b/test/fuzzing/consensus_fuzz.cpp
@@ -36,8 +36,7 @@ namespace fuzzing {
     std::shared_ptr<iroha::consensus::yac::CleanupStrategy> cleanup_strategy_;
     const shared_model::crypto::Keypair keypair_;
     std::shared_ptr<iroha::consensus::yac::YacNetworkNotifications> yac_;
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call_;
+    std::shared_ptr<iroha::network::AsyncGrpcClient> async_call_;
     std::shared_ptr<iroha::consensus::yac::NetworkImpl> network_;
     iroha::consensus::Round initial_round_;
 
@@ -47,8 +46,7 @@ namespace fuzzing {
                             iroha::consensus::yac::BufferedCleanupStrategy>()),
           keypair_(shared_model::crypto::DefaultCryptoAlgorithmType::
                        generateKeypair()),
-          async_call_(std::make_shared<
-                      iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
+          async_call_(std::make_shared<iroha::network::AsyncGrpcClient>(
               logger::getDummyLoggerPtr())),
           initial_round_{1, 1} {
       network_ = std::make_shared<iroha::consensus::yac::NetworkImpl>(

--- a/test/fuzzing/mst_fuzz.cpp
+++ b/test/fuzzing/mst_fuzz.cpp
@@ -32,8 +32,7 @@ namespace fuzzing {
     std::shared_ptr<MstTransportGrpc> mst_transport_grpc_;
 
     MstFixture() {
-      auto async_call_ = std::make_shared<
-          iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
+      auto async_call_ = std::make_shared<iroha::network::AsyncGrpcClient>(
           logger::getDummyLoggerPtr());
       // TODO luckychess 25.12.2018 Component initialisation reuse
       // IR-1886, IR-142

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -73,8 +73,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
   void SetUp() override {
     cleanup_strategy =
         std::make_shared<iroha::consensus::yac::BufferedCleanupStrategy>();
-    auto async_call = std::make_shared<
-        iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
+    auto async_call = std::make_shared<iroha::network::AsyncGrpcClient>(
         getTestLogger("AsyncCall"));
     network = std::make_shared<NetworkImpl>(
         async_call,

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -43,8 +43,7 @@ namespace iroha {
 
         void SetUp() override {
           notifications = std::make_shared<MockYacNetworkNotifications>();
-          async_call = std::make_shared<
-              network::AsyncGrpcClient<google::protobuf::Empty>>(
+          async_call = std::make_shared<network::AsyncGrpcClient>(
               getTestLogger("AsyncCall"));
           mock_client_factory_ =
               new iroha::network::MockClientFactory<NetworkImpl::Service>();
@@ -70,8 +69,7 @@ namespace iroha {
         iroha::network::MockClientFactory<NetworkImpl::Service>
             *mock_client_factory_;
         std::shared_ptr<MockYacNetworkNotifications> notifications;
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call;
+        std::shared_ptr<network::AsyncGrpcClient> async_call;
         std::shared_ptr<NetworkImpl> network;
         std::shared_ptr<shared_model::interface::Peer> peer;
         VoteMessage message;

--- a/test/module/irohad/multi_sig_transactions/transport_test.cpp
+++ b/test/module/irohad/multi_sig_transactions/transport_test.cpp
@@ -43,8 +43,8 @@ class TransportTest : public ::testing::Test {
  public:
   TransportTest() : my_key_(makeKey()) {}
   void SetUp() override {
-    async_call_ = std::make_shared<AsyncGrpcClient<google::protobuf::Empty>>(
-        getTestLogger("AsyncClient"));
+    async_call_ =
+        std::make_shared<AsyncGrpcClient>(getTestLogger("AsyncClient"));
     parser_ = std::make_shared<TransactionBatchParserImpl>();
     batch_validator_ =
         std::make_shared<shared_model::validation::DefaultBatchValidator>(
@@ -97,7 +97,7 @@ class TransportTest : public ::testing::Test {
   iroha::network::MockClientFactory<MstTransportGrpc::Service>
       *mock_client_factory_{
           new iroha::network::MockClientFactory<MstTransportGrpc::Service>()};
-  std::shared_ptr<AsyncGrpcClient<google::protobuf::Empty>> async_call_;
+  std::shared_ptr<AsyncGrpcClient> async_call_;
   std::shared_ptr<TransactionBatchParserImpl> parser_;
   std::shared_ptr<shared_model::validation::AbstractValidator<
       shared_model::interface::TransactionBatch>>

--- a/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
@@ -46,8 +46,7 @@ class OnDemandOsClientGrpcTest : public ::testing::Test {
     auto ustub = std::make_unique<proto::MockOnDemandOrderingStub>();
     stub = ustub.get();
     async_call =
-        std::make_shared<network::AsyncGrpcClient<google::protobuf::Empty>>(
-            getTestLogger("AsyncCall"));
+        std::make_shared<network::AsyncGrpcClient>(getTestLogger("AsyncCall"));
     auto validator = std::make_unique<MockProposalValidator>();
     proposal_validator = validator.get();
     auto proto_validator = std::make_unique<MockProtoProposalValidator>();
@@ -64,7 +63,7 @@ class OnDemandOsClientGrpcTest : public ::testing::Test {
   }
 
   proto::MockOnDemandOrderingStub *stub;
-  std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>> async_call;
+  std::shared_ptr<network::AsyncGrpcClient> async_call;
   OnDemandOsClientGrpc::TimepointType timepoint;
   std::chrono::milliseconds timeout{1};
   std::shared_ptr<OnDemandOsClientGrpc> client;


### PR DESCRIPTION
### Description of the Change
Move class template to Call method to allow reusing the same client for different endpoints.

### Benefits
Simpler code

### Possible Drawbacks 
None