### PR TITLE
Extending queries by modifing TxPaginationMeta

### DIFF
--- a/docs/source/develop/api/queries.rst
+++ b/docs/source/develop/api/queries.rst
@@ -55,15 +55,11 @@ Now, the ordering itself:
 
 After ordering is specified, pagination can be executed:
 
-.. code-block:: proto
+.. literalinclude:: ../../../../shared_model/schema/queries.proto
+    :language: proto
+    :start-at: message TxPaginationMeta {
+    :end-before: message AssetPaginationMeta {
 
-    message TxPaginationMeta {
-        uint32 page_size = 1;
-        oneof opt_first_tx_hash {
-            string first_tx_hash = 2;
-        }
-        Ordering ordering = 3;
-    }
 
 What is added to the request structure in case of pagination
 ------------------------------------------------------------
@@ -76,7 +72,11 @@ What is added to the request structure in case of pagination
     "First tx hash", "hash of the first transaction in the page. If that field is not set — then the first transactions are returned", "hash in hex format", "bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929"
     "ordering", "how the results should be ordered (before pagination is applied)", "see fields below", "see fields below"
     "ordering.sequence", "ordeing spec, like in SQL ORDER BY", "sequence of fields and directions", "[{kCreatedTime, kAscending}, {kPosition, kDescending}]"
-
+    "First tx time", "time of the first transaction in query result. If that field is not set - then the transactions starting from first are returned", "Google Protocol Buffer Timestamp type", "0001-01-01T00:00:00Z <= first tx time <= 9999-12-31T23:59:59.999999999Z"
+    "Last tx time", "time of the last transaction in query result. If that field is not set - then the transactions up to the last are returned", "Google Protocol Buffer Timestamp type", "0001-01-01T00:00:00Z <= last tx time <= 9999-12-31T23:59:59.999999999Z"
+    "First tx height", "block height of the first transaction in query result. If that field is not set - then the transactions starting from height 1 are returned", "first tx height > 0", "4"
+    "Last tx height", "block height of the last transaction in query result. If that field is not set - then the transactions up to the last one are returned", "last tx height > 0", "6"
+    
 Engine Receipts
 ^^^^^^^^^^^^^^^
 

--- a/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_specific_query_executor.cpp
@@ -5,15 +5,15 @@
 
 #include "ametsuchi/impl/postgres_specific_query_executor.hpp"
 
-#include <tuple>
-#include <unordered_map>
-
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/irange.hpp>
+#include <tuple>
+#include <unordered_map>
+
 #include "ametsuchi/block_storage.hpp"
 #include "ametsuchi/impl/executor_common.hpp"
 #include "ametsuchi/impl/soci_std_optional.hpp"
@@ -453,6 +453,10 @@ namespace iroha {
                  FROM tx_positions
                  WHERE
                  {2} -- related_txs
+                 {5} -- time interval begin
+                 {6} -- time interval end
+                 {7} -- height begin
+                 {8} -- height end
                  {1} -- ordering
                  ),
                total_size AS (SELECT COUNT(*) FROM my_txs) {3}
@@ -471,7 +475,6 @@ namespace iroha {
                                                1,
                                                query_hash);
       }
-
       auto query = fmt::format(
           base,
           hasQueryPermissionTarget(creator_id, q.accountId(), perms...),
@@ -480,7 +483,11 @@ namespace iroha {
           (first_hash
                ? R"(, base_row AS(SELECT row FROM my_txs WHERE hash = lower(:hash) LIMIT 1))"
                : ""),
-          (first_hash ? R"(JOIN base_row ON my_txs.row >= base_row.row)" : ""));
+          (first_hash ? R"(JOIN base_row ON my_txs.row >= base_row.row)" : ""),
+          "AND (:first_tx_time::text IS NULL OR :first_tx_time<ts)",
+          "AND (:last_tx_time::text IS NULL OR :last_tx_time>ts )",
+          "AND (:first_tx_height::text IS NULL OR :first_tx_height<height)",
+          "AND (:last_tx_height::text IS NULL OR :last_tx_height>height )");
 
       return executeQuery<QueryTuple, PermissionTuple>(
           applier(query),
@@ -704,12 +711,12 @@ namespace iroha {
             return query_response_factory_->createSignatoriesResponse(
                 pubkeys, query_hash);
           },
+
           notEnoughPermissionsResponse(perm_converter_,
                                        Role::kGetMySignatories,
                                        Role::kGetAllSignatories,
                                        Role::kGetDomainSignatories));
     }
-
     QueryExecutorResult PostgresSpecificQueryExecutor::operator()(
         const shared_model::interface::GetAccountTransactions &q,
         const shared_model::interface::types::AccountIdType &creator_id,
@@ -724,17 +731,30 @@ namespace iroha {
       // retrieve one extra transaction to populate next_hash
       auto query_size = pagination_info.pageSize() + 1u;
 
+      auto first_tx_time = pagination_info.firstTxTime();
+      auto last_tx_time = pagination_info.lastTxTime();
+      auto first_tx_height = pagination_info.firstTxHeight();
+      auto last_tx_height = pagination_info.lastTxHeight();
+      soci::indicator ind = soci::i_null;
       auto apply_query = [&](const auto &query) {
         return [&] {
           if (first_hash) {
             return (sql_.prepare << query,
-                    soci::use(q.accountId()),
-                    soci::use(first_hash->hex()),
-                    soci::use(query_size));
+                    soci::use(q.accountId(), "account_id"),
+                    soci::use(first_hash->hex(), "hash"),
+                    soci::use(query_size, "page_size"),
+                    soci::use(first_tx_time, ind, "first_tx_time"),
+                    soci::use(last_tx_time, ind, "last_tx_time"),
+                    soci::use(first_tx_height, ind, "first_tx_height"),
+                    soci::use(last_tx_height, ind, "last_tx_height"));
           } else {
             return (sql_.prepare << query,
-                    soci::use(q.accountId()),
-                    soci::use(query_size));
+                    soci::use(q.accountId(), "account_id"),
+                    soci::use(query_size, "page_size"),
+                    soci::use(first_tx_time, ind, "first_tx_time"),
+                    soci::use(last_tx_time, ind, "last_tx_time"),
+                    soci::use(first_tx_height, ind, "first_tx_height"),
+                    soci::use(last_tx_height, ind, "last_tx_height"));
           }
         };
       };
