### PR TITLE
Docs: Fixing Getting Started Python Example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,8 +29,9 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'm2r',
-    'sphinx_extensions.iroha_permissions'
+    'm2r2',
+    'sphinx_extensions.iroha_permissions',
+    "sphinxext.remoteliteralinclude"
 ]
 
 html_static_path = ['_static']

--- a/docs/source/getting_started/python-guide.rst
+++ b/docs/source/getting_started/python-guide.rst
@@ -61,81 +61,11 @@ Running example transactions
 If you only want to try what Iroha transactions would look like,
 you can simply go to the examples from the repository
 `here <https://github.com/hyperledger/iroha-python/tree/master/examples>`_.
-Let's check out the `tx-example.py` file.
+Here is the `tx-example.py` file with comments to clarify each step:
 
-Here are Iroha dependencies.
-Python library generally consists of 3 parts: Iroha, IrohaCrypto and IrohaGrpc which we need to import:
+.. remoteliteralinclude:: https://raw.githubusercontent.com/hyperledger/iroha-python/master/examples/tx-example.py
+   :language: python
 
-.. code-block:: python
-
-	from iroha import Iroha, IrohaGrpc
-	from iroha import IrohaCrypto
-
-The line
-
-.. code-block:: python
-
-	from iroha.primitive_pb2 import can_set_my_account_detail
-
-
-is actually about the permissions you might be using for the transaction.
-You can find a full list here: `Permissions <../develop/api/permissions.html>`_.
-
-
-In the next block we can see the following:
-
-.. code-block:: python
-
-	admin_private_key = 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70'
-	user_private_key = IrohaCrypto.private_key()
-	user_public_key = IrohaCrypto.derive_public_key(user_private_key)
-	iroha = Iroha('admin@test')
-	net = IrohaGrpc()
-
-Here you can see the example account information.
-It will be used later with the commands.
-If you change the commands in the transaction,
-the set of data in this part might also change depending on what you need.
-
-Defining the commands
----------------------
-
-Let's look at the first of the defined commands:
-
-.. code-block:: python
-
-	def create_domain_and_asset():
-	    commands = [
-	        iroha.command('CreateDomain', domain_id='domain', default_role='user'),
-	        iroha.command('CreateAsset', asset_name='coin',
-	                      domain_id='domain', precision=2)
-	    ]
-	    tx = IrohaCrypto.sign_transaction(
-	        iroha.transaction(commands), admin_private_key)
-	    send_transaction_and_print_status(tx)
-
-Here we define a transaction made of 2 commands: CreateDomain and CreateAsset.
-You can find a full list here: `commands <../develop/api/commands.html>`_.
-Each of Iroha commands has its own set of parameters.
-You can check them in command descriptions in `iroha-api-reference <../develop/api.html>`_.
-
-Then we sign the transaction with the parameters defined earlier.
-
-You can define `queries <../develop/api/queries.html>`_ the same way.
-
-Running the commands
---------------------
-
-Last lines
-
-.. code-block:: python
-
-	create_domain_and_asset()
-	add_coin_to_admin()
-	create_account_userone()
-	...
-
-run the commands defined previously.
 
 Now, if you have `irohad` running, you can run the example or
 your own file by simply opening the .py file in another tab.

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -35,3 +35,4 @@ watchdog==0.8.3
 yarg==0.1.9
 m2r
 pygments-lexer-solidity
+sphinxext-remoteliteralinclude


### PR DESCRIPTION
Signed-off-by: Sara <lira.lemur@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Previously there was a page with step-by step description of the example that was actually changing: https://iroha.readthedocs.io/en/master/getting_started/python-guide.html and it is not working - neither conceptually as pieces of code nor de facto as the code is outdated.

So it was decided to simply include the actual example code there and just move the comments to the example itself. Here is the part that 1) includes the example; 2) provides the necessary extensions to allow this idea to build. Also see https://github.com/hyperledger/iroha-python/pull/68

Closes #872

### Benefits

Consistent example 

### Possible Drawbacks 

Python repo is not yet moved to main from master. Will need to update the include, otherwise it will simply break at some point. 
