### PR TITLE
Move main.rs into separate crate and enable default permissions for public blockchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroha_cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "iroha",
+ "iroha_error",
+ "iroha_logger",
+ "iroha_permissions_validators",
+ "tokio 1.6.1",
+ "tracing",
+]
+
+[[package]]
 name = "iroha_client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "iroha",
+  "iroha_cli",
   "iroha_client",
   "iroha_client_cli",
   "iroha_crypto",

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN set -ex; \
 COPY iroha/config.json .
 COPY iroha/trusted_peers.json .
 COPY iroha/genesis.json .
-ARG BIN=iroha
+ARG BIN=iroha_cli
 ARG TARGET_DIR=debug
 COPY --from=builder /iroha/target/$TARGET_DIR/$BIN .
 ENV IROHA_TARGET_BIN=$BIN

--- a/docker-compose-single.yml
+++ b/docker-compose-single.yml
@@ -15,4 +15,4 @@ services:
     ports:
       - "1337:1337"
       - "8080:8080"
-    command: ./iroha --genesis genesis.json
+    command: ./iroha_cli --genesis genesis.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "1337:1337"
       - "8080:8080"
-    command: ./iroha --genesis genesis.json
+    command: ./iroha_cli --genesis genesis.json
 
   iroha2:
     depends_on:

--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroha"
 version = "0.1.0"
-authors = [ "Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov < <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>" ]
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 edition = "2018"
 description = "Iroha is a straightforward distributed ledger technology (DLT), inspired by Japanese Kaizen principle — eliminate excessiveness (muri). Iroha has essential functionality for your asset, information and identity management needs, at the same time being an efficient and trustworthy crash fault-tolerant tool for your enterprise needs."
 readme = "README.md"

--- a/iroha_cli/Cargo.toml
+++ b/iroha_cli/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "iroha_cli"
+version = "0.1.0"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2018"
+description = "Iroha is a straightforward distributed ledger technology (DLT), inspired by Japanese Kaizen principle — eliminate excessiveness (muri). Iroha has essential functionality for your asset, information and identity management needs, at the same time being an efficient and trustworthy crash fault-tolerant tool for your enterprise needs."
+readme = "README.md"
+homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+repository = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+license = "Apache-2.0"
+keywords = ["crypto", "blockchain", "ledger"]
+categories = ["cryptography::cryptocurrencies"]
+
+[features]
+bridge = ["iroha/bridge"]
+dex = ["iroha/dex"]
+roles = ["iroha/roles"]
+network-mock = ["iroha/network-mock"]
+telemetry = ["iroha/telemetry"]
+dev-telemetry = ["iroha/dev-telemetry"]
+default = ["bridge"]
+
+[badges]
+is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledger/iroha" }
+is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/iroha" }
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+iroha = { path = "../iroha" }
+iroha_permissions_validators = { path = "../iroha_permissions_validators" }
+iroha_error = { version = "=0.1.0", path = "../iroha_error" }
+iroha_logger = { version = "=0.1.0", path = "../iroha_logger"}
+
+clap = "2.33.0"
+tracing = "0.1"
+tokio = { version = "1.6.0", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"]}

--- a/iroha_cli/README.md
+++ b/iroha_cli/README.md
@@ -44,7 +44,7 @@ Build and copy Iroha binary into the directory.
 
 ```bash
 cargo build
-cp ./target/debug/iroha iroha_deploy
+cp ./target/debug/iroha_cli iroha_deploy
 ```
 
 #### Copy configs
@@ -68,7 +68,7 @@ Start Iroha peer. It can be done either with `--genesis` param to specify `genes
 
 ```bash
 cd iroha_deploy
-./iroha --genesis="genesis.json"
+./iroha_cli --genesis="genesis.json"
 ```
 
 ### Docker Compose Deployment

--- a/iroha_cli/src/main.rs
+++ b/iroha_cli/src/main.rs
@@ -1,8 +1,9 @@
 //! Iroha peer command line
 
 use clap::{App, Arg};
-use iroha::{config::Configuration, smartcontracts::permissions::AllowAll, Iroha};
+use iroha::{config::Configuration, Iroha};
 use iroha_error::Reporter;
+use iroha_permissions_validators::public_blockchain::default_permissions;
 
 const CONFIGURATION_PATH: &str = "config.json";
 const TRUSTED_PEERS_PATH: &str = "trusted_peers.json";
@@ -36,6 +37,8 @@ async fn main() -> Result<(), Reporter> {
         configuration.add_genesis_block_path(genesis_path);
     }
 
-    Iroha::new(&configuration, AllowAll.into())?.start().await?;
+    Iroha::new(&configuration, default_permissions())?
+        .start()
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: i1i1 <vanyarybin1@live.ru>

### Description of the Change

This commit separates iroha and iroha_cli and makes permissions in iroha 2 for public blockchain use cases.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