@@ -766,7 +786,7 @@ namespace iroha {
       std::string hash_str = boost::algorithm::join(
           q.transactionHashes()
               | boost::adaptors::transformed(
-                    [](const auto &h) { return "lower('" + h.hex() + "')"; }),
+                  [](const auto &h) { return "lower('" + h.hex() + "')"; }),
           ", ");
 
       using QueryTuple =
@@ -854,20 +874,32 @@ namespace iroha {
       auto first_hash = pagination_info.firstTxHash();
       // retrieve one extra transaction to populate next_hash
       auto query_size = pagination_info.pageSize() + 1u;
-
+      auto first_tx_time = pagination_info.firstTxTime();
+      auto last_tx_time = pagination_info.lastTxTime();
+      auto first_tx_height = pagination_info.firstTxHeight();
+      auto last_tx_height = pagination_info.lastTxHeight();
+      soci::indicator ind = soci::i_null;
       auto apply_query = [&](const auto &query) {
         return [&] {
           if (first_hash) {
             return (sql_.prepare << query,
-                    soci::use(q.accountId()),
-                    soci::use(q.assetId()),
-                    soci::use(first_hash->hex()),
-                    soci::use(query_size));
+                    soci::use(q.accountId(), "account_id"),
+                    soci::use(q.assetId(), "asset_id"),
+                    soci::use(first_hash->hex(), "hash"),
+                    soci::use(query_size, "page_size"),
+                    soci::use(first_tx_time, ind, "first_tx_time"),
+                    soci::use(last_tx_time, ind, "last_tx_time"),
+                    soci::use(first_tx_height, ind, "first_tx_height"),
+                    soci::use(last_tx_height, ind, "last_tx_height"));
           } else {
             return (sql_.prepare << query,
-                    soci::use(q.accountId()),
-                    soci::use(q.assetId()),
-                    soci::use(query_size));
+                    soci::use(q.accountId(), "account_id"),
+                    soci::use(q.assetId(), "asset_id"),
+                    soci::use(query_size, "page_size"),
+                    soci::use(first_tx_time, ind, "first_tx_time"),
+                    soci::use(last_tx_time, ind, "last_tx_time"),
+                    soci::use(first_tx_height, ind, "first_tx_height"),
+                    soci::use(last_tx_height, ind, "last_tx_height"));
           }
         };
       };

--- a/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
+++ b/shared_model/backend/protobuf/queries/impl/proto_tx_pagination_meta.cpp
@@ -5,9 +5,11 @@
 
 #include "backend/protobuf/queries/proto_tx_pagination_meta.hpp"
 
-#include <optional>
-#include "cryptography/hash.hpp"
+#include <google/protobuf/util/time_util.h>
 
+#include <optional>
+
+#include "cryptography/hash.hpp"
 namespace types = shared_model::interface::types;
 
 using namespace shared_model::proto;
@@ -26,12 +28,49 @@ types::TransactionsNumberType TxPaginationMeta::pageSize() const {
 std::optional<types::HashType> TxPaginationMeta::firstTxHash() const {
   if (meta_.opt_first_tx_hash_case()
       == iroha::protocol::TxPaginationMeta::OptFirstTxHashCase::
-             OPT_FIRST_TX_HASH_NOT_SET) {
+          OPT_FIRST_TX_HASH_NOT_SET) {
     return std::nullopt;
   }
   return types::HashType::fromHexString(meta_.first_tx_hash());
 }
-
 shared_model::interface::Ordering const &TxPaginationMeta::ordering() const {
   return ordering_;
+}
+// first_tx_time
+std::optional<types::TimestampType> TxPaginationMeta::firstTxTime() const {
+  if (meta_.opt_first_tx_time_case()
+      == iroha::protocol::TxPaginationMeta::OptFirstTxTimeCase::
+          OPT_FIRST_TX_TIME_NOT_SET) {
+    return std::nullopt;
+  }
+  return google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+      meta_.first_tx_time());
+}
+// last_tx_time
+std::optional<types::TimestampType> TxPaginationMeta::lastTxTime() const {
+  if (meta_.opt_last_tx_time_case()
+      == iroha::protocol::TxPaginationMeta::OptLastTxTimeCase::
+          OPT_LAST_TX_TIME_NOT_SET) {
+    return std::nullopt;
+  }
+  return google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+      meta_.last_tx_time());
+}
+// first tx height
+std::optional<types::HeightType> TxPaginationMeta::firstTxHeight() const {
+  if (meta_.opt_first_tx_height_case()
+      == iroha::protocol::TxPaginationMeta::OptFirstTxHeightCase::
+          OPT_FIRST_TX_HEIGHT_NOT_SET) {
+    return std::nullopt;
+  }
+  return types::HeightType(meta_.first_tx_height());
+}
+// last tx height
+std::optional<types::HeightType> TxPaginationMeta::lastTxHeight() const {
+  if (meta_.opt_last_tx_height_case()
+      == iroha::protocol::TxPaginationMeta::OptLastTxHeightCase::
+          OPT_LAST_TX_HEIGHT_NOT_SET) {
+    return std::nullopt;
+  }
+  return types::HeightType(meta_.last_tx_height());
 }

