### PR TITLE
Replace constants with power of 2 IR-1035

### DIFF
--- a/iroha/src/queue.rs
+++ b/iroha/src/queue.rs
@@ -137,14 +137,12 @@ pub mod config {
     use serde::Deserialize;
 
     const MAXIMUM_TRANSACTIONS_IN_BLOCK: &str = "MAXIMUM_TRANSACTIONS_IN_BLOCK";
-    // 2^13
-    const DEFAULT_MAXIMUM_TRANSACTIONS_IN_BLOCK: u32 = 8_192;
+    const DEFAULT_MAXIMUM_TRANSACTIONS_IN_BLOCK: u32 = 2_u32.pow(13);
     const TRANSACTION_TIME_TO_LIVE_MS: &str = "TRANSACTION_TIME_TO_LIVE_MS";
     // 24 hours
     const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 24 * 60 * 60 * 1000;
     const MAXIMUM_TRANSACTIONS_IN_QUEUE: &str = "MAXIMUM_TRANSACTIONS_IN_QUEUE";
-    // 2^16
-    const DEFAULT_MAXIMUM_TRANSACTIONS_IN_QUEUE: u32 = 65_536;
+    const DEFAULT_MAXIMUM_TRANSACTIONS_IN_QUEUE: u32 = 2_u32.pow(16);
 
     /// Configuration for `Queue`.
     #[derive(Copy, Clone, Deserialize, Debug)]

--- a/iroha/src/torii.rs
+++ b/iroha/src/torii.rs
@@ -509,8 +509,8 @@ pub mod config {
     const TORII_MAX_INSTRUCTION_NUMBER: &str = "TORII_MAX_INSTRUCTION_NUMBER";
     const DEFAULT_TORII_P2P_URL: &str = "127.0.0.1:1337";
     const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
-    const DEFAULT_TORII_MAX_TRANSACTION_SIZE: usize = 32768;
-    const DEFAULT_TORII_MAX_INSTRUCTION_NUMBER: usize = 4096;
+    const DEFAULT_TORII_MAX_TRANSACTION_SIZE: usize = 2_usize.pow(15);
+    const DEFAULT_TORII_MAX_INSTRUCTION_NUMBER: usize = 2_usize.pow(12);
 
     /// `ToriiConfiguration` provides an ability to define parameters such as `TORII_URL`.
     #[derive(Clone, Deserialize, Debug)]

--- a/iroha_client/src/config.rs
+++ b/iroha_client/src/config.rs
@@ -16,7 +16,7 @@ const ACCOUNT_ID: &str = "IROHA_CLIENT_ACCOUNT_ID";
 const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
 const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
 const DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS: u64 = 3000;
-const DEFAULT_MAX_INSTRUCTION_NUMBER: usize = 4096;
+const DEFAULT_MAX_INSTRUCTION_NUMBER: usize = 2_usize.pow(12);
 
 /// `Configuration` provides an ability to define client parameters such as `TORII_URL`.
 // TODO: design macro to load config from env.

--- a/iroha_network/src/lib.rs
+++ b/iroha_network/src/lib.rs
@@ -24,7 +24,7 @@ use iroha_derive::{log, Io};
 use iroha_error::{error, Result};
 use parity_scale_codec::{Decode, Encode};
 
-const BUFFER_SIZE: usize = 4096;
+const BUFFER_SIZE: usize = 2_usize.pow(12);
 const REQUEST_TIMEOUT_MILLIS: u64 = 500;
 
 /// State type alias

--- a/iroha_network/src/mock.rs
+++ b/iroha_network/src/mock.rs
@@ -18,7 +18,7 @@ use iroha_derive::{log, Io};
 use iroha_error::{Error, Result};
 use parity_scale_codec::{Decode, Encode};
 
-const BUFFER_SIZE: usize = 2048;
+const BUFFER_SIZE: usize = 2_usize.pow(11);
 static mut ENDPOINTS: Vec<(String, Sender<RequestStream>)> = Vec::new();
 
 fn find_sender(server_url: &str) -> Sender<RequestStream> {


### PR DESCRIPTION
Signed-off-by: rkharisov <rinat@soramitsu.co.jp>

https://jira.hyperledger.org/browse/IR-1035

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Rust 1.50.0 introduced better const fns. Some constants has value of power of 2 and was written as literals. In this PR such constants  was represented as result of const function invocation.


### Benefits

More clear how the const was designated
### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
