### PR TITLE
Infrastructure: increase Windows CI disk size

### DIFF
--- a/.packer/win/windows-build-server.json
+++ b/.packer/win/windows-build-server.json
@@ -34,7 +34,7 @@
             "launch_block_device_mappings": [
                 {
                     "device_name": "/dev/sda1",
-                    "volume_size": 80,
+                    "volume_size": 240,
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
### Description of the Change
Increase disk size for Windows machines in order to have enough space for builds.

### Benefits
Windows builds work.

### Possible Drawbacks 
None