--- a/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
+++ b/shared_model/backend/protobuf/queries/proto_tx_pagination_meta.hpp
@@ -1,3 +1,4 @@
+
 /**
  * Copyright Soramitsu Co., Ltd. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -6,12 +7,10 @@
 #ifndef IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
 #define IROHA_SHARED_PROTO_MODEL_QUERY_TX_PAGINATION_META_HPP
 
-#include "interfaces/queries/tx_pagination_meta.hpp"
-
 #include "interfaces/common_objects/types.hpp"
-#include "queries.pb.h"
-
+#include "interfaces/queries/tx_pagination_meta.hpp"
 #include "proto_ordering.hpp"
+#include "queries.pb.h"
 
 namespace shared_model {
   namespace proto {
@@ -22,10 +21,16 @@ namespace shared_model {
       explicit TxPaginationMeta(iroha::protocol::TxPaginationMeta &meta);
 
       interface::types::TransactionsNumberType pageSize() const override;
-
       std::optional<interface::types::HashType> firstTxHash() const override;
       interface::Ordering const &ordering() const override;
-
+      std::optional<interface::types::TimestampType> firstTxTime()
+          const override;
+      std::optional<interface::types::TimestampType> lastTxTime()
+          const override;
+      std::optional<interface::types::HeightType> firstTxHeight()
+          const override;
+      std::optional<interface::types::HeightType> lastTxHeight()
+          const override;
      private:
       const iroha::protocol::TxPaginationMeta &meta_;
       OrderingImpl ordering_;

--- a/shared_model/builders/protobuf/builder_templates/query_template.hpp
+++ b/shared_model/builders/protobuf/builder_templates/query_template.hpp
@@ -6,6 +6,8 @@
 #ifndef IROHA_PROTO_QUERY_BUILDER_TEMPLATE_HPP
 #define IROHA_PROTO_QUERY_BUILDER_TEMPLATE_HPP
 
+#include <google/protobuf/util/time_util.h>
+
 #include <boost/range/algorithm/for_each.hpp>
 #include <optional>
 #include <string_view>
@@ -89,7 +91,15 @@ namespace shared_model {
           interface::types::TransactionsNumberType page_size,
           const std::optional<interface::types::HashType> &first_hash =
               std::nullopt,
-          const interface::Ordering *ordering = nullptr) {
+          const interface::Ordering *ordering = nullptr,
+          const std::optional<interface::types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &last_tx_height =
+              std::nullopt) {
         auto from_interface_2_proto_field =
             [](interface::Ordering::Field value) {
               switch (value) {
@@ -122,6 +132,24 @@ namespace shared_model {
         page_meta_payload->set_page_size(page_size);
         if (first_hash) {
           page_meta_payload->set_first_tx_hash(first_hash->hex());
+        }
+        if (first_tx_time) {
+          auto timestamp_begin = new google::protobuf::Timestamp{
+              google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+                  first_tx_time.value())};
+          page_meta_payload->set_allocated_first_tx_time(timestamp_begin);
+        }
+        if (last_tx_time) {
+          auto timestamp_end = new google::protobuf::Timestamp{
+              google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+                  last_tx_time.value())};
+          page_meta_payload->set_allocated_last_tx_time(timestamp_end);
+        }
+        if (first_tx_height) {
+          page_meta_payload->set_first_tx_height(first_tx_height.value());
+        }
+        if (last_tx_height) {
+          page_meta_payload->set_last_tx_height(last_tx_height.value());
         }
         if (ordering) {
           interface::Ordering::OrderingEntry const *ptr = nullptr;
@@ -190,14 +218,26 @@ namespace shared_model {
           interface::types::TransactionsNumberType page_size,
           const std::optional<interface::types::HashType> &first_hash =
               std::nullopt,
-          const interface::Ordering *ordering = nullptr) const {
+          const interface::Ordering *ordering = nullptr,
+          const std::optional<interface::types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &last_tx_height =
+              std::nullopt) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_transactions();
           query->set_account_id(account_id);
           setTxPaginationMeta(query->mutable_pagination_meta(),
                               page_size,
                               first_hash,
-                              ordering);
+                              ordering,
+                              first_tx_time,
+                              last_tx_time,
+                              first_tx_height,
+                              last_tx_height);
         });
       }
 
@@ -207,7 +247,15 @@ namespace shared_model {
           interface::types::TransactionsNumberType page_size,
           const std::optional<interface::types::HashType> &first_hash =
               std::nullopt,
-          const interface::Ordering *ordering = nullptr) const {
+          const interface::Ordering *ordering = nullptr,
+          const std::optional<interface::types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<interface::types::HeightType> &last_tx_height =
+              std::nullopt) const {
         return queryField([&](auto proto_query) {
           auto query = proto_query->mutable_get_account_asset_transactions();
           query->set_account_id(account_id);
@@ -215,7 +263,11 @@ namespace shared_model {
           setTxPaginationMeta(query->mutable_pagination_meta(),
                               page_size,
                               first_hash,
-                              ordering);
+                              ordering,
+                              first_tx_time,
+                              last_tx_time,
+                              first_tx_height,
+                              last_tx_height);
         });
       }
 

--- a/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
+++ b/shared_model/interfaces/queries/impl/tx_pagination_meta.cpp
@@ -18,8 +18,24 @@ std::string TxPaginationMeta::toString() const {
                             .init("TxPaginationMeta")
                             .appendNamed("page_size", pageSize());
   auto first_tx_hash = firstTxHash();
+  auto first_tx_time = firstTxTime();
+  auto last_tx_time = lastTxTime();
+  auto first_tx_height = firstTxHeight();
+  auto last_tx_height = lastTxHeight();
   if (first_tx_hash) {
     pretty_builder.appendNamed("first_tx_hash", first_tx_hash);
+  }
+  if (first_tx_time) {
+    pretty_builder.appendNamed("first_tx_time", first_tx_time);
+  }
+  if (last_tx_time) {
+    pretty_builder.appendNamed("last_tx_time", last_tx_time);
+  }
+  if (first_tx_height) {
+    pretty_builder.appendNamed("first_tx_height", first_tx_height);
+  }
+  if (last_tx_height) {
+    pretty_builder.appendNamed("last_tx_height", last_tx_height);
   }
   return pretty_builder.finalize();
 }

--- a/shared_model/interfaces/queries/tx_pagination_meta.hpp
+++ b/shared_model/interfaces/queries/tx_pagination_meta.hpp
@@ -7,9 +7,9 @@
 #define IROHA_SHARED_INTERFACE_MODEL_QUERY_TX_PAGINATION_META_HPP
 
 #include <optional>
+
 #include "interfaces/base/model_primitive.hpp"
 #include "interfaces/common_objects/types.hpp"
-
 #include "ordering.hpp"
 
 namespace shared_model {
@@ -24,7 +24,10 @@ namespace shared_model {
       /// Get the first requested transaction hash, if provided.
       virtual std::optional<types::HashType> firstTxHash() const = 0;
       virtual Ordering const &ordering() const = 0;
-
+      virtual std::optional<types::TimestampType> firstTxTime() const = 0;
+      virtual std::optional<types::TimestampType> lastTxTime() const = 0;
+      virtual std::optional<types::HeightType> firstTxHeight() const = 0;
+      virtual std::optional<types::HeightType> lastTxHeight() const = 0;
       std::string toString() const override;
 
       bool operator==(const ModelType &rhs) const override;

--- a/shared_model/schema/queries.proto
+++ b/shared_model/schema/queries.proto
@@ -9,7 +9,7 @@ package iroha.protocol;
 option go_package = "iroha.generated/protocol";
 
 import "primitive.proto";
-
+import "google/protobuf/timestamp.proto";
 enum Field {
   kCreatedTime = 0;
   kPosition = 1;
@@ -34,6 +34,18 @@ message TxPaginationMeta {
     string first_tx_hash = 2;
   }
   Ordering ordering = 3;
+  oneof opt_first_tx_time {
+    google.protobuf.Timestamp first_tx_time = 4;
+  }
+  oneof opt_last_tx_time {
+    google.protobuf.Timestamp last_tx_time = 5;
+  }
+  oneof opt_first_tx_height {
+    uint64 first_tx_height = 6;
+  }
+  oneof opt_last_tx_height {
+    uint64 last_tx_height = 7;
+  }
 }
 
 message AssetPaginationMeta {
@@ -81,13 +93,13 @@ message AccountDetailPaginationMeta {
 }
 
 message GetAccountDetail {
-  oneof opt_account_id{
+  oneof opt_account_id {
     string account_id = 1;
   }
-  oneof opt_key{
+  oneof opt_key {
     string key = 2;
   }
-  oneof opt_writer{
+  oneof opt_writer {
     string writer = 3;
   }
   AccountDetailPaginationMeta pagination_meta = 4;
@@ -97,11 +109,9 @@ message GetAssetInfo {
   string asset_id = 1;
 }
 
-message GetRoles {
+message GetRoles {}
 
-}
-
-message GetRolePermissions{
+message GetRolePermissions {
   string role_id = 1;
 }
 
@@ -109,9 +119,7 @@ message GetPendingTransactions {
   TxPaginationMeta pagination_meta = 1;
 }
 
-message GetPeers {
-
-}
+message GetPeers {}
 
 message QueryPayloadMeta {
   uint64 created_time = 1;
@@ -123,7 +131,6 @@ message QueryPayloadMeta {
 message GetEngineReceipts {
   string tx_hash = 1;
 }
-
 
 message Query {
   message Payload {

--- a/shared_model/validators/protobuf/proto_query_validator.cpp
+++ b/shared_model/validators/protobuf/proto_query_validator.cpp
@@ -5,6 +5,8 @@
 
 #include "validators/protobuf/proto_query_validator.hpp"
 
+#include <google/protobuf/util/time_util.h>
+
 #include <ciso646>
 
 #include "validators/validation_error_helpers.hpp"
@@ -21,6 +23,69 @@ namespace {
         return shared_model::validation::ValidationError{
             "TxPaginationMeta",
             {"First tx hash from pagination meta is not a hex string."}};
+      }
+    }
+    if (paginationMeta.opt_first_tx_time_case()
+        != iroha::protocol::TxPaginationMeta::OPT_FIRST_TX_TIME_NOT_SET) {
+      if (not validateTimeStamp(
+              google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+                  paginationMeta.first_tx_time()))) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"First tx time from pagination meta is not a "
+             "proper value."}};
+      }
+    }
+    if (paginationMeta.opt_last_tx_time_case()
+        != iroha::protocol::TxPaginationMeta::OPT_LAST_TX_TIME_NOT_SET) {
+      if (not validateTimeStamp(
+              google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+                  paginationMeta.last_tx_time()))) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"Last tx time from pagination meta is not a proper value."}};
+      }
+    }
+    if (paginationMeta.opt_first_tx_height_case()
+        != iroha::protocol::TxPaginationMeta::OPT_FIRST_TX_HEIGHT_NOT_SET) {
+      if (not validateHeight(paginationMeta.first_tx_height())) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"First tx Height from pagination meta is not a proper value."}};
+      }
+    }
+    if (paginationMeta.opt_last_tx_height_case()
+        != iroha::protocol::TxPaginationMeta::OPT_LAST_TX_HEIGHT_NOT_SET) {
+      if (not validateHeight(paginationMeta.last_tx_height())) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"Last tx Height from pagination meta is not a proper value."}};
+      }
+    }
+    if (paginationMeta.opt_first_tx_height_case()
+            != iroha::protocol::TxPaginationMeta::OPT_FIRST_TX_HEIGHT_NOT_SET
+        && paginationMeta.opt_last_tx_height_case()
+            != iroha::protocol::TxPaginationMeta::OPT_LAST_TX_HEIGHT_NOT_SET) {
+      if (not validateHeightOrder(paginationMeta.first_tx_height(),
+              paginationMeta.last_tx_height())) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"Last tx Height from pagination meta should be equal or greater than first tx height"}};
+      }
+    }
+    if (paginationMeta.opt_first_tx_time_case()
+            != iroha::protocol::TxPaginationMeta::OPT_FIRST_TX_TIME_NOT_SET
+        && paginationMeta.opt_last_tx_time_case()
+            != iroha::protocol::TxPaginationMeta::OPT_LAST_TX_TIME_NOT_SET) {
+      if (not validateTimeOrder(
+              google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+                  paginationMeta.first_tx_time()),
+              google::protobuf::util::TimeUtil::TimestampToMilliseconds(
+                  paginationMeta.last_tx_time()))) {
+        return shared_model::validation::ValidationError{
+            "TxPaginationMeta",
+            {"Last tx time from pagination meta should be equal or greater "
+             "than first tx time"}};
       }
     }
     return std::nullopt;

--- a/shared_model/validators/validators_common.cpp
+++ b/shared_model/validators/validators_common.cpp
@@ -7,6 +7,7 @@
 
 #include <regex>
 
+using google::protobuf::util::TimeUtil;
 namespace shared_model {
   namespace validation {
 
@@ -21,6 +22,23 @@ namespace shared_model {
       static const std::regex hex_regex{R"([0-9a-fA-F]*)"};
       return std::regex_match(str, hex_regex);
     }
-
+    bool validateTimeStamp(const int64_t &timestamp) {
+      const int64_t seconds_to_miliseconds = 1000;
+      return timestamp >= google::protobuf::util::TimeUtil::kTimestampMinSeconds * seconds_to_miliseconds
+          && timestamp
+          <= google::protobuf::util::TimeUtil::kTimestampMaxSeconds * seconds_to_miliseconds;
+    }
+    bool validateHeight(const uint64_t &height) {
+      const u_int64_t min_height = 1;
+      return height >= min_height;
+    }
+    bool validateHeightOrder(const uint64_t &first_height,
+                             const uint64_t &last_height){
+      return first_height <= last_height;
+    }
+    bool validateTimeOrder(const int64_t &first_time,
+                             const int64_t &last_time){
+      return first_time <= last_time;
+    }
   }  // namespace validation
 }  // namespace shared_model

--- a/shared_model/validators/validators_common.hpp
+++ b/shared_model/validators/validators_common.hpp
@@ -6,6 +6,8 @@
 #ifndef IROHA_VALIDATORS_COMMON_HPP
 #define IROHA_VALIDATORS_COMMON_HPP
 
+#include <google/protobuf/util/time_util.h>
+
 #include <string>
 
 namespace shared_model {
@@ -42,7 +44,34 @@ namespace shared_model {
      * @return true if string is in hex, false otherwise
      */
     bool validateHexString(const std::string &str);
