### PR TITLE
Captures logs in tests unless test fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ members = [
   "iroha_schema",
   "iroha_schema/iroha_schema_derive",
   "iroha_schema/iroha_schema_bin",
+  "iroha_logger",
 ]

--- a/iroha_logger/Cargo.toml
+++ b/iroha_logger/Cargo.toml
@@ -17,4 +17,4 @@ tracing-subscriber = { version = "0.2", default-features = false, features = ["f
 tokio = { version = "1.6.0", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.6.0", features = ["macros"] }
+tokio = { version = "1.6.0", features = ["macros", "time", "rt"] }

--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -27,12 +27,12 @@ pub fn init(configuration: config::LoggerConfiguration) -> Option<Receiver<Telem
     {
         return None;
     }
-
+    let level = configuration.max_log_level.into();
+    let subscriber_builder = tracing_subscriber::fmt().with_test_writer();
     if configuration.compact_mode {
-        let fmt = tracing_subscriber::fmt().compact().finish();
-        let level = configuration.max_log_level.into();
+        let subscriber = subscriber_builder.compact().finish();
         let (subscriber, receiver) = TelemetryLayer::from_capacity(
-            LevelFilter::new(level, fmt),
+            LevelFilter::new(level, subscriber),
             configuration.telemetry_capacity,
         );
 
@@ -40,10 +40,9 @@ pub fn init(configuration: config::LoggerConfiguration) -> Option<Receiver<Telem
         set_global_default(subscriber).expect("Failed to init logger");
         Some(receiver)
     } else {
-        let fmt = tracing_subscriber::fmt().finish();
-        let level = configuration.max_log_level.into();
+        let subscriber = subscriber_builder.finish();
         let (subscriber, receiver) = TelemetryLayer::from_capacity(
-            LevelFilter::new(level, fmt),
+            LevelFilter::new(level, subscriber),
             configuration.telemetry_capacity,
         );
 


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Captures logs in tests unless test fails

For more details see https://docs.rs/tracing-subscriber/0.2.18/tracing_subscriber/fmt/struct.TestWriter.html
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Tests output will not be full of unnecessary logs, only the logs of the tests that failed will be shown.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
