### PR TITLE
Infrastructure: increase Windows CI disk size

### DIFF
--- a/.packer/win/windows-build-server.json
+++ b/.packer/win/windows-build-server.json
@@ -34,7 +34,7 @@
             "launch_block_device_mappings": [
                 {
                     "device_name": "/dev/sda1",
-                    "volume_size": 80,
+                    "volume_size": 240,
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }

--- a/vcpkg/patches/0004-vcpkg_find_acquire_program-Use-msys-for-pkg-config.patch
+++ b/vcpkg/patches/0004-vcpkg_find_acquire_program-Use-msys-for-pkg-config.patch
@@ -1,0 +1,63 @@
+From 5e856909786d2f1bcb187288942a8fbef32b2748 Mon Sep 17 00:00:00 2001
+From: Andrei Lebedev <lebdron@gmail.com>
+Date: Wed, 31 Mar 2021 12:51:17 +0200
+Subject: [PATCH] [vcpkg_find_acquire_program] Use msys for pkg-config
+
+Signed-off-by: Andrei Lebedev <lebdron@gmail.com>
+---
+ .../cmake/vcpkg_find_acquire_program.cmake    | 36 ++++++-------------
+ 1 file changed, 11 insertions(+), 25 deletions(-)
+
+diff --git a/scripts/cmake/vcpkg_find_acquire_program.cmake b/scripts/cmake/vcpkg_find_acquire_program.cmake
+index d5afdfcf3..5d9528c74 100644
+--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
++++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
+@@ -432,34 +432,20 @@ function(vcpkg_find_acquire_program VAR)
+       set(PKGCONFIG $ENV{PKG_CONFIG} PARENT_SCOPE)
+       return()
+     elseif(CMAKE_HOST_WIN32)
+-      set(PROG_PATH_SUBDIR "${DOWNLOADS}/tools/${PROGNAME}/${VERSION}")
+-      set(PKGCONFIG "${PROG_PATH_SUBDIR}/mingw32/bin/pkg-config.exe")
+       if(NOT EXISTS "${PKGCONFIG}")
+-        vcpkg_download_distfile(PKGCONFIG_ARCHIVE
+-          URLS "https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-${VERSION}-any.pkg.tar.xz"
+-          SHA512 3b1b706a24d9aef7bbdf3ce4427aaa813ba6fbd292ed9dda181b4300e117c3d59a159ddcca8b013fd01ce76da2d95d590314ff9628c0d68a6966bac4842540f0
+-          FILENAME mingw-w64-i686-pkg-config-${VERSION}-any.pkg.tar.xz
++        set(VERSION 0.29.2-2)
++        set(LIBWINPTHREAD_VERSION git-8.0.0.5906.c9a21571-1)
++        vcpkg_acquire_msys(
++          PKGCONFIG_ROOT
++          NO_DEFAULT_PACKAGES
++          DIRECT_PACKAGES
++            "https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-${VERSION}-any.pkg.tar.zst"
++            54f8dad3b1a36a4515db47825a3214fbd2bd82f604aec72e7fb8d79068095fda3c836fb2296acd308522d6e12ce15f69e0c26dcf4eb0681fd105d057d912cdb7
++            "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-${LIBWINPTHREAD_VERSION}-any.pkg.tar.zst"
++            2c3d9e6b2eee6a4c16fd69ddfadb6e2dc7f31156627d85845c523ac85e5c585d4cfa978659b1fe2ec823d44ef57bc2b92a6127618ff1a8d7505458b794f3f01c
+         )
+-        vcpkg_download_distfile(LIBWINPTHREAD_ARCHIVE
+-          URLS "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-${LIBWINPTHREAD_VERSION}-any.pkg.tar.zst"
+-          SHA512 2c3d9e6b2eee6a4c16fd69ddfadb6e2dc7f31156627d85845c523ac85e5c585d4cfa978659b1fe2ec823d44ef57bc2b92a6127618ff1a8d7505458b794f3f01c
+-          FILENAME mingw-w64-i686-libwinpthread-${LIBWINPTHREAD_VERSION}-any.pkg.tar.zst
+-        )
+-        file(REMOVE_RECURSE ${PROG_PATH_SUBDIR} ${PROG_PATH_SUBDIR}.tmp)
+-        file(MAKE_DIRECTORY ${PROG_PATH_SUBDIR}.tmp)
+-        vcpkg_execute_required_process(
+-          ALLOW_IN_DOWNLOAD_MODE
+-          COMMAND ${CMAKE_COMMAND} -E tar xzf ${LIBWINPTHREAD_ARCHIVE}
+-          WORKING_DIRECTORY ${PROG_PATH_SUBDIR}.tmp
+-        )
+-        vcpkg_execute_required_process(
+-          ALLOW_IN_DOWNLOAD_MODE
+-          COMMAND ${CMAKE_COMMAND} -E tar xzf ${PKGCONFIG_ARCHIVE}
+-          WORKING_DIRECTORY ${PROG_PATH_SUBDIR}.tmp
+-        )
+-        file(RENAME ${PROG_PATH_SUBDIR}.tmp ${PROG_PATH_SUBDIR})
+       endif()
+-      set(${VAR} "${${VAR}}" PARENT_SCOPE)
++      set(${VAR} "${PKGCONFIG_ROOT}/mingw32/bin/pkg-config.exe" PARENT_SCOPE)
+       return()
+     else()
+       set(BREW_PACKAGE_NAME pkg-config)
+-- 
+2.31.0
+


### PR DESCRIPTION
### Description of the Change
Increase disk size for Windows machines in order to have enough space for builds.

### Benefits
Windows builds work.

### Possible Drawbacks 
None