-
+    /**
+     * Check if given Timestamp has correct range
+     * @param timestamp Timestamp to check
+     * @return true if timestamp is in proper range, false otherwise
+     */
+    bool validateTimeStamp(const int64_t &timestamp);
+    /**
+     * Check if given block height has correct value
+     * @param height Height to check
+     * @return true if height is corect value, false otherwise
+     */
+    bool validateHeight(const uint64_t &height);
+    /**
+     * Check if two given block heights has correct value ordering
+     * @param first_height Height to check
+     * @param second_height Height to check
+     * @return true if first_height <= last_height, false otherwise
+     */
+    bool validateHeightOrder(const uint64_t &first_height,
+                             const uint64_t &last_height);
+    /**
+     * Check if two given timestamps has correct ordering
+     * @param first_time Time to check
+     * @param last_time Time to check
+     * @return true if first_height <= last_height, false otherwise
+     */
+    bool validateTimeOrder(const int64_t &first_time,
+                             const int64_t &last_time);
   }  // namespace validation
 }  // namespace shared_model
 

--- a/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_query_executor_test.cpp
@@ -5,17 +5,19 @@
 
 #include "ametsuchi/impl/postgres_query_executor.hpp"
 
+#include <rapidjson/document.h>
+#include <rapidjson/rapidjson.h>
+
+#include <boost/format.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/size.hpp>
 #include <chrono>
 #include <cstring>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 #include <type_traits>
 
