### PR TITLE
Ci timeout test fix

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           name: cargo-doc
           path: target/doc
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +54,7 @@ jobs:
           key: ${{ hashFiles('Cargo.toml') }}
       - name: Run tests
         run: cargo test --workspace --verbose
+
   test-iroha_network-mock:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set nightly toolchain  
+    - name: Set nightly toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly-2021-02-20

--- a/iroha/src/event.rs
+++ b/iroha/src/event.rs
@@ -19,6 +19,9 @@ pub type EventsSender = Sender<Event>;
 /// Type of `Receiver<Event>` which should be used for channels of `Event` messages.
 pub type EventsReceiver = Receiver<Event>;
 
+#[cfg(test)]
+const TIMEOUT: Duration = Duration::from_millis(10_000);
+#[cfg(not(test))]
 const TIMEOUT: Duration = Duration::from_millis(1000);
 
 /// Consumer for Iroha `Event`(s).


### PR DESCRIPTION
Signed-off-by: i1i1 <vanyarybin1@live.ru>

### Description of the Change

This pr fixes ci by adding more time for timeout to requests to peers in tests.

### Benefits

CI with extremely fast network speed (as it is within one device) doesn't handle incoming messages fast enough, so it fills up with messages and peers have to wait.

### Possible Drawbacks 

Longer ci times

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
