### PR TITLE
Add lock free data structures to wsv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,16 +156,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task 4.0.3",
  "concurrent-queue",
  "fastrand",
  "futures-lite 1.11.3",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
+checksum = "69b0a74e7f70af3c8cf1aa539edbd044795706659ac52b78a71dc1a205ecefdf"
 dependencies = [
  "async-io",
  "blocking 1.0.2",
@@ -220,15 +220,16 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
 dependencies = [
  "async-io",
  "blocking 1.0.2",
  "cfg-if 1.0.0",
  "event-listener",
  "futures-lite 1.11.3",
+ "libc",
  "once_cell",
  "signal-hook",
  "winapi",
@@ -907,6 +908,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+ "serde",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +1017,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -1026,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fce69af4d4582ea989e6adfc5c9b81fd2071ff89234e5c14675c82a85217df"
+checksum = "fa9d66b91e902db43baefd8e40c8678ce29db2cf1d88ebd715174368d5fe70a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1559,6 +1571,7 @@ dependencies = [
  "iroha_logger",
  "iroha_macro",
  "iroha_network",
+ "iroha_structs",
  "iroha_version",
  "maplit",
  "parity-scale-codec",
@@ -1669,12 +1682,14 @@ dependencies = [
 name = "iroha_data_model"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "chrono",
  "iroha_crypto",
  "iroha_derive",
  "iroha_error",
  "iroha_http_server",
  "iroha_macro",
+ "iroha_structs",
  "iroha_version",
  "parity-scale-codec",
  "serde",
@@ -1805,7 +1820,18 @@ dependencies = [
  "iroha",
  "iroha_data_model",
  "iroha_macro",
+ "iroha_structs",
  "maplit",
+]
+
+[[package]]
+name = "iroha_structs"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "dashmap",
+ "parity-scale-codec",
+ "serde",
 ]
 
 [[package]]
@@ -3140,6 +3166,7 @@ dependencies = [
  "iroha_data_model",
  "iroha_error",
  "iroha_logger",
+ "iroha_network",
  "rand 0.7.3",
  "tempfile",
  "unique_port",

--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -33,6 +33,7 @@ iroha_logger = { version = "=0.1.0", path = "../iroha_logger"}
 iroha_crypto = { version = "=0.1.0", path = "../iroha_crypto" }
 iroha_http_server = { version = "=0.1.0", path = "../iroha_http_server" }
 iroha_version = { version = "=0.1.0", path = "../iroha_version", features = ["http_error"] }
+iroha_structs = { path = "../iroha_structs" }
 async-std = { version = "=1.6.2", features = ["attributes", "unstable"] }
 iroha_config = { version = "=0.1.0", path = "../iroha_config" }
 chrono = "0.4"

--- a/iroha/benches/sumeragi.rs
+++ b/iroha/benches/sumeragi.rs
@@ -1,15 +1,14 @@
 #![allow(missing_docs, clippy::restriction)]
 
-use std::collections::BTreeSet;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha::sumeragi::NetworkTopology;
 use iroha_crypto::{Hash, KeyPair};
 use iroha_data_model::prelude::*;
+use iroha_structs::HashSet;
 
 const N_PEERS: usize = 255;
 
-fn get_n_peers(n: usize) -> BTreeSet<PeerId> {
+fn get_n_peers(n: usize) -> HashSet<PeerId> {
     (0..n)
         .map(|i| PeerId {
             address: format!("127.0.0.{}", i),

--- a/iroha/benches/validation.rs
+++ b/iroha/benches/validation.rs
@@ -1,10 +1,9 @@
 #![allow(missing_docs, clippy::restriction)]
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha::{prelude::*, tx::AcceptedTransaction};
 use iroha_data_model::prelude::*;
+use iroha_structs::{HashMap, HashSet};
 
 const TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
 
@@ -43,14 +42,14 @@ fn build_test_transaction(keys: &KeyPair) -> Transaction {
 
 fn build_test_wsv(keys: &KeyPair) -> WorldStateView {
     WorldStateView::new({
-        let mut domains = BTreeMap::new();
-        let mut domain = Domain::new(START_DOMAIN);
+        let domains = HashMap::new();
+        let domain = Domain::new(START_DOMAIN);
         let account_id = AccountId::new(START_ACCOUNT, START_DOMAIN);
-        let mut account = Account::new(account_id.clone());
-        account.signatories.push(keys.public_key.clone());
-        let _ = domain.accounts.insert(account_id, account);
-        let _ = domains.insert(START_DOMAIN.to_string(), domain);
-        World::with(domains, BTreeSet::new())
+        let account = Account::new(account_id.clone());
+        account.signatories.write().push(keys.public_key.clone());
+        drop(domain.accounts.insert(account_id, account));
+        drop(domains.insert(START_DOMAIN.to_string(), domain));
+        World::with(domains, HashSet::new())
     })
 }
 
@@ -161,19 +160,19 @@ fn validate_blocks(criterion: &mut Criterion) {
     // Prepare WSV
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
     let domain_name = "global".to_string();
-    let asset_definitions = BTreeMap::new();
+    let asset_definitions = HashMap::new();
     let account_id = AccountId::new("root", &domain_name);
     let account = Account::with_signatory(account_id.clone(), key_pair.public_key);
-    let mut accounts = BTreeMap::new();
-    let _ = accounts.insert(account_id, account);
+    let accounts = HashMap::new();
+    drop(accounts.insert(account_id, account));
     let domain = Domain {
         name: domain_name.clone(),
         accounts,
         asset_definitions,
     };
-    let mut domains = BTreeMap::new();
-    let _ = domains.insert(domain_name, domain);
-    let world_state_view = WorldStateView::new(World::with(domains, BTreeSet::new()));
+    let domains = HashMap::new();
+    drop(domains.insert(domain_name, domain));
+    let world_state_view = WorldStateView::new(World::with(domains, HashSet::new()));
     // Pepare test transaction
     let keys = KeyPair::generate().expect("Failed to generate keys");
     let transaction = AcceptedTransaction::from_transaction(build_test_transaction(&keys), 4096)

--- a/iroha/src/config.rs
+++ b/iroha/src/config.rs
@@ -118,8 +118,6 @@ impl Configuration {
 mod tests {
     #![allow(clippy::restriction)]
 
-    use std::collections::BTreeSet;
-
     use super::*;
 
     const CONFIGURATION_PATH: &str = "tests/test_config.json";
@@ -156,7 +154,7 @@ mod tests {
             )
             .expect("Failed to decode"),
         };
-        let expected_trusted_peers: BTreeSet<PeerId> = vec![
+        let expected_trusted_peers = vec![
             PeerId {
                 address: "127.0.0.1:1337".to_string(),
                 public_key: public_key.clone(),
@@ -175,7 +173,7 @@ mod tests {
             },
         ]
         .into_iter()
-        .collect();
+        .collect::<iroha_structs::HashSet<_>>();
         assert_eq!(1000, configuration.sumeragi_configuration.block_time_ms);
         assert_eq!(
             expected_trusted_peers,

--- a/iroha/src/init.rs
+++ b/iroha/src/init.rs
@@ -1,20 +1,17 @@
-use std::collections::BTreeMap;
-
 use iroha_data_model::prelude::*;
+use iroha_structs::HashMap;
 
 use crate::config::Configuration;
 
 /// Returns the a map of a form `domain_name -> domain`, for initial domains.
-pub fn domains(configuration: &Configuration) -> BTreeMap<String, Domain> {
+pub fn domains(configuration: &Configuration) -> HashMap<String, Domain> {
+    let key = configuration
+        .genesis_configuration
+        .genesis_account_public_key
+        .clone();
     std::iter::once((
         GENESIS_DOMAIN_NAME.to_owned(),
-        GenesisDomain::new(
-            configuration
-                .genesis_configuration
-                .genesis_account_public_key
-                .clone(),
-        )
-        .into(),
+        Domain::from(GenesisDomain::new(key)),
     ))
     .collect()
 }

--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -1,13 +1,12 @@
 //! This module provides `WorldStateView` - in-memory representations of the current blockchain
 //! state.
 
-use std::collections::HashMap;
-
 use config::Configuration;
-use iroha_data_model::prelude::*;
-use iroha_error::{error, Result};
+use iroha_data_model::{domain::DomainsMap, peer::PeersIds, prelude::*};
+use iroha_error::Result;
+use iroha_structs::{HashMap, RwLock};
 
-use crate::prelude::*;
+use crate::{isi::FindError, prelude::*};
 
 /// Current state of the blockchain alligned with `Iroha` module.
 #[derive(Debug, Clone)]
@@ -42,187 +41,199 @@ impl WorldStateView {
     }
 
     /// Initializes WSV with the blocks from block storage.
-    pub fn init(&mut self, blocks: &[VersionedValidBlock]) {
+    pub fn init(&self, blocks: &[VersionedValidBlock]) {
         for block in blocks {
             self.apply(&block.clone().commit());
         }
     }
 
     /// Apply `CommittedBlock` with changes in form of **Iroha Special Instructions** to `self`.
-    pub fn apply(&mut self, block: &VersionedCommittedBlock) {
+    pub fn apply(&self, block: &VersionedCommittedBlock) {
         for transaction in &block.as_inner_v1().transactions {
             if let Err(e) = transaction.proceed(self) {
                 iroha_logger::warn!("Failed to proceed transaction on WSV: {}", e);
             }
-            let _ = self.transactions.insert(
+            drop(self.transactions.insert(
                 transaction.hash(),
                 TransactionValue::Transaction(transaction.clone().into()),
-            );
+            ));
         }
         for transaction in &block.as_inner_v1().rejected_transactions {
-            let _ = self.transactions.insert(
+            drop(self.transactions.insert(
                 transaction.hash(),
                 TransactionValue::RejectedTransaction(transaction.clone()),
-            );
+            ));
         }
     }
 
     /// Get `World` without an ability to modify it.
-    pub const fn read_world(&self) -> &World {
+    pub const fn world(&self) -> &World {
         &self.world
-    }
-
-    /// Get `World` with an ability to modify it.
-    pub fn world(&mut self) -> &mut World {
-        &mut self.world
     }
 
     /// Add new `Domain` entity.
     pub fn add_domain(&mut self, domain: Domain) {
-        let _ = self.world.domains.insert(domain.name.clone(), domain);
+        drop(self.world.domains.insert(domain.name.clone(), domain));
+    }
+
+    /// Returns reference for domains map
+    pub const fn domains(&self) -> &DomainsMap {
+        &self.world.domains
+    }
+
+    /// Returns reference for trusted peer ids
+    pub const fn trusted_peers_ids(&self) -> &PeersIds {
+        &self.world.trusted_peers_ids
+    }
+
+    /// Returns reference for parameters
+    pub const fn parameters(&self) -> &RwLock<Vec<Parameter>> {
+        &self.world.parameters
     }
 
     /// Get `Domain` without an ability to modify it.
-    pub fn read_domain(&self, name: &str) -> Option<&Domain> {
-        self.world.domains.get(name)
-    }
-
-    /// Get `Domain` with an ability to modify it.
-    pub fn domain(&mut self, name: &str) -> Option<&mut Domain> {
-        self.world.domains.get_mut(name)
-    }
-
-    /// Get all `Domain`s without an ability to modify them.
-    pub fn read_all_domains(&self) -> Vec<&Domain> {
-        let mut vec = self.world.domains.values().collect::<Vec<&Domain>>();
-        vec.sort();
-        vec
-    }
-
-    /// Get all `Account`s without an ability to modify them.
-    pub fn read_all_accounts(&self) -> Vec<&Account> {
-        let mut vec = self
+    /// # Errors
+    /// Fails if there is no domain
+    pub fn domain<T>(&self, name: &str, f: impl FnOnce(&Domain) -> T) -> Result<T> {
+        let domain = self
             .world
             .domains
-            .values()
-            .flat_map(|domain| domain.accounts.values())
-            .collect::<Vec<&Account>>();
-        vec.sort();
-        vec
+            .get(name)
+            .ok_or_else(|| FindError::Domain(name.to_owned()))?;
+        Ok(f(domain.value()))
     }
 
-    /// Get `Account` without an ability to modify it.
-    pub fn read_account(&self, id: &<Account as Identifiable>::Id) -> Option<&Account> {
-        self.read_domain(&id.domain_name)?.accounts.get(id)
+    /// Get `Account` and pass it to closure
+    /// # Errors
+    /// Fails if there is no domain or account
+    pub fn account<T>(
+        &self,
+        id: &<Account as Identifiable>::Id,
+        f: impl FnOnce(&Account) -> T,
+    ) -> Result<T> {
+        let result = self.domain(&id.domain_name, |domain| -> Result<T> {
+            let account = domain
+                .accounts
+                .get(id)
+                .ok_or_else(|| FindError::Account(id.clone()))?;
+            Ok(f(account.value()))
+        })??;
+        Ok(result)
     }
 
-    /// Get `Account`'s `Asset`s without an ability to modify it.
-    pub fn read_account_assets(&self, id: &<Account as Identifiable>::Id) -> Option<Vec<&Asset>> {
-        let mut vec = self
-            .read_account(id)?
-            .assets
-            .values()
-            .collect::<Vec<&Asset>>();
-        vec.sort();
-        Some(vec)
+    /// Get `Account`'s `Asset`s and pass it to closure
+    /// # Errors
+    /// Fails if account finding fails
+    pub fn account_assets(
+        &self,
+        id: &<Account as Identifiable>::Id,
+        mut f: impl FnMut(&Asset),
+    ) -> Result<()> {
+        self.account(id, |account| {
+            account.assets.iter().for_each(|guard| f(&*guard.value()))
+        })
     }
 
-    /// Get `Account` with an ability to modify it.
-    pub fn account(&mut self, id: &<Account as Identifiable>::Id) -> Option<&mut Account> {
-        self.domain(&id.domain_name)?.accounts.get_mut(id)
+    /// Insert new account
+    /// # Errors
+    /// Fails if there are no such domain
+    pub fn update_account(&self, account: Account) -> Result<()> {
+        let id = account.id.domain_name.clone();
+        self.domain(&id, move |domain| {
+            drop(domain.accounts.insert(account.id.clone(), account));
+        })
     }
 
     /// Get all `PeerId`s without an ability to modify them.
     pub fn read_all_peers(&self) -> Vec<Peer> {
         let mut vec = self
-            .read_world()
+            .world
             .trusted_peers_ids
             .iter()
-            .cloned()
-            .map(Peer::new)
+            .map(|peer| Peer::new((&*peer).clone()))
             .collect::<Vec<Peer>>();
         vec.sort();
         vec
     }
 
-    /// Get all `Asset`s without an ability to modify them.
-    pub fn read_all_assets(&self) -> Vec<&Asset> {
-        let mut vec = self
-            .world
-            .domains
-            .values()
-            .flat_map(|domain| domain.accounts.values())
-            .flat_map(|account| account.assets.values())
-            .collect::<Vec<&Asset>>();
-        vec.sort();
-        vec
-    }
-
-    /// Get all `Asset Definition Entry`s without an ability to modify them.
-    pub fn read_all_assets_definitions_entries(&self) -> Vec<&AssetDefinitionEntry> {
-        let mut vec = self
-            .world
-            .domains
-            .values()
-            .flat_map(|domain| domain.asset_definitions.values())
-            .collect::<Vec<&AssetDefinitionEntry>>();
-        vec.sort();
-        vec
-    }
-
-    /// Get `Asset` without an ability to modify it.
-    pub fn read_asset(&self, id: &<Asset as Identifiable>::Id) -> Option<&Asset> {
-        self.read_account(&id.account_id)?.assets.get(id)
-    }
-
-    /// Get `Asset` with an ability to modify it.
-    pub fn asset(&mut self, id: &<Asset as Identifiable>::Id) -> Option<&mut Asset> {
-        self.account(&id.account_id)?.assets.get_mut(id)
-    }
-
-    /// Get `Asset` with an ability to modify it.
-    /// If no asset is present - create it. Similar to Entry API.
-    ///
-    /// Returns `None` if no corresponding account was found.
-    pub fn asset_or_insert<V: Into<AssetValue>>(
-        &mut self,
+    /// Get `Asset` and passes it to closure
+    /// # Errors
+    /// Fails if there are no such asset or account
+    pub fn asset<T>(
+        &self,
         id: &<Asset as Identifiable>::Id,
-        default_value: V,
-    ) -> Option<&mut Asset> {
-        Some(
-            self.account(&id.account_id)?
+        f: impl FnOnce(&Asset) -> T,
+    ) -> Result<T> {
+        self.account(&id.account_id, |account| -> Result<T> {
+            let asset = account
                 .assets
-                .entry(id.clone())
-                .or_insert_with(|| Asset::new(id.clone(), default_value)),
-        )
+                .get(id)
+                .ok_or_else(|| FindError::Asset(id.clone()))?;
+            Ok(f(asset.value()))
+        })?
     }
 
+    /// Tries to get asset and call closure, if fails calls else closure
+    pub fn asset_or<T>(
+        &self,
+        id: &<Asset as Identifiable>::Id,
+        ok: impl FnOnce(&Asset) -> T,
+        else_: impl FnOnce() -> T,
+    ) -> T {
+        match self.asset(id, ok) {
+            Ok(ok) => ok,
+            Err(_) => else_(),
+        }
+    }
+
+    /// Tries to get asset and call closure, if fails, inserts new asset and calls else closure
+    /// # Panics
+    /// Can panic if getting after insert fails
+    /// # Errors
+    /// Fails if there is  no account with such name
+    pub fn asset_or_insert<T>(
+        &self,
+        id: &<Asset as Identifiable>::Id,
+        v: impl Into<AssetValue>,
+        f: impl FnOnce(&Asset) -> T,
+    ) -> Result<T> {
+        self.account(&id.account_id, |account| -> Result<T> {
+            let asset = account.assets.get(id).unwrap_or_else(|| {
+                drop(
+                    account
+                        .assets
+                        .insert(id.clone(), Asset::new(id.clone(), v.into())),
+                );
+                account.assets.get(id).unwrap()
+            });
+            Ok(f(asset.value()))
+        })?
+    }
     /// Add new `Asset` entity.
     /// # Errors
     /// Fails if there is no account for asset
-    pub fn add_asset(&mut self, asset: Asset) -> Result<()> {
-        let _ = self
-            .account(&asset.id.account_id)
-            .ok_or_else(|| error!("Failed to find account"))?
-            .assets
-            .insert(asset.id.clone(), asset);
-        Ok(())
+    pub fn add_asset(&self, asset: Asset) -> Result<()> {
+        let id = asset.id.account_id.clone();
+        self.account(&id, move |account| {
+            drop(account.assets.insert(asset.id.clone(), asset));
+        })
     }
 
     /// Get `AssetDefinitionEntry` without an ability to modify it.
-    pub fn read_asset_definition_entry(
+    /// # Errors
+    /// Fails if asset definition entry does not exist
+    pub fn asset_definition_entry<T>(
         &self,
         id: &<AssetDefinition as Identifiable>::Id,
-    ) -> Option<&AssetDefinitionEntry> {
-        self.read_domain(&id.domain_name)?.asset_definitions.get(id)
-    }
-
-    /// Get `AssetDefinitionEntry` with an ability to modify it.
-    pub fn asset_definition_entry(
-        &mut self,
-        id: &<AssetDefinition as Identifiable>::Id,
-    ) -> Option<&mut AssetDefinitionEntry> {
-        self.domain(&id.domain_name)?.asset_definitions.get_mut(id)
+        f: impl FnOnce(&AssetDefinitionEntry) -> T,
+    ) -> Result<T> {
+        self.domain(&id.domain_name, |domain| {
+            let asset = domain
+                .asset_definitions
+                .get(id)
+                .ok_or_else(|| FindError::AssetDefinition(id.clone()))?;
+            Ok(f(asset.value()))
+        })?
     }
 
     /// Checks if this `transaction_hash` is already committed or rejected.
@@ -231,11 +242,12 @@ impl WorldStateView {
     }
 
     /// Get committed and rejected transaction of the account.
-    pub fn read_transactions(&self, account_id: &AccountId) -> Vec<&TransactionValue> {
-        let mut vec: Vec<&TransactionValue> = self
+    pub fn read_transactions(&self, account_id: &AccountId) -> Vec<TransactionValue> {
+        let mut vec: Vec<TransactionValue> = self
             .transactions
-            .values()
-            .filter(|tx| &tx.payload().account_id == account_id)
+            .iter()
+            .filter(|read_guard| &read_guard.value().payload().account_id == account_id)
+            .map(|read_guard| read_guard.value().clone())
             .collect();
         vec.sort();
         vec

--- a/iroha_client/tests/cucumber.rs
+++ b/iroha_client/tests/cucumber.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, clippy::restriction, clippy::too_many_lines)]
 
-use std::{convert::Infallible, thread, time::Duration};
+use std::{convert::Infallible, panic::UnwindSafe, thread, time::Duration};
 
 use async_std::task::{self, JoinHandle};
 use async_trait::async_trait;
@@ -26,6 +26,8 @@ pub struct IrohaWorld {
     result: Option<QueryResult>,
     join_handle: Option<JoinHandle<()>>,
 }
+
+impl UnwindSafe for IrohaWorld {}
 
 #[async_trait(?Send)]
 impl CucumberWorld for IrohaWorld {
@@ -202,7 +204,7 @@ mod asset_steps {
                         if let Value::Identifiable(IdentifiableBox::Asset(asset)) =
                             asset
                         {
-                            if let AssetValue::Quantity(quantity) = asset.value {
+                            if let AssetValue::Quantity(quantity) = *asset.value.read() {
                                 total_quantity += quantity;
                             }
                         }

--- a/iroha_client/tests/tests/tests/account_with_multiple_signatories.rs
+++ b/iroha_client/tests/tests/tests/account_with_multiple_signatories.rs
@@ -45,7 +45,9 @@ mod tests {
             |result| {
                 result
                     .find_asset_by_id(&asset_definition_id)
-                    .map_or(false, |asset| asset.value == AssetValue::Quantity(quantity))
+                    .map_or(false, |asset| {
+                        *asset.value.read() == AssetValue::Quantity(quantity)
+                    })
             },
         );
         Ok(())

--- a/iroha_client/tests/tests/tests/add_asset.rs
+++ b/iroha_client/tests/tests/tests/add_asset.rs
@@ -37,7 +37,9 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
     test_client.submit_till(mint, &client::asset::by_account_id(account_id), |result| {
         result
             .find_asset_by_id(&asset_definition_id)
-            .map_or(false, |asset| asset.value == AssetValue::Quantity(quantity))
+            .map_or(false, |asset| {
+                *asset.value.read() == AssetValue::Quantity(quantity)
+            })
     });
     Ok(())
 }

--- a/iroha_client/tests/tests/tests/add_asset_should_propagate_to_another_peer.rs
+++ b/iroha_client/tests/tests/tests/add_asset_should_propagate_to_another_peer.rs
@@ -50,7 +50,9 @@ mod tests {
             |result| {
                 result
                     .find_asset_by_id(&asset_definition_id)
-                    .map_or(false, |asset| asset.value == AssetValue::Quantity(quantity))
+                    .map_or(false, |asset| {
+                        *asset.value.read() == AssetValue::Quantity(quantity)
+                    })
             },
         );
         Ok(())

--- a/iroha_client/tests/tests/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
+++ b/iroha_client/tests/tests/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
@@ -51,7 +51,9 @@ mod tests {
         iroha_client.poll_request(&client::asset::by_account_id(account_id), |result| {
             result
                 .find_asset_by_id(&asset_definition_id)
-                .map_or(false, |asset| asset.value == AssetValue::Quantity(quantity))
+                .map_or(false, |asset| {
+                    *asset.value.read() == AssetValue::Quantity(quantity)
+                })
         });
         Ok(())
     }

--- a/iroha_client/tests/tests/tests/genesis_submission_with_offline_peers.rs
+++ b/iroha_client/tests/tests/tests/genesis_submission_with_offline_peers.rs
@@ -26,6 +26,6 @@ mod tests {
         let asset = query_result
             .find_asset_by_id(&AssetDefinitionId::new("rose", "wonderland"))
             .unwrap();
-        assert_eq!(AssetValue::Quantity(alice_has_roses), asset.value);
+        assert_eq!(&AssetValue::Quantity(alice_has_roses), &*asset.value.read());
     }
 }

--- a/iroha_client/tests/tests/tests/multiple_blocks_created.rs
+++ b/iroha_client/tests/tests/tests/multiple_blocks_created.rs
@@ -72,7 +72,7 @@ mod tests {
                 result
                     .find_asset_by_id(&asset_definition_id)
                     .map_or(false, |asset| {
-                        asset.value == AssetValue::Quantity(account_has_quantity)
+                        *asset.value.read() == AssetValue::Quantity(account_has_quantity)
                     })
             },
         );

--- a/iroha_client/tests/tests/tests/multisignature_transaction.rs
+++ b/iroha_client/tests/tests/tests/multisignature_transaction.rs
@@ -112,7 +112,7 @@ mod tests {
             if let Value::Identifiable(IdentifiableBox::Asset(asset)) =
                 assets.first().expect("Asset should exist.")
             {
-                assert_eq!(AssetValue::Quantity(quantity), asset.value);
+                assert_eq!(&AssetValue::Quantity(quantity), &*asset.value.read());
             } else {
                 panic!("Wrong Query Result Type.")
             }

--- a/iroha_client/tests/tests/tests/restart_peer.rs
+++ b/iroha_client/tests/tests/tests/restart_peer.rs
@@ -78,7 +78,7 @@ fn restarted_peer_should_have_the_same_asset_amount() {
             })
             .expect("Asset should exist.");
 
-        assert_eq!(AssetValue::Quantity(quantity), asset.value);
+        assert_eq!(&AssetValue::Quantity(quantity), &*asset.value.read());
     } else {
         panic!("Wrong Query Result Type.");
     }
@@ -105,7 +105,7 @@ fn restarted_peer_should_have_the_same_asset_amount() {
             })
             .expect("Asset should exist.");
 
-        assert_eq!(AssetValue::Quantity(quantity), asset.value);
+        assert_eq!(&AssetValue::Quantity(quantity), &*asset.value.read());
     } else {
         panic!("Wrong Query Result Type.");
     }

--- a/iroha_client/tests/tests/tests/transfer_asset.rs
+++ b/iroha_client/tests/tests/tests/transfer_asset.rs
@@ -83,7 +83,7 @@ mod tests {
                 result
                     .find_asset_by_id(&asset_definition_id)
                     .map_or(false, |asset| {
-                        asset.value == AssetValue::Quantity(quantity)
+                        *asset.value.read() == AssetValue::Quantity(quantity)
                             && asset.id.account_id == account2_id
                     })
             },

--- a/iroha_client/tests/tests/tests/unstable_network.rs
+++ b/iroha_client/tests/tests/tests/unstable_network.rs
@@ -68,7 +68,7 @@ fn unstable_network(
             result
                 .find_asset_by_id(&asset_definition_id)
                 .map_or(false, |asset| {
-                    asset.value == AssetValue::Quantity(account_has_quantity)
+                    *asset.value.read() == AssetValue::Quantity(account_has_quantity)
                 })
         },
     );

--- a/iroha_data_model/Cargo.toml
+++ b/iroha_data_model/Cargo.toml
@@ -28,8 +28,10 @@ iroha_derive = { version = "=0.1.0", path = "../iroha_macro/iroha_derive" }
 iroha_macro = { version = "=0.1.0", path = "../iroha_macro" }
 iroha_version = { version = "=0.1.0", path = "../iroha_version" }
 iroha_error = { version = "=0.1.0", path = "../iroha_error" }
+iroha_structs = { version = "=0.1.0", path = "../iroha_structs" }
 iroha_http_server = { version = "=0.1.0", path = "../iroha_http_server", optional = true }
 ursa = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 parity-scale-codec = { version = "2", features = ["derive"] }
 serde_json = "1.0"
+async-std = { version = "1.6.2", features = ["unstable"] }

--- a/iroha_data_model/src/events.rs
+++ b/iroha_data_model/src/events.rs
@@ -120,7 +120,7 @@ pub mod data {
     #[derive(Clone, Debug, Serialize, Deserialize, FromVariant)]
     pub enum Entity {
         /// Account.
-        Account(Account),
+        Account(Box<Account>),
         /// AssetDefinition.
         AssetDefinition(AssetDefinition),
         /// Asset.

--- a/iroha_data_model/src/query.rs
+++ b/iroha_data_model/src/query.rs
@@ -34,47 +34,47 @@ use crate::Value;
 )]
 pub enum QueryBox {
     /// `FindAllAccounts` variant.
-    FindAllAccounts(Box<FindAllAccounts>),
+    FindAllAccounts(FindAllAccounts),
     /// `FindAccountById` variant.
-    FindAccountById(Box<FindAccountById>),
+    FindAccountById(FindAccountById),
     /// `FindAccountKeyValueByIdAndKey` variant.
-    FindAccountKeyValueByIdAndKey(Box<FindAccountKeyValueByIdAndKey>),
+    FindAccountKeyValueByIdAndKey(FindAccountKeyValueByIdAndKey),
     /// `FindAccountsByName` variant.
-    FindAccountsByName(Box<FindAccountsByName>),
+    FindAccountsByName(FindAccountsByName),
     /// `FindAccountsByDomainName` variant.
-    FindAccountsByDomainName(Box<FindAccountsByDomainName>),
+    FindAccountsByDomainName(FindAccountsByDomainName),
     /// `FindAllAssets` variant.
-    FindAllAssets(Box<FindAllAssets>),
+    FindAllAssets(FindAllAssets),
     /// `FindAllAssetsDefinitions` variant.
-    FindAllAssetsDefinitions(Box<FindAllAssetsDefinitions>),
+    FindAllAssetsDefinitions(FindAllAssetsDefinitions),
     /// `FindAssetById` variant.
-    FindAssetById(Box<FindAssetById>),
+    FindAssetById(FindAssetById),
     /// `FindAssetByName` variant.
-    FindAssetsByName(Box<FindAssetsByName>),
+    FindAssetsByName(FindAssetsByName),
     /// `FindAssetsByAccountId` variant.
-    FindAssetsByAccountId(Box<FindAssetsByAccountId>),
+    FindAssetsByAccountId(FindAssetsByAccountId),
     /// `FindAssetsByAssetDefinitionId` variant.
-    FindAssetsByAssetDefinitionId(Box<FindAssetsByAssetDefinitionId>),
+    FindAssetsByAssetDefinitionId(FindAssetsByAssetDefinitionId),
     /// `FindAssetsByDomainName` variant.
-    FindAssetsByDomainName(Box<FindAssetsByDomainName>),
+    FindAssetsByDomainName(FindAssetsByDomainName),
     /// `FindAssetsByAccountIdAndAssetDefinitionId` variant.
-    FindAssetsByAccountIdAndAssetDefinitionId(Box<FindAssetsByAccountIdAndAssetDefinitionId>),
+    FindAssetsByAccountIdAndAssetDefinitionId(FindAssetsByAccountIdAndAssetDefinitionId),
     /// `FindAssetsByDomainNameAndAssetDefinitionId` variant.
-    FindAssetsByDomainNameAndAssetDefinitionId(Box<FindAssetsByDomainNameAndAssetDefinitionId>),
+    FindAssetsByDomainNameAndAssetDefinitionId(FindAssetsByDomainNameAndAssetDefinitionId),
     /// `FindAssetQuantityById` variant.
-    FindAssetQuantityById(Box<FindAssetQuantityById>),
+    FindAssetQuantityById(FindAssetQuantityById),
     /// `FindAssetQuantityById` variant.
-    FindAssetKeyValueByIdAndKey(Box<FindAssetKeyValueByIdAndKey>),
+    FindAssetKeyValueByIdAndKey(FindAssetKeyValueByIdAndKey),
     /// `FindAllDomains` variant.
-    FindAllDomains(Box<FindAllDomains>),
+    FindAllDomains(FindAllDomains),
     /// `FindDomainByName` variant.
-    FindDomainByName(Box<FindDomainByName>),
+    FindDomainByName(FindDomainByName),
     /// `FindAllPeers` variant.
-    FindAllPeers(Box<FindAllPeers>),
+    FindAllPeers(FindAllPeers),
     /// `FindAllParameters` variant.
-    FindAllParameters(Box<FindAllParameters>),
+    FindAllParameters(FindAllParameters),
     /// `FindTransactionsByAccountId` variant.
-    FindTransactionsByAccountId(Box<FindTransactionsByAccountId>),
+    FindTransactionsByAccountId(FindTransactionsByAccountId),
 }
 
 /// I/O ready structure to send queries.

--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -21,13 +21,17 @@ pub fn init(configuration: config::LoggerConfiguration) {
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
         .is_ok()
     {
+        #[cfg(not(test))]
         let subscriber = tracing_subscriber::fmt()
             .compact()
             .finish()
             .with(LevelFilter::from(configuration.max_log_level));
+        #[cfg(test)]
+        let subscriber = tracing_subscriber::fmt()
+            .finish()
+            .with(LevelFilter::from(configuration.max_log_level));
         #[allow(clippy::expect_used)]
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("Fine as only we have access to atomic and we ensure that we set it once");
+        tracing::subscriber::set_global_default(subscriber).expect("Failed to init logger");
     }
 }
 

--- a/iroha_permissions_validators/Cargo.toml
+++ b/iroha_permissions_validators/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 iroha = { path = "../iroha"}
 iroha_data_model = { path = "../iroha_data_model" }
 iroha_macro = { path = "../iroha_macro" }
+iroha_structs = { path = "../iroha_structs" }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/iroha_permissions_validators/src/lib.rs
+++ b/iroha_permissions_validators/src/lib.rs
@@ -293,10 +293,10 @@ pub mod public_blockchain {
             ));
         };
         let registered_by_signer_account = wsv
-            .read_asset_definition_entry(definition_id)
-            .map_or(false, |asset_definiton_entry| {
+            .asset_definition_entry(definition_id, |asset_definiton_entry| {
                 &asset_definiton_entry.registered_by == authority
-            });
+            })
+            .unwrap_or(false);
         if !registered_by_signer_account {
             return Err(
                 "Can not grant access for unregistering assets, registered by another account."
@@ -439,10 +439,10 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?;
                 let asset_definition_id: AssetDefinitionId = try_into_or_exit!(object_id);
                 let registered_by_signer_account = wsv
-                    .read_asset_definition_entry(&asset_definition_id)
-                    .map_or(false, |asset_definiton_entry| {
+                    .asset_definition_entry(&asset_definition_id, |asset_definiton_entry| {
                         &asset_definiton_entry.registered_by == authority
-                    });
+                    })
+                    .unwrap_or(false);
                 if !registered_by_signer_account {
                     return Err("Can't unregister assets registered by other accounts.".to_owned());
                 }
@@ -551,10 +551,10 @@ pub mod public_blockchain {
                 let asset_id: AssetId = try_into_or_exit!(destination_id);
 
                 let low_authority = wsv
-                    .read_asset_definition_entry(&asset_id.definition_id)
-                    .map_or(false, |asset_definiton_entry| {
+                    .asset_definition_entry(&asset_id.definition_id, |asset_definiton_entry| {
                         &asset_definiton_entry.registered_by != authority
-                    });
+                    })
+                    .unwrap_or(false);
 
                 if low_authority {
                     return Err("Can't mint assets registered by other accounts.".to_owned());
@@ -666,10 +666,10 @@ pub mod public_blockchain {
                 let asset_id: AssetId = try_into_or_exit!(destination_id);
 
                 let low_authority = wsv
-                    .read_asset_definition_entry(&asset_id.definition_id)
-                    .map_or(false, |asset_definiton_entry| {
+                    .asset_definition_entry(&asset_id.definition_id, |asset_definiton_entry| {
                         &asset_definiton_entry.registered_by != authority
-                    });
+                    })
+                    .unwrap_or(false);
                 if low_authority {
                     return Err("Can't mint assets registered by other accounts.".to_owned());
                 }
@@ -1239,6 +1239,7 @@ pub mod public_blockchain {
     mod tests {
         #![allow(clippy::restriction)]
 
+        use iroha_structs::{HashMap, HashSet};
         use maplit::{btreemap, btreeset};
 
         use super::*;
@@ -1271,19 +1272,20 @@ pub mod public_blockchain {
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
-            let mut domain = Domain::new("test");
-            let mut bob_account = Account::new(bob_id.clone());
-            let _ = bob_account.insert_permission_token(PermissionToken::new(
-                transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_owned() => alice_xor_id.clone().into(),
-                },
-            ));
-            let _ = domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
-            let wsv = WorldStateView::new(World::with(domains, btreeset! {}));
+            let domain = Domain::new("test");
+            let bob_account = Account::new(bob_id.clone());
+            let _ = bob_account
+                .permission_tokens
+                .write()
+                .insert(PermissionToken::new(
+                    transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
+                    btreemap! {
+                        ASSET_ID_TOKEN_PARAM_NAME.to_string() => alice_xor_id.clone().into(),
+                    },
+                ));
+            drop(domain.accounts.insert(bob_id.clone(), bob_account));
+            let domains = vec![("test".to_string(), domain)];
+            let wsv = WorldStateView::new(World::with(domains, HashSet::new()));
             let transfer = Instruction::Transfer(TransferBox {
                 source_id: IdBox::AssetId(alice_xor_id).into(),
                 object: Value::U32(10).into(),
@@ -1330,16 +1332,16 @@ pub mod public_blockchain {
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
             let wsv = WorldStateView::new(World::with(
                 btreemap! {
-                    "test".to_owned() => Domain {
-                    accounts: btreemap! {},
-                    name: "test".to_owned(),
+                    "test".to_string() => Domain {
+                    accounts: HashMap::new(),
+                    name: "test".to_string(),
                     asset_definitions: btreemap! {
                         xor_id.clone() =>
                         AssetDefinitionEntry {
                             definition: xor_definition,
                             registered_by: alice_id.clone()
                         }
-                    },
+                    }.into_iter().collect(),
                 }},
                 btreeset! {},
             ));
@@ -1359,19 +1361,22 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
-            let mut domain = Domain::new("test");
-            let mut bob_account = Account::new(bob_id.clone());
-            let _ = bob_account.insert_permission_token(PermissionToken::new(
-                unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
-            ));
-            let _ = domain.accounts.insert(bob_id.clone(), bob_account);
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            let bob_account = Account::new(bob_id.clone());
+            let _ = bob_account
+                .permission_tokens
+                .write()
+                .insert(PermissionToken::new(
+                    unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
+                    btreemap! {
+                        ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
+                    },
+                ));
+            drop(domain.accounts.insert(bob_id.clone(), bob_account));
+            drop(domain.asset_definitions.insert(
                 xor_id.clone(),
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
@@ -1400,11 +1405,11 @@ pub mod public_blockchain {
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
                 },
             );
-            let mut domain = Domain::new("test");
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            drop(domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
@@ -1428,16 +1433,18 @@ pub mod public_blockchain {
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
             let wsv = WorldStateView::new(World::with(
                 btreemap! {
-                    "test".to_owned() => Domain {
-                    accounts: btreemap! {},
-                    name: "test".to_owned(),
+                    "test".to_string() => Domain {
+                    accounts: HashMap::new(),
+                    name: "test".to_string(),
                     asset_definitions: btreemap! {
                         xor_id =>
                         AssetDefinitionEntry {
                             definition: xor_definition,
                             registered_by: alice_id.clone()
                         }
-                    },
+                    }
+                    .into_iter()
+                    .collect(),
                 }},
                 btreeset! {},
             ));
@@ -1461,19 +1468,22 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
-            let mut domain = Domain::new("test");
-            let mut bob_account = Account::new(bob_id.clone());
-            let _ = bob_account.insert_permission_token(PermissionToken::new(
-                mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
-            ));
-            let _ = domain.accounts.insert(bob_id.clone(), bob_account);
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            let bob_account = Account::new(bob_id.clone());
+            let _ = bob_account
+                .permission_tokens
+                .write()
+                .insert(PermissionToken::new(
+                    mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
+                    btreemap! {
+                        ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
+                    },
+                ));
+            drop(domain.accounts.insert(bob_id.clone(), bob_account));
+            drop(domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
@@ -1505,15 +1515,15 @@ pub mod public_blockchain {
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
                 },
             );
-            let mut domain = Domain::new("test");
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            drop(domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
-            let wsv = WorldStateView::new(World::with(domains, btreeset! {}));
+            let wsv = WorldStateView::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
                 destination_id: IdBox::AccountId(bob_id.clone()).into(),
@@ -1533,18 +1543,21 @@ pub mod public_blockchain {
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
             let wsv = WorldStateView::new(World::with(
                 btreemap! {
-                    "test".to_owned() => Domain {
-                    accounts: btreemap! {},
-                    name: "test".to_owned(),
+                    "test".to_string() => Domain {
+                    accounts: HashMap::new(),
+                    name: "test".to_string(),
                     asset_definitions: btreemap! {
                         xor_id =>
                         AssetDefinitionEntry {
                             definition: xor_definition,
                             registered_by: alice_id.clone()
                         }
-                    },
-                }},
-                btreeset! {},
+                    }
+                    .into_iter()
+                    .collect(),
+                    }
+                },
+                vec![],
             ));
             let burn = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -1566,23 +1579,26 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = AssetDefinition::new_quantity(xor_id.clone());
-            let mut domain = Domain::new("test");
-            let mut bob_account = Account::new(bob_id.clone());
-            let _ = bob_account.insert_permission_token(PermissionToken::new(
-                burn::CAN_BURN_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
-            ));
-            let _ = domain.accounts.insert(bob_id.clone(), bob_account);
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            let bob_account = Account::new(bob_id.clone());
+            let _ = bob_account
+                .permission_tokens
+                .write()
+                .insert(PermissionToken::new(
+                    burn::CAN_BURN_ASSET_WITH_DEFINITION,
+                    btreemap! {
+                        ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
+                    },
+                ));
+            drop(domain.accounts.insert(bob_id.clone(), bob_account));
+            drop(domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
-            let wsv = WorldStateView::new(World::with(domains, btreeset! {}));
+            let wsv = WorldStateView::new(World::with(domains, vec![]));
             let instruction = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
                 destination_id: IdBox::AssetId(alice_xor_id).into(),
@@ -1610,15 +1626,15 @@ pub mod public_blockchain {
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
                 },
             );
-            let mut domain = Domain::new("test");
-            let _ = domain.asset_definitions.insert(
+            let domain = Domain::new("test");
+            drop(domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
-            );
+            ));
             let domains = btreemap! {
                 "test".to_owned() => domain
             };
-            let wsv = WorldStateView::new(World::with(domains, btreeset! {}));
+            let wsv = WorldStateView::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
                 destination_id: IdBox::AccountId(bob_id.clone()).into(),
@@ -1653,19 +1669,20 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let mut domain = Domain::new("test");
-            let mut bob_account = Account::new(bob_id.clone());
-            let _ = bob_account.insert_permission_token(PermissionToken::new(
-                burn::CAN_BURN_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_owned() => alice_xor_id.clone().into(),
-                },
-            ));
-            let _ = domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
-            let wsv = WorldStateView::new(World::with(domains, btreeset! {}));
+            let domain = Domain::new("test");
+            let bob_account = Account::new(bob_id.clone());
+            let _ = bob_account
+                .permission_tokens
+                .write()
+                .insert(PermissionToken::new(
+                    burn::CAN_BURN_USER_ASSETS_TOKEN,
+                    btreemap! {
+                        ASSET_ID_TOKEN_PARAM_NAME.to_string() => alice_xor_id.clone().into(),
+                    },
+                ));
+            drop(domain.accounts.insert(bob_id.clone(), bob_account));
+            let domains = vec![("test".to_string(), domain)];
+            let wsv = WorldStateView::new(World::with(domains, vec![]));
             let transfer = Instruction::Burn(BurnBox {
                 object: Value::U32(10).into(),
                 destination_id: IdBox::AssetId(alice_xor_id).into(),

--- a/iroha_structs/Cargo.toml
+++ b/iroha_structs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "iroha_structs"
+version = "0.1.0"
+authors = ["taisei"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dashmap = { version = "4.0", features = ["serde"] }
+parity-scale-codec = "2"
+serde = { version = "1", features = ["derive"] }
+async-std = { version = "1.6.2", features = ["unstable"] }

--- a/iroha_structs/src/hashmap.rs
+++ b/iroha_structs/src/hashmap.rs
@@ -1,0 +1,147 @@
+//! hash map module
+
+use std::{
+    collections::{hash_map::RandomState, BTreeMap as StdBTreeMap, HashMap as StdHashMap},
+    fmt::{self, Debug},
+    hash::Hash,
+    iter::FromIterator,
+    ops::{Deref, DerefMut},
+};
+
+use dashmap::iter::OwningIter;
+pub use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Concurent lock-free hash map
+#[derive(Deserialize, Serialize)]
+#[serde(transparent)]
+#[serde(bound(
+    deserialize = "
+    K: DeserializeOwned + Eq + Hash,
+    V: DeserializeOwned,
+",
+    serialize = "
+    K: Serialize + Eq + Hash,
+    V: Serialize,
+"
+))]
+pub struct HashMap<K, V>(pub DashMap<K, V>);
+
+impl<K: Eq + Hash + Debug, V: Debug> Debug for HashMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<K: Hash + Eq, V: Eq> Eq for HashMap<K, V> {}
+impl<K: Hash + Eq, V: PartialEq> PartialEq for HashMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        for readguard in &self.0 {
+            match other.get(readguard.key()) {
+                Some(guard) if *guard == *readguard.value() => (),
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+impl<K: Hash + Eq, V> HashMap<K, V> {
+    /// Constructor for hashmap
+    pub fn new() -> Self {
+        Self(DashMap::new())
+    }
+}
+
+impl<K: Hash + Eq, V> Default for HashMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: Decode + Ord + Eq + Hash, V: Decode> Decode for HashMap<K, V> {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        <StdBTreeMap<K, V> as Decode>::decode(input).map(|tree| Self(tree.into_iter().collect()))
+    }
+
+    fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+        <StdBTreeMap<K, V> as Decode>::skip(input)
+    }
+
+    fn encoded_fixed_size() -> Option<usize> {
+        <StdBTreeMap<K, V> as Decode>::encoded_fixed_size()
+    }
+}
+
+impl<K: Encode + Eq + Ord + Hash + Clone, V: Encode + Clone> Encode for HashMap<K, V> {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        self.iter()
+            .map(|readguard| (readguard.key().clone(), readguard.value().clone()))
+            .collect::<StdBTreeMap<K, V>>()
+            .encode_to(dest)
+    }
+    fn encode(&self) -> Vec<u8> {
+        self.iter()
+            .map(|readguard| (readguard.key().clone(), readguard.value().clone()))
+            .collect::<StdBTreeMap<K, V>>()
+            .encode()
+    }
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.iter()
+            .map(|readguard| (readguard.key().clone(), readguard.value().clone()))
+            .collect::<StdBTreeMap<K, V>>()
+            .using_encoded(f)
+    }
+}
+
+impl<K, V> Deref for HashMap<K, V> {
+    type Target = DashMap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K, V> DerefMut for HashMap<K, V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K: Eq + Hash, V> From<StdHashMap<K, V>> for HashMap<K, V> {
+    fn from(hm: StdHashMap<K, V>) -> Self {
+        Self(hm.into_iter().collect())
+    }
+}
+
+impl<K: Eq + Hash, V> From<HashMap<K, V>> for StdHashMap<K, V, RandomState> {
+    fn from(HashMap(iroha_map): HashMap<K, V>) -> Self {
+        iroha_map.into_iter().collect()
+    }
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> Clone for HashMap<K, V> {
+    fn clone(&self) -> Self {
+        let new = self
+            .iter()
+            .map(|readguard| (readguard.key().clone(), readguard.value().clone()))
+            .collect();
+        Self(new)
+    }
+}
+
+impl<K: Eq + Hash, V> FromIterator<(K, V)> for HashMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        Self(DashMap::from_iter(iter))
+    }
+}
+
+impl<'a, K: Eq + Hash, V> IntoIterator for HashMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = OwningIter<K, V, RandomState>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/iroha_structs/src/hashset.rs
+++ b/iroha_structs/src/hashset.rs
@@ -1,0 +1,149 @@
+//! Module with concurent lock-free hash set
+
+use std::{
+    collections::{hash_map::RandomState, BTreeSet as StdBTreeSet, HashSet as StdHashSet},
+    fmt::{self, Debug},
+    hash::Hash,
+    iter::FromIterator,
+    ops::{Deref, DerefMut},
+};
+
+use dashmap::iter_set::OwningIter;
+use dashmap::DashSet;
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Concurent lock-free hash set
+#[derive(Deserialize, Serialize)]
+#[serde(transparent)]
+#[serde(bound(
+    deserialize = "K: DeserializeOwned + Eq + Hash",
+    serialize = "K: Serialize + Eq + Hash"
+))]
+pub struct HashSet<K>(pub DashSet<K>);
+
+impl<K: Eq + Hash + Debug> Debug for HashSet<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<K: Eq + Hash> Default for HashSet<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: Eq + Hash> HashSet<K> {
+    /// Default constructor
+    pub fn new() -> Self {
+        Self(DashSet::new())
+    }
+}
+
+impl<K: Eq + Hash + Clone> HashSet<K> {
+    /// Clears hashset by removing all its keys
+    pub fn clear(&self) {
+        for key in self
+            .iter()
+            .map(|guard| (&*guard).clone())
+            .collect::<Vec<_>>()
+        {
+            drop(self.remove(&key));
+        }
+    }
+}
+
+impl<K: Hash + Eq> Eq for HashSet<K> {}
+impl<K: Hash + Eq> PartialEq for HashSet<K> {
+    fn eq(&self, other: &Self) -> bool {
+        for readguard in self.iter() {
+            if other.get(&*readguard).is_none() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<K: Eq + Hash> From<StdHashSet<K>> for HashSet<K> {
+    fn from(hs: StdHashSet<K>) -> Self {
+        hs.into_iter().collect()
+    }
+}
+
+impl<K: Eq + Hash> From<HashSet<K>> for StdHashSet<K, RandomState> {
+    fn from(HashSet(hs): HashSet<K>) -> Self {
+        hs.into_iter().collect()
+    }
+}
+
+impl<K: Eq + Hash + Clone> Clone for HashSet<K> {
+    fn clone(&self) -> Self {
+        let new = self.iter().map(|readguard| (&*readguard).clone()).collect();
+        Self(new)
+    }
+}
+
+impl<K: Decode + Ord + Eq + Hash> Decode for HashSet<K> {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        <StdBTreeSet<K> as Decode>::decode(input).map(|tree| Self(tree.into_iter().collect()))
+    }
+
+    fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+        <StdBTreeSet<K> as Decode>::skip(input)
+    }
+
+    fn encoded_fixed_size() -> Option<usize> {
+        <StdBTreeSet<K> as Decode>::encoded_fixed_size()
+    }
+}
+
+impl<K: Encode + Ord + Eq + Hash + Clone> Encode for HashSet<K> {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        self.iter()
+            .map(|readguard| (&*readguard).clone())
+            .collect::<StdBTreeSet<K>>()
+            .encode_to(dest)
+    }
+    fn encode(&self) -> Vec<u8> {
+        self.iter()
+            .map(|readguard| (&*readguard).clone())
+            .collect::<StdBTreeSet<K>>()
+            .encode()
+    }
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.iter()
+            .map(|readguard| (&*readguard).clone())
+            .collect::<StdBTreeSet<K>>()
+            .using_encoded(f)
+    }
+}
+
+impl<K> Deref for HashSet<K> {
+    type Target = DashSet<K>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K> DerefMut for HashSet<K> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K: Eq + Hash> FromIterator<K> for HashSet<K> {
+    fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
+        Self(DashSet::from_iter(iter))
+    }
+}
+
+impl<K: Eq + Hash> IntoIterator for HashSet<K> {
+    type Item = K;
+    type IntoIter = OwningIter<K, RandomState>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/iroha_structs/src/lib.rs
+++ b/iroha_structs/src/lib.rs
@@ -1,0 +1,9 @@
+//! Proxy crate for easy changing and substituting other crates' data structures
+
+pub use hashmap::HashMap;
+pub use hashset::HashSet;
+pub use rwlock::RwLock;
+
+pub mod hashmap;
+pub mod hashset;
+pub mod rwlock;

--- a/iroha_structs/src/rwlock.rs
+++ b/iroha_structs/src/rwlock.rs
@@ -1,0 +1,105 @@
+//! Module with asynchronous read write lock
+
+use async_std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use async_std::task;
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Asynchronous read write lock
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "T: Serialize + Clone",
+    deserialize = "T: DeserializeOwned",
+))]
+#[serde(from = "T")]
+#[serde(into = "IntoWrapper<T>")]
+pub struct RwLock<T>(pub async_std::sync::RwLock<T>);
+
+impl<T: PartialEq> PartialEq for RwLock<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.read().eq(&*other.read())
+    }
+}
+impl<T: Eq> Eq for RwLock<T> {}
+
+impl<T: Clone> Clone for RwLock<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.read().clone())
+    }
+}
+
+impl<T> From<T> for RwLock<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+struct IntoWrapper<T>(T);
+
+impl<T> From<RwLock<T>> for IntoWrapper<T> {
+    fn from(RwLock(value): RwLock<T>) -> Self {
+        Self(value.into_inner())
+    }
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> RwLock<T> {
+    /// Constructor
+    pub fn new(value: T) -> Self {
+        Self(async_std::sync::RwLock::new(value))
+    }
+}
+
+impl<T> RwLock<T> {
+    /// Returns read guard in synchronous context
+    pub fn read(&'_ self) -> RwLockReadGuard<'_, T> {
+        task::block_on(self.read_async())
+    }
+    /// Returns read guard in asynchronous context
+    #[allow(clippy::future_not_send)]
+    pub async fn read_async(&'_ self) -> RwLockReadGuard<'_, T> {
+        self.0.read().await
+    }
+    /// Returns write guard in synchronous context
+    pub fn write(&'_ self) -> RwLockWriteGuard<'_, T> {
+        task::block_on(self.write_async())
+    }
+    /// Returns write guard in asynchronous context
+    #[allow(clippy::future_not_send)]
+    pub async fn write_async(&'_ self) -> RwLockWriteGuard<'_, T> {
+        self.0.write().await
+    }
+}
+
+impl<W: Encode> Encode for RwLock<W> {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        self.read().encode_to(dest)
+    }
+    fn encode(&self) -> Vec<u8> {
+        self.read().encode()
+    }
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.read().using_encoded(f)
+    }
+}
+
+impl<T: Decode> Decode for RwLock<T> {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        Ok(Self::new(T::decode(input)?))
+    }
+
+    fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+        T::skip(input)
+    }
+
+    fn encoded_fixed_size() -> Option<usize> {
+        T::encoded_fixed_size()
+    }
+}


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1065
https://jira.hyperledger.org/browse/IR-1066
Signed-off-by: i1i1 <vanyarybin1@live.ru>


### Description of the Change

Remove lock from WSV and make maps and sets mutable concurrently. It uses [dashmap](https://crates.io/crates/dashmap) crate for that.

### Benefits

This change removes racing for whole wsv and adds locks for its subparts.

### Possible Drawbacks 

Lockfree actually caused several panics and needs for rework.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

[dashmap](https://crates.io/crates/dashmap) is also good, it offers entry api and some lock free functions, but there are cautions about deadlocks. It is probably a good candidate, but should be used wisely.
[lockfree](https://crates.io/crates/lockfree) is very generic and good crate, but it seems very unsafe to use it, as it can panic. Also it is quiete slow
[flurry](https://crates.io/crates/flurry) is a port of java hashmap, so it seems to be very robust, but it requires using [crossbeam epoch](https://docs.rs/crossbeam/0.7.3/crossbeam/epoch/index.html) in api, so we need to drastically change it in order to use it.
