### PR TITLE
Added vendored OpenSSL to build, fixes pkg-config dependency.

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -28,8 +28,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Install clippy
         run: rustup component add clippy
       - name: Print all info
@@ -68,8 +67,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Run tests
         run: cargo test --workspace
 
@@ -89,8 +87,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Run iroha_network mock tests
         run: cargo test --features mock
         working-directory: iroha_network
@@ -114,8 +111,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Run iroha_actor deadlock detection tests
         run: cargo test --features deadlock_detection
         working-directory: iroha_actor
@@ -141,8 +137,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Build Client CLI
         run: cargo build
         working-directory: iroha_client_cli
@@ -260,8 +255,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Cargo clean
         uses: actions-rs/cargo@v1
         with:
@@ -296,7 +290,6 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Run benchmarks
         run: cargo bench --workspace --verbose

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -28,8 +28,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Build
         run: cargo build --release --verbose
       - name: Archive build
@@ -112,8 +111,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Cargo clean
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -27,8 +27,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Run long tests
         run: cargo test --workspace --verbose -- --ignored --test-threads=1 long
   test-docker:
@@ -46,8 +45,7 @@ jobs:
             build-essential \
             ca-certificates \
             clang \
-            llvm-dev \
-            libssl-dev
+            llvm-dev
       - name: Install latest rust
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "hex-literal",
  "iroha_error",
  "iroha_schema",
+ "openssl-sys",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -2286,6 +2287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.15.0+1.1.1k"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2304,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,12 @@ ENV PATH="$CARGO_HOME/bin:$PATH"
 
 RUN set -ex; \
     apt-get update  -yq; \
-    apt-get install -y --no-install-recommends curl pkg-config apt-utils; \
+    apt-get install -y --no-install-recommends curl apt-utils; \
     apt-get install -y --no-install-recommends \
        build-essential \
        ca-certificates \
        clang \
-       llvm-dev \
-       libssl-dev; \
+       llvm-dev; \
     rm -rf /var/lib/apt/lists/*
 
 ARG TOOLCHAIN=stable
@@ -47,8 +46,8 @@ RUN cargo build $PROFILE --all
 FROM $BASE_IMAGE
 RUN set -ex; \
     apt-get update  -yq; \
-    apt-get install -y --no-install-recommends pkg-config apt-utils; \
-    apt-get install -y --no-install-recommends ca-certificates libssl1.1; \
+    apt-get install -y --no-install-recommends apt-utils; \
+    apt-get install -y --no-install-recommends ca-certificates; \
     rm -rf /var/lib/apt/lists/*
 COPY iroha/config.json .
 COPY iroha/trusted_peers.json .

--- a/iroha_crypto/Cargo.toml
+++ b/iroha_crypto/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 ursa = "=0.3.5"
+openssl-sys = { version = "0", features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 parity-scale-codec = { version = "2", features = ["derive"] }


### PR DESCRIPTION
### Description of the Change

Fixed dependency on pkg-config for using OpenSSL sources from the system. It will compile them from `openssl-src` crate.
https://jira.hyperledger.org/browse/IR-1133

### Benefits

Easier build of iroha2.

### Possible Drawbacks 

I think none.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
