### PR TITLE
Metrics all in one

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+CMakeLists.txt
+*.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
   endif()
 endif()
 
+## FIXME revert this after change CI to GitHub actions.
+## Temporal fix for 'bytecode stream version incompatible' between gcc-9 and gcc-10 and clang
+## when dependancies were build via vcpkg with default GCC9 could not be linked with iroha built with GCC-10
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+
 if(WIN32)
     # We have to set _WIN32_WINNT for gRPC
     if(${CMAKE_SYSTEM_VERSION} EQUAL 10) # Windows 10

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -187,6 +187,7 @@ target_link_libraries(ametsuchi
     SOCI::postgresql
     SOCI::core
     postgres_query_executor
+    async_subscription
     )
 
 target_compile_definitions(ametsuchi

--- a/irohad/ametsuchi/impl/postgres_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/postgres_wsv_query.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_POSTGRES_WSV_QUERY_HPP
 #define IROHA_POSTGRES_WSV_QUERY_HPP
 
-#include "ametsuchi/wsv_query.hpp"
-
 #include <soci/soci.h>
+
+#include "ametsuchi/wsv_query.hpp"
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {
@@ -28,6 +28,10 @@ namespace iroha {
           std::vector<std::shared_ptr<shared_model::interface::Peer>>>
       getPeers() override;
 
+      iroha::expected::Result<size_t, std::string> countPeers() override;
+      iroha::expected::Result<size_t, std::string> countDomains() override;
+      iroha::expected::Result<size_t, std::string> countTransactions() override;
+
       boost::optional<std::shared_ptr<shared_model::interface::Peer>>
       getPeerByPublicKey(shared_model::interface::types::PublicKeyHexStringView
                              public_key) override;
@@ -42,6 +46,9 @@ namespace iroha {
        */
       template <typename T, typename F>
       auto execute(F &&f) -> boost::optional<soci::rowset<T>>;
+
+      iroha::expected::Result<size_t, std::string> count(
+          std::string_view, std::string_view column = "*");
 
       // TODO andrei 24.09.2018: IR-1718 Consistent soci::session fields in
       // storage classes

--- a/irohad/ametsuchi/impl/rocksdb_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_wsv_query.cpp
@@ -186,4 +186,17 @@ namespace iroha::ametsuchi {
     }
   }
 
+  iroha::expected::Result<size_t, std::string> RocksDBWsvQuery::countPeers(){
+    return iroha::expected::makeError("unimplemented yet");
+  }
+  
+  iroha::expected::Result<size_t, std::string> RocksDBWsvQuery::countDomains(){
+      return iroha::expected::makeError("unimplemented yet");
+  }
+  
+  iroha::expected::Result<size_t, std::string> 
+      RocksDBWsvQuery::countTransactions() {
+    return iroha::expected::makeError("unimplemented yet");
+  }
+
 }  // namespace iroha::ametsuchi

--- a/irohad/ametsuchi/impl/rocksdb_wsv_query.hpp
+++ b/irohad/ametsuchi/impl/rocksdb_wsv_query.hpp
@@ -33,6 +33,10 @@ namespace iroha {
       iroha::expected::Result<iroha::TopBlockInfo, std::string>
       getTopBlockInfo() const override;
 
+      iroha::expected::Result<size_t, std::string> countPeers() override;
+      iroha::expected::Result<size_t, std::string> countDomains() override;
+      iroha::expected::Result<size_t, std::string> countTransactions() override;
+      
      private:
       std::shared_ptr<RocksDBPort> db_port_;
       std::shared_ptr<RocksDBContext> db_context_;

--- a/irohad/ametsuchi/wsv_query.hpp
+++ b/irohad/ametsuchi/wsv_query.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_WSV_QUERY_HPP
 #define IROHA_WSV_QUERY_HPP
 
+#include <boost/optional.hpp>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "common/result.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "interfaces/common_objects/string_view_types.hpp"
@@ -39,6 +39,35 @@ namespace iroha {
       virtual boost::optional<
           std::vector<std::shared_ptr<shared_model::interface::Peer>>>
       getPeers() = 0;
+
+      // ToDo?(kuvaldini,iceseer) #997
+      // /**
+      //  * @brief Fetch domains stored in ledger
+      //  * @return list of domains in insertion to ledger order
+      //  */
+      // virtual iroha::expected::Result<
+      //   std::vector<std::shared_ptr<shared_model::interface::Domain>>,
+      //   std::string>
+      // getDomains() = 0;
+
+      /**
+       * @brief Fetch number of domains in ledger
+       * @return number of domains in ledger
+       */
+      virtual iroha::expected::Result<size_t, std::string> countPeers() = 0;
+
+      /**
+       * @brief Fetch number of domains in ledger
+       * @return number of domains in ledger
+       */
+      virtual iroha::expected::Result<size_t, std::string> countDomains() = 0;
+
+      /**
+       * @brief Fetch number of valid transactions in ledger
+       * @return number of transactions in ledger
+       */
+      virtual iroha::expected::Result<size_t, std::string>
+      countTransactions() = 0;
 
       /**
        * Fetch peer with given public key from ledger

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -115,7 +115,8 @@ Irohad::Irohad(
     const boost::optional<GossipPropagationStrategyParams>
         &opt_mst_gossip_params,
     boost::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config)
-    : config_(config),
+    : se_(getSubscription()),
+      config_(config),
       listen_ip_(listen_ip),
       keypair_(keypair),
       startup_wsv_sync_policy_(startup_wsv_sync_policy),

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -230,6 +230,7 @@ class Irohad {
   virtual RunResult initWsvRestorer();
 
   // constructor dependencies
+  std::shared_ptr<iroha::Subscription> se_;
   IrohadConfig config_;
   const std::string listen_ip_;
   boost::optional<shared_model::crypto::Keypair> keypair_;

--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -259,12 +259,6 @@ int main(int argc, char *argv[]) {
           log_manager);
     }
 
-    if (FLAGS_metrics_port.size()) {
-      maintenance_metrics_init(FLAGS_metrics_addr + ":" + FLAGS_metrics_port);
-    } else if (config.metrics_addr_port.size()) {
-      maintenance_metrics_init(config.metrics_addr_port);
-    }
-
     daemon_status_notifier->notify(
         ::iroha::utility_service::Status::kInitialization);
 
@@ -374,10 +368,18 @@ int main(int argc, char *argv[]) {
 
         // clear previous storage if any
         irohad->dropStorage();
+        // Check if iroha daemon storage was successfully re-initialized
+        if (not irohad->storage) {
+          // Abort execution if not
+          log->error("Failed to re-initialize storage");
+          daemon_status_notifier->notify(
+              ::iroha::utility_service::Status::kFailed);
+          return EXIT_FAILURE;
+        }
 
         const auto txs_num = block->transactions().size();
-        if (auto e = iroha::expected::resultToOptionalError(
-                irohad->storage->insertBlock(std::move(block)))) {
+        auto inserted = irohad->storage->insertBlock(std::move(block));
+        if (auto e = iroha::expected::resultToOptionalError(inserted)) {
           log->critical("Could not apply genesis block: {}", e.value());
           return EXIT_FAILURE;
         }
@@ -391,19 +393,17 @@ int main(int argc, char *argv[]) {
             "genesis block is provided. Please pecify new genesis block using "
             "--genesis_block parameter.");
         return EXIT_FAILURE;
-      } else {
-        if (overwrite) {
-          // no genesis, blockstore present, overwrite specified -> new block
-          // store, world state should be reset
-          irohad->resetWsv();
-          if (not FLAGS_reuse_state) {
-            log->warn(
-                "No new genesis block is specified - blockstore will not be "
-                "overwritten. If you want overwrite ledger state, please "
-                "specify new genesis block using --genesis_block parameter. "
-                "If you want to reuse existing state data (WSV), consider the "
-                "--reuse_state flag.");
-          }
+      } else if (overwrite) {
+        // no genesis, blockstore present, overwrite specified -> new block
+        // store, world state should be reset
+        irohad->resetWsv();
+        if (not FLAGS_reuse_state) {
+          log->warn(
+              "No new genesis block is specified - blockstore will not be "
+              "overwritten. If you want overwrite ledger state, please "
+              "specify new genesis block using --genesis_block parameter. "
+              "If you want to reuse existing state data (WSV), consider the "
+              "--reuse_state flag.");
         }
       }
     }
@@ -445,6 +445,29 @@ int main(int argc, char *argv[]) {
 #ifdef SIGQUIT
     std::signal(SIGQUIT, handler);
 #endif
+
+    // start metrics
+    std::shared_ptr<Metrics> metrics;  // Must be a pointer because 'this' is
+                                       // captured to lambdas in constructor.
+    std::string metrics_addr;
+    if (FLAGS_metrics_port.size()) {
+      metrics_addr = FLAGS_metrics_addr + ":" + FLAGS_metrics_port;
+    } else if (config.metrics_addr_port.size()) {
+      metrics_addr = config.metrics_addr_port;
+    }
+    if (metrics_addr.empty()) {
+      log->info("Skiping Metrics initialization.");
+    } else {
+      try {
+        metrics =
+            Metrics::create(metrics_addr,
+                            irohad->storage,
+                            log_manager->getChild("Metrics")->getLogger());
+        log->info("Metrics listens on {}", metrics->getListenAddress());
+      } catch (std::exception const &ex) {
+        log->warn("Failed to initialize Metrics: {}", ex.what());
+      }
+    }
 
     // runs iroha
     log->info("Running iroha");

--- a/irohad/main/subscription_fwd.hpp
+++ b/irohad/main/subscription_fwd.hpp
@@ -13,6 +13,7 @@ namespace iroha {
     kYac = 0,
     kRequestProposal,
     kVoteProcess,
+    kMetrics,
     //---------------
     kTotalCount
   };

--- a/irohad/maintenance/CMakeLists.txt
+++ b/irohad/maintenance/CMakeLists.txt
@@ -6,4 +6,5 @@
 add_library(maintenance metrics.cpp)
 target_link_libraries(maintenance
     prometheus-cpp::core prometheus-cpp::pull
+    async_subscription
 )

--- a/irohad/maintenance/metrics.cpp
+++ b/irohad/maintenance/metrics.cpp
@@ -94,16 +94,6 @@ Metrics::Metrics(std::string const &listen_addr,
   total_number_of_transactions.Set(
       storage_->getWsvQuery()->countTransactions().assumeValue());
 
-  auto &total_number_of_transactions_from_db_gauge =
-      BuildGauge()
-          .Name("total_number_of_transactions_from_db")
-          .Help("Total number of transactions in blockchain taken from DB")
-          .Register(*registry_);
-  auto &total_number_of_transactions_from_db =
-      total_number_of_transactions_from_db_gauge.Add({});
-  total_number_of_transactions_from_db.Set(
-      storage_->getWsvQuery()->countTransactions().assumeValue());
-
   auto &number_of_signatures_in_last_block_gauge =
       BuildGauge()
           .Name("number_of_signatures_in_last_block")
@@ -131,12 +121,8 @@ Metrics::Metrics(std::string const &listen_addr,
                 boost::size(pblock->signatures()));
             total_number_of_transactions.Increment(
                 boost::size(pblock->transactions()));
-            total_number_of_transactions_from_db.Set(
-                storage_->getWsvQuery()->countTransactions().assumeValue());
             logger_->info("total_number_of_transactions {}",
                        total_number_of_transactions.Value());
-            logger_->info("total_number_of_transactions_from_db {}",
-                          total_number_of_transactions_from_db.Value());
             int domains_diff = 0, peers_diff = 0;
             using namespace shared_model::interface;
             for (Transaction const &trx : pblock->transactions()) {

--- a/irohad/maintenance/metrics.cpp
+++ b/irohad/maintenance/metrics.cpp
@@ -9,88 +9,144 @@
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
 
-#include <array>
-#include <chrono>
-#include <cstdlib>
 #include <memory>
-#include <string>
-#include <thread>
-#include <future>
 #include <regex>
 
-std::shared_ptr<prometheus::Registry> maintenance_metrics_init(std::string const& listen_addr)
-{
-  using namespace prometheus;
+#include "CivetServer.h"  // for CivetCallbacks
+#include "interfaces/commands/add_peer.hpp"
+#include "interfaces/commands/command.hpp"
+#include "interfaces/commands/create_domain.hpp"
+#include "interfaces/commands/remove_peer.hpp"
+#include "interfaces/iroha_internal/block.hpp"
+#include "interfaces/transaction.hpp"
+#include "logger/logger.hpp"
+#include "main/subscription.hpp"
 
-  static const std::regex full_matcher("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]):[0-9]+$");
+using namespace iroha;
+using namespace prometheus;
+
+Metrics::Metrics(std::string const &listen_addr,
+                 std::shared_ptr<iroha::ametsuchi::Storage> storage,
+                 logger::LoggerPtr const &logger)
+    : storage_(storage), logger_(logger) {
+  static const std::regex full_matcher(
+      "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-"
+      "9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]):[0-9]+$");
   static const std::regex port_matcher("^:?([0-9]{1,5})$");
-  std::string listen_addr_port;
-  if(std::regex_match(listen_addr,full_matcher)) {
-    listen_addr_port = listen_addr;
-  } else if(std::regex_match(listen_addr,port_matcher)) {
-    listen_addr_port = "127.0.0.1";
+  if (std::regex_match(listen_addr, full_matcher)) {
+    listen_addr_port_ = listen_addr;
+  } else if (std::regex_match(listen_addr, port_matcher)) {
+    listen_addr_port_ = "127.0.0.1";
     if (listen_addr[0] != ':')
-      listen_addr_port += ":";
-    listen_addr_port += listen_addr;
+      listen_addr_port_ += ":";
+    listen_addr_port_ += listen_addr;
   } else {
-    return nullptr;
+    throw std::runtime_error("Metrics does not accept listen address '"
+                             + listen_addr + "'");
   }
 
-  // create a metrics registry
   // @note it's the users responsibility to keep the object alive
-  auto registry = std::make_shared<Registry>();
+  registry_ = std::make_shared<Registry>();
 
-  // Just for example
-  std::thread([registry,listen_addr_port](){
-      // create an http server running on addr:port
-      Exposer exposer{listen_addr_port};
+  CivetCallbacks cvcbs;
+  auto civet_no_log = [](const struct mg_connection *conn,
+                         const char *message) { return 1; };
+  cvcbs.log_message = civet_no_log;
+  cvcbs.log_access = civet_no_log;
 
-      // ask the exposer to scrape the registry on incoming HTTP requests
-      exposer.RegisterCollectable(registry);
+  // create an http server running on addr:port
+  exposer_ = std::make_shared<Exposer>(listen_addr_port_,
+                                       /*num_threads*/ 2,
+                                       &cvcbs);
 
-    // add a new counter family to the registry (families combine values with the
-    // same name, but distinct label dimensions)
-    //
-    // @note please follow the metric-naming best-practices:
-    // https://prometheus.io/docs/practices/naming/
-    auto& packet_counter = BuildCounter()
-        .Name("observed_packets_total")
-        .Help("Number of observed packets")
-        .Register(*registry);
+  // ask the exposer_ to scrape the registry_ on incoming HTTP requests
+  exposer_->RegisterCollectable(registry_, "/metrics");
 
-    // add and remember dimensional data, incrementing those is very cheap
-    auto& tcp_rx_counter =
-        packet_counter.Add({{"protocol", "tcp"}, {"direction", "rx"}});
-    auto& tcp_tx_counter =
-        packet_counter.Add({{"protocol", "tcp"}, {"direction", "tx"}});
-    auto& udp_rx_counter =
-        packet_counter.Add({{"protocol", "udp"}, {"direction", "rx"}});
-    auto& udp_tx_counter =
-        packet_counter.Add({{"protocol", "udp"}, {"direction", "tx"}});
+  auto &block_height_gauge = BuildGauge()
+                                 .Name("blocks_height")
+                                 .Help("Total number of blocks in chain")
+                                 .Register(*registry_);
+  auto &block_height = block_height_gauge.Add({});
+  block_height.Set(storage_->getBlockQuery()->getTopBlockHeight());
 
-    // add a counter whose dimensional data is not known at compile time
-    // nevertheless dimensional values should only occur in low cardinality:
-    // https://prometheus.io/docs/practices/naming/#labels
-    auto& http_requests_counter = BuildCounter()
-        .Name("http_requests_total")
-        .Help("Number of HTTP requests")
-        .Register(*registry);
+  auto &peers_number_gauge =
+      BuildGauge()
+          .Name("peers_number")
+          .Help("Total number peers to send transactions and request proposals")
+          .Register(*registry_);
+  auto &number_of_peers = peers_number_gauge.Add({});
+  number_of_peers.Set(storage_->getWsvQuery()->getPeers()->size());
 
-    for (;;) {
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      const auto random_value = std::rand();
+  auto &domains_number_gauge = BuildGauge()
+                                   .Name("number_of_domains")
+                                   .Help("Total number of domains in WSV")
+                                   .Register(*registry_);
+  auto &domains_number = domains_number_gauge.Add({});
+  domains_number.Set(storage_->getWsvQuery()->countDomains().assumeValue());
 
-      if (random_value & 1) tcp_rx_counter.Increment();
-      if (random_value & 2) tcp_tx_counter.Increment();
-      if (random_value & 4) udp_rx_counter.Increment();
-      if (random_value & 8) udp_tx_counter.Increment();
+  auto &total_number_of_transactions_gauge =
+      BuildGauge()
+          .Name("total_number_of_transactions")
+          .Help("Total number of transactions in blockchain")
+          .Register(*registry_);
+  auto &total_number_of_transactions =
+      total_number_of_transactions_gauge.Add({});
+  total_number_of_transactions.Set(
+      storage_->getWsvQuery()->countTransactions().assumeValue());
 
-      const std::array<std::string, 4> methods = {"GET", "PUT", "POST", "HEAD"};
-      auto method = methods.at(random_value % methods.size());
-      // dynamically calling Family<T>.Add() works but is slow and should be avoided
-      http_requests_counter.Add({{"method", method}}).Increment();
-    }
-  }).detach();
+  auto &total_number_of_transactions_from_db_gauge =
+      BuildGauge()
+          .Name("total_number_of_transactions_from_db")
+          .Help("Total number of transactions in blockchain taken from DB")
+          .Register(*registry_);
+  auto &total_number_of_transactions_from_db =
+      total_number_of_transactions_from_db_gauge.Add({});
+  total_number_of_transactions_from_db.Set(
+      storage_->getWsvQuery()->countTransactions().assumeValue());
 
-  return {registry};
+  auto &number_of_signatures_in_last_block_gauge =
+      BuildGauge()
+          .Name("number_of_signatures_in_last_block")
+          .Help("Number of signatures in last block")
+          .Register(*registry_);
+  auto &number_of_signatures_in_last_block =
+      number_of_signatures_in_last_block_gauge.Add({});
+  auto ptopblock =
+      storage_->getBlockQuery()
+          ->getBlock(storage_->getBlockQuery()->getTopBlockHeight())
+          .assumeValue();
+  number_of_signatures_in_last_block.Set(boost::size(ptopblock->signatures()));
+
+  block_subscriber_ =
+      SubscriberCreator<bool, BlockPtr>::template create<EventTypes::kOnBlock>(
+          SubscriptionEngineHandlers::kMetrics,
+          [&, wregistry = std::weak_ptr<Registry>(registry_)](auto &,
+                                                              BlockPtr pblock) {
+            // Metrics values are stored inside and owned by registry,
+            // capture them by reference is legal.
+            std::shared_ptr<Registry> registry{wregistry};  // throw if expired
+            assert(pblock);
+            block_height.Set(pblock->height());
+            number_of_signatures_in_last_block.Set(
+                boost::size(pblock->signatures()));
+            total_number_of_transactions.Increment(
+                boost::size(pblock->transactions()));
+            total_number_of_transactions_from_db.Set(
+                storage_->getWsvQuery()->countTransactions().assumeValue());
+            logger_->info("total_number_of_transactions {}",
+                       total_number_of_transactions.Value());
+            logger_->info("total_number_of_transactions_from_db {}",
+                          total_number_of_transactions_from_db.Value());
+            int domains_diff = 0, peers_diff = 0;
+            using namespace shared_model::interface;
+            for (Transaction const &trx : pblock->transactions()) {
+              for (Command const &cmd : trx.commands()) {
+                domains_diff += cmd.is<CreateDomain>() ? 1 : 0;
+                peers_diff += cmd.is<AddPeer>() ? 1 : 0;
+                peers_diff -= cmd.is<RemovePeer>() ? 1 : 0;
+              }
+            }
+            number_of_peers.Increment(peers_diff);
+            domains_number.Increment(domains_diff);
+          });
 }

