### PR TITLE
Introduces SubscriptionAccepted message

### DIFF
--- a/iroha/src/torii.rs
+++ b/iroha/src/torii.rs
@@ -396,8 +396,13 @@ async fn handle_subscription(
     _query_params: QueryParams,
     stream: WebSocketStream,
 ) -> iroha_error::Result<()> {
+    let state = state.read().await;
+
+    // The lock is kept on `consumers` for the whole function so that a consumer can tell the client that it is ready,
+    // before sending events.
+    let mut consumers = state.consumers.write().await;
     let consumer = Consumer::new(stream).await?;
-    state.read().await.consumers.write().await.push(consumer);
+    consumers.push(consumer);
     Ok(())
 }
 

--- a/iroha_client/src/config.rs
+++ b/iroha_client/src/config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
 const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
-const DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS: u64 = 3000;
+const DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_MAX_INSTRUCTION_NUMBER: usize = 2_usize.pow(12);
 
 /// `Configuration` provides an ability to define client parameters such as `TORII_URL`.

--- a/iroha_client/tests/permissions.rs
+++ b/iroha_client/tests/permissions.rs
@@ -65,7 +65,9 @@ fn permissions_disallow_asset_transfer() {
     let err = iroha_client
         .submit_blocking(transfer_asset.into())
         .expect_err("Transaction was not rejected.");
-    let rejection_reason = err.downcast_ref::<PipelineRejectionReason>().unwrap();
+    let rejection_reason = err
+        .downcast_ref::<PipelineRejectionReason>()
+        .unwrap_or_else(|| panic!("Error {} is not PipelineRejectionReasons.", err));
     //Then
     assert_eq!(
         rejection_reason,

--- a/iroha_schema/iroha_schema_bin/src/main.rs
+++ b/iroha_schema/iroha_schema_bin/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
             Instruction,
             Domain,
             QueryBox,
-            VersionedEvent,
+            VersionedEventSocketMessage,
             VersionedTransaction,
             VersionedQueryResult,
         )


### PR DESCRIPTION

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
The message means that event connection is initialized and will be supplying events starting from the next one.

This fixes the problem that client does not know at what point he will start receiving all events that are specified by its filter.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
`submit_blocking` is reliable now, previously there were conditions when it might fail due to peer being faster than the client.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
### Jira Issue
https://jira.hyperledger.org/browse/IR-1137

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