-#include <rapidjson/document.h>
-#include <rapidjson/rapidjson.h>
-#include <boost/format.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/size.hpp>
 #include "ametsuchi/impl/flat_file/flat_file.hpp"
 #include "ametsuchi/impl/postgres_command_executor.hpp"
 #include "ametsuchi/impl/postgres_specific_query_executor.hpp"
@@ -675,30 +677,101 @@ namespace iroha {
      protected:
       using Impl = QueryTxPaginationTest;
 
-      // create valid transactions and commit them
-      void createTransactionsAndCommit(size_t transactions_amount) {
+      void commitTransactionsBlock(
+          const std::vector<shared_model::proto::Transaction> txs,
+          size_t height) {
+        auto block = createBlock(txs, height);
+        apply(storage, block);
+      }
+
+      void commitEachTransactionBlock(
+          const std::vector<shared_model::proto::Transaction> txs,
+          size_t first,
+          size_t last,
+          size_t offset) {
+        for (size_t i = first; i < last; i++) {
+          commitTransactionsBlock(
+              std::vector<shared_model::proto::Transaction>{txs[i]},
+              i + offset);
+        }
+      }
+      void createTransactionsAndCommitGetTime(size_t transactions_amount,
+                                              size_t first_tx_no,
+                                              size_t last_tx_no,
+                                              uint64_t &first_tx_time,
+                                              uint64_t &last_tx_time) {
         addPerms(Impl::getUserPermissions());
-
         auto initial_txs = Impl::makeInitialTransactions(transactions_amount);
-        auto target_txs = Impl::makeTargetTransactions(transactions_amount);
-
+        std::vector<shared_model::proto::Transaction> target_txs;
+        for (size_t i = 0; i < transactions_amount; i++) {
+          auto tx = Impl::makeTargetTransactions(1).at(0);
+          target_txs.emplace_back(tx);
+          if (i == first_tx_no) {
+            first_tx_time = tx.createdTime();
+          }
+          if (i == last_tx_no) {
+            last_tx_time = tx.createdTime();
+          }
+          std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
         tx_hashes_.reserve(target_txs.size());
         initial_txs.reserve(initial_txs.size() + target_txs.size());
         for (auto &tx : target_txs) {
           tx_hashes_.emplace_back(tx.hash());
           initial_txs.emplace_back(std::move(tx));
         }
+        commitTransactionsBlock(initial_txs, 1);
+      }
+      // create valid transactions and commit them
+      void createTransactionsAndCommit(size_t transactions_amount,
+                                       bool build_blocks = false) {
+        addPerms(Impl::getUserPermissions());
 
-        auto block = createBlock(initial_txs, 1);
-
-        apply(storage, block);
+        auto initial_txs = Impl::makeInitialTransactions(transactions_amount);
+        auto target_txs = Impl::makeTargetTransactions(transactions_amount);
+        auto size_diff = initial_txs.size();
+        tx_hashes_.reserve(target_txs.size());
+        initial_txs.reserve(initial_txs.size() + target_txs.size());
+        for (auto &tx : target_txs) {
+          tx_hashes_.emplace_back(tx.hash());
+          initial_txs.emplace_back(std::move(tx));
+        }
+        if (build_blocks) {
+          if (size_diff != 0) {
+            commitTransactionsBlock(
+                std::vector<shared_model::proto::Transaction>(
+                    initial_txs.begin(), initial_txs.begin() + size_diff + 1),
+                1);
+            commitEachTransactionBlock(
+                initial_txs, size_diff + 1, initial_txs.size(), 0);
+          } else {
+            commitEachTransactionBlock(
+                initial_txs, size_diff, initial_txs.size(), 1);
+          }
+        } else {
+          commitTransactionsBlock(initial_txs, 1);
+        }
       }
 
       auto queryPage(
           types::TransactionsNumberType page_size,
           const std::optional<types::HashType> &first_hash = std::nullopt,
-          const shared_model::interface::Ordering *ordering = nullptr) {
-        auto query = Impl::makeQuery(page_size, first_hash, ordering);
+          const shared_model::interface::Ordering *ordering = nullptr,
+          const std::optional<types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<types::HeightType> &last_tx_height =
+              std::nullopt) {
+        auto query = Impl::makeQuery(page_size,
+                                     first_hash,
+                                     ordering,
+                                     first_tx_time,
+                                     last_tx_time,
+                                     first_tx_height,
+                                     last_tx_height);
         return executeQuery(query);
       }
 
@@ -788,15 +861,29 @@ namespace iroha {
         }
         return transactions;
       }
-
       static shared_model::proto::Query makeQuery(
           types::TransactionsNumberType page_size,
           const std::optional<types::HashType> &first_hash = std::nullopt,
-          const shared_model::interface::Ordering *ordering = nullptr) {
+          const shared_model::interface::Ordering *ordering = nullptr,
+          const std::optional<types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<types::HeightType> &last_tx_height =
+              std::nullopt) {
         return TestQueryBuilder()
             .creatorAccountId(account_id)
             .createdTime(iroha::time::now())
-            .getAccountTransactions(account_id, page_size, first_hash, ordering)
+            .getAccountTransactions(account_id,
+                                    page_size,
+                                    first_hash,
+                                    ordering,
+                                    first_tx_time,
+                                    last_tx_time,
+                                    first_tx_height,
+                                    last_tx_height)
             .build();
       }
     };
@@ -846,12 +933,27 @@ namespace iroha {
       static shared_model::proto::Query makeQuery(
           types::TransactionsNumberType page_size,
           const std::optional<types::HashType> &first_hash = std::nullopt,
-          const shared_model::interface::Ordering *ordering = nullptr) {
+          const shared_model::interface::Ordering *ordering = nullptr,
+          const std::optional<types::TimestampType> &first_tx_time =
+              std::nullopt,
+          const std::optional<types::TimestampType> &last_tx_time =
+              std::nullopt,
+          const std::optional<types::HeightType> &first_tx_height =
+              std::nullopt,
+          const std::optional<types::HeightType> &last_tx_height =
+              std::nullopt) {
         return TestQueryBuilder()
             .creatorAccountId(account_id)
             .createdTime(iroha::time::now())
-            .getAccountAssetTransactions(
-                account_id, asset_id, page_size, first_hash, ordering)
+            .getAccountAssetTransactions(account_id,
+                                         asset_id,
+                                         page_size,
+                                         first_hash,
+                                         ordering,
+                                         first_tx_time,
+                                         last_tx_time,
+                                         first_tx_height,
+                                         last_tx_height)
             .build();
       }
     };
@@ -1076,7 +1178,6 @@ namespace iroha {
     }
 
     // ------------------------/ tx pagination tests \----------------------- //
-
     using QueryTxPaginationTestingTypes =
         ::testing::Types<GetAccountTxPaginationImpl,
                          GetAccountAssetTxPaginationImpl>;
@@ -1395,6 +1496,169 @@ namespace iroha {
           std::move(query_response),
           [this, size](const auto &tx_page_response) {
             this->generalTransactionsPageResponseCheck(tx_page_response, size);
+          });
+    }
+
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 10 page size
+     * @and first transaction time is before creating transactions
+     * @and last transaction time is after creating transactions
+     * @then response contains all 10 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, ValidTimeRange) {
+      auto first_tx_time = iroha::time::now();
+      this->createTransactionsAndCommit(10);
+      auto last_tx_time = iroha::time::now() + 1;
+      auto size = 10;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, first_tx_time, last_tx_time);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 2 page size
+     * @and first tx time is after 2nd transaction
+     * @and last tx time is after 5th transaction
+     * @then response contains 3 committed transactions
+     */
+
+    TYPED_TEST(GetPagedTransactionsExecutorTest,
+               FirstAndLastTimeSpecifiedInside) {
+      uint64_t first_tx_time;
+      uint64_t last_tx_time;
+      this->createTransactionsAndCommitGetTime(
+          10, 2, 5, first_tx_time, last_tx_time);
+      auto size = 2;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, first_tx_time, last_tx_time);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 10 page size
+     * @and first transaction time is before commiting transactions
+     * @then response contains 10 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, TimeRangeNoEnd) {
+      auto first_tx_time = iroha::time::now();
+      this->createTransactionsAndCommit(10);
+      auto size = 10;
+      auto query_response =
+          this->queryPage(size, std::nullopt, nullptr, first_tx_time);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 10 page size
+     * @and last transaction time is after creating last transaction
+     * @then response contains 10 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, LastTimeSpecified) {
+      this->createTransactionsAndCommit(10);
+      auto last_tx_time = iroha::time::now() + 1;
+      auto size = 10;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, std::nullopt, last_tx_time);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+
+    /**
+     * @given initialized storage, user has 3 transactions committed
+     * @when query contains 2 page size
+     * @and first block height is 1
+     * @and last block height is not specified
+     * @then response contains 2 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, FirstHeightSpecified) {
+      this->createTransactionsAndCommit(3, true);
+      auto size = 2;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, std::nullopt, std::nullopt, 1);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 4 page size
+     * @and last block height is 5
+     * @then response contains 4 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, LastHeightSpecified) {
+      this->createTransactionsAndCommit(10, true);
+      auto size = 4;
+      auto query_response = this->queryPage(size,
+                                            std::nullopt,
+                                            nullptr,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            5);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 2 page size
+     * @and first block time is before transactions
+     * @and last block time is after transactions
+     * @and first block height is 2
+     * @and last block height is 5
+     * @then response contains 2 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest,
+               FirstTimeLastTimeFirstHeightLastHeightSpecified) {
+      auto first_tx_time = iroha::time::now();
+      this->createTransactionsAndCommit(10, true);
+      auto last_tx_time = iroha::time::now();
+      auto size = 2;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, first_tx_time, last_tx_time, 2, 5);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
+          });
+    }
+    /**
+     * @given initialized storage, user has 10 transactions committed
+     * @when query contains 2 page size
+     * @and first block height is 2
+     * @and last block height is 5
+     * @then response contains 2 committed transactions
+     */
+    TYPED_TEST(GetPagedTransactionsExecutorTest, FirstAndLastHeightSpecified) {
+      this->createTransactionsAndCommit(10, true);
+      auto size = 2;
+      auto query_response = this->queryPage(
+          size, std::nullopt, nullptr, std::nullopt, std::nullopt, 2, 5);
+      checkSuccessfulResult<TransactionsPageResponse>(
+          std::move(query_response),
+          [this, size](const auto &tx_page_response) {
+            EXPECT_EQ(tx_page_response.transactions().size(), size);
           });
     }
 

