### PR TITLE
Fixed error message if child block not found.

### DIFF
--- a/iroha/src/smartcontracts/isi/mod.rs
+++ b/iroha/src/smartcontracts/isi/mod.rs
@@ -60,9 +60,9 @@ pub enum FindError {
     #[cfg(feature = "roles")]
     #[error("Failed to find role by id")]
     Role(RoleId),
-    /// Block with supplied hash not found.
-    #[error("Failed to find block with this hash")]
-    Block(Hash),
+    /// Block with supplied parent hash not found. More description in a string.
+    #[error("Block not found")]
+    Block(#[source] ParentHashNotFound),
 }
 
 /// Type assertion error
@@ -106,6 +106,18 @@ pub enum MathError {
     #[error("Overflow occured.")]
     OverflowError,
 }
+
+/// Block with parent hash not found struct
+#[derive(Debug, Clone, Copy)]
+pub struct ParentHashNotFound(pub Hash);
+
+impl Display for ParentHashNotFound {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Block with parent hash {} not found", self.0)
+    }
+}
+
+impl StdError for ParentHashNotFound {}
 
 impl Execute for Instruction {
     type Error = Error;

--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -12,6 +12,7 @@ use iroha_data_model::{domain::DomainsMap, peer::PeersIds, prelude::*};
 use iroha_error::Result;
 use tokio::task;
 
+use crate::smartcontracts::ParentHashNotFound;
 use crate::{block::Chain, prelude::*, smartcontracts::FindError};
 
 /// Current state of the blockchain alligned with `Iroha` module.
@@ -104,7 +105,7 @@ impl WorldStateView {
             .blocks
             .iter()
             .position(|block_entry| block_entry.value().header().previous_block_hash == hash)
-            .ok_or(FindError::Block(hash))?;
+            .ok_or(FindError::Block(ParentHashNotFound(hash)))?;
         Ok(self
             .blocks
             .iter()


### PR DESCRIPTION
### Description of the Change

The message:
`ERROR iroha::block_sync::message: error=Failed to find block with this hash. Caused by: ef92eb136a9a499d52eb72d131aa882560a2ed74cd386a9abda8d583e0a43f8b`
Will become:
`ERROR iroha::block_sync::message: error=Block not found. Block with parent hash ef92eb136a9a499d52eb72d131aa882560a2ed74cd386a9abda8d583e0a43f8b not found`

### Benefits

More clear error description.

### Possible Drawbacks 

Partial repetition of error message is a drawback of current error deriving mechanism.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
