### PR TITLE
Refactor/remove rxcpp

### DIFF
--- a/irohad/ametsuchi/impl/mutable_storage_impl.cpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.cpp
@@ -7,7 +7,6 @@
 
 #include <fmt/core.h>
 #include <boost/variant/apply_visitor.hpp>
-#include <rxcpp/operators/rx-all.hpp>
 #include <stdexcept>
 #include "ametsuchi/command_executor.hpp"
 #include "ametsuchi/impl/peer_query_wsv.hpp"
@@ -47,7 +46,7 @@ namespace iroha {
       sql_ << "BEGIN";
     }
 
-    bool MutableStorageImpl::apply(
+    bool MutableStorageImpl::applyBlock(
         std::shared_ptr<const shared_model::interface::Block> block,
         MutableStoragePredicate predicate) {
       auto execute_transaction = [this](auto &transaction) -> bool {
@@ -115,26 +114,14 @@ namespace iroha {
     bool MutableStorageImpl::apply(
         std::shared_ptr<const shared_model::interface::Block> block) {
       return withSavepoint([&] {
-        return this->apply(block, [](const auto &, auto &) { return true; });
+        return this->applyBlock(block, [](const auto &, auto &) { return true; });
       });
     }
 
     bool MutableStorageImpl::apply(
-        rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-            blocks,
+        std::shared_ptr<const shared_model::interface::Block> block,
         MutableStoragePredicate predicate) {
-      try {
-        return blocks
-            .all([&](auto block) {
-              return withSavepoint(
-                  [&] { return this->apply(block, predicate); });
-            })
-            .as_blocking()
-            .first();
-      } catch (std::runtime_error const &e) {
-        log_->warn("Apply has been failed: {}", e.what());
-        return false;
-      }
+      return withSavepoint([&] { return this->applyBlock(block, predicate); });
     }
 
     boost::optional<std::shared_ptr<const iroha::LedgerState>>

--- a/irohad/ametsuchi/impl/mutable_storage_impl.hpp
+++ b/irohad/ametsuchi/impl/mutable_storage_impl.hpp
@@ -37,8 +37,7 @@ namespace iroha {
       bool apply(
           std::shared_ptr<const shared_model::interface::Block> block) override;
 
-      bool apply(rxcpp::observable<
-                     std::shared_ptr<shared_model::interface::Block>> blocks,
+      bool apply(std::shared_ptr<const shared_model::interface::Block> block,
                  MutableStoragePredicate predicate) override;
 
       boost::optional<std::shared_ptr<const iroha::LedgerState>>
@@ -63,7 +62,7 @@ namespace iroha {
        * Verifies whether the block is applicable using predicate, and applies
        * the block
        */
-      bool apply(std::shared_ptr<const shared_model::interface::Block> block,
+      bool applyBlock(std::shared_ptr<const shared_model::interface::Block> block,
                  MutableStoragePredicate predicate);
 
       boost::optional<std::shared_ptr<const iroha::LedgerState>> ledger_state_;

--- a/irohad/ametsuchi/mutable_storage.hpp
+++ b/irohad/ametsuchi/mutable_storage.hpp
@@ -8,7 +8,6 @@
 
 #include <functional>
 
-#include <rxcpp/rx-observable-fwd.hpp>
 #include "ametsuchi/block_storage.hpp"
 #include "ametsuchi/ledger_state.hpp"
 #include "common/result.hpp"
@@ -56,16 +55,15 @@ namespace iroha {
           std::shared_ptr<const shared_model::interface::Block> block) = 0;
 
       /**
-       * Applies an observable of blocks to current mutable state using logic
-       * specified in function
-       * @param blocks Blocks to be applied
+       * Applies a block to current mutable state using logic specified in
+       * function
+       * @param block Block to be applied
        * @param predicate Checks whether block is applicable prior to applying
        * transactions
-       * @return True if blocks were successfully applied, false otherwise.
+       * @return True if block was successfully applied, false otherwise.
        */
       virtual bool apply(
-          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-              blocks,
+          std::shared_ptr<const shared_model::interface::Block> block,
           MutableStoragePredicate predicate) = 0;
 
       /// Apply the local changes made to this MutableStorage to block_storage

--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -32,11 +32,11 @@ namespace iroha {
 
     /// Current pair is valid
     struct PairValid : public BaseGateObject {
-      std::shared_ptr<shared_model::interface::Block> block;
+      std::shared_ptr<const shared_model::interface::Block> block;
 
       PairValid(consensus::Round round,
                 std::shared_ptr<const LedgerState> ledger_state,
-                std::shared_ptr<shared_model::interface::Block> block)
+                std::shared_ptr<const shared_model::interface::Block> block)
           : BaseGateObject(std::move(round), std::move(ledger_state)),
             block(std::move(block)) {}
     };

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -41,7 +41,6 @@ namespace iroha {
           boost::optional<ClusterOrdering> alternative_order,
           std::shared_ptr<const LedgerState> ledger_state,
           std::shared_ptr<YacHashProvider> hash_provider,
-          std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<consensus::ConsensusResultCache>
               consensus_result_cache,
           logger::LoggerPtr log,
@@ -99,12 +98,8 @@ namespace iroha {
             }()),
             orderer_(std::move(orderer)),
             hash_provider_(std::move(hash_provider)),
-            block_creator_(std::move(block_creator)),
             consensus_result_cache_(std::move(consensus_result_cache)),
-            hash_gate_(std::move(hash_gate)) {
-        block_creator_->onBlock().subscribe(
-            [this](const auto &event) { this->vote(event); });
-      }
+            hash_gate_(std::move(hash_gate)) {}
 
       void YacGateImpl::vote(const simulator::BlockCreatorEvent &event) {
         if (current_hash_.vote_round >= event.round) {

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -41,7 +41,6 @@ namespace iroha {
             boost::optional<ClusterOrdering> alternative_order,
             std::shared_ptr<const LedgerState> ledger_state,
             std::shared_ptr<YacHashProvider> hash_provider,
-            std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<consensus::ConsensusResultCache>
                 consensus_result_cache,
             logger::LoggerPtr log,
@@ -76,7 +75,6 @@ namespace iroha {
         rxcpp::observable<GateObject> published_events_;
         std::shared_ptr<YacPeerOrderer> orderer_;
         std::shared_ptr<YacHashProvider> hash_provider_;
-        std::shared_ptr<simulator::BlockCreator> block_creator_;
         std::shared_ptr<consensus::ConsensusResultCache>
             consensus_result_cache_;
         std::shared_ptr<HashGate> hash_gate_;

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -110,7 +110,6 @@ target_link_libraries(irohad
     logger_manager
     irohad_version
     pg_connection_init
-    async_subscription
     maintenance
     )
 

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -37,6 +37,7 @@
 #include "main/impl/pg_connection_init.hpp"
 #include "main/impl/storage_init.hpp"
 #include "main/server_runner.hpp"
+#include "main/subscription.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy.hpp"
 #include "multi_sig_transactions/mst_processor_impl.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy_stub.hpp"
@@ -128,7 +129,8 @@ Irohad::Irohad(
       yac_init(std::make_unique<iroha::consensus::yac::YacInit>()),
       consensus_gate_objects(consensus_gate_objects_lifetime),
       log_manager_(std::move(logger_manager)),
-      log_(log_manager_->getLogger()) {
+      log_(log_manager_->getLogger()),
+      subscription_engine_(getSubscription()) {
   log_->info("created");
   // TODO: rework in a more C++11+ - ish way luckychess 29.06.2019 IR-575
   std::srand(std::time(0));
@@ -154,6 +156,7 @@ Irohad::~Irohad() {
   }
   consensus_gate_objects_lifetime.unsubscribe();
   consensus_gate_events_subscription.unsubscribe();
+  subscription_engine_->dispose();
 }
 
 /**
@@ -1018,6 +1021,7 @@ Irohad::RunResult Irohad::run() {
             SynchronizationOutcomeType::kCommit,
             {block_height, ordering::kFirstRejectRound},
             *initial_ledger_state});
+
     return {};
   };
 }

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -350,6 +350,7 @@ class Irohad {
   std::shared_ptr<iroha::MstProcessor> mst_processor;
 
   // transaction service
+  rxcpp::composite_subscription tx_processor_lifetime_;
   std::shared_ptr<iroha::torii::CommandService> command_service;
   std::shared_ptr<iroha::torii::CommandServiceTransportGrpc>
       command_service_transport;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -71,7 +71,7 @@ namespace iroha {
     class CommandService;
     class CommandServiceTransportGrpc;
     class QueryService;
-
+    class TransactionProcessor;
     struct TlsParams;
   }  // namespace torii
   namespace validation {
@@ -351,6 +351,7 @@ class Irohad {
 
   // transaction service
   rxcpp::composite_subscription tx_processor_lifetime_;
+  std::shared_ptr<iroha::torii::TransactionProcessor> tx_processor;
   std::shared_ptr<iroha::torii::CommandService> command_service;
   std::shared_ptr<iroha::torii::CommandServiceTransportGrpc>
       command_service_transport;

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -21,6 +21,7 @@
 #include "main/iroha_conf_loader.hpp"
 #include "main/server_runner.hpp"
 #include "main/startup_params.hpp"
+#include "main/subscription_fwd.hpp"
 #include "multi_sig_transactions/gossip_propagation_strategy_params.hpp"
 #include "torii/tls_params.hpp"
 
@@ -370,6 +371,8 @@ class Irohad {
   logger::LoggerManagerTreePtr log_manager_;  ///< application root log manager
 
   logger::LoggerPtr log_;  ///< log for local messages
+
+  std::shared_ptr<iroha::Subscription> subscription_engine_;
 };
 
 #endif  // IROHA_APPLICATION_HPP

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -90,7 +90,6 @@ namespace iroha {
           boost::optional<shared_model::interface::types::PeerList>
               alternative_peers,
           std::shared_ptr<const LedgerState> ledger_state,
-          std::shared_ptr<simulator::BlockCreator> block_creator,
           std::shared_ptr<network::BlockLoader> block_loader,
           const shared_model::crypto::Keypair &keypair,
           std::shared_ptr<consensus::ConsensusResultCache>
@@ -136,7 +135,6 @@ namespace iroha {
                 [](auto &peers) { return ClusterOrdering::create(peers); },
             std::move(ledger_state),
             hash_provider,
-            block_creator,
             std::move(consensus_result_cache),
             consensus_log_manager->getChild("Gate")->getLogger(),
             ConsensusOutcomeDelay(delay));

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -22,7 +22,6 @@
 #include "logger/logger_manager_fwd.hpp"
 #include "network/block_loader.hpp"
 #include "network/impl/async_grpc_client.hpp"
-#include "simulator/block_creator.hpp"
 
 namespace iroha {
   namespace network {
@@ -40,7 +39,6 @@ namespace iroha {
             boost::optional<shared_model::interface::types::PeerList>
                 alternative_peers,
             std::shared_ptr<const LedgerState> ledger_state,
-            std::shared_ptr<simulator::BlockCreator> block_creator,
             std::shared_ptr<network::BlockLoader> block_loader,
             const shared_model::crypto::Keypair &keypair,
             std::shared_ptr<consensus::ConsensusResultCache> block_cache,

--- a/irohad/main/subscription.hpp
+++ b/irohad/main/subscription.hpp
@@ -8,65 +8,13 @@
 
 #include <memory>
 
+#include "main/subscription_fwd.hpp"
+
 #include "subscription/common.hpp"
 #include "subscription/subscriber_impl.hpp"
 #include "subscription/subscription_manager.hpp"
 
 namespace iroha {
-  enum SubscriptionEngineHandlers {
-    kYac = 0,
-    kRequestProposal,
-    kVoteProcess,
-    //---------------
-    kTotalCount
-  };
-
-  enum EventTypes {
-    kOnOutcome = 0,
-    kOnSynchronization,
-    kOnInitialSynchronization,
-    kOnCurrentRoundPeers,
-    kOnRoundSwitch,
-    kOnProposal,
-    kOnVerifiedProposal,
-    kOnProcessedHashes,
-    kOnOutcomeFromYac,
-    kOnOutcomeDelayed,
-    kOnBlock,
-    kOnInitialBlock,
-    kOnBlockCreatorEvent,
-    kOnFinalizedTxs,
-    kOnApplyState,
-    kOnNeedProposal,
-    kOnNewProposal,
-
-    // MST
-    kOnStateUpdate,
-    kOnPreparedBatches,
-    kOnExpiredBatches,
-
-    // YAC
-    kTimer,
-
-    // TEST
-    kOnTestOperationComplete
-  };
-
-  static constexpr uint32_t kThreadPoolSize = 3u;
-
-  using Dispatcher =
-      subscription::IDispatcher<SubscriptionEngineHandlers::kTotalCount,
-                                kThreadPoolSize>;
-  using Subscription =
-      subscription::SubscriptionManager<SubscriptionEngineHandlers::kTotalCount,
-                                        kThreadPoolSize>;
-  template <typename ObjectType, typename... EventData>
-  using BaseSubscriber =
-      subscription::SubscriberImpl<EventTypes,
-                                   typename Subscription::Dispatcher,
-                                   ObjectType,
-                                   EventData...>;
-
   std::shared_ptr<Dispatcher> getDispatcher();
   std::shared_ptr<Subscription> getSubscription();
 

--- a/irohad/main/subscription_fwd.hpp
+++ b/irohad/main/subscription_fwd.hpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_SUBSCRIPTION_FWD_HPP
+#define IROHA_SUBSCRIPTION_FWD_HPP
+
+#include <memory>
+
+namespace iroha {
+  enum SubscriptionEngineHandlers {
+    kYac = 0,
+    kRequestProposal,
+    kVoteProcess,
+    //---------------
+    kTotalCount
+  };
+
+  enum EventTypes {
+    kOnOutcome = 0,
+    kOnSynchronization,
+    kOnInitialSynchronization,
+    kOnCurrentRoundPeers,
+    kOnRoundSwitch,
+    kOnProposal,
+    kOnVerifiedProposal,
+    kOnProcessedHashes,
+    kOnOutcomeFromYac,
+    kOnOutcomeDelayed,
+    kOnBlock,
+    kOnInitialBlock,
+    kOnBlockCreatorEvent,
+    kOnFinalizedTxs,
+    kOnApplyState,
+    kOnNeedProposal,
+    kOnNewProposal,
+
+    // MST
+    kOnStateUpdate,
+    kOnPreparedBatches,
+    kOnExpiredBatches,
+
+    // YAC
+    kTimer,
+
+    // TEST
+    kOnTestOperationComplete
+  };
+
+  static constexpr uint32_t kThreadPoolSize = 3u;
+
+  namespace subscription {
+    template <uint32_t kCount, uint32_t kPoolSize>
+    struct IDispatcher;
+
+    template <uint32_t kHandlersCount, uint32_t kPoolSize>
+    class SubscriptionManager;
+
+    template <typename EventKey,
+              typename Dispatcher,
+              typename Receiver,
+              typename... Arguments>
+    class SubscriberImpl;
+  }  // namespace subscription
+
+  using Dispatcher =
+      subscription::IDispatcher<SubscriptionEngineHandlers::kTotalCount,
+                                kThreadPoolSize>;
+  using Subscription =
+      subscription::SubscriptionManager<SubscriptionEngineHandlers::kTotalCount,
+                                        kThreadPoolSize>;
+  template <typename ObjectType, typename... EventData>
+  using BaseSubscriber = subscription::SubscriberImpl<
+      EventTypes,
+      Dispatcher,
+      ObjectType,
+      EventData...>;
+
+}  // namespace iroha
+
+#endif  // IROHA_SUBSCRIPTION_FWD_HPP

--- a/irohad/network/block_loader.hpp
+++ b/irohad/network/block_loader.hpp
@@ -7,7 +7,8 @@
 #define IROHA_BLOCK_LOADER_HPP
 
 #include <memory>
-#include <rxcpp/rx-observable-fwd.hpp>
+
+#include <boost/range/any_range.hpp>
 
 #include "interfaces/common_objects/types.hpp"
 #include "interfaces/iroha_internal/block.hpp"
@@ -26,7 +27,9 @@ namespace iroha {
        * @return
        */
       virtual iroha::expected::Result<
-          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>,
+          boost::any_range<
+              std::shared_ptr<const shared_model::interface::Block>,
+              boost::single_pass_traversal_tag>,
           std::string>
       retrieveBlocks(const shared_model::interface::types::HeightType height,
                      shared_model::interface::types::PublicKeyHexStringView

--- a/irohad/network/impl/block_loader_impl.cpp
+++ b/irohad/network/impl/block_loader_impl.cpp
@@ -10,7 +10,6 @@
 
 #include <fmt/core.h>
 #include <grpc++/create_channel.h>
-#include <rxcpp/rx-lite.hpp>
 #include "backend/protobuf/block.hpp"
 #include "builders/protobuf/transport_builder.hpp"
 #include "common/bind.hpp"
@@ -35,44 +34,99 @@ BlockLoaderImpl::BlockLoaderImpl(
       client_factory_(std::move(client_factory)),
       log_(std::move(log)) {}
 
-Result<rxcpp::observable<std::shared_ptr<Block>>, std::string>
+Result<boost::any_range<std::shared_ptr<const shared_model::interface::Block>,
+                        boost::single_pass_traversal_tag>,
+       std::string>
 BlockLoaderImpl::retrieveBlocks(
     const shared_model::interface::types::HeightType height,
     types::PublicKeyHexStringView peer_pubkey) {
   return findPeer(peer_pubkey) | [&](const auto &peer) {
     return client_factory_->createClient(*peer) | [&](auto client) {
-      std::shared_ptr<typename decltype(client)::element_type> shared_client(
-          std::move(client));
-      return rxcpp::observable<std::shared_ptr<Block>>(
-          rxcpp::observable<>::create<std::shared_ptr<Block>>(
-              [height, shared_client, block_factory = block_factory_](
-                  auto subscriber) {
-                grpc::ClientContext context;
-                context.set_deadline(std::chrono::system_clock::now() + std::chrono::minutes(1ull));
+      using ClientType = decltype(client);
 
-                proto::BlockRequest request;
-                request.set_height(height
-                                   + 1);  // request next block to our top
-                auto reader = shared_client->retrieveBlocks(&context, request);
-                protocol::Block block;
-                while (subscriber.is_subscribed() and reader->Read(&block)) {
-                  block_factory->createBlock(std::move(block))
-                      .match(
-                          [&](auto &&result) {
-                            subscriber.on_next(std::move(result.value));
-                          },
-                          [&](const auto &error) {
-                            context.TryCancel();
-                            reader->Finish();
-                            subscriber.on_error(std::make_exception_ptr(
-                                std::runtime_error(fmt::format(
-                                    "Failed to parse received block: {}.",
-                                    error.error))));
-                          });
-                }
-                reader->Finish();
-                subscriber.on_completed();
-              }));
+      proto::BlockRequest request;
+      request.set_height(height + 1);  // request next block to our top
+
+      struct iterator {
+        using iterator_category = std::input_iterator_tag;
+        using value_type =
+            std::shared_ptr<const shared_model::interface::Block>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = std::add_pointer_t<value_type>;
+        using reference =
+            std::add_lvalue_reference_t<std::add_const_t<value_type>>;
+
+        iterator() {}
+
+        iterator(
+            std::weak_ptr<shared_model::proto::ProtoBlockFactory> block_factory,
+            std::weak_ptr<logger::Logger> log,
+            ClientType client,
+            proto::BlockRequest request)
+            : state(std::make_shared<struct state>()) {
+          state->block_factory = std::move(block_factory);
+          state->log = std::move(log);
+          state->reader = client->retrieveBlocks(&state->context, request);
+          state->client = std::move(client);
+          state->context.set_deadline(std::chrono::system_clock::now()
+                                      + std::chrono::minutes(1ull));
+          ++(*this);
+        }
+
+        iterator &operator++() {
+          auto maybe_block_factory = state->block_factory.lock();
+          auto maybe_log = state->log.lock();
+          protocol::Block proto_block;
+          if (maybe_block_factory and state->reader->Read(&proto_block)) {
+            maybe_block_factory->createBlock(std::move(proto_block))
+                .match([&](auto &&result) { block = std::move(result.value); },
+                       [&](const auto &error) {
+                         state->context.TryCancel();
+                         state->reader->Finish();
+                         block.reset();
+                         maybe_log->error("Failed to parse received block: {}.",
+                                          error.error);
+                       });
+          } else {
+            state->reader->Finish();
+            block.reset();
+          }
+          return *this;
+        }
+
+        iterator operator++(int) {
+          iterator ret = *this;
+          ++(*this);
+          return ret;
+        }
+
+        reference operator*() const {
+          return block;
+        }
+
+        bool operator==(iterator const &other) const {
+          return block == other.block;
+        }
+
+        bool operator!=(iterator const &other) const {
+          return !(*this == other);
+        }
+
+        struct state {
+          std::weak_ptr<shared_model::proto::ProtoBlockFactory> block_factory;
+          std::weak_ptr<logger::Logger> log;
+          grpc::ClientContext context;
+          ClientType client;
+          std::unique_ptr<grpc::ClientReaderInterface<protocol::Block>> reader;
+        };
+
+        std::shared_ptr<state> state;
+        std::shared_ptr<const shared_model::interface::Block> block;
+      };
+
+      return boost::make_iterator_range(
+          iterator(block_factory_, log_, std::move(client), std::move(request)),
+          iterator{});
     };
   };
 }

--- a/irohad/network/impl/block_loader_impl.hpp
+++ b/irohad/network/impl/block_loader_impl.hpp
@@ -34,7 +34,9 @@ namespace iroha {
           std::unique_ptr<ClientFactory> client_factory);
 
       iroha::expected::Result<
-          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>,
+          boost::any_range<
+              std::shared_ptr<const shared_model::interface::Block>,
+              boost::single_pass_traversal_tag>,
           std::string>
       retrieveBlocks(const shared_model::interface::types::HeightType height,
                      shared_model::interface::types::PublicKeyHexStringView

--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -10,18 +10,15 @@
 #include "logger/logger.hpp"
 #include "network/ordering_gate.hpp"
 #include "simulator/verified_proposal_creator.hpp"
-#include "synchronizer/synchronizer.hpp"
 
 namespace iroha {
   namespace network {
     PeerCommunicationServiceImpl::PeerCommunicationServiceImpl(
         std::shared_ptr<OrderingGate> ordering_gate,
-        std::shared_ptr<synchronizer::Synchronizer> synchronizer,
         std::shared_ptr<iroha::simulator::VerifiedProposalCreator>
             proposal_creator,
         logger::LoggerPtr log)
         : ordering_gate_(std::move(ordering_gate)),
-          synchronizer_(std::move(synchronizer)),
           proposal_creator_(std::move(proposal_creator)),
           log_{std::move(log)} {}
 
@@ -40,11 +37,6 @@ namespace iroha {
     rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
     PeerCommunicationServiceImpl::onVerifiedProposal() const {
       return proposal_creator_->onVerifiedProposal();
-    }
-
-    rxcpp::observable<synchronizer::SynchronizationEvent>
-    PeerCommunicationServiceImpl::onSynchronization() const {
-      return synchronizer_->on_commit_chain();
     }
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/impl/peer_communication_service_impl.cpp
+++ b/irohad/network/impl/peer_communication_service_impl.cpp
@@ -9,17 +9,13 @@
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "logger/logger.hpp"
 #include "network/ordering_gate.hpp"
-#include "simulator/verified_proposal_creator.hpp"
 
 namespace iroha {
   namespace network {
     PeerCommunicationServiceImpl::PeerCommunicationServiceImpl(
         std::shared_ptr<OrderingGate> ordering_gate,
-        std::shared_ptr<iroha::simulator::VerifiedProposalCreator>
-            proposal_creator,
         logger::LoggerPtr log)
         : ordering_gate_(std::move(ordering_gate)),
-          proposal_creator_(std::move(proposal_creator)),
           log_{std::move(log)} {}
 
     void PeerCommunicationServiceImpl::propagate_batch(
@@ -32,11 +28,6 @@ namespace iroha {
     rxcpp::observable<OrderingEvent> PeerCommunicationServiceImpl::onProposal()
         const {
       return ordering_gate_->onProposal();
-    }
-
-    rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
-    PeerCommunicationServiceImpl::onVerifiedProposal() const {
-      return proposal_creator_->onVerifiedProposal();
     }
   }  // namespace network
 }  // namespace iroha

--- a/irohad/network/impl/peer_communication_service_impl.hpp
+++ b/irohad/network/impl/peer_communication_service_impl.hpp
@@ -11,14 +11,6 @@
 #include "logger/logger_fwd.hpp"
 
 namespace iroha {
-  namespace simulator {
-    class VerifiedProposalCreator;
-  }  // namespace simulator
-
-  namespace synchronizer {
-    class Synchronizer;
-  }  // namespace synchronizer
-
   namespace network {
     class OrderingGate;
 
@@ -26,7 +18,6 @@ namespace iroha {
      public:
       PeerCommunicationServiceImpl(
           std::shared_ptr<OrderingGate> ordering_gate,
-          std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator,
           logger::LoggerPtr log);
 
       void propagate_batch(
@@ -35,12 +26,8 @@ namespace iroha {
 
       rxcpp::observable<OrderingEvent> onProposal() const override;
 
-      rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
-      onVerifiedProposal() const override;
-
      private:
       std::shared_ptr<OrderingGate> ordering_gate_;
-      std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator_;
       logger::LoggerPtr log_;
     };
   }  // namespace network

--- a/irohad/network/impl/peer_communication_service_impl.hpp
+++ b/irohad/network/impl/peer_communication_service_impl.hpp
@@ -26,7 +26,6 @@ namespace iroha {
      public:
       PeerCommunicationServiceImpl(
           std::shared_ptr<OrderingGate> ordering_gate,
-          std::shared_ptr<synchronizer::Synchronizer> synchronizer,
           std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator,
           logger::LoggerPtr log);
 
@@ -39,12 +38,8 @@ namespace iroha {
       rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
       onVerifiedProposal() const override;
 
-      rxcpp::observable<synchronizer::SynchronizationEvent> onSynchronization()
-          const override;
-
      private:
       std::shared_ptr<OrderingGate> ordering_gate_;
-      std::shared_ptr<synchronizer::Synchronizer> synchronizer_;
       std::shared_ptr<simulator::VerifiedProposalCreator> proposal_creator_;
       logger::LoggerPtr log_;
     };

--- a/irohad/network/peer_communication_service.hpp
+++ b/irohad/network/peer_communication_service.hpp
@@ -9,7 +9,6 @@
 #include <rxcpp/rx-observable-fwd.hpp>
 #include "network/ordering_gate_common.hpp"
 #include "simulator/verified_proposal_creator_common.hpp"
-#include "synchronizer/synchronizer_common.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -47,17 +46,6 @@ namespace iroha {
        */
       virtual rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
       onVerifiedProposal() const = 0;
-
-      /**
-       * Event is triggered when commit block arrives.
-       * @return observable with sequence of committed blocks.
-       * In common case observable<Block> will contain one element.
-       * But there are scenarios when consensus provide many blocks, e.g.
-       * on peer startup - peer will get all actual blocks.
-       * Also, it can provide no blocks at all, if commit was empty
-       */
-      virtual rxcpp::observable<synchronizer::SynchronizationEvent>
-      onSynchronization() const = 0;
 
       virtual ~PeerCommunicationService() = default;
     };

--- a/irohad/network/peer_communication_service.hpp
+++ b/irohad/network/peer_communication_service.hpp
@@ -8,7 +8,6 @@
 
 #include <rxcpp/rx-observable-fwd.hpp>
 #include "network/ordering_gate_common.hpp"
-#include "simulator/verified_proposal_creator_common.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -39,13 +38,6 @@ namespace iroha {
        * (List of Proposals)
        */
       virtual rxcpp::observable<OrderingEvent> onProposal() const = 0;
-
-      /**
-       * Event is triggered when verified proposal arrives
-       * @return verified proposal and list of stateful validation errors
-       */
-      virtual rxcpp::observable<simulator::VerifiedProposalCreatorEvent>
-      onVerifiedProposal() const = 0;
 
       virtual ~PeerCommunicationService() = default;
     };

--- a/irohad/simulator/block_creator.hpp
+++ b/irohad/simulator/block_creator.hpp
@@ -6,15 +6,11 @@
 #ifndef IROHA_BLOCK_CREATOR_HPP
 #define IROHA_BLOCK_CREATOR_HPP
 
-#include <rxcpp/rx-observable-fwd.hpp>
 #include "simulator/block_creator_common.hpp"
 
 namespace iroha {
-  namespace validation {
-    struct VerifiedProposalAndErrors;
-  }
-
   namespace simulator {
+    struct VerifiedProposalCreatorEvent;
 
     /**
      * Interface for creating blocks from proposal
@@ -24,16 +20,8 @@ namespace iroha {
       /**
        * Creates a block from given proposal and top block info
        */
-      virtual boost::optional<std::shared_ptr<shared_model::interface::Block>>
-      processVerifiedProposal(
-          const std::shared_ptr<validation::VerifiedProposalAndErrors>
-              &verified_proposal_and_errors,
-          const TopBlockInfo &top_block_info) = 0;
-
-      /**
-       * Emit blocks made from proposals
-       */
-      virtual rxcpp::observable<BlockCreatorEvent> onBlock() = 0;
+      virtual BlockCreatorEvent processVerifiedProposal(
+          VerifiedProposalCreatorEvent const &event) = 0;
 
       virtual ~BlockCreator() = default;
     };

--- a/irohad/simulator/impl/simulator.hpp
+++ b/irohad/simulator/impl/simulator.hpp
@@ -9,8 +9,6 @@
 #include "simulator/block_creator.hpp"
 #include "simulator/verified_proposal_creator.hpp"
 
-#include <boost/optional.hpp>
-#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/temporary_factory.hpp"
 #include "cryptography/crypto_provider/abstract_crypto_model_signer.hpp"
 #include "interfaces/iroha_internal/unsafe_block_factory.hpp"
@@ -34,7 +32,6 @@ namespace iroha {
           // TODO IR-598 mboldyrev 2019.08.10: remove command_executor from
           // Simulator
           std::unique_ptr<iroha::ametsuchi::CommandExecutor> command_executor,
-          std::shared_ptr<network::OrderingGate> ordering_gate,
           std::shared_ptr<validation::StatefulValidator> statefulValidator,
           std::shared_ptr<ametsuchi::TemporaryFactory> factory,
           std::shared_ptr<CryptoSignerType> crypto_signer,
@@ -42,33 +39,15 @@ namespace iroha {
               block_factory,
           logger::LoggerPtr log);
 
-      ~Simulator() override;
+      VerifiedProposalCreatorEvent processProposal(
+          network::OrderingEvent const &event) override;
 
-      std::shared_ptr<validation::VerifiedProposalAndErrors> processProposal(
-          const shared_model::interface::Proposal &proposal) override;
-
-      rxcpp::observable<VerifiedProposalCreatorEvent> onVerifiedProposal()
-          override;
-
-      boost::optional<std::shared_ptr<shared_model::interface::Block>>
-      processVerifiedProposal(
-          const std::shared_ptr<iroha::validation::VerifiedProposalAndErrors>
-              &verified_proposal_and_errors,
-          const TopBlockInfo &top_block_info) override;
-
-      rxcpp::observable<BlockCreatorEvent> onBlock() override;
+      BlockCreatorEvent processVerifiedProposal(
+          VerifiedProposalCreatorEvent const &event) override;
 
      private:
       // internal
       std::shared_ptr<iroha::ametsuchi::CommandExecutor> command_executor_;
-
-      rxcpp::composite_subscription notifier_lifetime_;
-      rxcpp::subjects::subject<VerifiedProposalCreatorEvent> notifier_;
-      rxcpp::composite_subscription block_notifier_lifetime_;
-      rxcpp::subjects::subject<BlockCreatorEvent> block_notifier_;
-
-      rxcpp::composite_subscription proposal_subscription_;
-      rxcpp::composite_subscription verified_proposal_subscription_;
 
       std::shared_ptr<validation::StatefulValidator> validator_;
       std::shared_ptr<ametsuchi::TemporaryFactory> ametsuchi_factory_;

--- a/irohad/simulator/verified_proposal_creator.hpp
+++ b/irohad/simulator/verified_proposal_creator.hpp
@@ -6,20 +6,12 @@
 #ifndef IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 #define IROHA_VERIFIED_PROPOSAL_CREATOR_HPP
 
-#include <rxcpp/rx-observable-fwd.hpp>
 #include "simulator/verified_proposal_creator_common.hpp"
 
-namespace shared_model {
-  namespace interface {
-    class Proposal;
-  }  // namespace interface
-}  // namespace shared_model
-
 namespace iroha {
-  namespace consensus {
-    struct Round;
-  }  // namespace consensus
-
+  namespace network {
+    struct OrderingEvent;
+  }
   namespace simulator {
 
     /**
@@ -30,14 +22,8 @@ namespace iroha {
       /**
        * Execute stateful validation for given proposal
        */
-      virtual std::shared_ptr<validation::VerifiedProposalAndErrors>
-      processProposal(const shared_model::interface::Proposal &proposal) = 0;
-
-      /**
-       * Emit proposals which were verified by stateful validator
-       */
-      virtual rxcpp::observable<VerifiedProposalCreatorEvent>
-      onVerifiedProposal() = 0;
+      virtual VerifiedProposalCreatorEvent processProposal(
+          network::OrderingEvent const &event) = 0;
 
       virtual ~VerifiedProposalCreator() = default;
     };

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -8,14 +8,12 @@
 
 #include "synchronizer/synchronizer.hpp"
 
-#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/commit_result.hpp"
 #include "ametsuchi/mutable_factory.hpp"
 #include "ametsuchi/peer_query_factory.hpp"
 #include "common/result_fwd.hpp"
 #include "logger/logger_fwd.hpp"
 #include "network/block_loader.hpp"
-#include "network/consensus_gate.hpp"
 #include "validation/chain_validator.hpp"
 
 namespace iroha {
@@ -31,17 +29,13 @@ namespace iroha {
      public:
       SynchronizerImpl(
           std::unique_ptr<iroha::ametsuchi::CommandExecutor> command_executor,
-          std::shared_ptr<network::ConsensusGate> consensus_gate,
           std::shared_ptr<validation::ChainValidator> validator,
           std::shared_ptr<ametsuchi::MutableFactory> mutable_factory,
           std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory,
           std::shared_ptr<network::BlockLoader> block_loader,
           logger::LoggerPtr log);
 
-      ~SynchronizerImpl() override;
-
-      void processOutcome(consensus::GateObject object) override;
-      rxcpp::observable<SynchronizationEvent> on_commit_chain() override;
+      SynchronizationEvent processOutcome(consensus::GateObject object) override;
 
      private:
       /**
@@ -58,14 +52,14 @@ namespace iroha {
           const shared_model::interface::types::PublicKeyCollectionType
               &public_keys);
 
-      void processNext(const consensus::PairValid &msg);
+      SynchronizationEvent processNext(const consensus::PairValid &msg);
 
       /**
        * Performs synchronization on rejects
        * @param msg - consensus gate message with a list of peers and a round
        * @param required_height - minimal top block height to be downloaded
        */
-      void processDifferent(
+      SynchronizationEvent processDifferent(
           const consensus::Synchronizable &msg,
           shared_model::interface::types::HeightType required_height);
 
@@ -79,11 +73,6 @@ namespace iroha {
       std::shared_ptr<ametsuchi::MutableFactory> mutable_factory_;
       std::shared_ptr<ametsuchi::BlockQueryFactory> block_query_factory_;
       std::shared_ptr<network::BlockLoader> block_loader_;
-
-      // internal
-      rxcpp::composite_subscription notifier_lifetime_;
-      rxcpp::subjects::subject<SynchronizationEvent> notifier_;
-      rxcpp::composite_subscription subscription_;
 
       logger::LoggerPtr log_;
     };

--- a/irohad/synchronizer/synchronizer.hpp
+++ b/irohad/synchronizer/synchronizer.hpp
@@ -6,8 +6,6 @@
 #ifndef IROHA_SYNCHRONIZER_HPP
 #define IROHA_SYNCHRONIZER_HPP
 
-#include <rxcpp/rx-observable-fwd.hpp>
-
 #include "consensus/gate_object.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
@@ -21,13 +19,8 @@ namespace iroha {
       /**
        * Processing entry point for consensus outcome
        */
-      virtual void processOutcome(consensus::GateObject object) = 0;
-
-      /**
-       * After synchronization this observable emits zero or more blocks plus
-       * outcome of synchronization
-       */
-      virtual rxcpp::observable<SynchronizationEvent> on_commit_chain() = 0;
+      virtual SynchronizationEvent processOutcome(
+          consensus::GateObject object) = 0;
 
       virtual ~Synchronizer() = default;
     };

--- a/irohad/synchronizer/synchronizer_common.hpp
+++ b/irohad/synchronizer/synchronizer_common.hpp
@@ -18,7 +18,12 @@ namespace iroha {
      * Outcome, which was decided by synchronizer based on consensus result and
      * current local ledger state
      */
-    enum class SynchronizationOutcomeType { kCommit, kReject, kNothing };
+    enum class SynchronizationOutcomeType {
+      kCommit,
+      kReject,
+      kNothing,
+      kError
+    };
 
     /**
      * Event, which is emitted by synchronizer, when it receives and processes

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/iroha_internal/transaction_sequence.hpp"
 #include "logger/logger.hpp"
 #include "multi_sig_transactions/state/mst_state.hpp"
+#include "simulator/verified_proposal_creator_common.hpp"
 #include "validation/stateful_validator_common.hpp"
 
 namespace iroha {

--- a/irohad/torii/processor/impl/transaction_processor_impl.cpp
+++ b/irohad/torii/processor/impl/transaction_processor_impl.cpp
@@ -5,8 +5,6 @@
 
 #include "torii/processor/transaction_processor_impl.hpp"
 
-#include <boost/format.hpp>
-
 #include "interfaces/iroha_internal/block.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
@@ -26,21 +24,24 @@ namespace iroha {
         const auto tx_hash = tx_hash_and_error.tx_hash.hex();
         const auto &cmd_error = tx_hash_and_error.error;
         if (not cmd_error.tx_passed_initial_validation) {
-          return (boost::format(
-                      "Stateful validation error: transaction %s "
-                      "did not pass initial verification: "
-                      "checking '%s', error code '%d', query arguments: %s")
-                  % tx_hash % cmd_error.name % cmd_error.error_code
-                  % cmd_error.error_extra)
-              .str();
+          return fmt::format(
+              "Stateful validation error: transaction {} did not pass initial "
+              "verification: checking '{}', error code '{}', query arguments: "
+              "{}",
+              tx_hash,
+              cmd_error.name,
+              cmd_error.error_code,
+              cmd_error.error_extra);
         }
-        return (boost::format(
-                    "Stateful validation error in transaction %s: "
-                    "command '%s' with index '%d' did not pass "
-                    "verification with code '%d', query arguments: %s")
-                % tx_hash % cmd_error.name % cmd_error.index
-                % cmd_error.error_code % cmd_error.error_extra)
-            .str();
+        return fmt::format(
+            "Stateful validation error in transaction {}: "
+            "command '{}' with index '{}' did not pass "
+            "verification with code '{}', query arguments: {}",
+            tx_hash,
+            cmd_error.name,
+            cmd_error.index,
+            cmd_error.error_code,
+            cmd_error.error_extra);
       }
     }  // namespace
 
@@ -50,75 +51,12 @@ namespace iroha {
         std::shared_ptr<iroha::torii::StatusBus> status_bus,
         std::shared_ptr<shared_model::interface::TxStatusFactory>
             status_factory,
-        rxcpp::observable<std::shared_ptr<const shared_model::interface::Block>>
-            commits,
         logger::LoggerPtr log)
         : pcs_(std::move(pcs)),
           mst_processor_(std::move(mst_processor)),
           status_bus_(std::move(status_bus)),
           status_factory_(std::move(status_factory)),
-          log_(std::move(log)) {
-      // process stateful validation results
-      pcs_->onVerifiedProposal().subscribe(
-          [this](const simulator::VerifiedProposalCreatorEvent &event) {
-            if (not event.verified_proposal_result) {
-              return;
-            }
-
-            const auto &proposal_and_errors = getVerifiedProposalUnsafe(event);
-
-            // notify about failed txs
-            const auto &errors = proposal_and_errors->rejected_transactions;
-            for (const auto &tx_error : errors) {
-              log_->info("{}", composeErrorMessage(tx_error));
-              this->publishStatus(TxStatusType::kStatefulFailed,
-                                  tx_error.tx_hash,
-                                  tx_error.error);
-            }
-            // notify about success txs
-            for (const auto &successful_tx :
-                 proposal_and_errors->verified_proposal->transactions()) {
-              log_->info("VerifiedProposalCreatorEvent StatefulValid: {}",
-                         successful_tx.hash().hex());
-              this->publishStatus(TxStatusType::kStatefulValid,
-                                  successful_tx.hash());
-            }
-          });
-
-      // commit transactions
-      commits.subscribe(
-          // on next
-          [this](auto block) {
-            for (const auto &tx : block->transactions()) {
-              const auto &hash = tx.hash();
-              log_->debug("Committed transaction: {}", hash.hex());
-              this->publishStatus(TxStatusType::kCommitted, hash);
-            }
-            for (const auto &rejected_tx_hash :
-                 block->rejected_transactions_hashes()) {
-              log_->debug("Rejected transaction: {}", rejected_tx_hash.hex());
-              this->publishStatus(TxStatusType::kRejected, rejected_tx_hash);
-            }
-          });
-
-      mst_processor_->onStateUpdate().subscribe([this](auto &&state) {
-        log_->info("MST state updated");
-        state->iterateTransactions([this](const auto &tx) {
-          this->publishStatus(TxStatusType::kMstPending, tx->hash());
-        });
-      });
-      mst_processor_->onPreparedBatches().subscribe([this](auto &&batch) {
-        log_->info("MST batch prepared");
-        this->publishEnoughSignaturesStatus(batch->transactions());
-        this->pcs_->propagate_batch(batch);
-      });
-      mst_processor_->onExpiredBatches().subscribe([this](auto &&batch) {
-        log_->info("MST batch {} is expired", batch->reducedHash());
-        for (auto &&tx : batch->transactions()) {
-          this->publishStatus(TxStatusType::kMstExpired, tx->hash());
-        }
-      });
-    }
+          log_(std::move(log)) {}
 
     void TransactionProcessorImpl::batchHandle(
         std::shared_ptr<shared_model::interface::TransactionBatch>
@@ -127,11 +65,74 @@ namespace iroha {
       if (transaction_batch->hasAllSignatures()
           and not mst_processor_->batchInStorage(transaction_batch)) {
         log_->info("propagating batch to PCS");
-        this->publishEnoughSignaturesStatus(transaction_batch->transactions());
+        publishEnoughSignaturesStatus(transaction_batch->transactions());
         pcs_->propagate_batch(transaction_batch);
       } else {
         log_->info("propagating batch to MST");
         mst_processor_->propagateBatch(transaction_batch);
+      }
+    }
+
+    void TransactionProcessorImpl::processVerifiedProposalCreatorEvent(
+        simulator::VerifiedProposalCreatorEvent const &event) {
+      if (not event.verified_proposal_result) {
+        return;
+      }
+
+      const auto &proposal_and_errors = getVerifiedProposalUnsafe(event);
+
+      // notify about failed txs
+      const auto &errors = proposal_and_errors->rejected_transactions;
+      for (const auto &tx_error : errors) {
+        log_->info("{}", composeErrorMessage(tx_error));
+        publishStatus(
+            TxStatusType::kStatefulFailed, tx_error.tx_hash, tx_error.error);
+      }
+      // notify about success txs
+      for (const auto &successful_tx :
+           proposal_and_errors->verified_proposal->transactions()) {
+        log_->info("VerifiedProposalCreatorEvent StatefulValid: {}",
+                   successful_tx.hash().hex());
+        publishStatus(TxStatusType::kStatefulValid, successful_tx.hash());
+      }
+    }
+
+    void TransactionProcessorImpl::processCommit(
+        std::shared_ptr<const shared_model::interface::Block> const &block) {
+      for (const auto &tx : block->transactions()) {
+        const auto &hash = tx.hash();
+        log_->debug("Committed transaction: {}", hash.hex());
+        publishStatus(TxStatusType::kCommitted, hash);
+      }
+      for (const auto &rejected_tx_hash :
+           block->rejected_transactions_hashes()) {
+        log_->debug("Rejected transaction: {}", rejected_tx_hash.hex());
+        publishStatus(TxStatusType::kRejected, rejected_tx_hash);
+      }
+    }
+
+    void TransactionProcessorImpl::processStateUpdate(
+        std::shared_ptr<MstState> const &state) {
+      log_->info("MST state updated");
+      state->iterateTransactions([this](const auto &tx) {
+        publishStatus(TxStatusType::kMstPending, tx->hash());
+      });
+    }
+
+    void TransactionProcessorImpl::processPreparedBatch(
+        std::shared_ptr<shared_model::interface::TransactionBatch> const
+            &batch) {
+      log_->info("MST batch prepared");
+      publishEnoughSignaturesStatus(batch->transactions());
+      pcs_->propagate_batch(batch);
+    }
+
+    void TransactionProcessorImpl::processExpiredBatch(
+        std::shared_ptr<shared_model::interface::TransactionBatch> const
+            &batch) {
+      log_->info("MST batch {} is expired", batch->reducedHash());
+      for (auto &&tx : batch->transactions()) {
+        publishStatus(TxStatusType::kMstExpired, tx->hash());
       }
     }
 
@@ -142,7 +143,7 @@ namespace iroha {
       auto tx_error = cmd_error.name.empty()
           ? shared_model::interface::TxStatusFactory::TransactionError{}
           : shared_model::interface::TxStatusFactory::TransactionError{
-                cmd_error.name, cmd_error.index, cmd_error.error_code};
+              cmd_error.name, cmd_error.index, cmd_error.error_code};
       switch (tx_status) {
         case TxStatusType::kStatelessFailed: {
           status_bus_->publish(
@@ -197,8 +198,7 @@ namespace iroha {
         const shared_model::interface::types::SharedTxsCollectionType &txs)
         const {
       for (const auto &tx : txs) {
-        this->publishStatus(TxStatusType::kEnoughSignaturesCollected,
-                            tx->hash());
+        publishStatus(TxStatusType::kEnoughSignaturesCollected, tx->hash());
       }
     }
   }  // namespace torii

--- a/irohad/torii/processor/transaction_processor.hpp
+++ b/irohad/torii/processor/transaction_processor.hpp
@@ -10,11 +10,16 @@
 
 namespace shared_model {
   namespace interface {
+    class Block;
     class TransactionBatch;
   }  // namespace interface
 }  // namespace shared_model
 
 namespace iroha {
+  class MstState;
+  namespace simulator {
+    struct VerifiedProposalCreatorEvent;
+  }
   namespace torii {
     /**
      * Transaction processor is interface with start point
@@ -29,6 +34,24 @@ namespace iroha {
       virtual void batchHandle(
           std::shared_ptr<shared_model::interface::TransactionBatch>
               transaction_batch) const = 0;
+
+      virtual void processVerifiedProposalCreatorEvent(
+          simulator::VerifiedProposalCreatorEvent const &event) = 0;
+
+      virtual void processCommit(
+          std::shared_ptr<shared_model::interface::Block const> const
+              &block) = 0;
+
+      virtual void processStateUpdate(
+          std::shared_ptr<MstState> const &state) = 0;
+
+      virtual void processPreparedBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> const
+              &batch) = 0;
+
+      virtual void processExpiredBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> const
+              &batch) = 0;
 
       virtual ~TransactionProcessor() = default;
     };

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -15,6 +15,7 @@
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "network/peer_communication_service.hpp"
 #include "torii/status_bus.hpp"
+#include "validation/stateful_validator_common.hpp"
 
 namespace iroha {
   namespace torii {

--- a/irohad/torii/processor/transaction_processor_impl.hpp
+++ b/irohad/torii/processor/transaction_processor_impl.hpp
@@ -8,9 +8,6 @@
 
 #include "torii/processor/transaction_processor.hpp"
 
-#include <mutex>
-
-#include <rxcpp/rx-lite.hpp>
 #include "interfaces/common_objects/transaction_sequence_common.hpp"
 #include "interfaces/iroha_internal/tx_status_factory.hpp"
 #include "interfaces/transaction_responses/tx_response.hpp"
@@ -28,7 +25,6 @@ namespace iroha {
        * @param mst_processor is a handler for multisignature transactions
        * @param status_bus is a common notifier for tx statuses
        * @param status_factory creates transaction statuses
-       * @param commits - an observable on committed blocks
        * @param log to print the progress
        */
       TransactionProcessorImpl(
@@ -37,13 +33,29 @@ namespace iroha {
           std::shared_ptr<iroha::torii::StatusBus> status_bus,
           std::shared_ptr<shared_model::interface::TxStatusFactory>
               status_factory,
-          rxcpp::observable<
-              std::shared_ptr<const shared_model::interface::Block>> commits,
           logger::LoggerPtr log);
 
       void batchHandle(
           std::shared_ptr<shared_model::interface::TransactionBatch>
               transaction_batch) const override;
+
+      void processVerifiedProposalCreatorEvent(
+          simulator::VerifiedProposalCreatorEvent const &event) override;
+
+      void processCommit(
+          std::shared_ptr<const shared_model::interface::Block> const
+              &block) override;
+
+      void processStateUpdate(
+          std::shared_ptr<MstState> const &state) override;
+
+      void processPreparedBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> const
+              &batch) override;
+
+      void processExpiredBatch(
+          std::shared_ptr<shared_model::interface::TransactionBatch> const
+              &batch) override;
 
      private:
       // connections
@@ -53,11 +65,6 @@ namespace iroha {
       std::shared_ptr<MstProcessor> mst_processor_;
 
       std::shared_ptr<iroha::torii::StatusBus> status_bus_;
-
-      // internal
-      rxcpp::subjects::subject<
-          std::shared_ptr<shared_model::interface::TransactionResponse>>
-          notifier_;
 
       // keeps hashes of transaction, which were committed during this round
       std::vector<shared_model::interface::types::HashType> current_txs_hashes_;

--- a/irohad/validation/chain_validator.hpp
+++ b/irohad/validation/chain_validator.hpp
@@ -8,8 +8,6 @@
 
 #include <memory>
 
-#include <rxcpp/rx-observable-fwd.hpp>
-
 namespace shared_model {
   namespace interface {
     class Block;
@@ -32,20 +30,18 @@ namespace iroha {
       virtual ~ChainValidator() = default;
 
       /**
-       * Try to apply the blocks from observable to the storage.
+       * Try to apply the block to the storage.
        *
-       * While applying the blocks it will validate all their signatures
+       * While applying the block it will validate all its signatures
        * and related meta information such as previous hash, height and
        * other meta information
-       * @param blocks - observable with all blocks, that should be applied
-       * atomically
+       * @param block - blocks that should be applied atomically
        * @param storage - storage to which the blocks are applied
        * @return true if commit is valid and successfully applied, false
        * otherwise
        */
       virtual bool validateAndApply(
-          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-              blocks,
+          std::shared_ptr<const shared_model::interface::Block> block,
           ametsuchi::MutableStorage &storage) const = 0;
     };
   }  // namespace validation

--- a/irohad/validation/impl/chain_validator_impl.cpp
+++ b/irohad/validation/impl/chain_validator_impl.cpp
@@ -6,7 +6,6 @@
 #include "validation/impl/chain_validator_impl.hpp"
 
 #include <boost/algorithm/string/join.hpp>
-#include <rxcpp/rx-lite.hpp>
 #include "ametsuchi/ledger_state.hpp"
 #include "ametsuchi/mutable_storage.hpp"
 #include "consensus/yac/supermajority_checker.hpp"
@@ -24,15 +23,13 @@ namespace iroha {
         : supermajority_checker_(supermajority_checker), log_(std::move(log)) {}
 
     bool ChainValidatorImpl::validateAndApply(
-        rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-            blocks,
+        std::shared_ptr<const shared_model::interface::Block> block,
         ametsuchi::MutableStorage &storage) const {
-      log_->info("validate chain...");
+      log_->info("validate block...");
 
-      return storage.apply(blocks,
-                           [this](auto block, const auto &ledger_state) {
-                             return this->validateBlock(block, ledger_state);
-                           });
+      return storage.apply(block, [this](auto block, const auto &ledger_state) {
+        return this->validateBlock(block, ledger_state);
+      });
     }
 
     bool ChainValidatorImpl::validatePreviousHash(

--- a/irohad/validation/impl/chain_validator_impl.hpp
+++ b/irohad/validation/impl/chain_validator_impl.hpp
@@ -37,8 +37,7 @@ namespace iroha {
                          logger::LoggerPtr log);
 
       bool validateAndApply(
-          rxcpp::observable<std::shared_ptr<shared_model::interface::Block>>
-              blocks,
+          std::shared_ptr<const shared_model::interface::Block> block,
           ametsuchi::MutableStorage &storage) const override;
 
      private:

--- a/test/framework/integration_framework/fake_peer/network/loader_grpc.cpp
+++ b/test/framework/integration_framework/fake_peer/network/loader_grpc.cpp
@@ -112,7 +112,10 @@ namespace integration_framework {
       for (auto &block : blocks) {
         iroha::protocol::Block proto_block;
         *proto_block.mutable_block_v1() = block->getTransport();
-        writer->Write(proto_block);
+        if (not writer->Write(proto_block)) {
+          log_->error("Broken stream to {}", context->peer());
+          break;
+        }
       }
       return ::grpc::Status::OK;
     }

--- a/test/framework/integration_framework/fake_peer/types.hpp
+++ b/test/framework/integration_framework/fake_peer/types.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <boost/optional.hpp>
+#include <boost/range/any_range.hpp>
 #include "interfaces/common_objects/types.hpp"
 
 namespace shared_model {
@@ -82,7 +83,8 @@ namespace integration_framework {
     using LoaderBlockRequestResult =
         boost::optional<std::shared_ptr<const shared_model::proto::Block>>;
     using LoaderBlocksRequestResult =
-        std::vector<std::shared_ptr<const shared_model::proto::Block>>;
+        boost::any_range<std::shared_ptr<const shared_model::proto::Block>,
+                         boost::single_pass_traversal_tag>;
     using OrderingProposalRequest = iroha::consensus::Round;
     using OrderingProposalRequestResult =
         boost::optional<std::shared_ptr<const shared_model::proto::Proposal>>;

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -509,13 +509,6 @@ namespace integration_framework {
     return iroha_instance_->getIrohaInstance()->getConsensusGate()->onOutcome();
   }
 
-  rxcpp::observable<iroha::synchronizer::SynchronizationEvent>
-  IntegrationTestFramework::getPcsOnCommitObservable() {
-    return iroha_instance_->getIrohaInstance()
-        ->getPeerCommunicationService()
-        ->onSynchronization();
-  }
-
   std::shared_ptr<iroha::ametsuchi::BlockQuery>
   IntegrationTestFramework::getBlockQuery() {
     return getIrohaInstance().getIrohaInstance()->getStorage()->getBlockQuery();

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -10,9 +10,7 @@
 #include <limits>
 #include <memory>
 #include <rxcpp/operators/rx-filter.hpp>
-#include <rxcpp/operators/rx-flat_map.hpp>
 #include <rxcpp/operators/rx-take.hpp>
-#include <rxcpp/operators/rx-zip.hpp>
 
 #include "ametsuchi/storage.hpp"
 #include "backend/protobuf/block.hpp"
@@ -44,6 +42,7 @@
 #include "interfaces/permissions.hpp"
 #include "logger/logger.hpp"
 #include "logger/logger_manager.hpp"
+#include "main/subscription.hpp"
 #include "module/irohad/ametsuchi/tx_presence_cache_stub.hpp"
 #include "module/irohad/common/validators_config.hpp"
 #include "module/shared_model/builders/protobuf/block.hpp"
@@ -57,6 +56,7 @@
 #include "network/impl/client_factory.hpp"
 #include "network/peer_communication_service.hpp"
 #include "ordering/impl/on_demand_os_client_grpc.hpp"
+#include "simulator/verified_proposal_creator_common.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 #include "torii/command_client.hpp"
 #include "torii/query_client.hpp"
@@ -416,31 +416,27 @@ namespace integration_framework {
       log_->info("proposal");
     });
 
-    auto proposal_flat_map =
-        [](auto t) -> rxcpp::observable<std::tuple_element_t<0, decltype(t)>> {
-      if (std::get<1>(t).proposal) {
-        return rxcpp::observable<>::just(std::get<0>(t));
-      }
-      return rxcpp::observable<>::empty<std::tuple_element_t<0, decltype(t)>>();
-    };
-
-    rxcpp::observable<iroha::simulator::VerifiedProposalCreatorEvent>
-        verified_proposals = iroha_instance_->getIrohaInstance()
-                                 ->getPeerCommunicationService()
-                                 ->onVerifiedProposal();
-
-    rxcpp::observable<std::tuple<iroha::simulator::VerifiedProposalCreatorEvent,
-                                 iroha::network::OrderingEvent>>
-        verified_proposals_with_events =
-            verified_proposals.zip(requested_proposals);
-    rxcpp::observable<iroha::simulator::VerifiedProposalCreatorEvent>
-        nonempty_proposals =
-            verified_proposals_with_events.flat_map(proposal_flat_map);
-    nonempty_proposals.subscribe([this](auto verified_proposal_and_errors) {
-      verified_proposal_queue_->push(
-          getVerifiedProposalUnsafe(verified_proposal_and_errors));
-      log_->info("verified proposal");
-    });
+    verified_proposal_subscription_ = iroha::SubscriberCreator<
+        bool,
+        iroha::simulator::VerifiedProposalCreatorEvent>::
+        template create<iroha::EventTypes::kOnVerifiedProposal,
+                        static_cast<iroha::SubscriptionEngineHandlers>(
+                            decltype(iroha::getSubscription())::element_type::
+                                Dispatcher::kExecuteInPool)>(
+            [verified_proposal_queue = std::weak_ptr(verified_proposal_queue_),
+             log = std::weak_ptr(log_)](auto,
+                                        auto verified_proposal_and_errors) {
+              auto maybe_verified_proposal_queue =
+                  verified_proposal_queue.lock();
+              auto maybe_log = log.lock();
+              if (maybe_verified_proposal_queue and maybe_log
+                  and verified_proposal_and_errors.verified_proposal_result) {
+                maybe_verified_proposal_queue->push(
+                    iroha::simulator::getVerifiedProposalUnsafe(
+                        verified_proposal_and_errors));
+                maybe_log->info("verified proposal");
+              }
+            });
 
     iroha_instance_->getIrohaInstance()->getStorage()->on_commit().subscribe(
         [this](auto committed_block) {

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -427,9 +427,6 @@ namespace integration_framework {
 
     rxcpp::observable<iroha::consensus::GateObject> getYacOnCommitObservable();
 
-    rxcpp::observable<iroha::synchronizer::SynchronizationEvent>
-    getPcsOnCommitObservable();
-
     /// Get block query for iroha block storage.
     std::shared_ptr<iroha::ametsuchi::BlockQuery> getBlockQuery();
 

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -19,6 +19,7 @@
 #include "logger/logger_manager_fwd.hpp"
 #include "main/iroha_conf_loader.hpp"
 #include "main/startup_params.hpp"
+#include "main/subscription_fwd.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
 namespace google {
@@ -79,6 +80,9 @@ namespace iroha {
     class Proposal;
     class Transaction;
   }  // namespace protocol
+  namespace simulator {
+      struct VerifiedProposalCreatorEvent;
+  }
   namespace validation {
     struct VerifiedProposalAndErrors;
   }
@@ -500,8 +504,12 @@ namespace integration_framework {
     std::unique_ptr<
         CheckerQueue<std::shared_ptr<const shared_model::interface::Proposal>>>
         proposal_queue_;
-    std::unique_ptr<CheckerQueue<VerifiedProposalType>>
+    std::shared_ptr<CheckerQueue<VerifiedProposalType>>
         verified_proposal_queue_;
+    std::shared_ptr<
+        iroha::BaseSubscriber<bool,
+                              iroha::simulator::VerifiedProposalCreatorEvent>>
+        verified_proposal_subscription_;
     std::unique_ptr<CheckerQueue<BlockType>> block_queue_;
     std::map<std::string, std::unique_ptr<CheckerQueue<TxResponseType>>>
         responses_queues_;

--- a/test/fuzzing/status_fuzz.cpp
+++ b/test/fuzzing/status_fuzz.cpp
@@ -44,8 +44,6 @@ struct CommandFixture {
   std::shared_ptr<iroha::ametsuchi::MockTxPresenceCache> tx_presence_cache_;
 
   rxcpp::subjects::subject<iroha::network::OrderingEvent> prop_notifier_;
-  rxcpp::subjects::subject<iroha::simulator::VerifiedProposalCreatorEvent>
-      vprop_notifier_;
   rxcpp::subjects::subject<iroha::DataType> mst_notifier_;
   rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
       mst_state_notifier_;
@@ -55,8 +53,6 @@ struct CommandFixture {
     pcs_ = std::make_shared<iroha::network::MockPeerCommunicationService>();
     EXPECT_CALL(*pcs_, onProposal())
         .WillRepeatedly(Return(prop_notifier_.get_observable()));
-    EXPECT_CALL(*pcs_, onVerifiedProposal())
-        .WillRepeatedly(Return(vprop_notifier_.get_observable()));
 
     mst_processor_ =
         std::make_shared<iroha::MockMstProcessor>(logger::getDummyLoggerPtr());

--- a/test/fuzzing/status_fuzz.cpp
+++ b/test/fuzzing/status_fuzz.cpp
@@ -21,7 +21,6 @@
 #include "module/irohad/common/validators_config.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
-#include "synchronizer/synchronizer_common.hpp"
 #include "torii/impl/command_service_impl.hpp"
 #include "torii/impl/status_bus_impl.hpp"
 #include "torii/processor/transaction_processor_impl.hpp"
@@ -47,9 +46,6 @@ struct CommandFixture {
   rxcpp::subjects::subject<iroha::network::OrderingEvent> prop_notifier_;
   rxcpp::subjects::subject<iroha::simulator::VerifiedProposalCreatorEvent>
       vprop_notifier_;
-  rxcpp::subjects::subject<
-      std::shared_ptr<const shared_model::interface::Block>>
-      commit_notifier_;
   rxcpp::subjects::subject<iroha::DataType> mst_notifier_;
   rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
       mst_state_notifier_;
@@ -79,7 +75,6 @@ struct CommandFixture {
         mst_processor_,
         status_bus,
         status_factory,
-        commit_notifier_.get_observable(),
         logger::getDummyLoggerPtr());
 
     std::unique_ptr<shared_model::validation::AbstractValidator<

--- a/test/fuzzing/torii_fuzz.cpp
+++ b/test/fuzzing/torii_fuzz.cpp
@@ -20,7 +20,6 @@
 #include "module/irohad/common/validators_config.hpp"
 #include "module/irohad/multi_sig_transactions/mst_mocks.hpp"
 #include "module/irohad/network/network_mocks.hpp"
-#include "synchronizer/synchronizer_common.hpp"
 #include "torii/impl/command_service_impl.hpp"
 #include "torii/impl/status_bus_impl.hpp"
 #include "torii/processor/transaction_processor_impl.hpp"
@@ -44,22 +43,15 @@ struct CommandFixture {
   rxcpp::subjects::subject<iroha::network::OrderingEvent> prop_notifier_;
   rxcpp::subjects::subject<iroha::simulator::VerifiedProposalCreatorEvent>
       vprop_notifier_;
-  rxcpp::subjects::subject<iroha::synchronizer::SynchronizationEvent>
-      sync_event_notifier_;
   rxcpp::subjects::subject<iroha::DataType> mst_notifier_;
   rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
       mst_state_notifier_;
   rxcpp::subjects::subject<iroha::consensus::GateObject> consensus_notifier_;
-  rxcpp::subjects::subject<
-      std::shared_ptr<const shared_model::interface::Block>>
-      commit_notifier_;
 
   CommandFixture() {
     pcs_ = std::make_shared<iroha::network::MockPeerCommunicationService>();
     EXPECT_CALL(*pcs_, onProposal())
         .WillRepeatedly(Return(prop_notifier_.get_observable()));
-    EXPECT_CALL(*pcs_, onSynchronization())
-        .WillRepeatedly(Return(sync_event_notifier_.get_observable()));
     EXPECT_CALL(*pcs_, onVerifiedProposal())
         .WillRepeatedly(Return(vprop_notifier_.get_observable()));
 
@@ -82,7 +74,6 @@ struct CommandFixture {
         mst_processor_,
         status_bus,
         status_factory,
-        commit_notifier_.get_observable(),
         logger::getDummyLoggerPtr());
     auto storage = std::make_shared<iroha::ametsuchi::MockStorage>();
     service_ = std::make_shared<iroha::torii::CommandServiceImpl>(

--- a/test/fuzzing/torii_fuzz.cpp
+++ b/test/fuzzing/torii_fuzz.cpp
@@ -41,8 +41,6 @@ struct CommandFixture {
   std::shared_ptr<iroha::ametsuchi::MockTxPresenceCache> tx_presence_cache_;
 
   rxcpp::subjects::subject<iroha::network::OrderingEvent> prop_notifier_;
-  rxcpp::subjects::subject<iroha::simulator::VerifiedProposalCreatorEvent>
-      vprop_notifier_;
   rxcpp::subjects::subject<iroha::DataType> mst_notifier_;
   rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
       mst_state_notifier_;
@@ -52,8 +50,6 @@ struct CommandFixture {
     pcs_ = std::make_shared<iroha::network::MockPeerCommunicationService>();
     EXPECT_CALL(*pcs_, onProposal())
         .WillRepeatedly(Return(prop_notifier_.get_observable()));
-    EXPECT_CALL(*pcs_, onVerifiedProposal())
-        .WillRepeatedly(Return(vprop_notifier_.get_observable()));
 
     mst_processor_ =
         std::make_shared<iroha::MockMstProcessor>(logger::getDummyLoggerPtr());

--- a/test/integration/validation/chain_validator_storage_test.cpp
+++ b/test/integration/validation/chain_validator_storage_test.cpp
@@ -104,10 +104,15 @@ namespace iroha {
 
     /// Create an observable from chain and return its validation status
     auto createAndValidateChain(
-        std::vector<std::shared_ptr<shared_model::interface::Block>> chain) {
+        std::vector<std::shared_ptr<const shared_model::interface::Block>>
+            chain) {
       auto ms = createMutableStorage();
-      return validator->validateAndApply(rxcpp::observable<>::iterate(chain),
-                                         *ms);
+      for (auto &block : chain) {
+        if (not validator->validateAndApply(block, *ms)) {
+          return false;
+        }
+      }
+      return true;
     }
 
     std::shared_ptr<validation::ChainValidatorImpl> validator;

--- a/test/module/irohad/ametsuchi/ametsuchi_test.cpp
+++ b/test/module/irohad/ametsuchi/ametsuchi_test.cpp
@@ -448,9 +448,9 @@ TEST_F(AmetsuchiTest, TestingStorageWhenCommitBlock) {
 class IdentityChainValidator : public iroha::validation::ChainValidator {
  public:
   bool validateAndApply(
-      rxcpp::observable<std::shared_ptr<shared_model::interface::Block>> blocks,
+      std::shared_ptr<const shared_model::interface::Block> block,
       MutableStorage &storage) const override {
-    return storage.apply(blocks, [](auto const &, auto &) { return true; });
+    return storage.apply(block, [](auto const &, auto &) { return true; });
   }
 };
 using MockBlockIValidator =

--- a/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_mutable_storage.hpp
@@ -9,7 +9,6 @@
 #include "ametsuchi/mutable_storage.hpp"
 
 #include <gmock/gmock.h>
-#include <rxcpp/rx-lite.hpp>
 
 namespace iroha {
   namespace ametsuchi {
@@ -18,8 +17,7 @@ namespace iroha {
      public:
       MOCK_METHOD2(
           apply,
-          bool(rxcpp::observable<
-                   std::shared_ptr<shared_model::interface::Block>>,
+          bool(std::shared_ptr<const shared_model::interface::Block>,
                std::function<
                    bool(std::shared_ptr<const shared_model::interface::Block>,
                         const iroha::LedgerState &)>));

--- a/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
+++ b/test/module/irohad/multi_sig_transactions/mst_mocks.hpp
@@ -7,6 +7,8 @@
 #define IROHA_MST_MOCKS_HPP
 
 #include <gmock/gmock.h>
+#include <rxcpp/rx-lite.hpp>
+
 #include "logger/logger_fwd.hpp"
 #include "multi_sig_transactions/mst_processor.hpp"
 #include "multi_sig_transactions/mst_propagation_strategy.hpp"

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -46,12 +46,15 @@ namespace iroha {
 
     class MockBlockLoader : public BlockLoader {
      public:
-      MOCK_METHOD2(retrieveBlocks,
-                   iroha::expected::Result<rxcpp::observable<std::shared_ptr<
-                                               shared_model::interface::Block>>,
-                                           std::string>(
-                       const shared_model::interface::types::HeightType,
-                       shared_model::interface::types::PublicKeyHexStringView));
+      MOCK_METHOD2(
+          retrieveBlocks,
+          iroha::expected::Result<
+              boost::any_range<
+                  std::shared_ptr<const shared_model::interface::Block>,
+                  boost::single_pass_traversal_tag>,
+              std::string>(
+              const shared_model::interface::types::HeightType,
+              shared_model::interface::types::PublicKeyHexStringView));
       MOCK_METHOD2(retrieveBlock,
                    iroha::expected::Result<
                        std::unique_ptr<shared_model::interface::Block>,

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -35,10 +35,6 @@ namespace iroha {
           void(std::shared_ptr<shared_model::interface::TransactionBatch>));
 
       MOCK_CONST_METHOD0(onProposal, rxcpp::observable<OrderingEvent>());
-
-      MOCK_CONST_METHOD0(
-          onVerifiedProposal,
-          rxcpp::observable<simulator::VerifiedProposalCreatorEvent>());
     };
 
     class MockBlockLoader : public BlockLoader {

--- a/test/module/irohad/network/network_mocks.hpp
+++ b/test/module/irohad/network/network_mocks.hpp
@@ -7,13 +7,14 @@
 #define IROHA_NETWORK_MOCKS_HPP
 
 #include <gmock/gmock.h>
+#include <rxcpp/rx-lite.hpp>
+
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "network/block_loader.hpp"
 #include "network/consensus_gate.hpp"
 #include "network/ordering_gate.hpp"
 #include "network/peer_communication_service.hpp"
 #include "simulator/block_creator_common.hpp"
-#include "synchronizer/synchronizer_common.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -34,10 +35,6 @@ namespace iroha {
           void(std::shared_ptr<shared_model::interface::TransactionBatch>));
 
       MOCK_CONST_METHOD0(onProposal, rxcpp::observable<OrderingEvent>());
-
-      MOCK_CONST_METHOD0(
-          onSynchronization,
-          rxcpp::observable<synchronizer::SynchronizationEvent>());
 
       MOCK_CONST_METHOD0(
           onVerifiedProposal,

--- a/test/module/irohad/simulator/simulator_mocks.hpp
+++ b/test/module/irohad/simulator/simulator_mocks.hpp
@@ -13,13 +13,10 @@ namespace iroha {
   namespace simulator {
     class MockBlockCreator : public BlockCreator {
      public:
-      MOCK_METHOD2(
-          processVerifiedProposal,
-          boost::optional<std::shared_ptr<shared_model::interface::Block>>(
-              const std::shared_ptr<
-                  iroha::validation::VerifiedProposalAndErrors> &,
-              const TopBlockInfo &));
-      MOCK_METHOD0(onBlock, rxcpp::observable<BlockCreatorEvent>());
+      MOCK_METHOD(BlockCreatorEvent,
+                  processVerifiedProposal,
+                  (VerifiedProposalCreatorEvent const &),
+                  (override));
     };
   }  // namespace simulator
 }  // namespace iroha

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -13,7 +13,6 @@
 #include "framework/batch_helper.hpp"
 #include "framework/crypto_literals.hpp"
 #include "framework/test_logger.hpp"
-#include "framework/test_subscriber.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/iroha_internal/transaction_sequence_factory.hpp"
 #include "module/irohad/common/validators_config.hpp"
@@ -31,8 +30,6 @@
 using namespace iroha;
 using namespace iroha::network;
 using namespace iroha::torii;
-using namespace iroha::synchronizer;
-using namespace framework::test_subscriber;
 
 using ::testing::_;
 using ::testing::A;

--- a/test/module/irohad/torii/processor/transaction_processor_test.cpp
+++ b/test/module/irohad/torii/processor/transaction_processor_test.cpp
@@ -46,23 +46,12 @@ class TransactionProcessorTest : public ::testing::Test {
     pcs = std::make_shared<MockPeerCommunicationService>();
     mst = std::make_shared<MockMstProcessor>(getTestLogger("MstProcessor"));
 
-    EXPECT_CALL(*pcs, onVerifiedProposal())
-        .WillRepeatedly(Return(verified_prop_notifier.get_observable()));
-
-    EXPECT_CALL(*mst, onStateUpdateImpl())
-        .WillRepeatedly(Return(mst_update_notifier.get_observable()));
-    EXPECT_CALL(*mst, onPreparedBatchesImpl())
-        .WillRepeatedly(Return(mst_prepared_notifier.get_observable()));
-    EXPECT_CALL(*mst, onExpiredBatchesImpl())
-        .WillRepeatedly(Return(mst_expired_notifier.get_observable()));
-
     status_bus = std::make_shared<MockStatusBus>();
     tp = std::make_shared<TransactionProcessorImpl>(
         pcs,
         mst,
         status_bus,
         std::make_shared<shared_model::proto::ProtoTxStatusFactory>(),
-        commit_notifier.get_observable(),
         getTestLogger("TransactionProcessor"));
 
     auto peer = makePeer("127.0.0.1", "111"_hex_pubkey);
@@ -130,16 +119,6 @@ class TransactionProcessorTest : public ::testing::Test {
       ASSERT_NO_THROW(boost::get<const Status &>(tx_status->second->get()));
     }
   }
-
-  rxcpp::subjects::subject<std::shared_ptr<iroha::MstState>>
-      mst_update_notifier;
-  rxcpp::subjects::subject<iroha::DataType> mst_prepared_notifier;
-  rxcpp::subjects::subject<iroha::DataType> mst_expired_notifier;
-  rxcpp::subjects::subject<
-      std::shared_ptr<const shared_model::interface::Block>>
-      commit_notifier;
-  rxcpp::subjects::subject<simulator::VerifiedProposalCreatorEvent>
-      verified_prop_notifier;
 
   std::shared_ptr<MockPeerCommunicationService> pcs;
   std::shared_ptr<MockStatusBus> status_bus;
@@ -282,7 +261,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorVerifiedProposalTest) {
           TestProposalBuilder().transactions(txs).build());
 
   // empty transactions errors - all txs are valid
-  verified_prop_notifier.get_subscriber().on_next(
+  tp->processVerifiedProposalCreatorEvent(
       simulator::VerifiedProposalCreatorEvent{
           validation_result, round, ledger_state});
 
@@ -326,14 +305,14 @@ TEST_F(TransactionProcessorTest, TransactionProcessorOnCommitTest) {
           TestProposalBuilder().transactions(txs).build());
 
   // empty transactions errors - all txs are valid
-  verified_prop_notifier.get_subscriber().on_next(
+  tp->processVerifiedProposalCreatorEvent(
       simulator::VerifiedProposalCreatorEvent{
           validation_result, round, ledger_state});
 
   auto block = TestBlockBuilder().transactions(txs).build();
 
   // 2. Create block and notify transaction processor about it
-  commit_notifier.get_subscriber().on_next(
+  tp->processCommit(
       std::shared_ptr<shared_model::interface::Block>(clone(block)));
 
   SCOPED_TRACE("Committed status verification");
@@ -396,7 +375,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
                                      iroha::validation::CommandError{
                                          "SomeCommandName", 1, "", true, i}});
   }
-  verified_prop_notifier.get_subscriber().on_next(
+  tp->processVerifiedProposalCreatorEvent(
       simulator::VerifiedProposalCreatorEvent{
           validation_result, round, ledger_state});
 
@@ -415,7 +394,7 @@ TEST_F(TransactionProcessorTest, TransactionProcessorInvalidTxsTest) {
                        }))
                    .build();
 
-  commit_notifier.get_subscriber().on_next(
+  tp->processCommit(
       std::shared_ptr<shared_model::interface::Block>(clone(block)));
 
   {
@@ -460,7 +439,7 @@ TEST_F(TransactionProcessorTest, MultisigTransactionFromMst) {
       std::shared_ptr<shared_model::interface::Transaction>(clone(tx)));
 
   EXPECT_CALL(*pcs, propagate_batch(_)).Times(1);
-  mst_prepared_notifier.get_subscriber().on_next(after_mst);
+  tp->processPreparedBatch(after_mst);
 }
 
 /**
@@ -487,6 +466,6 @@ TEST_F(TransactionProcessorTest, MultisigExpired) {
                 response->get()));
       }));
   tp->batchHandle(framework::batch::createBatchFromSingleTransaction(tx));
-  mst_expired_notifier.get_subscriber().on_next(
+  tp->processExpiredBatch(
       framework::batch::createBatchFromSingleTransaction(tx));
 }

--- a/test/module/irohad/torii/torii_mocks.hpp
+++ b/test/module/irohad/torii/torii_mocks.hpp
@@ -13,6 +13,7 @@
 #include "endpoint.pb.h"
 #include "interfaces/query_responses/block_query_response.hpp"
 #include "interfaces/query_responses/query_response.hpp"
+#include "simulator/verified_proposal_creator_common.hpp"
 #include "torii/command_service.hpp"
 #include "torii/processor/query_processor.hpp"
 #include "torii/processor/transaction_processor.hpp"
@@ -49,6 +50,29 @@ namespace iroha {
           batchHandle,
           void(std::shared_ptr<shared_model::interface::TransactionBatch>
                    transaction_batch));
+      MOCK_METHOD(void,
+                  processVerifiedProposalCreatorEvent,
+                  (simulator::VerifiedProposalCreatorEvent const &),
+                  (override));
+      MOCK_METHOD(
+          void,
+          processCommit,
+          (std::shared_ptr<shared_model::interface::Block const> const &),
+          (override));
+      MOCK_METHOD(void,
+                  processStateUpdate,
+                  (std::shared_ptr<MstState> const &),
+                  (override));
+      MOCK_METHOD(
+          void,
+          processPreparedBatch,
+          (std::shared_ptr<shared_model::interface::TransactionBatch> const &),
+          (override));
+      MOCK_METHOD(
+          void,
+          processExpiredBatch,
+          (std::shared_ptr<shared_model::interface::TransactionBatch> const &),
+          (override));
     };
 
   }  // namespace torii

--- a/test/module/irohad/validation/chain_validation_test.cpp
+++ b/test/module/irohad/validation/chain_validation_test.cpp
@@ -45,14 +45,14 @@ class ChainValidationTest : public ::testing::Test {
             iroha::bytestringToHexstring(std::string(32, '0'))));
     signatures.push_back(signature);
 
-    EXPECT_CALL(*block, height()).WillRepeatedly(Return(height));
-    EXPECT_CALL(*block, prevHash())
+    EXPECT_CALL(*mock_block, height()).WillRepeatedly(Return(height));
+    EXPECT_CALL(*mock_block, prevHash())
         .WillRepeatedly(testing::ReturnRef(prev_hash));
-    EXPECT_CALL(*block, signatures())
+    EXPECT_CALL(*mock_block, signatures())
         .WillRepeatedly(Return(signatures | boost::adaptors::indirected));
-    EXPECT_CALL(*block, payload())
+    EXPECT_CALL(*mock_block, payload())
         .WillRepeatedly(ReturnRefOfCopy(shared_model::crypto::Blob{"blob"}));
-    EXPECT_CALL(*block, hash())
+    EXPECT_CALL(*mock_block, hash())
         .WillRepeatedly(
             testing::ReturnRefOfCopy(shared_model::crypto::Hash("hash")));
   }
@@ -69,10 +69,8 @@ class ChainValidationTest : public ::testing::Test {
       shared_model::crypto::Hash("previous top hash");
   shared_model::interface::types::HeightType prev_height = 1;
   shared_model::interface::types::HeightType height = prev_height + 1;
-  std::shared_ptr<MockBlock> block = std::make_shared<MockBlock>();
-  rxcpp::observable<std::shared_ptr<shared_model::interface::Block>> blocks =
-      rxcpp::observable<>::just(
-          std::shared_ptr<shared_model::interface::Block>(block));
+  std::shared_ptr<MockBlock> mock_block = std::make_shared<MockBlock>();
+  std::shared_ptr<const shared_model::interface::Block> block = mock_block;
 };
 
 /**
@@ -86,11 +84,11 @@ TEST_F(ChainValidationTest, ValidCase) {
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(DoAll(SaveArg<0>(&block_signatures_amount), Return(true)));
 
-  EXPECT_CALL(*storage, apply(blocks, _))
+  EXPECT_CALL(*storage, apply(block, _))
       .WillOnce(
           InvokeArgument<1>(block, LedgerState{peers, prev_height, prev_hash}));
 
-  ASSERT_TRUE(validator->validateAndApply(blocks, *storage));
+  ASSERT_TRUE(validator->validateAndApply(block, *storage));
   ASSERT_EQ(boost::size(block->signatures()), block_signatures_amount);
 }
 
@@ -107,11 +105,11 @@ TEST_F(ChainValidationTest, FailWhenDifferentPrevHash) {
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillRepeatedly(Return(true));
 
-  EXPECT_CALL(*storage, apply(blocks, _))
+  EXPECT_CALL(*storage, apply(block, _))
       .WillOnce(InvokeArgument<1>(
           block, LedgerState{peers, prev_height, another_hash}));
 
-  ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
+  ASSERT_FALSE(validator->validateAndApply(block, *storage));
 }
 
 /**
@@ -125,10 +123,10 @@ TEST_F(ChainValidationTest, FailWhenNoSupermajority) {
   EXPECT_CALL(*supermajority_checker, hasSupermajority(_, _))
       .WillOnce(DoAll(SaveArg<0>(&block_signatures_amount), Return(false)));
 
-  EXPECT_CALL(*storage, apply(blocks, _))
+  EXPECT_CALL(*storage, apply(block, _))
       .WillOnce(
           InvokeArgument<1>(block, LedgerState{peers, prev_height, prev_hash}));
 
-  ASSERT_FALSE(validator->validateAndApply(blocks, *storage));
+  ASSERT_FALSE(validator->validateAndApply(block, *storage));
   ASSERT_EQ(boost::size(block->signatures()), block_signatures_amount);
 }

--- a/test/module/irohad/validation/validation_mocks.hpp
+++ b/test/module/irohad/validation/validation_mocks.hpp
@@ -20,8 +20,7 @@ namespace iroha {
      public:
       MOCK_CONST_METHOD2(
           validateAndApply,
-          bool(rxcpp::observable<
-                   std::shared_ptr<shared_model::interface::Block>>,
+          bool(std::shared_ptr<const shared_model::interface::Block>,
                ametsuchi::MutableStorage &));
     };
   }  // namespace validation

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -222,7 +222,7 @@ TEST(RegressionTest, PoisonedBlock) {
       ADD_FAILURE() << "No exception thrown";
     } catch (std::runtime_error const &e) {
       using ::testing::HasSubstr;
-      EXPECT_THAT(e.what(), HasSubstr("Cannot validate and apply blocks"));
+      EXPECT_THAT(e.what(), HasSubstr("Bad signature"));
     } catch (...) {
       ADD_FAILURE() << "Unexpected exception thrown";
     }


### PR DESCRIPTION
- SE field in Irohad class
- Remove rxcpp from TransactionProcessorImpl
- Use any_range in BlockLoader interface
- Remove rxcpp from Synchronizer
- Remove rxcpp from Simulator