### PR TITLE
Fix wsv panic at adding asset IR-1061

### DIFF
--- a/iroha/src/asset.rs
+++ b/iroha/src/asset.rs
@@ -55,7 +55,7 @@ pub mod isi {
                 None => world_state_view.add_asset(Asset::with_quantity(
                     self.destination_id.clone(),
                     self.object,
-                )),
+                ))?,
             }
             Ok(world_state_view)
         }
@@ -83,7 +83,7 @@ pub mod isi {
                 None => world_state_view.add_asset(Asset::with_big_quantity(
                     self.destination_id.clone(),
                     self.object,
-                )),
+                ))?,
             }
             Ok(world_state_view)
         }
@@ -112,7 +112,7 @@ pub mod isi {
                     self.key,
                     self.value,
                     asset_metadata_limits,
-                )?),
+                )?)?,
             }
             Ok(world_state_view)
         }

--- a/iroha/src/query.rs
+++ b/iroha/src/query.rs
@@ -201,7 +201,7 @@ mod tests {
             Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
             MetadataLimits::new(10, 100),
         );
-        wsv.add_asset(Asset::new(asset_id.clone(), AssetValue::Store(store)));
+        wsv.add_asset(Asset::new(asset_id.clone(), AssetValue::Store(store)))?;
         let bytes =
             FindAssetKeyValueByIdAndKey::new(asset_id, "Bytes".to_string()).execute(&wsv)?;
         assert_eq!(

--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use config::Configuration;
 use iroha_data_model::prelude::*;
+use iroha_error::{error, Result};
 
 use crate::prelude::*;
 
@@ -196,12 +197,15 @@ impl WorldStateView {
     }
 
     /// Add new `Asset` entity.
-    pub fn add_asset(&mut self, asset: Asset) {
+    /// # Errors
+    /// Fails if there is no account for asset
+    pub fn add_asset(&mut self, asset: Asset) -> Result<()> {
         let _ = self
             .account(&asset.id.account_id)
-            .expect("Failed to find an account.")
+            .ok_or_else(|| error!("Failed to find account"))?
             .assets
             .insert(asset.id.clone(), asset);
+        Ok(())
     }
 
     /// Get `AssetDefinitionEntry` without an ability to modify it.


### PR DESCRIPTION
Signed-off-by: i1i1 <vanyarybin1@live.ru>
https://jira.hyperledger.org/browse/IR-1061

### Description of the Change

Fixup of panic on adding asset to blockchain. It could panic if there is no account for asset.

### Benefits

No panics and accidental peer crush.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
