### PR TITLE
Remove zero-value assets from accounts after operating upon.

### DIFF
--- a/iroha/src/wsv.rs
+++ b/iroha/src/wsv.rs
@@ -241,7 +241,11 @@ impl WorldStateView {
                 .assets
                 .get_mut(id)
                 .ok_or_else(|| FindError::Asset(id.clone()))?;
-            f(&mut asset)
+            f(&mut asset)?;
+            if asset.value.is_zero_value() {
+                drop(account.assets.remove(id));
+            }
+            Ok(())
         })
     }
 

--- a/iroha_data_model/src/lib.rs
+++ b/iroha_data_model/src/lib.rs
@@ -1203,6 +1203,14 @@ pub mod asset {
                 AssetValue::Store(_) => AssetValueType::Store,
             }
         }
+        /// Returns true if this value is zero, false if it contains [`Metadata`] or positive value
+        pub const fn is_zero_value(&self) -> bool {
+            match *self {
+                AssetValue::Quantity(q) => q == 0_u32,
+                AssetValue::BigQuantity(q) => q == 0_u128,
+                AssetValue::Store(_) => false,
+            }
+        }
     }
 
     macro_rules! impl_try_as_for_asset_value {

--- a/iroha_dsl/tests/dsl.rs
+++ b/iroha_dsl/tests/dsl.rs
@@ -206,7 +206,6 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         .expect("Failed to execute Iroha Special Instruction.");
     thread::sleep(pipeline_time * 3);
     let expected_seller_eth = 20;
-    let expected_seller_btc = 0;
     let expected_buyer_eth = 180;
     let expected_buyer_btc = 20;
 
@@ -217,12 +216,14 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         .expect("Failed to execute Iroha Query");
     assert_eq!(expected_seller_eth, eth_quantity);
 
-    let btc_quantity = iroha_client
-        .request(FindAssetQuantityById::new(AssetId::from_names(
-            "btc", "crypto", "seller", "company",
-        )))
-        .expect("Failed to execute Iroha Query");
-    assert_eq!(expected_seller_btc, btc_quantity);
+    // For the btc amount we expect an error, as zero assets are purged from accounts
+    drop(
+        iroha_client
+            .request(FindAssetQuantityById::new(AssetId::from_names(
+                "btc", "crypto", "seller", "company",
+            )))
+            .expect_err("Failed to execute Iroha Query"),
+    );
 
     let buyer_eth_quantity = iroha_client
         .request(FindAssetQuantityById::new(AssetId::from_names(


### PR DESCRIPTION
### Description of the Change

Remove assets that have zero value after some operations on them.
For example, if user has moved all assets elsewhere.

### Benefits

It will give storage and performance improvement.

### Possible Drawbacks 

Checks are performed after any operation. Could they slowdown or not?

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
