### PR TITLE
Docs: Fixed Config example in Docs

### DIFF
--- a/docs/source/configure/index.rst
+++ b/docs/source/configure/index.rst
@@ -18,7 +18,7 @@ at ``example/config.sample``
 We will start with looking at config file and then look at how Iroha can be configured with
 `environment parameters <#environment-variables>`_.
 
-.. remoteliteralinclude:: https://raw.githubusercontent.com/hyperledger/iroha/main/example/config.sample
+.. literalinclude:: ../../../example/config.sample
    :language: json
 
 As you can see, configuration file is a valid ``json`` structure.

--- a/docs/source/configure/index.rst
+++ b/docs/source/configure/index.rst
@@ -41,7 +41,7 @@ Deployment-specific parameters
   (see below).
 - ``utility_service`` (optional) endpoint for maintenance tasks.
   If present, must include ``ip`` address and ``port`` to bind to.
-  See `shepherd docs <../maintenance/shepherd.html>` for an example usage of maintenance endpoint.
+  See `shepherd docs <../maintenance/shepherd.html>`_ for an example usage of maintenance endpoint.
 - ``metrics`` (optional) endpoint to monitor iroha's metrics. Prometheus HTTP server listens on this endpoint.
   If present, must correspond format "[addr]:<port>" and could be for example "127.0.0.1:8080", "9090", or ":1234".
   Wrong values implicitly disables Prometheus metrics server. There are also cmdline options ```--metrics_port`` and

--- a/docs/source/configure/index.rst
+++ b/docs/source/configure/index.rst
@@ -18,39 +18,8 @@ at ``example/config.sample``
 We will start with looking at config file and then look at how Iroha can be configured with
 `environment parameters <#environment-variables>`_.
 
-.. code-block:: javascript
-  :linenos:
-
-  {
-    "block_store_path": "/tmp/block_store/",
-    "torii_port": 50051,
-    "torii_tls_params": {
-      "port": 55552,
-      "key_pair_path": "/path/to/the/keypair"
-    },
-    "internal_port": 10001,
-    "pg_opt": "host=localhost port=5432 user=postgres password=mysecretpassword dbname=iroha",
-    "database": {
-      "host": "localhost",
-      "port": 5432,
-      "user": "postgres",
-      "password": "mysecretpassword",
-      "working database": "iroha_data",
-      "maintenance database": "postgres"
-    },
-    "max_proposal_size": 10,
-    "proposal_delay": 5000,
-    "vote_delay": 5000,
-    "mst_enable" : false,
-    "mst_expiration_time" : 1440,
-    "max_rounds_delay": 3000,
-    "stale_stream_max_rounds": 2,
-    "utility_service": {
-      "ip": "127.0.0.1",
-      "port": 11001
-    },
-    "metrics":"127.0.0.1:8080"
-  }
+.. remoteliteralinclude:: https://raw.githubusercontent.com/hyperledger/iroha/main/example/config.sample
+   :language: json
 
 As you can see, configuration file is a valid ``json`` structure.
 Let's go line-by-line and understand what every parameter means in configuration file format.
@@ -64,7 +33,7 @@ Deployment-specific parameters
 - ``internal_port`` sets the port for internal communications: ordering
   service, consensus and block loader.
 - ``database`` (optional) is used to set the database configuration (see below)
-- ``pg_opt`` (optional) is a deprecated way of setting credentials of PostgreSQL:
+- ``pg_opt`` (optional) is a **deprecated** way of setting credentials of PostgreSQL:
   hostname, port, username, password and database name.
   All data except the database name are mandatory.
   If database name is not provided, the default one gets used, which is ``iroha_default``.

--- a/example/config.sample
+++ b/example/config.sample
@@ -2,7 +2,14 @@
   "block_store_path" : "/tmp/block_store/",
   "torii_port" : 50051,
   "internal_port" : 10001,
-  "pg_opt" : "host=localhost port=5432 user=postgres password=mysecretpassword",
+  "database": {
+     "host": "localhost",
+     "port": 5432,
+     "user": "postgres",
+     "password": "mysecretpassword",
+     "working database": "iroha_data",
+     "maintenance database": "postgres"
+  }
   "max_proposal_size" : 10,
   "proposal_delay" : 5000,
   "vote_delay" : 5000,


### PR DESCRIPTION
Signed-off-by: Sara <lira.lemur@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Emphasized that pg_opt are depricated, made example in the docs load from https://raw.githubusercontent.com/hyperledger/iroha/main/example/config.sample

Also fixed the `example/config.sample` so it would contain "database" parameter instead of "pg_opt". 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Config example will be up to date automatically. 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

Relative links are not possible here and the absolute links to the config example should lead to the default branch, which might not be yet updated. 
Not a big issue as in the description of the parameters after the example it is possible to still add the missing parameters as they are mostly optional in cases where they are not in the default branch. 

Another one is that the example in docs was way fuller - it also included parameters that are bit too advanced for the config.sample and are not needed for, say, getting started manual. 
It is possible to fix this by adding these parameters to the config.sample if they will not break anything (like the "utility_service" one) 

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Closes #907 
