### PR TITLE
Uses source based coverage with grcov

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -243,11 +243,6 @@ jobs:
     container: rust:1.52-buster
     steps:
       - uses: actions/checkout@v2
-      - name: Set nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2021-02-20
-          override: true
       - name: Install dependencies
         run: |
           apt-get update
@@ -256,23 +251,29 @@ jobs:
             ca-certificates \
             clang \
             llvm-dev
+      - name: Install grcov
+        run: cargo install grcov
       - name: Cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        run: cargo clean
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+      - name: Cargo build
+        run: cargo build
+        env:
+          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTC_BOOTSTRAP: 1
       - name: Run tests
         run: cargo test --workspace -- --test-threads=1
         env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTC_BOOTSTRAP: 1
+          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate coverage report
-        id: coverage
-        uses: actions-rs/grcov@v0.1
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v1
         with:
-          file: ${{ steps.coverage.outputs.report }}
+          file: lcov.info
 
   bench:
     runs-on: [self-hosted, Linux]

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -91,11 +91,6 @@ jobs:
     container: rust:1.52-buster
     steps:
       - uses: actions/checkout@v2
-      - name: Set nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2021-02-20
-          override: true
       - name: Install dependencies
         run: |
           apt-get update
@@ -104,20 +99,26 @@ jobs:
             ca-certificates \
             clang \
             llvm-dev
+      - name: Install grcov
+        run: cargo install grcov
       - name: Cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        run: cargo clean
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+      - name: Cargo build
+        run: cargo build
+        env:
+          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTC_BOOTSTRAP: 1
       - name: Run tests
         run: cargo test --workspace -- --test-threads=1
         env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTC_BOOTSTRAP: 1
+          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate coverage report
-        id: coverage
-        uses: actions-rs/grcov@v0.1
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v1
         with:
-          file: ${{ steps.coverage.outputs.report }}
+          file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 **/*.rs.bk
 **/rusty-tags.vi
 
-config/__pycahe__
+config/__pycaсhe__
 **/__pycache__/*
 __pycache__/*
 build/*
+*.profraw
 *.DS_Store
 *.vscode/
 *.swp


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Uses source based coverage with grcov.
https://github.com/mozilla/grcov#example-how-to-generate-source-based-coverage-for-a-rust-project

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

This should improve the correctness of coverage reports.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Jira Issue

https://jira.hyperledger.org/browse/IR-1136

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