--- a/irohad/maintenance/metrics.hpp
+++ b/irohad/maintenance/metrics.hpp
@@ -6,11 +6,53 @@
 #ifndef IROHA_MAINTENANCE_METRICS_HPP
 #define IROHA_MAINTENANCE_METRICS_HPP
 
-#include <string>
-#include <memory>
+#include <prometheus/exposer.h>
 #include <prometheus/registry.h>
 
-std::shared_ptr<prometheus::Registry>
-    maintenance_metrics_init(std::string const& listen_addr);
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
 
-#endif //IROHA_MAINTENANCE_METRICS_HPP
+#include "ametsuchi/storage.hpp"
+#include "ametsuchi/wsv_query.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "interfaces/iroha_internal/block.hpp"
+#include "logger/logger_fwd.hpp"
+#include "main/subscription.hpp"
+#include "network/ordering_gate_common.hpp"
+
+class Metrics : public std::enable_shared_from_this<Metrics> {
+  using OnProposalSubscription = iroha::BaseSubscriber<
+      bool,
+      iroha::network::OrderingEvent>;  // FixMe subscribtion ≠ subscriber
+  using BlockPtr = std::shared_ptr<const shared_model::interface::Block>;
+  using BlockSubscriber = iroha::BaseSubscriber<bool, BlockPtr>;
+
+  std::string listen_addr_port_;
+  std::shared_ptr<prometheus::Exposer> exposer_;
+  std::shared_ptr<prometheus::Registry> registry_;
+  std::shared_ptr<iroha::ametsuchi::Storage> storage_;
+  std::shared_ptr<BlockSubscriber> block_subscriber_;
+  std::shared_ptr<OnProposalSubscription> on_proposal_subscription_;
+  logger::LoggerPtr logger_;
+
+  Metrics(std::string const &listen_addr,
+          std::shared_ptr<iroha::ametsuchi::Storage> storage,
+          logger::LoggerPtr const &logger);
+
+ public:
+  std::string const &getListenAddress() const {
+    return listen_addr_port_;
+  }
+
+  template <class... Ts>
+  static std::shared_ptr<Metrics> create(Ts &&... args) {
+    struct Resolver : Metrics {
+      Resolver(Ts &&... args) : Metrics(std::forward<Ts>(args)...) {}
+    };
+    return std::make_shared<Resolver>(std::forward<Ts>(args)...);
+  }
+};
+
+#endif  // IROHA_MAINTENANCE_METRICS_HPP

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -6,10 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_PROTO_BLOCK_HPP
 #define IROHA_SHARED_MODEL_PROTO_BLOCK_HPP
 
