### PR TITLE
[RDB] read precision in SubstractAssetQuantity

### DIFF
--- a/irohad/ametsuchi/impl/rocksdb_command_executor.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_command_executor.cpp
@@ -826,7 +826,7 @@ RocksDbCommandExecutor::ExecutionResult RocksDbCommandExecutor::operator()(
 
   // check if asset exists
   RDB_TRY_GET_VALUE(opt_result,
-                    forAsset<kDbOperation::kCheck, kDbEntry::kMustExist>(
+                    forAsset<kDbOperation::kGet, kDbEntry::kMustExist>(
                         common, asset_name, domain_id));
 
   if (*opt_result < command.amount().precision())

--- a/test/module/irohad/ametsuchi/rocksdb_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/rocksdb_executor_test.cpp
@@ -56,8 +56,7 @@ namespace iroha {
             std::make_shared<shared_model::proto::ProtoQueryResponseFactory>();
       }
 
-      void SetUp() override {
-        AmetsuchiTest::SetUp();
+      void initExecutors() {
         db_name_ = (fs::temp_directory_path() / fs::unique_path()).string();
         auto db_port = std::make_shared<RocksDBPort>();
         db_port->initialize(db_name_);
@@ -71,10 +70,22 @@ namespace iroha {
             db_port, perm_converter, std::nullopt);
       }
 
+      void SetUp() override {
+        AmetsuchiTest::SetUp();
+        initExecutors();
+      }
+
       void TearDown() override {
         AmetsuchiTest::TearDown();
         tx_context_.reset();
-        fs::remove_all(db_name_);
+        wsv_query.reset();
+        pending_txs_storage.reset();
+        executor.reset();
+
+        try {
+          fs::remove_all(db_name_);
+        } catch (std::exception &) {
+        }
       }
 
       std::vector<std::string> getRoles(std::string_view account_id) {


### PR DESCRIPTION
Signed-off-by: iceseer <iceseer@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Hotfix! Read precision in SubstractAssetQuantity.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