--- a/test/module/shared_model/mock_objects_factories/mock_query_factory.cpp
+++ b/test/module/shared_model/mock_objects_factories/mock_query_factory.cpp
@@ -165,12 +165,26 @@ MockQueryFactory::constructGetPeers() const {
 MockQueryFactory::FactoryResult<MockTxPaginationMeta>
 MockQueryFactory::constructTxPaginationMeta(
     types::TransactionsNumberType page_size,
-    std::optional<types::HashType> first_tx_hash) const {
-  return createFactoryResult<MockTxPaginationMeta>(
-      [&page_size, &first_tx_hash](MockTxPaginationMeta &mock) {
-        EXPECT_CALL(mock, pageSize()).WillRepeatedly(Return(page_size));
-        EXPECT_CALL(mock, firstTxHash()).WillRepeatedly(Return(first_tx_hash));
-      });
+    std::optional<types::HashType> first_tx_hash,
+    std::optional<types::TimestampType> first_tx_time,
+    std::optional<types::TimestampType> last_tx_time,
+    std::optional<types::HeightType> first_tx_height,
+    std::optional<types::HeightType> last_tx_height) const {
+  return createFactoryResult<MockTxPaginationMeta>([&page_size,
+                                                    &first_tx_hash,
+                                                    &first_tx_time,
+                                                    &last_tx_time,
+                                                    &first_tx_height,
+                                                    &last_tx_height](
+                                                       MockTxPaginationMeta
+                                                           &mock) {
+    EXPECT_CALL(mock, pageSize()).WillRepeatedly(Return(page_size));
+    EXPECT_CALL(mock, firstTxHash()).WillRepeatedly(Return(first_tx_hash));
+    EXPECT_CALL(mock, firstTxTime()).WillRepeatedly(Return(first_tx_time));
+    EXPECT_CALL(mock, lastTxTime()).WillRepeatedly(Return(last_tx_time));
+    EXPECT_CALL(mock, firstTxHeight()).WillRepeatedly(Return(first_tx_height));
+    EXPECT_CALL(mock, lastTxHeight()).WillRepeatedly(Return(last_tx_height));
+  });
 }
 
 MockQueryFactory::FactoryResult<MockGetEngineReceipts>

--- a/test/module/shared_model/mock_objects_factories/mock_query_factory.hpp
+++ b/test/module/shared_model/mock_objects_factories/mock_query_factory.hpp
@@ -72,7 +72,11 @@ namespace shared_model {
 
       FactoryResult<MockTxPaginationMeta> constructTxPaginationMeta(
           types::TransactionsNumberType page_size,
-          std::optional<types::HashType> first_tx_hash) const;
+          std::optional<types::HashType> first_tx_hash,
+          std::optional<types::TimestampType> first_tx_time,
+          std::optional<types::TimestampType> last_tx_time,
+          std::optional<types::HeightType> first_tx_height,
+          std::optional<types::HeightType> last_tx_height) const;
 
       FactoryResult<MockGetEngineReceipts> constructGetEngineReceipts(
           const std::string &tx_hash) const;

--- a/test/module/shared_model/query_mocks.hpp
+++ b/test/module/shared_model/query_mocks.hpp
@@ -7,6 +7,7 @@
 #define IROHA_QUERY_MOCKS_HPP
 
 #include <gmock/gmock.h>
+
 #include "interfaces/queries/asset_pagination_meta.hpp"
 #include "interfaces/queries/blocks_query.hpp"
 #include "interfaces/queries/get_account.hpp"
@@ -140,6 +141,10 @@ namespace shared_model {
     struct MockTxPaginationMeta : public TxPaginationMeta {
       MOCK_CONST_METHOD0(pageSize, types::TransactionsNumberType());
       MOCK_CONST_METHOD0(firstTxHash, std::optional<types::HashType>());
+      MOCK_CONST_METHOD0(firstTxTime, std::optional<types::TimestampType>());
+      MOCK_CONST_METHOD0(lastTxTime, std::optional<types::TimestampType>());
+      MOCK_CONST_METHOD0(firstTxHeight, std::optional<types::HeightType>());
+      MOCK_CONST_METHOD0(lastTxHeight, std::optional<types::HeightType>());
       MOCK_CONST_METHOD0(clone, TxPaginationMeta *());
       MOCK_CONST_METHOD0(ordering, Ordering const &());
     };

--- a/test/module/shared_model/validators/protobuf/proto_query_validator_test.cpp
+++ b/test/module/shared_model/validators/protobuf/proto_query_validator_test.cpp
@@ -6,13 +6,15 @@
 #include "validators/protobuf/proto_query_validator.hpp"
 
 #include <gmock/gmock-matchers.h>
+#include <google/protobuf/util/time_util.h>
+
 #include <optional>
+
 #include "module/shared_model/validators/validators_fixture.hpp"
 #include "queries.pb.h"
 #include "validators/validation_error_output.hpp"
 
 using testing::HasSubstr;
-
 class ProtoQueryValidatorTest : public ValidatorsTest {
  public:
   shared_model::validation::ProtoQueryValidator validator;
@@ -47,28 +49,109 @@ TEST_F(ProtoQueryValidatorTest, SetQuery) {
 }
 
 iroha::protocol::Query generateGetAccountAssetTransactionsQuery(
-    const std::string &first_tx_hash) {
+    const std::optional<std::string> &first_tx_hash = std::nullopt,
+    const std::optional<int64_t> &first_tx_time = std::nullopt,
+    const std::optional<int64_t> &last_tx_time = std::nullopt,
+    const std::optional<uint64_t> &first_tx_height = std::nullopt,
+    const std::optional<uint64_t> &last_tx_height = std::nullopt) {
   iroha::protocol::Query result;
-  result.mutable_payload()
-      ->mutable_get_account_asset_transactions()
-      ->mutable_pagination_meta()
-      ->set_first_tx_hash(first_tx_hash);
+  if (first_tx_hash) {
+    result.mutable_payload()
+        ->mutable_get_account_asset_transactions()
+        ->mutable_pagination_meta()
+        ->set_first_tx_hash(first_tx_hash.value());
+  }
+  if (first_tx_time) {
+    auto first_time = new google::protobuf::Timestamp(
+        google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+            first_tx_time.value()));
+    result.mutable_payload()
+        ->mutable_get_account_asset_transactions()
+        ->mutable_pagination_meta()
+        ->set_allocated_first_tx_time(first_time);
+  }
+  if (last_tx_time) {
+    auto last_time = new google::protobuf::Timestamp(
+        google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+            last_tx_time.value()));
+    result.mutable_payload()
+        ->mutable_get_account_asset_transactions()
+        ->mutable_pagination_meta()
+        ->set_allocated_last_tx_time(last_time);
+  }
+  if (first_tx_height) {
+    result.mutable_payload()
+        ->mutable_get_account_asset_transactions()
+        ->mutable_pagination_meta()
+        ->set_first_tx_height(first_tx_height.value());
+  }
+  if (last_tx_height) {
+    result.mutable_payload()
+        ->mutable_get_account_asset_transactions()
+        ->mutable_pagination_meta()
+        ->set_last_tx_height(last_tx_height.value());
+  }
   return result;
 }
 
 iroha::protocol::Query generateGetAccountTransactionsQuery(
-    const std::string &first_tx_hash) {
+    const std::optional<std::string> &first_tx_hash = std::nullopt,
+    const std::optional<int64_t> &first_tx_time = std::nullopt,
+    const std::optional<int64_t> &last_tx_time = std::nullopt,
+    const std::optional<uint64_t> &first_tx_height = std::nullopt,
+    const std::optional<uint64_t> &last_tx_height = std::nullopt) {
   iroha::protocol::Query result;
-  result.mutable_payload()
-      ->mutable_get_account_transactions()
-      ->mutable_pagination_meta()
-      ->set_first_tx_hash(first_tx_hash);
+  if (first_tx_hash) {
+    result.mutable_payload()
+        ->mutable_get_account_transactions()
+        ->mutable_pagination_meta()
+        ->set_first_tx_hash(first_tx_hash.value());
+  }
+  if (first_tx_time) {
+    auto first_time = new google::protobuf::Timestamp(
+        google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+            first_tx_time.value()));
+    result.mutable_payload()
+        ->mutable_get_account_transactions()
+        ->mutable_pagination_meta()
+        ->set_allocated_first_tx_time(first_time);
+  }
+  if (last_tx_time) {
+    auto last_time = new google::protobuf::Timestamp(
+        google::protobuf::util::TimeUtil::MillisecondsToTimestamp(
+            last_tx_time.value()));
+    result.mutable_payload()
+        ->mutable_get_account_transactions()
+        ->mutable_pagination_meta()
+        ->set_allocated_last_tx_time(last_time);
+  }
+  if (first_tx_height) {
+    result.mutable_payload()
+        ->mutable_get_account_transactions()
+        ->mutable_pagination_meta()
+        ->set_first_tx_height(first_tx_height.value());
+  }
+  if (last_tx_height) {
+    result.mutable_payload()
+        ->mutable_get_account_transactions()
+        ->mutable_pagination_meta()
+        ->set_last_tx_height(last_tx_height.value());
+  }
   return result;
 }
 
 static std::string valid_tx_hash("123abc");
 static std::string invalid_tx_hash("not_hex");
