### PR TITLE
Added clear error text and filename if TrustedPeers could not be loaded.

### DIFF
--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -1811,7 +1811,8 @@ pub mod config {
         /// # Errors
         /// Fails if there is no file or if file is not valid json
         pub fn from_path<P: AsRef<Path> + Debug>(path: P) -> Result<TrustedPeers> {
-            let file = File::open(path).wrap_err("Failed to open a file")?;
+            let file = File::open(&path)
+                .wrap_err_with(|| format!("Failed to open trusted peers file {:?}", &path))?;
             let reader = BufReader::new(file);
             let trusted_peers: HashSet<PeerId> = serde_json::from_reader(reader)
                 .wrap_err("Failed to deserialize json from reader")?;


### PR DESCRIPTION
### Description of the Change

If trusted peers' file could not be opened it is not clear which file failed to load. Now it will log file type and path.
https://jira.hyperledger.org/browse/IR-1129

### Benefits

It will be clearer what file is missing or unavailable.

### Possible Drawbacks 

I create an error message ahead of opening the file because otherwise the path will be taken by `Path::open()`, and we have no clear type of parameter, it couldn't be cloned.
I think one such string allocation on the start of app is no big deal.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
