### PR TITLE
Introduces Generic Permission Validator

### DIFF
--- a/iroha/src/block.rs
+++ b/iroha/src/block.rs
@@ -22,7 +22,7 @@ use crate::wsv::WorldTrait;
 use crate::{
     merkle::MerkleTree,
     prelude::*,
-    smartcontracts::permissions::PermissionsValidatorBox,
+    smartcontracts::permissions::InstructionPermissionsValidatorBox,
     sumeragi::InitializedNetworkTopology,
     tx::{VersionedAcceptedTransaction, VersionedValidTransaction},
 };
@@ -208,7 +208,7 @@ impl ChainedBlock {
     pub fn validate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,
-        permissions_validator: &PermissionsValidatorBox<W>,
+        permissions_validator: &InstructionPermissionsValidatorBox<W>,
     ) -> VersionedValidBlock {
         let mut transactions = Vec::new();
         let mut rejected_transactions = Vec::new();
@@ -288,7 +288,7 @@ impl VersionedValidBlock {
     pub fn revalidate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,
-        permissions_validator: &PermissionsValidatorBox<W>,
+        permissions_validator: &InstructionPermissionsValidatorBox<W>,
     ) -> VersionedValidBlock {
         self.into_inner_v1()
             .revalidate(wsv, permissions_validator)
@@ -392,7 +392,7 @@ impl ValidBlock {
     pub fn revalidate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,
-        permissions_validator: &PermissionsValidatorBox<W>,
+        permissions_validator: &InstructionPermissionsValidatorBox<W>,
     ) -> ValidBlock {
         ValidBlock {
             signatures: self.signatures,

--- a/iroha/src/lib.rs
+++ b/iroha/src/lib.rs
@@ -25,7 +25,7 @@ use genesis::GenesisNetworkTrait;
 use iroha_actor::{broker::*, prelude::*};
 use iroha_data_model::prelude::*;
 use iroha_error::{error, Result, WrapErr};
-use smartcontracts::permissions::PermissionsValidatorBox;
+use smartcontracts::permissions::InstructionPermissionsValidatorBox;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use wsv::{World, WorldTrait};
@@ -97,7 +97,7 @@ where
     /// - Initialization of sumeragi
     pub async fn new(
         config: &Configuration,
-        validiator: PermissionsValidatorBox<K::World>,
+        validiator: InstructionPermissionsValidatorBox<K::World>,
     ) -> Result<Self> {
         let broker = Broker::new();
         Self::with_broker(config, validiator, broker).await
@@ -111,7 +111,7 @@ where
     /// - Initialization of sumeragi
     pub async fn with_broker(
         config: &Configuration,
-        validiator: PermissionsValidatorBox<K::World>,
+        validiator: InstructionPermissionsValidatorBox<K::World>,
         broker: Broker,
     ) -> Result<Self> {
         // TODO: use channel for prometheus/telemetry endpoint

--- a/iroha/src/smartcontracts/isi/mod.rs
+++ b/iroha/src/smartcontracts/isi/mod.rs
@@ -16,8 +16,7 @@ use iroha_data_model::{expression::prelude::*, isi::*, prelude::*};
 use iroha_derive::FromVariant;
 use iroha_error::{derive::Error, error, Result};
 
-use super::Evaluate;
-use super::Execute;
+use super::{Evaluate, Execute};
 use crate::prelude::*;
 use crate::wsv::WorldTrait;
 

--- a/iroha/src/sumeragi.rs
+++ b/iroha/src/sumeragi.rs
@@ -31,7 +31,7 @@ use crate::{
     kura::StoreBlock,
     prelude::*,
     queue::{PopPendingTransactions, QueueTrait},
-    smartcontracts::permissions::PermissionsValidatorBox,
+    smartcontracts::permissions::InstructionPermissionsValidatorBox,
     wsv::WorldTrait,
     VersionedValidBlock,
 };
@@ -108,7 +108,7 @@ where
     number_of_view_changes: u32,
     /// Hashes of invalidated blocks
     pub invalidated_blocks_hashes: Vec<Hash>,
-    permissions_validator: Arc<PermissionsValidatorBox<W>>,
+    permissions_validator: Arc<InstructionPermissionsValidatorBox<W>>,
     n_topology_shifts_before_reshuffle: u32,
     max_instruction_number: usize,
     /// Genesis network
@@ -145,7 +145,7 @@ pub trait SumeragiTrait:
         configuration: &config::SumeragiConfiguration,
         events_sender: EventsSender,
         wsv: Arc<WorldStateView<Self::World>>,
-        permissions_validator: PermissionsValidatorBox<Self::World>,
+        permissions_validator: InstructionPermissionsValidatorBox<Self::World>,
         genesis_network: Option<Self::GenesisNetwork>,
         queue: AlwaysAddr<Self::Queue>,
         broker: Broker,
@@ -162,7 +162,7 @@ impl<Q: QueueTrait, G: GenesisNetworkTrait, W: WorldTrait> SumeragiTrait for Sum
         configuration: &config::SumeragiConfiguration,
         events_sender: EventsSender,
         wsv: Arc<WorldStateView<W>>,
-        permissions_validator: PermissionsValidatorBox<W>,
+        permissions_validator: InstructionPermissionsValidatorBox<W>,
         genesis_network: Option<G>,
         queue: AlwaysAddr<Self::Queue>,
         broker: Broker,

--- a/iroha/test_network/src/lib.rs
+++ b/iroha/test_network/src/lib.rs
@@ -21,7 +21,7 @@ use iroha::{
     kura::{Kura, KuraTrait},
     prelude::*,
     queue::{Queue, QueueTrait},
-    smartcontracts::permissions::PermissionsValidatorBox,
+    smartcontracts::permissions::InstructionPermissionsValidatorBox,
     sumeragi::{config::SumeragiConfiguration, Sumeragi, SumeragiTrait},
     torii::config::ToriiConfiguration,
     wsv::{World, WorldTrait},
@@ -356,7 +356,7 @@ where
     pub async fn start_with_config_permissions_dir(
         &mut self,
         configuration: Configuration,
-        permissions: impl Into<PermissionsValidatorBox<W>> + Send + 'static,
+        permissions: impl Into<InstructionPermissionsValidatorBox<W>> + Send + 'static,
         temp_dir: &TempDir,
     ) {
         let mut configuration = self.get_config(configuration);
@@ -396,7 +396,7 @@ where
     pub async fn start_with_config_permissions(
         &mut self,
         configuration: Configuration,
-        permissions: impl Into<PermissionsValidatorBox<W>> + Send + 'static,
+        permissions: impl Into<InstructionPermissionsValidatorBox<W>> + Send + 'static,
     ) {
         let temp_dir = TempDir::new().expect("Failed to create temp dir.");
         let mut configuration = self.get_config(configuration);
@@ -489,7 +489,7 @@ where
     /// Starts peer with default configuration and specified permissions.
     /// Returns its info and client for connecting to it.
     pub async fn start_test_with_permissions(
-        permissions: PermissionsValidatorBox<W>,
+        permissions: InstructionPermissionsValidatorBox<W>,
     ) -> (Self, Client) {
         let mut configuration = Configuration::test();
         let mut peer = Self::new().expect("Failed to create peer.");

--- a/iroha/test_network/tests/mock.rs
+++ b/iroha/test_network/tests/mock.rs
@@ -16,7 +16,7 @@ use iroha::genesis::config::GenesisConfiguration;
 use iroha::genesis::GenesisNetworkTrait;
 use iroha::kura::StoreBlock;
 use iroha::queue::QueueTrait;
-use iroha::smartcontracts::permissions::PermissionsValidatorBox;
+use iroha::smartcontracts::permissions::InstructionPermissionsValidatorBox;
 use iroha::sumeragi::message::Message as SumeragiMessage;
 use iroha::wsv::WorldTrait;
 use iroha::{block_sync::BlockSynchronizer, queue::Queue};
@@ -333,7 +333,7 @@ pub mod utils {
                 configuration: &config::SumeragiConfiguration,
                 events_sender: EventsSender,
                 wsv: Arc<WorldStateView<W>>,
-                permissions_validator: PermissionsValidatorBox<W>,
+                permissions_validator: InstructionPermissionsValidatorBox<W>,
                 genesis_network: Option<Self::GenesisNetwork>,
                 queue: AlwaysAddr<Self::Queue>,
                 broker: Broker,


### PR DESCRIPTION
This will enable us to check permissions for query, with the use of already written combinators.

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Introduces Generic Permission Validator
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
This will enable us to check permissions for query, with the use of already written combinators.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
More generics make code harder to read, but this is somewhat mitigated by type aliases.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
