### PR TITLE
Move blocks from kura to wsv IR-1047

### DIFF
--- a/iroha/src/queue.rs
+++ b/iroha/src/queue.rs
@@ -328,10 +328,7 @@ mod tests {
         let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
         let transaction = accepted_tx("alice", "wonderland", 100_000, Some(&alice_key));
         let world_state_view = WorldStateView::new(world_with_test_domains(alice_key.public_key));
-        drop(world_state_view.transactions.insert(
-            transaction.hash(),
-            TransactionValue::Transaction(transaction.clone().into()),
-        ));
+        let _ = world_state_view.transactions.insert(transaction.hash());
         queue
             .push_pending_transaction(transaction)
             .expect("Failed to push tx into queue");


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1047
Signed-off-by: i1i1 <vanyarybin1@live.ru>

### Description of the Change

Blocks right now are in kura which supposed to be used for initialization from disk, while we have world state view which supposed to have all blocks (as name suggests and according to whitepaper).

### Benefits

Queries will be easier to implement.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
