### PR TITLE
Reporter fixup

### DIFF
--- a/iroha_error/src/wrap_err.rs
+++ b/iroha_error/src/wrap_err.rs
@@ -25,7 +25,7 @@ impl<D: Display, E> Display for WrappedError<D, E> {
 impl<D: Display, E: Debug> Debug for WrappedError<D, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Error")
-            .field("msg", &format!("\"{}\"", &self.msg))
+            .field("msg", &self.msg.to_string())
             .field("source", &self.error)
             .finish()
     }
@@ -51,7 +51,7 @@ impl<D: Display> StdError for WrappedError<D, Error> {
     }
 
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.error.inner.source()
+        Some(&*self.error.inner)
     }
 }
 


### PR DESCRIPTION
### Description of the Change

Fix of error reporter. Beforehand we skipped one error and just went to its source (this was unintentional). This pr goes straight to wrapped error's error as source.

### Benefits

All error level printings. No error skipping.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
