### PR TITLE
Changed text entities to links in docs.

### DIFF
--- a/iroha/src/block.rs
+++ b/iroha/src/block.rs
@@ -251,21 +251,21 @@ declare_versioned_with_scale!(VersionedValidBlock 1..2, Debug, Clone, iroha_deri
 
 #[allow(clippy::missing_errors_doc)]
 impl VersionedValidBlock {
-    /// Same as [`as_v1`] but also does conversion
+    /// Same as [`as_v1`](`VersionedValidBlock::as_v1()`) but also does conversion
     pub const fn as_inner_v1(&self) -> &ValidBlock {
         match self {
             Self::V1(v1) => &v1.0,
         }
     }
 
-    /// Same as [`as_inner_v1`] but returns mutable reference
+    /// Same as [`as_inner_v1`](`VersionedValidBlock::as_inner_v1()`) but returns mutable reference
     pub fn as_mut_inner_v1(&mut self) -> &mut ValidBlock {
         match self {
             Self::V1(v1) => &mut v1.0,
         }
     }
 
-    /// Same as [`into_v1`] but also does conversion
+    /// Same as [`into_v1`](`VersionedValidBlock::into_v1()`) but also does conversion
     #[allow(clippy::missing_const_for_fn)]
     pub fn into_inner_v1(self) -> ValidBlock {
         match self {
@@ -299,7 +299,7 @@ impl VersionedValidBlock {
         self.as_inner_v1().header.hash()
     }
 
-    /// Sign this block and get `VersionedValidBlock`.
+    /// Sign this block and get [`VersionedValidBlock`](`Self`).
     pub fn sign(self, key_pair: &KeyPair) -> Result<VersionedValidBlock> {
         self.into_inner_v1().sign(key_pair).map(Into::into)
     }
@@ -495,21 +495,21 @@ impl From<&ValidBlock> for Vec<Event> {
 declare_versioned_with_scale!(VersionedCommittedBlock 1..2, Debug, Clone, iroha_derive::FromVariant);
 
 impl VersionedCommittedBlock {
-    /// Same as [`as_v1`] but also does conversion
+    /// Same as [`as_v1`](`VersionedCommittedBlock::as_v1()`) but also does conversion
     pub const fn as_inner_v1(&self) -> &CommittedBlock {
         match self {
             Self::V1(v1) => &v1.0,
         }
     }
 
-    /// Same as [`as_inner_v1`] but returns mutable reference
+    /// Same as [`as_inner_v1`](`VersionedCommittedBlock::as_inner_v1()`) but returns mutable reference
     pub fn as_mut_inner_v1(&mut self) -> &mut CommittedBlock {
         match self {
             Self::V1(v1) => &mut v1.0,
         }
     }
 
-    /// Same as [`into_v1`] but also does conversion
+    /// Same as [`into_v1`](`VersionedCommittedBlock::into_v1()`) but also does conversion
     pub fn into_inner_v1(self) -> CommittedBlock {
         match self {
             Self::V1(v1) => v1.into(),

--- a/iroha/src/block_sync.rs
+++ b/iroha/src/block_sync.rs
@@ -165,21 +165,21 @@ pub mod message {
     declare_versioned_with_scale!(VersionedMessage 1..2, Debug, Clone, iroha_derive::FromVariant);
 
     impl VersionedMessage {
-        /// Same as [`as_v1`] but also does conversion
+        /// Same as [`as_v1`](`VersionedMessage::as_v1()`) but also does conversion
         pub const fn as_inner_v1(&self) -> &Message {
             match self {
                 Self::V1(v1) => &v1.0,
             }
         }
 
-        /// Same as [`as_inner_v1`] but returns mutable reference
+        /// Same as [`as_inner_v1`](`VersionedMessage::as_inner_v1()`) but returns mutable reference
         pub fn as_mut_inner_v1(&mut self) -> &mut Message {
             match self {
                 Self::V1(v1) => &mut v1.0,
             }
         }
 
-        /// Same as [`into_v1`] but also does conversion
+        /// Same as [`into_v1`](`VersionedMessage::into_v1()`) but also does conversion
         #[allow(clippy::missing_const_for_fn)]
         pub fn into_inner_v1(self) -> Message {
             match self {

--- a/iroha/src/config.rs
+++ b/iroha/src/config.rs
@@ -1,4 +1,4 @@
-//! This module contains `Configuration` structure and related implementation.
+//! This module contains [`Configuration`] structure and related implementation.
 use std::{fmt::Debug, fs::File, io::BufReader, path::Path};
 
 use iroha_config::derive::Configurable;

--- a/iroha/src/kura.rs
+++ b/iroha/src/kura.rs
@@ -1,5 +1,5 @@
 //! This module contains persistence related Iroha logic.
-//! `Kura` is the main entity which should be used to store new `Block`s on the blockchain.
+//! [`Kura`] is the main entity which should be used to store new [`Block`](`crate::block::VersionedCommittedBlock`)s on the blockchain.
 
 use std::{
     fs,
@@ -28,8 +28,8 @@ pub struct Kura {
 
 #[allow(dead_code)]
 impl Kura {
-    /// Default `Kura` constructor.
-    /// Kura will not be ready to work with before `init` method invocation.
+    /// Default [`Kura`] constructor.
+    /// Kura will not be ready to work with before [`init`] method invocation.
     pub fn new(
         mode: Mode,
         block_store_path: &Path,
@@ -54,7 +54,7 @@ impl Kura {
         )
     }
 
-    /// After constructing `Kura` it should be initialized to be ready to work with it.
+    /// After constructing [`Kura`] it should be initialized to be ready to work with it.
     #[iroha_futures::telemetry_future]
     pub async fn init(&mut self) -> Result<Vec<VersionedCommittedBlock>> {
         let blocks = self.block_store.read_all().await;

--- a/iroha/src/smartcontracts/isi/account.rs
+++ b/iroha/src/smartcontracts/isi/account.rs
@@ -1,13 +1,15 @@
-//! This module contains `Account` structure, it's implementation and related traits and
-//! instructions implementations.
+//! This module contains implementations of smart-contract traits and instructions for [`Account`] structure
+//! and implementations of [`Query`]'s to [`WorldStateView`] about [`Account`].
 
 use iroha_data_model::prelude::*;
 
 use crate::prelude::*;
 
-/// Iroha Special Instructions module provides `AccountInstruction` enum with all possible types of
-/// Account related instructions as variants, implementations of generic Iroha Special Instructions
-/// and the `From/Into` implementations to convert `AccountInstruction` variants into generic ISI.
+/// ISI module contains all instructions related to accounts:
+/// - minting/burning public key into account signatories
+/// - minting/burning signature condition check
+/// - update metadata
+/// - grant permissions and roles
 pub mod isi {
     use super::super::prelude::*;
     use super::*;
@@ -155,7 +157,7 @@ pub mod isi {
     }
 }
 
-/// Query module provides `IrohaQuery` Account related implementations.
+/// Query module provides [`Query`] Account related implementations.
 pub mod query {
 
     use iroha_error::{error, Result, WrapErr};

--- a/iroha/src/smartcontracts/isi/asset.rs
+++ b/iroha/src/smartcontracts/isi/asset.rs
@@ -1,4 +1,4 @@
-//! This module contains `Asset` structure, it's implementation and related traits and
+//! This module contains [`Asset`] structure, it's implementation and related traits and
 //! instructions implementations.
 
 use iroha_data_model::prelude::*;
@@ -6,16 +6,17 @@ use iroha_data_model::prelude::*;
 use super::prelude::*;
 use crate::prelude::*;
 
-/// Iroha Special Instructions module provides `AssetInstruction` enum with all possible types of
-/// Asset related instructions as variants, implementations of generic Iroha Special Instructions
-/// and the `From/Into` implementations to convert `AssetInstruction` variants into generic ISI.
+/// ISI module contains all instructions related to assets:
+/// - minting/burning assets
+/// - update metadata
+/// - transfer, etc.
 pub mod isi {
     use iroha_error::error;
     use iroha_logger::log;
 
     use super::*;
 
-    /// Asserts that asset definition with `deifintion_id` has asset type `expected_value_type`.
+    /// Asserts that asset definition with [`definition_id`] has asset type [`expected_value_type`].
     fn assert_asset_type(
         definition_id: &AssetDefinitionId,
         wsv: &WorldStateView,
@@ -218,7 +219,7 @@ pub mod isi {
     }
 }
 
-/// Query module provides `IrohaQuery` Asset related implementations.
+/// Query module provides [`Query`] Asset related implementations.
 pub mod query {
     use iroha_error::{error, Result, WrapErr};
     use iroha_logger::log;

--- a/iroha/src/smartcontracts/isi/domain.rs
+++ b/iroha/src/smartcontracts/isi/domain.rs
@@ -1,4 +1,4 @@
-//! This module contains `Domain` structure and related implementations and trait implementations.
+//! This module contains [`Domain`] structure and related implementations and trait implementations.
 use std::collections::btree_map::Entry;
 
 use iroha_data_model::prelude::*;
@@ -7,9 +7,10 @@ use iroha_error::{error, Result};
 use super::super::isi::prelude::*;
 use crate::prelude::*;
 
-/// Iroha Special Instructions module provides `DomainInstruction` enum with all possible types of
-/// Domain related instructions as variants, implementations of generic Iroha Special Instructions
-/// and the `From/Into` implementations to convert `DomainInstruction` variants into generic ISI.
+/// ISI module contains all instructions related to domains:
+/// - creating/changing assets
+/// - registering/unregistering accounts
+/// - transfer, etc.
 pub mod isi {
     use super::*;
 
@@ -121,7 +122,7 @@ pub mod isi {
     }
 }
 
-/// Query module provides `IrohaQuery` Domain related implementations.
+/// Query module provides [`Query`] Domain related implementations.
 pub mod query {
     use iroha_error::{Result, WrapErr};
     use iroha_logger::log;

--- a/iroha/src/smartcontracts/isi/tx.rs
+++ b/iroha/src/smartcontracts/isi/tx.rs
@@ -1,4 +1,4 @@
-//! Query module provides [`IrohaQuery`] Transaction related implementations.
+//! Query module provides [`Query`] Transaction related implementations.
 
 use iroha_data_model::prelude::*;
 use iroha_error::{Result, WrapErr};

--- a/iroha/src/smartcontracts/mod.rs
+++ b/iroha/src/smartcontracts/mod.rs
@@ -11,7 +11,7 @@ pub use isi::*;
 
 use super::wsv::WorldStateView;
 
-/// Trait implementations should provide actions to apply changes on `WorldStateView`.
+/// Trait implementations should provide actions to apply changes on [`WorldStateView`].
 #[allow(clippy::missing_errors_doc)]
 pub trait Execute {
     /// Error type returned by execute function
@@ -39,8 +39,8 @@ pub trait Evaluate {
 /// This trait should be implemented for all Iroha Queries.
 #[allow(clippy::missing_errors_doc)]
 pub trait Query: QueryOutput {
-    /// Execute query on the `WorldStateView`.
-    /// Should not mutate `WorldStateView`!
+    /// Execute query on the [`WorldStateView`].
+    /// Should not mutate [`WorldStateView`]!
     ///
     /// Returns Ok(QueryResult) if succeeded and Err(String) if failed.
     fn execute(&self, wsv: &WorldStateView) -> iroha_error::Result<Self::Output>;

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -835,21 +835,21 @@ pub mod message {
     declare_versioned_with_scale!(VersionedMessage 1..2, Debug, Clone, iroha_derive::FromVariant);
 
     impl VersionedMessage {
-        /// Same as [`as_v1`] but also does conversion
+        /// Same as [`as_v1`](`VersionedMessage::as_v1()`) but also does conversion
         pub const fn as_inner_v1(&self) -> &Message {
             match self {
                 Self::V1(v1) => &v1.0,
             }
         }
 
-        /// Same as [`as_inner_v1`] but returns mutable reference
+        /// Same as [`as_inner_v1`](`VersionedMessage::as_inner_v1()`) but returns mutable reference
         pub fn as_mut_inner_v1(&mut self) -> &mut Message {
             match self {
                 Self::V1(v1) => &mut v1.0,
             }
         }
 
-        /// Same as [`into_v1`] but also does conversion
+        /// Same as [`into_v1`](`VersionedMessage::into_v1()`) but also does conversion
         #[allow(clippy::missing_const_for_fn)]
         pub fn into_inner_v1(self) -> Message {
             match self {

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -24,21 +24,21 @@ declare_versioned_with_scale!(VersionedAcceptedTransaction 1..2, Debug, Clone, i
 
 #[allow(clippy::missing_errors_doc)]
 impl VersionedAcceptedTransaction {
-    /// Same as [`as_v1`] but also does conversion
+    /// Same as [`as_v1`](`VersionedAcceptedTransaction::as_v1()`) but also does conversion
     pub const fn as_inner_v1(&self) -> &AcceptedTransaction {
         match self {
             VersionedAcceptedTransaction::V1(v1) => &v1.0,
         }
     }
 
-    /// Same as [`as_inner_v1`] but returns mutable reference
+    /// Same as [`as_inner_v1`](`VersionedAcceptedTransaction::as_inner_v1()`) but returns mutable reference
     pub fn as_mut_inner_v1(&mut self) -> &mut AcceptedTransaction {
         match self {
             VersionedAcceptedTransaction::V1(v1) => &mut v1.0,
         }
     }
 
-    /// Same as [`into_v1`] but also does conversion
+    /// Same as [`into_v1`](`VersionedAcceptedTransaction::into_v1()`) but also does conversion
     #[allow(clippy::missing_const_for_fn)]
     pub fn into_inner_v1(self) -> AcceptedTransaction {
         match self {
@@ -361,21 +361,21 @@ declare_versioned_with_scale!(VersionedValidTransaction 1..2, Debug, Clone, iroh
 
 #[allow(clippy::missing_errors_doc)]
 impl VersionedValidTransaction {
-    /// Same as [`as_v1`] but also does conversion
+    /// Same as [`as_v1`](`VersionedValidTransaction::as_v1()`) but also does conversion
     pub const fn as_inner_v1(&self) -> &ValidTransaction {
         match self {
             Self::V1(v1) => &v1.0,
         }
     }
 
-    /// Same as [`as_inner_v1`] but returns mutable reference
+    /// Same as [`as_inner_v1`](`VersionedValidTransaction::as_inner_v1()`) but returns mutable reference
     pub fn as_mut_inner_v1(&mut self) -> &mut ValidTransaction {
         match self {
             Self::V1(v1) => &mut v1.0,
         }
     }
 
-    /// Same as [`into_v1`] but also does conversion
+    /// Same as [`into_v1`](`VersionedValidTransaction::into_v1()`) but also does conversion
     #[allow(clippy::missing_const_for_fn)]
     pub fn into_inner_v1(self) -> ValidTransaction {
         match self {

--- a/iroha_config/src/lib.rs
+++ b/iroha_config/src/lib.rs
@@ -9,7 +9,7 @@ pub mod derive {
     use std::error::Error as StdError;
     use std::fmt;
 
-    /// Derive macro for implementing [`iroha_config::Configurable`] for config structures.
+    /// Derive macro for implementing [`iroha_config::Configurable`](`crate::Configurable`) for config structures.
     ///
     /// Has several attributes:
     ///

--- a/iroha_crypto/src/lib.rs
+++ b/iroha_crypto/src/lib.rs
@@ -213,7 +213,7 @@ pub struct KeyPair {
 }
 
 impl KeyPair {
-    /// Generates a pair of Public and Private key with `Algorithm::default()` selected as generation algorithm.
+    /// Generates a pair of Public and Private key with [`Algorithm::default()`] selected as generation algorithm.
     ///
     /// # Errors
     /// Fails if decoding fails
@@ -221,7 +221,7 @@ impl KeyPair {
         Self::generate_with_configuration(KeyGenConfiguration::default())
     }
 
-    /// Generates a pair of Public and Private key with the corresponding `KeyGenConfiguration`.
+    /// Generates a pair of Public and Private key with the corresponding [`KeyGenConfiguration`].
     ///
     /// # Errors
     /// Fails if decoding fails
@@ -406,7 +406,7 @@ pub struct Signature {
 }
 
 impl Signature {
-    /// Creates new `Signature` by signing payload via `private_key`.
+    /// Creates new [`Signature`] by signing payload via [`KeyPair::private_key`].
     ///
     /// # Errors
     /// Fails if decoding digest of key pair fails
@@ -426,7 +426,7 @@ impl Signature {
         })
     }
 
-    /// Verify `message` using signed data and `public_key`.
+    /// Verify `message` using signed data and [`KeyPair::public_key`].
     ///
     /// # Errors
     /// Fails if decoding digest of key pair fails or if message didn't pass verification

--- a/iroha_data_model/src/events.rs
+++ b/iroha_data_model/src/events.rs
@@ -37,21 +37,21 @@ pub struct EventReceived;
 declare_versioned_with_json!(VersionedEvent 1..2, Debug, Clone, FromVariant, IntoSchema);
 
 impl VersionedEvent {
-    /// The same as `as_v1` but also runs into on it
+    /// The same as [`as_v1`](`VersionedEvent::as_v1()`) but also runs into on it
     pub const fn as_inner_v1(&self) -> &Event {
         match self {
             Self::V1(v1) => &v1.0,
         }
     }
 
-    /// The same as `as_v1` but also runs into on it
+    /// The same as [`as_v1`](`VersionedEvent::as_v1()`) but also runs into on it
     pub fn as_mut_inner_v1(&mut self) -> &mut Event {
         match self {
             Self::V1(v1) => &mut v1.0,
         }
     }
 
-    /// The same as `as_v1` but also runs into on it
+    /// The same as [`as_v1`](`VersionedEvent::as_v1()`) but also runs into on it
     #[allow(clippy::missing_const_for_fn)]
     pub fn into_inner_v1(self) -> Event {
         match self {
@@ -126,7 +126,7 @@ pub mod data {
         /// Entity's state was changed, any parameter updated it's value.
         Updated,
         /// Entity was archived or by any other way was put into state that guarantees absense of
-        /// `Updated` events for this entity.
+        /// [`Updated`](`Status::Updated`) events for this entity.
         Deleted,
     }
 

--- a/iroha_data_model/src/lib.rs
+++ b/iroha_data_model/src/lib.rs
@@ -24,7 +24,7 @@ pub mod expression;
 pub mod isi;
 pub mod query;
 
-/// `Name` struct represents type for Iroha Entities names, like `Domain`'s name or `Account`'s
+/// `Name` struct represents type for Iroha Entities names, like [`Domain`](`domain::Domain`)'s name or [`Account`](`account::Account`)'s
 /// name.
 pub type Name = String;
 
@@ -94,17 +94,17 @@ pub enum Parameter {
     IntoSchema,
 )]
 pub enum IdBox {
-    /// `AccountId` variant.
+    /// [`AccountId`](`account::Id`) variant.
     AccountId(account::Id),
-    /// `AssetId` variant.
+    /// [`AssetId`](`asset::Id`) variant.
     AssetId(asset::Id),
-    /// `AssetDefinitionId` variant.
+    /// [`AssetDefinitionId`](`asset::DefinitionId`) variant.
     AssetDefinitionId(asset::DefinitionId),
-    /// `DomainName` variant.
+    /// [`DomainName`](`Name`) variant.
     DomainName(Name),
-    /// `PeerId` variant.
+    /// [`PeerId`](`peer::Id`) variant.
     PeerId(peer::Id),
-    /// `RoleId` variant.
+    /// [`RoleId`](`role::Id`) variant.
     #[cfg(feature = "roles")]
     RoleId(role::Id),
     /// `World`.
@@ -127,26 +127,26 @@ pub enum IdBox {
     IntoSchema,
 )]
 pub enum IdentifiableBox {
-    /// `Account` variant.
+    /// [`Account`](`account::Account`) variant.
     Account(Box<account::Account>),
-    /// `NewAccount` variant.
+    /// [`NewAccount`](`account::NewAccount`) variant.
     NewAccount(Box<account::NewAccount>),
-    /// `Asset` variant.
+    /// [`Asset`](`asset::Asset`) variant.
     Asset(Box<asset::Asset>),
-    /// `AssetDefinition` variant.
+    /// [`AssetDefinition`](`asset::AssetDefinition`) variant.
     AssetDefinition(Box<asset::AssetDefinition>),
-    /// `Domain` variant.
+    /// [`Domain`](`domain::Domain`) variant.
     Domain(Box<domain::Domain>),
-    /// `Peer` variant.
+    /// [`Peer`](`peer::Peer`) variant.
     Peer(Box<peer::Peer>),
-    /// `Role` variant.
+    /// [`Role`](`role::Role`) variant.
     #[cfg(feature = "roles")]
     Role(Box<role::Role>),
-    /// `World`.
+    /// [`World`](`world::World`).
     World,
 }
 
-/// Boxed `Value`.
+/// Boxed [`Value`].
 pub type ValueBox = Box<Value>;
 
 /// Sized container for all possible values.
@@ -355,7 +355,7 @@ pub trait Identifiable: Debug + Clone {
     type Id: Into<IdBox> + Debug + Clone + Eq + Ord;
 }
 
-/// Limits of length of the identifiers (e.g. in [`Domain`], [`NewAccount`], [`AssetDefinition`]) in bytes
+/// Limits of length of the identifiers (e.g. in [`domain::Domain`], [`account::NewAccount`], [`asset::AssetDefinition`]) in bytes
 #[derive(Debug, Clone, Copy, Decode, Encode, Serialize, Deserialize)]
 pub struct LengthLimits {
     /// Minimal length in bytes (inclusive).
@@ -836,11 +836,11 @@ pub mod account {
         Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Io, Encode, Decode, IntoSchema,
     )]
     pub struct Account {
-        /// An Identification of the `Account`.
+        /// An Identification of the [`Account`].
         pub id: Id,
-        /// Asset's in this `Account`.
+        /// Asset's in this [`Account`].
         pub assets: AssetsMap,
-        /// `Account`'s signatories.
+        /// [`Account`]'s signatories.
         pub signatories: Signatories,
         /// Permissions tokens of this account
         pub permission_tokens: Permissions,
@@ -891,14 +891,14 @@ pub mod account {
         IntoSchema,
     )]
     pub struct Id {
-        /// `Account`'s name.
+        /// [`Account`]'s name.
         pub name: Name,
-        /// `Account`'s `Domain`'s name.
+        /// [`Account`]'s [`Domain`](`crate::domain::Domain`)'s name.
         pub domain_name: Name,
     }
 
     impl Account {
-        /// Default `Account` constructor.
+        /// Default [`Account`] constructor.
         pub fn new(id: Id) -> Self {
             Account {
                 id,
@@ -1037,7 +1037,7 @@ pub mod account {
 }
 
 pub mod asset {
-    //! This module contains `Asset` structure, it's implementation and related traits and
+    //! This module contains [`Asset`] structure, it's implementation and related traits and
     //! instructions implementations.
 
     use std::ops::RangeInclusive;
@@ -1061,14 +1061,14 @@ pub mod asset {
         Identifiable, Name, TryAsMut, TryAsRef, Value,
     };
 
-    /// `AssetsMap` provides an API to work with collection of key (`Id`) - value
-    /// (`Asset`) pairs.
+    /// [`AssetsMap`] provides an API to work with collection of key ([`Id`]) - value
+    /// ([`Asset`]) pairs.
     pub type AssetsMap = BTreeMap<Id, Asset>;
-    /// `AssetDefinitionsMap` provides an API to work with collection of key (`DefinitionId`) - value
+    /// [`AssetDefinitionsMap`] provides an API to work with collection of key ([`DefinitionId`]) - value
     /// (`AssetDefinition`) pairs.
     pub type AssetDefinitionsMap = BTreeMap<DefinitionId, AssetDefinitionEntry>;
 
-    /// An entry in `AssetDefinitionsMap`.
+    /// An entry in [`AssetDefinitionsMap`].
     #[derive(
         Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Io, Encode, Decode, IntoSchema,
     )]
@@ -1120,14 +1120,14 @@ pub mod asset {
         IntoSchema,
     )]
     pub struct AssetDefinition {
-        /// Type of `AssetValue`
+        /// Type of [`AssetValue`]
         pub value_type: AssetValueType,
-        /// An Identification of the `AssetDefinition`.
+        /// An Identification of the [`AssetDefinition`].
         pub id: DefinitionId,
     }
 
     /// Asset represents some sort of commodity or value.
-    /// All possible variants of `Asset` entity's components.
+    /// All possible variants of [`Asset`] entity's components.
     #[derive(
         Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Io, Encode, Decode, IntoSchema,
     )]
@@ -1296,7 +1296,7 @@ pub mod asset {
         pub domain_name: Name,
     }
 
-    /// Identification of an Asset's components include Entity Id (`Asset::Id`) and `Account::Id`.
+    /// Identification of an Asset's components include Entity Id ([`Asset::Id`]) and [`Account::Id`].
     #[derive(
         Clone,
         Debug,
@@ -1320,7 +1320,7 @@ pub mod asset {
     }
 
     impl AssetDefinition {
-        /// Default `AssetDefinition` constructor.
+        /// Default [`AssetDefinition`] constructor.
         pub const fn new(id: DefinitionId, value_type: AssetValueType) -> Self {
             AssetDefinition { value_type, id }
         }
@@ -1430,7 +1430,7 @@ pub mod asset {
     }
 
     impl DefinitionId {
-        /// `Id` constructor used to easily create an `Id` from three string slices - one for the
+        /// [`Id`] constructor used to easily create an [`Id`] from three string slices - one for the
         /// asset definition's name, another one for the domain's name.
         pub fn new(name: &str, domain_name: &str) -> Self {
             DefinitionId {
@@ -1441,7 +1441,7 @@ pub mod asset {
     }
 
     impl Id {
-        /// `Id` constructor used to easily create an `Id` from an names of asset definition and
+        /// [`Id`] constructor used to easily create an [`Id`] from an names of asset definition and
         /// account.
         pub fn from_names(
             asset_definition_name: &str,
@@ -1458,8 +1458,8 @@ pub mod asset {
             }
         }
 
-        /// `Id` constructor used to easily create an `Id` from an `AssetDefinitionId` and
-        /// an `AccountId`.
+        /// [`Id`] constructor used to easily create an [`Id`] from an [`DefinitionId`](`crate::asset::DefinitionId`) and
+        /// an [`AccountId`].
         pub const fn new(definition_id: DefinitionId, account_id: AccountId) -> Self {
             Id {
                 definition_id,
@@ -1534,7 +1534,7 @@ pub mod asset {
 }
 
 pub mod domain {
-    //! This module contains `Domain` structure and related implementations and trait implementations.
+    //! This module contains [`Domain`](`crate::domain::Domain`) structure and related implementations and trait implementations.
 
     use std::{
         cmp::Ordering, collections::BTreeMap, convert::Infallible, iter, iter::FromIterator,
@@ -1591,7 +1591,7 @@ pub mod domain {
         }
     }
 
-    /// Named group of `Account` and `Asset` entities.
+    /// Named group of [`Account`] and [`Asset`](`crate::asset::Asset`) entities.
     #[derive(
         Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Io, Encode, Decode, IntoSchema,
     )]
@@ -1671,7 +1671,7 @@ pub mod domain {
 }
 
 pub mod peer {
-    //! This module contains `Peer` structure and related implementations and traits implementations.
+    //! This module contains [`Peer`] structure and related implementations and traits implementations.
 
     #![allow(clippy::missing_inline_in_public_items)]
 
@@ -1743,7 +1743,7 @@ pub mod peer {
     }
 
     impl Id {
-        /// Default `PeerId` constructor.
+        /// Default peer `Id` constructor.
         pub fn new(address: &str, public_key: &PublicKey) -> Self {
             Id {
                 address: address.to_owned(),
@@ -1768,7 +1768,7 @@ pub mod peer {
 }
 
 pub mod transaction {
-    //! This module contains `Transaction` structures and related implementations
+    //! This module contains [`Transaction`] structures and related implementations
     //! and traits implementations.
     // TODO remove `allow` when the task https://jira.hyperledger.org/browse/IR-1048 will be closed
     #![allow(unused_results, clippy::missing_inline_in_public_items)]
@@ -1808,7 +1808,7 @@ pub mod transaction {
 
     /// This structure represents transaction in non-trusted form.
     ///
-    /// `Iroha` and its' clients use `Transaction` to send transactions via network.
+    /// `Iroha` and its' clients use [`Transaction`] to send transactions via network.
     /// Direct usage in business logic is strongly prohibited. Before any interactions
     /// `accept`.
     #[version(
@@ -1820,13 +1820,13 @@ pub mod transaction {
         Clone, Debug, Io, Encode, Decode, Serialize, Deserialize, Eq, PartialEq, IntoSchema,
     )]
     pub struct Transaction {
-        /// `Transaction` payload.
+        /// [`Transaction`] payload.
         pub payload: Payload,
-        /// `Transaction`'s `Signature`s.
+        /// [`Transaction`]'s [`Signature`]s.
         pub signatures: Vec<Signature>,
     }
 
-    /// Iroha `Transaction` payload.
+    /// Iroha [`Transaction`] payload.
     #[derive(
         Clone, Debug, Io, Encode, Decode, Serialize, Deserialize, Eq, PartialEq, IntoSchema,
     )]
@@ -1844,21 +1844,21 @@ pub mod transaction {
     }
 
     impl VersionedTransaction {
-        /// Same as [`as_v1`] but also does conversion
+        /// Same as [`as_v1`](`VersionedTransaction::as_v1()`) but also does conversion
         pub const fn as_inner_v1(&self) -> &Transaction {
             match self {
                 Self::V1(v1) => &v1.0,
             }
         }
 
-        /// Same as [`as_inner_v1`] but returns mutable reference
+        /// Same as [`as_inner_v1`](`VersionedTransaction::as_inner_v1()`) but returns mutable reference
         pub fn as_mut_inner_v1(&mut self) -> &mut Transaction {
             match self {
                 Self::V1(v1) => &mut v1.0,
             }
         }
 
-        /// Same as [`into_v1`] but also does conversion
+        /// Same as [`into_v1`](`VersionedTransaction::into_v1()`) but also does conversion
         #[allow(clippy::missing_const_for_fn)]
         pub fn into_inner_v1(self) -> Transaction {
             match self {
@@ -1866,7 +1866,7 @@ pub mod transaction {
             }
         }
 
-        /// Default `Transaction` constructor.
+        /// Default [`Transaction`] constructor.
         pub fn new(
             instructions: Vec<Instruction>,
             account_id: <Account as Identifiable>::Id,
@@ -1875,7 +1875,7 @@ pub mod transaction {
             Transaction::new(instructions, account_id, proposed_ttl_ms).into()
         }
 
-        /// Calculate transaction `Hash`.
+        /// Calculate transaction [`Hash`](`iroha_crypto::Hash`).
         pub fn hash(&self) -> Hash {
             self.as_inner_v1().hash()
         }
@@ -1906,7 +1906,7 @@ pub mod transaction {
     }
 
     impl Transaction {
-        /// Default `Transaction` constructor.
+        /// Default [`Transaction`] constructor.
         pub fn new(
             instructions: Vec<Instruction>,
             account_id: <Account as Identifiable>::Id,
@@ -1920,7 +1920,7 @@ pub mod transaction {
             )
         }
 
-        /// [`Transactions`] constructor with metadata.
+        /// [`Transaction`] constructor with metadata.
         pub fn with_metadata(
             instructions: Vec<Instruction>,
             account_id: <Account as Identifiable>::Id,
@@ -1943,7 +1943,7 @@ pub mod transaction {
             }
         }
 
-        /// Calculate transaction `Hash`.
+        /// Calculate transaction [`Hash`](`iroha_crypto::Hash`).
         pub fn hash(&self) -> Hash {
             let bytes: Vec<u8> = self.payload.clone().into();
             Hash::new(&bytes)
@@ -2008,21 +2008,21 @@ pub mod transaction {
     }
 
     impl VersionedPendingTransactions {
-        /// Same as [`as_v1`] but also does conversion
+        /// Same as [`as_v1`](`VersionedPendingTransactions::as_v1()`) but also does conversion
         pub const fn as_inner_v1(&self) -> &PendingTransactions {
             match self {
                 Self::V1(v1) => &v1.0,
             }
         }
 
-        /// Same as [`as_inner_v1`] but returns mutable reference
+        /// Same as [`as_inner_v1`](`VersionedPendingTransactions::as_inner_v1()`) but returns mutable reference
         pub fn as_mut_inner_v1(&mut self) -> &mut PendingTransactions {
             match self {
                 Self::V1(v1) => &mut v1.0,
             }
         }
 
-        /// Same as [`into_v1`] but also does conversion
+        /// Same as [`into_v1`](`VersionedPendingTransactions::into_v1()`) but also does conversion
         #[allow(clippy::missing_const_for_fn)]
         pub fn into_inner_v1(self) -> PendingTransactions {
             match self {
@@ -2098,21 +2098,21 @@ pub mod transaction {
 
     #[allow(clippy::missing_errors_doc)]
     impl VersionedRejectedTransaction {
-        /// The same as `as_v1` but also runs into on it
+        /// The same as [`as_v1`](`VersionedRejectedTransaction::as_v1()`) but also runs into on it
         pub const fn as_inner_v1(&self) -> &RejectedTransaction {
             match self {
                 Self::V1(v1) => &v1.0,
             }
         }
 
-        /// The same as `as_v1` but also runs into on it
+        /// The same as [`as_v1`](`VersionedRejectedTransaction::as_v1()`) but also runs into on it
         pub fn as_mut_inner_v1(&mut self) -> &mut RejectedTransaction {
             match self {
                 Self::V1(v1) => &mut v1.0,
             }
         }
 
-        /// The same as `as_v1` but also runs into on it
+        /// The same as [`as_v1`](`VersionedRejectedTransaction::as_v1()`) but also runs into on it
         #[allow(clippy::missing_const_for_fn)]
         pub fn into_inner_v1(self) -> RejectedTransaction {
             match self {
@@ -2120,7 +2120,7 @@ pub mod transaction {
             }
         }
 
-        /// Calculate transaction `Hash`.
+        /// Calculate transaction [`Hash`](`iroha_crypto::Hash`).
         pub fn hash(&self) -> Hash {
             self.as_inner_v1().hash()
         }
@@ -2177,9 +2177,9 @@ pub mod transaction {
         Clone, Debug, Io, Encode, Decode, Serialize, Deserialize, Eq, PartialEq, IntoSchema,
     )]
     pub struct RejectedTransaction {
-        /// `Transaction` payload.
+        /// [`Transaction`] payload.
         pub payload: Payload,
-        /// `Transaction`'s `Signature`s.
+        /// [`Transaction`]'s [`Signature`]s.
         pub signatures: Vec<Signature>,
         /// The reason for rejecting this transaction during the validation pipeline.
         pub rejection_reason: TransactionRejectionReason,
@@ -2192,7 +2192,7 @@ pub mod transaction {
             self.payload.check_instruction_len(max_instruction_len)
         }
 
-        /// Calculate transaction [`Hash`].
+        /// Calculate transaction [`Hash`](`iroha_crypto::Hash`).
         pub fn hash(&self) -> Hash {
             let bytes: Vec<u8> = self.payload.clone().into();
             Hash::new(&bytes)

--- a/iroha_error/src/lib.rs
+++ b/iroha_error/src/lib.rs
@@ -1,6 +1,6 @@
 //! Iroha Error crate contains error type similar to anyhow and eyre crates.
 //!
-//! It has general `Error` type which can wrap any type implementing `std::error::Error`.
+//! It has general [`Error`] type which can wrap any type implementing [`std::error::Error`].
 //! Also it contains alias `iroha_error::Result<T> = Result<T, iroha_error::Error>`.
 //!
 //! Example:

--- a/iroha_error/src/message_error.rs
+++ b/iroha_error/src/message_error.rs
@@ -23,7 +23,7 @@ impl<M: Display> Display for MessageError<M> {
 impl<M: Display + Debug + 'static> StdError for MessageError<M> {}
 
 impl<D> MessageError<D> {
-    /// Constructor for `MessageError`
+    /// Constructor for [`MessageError`]
     pub const fn new(msg: D) -> Self {
         Self { msg }
     }

--- a/iroha_logger/src/layer.rs
+++ b/iroha_logger/src/layer.rs
@@ -25,7 +25,7 @@ pub trait EventInspectorTrait: 'static {
     fn inner_subscriber(&self) -> &Self::Subscriber;
 }
 
-/// Wrapper which implements `Subscriber` trait for any implementator of `EventfilterTrait`
+/// Wrapper which implements [`Subscriber`] trait for any implementor of [`EventInspectorTrait`]
 #[derive(Debug, Clone)]
 pub struct EventSubscriber<E>(pub E);
 

--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -18,7 +18,7 @@ pub mod telemetry;
 
 static LOGGER_SET: AtomicBool = AtomicBool::new(false);
 
-/// Initializes `Logger` with given `LoggerConfiguration`.
+/// Initializes `Logger` with given [`LoggerConfiguration`](`config::LoggerConfiguration`).
 /// After the initialization `log` macros will print with the use of this `Logger`.
 pub fn init(configuration: config::LoggerConfiguration) -> Option<Receiver<Telemetry>> {
     if LOGGER_SET

--- a/iroha_macro/iroha_derive/src/lib.rs
+++ b/iroha_macro/iroha_derive/src/lib.rs
@@ -34,7 +34,7 @@ pub fn into_query_derive(input: TokenStream) -> TokenStream {
     impl_into_query(&ast)
 }
 
-/// `FromVariant` is used for implementing `From<Variant> for Enum` and `TryFrom<Enum> for Variant`.
+/// [`FromVariant`] is used for implementing `From<Variant> for Enum` and `TryFrom<Enum> for Variant`.
 ///
 /// ```rust
 /// use iroha_derive::FromVariant;

--- a/iroha_version/iroha_version_derive/src/lib.rs
+++ b/iroha_version/iroha_version_derive/src/lib.rs
@@ -29,14 +29,14 @@ const DERIVE_FIELD_NAME: &str = "derive";
 
 /// Used to declare that this struct represents a particular version as a part of the versioned container.
 ///
-/// Adds support for both scale codec and json serialization. To declare only with json support use [`version_with_json`], for scale - [`version_with_scale`].
+/// Adds support for both scale codec and json serialization. To declare only with json support use [`version_with_json()`], for scale - [`version_with_scale()`].
 ///
 /// ### Arguments:
 /// - named `n: u8` - what version this particular struct represents.
-/// - named `versioned: String` - to which versioned container to link this struct. Versioned containers are created with [`declare_versioned`].
+/// - named `versioned: String` - to which versioned container to link this struct. Versioned containers are created with [`declare_versioned`](`declare_versioned()`).
 ///
 /// ### Examples
-/// See [`declare_versioned`].
+/// See [`declare_versioned`](`declare_versioned()`).
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn version(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -44,7 +44,7 @@ pub fn version(attr: TokenStream, item: TokenStream) -> TokenStream {
     impl_version(args, item, true, true).into()
 }
 
-/// See [`version`] for more information.
+/// See [`version()`] for more information.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn version_with_scale(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -52,7 +52,7 @@ pub fn version_with_scale(attr: TokenStream, item: TokenStream) -> TokenStream {
     impl_version(args, item, false, true).into()
 }
 
-/// See [`version`] for more information.
+/// See [`version()`] for more information.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn version_with_json(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -62,7 +62,7 @@ pub fn version_with_json(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Used to generate a versioned container with the given name and given range of supported versions.
 ///
-/// Adds support for both scale codec and json serialization. To declare only with json support use [`declare_versioned_with_json`], for scale - [`declare_versioned_with_scale`].
+/// Adds support for both scale codec and json serialization. To declare only with json support use [`declare_versioned_with_json`](`declare_versioned_with_json()`), for scale - [`declare_versioned_with_scale`](`declare_versioned_with_json()`).
 ///
 /// ### Arguments
 /// 1. positional `versioned_enum_name`
@@ -98,14 +98,14 @@ pub fn declare_versioned(input: TokenStream) -> TokenStream {
     impl_declare_versioned(&args, true, true).into()
 }
 
-/// See [`declare_versioned`] for more information.
+/// See [`declare_versioned`](`declare_versioned()`) for more information.
 #[proc_macro]
 pub fn declare_versioned_with_scale(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DeclareVersionedArgs);
     impl_declare_versioned(&args, true, false).into()
 }
 
-/// See [`declare_versioned`] for more information.
+/// See [`declare_versioned`](`declare_versioned()`) for more information.
 #[proc_macro]
 pub fn declare_versioned_with_json(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DeclareVersionedArgs);

--- a/iroha_version/src/lib.rs
+++ b/iroha_version/src/lib.rs
@@ -129,7 +129,7 @@ pub mod scale {
     use super::error::Result;
     use super::Version;
 
-    /// `Decode` versioned analog.
+    /// [`Decode`] versioned analog.
     pub trait DecodeVersioned: Decode + Version {
         /// Use this function for versioned objects instead of `decode`.
         ///
@@ -138,7 +138,7 @@ pub mod scale {
         fn decode_versioned(input: &[u8]) -> Result<Self>;
     }
 
-    /// `Encode` versioned analog.
+    /// [`Encode`] versioned analog.
     pub trait EncodeVersioned: Encode + Version {
         #[allow(clippy::missing_errors_doc)]
         /// Use this function for versioned objects instead of `encode`.
@@ -154,9 +154,9 @@ pub mod json {
     use super::error::Result;
     use super::Version;
 
-    /// `Serialize` versioned analog, specifically for JSON.
+    /// [`Serialize`] versioned analog, specifically for JSON.
     pub trait DeserializeVersioned<'a>: Deserialize<'a> + Version {
-        /// Use this function for versioned objects instead of `serde_json::from_str`.
+        /// Use this function for versioned objects instead of [`serde_json::from_str`].
         ///
         /// # Errors
         /// Return error if:
@@ -166,9 +166,9 @@ pub mod json {
         fn from_versioned_json_str(input: &str) -> Result<Self>;
     }
 
-    /// `Deserialize` versioned analog, specifically for JSON.
+    /// [`Deserialize`] versioned analog, specifically for JSON.
     pub trait SerializeVersioned: Serialize + Version {
-        /// Use this function for versioned objects instead of `serde_json::to_string`.
+        /// Use this function for versioned objects instead of [`serde_json::to_string`].
         ///
         /// # Errors
         /// Return error if serde fails to decode json


### PR DESCRIPTION
### Description of the Change

Right now structs, enums and etc. are mentioned by simply putting them in ``.
I changed them to actual links instead, so that documentation will be easier to browse.

### Benefits

Documentation is easier to browse.

### Possible Drawbacks 

None.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
