### PR TITLE
Tracing telemetry subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
 name = "iroha_logger"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "chrono",
  "iroha_config",
  "iroha_error",
@@ -1788,6 +1789,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "tracing-core",
  "tracing-futures",
  "tracing-subscriber",
 ]

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -43,7 +43,9 @@ Configuration of iroha is done via options in the following document. Here is de
     "TRANSACTION_TIME_TO_LIVE_MS": 86400000
   },
   "LOGGER_CONFIGURATION": {
-    "MAX_LOG_LEVEL": "DEBUG"
+    "MAX_LOG_LEVEL": "DEBUG",
+    "TELEMETRY_CAPACITY": 1000,
+    "COMPACT_MODE": false
   },
   "GENESIS_CONFIGURATION": {
     "GENESIS_ACCOUNT_PUBLIC_KEY": "ed0100",
@@ -209,8 +211,20 @@ Has type `LoggerConfiguration`. Can be configured via environment variable `IROH
 
 ```json
 {
-  "MAX_LOG_LEVEL": "DEBUG"
+  "COMPACT_MODE": false,
+  "MAX_LOG_LEVEL": "DEBUG",
+  "TELEMETRY_CAPACITY": 1000
 }
+```
+
+### `logger_configuration.compact_mode`
+
+Compact mode (no spans from telemetry)
+
+Has type `bool`. Can be configured via environment variable `COMPACT_MODE`
+
+```json
+false
 ```
 
 ### `logger_configuration.max_log_level`
@@ -221,6 +235,16 @@ Has type `LevelEnv`. Can be configured via environment variable `MAX_LOG_LEVEL`
 
 ```json
 "DEBUG"
+```
+
+### `logger_configuration.telemetry_capacity`
+
+Capacity (or batch size) for telemetry channel
+
+Has type `usize`. Can be configured via environment variable `TELEMETRY_CAPACITY`
+
+```json
+1000
 ```
 
 ## `private_key`

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -101,7 +101,8 @@ impl Iroha {
         config: &Configuration,
         permissions_validator: PermissionsValidatorBox,
     ) -> Result<Self> {
-        iroha_logger::init(config.logger_configuration);
+        // TODO: use channel for prometheus/telemetry endpoint
+        let telemetry = iroha_logger::init(config.logger_configuration);
         iroha_logger::info!(?config, "Loaded configuration");
 
         let (transactions_sender, transactions_receiver) = sync::channel(100);
@@ -141,6 +142,7 @@ impl Iroha {
             Arc::clone(&queue),
             Arc::clone(&sumeragi),
             (events_sender, events_receiver),
+            telemetry,
         );
         let kura = Kura::from_configuration(&config.kura_configuration, wsv_blocks_sender)?;
         let kura = Arc::new(RwLock::new(kura));

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -1985,7 +1985,7 @@ mod tests {
         config
             .load_trusted_peers_from_path(TRUSTED_PEERS_PATH)
             .expect("Failed to load trusted peers.");
-        iroha_logger::init(config.logger_configuration);
+        drop(iroha_logger::init(config.logger_configuration));
         config.sumeragi_configuration.commit_time_ms = COMMIT_TIME_MS;
         config.sumeragi_configuration.tx_receipt_time_ms = TX_RECEIPT_TIME_MS;
         config.sumeragi_configuration.block_time_ms = BLOCK_TIME_MS;
@@ -2033,6 +2033,7 @@ mod tests {
                 queue,
                 sumeragi.clone(),
                 (events_sender.clone(), events_receiver),
+                None,
             );
             drop(task::spawn(async move {
                 torii.start().await.expect("Torii failed.");
@@ -2112,7 +2113,7 @@ mod tests {
         config
             .load_trusted_peers_from_path(TRUSTED_PEERS_PATH)
             .expect("Failed to load trusted peers.");
-        iroha_logger::init(config.logger_configuration);
+        drop(iroha_logger::init(config.logger_configuration));
         config.sumeragi_configuration.commit_time_ms = COMMIT_TIME_MS;
         config.sumeragi_configuration.tx_receipt_time_ms = TX_RECEIPT_TIME_MS;
         config.sumeragi_configuration.block_time_ms = BLOCK_TIME_MS;
@@ -2161,6 +2162,7 @@ mod tests {
                 queue,
                 sumeragi.clone(),
                 (events_sender.clone(), events_receiver),
+                None,
             );
             drop(task::spawn(async move {
                 torii.start().await.expect("Torii failed.");
@@ -2264,7 +2266,7 @@ mod tests {
         config
             .load_trusted_peers_from_path(TRUSTED_PEERS_PATH)
             .expect("Failed to load trusted peers.");
-        iroha_logger::init(config.logger_configuration);
+        drop(iroha_logger::init(config.logger_configuration));
         config.sumeragi_configuration.commit_time_ms = COMMIT_TIME_MS;
         config.sumeragi_configuration.tx_receipt_time_ms = TX_RECEIPT_TIME_MS;
         config.sumeragi_configuration.block_time_ms = BLOCK_TIME_MS;
@@ -2313,6 +2315,7 @@ mod tests {
                 queue,
                 sumeragi.clone(),
                 (events_sender.clone(), events_receiver),
+                None,
             );
             drop(task::spawn(async move {
                 torii.start().await.expect("Torii failed.");
@@ -2430,7 +2433,7 @@ mod tests {
         config
             .load_trusted_peers_from_path(TRUSTED_PEERS_PATH)
             .expect("Failed to load trusted peers.");
-        iroha_logger::init(config.logger_configuration);
+        drop(iroha_logger::init(config.logger_configuration));
         config.sumeragi_configuration.commit_time_ms = COMMIT_TIME_MS;
         config.sumeragi_configuration.tx_receipt_time_ms = TX_RECEIPT_TIME_MS;
         config.sumeragi_configuration.block_time_ms = BLOCK_TIME_MS;
@@ -2479,6 +2482,7 @@ mod tests {
                 queue,
                 sumeragi.clone(),
                 (events_sender.clone(), events_receiver),
+                None,
             );
             drop(task::spawn(async move {
                 torii.start().await.expect("Torii failed.");
@@ -2593,7 +2597,7 @@ mod tests {
         config
             .load_trusted_peers_from_path(TRUSTED_PEERS_PATH)
             .expect("Failed to load trusted peers.");
-        iroha_logger::init(config.logger_configuration);
+        drop(iroha_logger::init(config.logger_configuration));
         config.sumeragi_configuration.commit_time_ms = COMMIT_TIME_MS;
         config.sumeragi_configuration.tx_receipt_time_ms = TX_RECEIPT_TIME_MS;
         config.sumeragi_configuration.block_time_ms = BLOCK_TIME_MS;
@@ -2641,6 +2645,7 @@ mod tests {
                 queue,
                 sumeragi.clone(),
                 (events_sender.clone(), events_receiver),
+                None,
             );
             drop(task::spawn(async move {
                 torii.start().await.expect("Torii failed.");

--- a/iroha/test_network/src/lib.rs
+++ b/iroha/test_network/src/lib.rs
@@ -189,6 +189,8 @@ impl Peer {
                 max_log_level: LevelEnv::ERROR,
                 #[cfg(not(profile = "bench"))]
                 max_log_level: LevelEnv::INFO,
+                compact_mode: false,
+                ..LoggerConfiguration::default()
             },
             public_key: self.key_pair.public_key.clone(),
             private_key: self.key_pair.private_key.clone(),

--- a/iroha_logger/Cargo.toml
+++ b/iroha_logger/Cargo.toml
@@ -12,5 +12,7 @@ once_cell = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
+tracing-core = "0.1"
 tracing-futures = { version = "0.2", default-features = false, features = ["std-future", "std"] }
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "ansi"] }
+async-std = { version = "1.6.2", features = ["unstable", "attributes"] }

--- a/iroha_logger/src/layer.rs
+++ b/iroha_logger/src/layer.rs
@@ -1,0 +1,151 @@
+//! Module for adding layers for events for subscribers
+
+use std::{
+    any::TypeId,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicU8, Ordering},
+};
+
+use tracing::{
+    level_filters::LevelFilter as TracingLevelFilter,
+    span::{Attributes, Record},
+    subscriber::Interest,
+    Event, Id, Level, Metadata, Subscriber,
+};
+use tracing_core::span::Current;
+
+/// Trait for filtering or inspecting events
+pub trait EventInspectorTrait: 'static {
+    /// Inner subscriber of current layer
+    type Subscriber: Subscriber;
+    /// Function which filters or inspects events
+    fn event(&self, event: &Event<'_>);
+    /// Basically deref for inner subscriber
+    fn inner_subscriber(&self) -> &Self::Subscriber;
+}
+
+/// Wrapper which implements `Subscriber` trait for any implementator of `EventfilterTrait`
+#[derive(Debug, Clone)]
+pub struct EventSubscriber<E>(pub E);
+
+impl<E> Deref for EventSubscriber<E> {
+    type Target = E;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E> DerefMut for EventSubscriber<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<E: EventInspectorTrait> Subscriber for EventSubscriber<E> {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.inner_subscriber().enabled(metadata)
+    }
+
+    fn new_span(&self, span: &Attributes<'_>) -> Id {
+        self.inner_subscriber().new_span(span)
+    }
+
+    fn record(&self, span: &Id, values: &Record<'_>) {
+        self.inner_subscriber().record(span, values)
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        self.inner_subscriber().record_follows_from(span, follows)
+    }
+
+    fn enter(&self, span: &Id) {
+        self.inner_subscriber().enter(span)
+    }
+
+    fn exit(&self, span: &Id) {
+        self.inner_subscriber().exit(span)
+    }
+
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        self.inner_subscriber().register_callsite(metadata)
+    }
+
+    fn max_level_hint(&self) -> Option<TracingLevelFilter> {
+        self.inner_subscriber().max_level_hint()
+    }
+
+    fn clone_span(&self, id: &Id) -> Id {
+        self.inner_subscriber().clone_span(id)
+    }
+
+    #[allow(deprecated)]
+    fn drop_span(&self, id: Id) {
+        self.inner_subscriber().drop_span(id)
+    }
+
+    fn try_close(&self, id: Id) -> bool {
+        self.inner_subscriber().try_close(id)
+    }
+
+    fn current_span(&self) -> Current {
+        self.inner_subscriber().current_span()
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        self.inner_subscriber().downcast_raw(id)
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        E::event(self, event)
+    }
+}
+
+/// Filter of logs by level
+#[derive(Debug, Clone)]
+pub struct LevelFilter<S> {
+    subscriber: S,
+}
+
+static CURRENT_LEVEL: AtomicU8 = AtomicU8::new(0);
+
+impl<S: Subscriber> LevelFilter<S> {
+    fn level_as_u8(level: Level) -> u8 {
+        match level {
+            Level::TRACE => 0,
+            Level::DEBUG => 1,
+            Level::INFO => 2,
+            Level::WARN => 3,
+            Level::ERROR => 4,
+        }
+    }
+
+    /// Constructor of level filter
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(level: Level, subscriber: S) -> impl Subscriber {
+        Self::update_max_level(level);
+        EventSubscriber(Self { subscriber })
+    }
+
+    /// Updater of max level
+    pub fn update_max_level(level: Level) {
+        CURRENT_LEVEL.store(Self::level_as_u8(level), Ordering::SeqCst)
+    }
+}
+
+impl<S: Subscriber> EventInspectorTrait for LevelFilter<S> {
+    type Subscriber = S;
+
+    fn inner_subscriber(&self) -> &Self::Subscriber {
+        &self.subscriber
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        let level = Self::level_as_u8(*event.metadata().level());
+        if level >= CURRENT_LEVEL.load(Ordering::Relaxed) {
+            self.subscriber.event(event)
+        }
+    }
+}

--- a/iroha_logger/src/telemetry.rs
+++ b/iroha_logger/src/telemetry.rs
@@ -1,0 +1,151 @@
+//! Module with telemetry layer for tracing
+
+#![allow(clippy::module_name_repetitions)]
+
+use std::error::Error;
+use std::fmt::Debug;
+use std::ops::{Deref, DerefMut};
+
+use async_std::sync::{self, Receiver, Sender};
+use serde_json::Value;
+use tracing::{
+    field::{Field, Visit},
+    Event, Subscriber,
+};
+
+use crate::layer::{EventInspectorTrait, EventSubscriber};
+
+/// Target for telemetry in `tracing`
+pub const TELEMETRY_TARGET_PREFIX: &str = "telemetry::";
+
+/// Fields for telemetry (type for efficient saving)
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct TelemetryFields(pub Vec<(&'static str, Value)>);
+
+impl From<TelemetryFields> for Value {
+    fn from(TelemetryFields(fields): TelemetryFields) -> Self {
+        fields
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value))
+            .collect()
+    }
+}
+
+impl Deref for TelemetryFields {
+    type Target = Vec<(&'static str, Value)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TelemetryFields {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Telemetry which can be recieved from telemetry layer
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Telemetry {
+    /// Subsystem from which telemetry was recieved
+    pub target: &'static str,
+    /// Fields which was recorded
+    pub fields: TelemetryFields,
+}
+
+impl Visit for Telemetry {
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.fields
+            .push((field.name(), format!("{:?}", &value).into()))
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields.push((field.name(), value.into()))
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields.push((field.name(), value.into()))
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.push((field.name(), value.into()))
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.push((field.name(), value.into()))
+    }
+
+    fn record_error(&mut self, field: &Field, mut error: &(dyn Error + 'static)) {
+        let mut vec = vec![error.to_string()];
+        while let Some(inner) = error.source() {
+            error = inner;
+            vec.push(inner.to_string())
+        }
+        self.fields.push((field.name(), vec.into()))
+    }
+}
+
+impl Telemetry {
+    fn from_event(target: &'static str, event: &Event<'_>) -> Self {
+        let fields = TelemetryFields::default();
+        let mut telemetry = Self { target, fields };
+        event.record(&mut telemetry);
+        telemetry
+    }
+}
+
+/// Telemetry layer
+#[derive(Debug, Clone)]
+pub struct TelemetryLayer<S: Subscriber> {
+    telemetry_sender: Sender<Telemetry>,
+    subscriber: S,
+}
+
+impl<S: Subscriber> TelemetryLayer<S> {
+    /// Create telemetry from channel sender
+    pub fn from_sender(subscriber: S, telemetry_sender: Sender<Telemetry>) -> impl Subscriber {
+        EventSubscriber(Self {
+            subscriber,
+            telemetry_sender,
+        })
+    }
+
+    /// Create new telemetry layer with specific channel size (via const generic)
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<const CHANNEL_SIZE: usize>(subscriber: S) -> (impl Subscriber, Receiver<Telemetry>) {
+        let (sender, reciever) = sync::channel(CHANNEL_SIZE);
+        let telemetry = Self::from_sender(subscriber, sender);
+        (telemetry, reciever)
+    }
+
+    /// Create new telemetry layer with specific channel size
+    #[allow(clippy::new_ret_no_self)]
+    pub fn from_capacity(
+        subscriber: S,
+        channel_size: usize,
+    ) -> (impl Subscriber, Receiver<Telemetry>) {
+        let (sender, reciever) = sync::channel(channel_size);
+        let telemetry = Self::from_sender(subscriber, sender);
+        (telemetry, reciever)
+    }
+}
+
+impl<S: Subscriber> EventInspectorTrait for TelemetryLayer<S> {
+    type Subscriber = S;
+
+    fn inner_subscriber(&self) -> &Self::Subscriber {
+        &self.subscriber
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        let target = event.metadata().target();
+        if let Some(target) = target.strip_prefix(TELEMETRY_TARGET_PREFIX) {
+            let _ = self
+                .telemetry_sender
+                .try_send(Telemetry::from_event(target, event));
+        } else {
+            self.subscriber.event(event)
+        }
+    }
+}

--- a/iroha_logger/tests/telemetry.rs
+++ b/iroha_logger/tests/telemetry.rs
@@ -1,0 +1,30 @@
+#![allow(clippy::restriction)]
+
+use std::time::Duration;
+
+use async_std::future;
+use iroha_logger::{
+    config::LoggerConfiguration,
+    info, init,
+    telemetry::{Telemetry, TelemetryFields},
+};
+
+#[async_std::test]
+async fn test() {
+    let reciever = init(LoggerConfiguration::default()).unwrap();
+    info!(target: "telemetry::test", a = 2, c = true, d = "this won't be logged");
+    info!("This will be logged");
+    let telemetry = Telemetry {
+        target: "test",
+        fields: TelemetryFields(vec![
+            ("a", serde_json::json!(2)),
+            ("c", serde_json::json!(true)),
+            ("d", serde_json::json!("this won't be logged")),
+        ]),
+    };
+    let recieved = future::timeout(Duration::from_millis(10), reciever.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(recieved, telemetry);
+}


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1056

### Description of the Change

This pr adds telemetry for future prometheus endpoint. It is done by using tracing and its specific filters.

### Benefits

Easy and transparent telemetry gathering.

### Possible Drawbacks 

Slowing down of system.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