-
+static int64_t valid_timestamp =
+    google::protobuf::util::TimeUtil::kTimestampMinSeconds + 1234;
+static uint64_t valid_height = 12;
+static uint64_t invalid_height = 0;
+static uint64_t height_2 = 2;
+static uint64_t height_5 = 5;
+static int64_t timestamp_123 =
+    google::protobuf::util::TimeUtil::kTimestampMinSeconds + 123;
+static int64_t timestamp_100 =
+    google::protobuf::util::TimeUtil::kTimestampMinSeconds + 100;
 // valid pagination query tests
 
 class ValidProtoPaginationQueryValidatorTest
@@ -83,8 +166,36 @@ TEST_P(ValidProtoPaginationQueryValidatorTest, ValidPaginationQuery) {
 INSTANTIATE_TEST_SUITE_P(
     ProtoPaginationQueryTest,
     ValidProtoPaginationQueryValidatorTest,
-    ::testing::Values(generateGetAccountAssetTransactionsQuery(valid_tx_hash),
-                      generateGetAccountTransactionsQuery(valid_tx_hash)));
+    ::testing::Values(
+        generateGetAccountAssetTransactionsQuery(valid_tx_hash),
+        generateGetAccountTransactionsQuery(valid_tx_hash),
+        generateGetAccountAssetTransactionsQuery(std::nullopt, valid_timestamp),
+        generateGetAccountTransactionsQuery(std::nullopt, valid_timestamp),
+        generateGetAccountAssetTransactionsQuery(std::nullopt,
+                                                 std::nullopt,
+                                                 valid_timestamp),
+        generateGetAccountTransactionsQuery(std::nullopt,
+                                            std::nullopt,
+                                            valid_timestamp),
+        generateGetAccountAssetTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, valid_height),
+        generateGetAccountTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, valid_height),
+        generateGetAccountAssetTransactionsQuery(std::nullopt,
+                                                 std::nullopt,
+                                                 std::nullopt,
+                                                 std::nullopt,
+                                                 valid_height),
+        generateGetAccountTransactionsQuery(std::nullopt,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            valid_height),
+        generateGetAccountTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, height_2, height_5),
+        generateGetAccountTransactionsQuery(std::nullopt,
+                                            timestamp_100,
+                                            timestamp_123)));
 
 // invalid pagination query tests
 
