### PR TITLE
Migrate from clap to structopts for cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "heim"
 version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,7 +1551,6 @@ dependencies = [
 name = "iroha_client_cli"
 version = "0.1.0"
 dependencies = [
- "clap",
  "dialoguer",
  "futures 0.3.15",
  "iroha_client",
@@ -1550,6 +1558,7 @@ dependencies = [
  "iroha_dsl",
  "iroha_error",
  "serde_json",
+ "structopt",
  "tempfile",
 ]
 
@@ -3122,6 +3131,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3690,12 @@ checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/docs/source/tutorials/mint-your-first-asset.md
+++ b/docs/source/tutorials/mint-your-first-asset.md
@@ -41,7 +41,7 @@ TL;DR - after [configuration of Iroha CLI](https://github.com/hyperledger/iroha/
 run this command:
 
 ```bash
-./iroha_client_cli account register --domain="my_domain" --name="my_account" --key="{account_public_key}"
+./iroha_client_cli account register --id="my_account@my_domain" --key="{account_public_key}"
 ```
 
 ### 4. Construct Iroha Special Instruction

--- a/iroha_client_cli/Cargo.toml
+++ b/iroha_client_cli/Cargo.toml
@@ -21,7 +21,7 @@ iroha_client = { version = "=0.1.0", path = "../iroha_client" }
 iroha_crypto = { version = "=0.1.0", path = "../iroha_crypto" }
 iroha_error = { version = "=0.1.0", path = "../iroha_error" }
 iroha_dsl = { path = "../iroha_dsl" }
-clap = "2.33.0"
+structopt = "0.3"
 futures = "0.3.4"
 dialoguer = "0.8"
 serde_json = "1.0"

--- a/iroha_client_cli/README.md
+++ b/iroha_client_cli/README.md
@@ -33,56 +33,57 @@ Full description and list of commands detailed in `iroha_cli --help`.
 
 ```
 $: ./iroha_client_cli --help
-Iroha CLI Client 0.1.0
-Iroha CLI Client provides an ability to interact with Iroha Peers Web API without direct network usage.
+iroha_client_cli 0.1.0
+Soramitsu Iroha2 team (https, //github.com/orgs/soramitsu/teams/iroha2)
+Iroha CLI Client provides an ability to interact with Iroha Peers Web API without direct network usage
 
 USAGE:
-    iroha_client_cli [OPTIONS] [SUBCOMMAND]
+    iroha_client_cli [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
-    -c, --config <FILE>    Sets a config file path. [default: config.json]
+    -c, --config <config>    Sets a config file path [default: config.json]
 
 SUBCOMMANDS:
-    account    Use this command to work with Account Entities in Iroha Peer.
-    asset      Use this command to work with Asset and Asset Definition Entities in Iroha Peer.
-    domain     Use this command to work with Domain Entities in Iroha Peer.
+    account    Use this command to work with Account Entities in Iroha Peer
+    asset      Use this command to work with Assets in Iroha Peer
+    domain     Use this command to work with Domain Entities in Iroha Peer
+    events     Use this command to listen to Iroha events over the streaming API
     help       Prints this message or the help of the given subcommand(s)
 ```
 
 ### TL;DR
 
 ```bash
-./iroha_client_cli domain add --name="Soramitsu"
-./iroha_client_cli account register --domain="Soramitsu" --name="White Rabbit" --key=""
-./iroha_client_cli asset register --domain="Soramitsu" --name="XOR" 
-./iroha_client_cli asset mint --account_id="White Rabbit@Soramitsu" --id="XOR#Soramitsu" --quantity=1010 
-./iroha_client_cli asset get --account_id="White Rabbit@Soramitsu" --id="XOR#Soramitsu" 
+./iroha_client_cli domain register --id="Soramitsu"
+./iroha_client_cli account register --id="White Rabbit@Soramitsu" --key=""
+./iroha_client_cli asset register --id="XOR#Soramitsu" --value-type=Quantity
+./iroha_client_cli asset mint --account="White Rabbit@Soramitsu" --asset="XOR#Soramitsu" --quantity=1010 
+./iroha_client_cli asset get --account="White Rabbit@Soramitsu" --asset="XOR#Soramitsu" 
 ```
 
 ### Create new Domain
 
-Let's start with domain creation. We need to provide `create` command first, 
-following by entity type (`domain` in our case) and list of required parameters.
-For domain entity we only need `name` parameter which is stringly typed.
+Let's start with domain creation. We need to provide `register` command first, 
+following by entity type (domain in our case) and list of required parameters.
+For domain entity we only need `id` parameter which is stringly typed.
 
 ```bash
-./iroha_client_cli domain add --name="Soramitsu"
+./iroha_client_cli domain register --id="Soramitsu"
 ```
 
 ### Create new Account
 
 Right now we have the only domain without any accounts, let's fix it.
-Like in the previous example, we need to define domain name, this time as 
-`domain` argument, because `name` argument should be filled with account's name.
+Like in the previous example, we need to define account name, it is done using `id` flag.
 We also give a `key` argument with account's public key as a double-quoted
 string value.
 
 ```bash
-./iroha_client_cli account register --domain="Soramitsu" --name="White Rabbit" --key=""
+./iroha_client_cli account register --id="White Rabbit@Soramitsu" --key=""
 ```
 
 ### Mint Asset to Account
@@ -90,10 +91,11 @@ string value.
 Okay, it's time to give something to our Account. We will add some Assets quantity to it.
 This time we need to register an Asset Definition first and then add some Assets to the account.
 As you can see, we use new command `asset` and it's subcommands `register` and `mint`. 
+Every asset has its own value type, here we define domain as quantity (integer/number).
 
 ```bash
-./iroha_client_cli asset register --domain="Soramitsu" --name="XOR" 
-./iroha_client_cli asset mint --account_id="White Rabbit@Soramitsu" --id="XOR#Soramitsu" --quantity=1010 
+./iroha_client_cli asset register --id="XOR#Soramitsu" --value-type=Quantity
+./iroha_client_cli asset mint --account="White Rabbit@Soramitsu" --asset="XOR#Soramitsu" --quantity=1010 
 ```
 
 ### Query Account Assets Quantity
@@ -107,7 +109,7 @@ Let's use Get Account Assets Query as an example. Command will look familar beca
 We need to know quantity so we skipp this argument and replace `update asset add` part with `get asset`.
 
 ```bash
-./iroha_client_cli asset get --account_id="White Rabbit@Soramitsu" --id="XOR#Soramitsu" 
+./iroha_client_cli asset get --account="White Rabbit@Soramitsu" --asset="XOR#Soramitsu" 
 ```
 
 ### Want to help us develop Iroha?

--- a/iroha_client_cli/src/main.rs
+++ b/iroha_client_cli/src/main.rs
@@ -2,89 +2,144 @@
 
 #![allow(missing_docs, clippy::print_stdout, clippy::use_debug)]
 
-use std::{fs::File, io::BufReader, str::FromStr, time::Duration};
+use std::{fmt, fs::File, str::FromStr, time::Duration};
 
-use clap::{App, Arg, ArgMatches};
 use dialoguer::Confirm;
-use iroha_client::{client::Client, config::Configuration};
+use iroha_client::{client::Client, config::Configuration as ClientConfiguration};
 use iroha_crypto::prelude::*;
 use iroha_dsl::prelude::*;
-use iroha_error::{error, Reporter, Result, WrapErr};
+use iroha_error::{Error, Reporter, Result, WrapErr};
+use structopt::StructOpt;
 
-const CONFIG: &str = "config";
-const DOMAIN: &str = "domain";
-const ACCOUNT: &str = "account";
-const ASSET: &str = "asset";
-const EVENTS: &str = "listen";
-const METADATA: &str = "metadata";
-const FILE_VALUE_NAME: &str = "FILE";
+/// Metadata wrapper, which can be captured from cli arguments (from user suplied file).
+#[derive(Debug, Clone)]
+pub struct Metadata(pub iroha_dsl::prelude::UnlimitedMetadata);
+
+impl fmt::Display for Metadata {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for Metadata {
+    type Err = Error;
+    fn from_str(file: &str) -> Result<Self> {
+        if file.is_empty() {
+            return Ok(Self(UnlimitedMetadata::default()));
+        }
+
+        let file = File::open(file).wrap_err("Failed to open the metadata file.")?;
+        let metadata: UnlimitedMetadata = serde_json::from_reader(file)
+            .wrap_err("Failed to deserialize metadata json from reader.")?;
+        Ok(Self(metadata))
+    }
+}
+
+/// Client configuration wrapper. Allows getting itself from arguments from cli (from user suplied file).
+#[derive(Debug, Clone)]
+pub struct Configuration(pub ClientConfiguration);
+
+impl FromStr for Configuration {
+    type Err = Error;
+    fn from_str(file: &str) -> Result<Self> {
+        let file = File::open(file).wrap_err("Failed to open config file")?;
+        let cfg = serde_json::from_reader(file).wrap_err("Failed to decode config file")?;
+        Ok(Self(cfg))
+    }
+}
+
+/// Iroha CLI Client provides an ability to interact with Iroha Peers Web API
+/// without direct network usage.
+#[derive(StructOpt, Debug)]
+#[structopt(
+    name = "iroha_client_cli",
+    version = "0.1.0",
+    author = "Soramitsu Iroha2 team (https://github.com/orgs/soramitsu/teams/iroha2)"
+)]
+pub struct Args {
+    /// Sets a config file path
+    #[structopt(short, long, default_value = "config.json")]
+    config: Configuration,
+    /// Subcommands of client cli
+    #[structopt(subcommand)]
+    subcommand: Subcommand,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum Subcommand {
+    /// Use this command to work with Domain Entities in Iroha Peer
+    Domain(domain::Args),
+    /// Use this command to work with Account Entities in Iroha Peer
+    Account(account::Args),
+    /// Use this command to work with Assets in Iroha Peer
+    Asset(asset::Args),
+    /// Use this command to listen to Iroha events over the streaming API
+    Events(events::Args),
+}
+
+/// Runs subcommand
+pub trait RunArgs {
+    /// Runs command
+    /// # Errors
+    /// Depends on inner command
+    fn run(self, cfg: &ClientConfiguration) -> Result<()>;
+}
+
+macro_rules! match_run_all {
+    (($self:ident, $cfg:ident), { $($variants:path),* }) => {
+        match $self {
+            $($variants(variant) => variant.run($cfg),)*
+        }
+    };
+}
+
+impl RunArgs for Subcommand {
+    fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+        use Subcommand::*;
+        match_run_all!((self, cfg), { Domain, Account, Asset, Events })
+    }
+}
 
 // TODO: move into config.
 const RETRY_COUNT_MST: u32 = 1;
-const RETRY_IN_MST_MS: u64 = 100;
+const RETRY_IN_MST: Duration = Duration::from_millis(100);
 
 fn main() -> Result<(), Reporter> {
     iroha_error::install_panic_reporter();
-    let matches = App::new("Iroha CLI Client")
-        .version("0.1.0")
-        .author("Soramitsu Iroha2 team (https://github.com/orgs/soramitsu/teams/iroha2)")
-        .about("Iroha CLI Client provides an ability to interact with Iroha Peers Web API without direct network usage.")
-        .arg(
-            Arg::with_name(CONFIG)
-                .short("c")
-                .long(CONFIG)
-                .value_name(FILE_VALUE_NAME)
-                .help("Sets a config file path.")
-                .takes_value(true)
-                .default_value("config.json"),
-        )
-        .subcommand(domain::build_app())
-        .subcommand(account::build_app())
-        .subcommand(asset::build_app())
-        .subcommand(events::build_app())
-        .get_matches();
-    let configuration_path = matches
-        .value_of(CONFIG)
-        .ok_or_else(|| error!("Failed to get configuration path."))?;
-    println!("Value for config: {}", configuration_path);
-    let configuration =
-        Configuration::from_path(configuration_path).wrap_err("Failed to load configuration")?;
-    if let Some(matches) = matches.subcommand_matches(DOMAIN) {
-        domain::process(matches, &configuration)?;
-    }
-    if let Some(matches) = matches.subcommand_matches(ACCOUNT) {
-        account::process(matches, &configuration)?;
-    }
-    if let Some(matches) = matches.subcommand_matches(ASSET) {
-        asset::process(matches, &configuration)?;
-    }
-    if let Some(matches) = matches.subcommand_matches(EVENTS) {
-        events::process(matches, &configuration)?;
-    }
+    let Args {
+        config: Configuration(config),
+        subcommand,
+    } = Args::from_args();
+
+    println!("Value for config: {:?}", &config);
+    subcommand
+        .run(&config)
+        .wrap_err("Failed to run subcommand")?;
     Ok(())
 }
 
 /// # Errors
 /// Fails if submitting over network fails
 pub fn submit(
-    instruction: Instruction,
-    configuration: &Configuration,
+    instruction: impl Into<Instruction>,
+    cfg: &ClientConfiguration,
     metadata: UnlimitedMetadata,
 ) -> Result<()> {
-    let mut iroha_client = Client::new(configuration);
+    let instruction = instruction.into();
+    let mut iroha_client = Client::new(cfg);
     let tx = iroha_client
         .build_transaction(vec![instruction], metadata)
         .wrap_err("Failed to build transaction.")?;
     let tx = match iroha_client.get_original_transaction(
         &tx,
         RETRY_COUNT_MST,
-        Duration::from_millis(RETRY_IN_MST_MS),
+        RETRY_IN_MST,
     ) {
         Ok(Some(original_transaction)) if Confirm::new()
             .with_prompt("There is a similar transaction from your account waiting for more signatures. Do you want to sign it instead of submitting a new transaction?")
             .interact()
             .wrap_err("Failed to show interactive prompt.")? => iroha_client.sign_transaction(original_transaction).wrap_err("Failed to sign transaction.")?,
-        Ok(_) | Err(_) => tx,
+        _ => tx,
     };
 
     let _ = iroha_client
@@ -93,63 +148,32 @@ pub fn submit(
     Ok(())
 }
 
-pub fn metadata_arg() -> Arg<'static, 'static> {
-    Arg::with_name(METADATA)
-        .long(METADATA)
-        .value_name(FILE_VALUE_NAME)
-        .help("The filename with key-value metadata pairs in JSON.")
-        .takes_value(true)
-        .required(false)
-}
-
-/// # Errors
-/// Fails if parsing metadata from file fails
-pub fn parse_metadata(matches: &ArgMatches<'_>) -> Result<UnlimitedMetadata> {
-    matches.value_of(METADATA).map_or_else(
-        || Ok(UnlimitedMetadata::new()),
-        |metadata_filename| {
-            let file =
-                File::open(metadata_filename).wrap_err("Failed to open the metadata file.")?;
-            let reader = BufReader::new(file);
-            let metadata: UnlimitedMetadata = serde_json::from_reader(reader)
-                .wrap_err("Failed to deserialize metadata json from reader.")?;
-            Ok(metadata)
-        },
-    )
-}
-
 mod events {
-    use clap::ArgMatches;
     use iroha_client::{client::Client, config::Configuration};
 
     use super::*;
 
-    const PIPELINE: &str = "pipeline";
-    const DATA: &str = "data";
-
-    pub fn build_app<'a, 'b>() -> App<'a, 'b> {
-        App::new(EVENTS)
-            .about("Use this command to listen to Iroha events over the streaming API.")
-            .subcommand(App::new(PIPELINE).about("Listen to pipeline events."))
-            .subcommand(App::new(DATA).about("Listen to data events."))
+    /// Get event stream from iroha peer
+    #[derive(StructOpt, Debug, Clone, Copy)]
+    pub enum Args {
+        /// Gets pipeline events
+        Pipeline,
+        /// Gets data events
+        Data,
     }
 
-    pub fn process(matches: &ArgMatches<'_>, configuration: &Configuration) -> Result<()> {
-        // TODO: let the user to setup the filter arguments.
-        if matches.subcommand_matches(PIPELINE).is_some() {
-            listen(
-                EventFilter::Pipeline(PipelineEventFilter::identity()),
-                configuration,
-            )?
+    impl RunArgs for Args {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let filter = match self {
+                Args::Data => EventFilter::Pipeline(PipelineEventFilter::identity()),
+                Args::Pipeline => EventFilter::Data(DataEventFilter),
+            };
+            listen(filter, cfg)
         }
-        if matches.subcommand_matches(DATA).is_some() {
-            listen(EventFilter::Data(DataEventFilter), configuration)?
-        }
-        Ok(())
     }
 
-    pub fn listen(filter: EventFilter, configuration: &Configuration) -> Result<()> {
-        let mut iroha_client = Client::new(configuration);
+    pub fn listen(filter: EventFilter, cfg: &Configuration) -> Result<()> {
+        let mut iroha_client = Client::new(cfg);
         println!("Listening to events with filter: {:?}", filter);
         for event in iroha_client
             .listen_for_events(filter)
@@ -165,465 +189,293 @@ mod events {
 }
 
 mod domain {
-    use clap::ArgMatches;
     use iroha_client::config::Configuration;
 
     use super::*;
 
-    const DOMAIN_NAME: &str = "name";
-    const ADD: &str = "add";
-
-    pub fn build_app<'a, 'b>() -> App<'a, 'b> {
-        App::new(DOMAIN)
-            .about("Use this command to work with Domain Entities in Iroha Peer.")
-            .subcommand(
-                App::new(ADD)
-                    .arg(
-                        Arg::with_name(DOMAIN_NAME)
-                            .long(DOMAIN_NAME)
-                            .value_name(DOMAIN_NAME)
-                            .help("Domain's name as double-quoted string.")
-                            .takes_value(true)
-                            .required(true),
-                    )
-                    .arg(metadata_arg()),
-            )
+    /// Arguments for domain subcommand
+    #[derive(Debug, StructOpt)]
+    pub enum Args {
+        /// Register domain
+        Register(Register),
     }
 
-    pub fn process(matches: &ArgMatches<'_>, configuration: &Configuration) -> Result<()> {
-        let matches = match matches.subcommand_matches(ADD) {
-            Some(matches) => matches,
-            None => return Ok(()),
-        };
-        let domain_name = match matches.value_of(DOMAIN_NAME) {
-            Some(domain_name) => domain_name,
-            None => return Ok(()),
-        };
-        println!("Adding a new Domain with a name: {}", domain_name);
-        create_domain(domain_name, configuration, parse_metadata(matches)?)
+    impl RunArgs for Args {
+        fn run(self, cfg: &Configuration) -> Result<()> {
+            match_run_all!((self, cfg), { Args::Register })
+        }
     }
 
-    fn create_domain(
-        domain_name: &str,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-    ) -> Result<()> {
-        let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::new(domain_name)));
-        submit(create_domain.into(), configuration, metadata)
+    /// Add subcommand for domain
+    #[derive(Debug, StructOpt)]
+    pub struct Register {
+        /// Domain's name as double-quoted string
+        #[structopt(short, long)]
+        pub id: Domain,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
+    }
+
+    impl RunArgs for Register {
+        fn run(self, cfg: &Configuration) -> Result<()> {
+            let Self {
+                id,
+                metadata: Metadata(metadata),
+            } = self;
+            let create_domain = RegisterBox::new(IdentifiableBox::from(id));
+            submit(create_domain, cfg, metadata).wrap_err("Failed to create domain")
+        }
     }
 }
 
 mod account {
-    use std::{fmt::Debug, fs::File, io::BufReader, path::Path};
-
-    use clap::ArgMatches;
-    use iroha_client::config::Configuration;
+    use std::{fmt::Debug, fs::File};
 
     use super::*;
 
-    const REGISTER: &str = "register";
-    const SET: &str = "set";
-    const ACCOUNT_NAME: &str = "name";
-    const ACCOUNT_DOMAIN_NAME: &str = "domain";
-    const ACCOUNT_KEY: &str = "key";
-    const ACCOUNT_SIGNATURE_CONDITION: &str = "signature_condition";
-    const ACCOUNT_SIGNATURE_CONDITION_FILE: &str = "file";
-
-    pub fn build_app<'a, 'b>() -> App<'a, 'b> {
-        App::new(ACCOUNT)
-            .about("Use this command to work with Account Entities in Iroha Peer.")
-            .subcommand(
-                App::new(REGISTER)
-                    .about("Use this command to register new Account in existing Iroha Domain.")
-                    .arg(
-                        Arg::with_name(ACCOUNT_NAME)
-                            .long(ACCOUNT_NAME)
-                            .value_name(ACCOUNT_NAME)
-                            .help("Account's name as double-quoted string.")
-                            .takes_value(true)
-                            .required(true),
-                    )
-                    .arg(
-                        Arg::with_name(ACCOUNT_DOMAIN_NAME)
-                            .long(ACCOUNT_DOMAIN_NAME)
-                            .value_name(ACCOUNT_DOMAIN_NAME)
-                            .help("Account's Domain's name as double-quoted string.")
-                            .takes_value(true)
-                            .required(true),
-                    )
-                    .arg(
-                        Arg::with_name(ACCOUNT_KEY)
-                            .long(ACCOUNT_KEY)
-                            .value_name(ACCOUNT_KEY)
-                            .help("Account's public key as double-quoted string.")
-                            .takes_value(true)
-                            .required(true),
-                    )
-                    .arg(metadata_arg()),
-            )
-            .subcommand(
-                App::new(SET)
-                    .about("Use this command to set Account Parameters in Iroha Peer.")
-                    .subcommand(
-                        App::new(ACCOUNT_SIGNATURE_CONDITION)
-                            .about("Use this command to set Signature Condition for Account in Iroha Peer.")
-                            .arg(
-                                Arg::with_name(ACCOUNT_SIGNATURE_CONDITION_FILE)
-                                    .long(ACCOUNT_SIGNATURE_CONDITION_FILE)
-                                    .value_name("FILE")
-                                    .help("A JSON file with Iroha Expression that represents signature condition.")
-                                    .takes_value(true)
-                                    .required(true),
-                            )
-                            .arg(metadata_arg())
-                    ),
-            )
+    #[allow(variant_size_differences)]
+    /// subcommands for account subcommand
+    #[derive(StructOpt, Debug)]
+    pub enum Args {
+        /// Register account
+        Register(Register),
+        /// Set something in account
+        Set(Set),
     }
 
-    pub fn process(matches: &ArgMatches<'_>, configuration: &Configuration) -> Result<()> {
-        process_create_account(matches, configuration)?;
-        process_set_account_signature_condition(matches, configuration)
-    }
-
-    fn process_create_account(
-        matches: &ArgMatches<'_>,
-        configuration: &Configuration,
-    ) -> Result<()> {
-        if let Some(matches) = matches.subcommand_matches(REGISTER) {
-            if let Some(account_name) = matches.value_of(ACCOUNT_NAME) {
-                println!("Creating account with a name: {}", account_name);
-                if let Some(domain_name) = matches.value_of(ACCOUNT_DOMAIN_NAME) {
-                    println!("Creating account with a domain's name: {}", domain_name);
-                    if let Some(public_key) = matches.value_of(ACCOUNT_KEY) {
-                        println!("Creating account with a public key: {}", public_key);
-                        let public_key: PublicKey =
-                            serde_json::from_value(serde_json::json!(public_key))
-                                .wrap_err("Failed to deserialize supplied public key argument.")?;
-                        create_account(
-                            account_name,
-                            domain_name,
-                            public_key,
-                            configuration,
-                            parse_metadata(matches)?,
-                        )?;
-                    }
-                }
-            }
+    impl RunArgs for Args {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            match_run_all!((self, cfg), { Args::Register, Args::Set })
         }
-        Ok(())
     }
 
-    fn process_set_account_signature_condition(
-        matches: &ArgMatches<'_>,
-        configuration: &Configuration,
-    ) -> Result<()> {
-        if let Some(matches) = matches.subcommand_matches(SET) {
-            if let Some(matches) = matches.subcommand_matches(ACCOUNT_SIGNATURE_CONDITION) {
-                if let Some(file) = matches.value_of(ACCOUNT_SIGNATURE_CONDITION_FILE) {
-                    println!("Setting account signature condition from file: {}", file);
-                    set_account_signature_condition(file, configuration, parse_metadata(matches)?)?;
-                }
-            }
+    /// Register account
+    #[derive(StructOpt, Debug)]
+    pub struct Register {
+        /// Id of account in form `name@domain_name'
+        #[structopt(short, long)]
+        pub id: AccountId,
+        /// Its public key
+        #[structopt(short, long)]
+        pub key: PublicKey,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
+    }
+
+    impl RunArgs for Register {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let Self {
+                id,
+                key,
+                metadata: Metadata(metadata),
+            } = self;
+            let create_account =
+                RegisterBox::new(IdentifiableBox::from(NewAccount::with_signatory(id, key)));
+            submit(create_account, cfg, metadata).wrap_err("Failed to register account")
         }
-        Ok(())
     }
 
-    fn create_account(
-        account_name: &str,
-        domain_name: &str,
-        public_key: PublicKey,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-    ) -> Result<()> {
-        let create_account = RegisterBox::new(IdentifiableBox::from(NewAccount::with_signatory(
-            AccountId::new(account_name, domain_name),
-            public_key,
-        )));
-        submit(create_account.into(), configuration, metadata)
+    /// Set subcommand of account
+    #[derive(StructOpt, Debug)]
+    pub enum Set {
+        /// Signature condition
+        SignatureCondition(SignatureCondition),
     }
 
-    fn signature_condition_from_file(
-        path: impl AsRef<Path> + Debug,
-    ) -> Result<SignatureCheckCondition> {
-        let file = File::open(path).wrap_err("Failed to open the signature condition file")?;
-        let reader = BufReader::new(file);
-        let condition: Box<Expression> =
-            serde_json::from_reader(reader).wrap_err("Failed to deserialize json from reader")?;
-        Ok(SignatureCheckCondition(condition.into()))
+    impl RunArgs for Set {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            match_run_all!((self, cfg), { Set::SignatureCondition })
+        }
     }
 
-    fn set_account_signature_condition(
-        file: &str,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-    ) -> Result<()> {
-        let account = Account::new(configuration.account_id.clone());
-        let condition =
-            signature_condition_from_file(file).wrap_err("Failed to get signature condition")?;
-        submit(
-            MintBox::new(account, condition).into(),
-            configuration,
-            metadata,
-        )
+    #[derive(Debug)]
+    pub struct Signature(SignatureCheckCondition);
+
+    impl FromStr for Signature {
+        type Err = Error;
+        fn from_str(s: &str) -> Result<Self> {
+            let file = File::open(s).wrap_err("Failed to open the signature condition file")?;
+            let condition: Box<Expression> = serde_json::from_reader(file)
+                .wrap_err("Failed to deserialize signature expression from reader")?;
+            Ok(Self(SignatureCheckCondition(condition.into())))
+        }
+    }
+
+    /// Set accounts signature condition
+    #[derive(StructOpt, Debug)]
+    pub struct SignatureCondition {
+        /// Signature condition file
+        pub condition: Signature,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
+    }
+
+    impl RunArgs for SignatureCondition {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let account = Account::new(cfg.account_id.clone());
+            let Self {
+                condition: Signature(condition),
+                metadata: Metadata(metadata),
+            } = self;
+            submit(MintBox::new(account, condition), cfg, metadata)
+                .wrap_err("Failed to set signature condition")
+        }
     }
 }
 
 mod asset {
-    use clap::ArgMatches;
-    use iroha_client::{
-        client::{asset, Client},
-        config::Configuration,
-    };
+    use iroha_client::client::{asset, Client};
 
     use super::*;
 
-    const REGISTER: &str = "register";
-    const MINT: &str = "mint";
-    const TRANSFER: &str = "transfer";
-    const GET: &str = "get";
-    const ASSET_NAME: &str = "name";
-    const ASSET_DOMAIN_NAME: &str = "domain";
-    const ASSET_ACCOUNT_ID: &str = "account_id";
-    const ASSET_VALUE_TYPE: &str = "value_type";
-    const DESTINATION_ACCOUNT_ID: &str = "dst_account_id";
-    const SOURCE_ACCOUNT_ID: &str = "src_account_id";
-    const ASSET_ID: &str = "id";
-    const QUANTITY: &str = "quantity";
-
-    fn parse_value_type(value_type: &str) -> Result<AssetValueType> {
-        serde_json::from_value(serde_json::json!(value_type))
-            .wrap_err("Failed to deserialize value type")
+    /// Subcommand for dealing with asset
+    #[derive(StructOpt, Debug)]
+    pub enum Args {
+        /// Register subcommand of asset
+        Register(Register),
+        /// Command for minting asset in existing Iroha account
+        Mint(Mint),
+        /// Transfer asset between accounts
+        Transfer(Transfer),
+        /// Get info of asset
+        Get(Get),
     }
 
-    pub fn build_app<'a, 'b>() -> App<'a, 'b> {
-        App::new(ASSET)
-            .about("Use this command to work with Asset and Asset Definition Entities in Iroha Peer.")
-            .subcommand(
-                App::new(REGISTER)
-                .about("Use this command to register new Asset Definition in existing Iroha Domain.")
-                .arg(
-                    Arg::with_name(ASSET_DOMAIN_NAME)
-                        .long(ASSET_DOMAIN_NAME)
-                        .value_name(ASSET_DOMAIN_NAME)
-                        .help("Asset's domain's name as double-quoted string.")
-                        .takes_value(true)
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name(ASSET_NAME)
-                        .long(ASSET_NAME)
-                        .value_name(ASSET_NAME)
-                        .help("Asset's name as double-quoted string.")
-                        .takes_value(true)
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name(ASSET_VALUE_TYPE)
-                        .long(ASSET_VALUE_TYPE)
-                        .value_name(ASSET_VALUE_TYPE)
-                        .help("Asset's value type as double-quoted string.")
-                        .takes_value(true)
-                        .required(true),
-                )
-                .arg(metadata_arg())
+    impl RunArgs for Args {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            match_run_all!(
+                (self, cfg),
+                { Args::Register, Args::Mint, Args::Transfer, Args::Get }
             )
-            .subcommand(
-                App::new(MINT)
-                    .about("Use this command to Mint Asset in existing Iroha Account.")
-                    .arg(Arg::with_name(ASSET_ACCOUNT_ID).long(ASSET_ACCOUNT_ID).value_name(ASSET_ACCOUNT_ID).help("Account's id as double-quoted string in the following format `account_name@domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(ASSET_ID).long(ASSET_ID).value_name(ASSET_ID).help("Asset's id as double-quoted string in the following format `asset_name#domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(QUANTITY).long(QUANTITY).value_name(QUANTITY).help("Asset's quantity as a number.").takes_value(true).required(true))
-                    .arg(metadata_arg())
-            )
-            .subcommand(
-                App::new(TRANSFER)
-                    .about("Use this command to Transfer Asset from Account to Account.")
-                    .arg(Arg::with_name(SOURCE_ACCOUNT_ID).long(SOURCE_ACCOUNT_ID).value_name(SOURCE_ACCOUNT_ID).help("Source Account's id as double-quoted string in the following format `account_name@domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(DESTINATION_ACCOUNT_ID).long(DESTINATION_ACCOUNT_ID).value_name(DESTINATION_ACCOUNT_ID).help("Destination Account's id as double-quoted string in the following format `account_name@domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(ASSET_ID).long(ASSET_ID).value_name(ASSET_ID).help("Asset's id as double-quoted string in the following format `asset_name#domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(QUANTITY).long(QUANTITY).value_name(QUANTITY).help("Asset's quantity as a number.").takes_value(true).required(true))
-                    .arg(metadata_arg())
-            )
-            .subcommand(
-                App::new(GET)
-                    .about("Use this command to get Asset information from Iroha Account.")
-                    .arg(Arg::with_name(ASSET_ACCOUNT_ID).long(ASSET_ACCOUNT_ID).value_name(ASSET_ACCOUNT_ID).help("Account's id as double-quoted string in the following format `account_name@domain_name`.").takes_value(true).required(true))
-                    .arg(Arg::with_name(ASSET_ID).long(ASSET_ID).value_name(ASSET_ID).help("Asset's id as double-quoted string in the following format `asset_name#domain_name`.").takes_value(true).required(true))
-            )
-    }
-
-    fn process_register(matches: &ArgMatches<'_>, configuration: &Configuration) -> Result<()> {
-        let matches = match matches.subcommand_matches(REGISTER) {
-            Some(matches) => matches,
-            None => return Ok(()),
-        };
-        let asset_name = match matches.value_of(ASSET_NAME) {
-            Some(asset_name) => asset_name,
-            None => return Ok(()),
-        };
-        let domain_name = match matches.value_of(ASSET_DOMAIN_NAME) {
-            Some(domain_name) => domain_name,
-            None => return Ok(()),
-        };
-        let value_type = match matches.value_of(ASSET_VALUE_TYPE) {
-            Some(value_type) => value_type,
-            None => return Ok(()),
-        };
-        println!("Registering asset defintion with a name: {}", asset_name);
-        println!(
-            "Registering asset definition with a value type: {:?}",
-            value_type
-        );
-        println!("Registering asset defintion with a name: {}", asset_name);
-        register_asset_definition(
-            asset_name,
-            domain_name,
-            configuration,
-            parse_metadata(matches)?,
-            parse_value_type(value_type)?,
-        )
-    }
-
-    pub fn process(matches: &ArgMatches<'_>, configuration: &Configuration) -> Result<()> {
-        process_register(matches, configuration)?;
-        if let Some(matches) = matches.subcommand_matches(MINT) {
-            if let Some(asset_id) = matches.value_of(ASSET_ID) {
-                println!("Minting asset with an identification: {}", asset_id);
-                if let Some(account_id) = matches.value_of(ASSET_ACCOUNT_ID) {
-                    println!(
-                        "Minting asset to account with an identification: {}",
-                        account_id
-                    );
-                    if let Some(amount) = matches.value_of(QUANTITY) {
-                        println!("Minting asset's quantity: {}", amount);
-                        mint_asset(
-                            asset_id,
-                            account_id,
-                            amount,
-                            configuration,
-                            parse_metadata(matches)?,
-                        )?;
-                    }
-                }
-            }
         }
-        if let Some(matches) = matches.subcommand_matches(TRANSFER) {
-            if let Some(asset_id) = matches.value_of(ASSET_ID) {
-                println!("Transfer asset with an identification: {}", asset_id);
-                if let Some(account1_id) = matches.value_of(SOURCE_ACCOUNT_ID) {
-                    println!(
-                        "Transfer asset from account with an identification: {}",
-                        account1_id
-                    );
-                    if let Some(account2_id) = matches.value_of(DESTINATION_ACCOUNT_ID) {
-                        println!(
-                            "Transfer asset to account with an identification: {}",
-                            account2_id
-                        );
-                        if let Some(quantity) = matches.value_of(QUANTITY) {
-                            println!("Transfer asset's amount: {}", quantity);
-                            transfer_asset(
-                                account1_id,
-                                account2_id,
-                                asset_id,
-                                quantity,
-                                configuration,
-                                parse_metadata(matches)?,
-                            )?;
-                        }
-                    }
-                }
-            }
+    }
+
+    /// Register subcommand of asset
+    #[derive(StructOpt, Debug)]
+    pub struct Register {
+        /// Asset id for registering (in form of `name#domain_name')
+        #[structopt(short, long)]
+        pub id: AssetDefinitionId,
+        /// Value type stored in asset
+        #[structopt(short, long)]
+        pub value_type: AssetValueType,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
+    }
+
+    impl RunArgs for Register {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let Self {
+                id,
+                value_type,
+                metadata: Metadata(metadata),
+            } = self;
+            submit(
+                RegisterBox::new(IdentifiableBox::AssetDefinition(
+                    AssetDefinition::new(id, value_type).into(),
+                )),
+                cfg,
+                metadata,
+            )
+            .wrap_err("Failed to register asset")
         }
-        if let Some(matches) = matches.subcommand_matches(GET) {
-            if let Some(asset_id) = matches.value_of(ASSET_ID) {
-                println!("Getting asset with an identification: {}", asset_id);
-                if let Some(account_id) = matches.value_of(ASSET_ACCOUNT_ID) {
-                    println!("Getting account with an identification: {}", account_id);
-                    get_asset(asset_id, account_id, configuration)?;
-                }
-            }
+    }
+
+    /// Command for minting asset in existing Iroha account
+    #[derive(StructOpt, Debug)]
+    pub struct Mint {
+        /// Account id where asset is stored (in form of `name@domain_name')
+        #[structopt(long)]
+        pub account: AccountId,
+        /// Asset id from which to mint (in form of `name#domain_name')
+        #[structopt(long)]
+        pub asset: AssetDefinitionId,
+        /// Quantity to mint
+        #[structopt(short, long)]
+        pub quantity: u32,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
+    }
+
+    impl RunArgs for Mint {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let Self {
+                account,
+                asset,
+                quantity,
+                metadata: Metadata(metadata),
+            } = self;
+            let mint_asset = MintBox::new(
+                Value::U32(quantity),
+                IdBox::AssetId(AssetId::new(asset, account)),
+            );
+            submit(mint_asset, cfg, metadata).wrap_err("Failed to mint asset value")
         }
-        Ok(())
     }
 
-    fn register_asset_definition(
-        asset_name: &str,
-        domain_name: &str,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-        value_type: AssetValueType,
-    ) -> Result<()> {
-        submit(
-            RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new(AssetDefinitionId::new(asset_name, domain_name), value_type)
-                    .into(),
-            ))
-            .into(),
-            configuration,
-            metadata,
-        )
+    /// Transfer asset between accounts
+    #[derive(StructOpt, Debug)]
+    pub struct Transfer {
+        /// Account from which to transfer (in form `name@domain_name')
+        #[structopt(short, long)]
+        pub from: AccountId,
+        /// Account from which to transfer (in form `name@domain_name')
+        #[structopt(short, long)]
+        pub to: AccountId,
+        /// Asset id to transfer (in form like `name#domain_name')
+        #[structopt(short, long)]
+        pub asset_id: AssetDefinitionId,
+        /// Quantity of asset as number
+        #[structopt(short, long)]
+        pub quantity: u32,
+        /// The filename with key-value metadata pairs in JSON
+        #[structopt(short, long, default_value = "")]
+        pub metadata: super::Metadata,
     }
 
-    fn mint_asset(
-        asset_definition_id: &str,
-        account_id: &str,
-        quantity: &str,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-    ) -> Result<()> {
-        let quantity: u32 = quantity
-            .parse::<u32>()
-            .wrap_err("Failed to parse Asset quantity.")?;
-        let mint_asset = MintBox::new(
-            Value::U32(quantity),
-            IdBox::AssetId(AssetId::new(
-                AssetDefinitionId::from_str(asset_definition_id)
-                    .wrap_err("Failed to parse Asset Definition Id.")?,
-                AccountId::from_str(account_id).wrap_err("Failed to parse Account Id.")?,
-            )),
-        );
-        submit(mint_asset.into(), configuration, metadata)
+    impl RunArgs for Transfer {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let Self {
+                from,
+                to,
+                asset_id,
+                quantity,
+                metadata: Metadata(metadata),
+            } = self;
+            let transfer_asset = TransferBox::new(
+                IdBox::AssetId(AssetId::new(asset_id.clone(), from)),
+                Value::U32(quantity),
+                IdBox::AssetId(AssetId::new(asset_id, to)),
+            );
+            submit(transfer_asset, cfg, metadata).wrap_err("Failed to transfer asset")
+        }
     }
 
-    fn transfer_asset(
-        account1_id: &str,
-        account2_id: &str,
-        asset_definition_id: &str,
-        quantity: &str,
-        configuration: &Configuration,
-        metadata: UnlimitedMetadata,
-    ) -> Result<()> {
-        let quantity = quantity
-            .parse::<u32>()
-            .wrap_err("Failed to parse Asset quantity.")?;
-        let transfer_asset = TransferBox::new(
-            IdBox::AssetId(AssetId::new(
-                AssetDefinitionId::from_str(asset_definition_id)
-                    .wrap_err("Failed to parse Source Definition Id")?,
-                AccountId::from_str(account1_id).wrap_err("Failed to parse Source Account Id.")?,
-            )),
-            Value::U32(quantity),
-            IdBox::AssetId(AssetId::new(
-                AssetDefinitionId::from_str(asset_definition_id)
-                    .wrap_err("Failed to parse Destination Definition Id")?,
-                AccountId::from_str(account2_id)
-                    .wrap_err("Failed to parse Destination Account Id.")?,
-            )),
-        );
-        submit(transfer_asset.into(), configuration, metadata)
+    /// Get info of asset
+    #[derive(StructOpt, Debug)]
+    pub struct Get {
+        /// Account where asset is stored (in form of `name@domain_name')
+        #[structopt(long)]
+        pub account: AccountId,
+        /// Asset name to lookup (in form of `name#domain_name')
+        #[structopt(long)]
+        pub asset: AssetDefinitionId,
     }
 
-    fn get_asset(asset_id: &str, account_id: &str, configuration: &Configuration) -> Result<()> {
-        let mut iroha_client = Client::new(configuration);
-        let account_id = AccountId::from_str(account_id).wrap_err("Failed to parse Account Id.")?;
-        let asset_id = AssetDefinitionId::from_str(asset_id)
-            .wrap_err("Failed to parse Asset Definition Id.")?;
-
-        let value = iroha_client
-            .request(asset::by_account_id_and_definition_id(account_id, asset_id))
-            .wrap_err("Failed to get asset.")?;
-        println!("Get Asset result: {:?}", value);
-        Ok(())
+    impl RunArgs for Get {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let Self { account, asset } = self;
+            let mut iroha_client = Client::new(cfg);
+            let value = iroha_client
+                .request(asset::by_account_id_and_definition_id(account, asset))
+                .wrap_err("Failed to get asset.")?;
+            println!("Get Asset result: {:?}", value);
+            Ok(())
+        }
     }
 }

--- a/iroha_crypto/Cargo.toml
+++ b/iroha_crypto/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 ursa = "=0.3.5"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 parity-scale-codec = { version = "2", features = ["derive"] }
 hex = "0.4.0"
 iroha_error = { path = "../iroha_error" }

--- a/iroha_crypto/src/lib.rs
+++ b/iroha_crypto/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     str::FromStr,
 };
 
-use iroha_error::{error, Error, Result};
+use iroha_error::{error, Error, Result, WrapErr};
 use iroha_schema::IntoSchema;
 use multihash::{DigestFunction as MultihashDigestFunction, Multihash};
 use parity_scale_codec::{Decode, Encode};
@@ -259,6 +259,14 @@ pub struct PublicKey {
     pub digest_function: String,
     /// payload of key
     pub payload: Vec<u8>,
+}
+
+impl FromStr for PublicKey {
+    type Err = Error;
+    fn from_str(key: &str) -> Result<Self> {
+        serde_json::from_value(serde_json::json!(key))
+            .wrap_err("Failed to deserialize supplied public key argument.")
+    }
 }
 
 impl Default for PublicKey {

--- a/iroha_data_model/src/lib.rs
+++ b/iroha_data_model/src/lib.rs
@@ -1050,7 +1050,7 @@ pub mod asset {
     };
 
     use iroha_derive::{FromVariant, Io};
-    use iroha_error::{error, Error, Result};
+    use iroha_error::{error, Error, Result, WrapErr};
     use iroha_schema::prelude::*;
     use parity_scale_codec::{Decode, Encode};
     use serde::{Deserialize, Serialize};
@@ -1161,6 +1161,14 @@ pub mod asset {
         BigQuantity,
         /// Asset's key-value structured data.
         Store,
+    }
+
+    impl FromStr for AssetValueType {
+        type Err = Error;
+        fn from_str(value_type: &str) -> Result<AssetValueType> {
+            serde_json::from_value(serde_json::json!(value_type))
+                .wrap_err("Failed to deserialize value type")
+        }
     }
 
     /// Asset's inner value.
@@ -1529,7 +1537,8 @@ pub mod domain {
     //! This module contains `Domain` structure and related implementations and trait implementations.
 
     use std::{
-        cmp::Ordering, collections::BTreeMap, iter, iter::FromIterator, ops::RangeInclusive,
+        cmp::Ordering, collections::BTreeMap, convert::Infallible, iter, iter::FromIterator,
+        ops::RangeInclusive, str::FromStr,
     };
 
     use dashmap::DashMap;
@@ -1593,6 +1602,13 @@ pub mod domain {
         pub accounts: AccountsMap,
         /// Assets of the domain.
         pub asset_definitions: AssetDefinitionsMap,
+    }
+
+    impl FromStr for Domain {
+        type Err = Infallible;
+        fn from_str(name: &str) -> Result<Self, Self::Err> {
+            Ok(Self::new(name))
+        }
     }
 
     impl PartialOrd for Domain {

--- a/scripts/test_docker_compose.sh
+++ b/scripts/test_docker_compose.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -ex
 cd test_docker
-./iroha_client_cli domain add --name="Soramitsu" --metadata="metadata.json"
+./iroha_client_cli domain register --id="Soramitsu" --metadata="metadata.json"
 sleep 2
-./iroha_client_cli account register --name="Alice" --domain="Soramitsu" --key="ed0120a753146e75b910ae5e2994dc8adea9e7d87e5d53024cfa310ce992f17106f92c"
+./iroha_client_cli account register --id="Alice@Soramitsu" --key="ed0120a753146e75b910ae5e2994dc8adea9e7d87e5d53024cfa310ce992f17106f92c"
 sleep 2
-./iroha_client_cli asset register --name="XOR" --domain="Soramitsu" --value_type=Quantity
+./iroha_client_cli asset register --id="XOR#Soramitsu" --value-type=Quantity
 sleep 2
-./iroha_client_cli asset mint --account_id="Alice@Soramitsu" --id="XOR#Soramitsu" --quantity="100"
+./iroha_client_cli asset mint --account="Alice@Soramitsu" --asset="XOR#Soramitsu" --quantity="100"
 sleep 2
-./iroha_client_cli asset get --account_id="Alice@Soramitsu" --id="XOR#Soramitsu" | grep -q 'Quantity(100)'
+./iroha_client_cli asset get --account="Alice@Soramitsu" --asset="XOR#Soramitsu" | grep -q 'Quantity(100)'

--- a/scripts/test_genesis_docker_compose.sh
+++ b/scripts/test_genesis_docker_compose.sh
@@ -2,4 +2,4 @@
 set -ex
 cd test_docker
 sleep 10
-./iroha_client_cli asset get --account_id alice@wonderland --id rose#wonderland | grep -q 'Quantity(13)'
+./iroha_client_cli asset get --account alice@wonderland --asset 'rose#wonderland' | grep -q 'Quantity(13)'


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1082
Signed-off-by: i1i1 <vanyarybin1@live.ru>


### Description of the Change

This pr migrates from using clap for parsing cli arguments to structopt crate. Also it introduces simple queries for accounts, assets and domains.

### Benefits

There will be typesafe descriptive structures for cli arguments which remove all boilerplate code. It will also let us easier add new commands to cli and manage existing ones. Apart from that it would be more error prune than our previous implementation.
Also now we are able to query domains, accounts, and assets via cli.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