-#include "interfaces/iroha_internal/block.hpp"
-
 #include "block.pb.h"
 #include "interfaces/common_objects/types.hpp"
+#include "interfaces/iroha_internal/block.hpp"
 
 namespace shared_model {
   namespace proto {

--- a/shared_model/backend/protobuf/block.hpp
+++ b/shared_model/backend/protobuf/block.hpp
@@ -40,8 +40,6 @@ namespace shared_model {
 
       interface::types::TimestampType createdTime() const override;
 
-      interface::types::TransactionsNumberType txsNumber() const override;
-
       interface::types::HashCollectionType rejected_transactions_hashes()
           const override;
 

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -131,11 +131,6 @@ namespace shared_model {
       return impl_->payload_.created_time();
     }
 
-    interface::types::TransactionsNumberType Block::txsNumber() const {
-      // return boost::size(transactions());
-      return impl_->payload_.tx_number();
-    }
-
     interface::types::HashCollectionType Block::rejected_transactions_hashes()
         const {
       return impl_->rejected_transactions_hashes_;

--- a/shared_model/backend/protobuf/impl/block.cpp
+++ b/shared_model/backend/protobuf/impl/block.cpp
@@ -6,6 +6,7 @@
 #include "backend/protobuf/block.hpp"
 
 #include <boost/range/adaptors.hpp>
+
 #include "backend/protobuf/common_objects/signature.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "backend/protobuf/util.hpp"
@@ -39,7 +40,7 @@ namespace shared_model {
       SignatureSetType<proto::Signature> signatures_{[this] {
         auto signatures = *proto_.mutable_signatures()
             | boost::adaptors::transformed(
-                  [](auto &x) { return proto::Signature(x); });
+                [](auto &x) { return proto::Signature(x); });
         return SignatureSetType<proto::Signature>(signatures.begin(),
                                                   signatures.end());
       }()};
@@ -113,7 +114,7 @@ namespace shared_model {
       impl_->signatures_ = [this] {
         auto signatures = *impl_->proto_.mutable_signatures()
             | boost::adaptors::transformed(
-                  [](auto &x) { return proto::Signature(x); });
+                [](auto &x) { return proto::Signature(x); });
         return SignatureSetType<proto::Signature>(signatures.begin(),
                                                   signatures.end());
       }();
@@ -131,6 +132,7 @@ namespace shared_model {
     }
 
     interface::types::TransactionsNumberType Block::txsNumber() const {
+      // return boost::size(transactions());
       return impl_->payload_.tx_number();
     }
 

--- a/shared_model/interfaces/commands/command.hpp
+++ b/shared_model/interfaces/commands/command.hpp
@@ -6,9 +6,9 @@
 #ifndef IROHA_SHARED_MODEL_COMMAND_HPP
 #define IROHA_SHARED_MODEL_COMMAND_HPP
 
-#include "interfaces/base/model_primitive.hpp"
-
 #include <boost/variant/variant_fwd.hpp>
+
+#include "interfaces/base/model_primitive.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -77,6 +77,11 @@ namespace shared_model {
       std::string toString() const override;
 
       bool operator==(const ModelType &rhs) const override;
+
+      template <class CmdType>
+      bool is() const {
+        return boost::get<CmdType const &>(&get()) != nullptr;
+      }
     };
 
   }  // namespace interface

--- a/shared_model/interfaces/iroha_internal/block.cpp
+++ b/shared_model/interfaces/iroha_internal/block.cpp
@@ -17,7 +17,6 @@ namespace shared_model {
           .appendNamed("hash", hash().hex())
           .appendNamed("height", height())
           .appendNamed("prevHash", prevHash().hex())
-          .appendNamed("txsNumber", txsNumber())
           .appendNamed("createdtime", createdTime())
           .appendNamed("transactions", transactions())
           .appendNamed("signatures", signatures())

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -24,6 +24,7 @@ namespace shared_model {
        * @return hash of a previous block
        */
       virtual const types::HashType &prevHash() const = 0;
+
       /**
        * @return amount of transactions in block
        */

--- a/shared_model/interfaces/iroha_internal/block.hpp
+++ b/shared_model/interfaces/iroha_internal/block.hpp
@@ -26,11 +26,6 @@ namespace shared_model {
       virtual const types::HashType &prevHash() const = 0;
 
       /**
-       * @return amount of transactions in block
-       */
-      virtual types::TransactionsNumberType txsNumber() const = 0;
-
-      /**
        * @return collection of transactions
        */
       virtual types::TransactionsCollectionType transactions() const = 0;

--- a/test/integration/validation/CMakeLists.txt
+++ b/test/integration/validation/CMakeLists.txt
@@ -8,4 +8,5 @@ target_link_libraries(chain_validator_storage_test
     yac
     chain_validator
     test_logger
+    sync_subscription
     )

--- a/test/module/irohad/CMakeLists.txt
+++ b/test/module/irohad/CMakeLists.txt
@@ -4,8 +4,9 @@
 #
 
 # Reusable tests
-add_subdirectory(ametsuchi)
 add_subdirectory(common)
+add_subdirectory(subscription)
+add_subdirectory(ametsuchi)
 add_subdirectory(consensus)
 add_subdirectory(logger)
 add_subdirectory(main)
@@ -18,4 +19,3 @@ add_subdirectory(synchronizer)
 add_subdirectory(torii)
 add_subdirectory(validation)
 add_subdirectory(pending_txs_storage)
-add_subdirectory(subscription)

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -11,12 +11,14 @@ target_link_libraries(ametsuchi_test
     flat_file_storage
     shared_model_stateless_validation
     test_logger
+    sync_subscription
     )
 
 addtest(wsv_query_command_test wsv_query_command_test.cpp)
 target_link_libraries(wsv_query_command_test
     ametsuchi
     ametsuchi_fixture
+    sync_subscription
     test_logger
     )
 
@@ -25,6 +27,7 @@ target_link_libraries(rdb_wsv_query_command_test
     test_logger
     ametsuchi_fixture
     ametsuchi_rocksdb
+    sync_subscription
     )
 
 addtest(rdb_wsv_query_test rdb_wsv_query_test.cpp)
@@ -32,6 +35,7 @@ target_link_libraries(rdb_wsv_query_test
     test_logger
     ametsuchi_fixture
     ametsuchi_rocksdb
+    sync_subscription
     )
 
 addtest(rocksdb_indexer_test rocksdb_indexer_test.cpp)
@@ -44,6 +48,7 @@ addtest(wsv_query_test wsv_query_test.cpp)
 target_link_libraries(wsv_query_test
     ametsuchi
     ametsuchi_fixture
+    sync_subscription
     test_logger
     )
 
@@ -59,6 +64,7 @@ addtest(flat_file_test flat_file_test.cpp)
 target_link_libraries(flat_file_test
     ametsuchi
     test_logger
+    sync_subscription
     )
 
 addtest(block_query_test block_query_test.cpp)
@@ -66,6 +72,7 @@ target_link_libraries(block_query_test
     ametsuchi
     ametsuchi_fixture
     shared_model_stateless_validation
+    sync_subscription
     )
 
 addtest(storage_init_test storage_init_test.cpp)
@@ -75,12 +82,14 @@ target_link_libraries(storage_init_test
     shared_model_proto_backend
     pg_connection_init
     test_logger
+    sync_subscription
     )
 
 addtest(postgres_options_test postgres_options_test.cpp)
 target_link_libraries(postgres_options_test
     ametsuchi
     test_logger
+    sync_subscription
     )
 
 addtest(postgres_executor_test postgres_executor_test.cpp)
@@ -93,6 +102,7 @@ target_link_libraries(postgres_executor_test
     pg_connection_init
     test_logger
     common_test_constants
+    sync_subscription
     )
 
 addtest(rocksdb_executor_test rocksdb_executor_test.cpp)
@@ -116,41 +126,47 @@ target_link_libraries(postgres_query_executor_test
     commands_mocks_factory
     test_logger
     RapidJSON::rapidjson
+    sync_subscription
     )
 
 addtest(tx_presence_cache_test tx_presence_cache_test.cpp)
 target_link_libraries(tx_presence_cache_test
     ametsuchi
     shared_model_interfaces_factories
+    sync_subscription
     )
 
 addtest(settings_test settings_test.cpp)
 target_link_libraries(settings_test
-        ametsuchi
-        ametsuchi_fixture
-        test_logger
-        commands_mocks_factory
-        )
+    ametsuchi
+    ametsuchi_fixture
+    test_logger
+    commands_mocks_factory
+    sync_subscription
+    )
 
 addtest(in_memory_block_storage_test in_memory_block_storage_test.cpp)
 target_link_libraries(in_memory_block_storage_test
     ametsuchi
+    sync_subscription
     )
 
 addtest(flat_file_block_storage_test flat_file_block_storage_test.cpp)
 target_link_libraries(flat_file_block_storage_test
     ametsuchi
     test_logger
+    sync_subscription
     )
 
 addtest(postgres_block_storage_test postgres_block_storage_test.cpp)
 target_link_libraries(postgres_block_storage_test
-     ametsuchi
-     generator
-     test_logger
-     integration_framework_config_helper
-     pg_connection_init
-     )
+    ametsuchi
+    generator
+    test_logger
+    integration_framework_config_helper
+    pg_connection_init
+    sync_subscription
+    )
 
 add_library(ametsuchi_fixture INTERFACE)
 target_link_libraries(ametsuchi_fixture INTERFACE
@@ -166,11 +182,13 @@ target_link_libraries(ametsuchi_fixture INTERFACE
 addtest(k_times_reconnection_strategy_test k_times_reconnection_strategy_test.cpp)
 target_link_libraries(k_times_reconnection_strategy_test
     ametsuchi
+    sync_subscription
     )
 
 addtest(peer_query_wsv_test peer_query_wsv_test.cpp)
 target_link_libraries(peer_query_wsv_test
     ametsuchi
+    sync_subscription
     )
 
 if(USE_BURROW)

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_libraries(rocksdb_executor_test
     commands_mocks_factory
     test_logger
     common_test_constants
+    sync_subscription
     )
 
 addtest(postgres_query_executor_test postgres_query_executor_test.cpp)

--- a/test/module/irohad/ametsuchi/mock_wsv_query.hpp
+++ b/test/module/irohad/ametsuchi/mock_wsv_query.hpp
@@ -6,10 +6,10 @@
 #ifndef IROHA_MOCK_WSV_QUERY_HPP
 #define IROHA_MOCK_WSV_QUERY_HPP
 
-#include "ametsuchi/wsv_query.hpp"
-
 #include <gmock/gmock.h>
+
 #include "ametsuchi/ledger_state.hpp"
+#include "ametsuchi/wsv_query.hpp"
 
 namespace testing {
   // iroha::TopBlockInfo is not default-constructible, so this provides a
@@ -50,6 +50,12 @@ namespace iroha {
       MOCK_CONST_METHOD0(
           getTopBlockInfo,
           iroha::expected::Result<iroha::TopBlockInfo, std::string>());
+
+      MOCK_METHOD0(countPeers, iroha::expected::Result<size_t, std::string>());
+      MOCK_METHOD0(countDomains,
+                   iroha::expected::Result<size_t, std::string>());
+      MOCK_METHOD0(countTransactions,
+                   iroha::expected::Result<size_t, std::string>());
     };
 
   }  // namespace ametsuchi

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "consensus/yac/impl/yac_gate_impl.hpp"
-
 #include <memory>
 
 #include "consensus/consensus_block_cache.hpp"
+#include "consensus/yac/impl/yac_gate_impl.hpp"
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "framework/crypto_literals.hpp"
 #include "framework/test_logger.hpp"
@@ -59,7 +58,6 @@ class YacGateTest : public ::testing::Test {
             A<shared_model::interface::types::PublicKeyHexStringView>()))
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*block, height()).WillRepeatedly(Return(round.block_round));
-    EXPECT_CALL(*block, txsNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*block, createdTime()).WillRepeatedly(Return(1));
     EXPECT_CALL(*block, transactions())
         .WillRepeatedly(

--- a/test/module/irohad/torii/processor/query_processor_test.cpp
+++ b/test/module/irohad/torii/processor/query_processor_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <boost/variant.hpp>
+
 #include "backend/protobuf/block.hpp"
 #include "backend/protobuf/proto_query_response_factory.hpp"
 #include "backend/protobuf/query_responses/proto_error_query_response.hpp"
@@ -17,7 +18,6 @@
 #include "module/irohad/ametsuchi/mock_block_query.hpp"
 #include "module/irohad/ametsuchi/mock_query_executor.hpp"
 #include "module/irohad/ametsuchi/mock_storage.hpp"
-#include "module/irohad/ametsuchi/mock_wsv_query.hpp"
 #include "module/irohad/validation/validation_mocks.hpp"
 #include "module/shared_model/builders/protobuf/test_block_builder.hpp"
 #include "module/shared_model/builders/protobuf/test_query_builder.hpp"

--- a/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
+++ b/test/module/shared_model/backend_proto/proto_query_response_factory_test.cpp
@@ -6,7 +6,9 @@
 #include "backend/protobuf/proto_query_response_factory.hpp"
 
 #include <gtest/gtest.h>
+
 #include <optional>
+
 #include "backend/plain/account_detail_record_id.hpp"
 #include "backend/protobuf/common_objects/proto_common_objects_factory.hpp"
 #include "interfaces/query_responses/account_asset_response.hpp"
@@ -499,7 +501,6 @@ TEST_F(ProtoQueryResponseFactoryTest, CreateBlockQueryResponseWithBlock) {
         boost::get<const shared_model::interface::BlockResponse &>(
             response->get());
 
-    ASSERT_EQ(block_resp.block().txsNumber(), 0);
     ASSERT_EQ(block_resp.block().height(), kBlockHeight);
     ASSERT_EQ(block_resp.block().createdTime(), kCreatedTime);
   });

--- a/vcpkg/VCPKG_DEPS_LIST
+++ b/vcpkg/VCPKG_DEPS_LIST
@@ -22,5 +22,4 @@ boost-accumulators
 boost-property-tree
 boost-process
 iroha-ed25519
-prometheus-cpp
 rocksdb

--- a/vcpkg/VCPKG_HEAD_DEPS_LIST
+++ b/vcpkg/VCPKG_HEAD_DEPS_LIST
@@ -1,1 +1,2 @@
 rxcpp
+prometheus-cpp

--- a/vcpkg/patches/0005-disable-prometheus-logs.patch
+++ b/vcpkg/patches/0005-disable-prometheus-logs.patch
@@ -1,0 +1,69 @@
+diff --git a/ports/prometheus-cpp/Add-CivetCallbacks-to-Exposer.patch b/ports/prometheus-cpp/Add-CivetCallbacks-to-Exposer.patch
+new file mode 100644
+index 000000000..0a237dd54
+--- /dev/null
++++ b/ports/prometheus-cpp/Add-CivetCallbacks-to-Exposer.patch
+@@ -0,0 +1,51 @@
++diff --git a/pull/include/prometheus/exposer.h b/pull/include/prometheus/exposer.h
++index 3e4e01c..6a9c3ff 100644
++--- a/pull/include/prometheus/exposer.h
+++++ b/pull/include/prometheus/exposer.h
++@@ -10,6 +10,7 @@
++ #include "prometheus/detail/pull_export.h"
++ 
++ class CivetServer;
+++class CivetCallbacks;
++ 
++ namespace prometheus {
++ 
++@@ -20,8 +21,9 @@ class Endpoint;
++ class PROMETHEUS_CPP_PULL_EXPORT Exposer {
++  public:
++   explicit Exposer(const std::string& bind_address,
++-                   const std::size_t num_threads = 2);
++-  explicit Exposer(std::vector<std::string> options);
+++                   const std::size_t num_threads = 2, 
+++                   const CivetCallbacks *callbacks = nullptr);
+++  explicit Exposer(std::vector<std::string> options, const CivetCallbacks *callbacks = nullptr);
++   ~Exposer();
++   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
++                            const std::string& uri = std::string("/metrics"));
++diff --git a/pull/src/exposer.cc b/pull/src/exposer.cc
++index ac53bc8..df1dbaa 100644
++--- a/pull/src/exposer.cc
+++++ b/pull/src/exposer.cc
++@@ -11,13 +11,18 @@
++ 
++ namespace prometheus {
++ 
++-Exposer::Exposer(const std::string& bind_address, const std::size_t num_threads)
+++Exposer::Exposer(const std::string& bind_address, 
+++                 const std::size_t num_threads, 
+++                 const CivetCallbacks *callbacks)
++     : Exposer(std::vector<std::string>{"listening_ports", bind_address,
++                                        "num_threads",
++-                                       std::to_string(num_threads)}) {}
+++                                       std::to_string(num_threads)},
+++              callbacks) {}
++ 
++-Exposer::Exposer(std::vector<std::string> options)
++-    : server_(detail::make_unique<CivetServer>(std::move(options))) {}
+++Exposer::Exposer(std::vector<std::string> options, 
+++                 const CivetCallbacks *callbacks)
+++    : server_(detail::make_unique<CivetServer>(std::move(options),
+++                                               callbacks)) {}
++ 
++ Exposer::~Exposer() = default;
++ 
+diff --git a/ports/prometheus-cpp/portfile.cmake b/ports/prometheus-cpp/portfile.cmake
+index c6048af18..4a9a749d5 100644
+--- a/ports/prometheus-cpp/portfile.cmake
++++ b/ports/prometheus-cpp/portfile.cmake
+@@ -8,6 +8,7 @@ vcpkg_from_github(
+     REF v0.9.0
+     SHA512 d9d5fbbd8c8aad5dd6a5e872275324d689a0c57199e4158d74e13ea62b286fa71dee01bb4197b906b79792bf1ca4e67a46b5c04621d7070241ac32876f6de891
+     HEAD_REF master
++    PATCHES Add-CivetCallbacks-to-Exposer.patch
+ )
+ 
+ macro(feature FEATURENAME OPTIONNAME)

--- a/vcpkg/patches/0006-prometheus-remove-self-metrics.patch
+++ b/vcpkg/patches/0006-prometheus-remove-self-metrics.patch
@@ -1,0 +1,105 @@
+diff --git a/ports/prometheus-cpp/portfile.cmake b/ports/prometheus-cpp/portfile.cmake
+index 4a9a749d5..4b49237c3 100644
+--- a/ports/prometheus-cpp/portfile.cmake
++++ b/ports/prometheus-cpp/portfile.cmake
+@@ -8,7 +8,7 @@ vcpkg_from_github(
+     REF v0.9.0
+     SHA512 d9d5fbbd8c8aad5dd6a5e872275324d689a0c57199e4158d74e13ea62b286fa71dee01bb4197b906b79792bf1ca4e67a46b5c04621d7070241ac32876f6de891
+     HEAD_REF master
+-    PATCHES Add-CivetCallbacks-to-Exposer.patch
++    PATCHES Add-CivetCallbacks-to-Exposer.patch remove-handler-self-metrics.patch
+ )
+ 
+ macro(feature FEATURENAME OPTIONNAME)
+diff --git a/ports/prometheus-cpp/remove-handler-self-metrics.patch b/ports/prometheus-cpp/remove-handler-self-metrics.patch
+new file mode 100644
+index 000000000..a26427035
+--- /dev/null
++++ b/ports/prometheus-cpp/remove-handler-self-metrics.patch
+@@ -0,0 +1,86 @@
++diff --git a/pull/src/handler.cc b/pull/src/handler.cc
++index cec37f3..d0b0bdf 100644
++--- a/pull/src/handler.cc
+++++ b/pull/src/handler.cc
++@@ -23,25 +23,25 @@
++ namespace prometheus {
++ namespace detail {
++ 
++-MetricsHandler::MetricsHandler(Registry& registry)
++-    : bytes_transferred_family_(
++-          BuildCounter()
++-              .Name("exposer_transferred_bytes_total")
++-              .Help("Transferred bytes to metrics services")
++-              .Register(registry)),
++-      bytes_transferred_(bytes_transferred_family_.Add({})),
++-      num_scrapes_family_(BuildCounter()
++-                              .Name("exposer_scrapes_total")
++-                              .Help("Number of times metrics were scraped")
++-                              .Register(registry)),
++-      num_scrapes_(num_scrapes_family_.Add({})),
++-      request_latencies_family_(
++-          BuildSummary()
++-              .Name("exposer_request_latencies")
++-              .Help("Latencies of serving scrape requests, in microseconds")
++-              .Register(registry)),
++-      request_latencies_(request_latencies_family_.Add(
++-          {}, Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}})) {}
+++MetricsHandler::MetricsHandler(Registry& registry) {}
+++    // : bytes_transferred_family_(
+++    //       BuildCounter()
+++    //           .Name("exposer_transferred_bytes_total")
+++    //           .Help("Transferred bytes to metrics services")
+++    //           .Register(registry)),
+++    //   bytes_transferred_(bytes_transferred_family_.Add({})),
+++    //   num_scrapes_family_(BuildCounter()
+++    //                           .Name("exposer_scrapes_total")
+++    //                           .Help("Number of times metrics were scraped")
+++    //                           .Register(registry)),
+++    //   num_scrapes_(num_scrapes_family_.Add({})),
+++    //   request_latencies_family_(
+++    //       BuildSummary()
+++    //           .Name("exposer_request_latencies")
+++    //           .Help("Latencies of serving scrape requests, in microseconds")
+++    //           .Register(registry)),
+++    //   request_latencies_(request_latencies_family_.Add(
+++    //       {}, Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}})) {}
++ 
++ #ifdef HAVE_ZLIB
++ static bool IsEncodingAccepted(struct mg_connection* conn,
++@@ -158,10 +158,10 @@ bool MetricsHandler::handleGet(CivetServer*, struct mg_connection* conn) {
++   auto stop_time_of_request = std::chrono::steady_clock::now();
++   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
++       stop_time_of_request - start_time_of_request);
++-  request_latencies_.Observe(duration.count());
+++  // request_latencies_.Observe(duration.count());
++ 
++-  bytes_transferred_.Increment(bodySize);
++-  num_scrapes_.Increment();
+++  // bytes_transferred_.Increment(bodySize);
+++  // num_scrapes_.Increment();
++   return true;
++ }
++ 
++diff --git a/pull/src/handler.h b/pull/src/handler.h
++index 10c90f9..94c433c 100644
++--- a/pull/src/handler.h
+++++ b/pull/src/handler.h
++@@ -28,12 +28,12 @@ class MetricsHandler : public CivetHandler {
++ 
++   std::mutex collectables_mutex_;
++   std::vector<std::weak_ptr<Collectable>> collectables_;
++-  Family<Counter>& bytes_transferred_family_;
++-  Counter& bytes_transferred_;
++-  Family<Counter>& num_scrapes_family_;
++-  Counter& num_scrapes_;
++-  Family<Summary>& request_latencies_family_;
++-  Summary& request_latencies_;
+++  // Family<Counter>& bytes_transferred_family_;
+++  // Counter& bytes_transferred_;
+++  // Family<Counter>& num_scrapes_family_;
+++  // Counter& num_scrapes_;
+++  // Family<Summary>& request_latencies_family_;
+++  // Summary& request_latencies_;
++ };
++ }  // namespace detail
++ }  // namespace prometheus


### PR DESCRIPTION
[Metrics] #837 #883 #919 #896 #835

Integrate kOnBlock to storage_impl.cpp
Closes #837 Add total number of blocks
Closes #883 Number of domains
Closes #919 Number of signatures in the last block
Closes #896 Measure total number of transactions
Closes #835 Total nodes/peers updated when kOnBlock
Should close #835 no online/connected peers parameter in this commit.
Add CMake files to .clang-format-ignore
Disable prometheus-cpp logs
Extend WSV to countDomains(), countTransactions(), countPeers()
-fno-lto to link GCC-10 and clang with civetweb which was built with GCC-9
Tests dependant on ametsuchi are linked against sync_subscription, not async