### PR TITLE
Add nice panic and error reporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,7 +1623,9 @@ dependencies = [
 name = "iroha_error"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "iroha_error_macro",
+ "owo-colors",
 ]
 
 [[package]]
@@ -1669,7 +1671,6 @@ dependencies = [
  "chrono",
  "iroha_config",
  "iroha_error",
- "once_cell",
  "serde",
  "serde_json",
  "tracing",
@@ -2094,6 +2095,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fe43bf372b08cc9ccee5144715db59c79ab00168bbe4cf0d274dc0d5f64d7f"
 
 [[package]]
 name = "parity-scale-codec"

--- a/iroha/src/config.rs
+++ b/iroha/src/config.rs
@@ -63,7 +63,7 @@ impl Configuration {
     /// # Errors
     /// This method will return error if system will fail to find a file or read it's content.
     pub fn from_path<P: AsRef<Path> + Debug>(path: P) -> Result<Configuration> {
-        let file = File::open(path).wrap_err("Failed to open a file")?;
+        let file = File::open(path).wrap_err("Failed to open the config file")?;
         let reader = BufReader::new(file);
         let mut configuration: Configuration =
             serde_json::from_reader(reader).wrap_err("Failed to deserialize json from reader")?;

--- a/iroha/src/main.rs
+++ b/iroha/src/main.rs
@@ -3,14 +3,15 @@
 use async_std::task;
 use clap::{App, Arg};
 use iroha::{config::Configuration, permissions::AllowAll, Iroha};
-use iroha_error::Result;
+use iroha_error::Reporter;
 
 const CONFIGURATION_PATH: &str = "config.json";
 const GENESIS: &str = "genesis";
 
 #[async_std::main]
 #[allow(clippy::non_ascii_literal)]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Reporter> {
+    iroha_error::install_panic_reporter();
     iroha_logger::info!("Hyperledgerいろは2にようこそ！");
     // TODO Add more information about iroha2
     let matches = App::new("Hyperledger/iroha 2")

--- a/iroha_client/src/config.rs
+++ b/iroha_client/src/config.rs
@@ -50,7 +50,7 @@ impl Configuration {
     /// # Errors
     /// This method will return error if system will fail to find a file or read it's content.
     pub fn from_path<P: AsRef<Path> + Debug>(path: P) -> Result<Configuration> {
-        let file = File::open(path).wrap_err("Failed to open a file")?;
+        let file = File::open(path).wrap_err("Failed to open the config file")?;
         let reader = BufReader::new(file);
         serde_json::from_reader(reader).wrap_err("Failed to deserialize json from reader")
     }

--- a/iroha_client/tests/end_to_end/unstable_network.rs
+++ b/iroha_client/tests/end_to_end/unstable_network.rs
@@ -29,6 +29,7 @@ fn unstable_network(
     n_transactions: usize,
     polling_max_attempts: u32,
 ) {
+    iroha_error::install_panic_reporter();
     // Given
     let (_, mut iroha_client) = Network::start_test_with_offline_and_set_max_faults(
         n_peers,

--- a/iroha_client_cli/src/main.rs
+++ b/iroha_client_cli/src/main.rs
@@ -9,7 +9,7 @@ use dialoguer::Confirm;
 use iroha_client::{client::Client, config::Configuration};
 use iroha_crypto::prelude::*;
 use iroha_dsl::prelude::*;
-use iroha_error::{error, Result, WrapErr};
+use iroha_error::{error, Reporter, Result, WrapErr};
 
 const CONFIG: &str = "config";
 const DOMAIN: &str = "domain";
@@ -23,10 +23,11 @@ const FILE_VALUE_NAME: &str = "FILE";
 const RETRY_COUNT_MST: u32 = 1;
 const RETRY_IN_MST_MS: u64 = 100;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Reporter> {
+    iroha_error::install_panic_reporter();
     let matches = App::new("Iroha CLI Client")
         .version("0.1.0")
-        .author("Nikita Puzankov <puzankov@soramitsu.co.jp>")
+        .author("Soramitsu Iroha2 team (https://github.com/orgs/soramitsu/teams/iroha2)")
         .about("Iroha CLI Client provides an ability to interact with Iroha Peers Web API without direct network usage.")
         .arg(
             Arg::with_name(CONFIG)
@@ -344,7 +345,7 @@ mod account {
     fn signature_condition_from_file(
         path: impl AsRef<Path> + Debug,
     ) -> Result<SignatureCheckCondition> {
-        let file = File::open(path).wrap_err("Failed to open a file")?;
+        let file = File::open(path).wrap_err("Failed to open the signature condition file")?;
         let reader = BufReader::new(file);
         let condition: Box<Expression> =
             serde_json::from_reader(reader).wrap_err("Failed to deserialize json from reader")?;
@@ -357,8 +358,8 @@ mod account {
         metadata: UnlimitedMetadata,
     ) -> Result<()> {
         let account = Account::new(configuration.account_id.clone());
-        let condition = signature_condition_from_file(file)
-            .wrap_err("Failed to get signature condition from file")?;
+        let condition =
+            signature_condition_from_file(file).wrap_err("Failed to get signature condition")?;
         submit(
             MintBox::new(account, condition).into(),
             configuration,

--- a/iroha_crypto_cli/src/main.rs
+++ b/iroha_crypto_cli/src/main.rs
@@ -2,9 +2,10 @@
 
 use clap::{App, Arg, ArgGroup};
 use iroha_crypto::{Algorithm, KeyGenConfiguration, KeyPair, PrivateKey};
-use iroha_error::{error, Result, WrapErr};
+use iroha_error::{error, Reporter, Result, WrapErr};
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Reporter> {
+    iroha_error::install_panic_reporter();
     let default_algorithm = Algorithm::default().to_string();
     let matches = App::new("iroha_crypto_cli")
         .version("0.1")

--- a/iroha_error/Cargo.toml
+++ b/iroha_error/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 
 [dependencies]
 iroha_error_macro = { path = "./iroha_error_macro" }
+owo-colors = "2"
+backtrace = "0.3"

--- a/iroha_error/src/lib.rs
+++ b/iroha_error/src/lib.rs
@@ -74,7 +74,10 @@ use std::ops::{Deref, DerefMut};
 use std::result::Result as StdResult;
 
 pub use message_error::MessageError;
+pub use reporter::{install as install_panic_reporter, Reporter};
 pub use wrap_err::{WrapErr, WrappedError};
+
+pub mod reporter;
 
 /// Module with derive macroses
 pub mod derive {
@@ -152,6 +155,11 @@ impl Error {
     pub fn wrap_err(self, msg: impl Display + Send + Sync + 'static) -> Self {
         let error = self;
         WrappedError { msg, error }.into()
+    }
+
+    /// Constructs reporter from error
+    pub const fn report(self) -> Reporter {
+        Reporter(self)
     }
 
     /// Creates error from message

--- a/iroha_error/src/reporter.rs
+++ b/iroha_error/src/reporter.rs
@@ -1,0 +1,198 @@
+//! Module with panic and error reporters
+
+#![allow(clippy::print_stdout)]
+
+use std::env;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::panic::{self, PanicInfo};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{error::Error as StdError, ptr};
+
+use owo_colors::OwoColorize;
+
+use super::Error;
+
+#[derive(Clone, Copy, Debug)]
+struct Backtrace;
+
+impl Display for Backtrace {
+    #[allow(clippy::unwrap_used)]
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        macro_rules! try_writeln {
+            ($res:expr, $dst:expr, $($arg:tt)*) => {
+                if let Err(e) = writeln!($dst, $($arg)*) {
+                    $res = Err(e);
+                    return;
+                }
+            }
+        }
+
+        const SKIPPED: &[&str] = &[
+            "backtrace::backtrace::",
+            "iroha_error::reporter",
+            "std::panicking::",
+            "std::sys_common::backtrace",
+            "std::panic::catch_unwind",
+            "std::rt::",
+            "_main",
+            "<iroha_error::reporter::Backtrace as core::fmt::Display>",
+            "core::fmt::",
+            "alloc::fmt::",
+            "core::ops::function",
+            "<core::future::from_generator::GenFuture<T>",
+            "std::thread::local::",
+        ];
+
+        let mut out = Ok(());
+        let mut i = 0;
+
+        backtrace::trace(|frame| {
+            backtrace::resolve_frame(frame, |symbol| {
+                let name = symbol
+                    .name()
+                    .map_or_else(|| "<unknown_name>".to_owned(), |name| name.to_string());
+                if SKIPPED.iter().any(|skip| name.starts_with(skip)) {
+                    return;
+                }
+
+                let addr = symbol.addr().unwrap_or(ptr::null_mut());
+                let filename = symbol
+                    .filename()
+                    .and_then(|name| {
+                        let buf = name.to_path_buf();
+                        buf.strip_prefix(env::current_dir().ok()?)
+                            .ok()
+                            .map(Path::to_path_buf)
+                    })
+                    .map_or_else(
+                        || "<unknown_file>".to_owned(),
+                        |name| name.into_os_string().into_string().unwrap(),
+                    );
+                let lineno = symbol.lineno().unwrap_or(0);
+                let colno = symbol.colno().unwrap_or(0);
+
+                let file = format!("{}:{}:{}", filename, lineno, colno);
+
+                try_writeln!(out, f, "{:6}: {}", i.red(), name.yellow());
+                try_writeln!(out, f, "{:12}at {}", "", file.green());
+                try_writeln!(out, f, "{:12}at addr {:p}", "", addr.blue());
+
+                i += 1;
+            });
+
+            true
+        });
+
+        out
+    }
+}
+
+/// Error reporter. Can be used like this:
+/// ```rust,should_panic
+/// use iroha_error::{Reporter, error, Result};
+///
+/// fn always_error() -> Result<()> {
+///     Err(error!("Will always panic"))
+/// }
+///
+/// fn main() -> Result<(), Reporter> {
+///     always_error()?;
+///     Ok(())
+/// }
+/// ```
+pub struct Reporter(pub Error);
+
+impl<E: StdError + Send + Sync + 'static> From<E> for Reporter {
+    fn from(error: E) -> Self {
+        Self(Error::new(error))
+    }
+}
+
+impl From<Error> for Reporter {
+    fn from(error: Error) -> Self {
+        Self(error)
+    }
+}
+
+impl Debug for Reporter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Reporter(error) = &self;
+        print_error(error, f)
+    }
+}
+
+impl Display for Reporter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Reporter(error) = &self;
+        print_error(error, f)
+    }
+}
+
+fn print_error(error: &Error, f: &mut Formatter) -> fmt::Result {
+    writeln!(f, "{}\n", error.green())?;
+    let mut error = error.source();
+    let mut indent = 0;
+
+    while let Some(err) = error {
+        writeln!(f, "{:>4}: {}", indent.red(), err.yellow())?;
+        indent += 1;
+        error = err.source();
+    }
+    Ok(())
+}
+
+fn panic_hook(info: &PanicInfo<'_>) {
+    let payload = info.payload();
+    let location = if let Some(location) = info.location() {
+        format!(
+            "{}:{}:{}",
+            location.file(),
+            location.line(),
+            location.column()
+        )
+    } else {
+        "Error at <unknown>".to_owned()
+    };
+    #[allow(clippy::option_if_let_else)]
+    let payload = if let Some(error) = payload.downcast_ref::<String>() {
+        error.red().to_string()
+    } else {
+        "".to_owned()
+    };
+
+    println!("{} {}:\n", "Error at".green(), location.red());
+    println!("\t{}", payload);
+    println!(
+        "\n{}\n{:>4}",
+        "Backtrace:".underline().yellow(),
+        Backtrace.to_string().red()
+    );
+}
+
+/// Hook that signals that panic hook is set. (it should be set once)
+static HOOK_SET: AtomicBool = AtomicBool::new(false);
+
+/// Failed to install error reporter
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct InstallError;
+
+impl Display for InstallError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to install panic hook.")
+    }
+}
+
+impl StdError for InstallError {}
+
+/// Installs panic hook for printing errors. Usually set up at the beginning of program.
+pub fn install() {
+    if HOOK_SET
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+
+    panic::set_hook(Box::new(panic_hook));
+}

--- a/iroha_logger/Cargo.toml
+++ b/iroha_logger/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 chrono = "0.4"
 iroha_config = { path = "../iroha_config" }
 iroha_error = { path = "../iroha_error" }
-once_cell = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_std::sync::Receiver;
 use layer::LevelFilter;
-use once_cell::sync::Lazy;
 use telemetry::{Telemetry, TelemetryLayer};
 pub use tracing::instrument as log;
 use tracing::subscriber::set_global_default;
@@ -17,7 +16,7 @@ pub use tracing_futures::Instrument as InstrumentFutures;
 pub mod layer;
 pub mod telemetry;
 
-static LOGGER_SET: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+static LOGGER_SET: AtomicBool = AtomicBool::new(false);
 
 /// Initializes `Logger` with given `LoggerConfiguration`.
 /// After the initialization `log` macros will print with the use of this `Logger`.


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1019
Signed-off-by: i1i1 <vanyarybin1@live.ru>

### Description of the Change

Add panic handler with stacktrace and error reporting. Add error reporter for `iroha_error::Error`. Now it can be nicely formatted  everywhere if needed.

### Benefits

More context where needed on errors.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