@@ -99,5 +210,24 @@ TEST_P(InvalidProtoPaginationQueryTest, InvalidPaginationQuery) {
 INSTANTIATE_TEST_SUITE_P(
     InvalidProtoPaginationQueryTest,
     InvalidProtoPaginationQueryTest,
-    ::testing::Values(generateGetAccountAssetTransactionsQuery(invalid_tx_hash),
-                      generateGetAccountTransactionsQuery(invalid_tx_hash)));
+    ::testing::Values(
+        generateGetAccountAssetTransactionsQuery(invalid_tx_hash),
+        generateGetAccountTransactionsQuery(invalid_tx_hash),
+        generateGetAccountAssetTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, invalid_height),
+        generateGetAccountTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, invalid_height),
+        generateGetAccountAssetTransactionsQuery(std::nullopt,
+                                                 std::nullopt,
+                                                 std::nullopt,
+                                                 std::nullopt,
+                                                 invalid_height),
+        generateGetAccountTransactionsQuery(std::nullopt,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            std::nullopt,
+                                            invalid_height),
+        generateGetAccountTransactionsQuery(
+            std::nullopt, timestamp_123, timestamp_100),
+        generateGetAccountTransactionsQuery(
+            std::nullopt, std::nullopt, std::nullopt, height_5, height_2)));


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Description of the Change
This is prove of concept for extending queries with time interval (from,to). Protobufs were modified and some basic logic was added. Validation of passed strings is not provided yet. Modified queries are getAccountTransactions and GetAccountAssetTransactions
Protobufs were modified, then neccesary getters were added.
Passed parameters are attached to sql query in executeTransactionsQuery, by applyer lamba function,
created separately in each function
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

 What benefits will be realized by the code change? 
Allowing to query for Transactions in given time interval and beetwen two given block heights
### Possible Drawbacks 

What are the possible side-effects or negative impacts of the code change? 
Usage of many if's in GetAccountTransactions/GetAccountAssetTransactions in postgres_specific_query_executor.cpp
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
By rebuilding python library with protbuffs from code you can use it in Python library
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->


### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Usage of different types for passing data as timestamp was considered, but I decided to use string, as it is not needed to cast from int to string