### PR TITLE
Remove old code from iroha_config

### DIFF
--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -127,8 +127,7 @@ impl Iroha {
             .expect("Failed to initialize Sumeragi."),
         ));
         let torii = Torii::from_configuration(
-            // TODO: change to real config and make configuration everywhere mutable
-            Arc::new(RwLock::new(config.clone())),
+            config.torii_configuration.clone(),
             Arc::clone(&world_state_view),
             transactions_sender,
             sumeragi_message_sender,

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -2037,7 +2037,7 @@ mod tests {
                 &config.queue_configuration,
             )));
             let mut torii = Torii::from_configuration(
-                Arc::new(RwLock::new(config.clone())),
+                config.torii_configuration.clone(),
                 wsv.clone(),
                 tx,
                 sumeragi_message_sender,
@@ -2165,7 +2165,7 @@ mod tests {
                 &config.queue_configuration,
             )));
             let mut torii = Torii::from_configuration(
-                Arc::new(RwLock::new(config.clone())),
+                config.torii_configuration.clone(),
                 wsv.clone(),
                 tx,
                 sumeragi_message_sender,
@@ -2317,7 +2317,7 @@ mod tests {
                 &config.queue_configuration,
             )));
             let mut torii = Torii::from_configuration(
-                Arc::new(RwLock::new(config.clone())),
+                config.torii_configuration.clone(),
                 wsv.clone(),
                 tx,
                 sumeragi_message_sender,
@@ -2483,7 +2483,7 @@ mod tests {
                 &config.queue_configuration,
             )));
             let mut torii = Torii::from_configuration(
-                Arc::new(RwLock::new(config.clone())),
+                config.torii_configuration.clone(),
                 wsv.clone(),
                 tx,
                 sumeragi_message_sender,
@@ -2645,7 +2645,7 @@ mod tests {
                 &config.queue_configuration,
             )));
             let mut torii = Torii::from_configuration(
-                Arc::new(RwLock::new(config.clone())),
+                config.torii_configuration.clone(),
                 wsv.clone(),
                 tx,
                 sumeragi_message_sender,

--- a/iroha_config/src/lib.rs
+++ b/iroha_config/src/lib.rs
@@ -142,32 +142,6 @@ pub trait Configurable: Serialize + DeserializeOwned {
     /// Error type returned by methods of trait
     type Error;
 
-    /// Sets field of structure with json-value
-    /// # Errors
-    /// Fails if field was unknown or if fails Deserialize value
-    fn set<'a, 'b>(
-        &'a mut self,
-        field: &'b str,
-        value: Value,
-    ) -> BoxedFuture<'a, Result<(), Self::Error>>
-    where
-        'b: 'a,
-    {
-        self.set_recursive([field], value)
-    }
-
-    /// Sets inner field of arbitrary inner depth with json-value
-    /// # Errors
-    /// Fails if field was unknown or if fails Deserialize value
-    fn set_recursive<'a, 'b, T>(
-        &'a mut self,
-        inner_field: T,
-        value: Value,
-    ) -> BoxedFuture<'a, Result<(), Self::Error>>
-    where
-        'b: 'a,
-        T: AsRef<[&'b str]> + Send + 'b;
-
     /// Gets field of structure and returns as json-value
     /// # Errors
     /// Fails if field was unknown

--- a/iroha_config/tests/simple.rs
+++ b/iroha_config/tests/simple.rs
@@ -18,53 +18,6 @@ struct InnerConfiguration {
     pub b: i32,
 }
 
-#[async_std::test]
-async fn test_inner() {
-    let mut x = InnerConfiguration {
-        a: "bc".to_owned(),
-        b: 10,
-    };
-    assert!(x.set("b", serde_json::json!(200)).await.is_ok());
-    assert!(x.set("a", serde_json::json!(200)).await.is_err());
-    assert_eq!(x.b, 200);
-}
-
-#[async_std::test]
-async fn test_outer() {
-    let mut x = Configuration {
-        inner: InnerConfiguration {
-            a: "bc".to_owned(),
-            b: 10,
-        },
-    };
-    assert!(x
-        .set_recursive(["inner", "b"], serde_json::json!(200))
-        .await
-        .is_ok());
-    assert!(x
-        .set_recursive(["inner", "a"], serde_json::json!(200))
-        .await
-        .is_err());
-    assert_eq!(x.inner.b, 200);
-    assert!(x
-        .set_recursive(
-            ["inner"],
-            serde_json::json!({
-                "a": "a",
-                "b": 20,
-            })
-        )
-        .await
-        .is_ok());
-    assert_eq!(
-        x.inner,
-        InnerConfiguration {
-            a: "a".to_owned(),
-            b: 20
-        }
-    );
-}
-
 #[test]
 fn test_docs() {
     assert_eq!(

--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -32,7 +32,6 @@ pub fn init(configuration: config::LoggerConfiguration) {
 /// This module contains all configuration related logic.
 pub mod config {
     use iroha_config::derive::Configurable;
-    use iroha_error::Result;
     use serde::{Deserialize, Serialize};
     use tracing_subscriber::filter::LevelFilter;
 


### PR DESCRIPTION
Signed-off-by: i1i1 <vanyarybin1@live.ru>

### Description of the Change

Pr removes setting of config variables inside locks, leaving only getting field and docs.

### Benefits

No unused code in repo

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
