### PR TITLE
Refactor YAC

### DIFF
--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -186,7 +186,6 @@ target_link_libraries(ametsuchi
     SOCI::postgresql
     SOCI::core
     postgres_query_executor
-    async_subscription
     )
 
 target_compile_definitions(ametsuchi

--- a/irohad/consensus/impl/round.cpp
+++ b/irohad/consensus/impl/round.cpp
@@ -31,13 +31,6 @@ namespace iroha {
       return not(*this == rhs);
     }
 
-    std::size_t RoundTypeHasher::operator()(const consensus::Round &val) const {
-      size_t seed = 0;
-      boost::hash_combine(seed, val.block_round);
-      boost::hash_combine(seed, val.reject_round);
-      return seed;
-    }
-
     std::string Round::toString() const {
       return shared_model::detail::PrettyStringBuilder()
           .init("Round")
@@ -45,5 +38,19 @@ namespace iroha {
           .appendNamed("reject", reject_round)
           .finalize();
     }
+
+    std::size_t hash_value(Round const &val) {
+      size_t seed = 0;
+      boost::hash_combine(seed, val.block_round);
+      boost::hash_combine(seed, val.reject_round);
+      return seed;
+    }
   }  // namespace consensus
 }  // namespace iroha
+
+namespace std {
+  std::size_t hash<iroha::consensus::Round>::operator()(
+      iroha::consensus::Round const &val) const noexcept {
+    return hash_value(val);
+  }
+}  // namespace std

--- a/irohad/consensus/round.hpp
+++ b/irohad/consensus/round.hpp
@@ -45,15 +45,16 @@ namespace iroha {
       std::string toString() const;
     };
 
-    /**
-     * Class provides hash function for Round
-     */
-    class RoundTypeHasher {
-     public:
-      std::size_t operator()(const consensus::Round &val) const;
-    };
+    std::size_t hash_value(Round const &val);
 
   }  // namespace consensus
 }  // namespace iroha
+
+namespace std {
+  template <>
+  struct hash<iroha::consensus::Round> {
+    std::size_t operator()(iroha::consensus::Round const &val) const noexcept;
+  };
+}  // namespace std
 
 #endif  // IROHA_ROUND_HPP

--- a/irohad/consensus/yac/cluster_order.hpp
+++ b/irohad/consensus/yac/cluster_order.hpp
@@ -7,9 +7,9 @@
 #define IROHA_CLUSTER_ORDER_HPP
 
 #include <memory>
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include "consensus/yac/yac_types.hpp"
 #include "interfaces/common_objects/types.hpp"
 
@@ -25,7 +25,7 @@ namespace iroha::consensus::yac {
      * @param peer_positions vector of indexes of peer positions
      * @return ClusterOrdering if vectors are not empty, null otherwise
      */
-    static boost::optional<ClusterOrdering> create(
+    static std::optional<ClusterOrdering> create(
         std::vector<std::shared_ptr<shared_model::interface::Peer>> const
             &order,
         std::vector<size_t> const &peer_positions);
@@ -35,7 +35,7 @@ namespace iroha::consensus::yac {
      * @param order vector of peers
      * @return ClusterOrdering if vectors are not empty, null otherwise
      */
-    static boost::optional<ClusterOrdering> create(
+    static std::optional<ClusterOrdering> create(
         std::vector<std::shared_ptr<shared_model::interface::Peer>> const
             &order);
 

--- a/irohad/consensus/yac/impl/cluster_order.cpp
+++ b/irohad/consensus/yac/impl/cluster_order.cpp
@@ -5,21 +5,23 @@
 
 #include "consensus/yac/cluster_order.hpp"
 
+#include <boost/assert.hpp>
+
 using iroha::consensus::yac::ClusterOrdering;
 
-boost::optional<ClusterOrdering> ClusterOrdering::create(
+std::optional<ClusterOrdering> ClusterOrdering::create(
     const std::vector<std::shared_ptr<shared_model::interface::Peer>> &order,
     std::vector<size_t> const &peer_positions) {
   if (order.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   return ClusterOrdering(order, peer_positions);
 }
 
-boost::optional<ClusterOrdering> ClusterOrdering::create(
+std::optional<ClusterOrdering> ClusterOrdering::create(
     const std::vector<std::shared_ptr<shared_model::interface::Peer>> &order) {
   if (order.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   return ClusterOrdering(order);
 }

--- a/irohad/consensus/yac/impl/peer_orderer_impl.cpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.cpp
@@ -15,11 +15,7 @@
 
 using iroha::consensus::yac::PeerOrdererImpl;
 
-PeerOrdererImpl::PeerOrdererImpl(
-    std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory)
-    : peer_query_factory_(peer_query_factory) {}
-
-boost::optional<iroha::consensus::yac::ClusterOrdering>
+std::optional<iroha::consensus::yac::ClusterOrdering>
 PeerOrdererImpl::getOrdering(
     const YacHash &hash,
     std::vector<std::shared_ptr<shared_model::interface::Peer>> const &peers) {

--- a/irohad/consensus/yac/impl/peer_orderer_impl.hpp
+++ b/irohad/consensus/yac/impl/peer_orderer_impl.hpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include "ametsuchi/peer_query_factory.hpp"
 #include "consensus/yac/yac_peer_orderer.hpp"
 
 namespace iroha::consensus::yac {
@@ -17,18 +16,13 @@ namespace iroha::consensus::yac {
 
   class PeerOrdererImpl : public YacPeerOrderer {
    public:
-    // TODO 30.01.2019 lebdron: IR-262 Remove PeerQueryFactory
-    explicit PeerOrdererImpl(
-        std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory);
-
-    boost::optional<ClusterOrdering> getOrdering(
+    std::optional<ClusterOrdering> getOrdering(
         const YacHash &hash,
         std::vector<std::shared_ptr<shared_model::interface::Peer>> const
             &peers) override;
 
    private:
     std::vector<size_t> peer_positions_;
-    std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory_;
   };
 }  // namespace iroha::consensus::yac
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -36,7 +36,7 @@ namespace iroha::consensus::yac {
     YacGateImpl(
         std::shared_ptr<HashGate> hash_gate,
         std::shared_ptr<YacPeerOrderer> orderer,
-        boost::optional<ClusterOrdering> alternative_order,
+        std::optional<ClusterOrdering> alternative_order,
         std::shared_ptr<const LedgerState> ledger_state,
         std::shared_ptr<YacHashProvider> hash_provider,
         std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache,
@@ -46,6 +46,10 @@ namespace iroha::consensus::yac {
     std::optional<GateObject> processOutcome(Answer const &outcome);
 
     void stop() override;
+
+    std::optional<GateObject> processRoundSwitch(
+        consensus::Round const &round,
+        std::shared_ptr<LedgerState const> ledger_state);
 
    private:
     /**
@@ -60,10 +64,10 @@ namespace iroha::consensus::yac {
 
     logger::LoggerPtr log_;
 
-    boost::optional<std::shared_ptr<shared_model::interface::Block>>
+    std::optional<std::shared_ptr<shared_model::interface::Block>>
         current_block_;
     YacHash current_hash_;
-    boost::optional<ClusterOrdering> alternative_order_;
+    std::optional<ClusterOrdering> alternative_order_;
     std::shared_ptr<const LedgerState> current_ledger_state_;
 
     std::shared_ptr<YacPeerOrderer> orderer_;

--- a/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
+++ b/irohad/consensus/yac/storage/impl/yac_vote_storage.cpp
@@ -110,6 +110,9 @@ boost::optional<iroha::consensus::yac::Answer> YacVoteStorage::store(
 bool YacVoteStorage::isCommitted(const Round &round) {
   auto iter = getProposalStorage(round);
   if (iter == proposal_storages_.end()) {
+    if (auto last_round = getLastFinalizedRound()) {
+      return *last_round >= round;
+    }
     return false;
   }
   return bool(iter->getState());

--- a/irohad/consensus/yac/storage/yac_vote_storage.hpp
+++ b/irohad/consensus/yac/storage/yac_vote_storage.hpp
@@ -161,7 +161,7 @@ namespace iroha::consensus::yac {
      * proposals/blocks.
      * If such round exists <=> processed
      */
-    std::unordered_map<Round, ProposalState, RoundTypeHasher> processing_state_;
+    std::unordered_map<Round, ProposalState> processing_state_;
 
     /**
      * Provides strategy managing rounds (adding and removing) for the

--- a/irohad/consensus/yac/transport/impl/network_impl.cpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.cpp
@@ -14,20 +14,16 @@
 #include "consensus/yac/vote_message.hpp"
 #include "interfaces/common_objects/peer.hpp"
 #include "logger/logger.hpp"
+#include "main/subscription.hpp"
 #include "network/impl/client_factory.hpp"
 #include "yac.pb.h"
 
 using iroha::consensus::yac::NetworkImpl;
 
 // ----------| Public API |----------
-NetworkImpl::NetworkImpl(
-    std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
-    std::unique_ptr<ClientFactory> client_factory,
-    logger::LoggerPtr log)
-    : async_call_(async_call),
-      client_factory_(std::move(client_factory)),
-      log_(std::move(log)) {}
+NetworkImpl::NetworkImpl(std::unique_ptr<ClientFactory> client_factory,
+                         logger::LoggerPtr log)
+    : client_factory_(std::move(client_factory)), log_(std::move(log)) {}
 
 void NetworkImpl::stop() {
   std::lock_guard<std::mutex> stop_lock(stop_mutex_);
@@ -48,20 +44,45 @@ void NetworkImpl::sendState(const shared_model::interface::Peer &to,
     *pb_vote = PbConverters::serializeVote(vote);
   }
 
-  client_factory_->createClient(to).match(
-      [&](auto client) {
-        async_call_->Call(
-            [client = std::move(client.value),
-             request = std::move(request),
-             log = log_,
-             log_sending_msg = fmt::format(
-                 "Send votes bundle[size={}] to {}", state.size(), to)](
-                auto context, auto cq) {
-              log->info(log_sending_msg);
-              return client->AsyncSendState(context, request, cq);
-            });
-      },
-      [&](const auto &error) {
-        log_->error("Could not send state to {}: {}", to, error.error);
+  auto maybe_client = client_factory_->createClient(to);
+  if (expected::hasError(maybe_client)) {
+    log_->error(
+        "Could not send state to {}: {}", to, maybe_client.assumeError());
+    return;
+  }
+  std::shared_ptr<decltype(maybe_client)::ValueInnerType::element_type> client =
+      std::move(maybe_client).assumeValue();
+
+  log_->debug("Propagating votes for {}, size={} to {}",
+              state.front().hash.vote_round,
+              state.size(),
+              to);
+  getSubscription()->dispatcher()->add(
+      getSubscription()->dispatcher()->kExecuteInPool,
+      [request(std::move(request)),
+       client(std::move(client)),
+       log(utils::make_weak(log_)),
+       log_sending_msg(fmt::format("Send votes bundle[size={}] for {} to {}",
+                                   state.size(),
+                                   state.front().hash.vote_round,
+                                   to))] {
+        auto maybe_log = log.lock();
+        if (not maybe_log) {
+          return;
+        }
+        grpc::ClientContext context;
+        context.set_wait_for_ready(true);
+        context.set_deadline(std::chrono::system_clock::now()
+                             + std::chrono::seconds(5));
+        google::protobuf::Empty response;
+        maybe_log->info(log_sending_msg);
+        auto status = client->SendState(&context, request, &response);
+        if (not status.ok()) {
+          maybe_log->warn(
+              "RPC failed: {} {}", context.peer(), status.error_message());
+          return;
+        } else {
+          maybe_log->info("RPC succeeded: {}", context.peer());
+        }
       });
 }

--- a/irohad/consensus/yac/transport/impl/network_impl.hpp
+++ b/irohad/consensus/yac/transport/impl/network_impl.hpp
@@ -14,7 +14,6 @@
 
 #include "consensus/yac/vote_message.hpp"
 #include "logger/logger_fwd.hpp"
-#include "network/impl/async_grpc_client.hpp"
 #include "network/impl/client_factory.hpp"
 
 namespace iroha::consensus::yac {
@@ -27,13 +26,9 @@ namespace iroha::consensus::yac {
     using Service = proto::Yac;
     using ClientFactory = iroha::network::ClientFactory<Service>;
 
-    NetworkImpl(
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call,
-        std::unique_ptr<
-            iroha::network::ClientFactory<::iroha::consensus::yac::proto::Yac>>
-            client_factory,
-        logger::LoggerPtr log);
+    NetworkImpl(std::unique_ptr<iroha::network::ClientFactory<
+                    ::iroha::consensus::yac::proto::Yac>> client_factory,
+                logger::LoggerPtr log);
 
     void sendState(const shared_model::interface::Peer &to,
                    const std::vector<VoteMessage> &state) override;
@@ -41,14 +36,6 @@ namespace iroha::consensus::yac {
     void stop() override;
 
    private:
-    std::function<void(std::vector<VoteMessage>)> callback_;
-
-    /**
-     * Rpc call to provide an ability to perform call grpc endpoints
-     */
-    std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call_;
-
     /**
      * Yac stub creator
      */

--- a/irohad/consensus/yac/vote_message.hpp
+++ b/irohad/consensus/yac/vote_message.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include <boost/functional/hash.hpp>
 #include "consensus/yac/yac_hash_provider.hpp"  // for YacHash
 #include "interfaces/common_objects/signature.hpp"
 #include "utils/string_builder.hpp"
@@ -37,5 +38,20 @@ namespace iroha::consensus::yac {
     }
   };
 }  // namespace iroha::consensus::yac
+
+namespace std {
+  template <>
+  struct hash<iroha::consensus::yac::VoteMessage> {
+    std::size_t operator()(iroha::consensus::yac::VoteMessage const &m) const
+        noexcept {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, m.signature->publicKey());
+      boost::hash_combine(seed, m.hash.vote_round);
+      boost::hash_combine(seed, m.hash.vote_hashes.proposal_hash);
+      boost::hash_combine(seed, m.hash.vote_hashes.block_hash);
+      return seed;
+    }
+  };
+}  // namespace std
 
 #endif  // IROHA_VOTE_MESSAGE_HPP

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -9,9 +9,10 @@
 #include "consensus/yac/transport/yac_network_interface.hpp"  // for YacNetworkNotifications
 #include "consensus/yac/yac_gate.hpp"                         // for HashGate
 
+#include <map>
 #include <memory>
+#include <unordered_set>
 
-#include <boost/optional.hpp>
 #include "consensus/yac/cluster_order.hpp"     //  for ClusterOrdering
 #include "consensus/yac/outcome_messages.hpp"  // because messages passed by value
 #include "consensus/yac/storage/yac_vote_storage.hpp"  // for VoteStorage
@@ -32,7 +33,7 @@ namespace iroha::consensus::yac {
         std::shared_ptr<YacNetwork> network,
         std::shared_ptr<YacCryptoProvider> crypto,
         std::shared_ptr<Timer> timer,
-        ClusterOrdering order,
+        shared_model::interface::types::PeerList order,
         Round round,
         logger::LoggerPtr log);
 
@@ -40,7 +41,7 @@ namespace iroha::consensus::yac {
         std::shared_ptr<YacNetwork> network,
         std::shared_ptr<YacCryptoProvider> crypto,
         std::shared_ptr<Timer> timer,
-        ClusterOrdering order,
+        shared_model::interface::types::PeerList order,
         Round round,
         logger::LoggerPtr log);
 
@@ -48,8 +49,12 @@ namespace iroha::consensus::yac {
 
     void vote(YacHash hash,
               ClusterOrdering order,
-              boost::optional<ClusterOrdering> alternative_order =
-                  boost::none) override;
+              std::optional<ClusterOrdering> alternative_order =
+                  std::nullopt) override;
+
+    std::optional<Answer> processRoundSwitch(
+        consensus::Round const &round,
+        shared_model::interface::types::PeerList const &peers) override;
 
     // ------|Network notifications|------
 
@@ -64,28 +69,27 @@ namespace iroha::consensus::yac {
      * Voting step is strategy of propagating vote
      * until commit/reject message received
      */
-    void votingStep(VoteMessage vote, uint32_t attempt = 0);
+    void votingStep(VoteMessage vote,
+                    ClusterOrdering order,
+                    uint32_t attempt = 0);
 
     /// Get cluster_order_ or alternative_order_ if present
-    ClusterOrdering &getCurrentOrder();
+    shared_model::interface::types::PeerList &getCurrentOrder();
 
     /**
      * Find corresponding peer in the ledger from vote message
      * @param vote message containing peer information
-     * @return peer if it is present in the ledger, boost::none otherwise
+     * @return peer if it is present in the ledger, std::nullopt otherwise
      */
-    boost::optional<std::shared_ptr<shared_model::interface::Peer>> findPeer(
+    std::optional<std::shared_ptr<shared_model::interface::Peer>> findPeer(
         const VoteMessage &vote);
 
     /// Remove votes from unknown peers from given vector.
-    void removeUnknownPeersVotes(std::vector<VoteMessage> &votes,
-                                 ClusterOrdering &order);
+    void removeUnknownPeersVotes(
+        std::vector<VoteMessage> &votes,
+        shared_model::interface::types::PeerList const &order);
 
     // ------|Apply data|------
-    /**
-     * @pre lock is locked
-     * @post lock is unlocked
-     */
     std::optional<Answer> applyState(const std::vector<VoteMessage> &state);
 
     // ------|Propagation|------
@@ -98,8 +102,8 @@ namespace iroha::consensus::yac {
     logger::LoggerPtr log_;
 
     // ------|One round|------
-    ClusterOrdering cluster_order_;
-    boost::optional<ClusterOrdering> alternative_order_;
+    shared_model::interface::types::PeerList cluster_order_;
+    std::optional<shared_model::interface::types::PeerList> alternative_order_;
     Round round_;
 
     // ------|Fields|------
@@ -107,6 +111,7 @@ namespace iroha::consensus::yac {
     std::shared_ptr<YacNetwork> network_;
     std::shared_ptr<YacCryptoProvider> crypto_;
     std::shared_ptr<Timer> timer_;
+    std::map<Round, std::unordered_set<VoteMessage>> future_states_;
   };
 }  // namespace iroha::consensus::yac
 

--- a/irohad/consensus/yac/yac_gate.hpp
+++ b/irohad/consensus/yac/yac_gate.hpp
@@ -6,8 +6,15 @@
 #ifndef IROHA_YAC_GATE_HPP
 #define IROHA_YAC_GATE_HPP
 
+#include <optional>
+
 #include "consensus/yac/cluster_order.hpp"
+#include "consensus/yac/storage/storage_result.hpp"
 #include "network/consensus_gate.hpp"
+
+namespace iroha::consensus {
+  struct Round;
+}
 
 namespace iroha::consensus::yac {
   class YacHash;
@@ -29,7 +36,19 @@ namespace iroha::consensus::yac {
     virtual void vote(
         YacHash hash,
         ClusterOrdering order,
-        boost::optional<ClusterOrdering> alternative_order = boost::none) = 0;
+        std::optional<ClusterOrdering> alternative_order = std::nullopt) = 0;
+
+    /**
+     * Update current state with the new round and peer list, possibly pruning
+     * the old state. Process states from future if available, and return the
+     * result
+     * @param round - new round
+     * @param peers - new peer list
+     * @return answer if storage already contains required votes
+     */
+    virtual std::optional<Answer> processRoundSwitch(
+        consensus::Round const &round,
+        shared_model::interface::types::PeerList const &peers) = 0;
 
     /// Prevent any new outgoing network activity. Be passive.
     virtual void stop() = 0;

--- a/irohad/consensus/yac/yac_peer_orderer.hpp
+++ b/irohad/consensus/yac/yac_peer_orderer.hpp
@@ -6,7 +6,7 @@
 #ifndef IROHA_YAC_PEER_ORDERER_HPP
 #define IROHA_YAC_PEER_ORDERER_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "consensus/yac/cluster_order.hpp"
 
@@ -24,7 +24,7 @@ namespace iroha::consensus::yac {
      * @param peers - an ordered list of peers
      * @return shuffled cluster order
      */
-    virtual boost::optional<ClusterOrdering> getOrdering(
+    virtual std::optional<ClusterOrdering> getOrdering(
         const YacHash &hash,
         std::vector<std::shared_ptr<shared_model::interface::Peer>> const
             &peers) = 0;

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -115,8 +115,7 @@ Irohad::Irohad(
     const boost::optional<GossipPropagationStrategyParams>
         &opt_mst_gossip_params,
     boost::optional<IrohadConfig::InterPeerTls> inter_peer_tls_config)
-    : se_(getSubscription()),
-      config_(config),
+    : config_(config),
       listen_ip_(listen_ip),
       keypair_(keypair),
       startup_wsv_sync_policy_(startup_wsv_sync_policy),
@@ -127,7 +126,7 @@ Irohad::Irohad(
       subscription_engine_(getSubscription()),
       ordering_init(std::make_shared<ordering::OnDemandOrderingInit>(
           logger_manager->getLogger())),
-      yac_init(std::make_unique<iroha::consensus::yac::YacInit>()),
+      yac_init(std::make_shared<iroha::consensus::yac::YacInit>()),
       log_manager_(std::move(logger_manager)),
       log_(log_manager_->getLogger()) {
   log_->info("created");
@@ -574,7 +573,6 @@ Irohad::RunResult Irohad::initOrderingGate() {
       transaction_factory,
       batch_parser,
       transaction_batch_factory_,
-      async_call_,
       std::move(factory),
       proposal_factory,
       persistent_cache,
@@ -646,36 +644,20 @@ Irohad::RunResult Irohad::initBlockLoader() {
  * Initializing consensus gate
  */
 Irohad::RunResult Irohad::initConsensusGate() {
-  auto block_query = storage->createBlockQuery();
-  if (not block_query) {
-    return iroha::expected::makeError<std::string>(
-        "Failed to create block query");
-  }
-  auto block_var =
-      (*block_query)->getBlock((*block_query)->getTopBlockHeight());
-  if (auto e = expected::resultToOptionalError(block_var)) {
-    return iroha::expected::makeError<std::string>(
-        "Failed to get the top block: " + e->message);
-  }
-
-  auto &block =
-      boost::get<expected::ValueOf<decltype(block_var)>>(&block_var)->value;
-
   auto initial_ledger_state = storage->getLedgerState();
   if (not initial_ledger_state) {
     return expected::makeError("Failed to fetch ledger state!");
   }
 
   consensus_gate = yac_init->initConsensusGate(
-      {block->height(), ordering::kFirstRejectRound},
-      storage,
+      {initial_ledger_state.value()->top_block_info.height + 1,
+       ordering::kFirstRejectRound},
       config_.initial_peers,
       *initial_ledger_state,
       block_loader,
       *keypair_,
       consensus_result_cache_,
       std::chrono::milliseconds(config_.vote_delay),
-      async_call_,
       kConsensusConsistencyModel,
       log_manager_->getChild("Consensus"),
       inter_peer_client_factory_);
@@ -910,6 +892,42 @@ Irohad::RunResult Irohad::initWsvRestorer() {
   return {};
 }
 
+namespace {
+  struct ProcessGateObjectContext {
+    std::shared_ptr<iroha::synchronizer::Synchronizer> synchronizer;
+    std::shared_ptr<iroha::ordering::OnDemandOrderingInit> ordering_init;
+    std::shared_ptr<iroha::consensus::yac::YacInit> yac_init;
+    logger::LoggerPtr log;
+    std::shared_ptr<iroha::Subscription> subscription;
+  };
+
+  void processGateObject(ProcessGateObjectContext context,
+                         consensus::GateObject const &object) {
+    context.subscription->notify(
+        EventTypes::kOnConsensusGateEvent,
+        ::torii::CommandServiceTransportGrpc::ConsensusGateEvent{});
+    context.log->info("~~~~~~~~~| PROPOSAL ^_^ |~~~~~~~~~ ");
+    auto event = context.synchronizer->processOutcome(std::move(object));
+    if (not event) {
+      return;
+    }
+    context.subscription->notify(EventTypes::kOnSynchronization,
+                                 SynchronizationEvent(*event));
+    printSynchronizationEvent(context.log, *event);
+    auto round_switch =
+        context.ordering_init->processSynchronizationEvent(std::move(*event));
+    if (auto maybe_object = context.yac_init->processRoundSwitch(
+            round_switch.next_round, round_switch.ledger_state)) {
+      auto round = [](auto &object) { return object.round; };
+      context.log->info("Ignoring object with {} because {} is newer",
+                        std::visit(round, object),
+                        std::visit(round, *maybe_object));
+      return processGateObject(std::move(context), *maybe_object);
+    }
+    context.ordering_init->processRoundSwitch(round_switch);
+  }
+}  // namespace
+
 /**
  * Run iroha daemon
  */
@@ -939,27 +957,23 @@ Irohad::RunResult Irohad::run() {
 
   yac_init->subscribe([synchronizer(utils::make_weak(synchronizer)),
                        ordering_init(utils::make_weak(ordering_init)),
+                       yac_init(utils::make_weak(yac_init)),
                        log(utils::make_weak(log_)),
                        subscription(utils::make_weak(getSubscription()))](
-                          consensus::GateObject object) {
+                          consensus::GateObject const &object) {
     auto maybe_synchronizer = synchronizer.lock();
     auto maybe_ordering_init = ordering_init.lock();
+    auto maybe_yac_init = yac_init.lock();
     auto maybe_log = log.lock();
     auto maybe_subscription = subscription.lock();
-    if (maybe_synchronizer and maybe_ordering_init and maybe_log
-        and maybe_subscription) {
-      maybe_subscription->notify(
-          EventTypes::kOnConsensusGateEvent,
-          ::torii::CommandServiceTransportGrpc::ConsensusGateEvent{});
-      maybe_log->info("~~~~~~~~~| PROPOSAL ^_^ |~~~~~~~~~ ");
-      auto event = maybe_synchronizer->processOutcome(std::move(object));
-      if (not event) {
-        return;
-      }
-      maybe_subscription->notify(EventTypes::kOnSynchronization,
-                                 SynchronizationEvent(*event));
-      printSynchronizationEvent(maybe_log, *event);
-      maybe_ordering_init->processSynchronizationEvent(std::move(*event));
+    if (maybe_synchronizer and maybe_ordering_init and maybe_yac_init
+        and maybe_log and maybe_subscription) {
+      processGateObject({std::move(maybe_synchronizer),
+                         std::move(maybe_ordering_init),
+                         std::move(maybe_yac_init),
+                         std::move(maybe_log),
+                         std::move(maybe_subscription)},
+                        object);
     }
   });
 
@@ -1040,14 +1054,41 @@ Irohad::RunResult Irohad::run() {
 
   subscription_engine_->dispatcher()->add(
       iroha::SubscriptionEngineHandlers::kYac,
-      [ordering_init(utils::make_weak(ordering_init)),
+      [synchronizer(utils::make_weak(synchronizer)),
+       ordering_init(utils::make_weak(ordering_init)),
+       yac_init(utils::make_weak(yac_init)),
+       log(utils::make_weak(log_)),
+       subscription(utils::make_weak(getSubscription())),
        block_height,
        initial_ledger_state] {
-        if (auto maybe_ordering_init = ordering_init.lock()) {
-          maybe_ordering_init->processSynchronizationEvent(
-              {SynchronizationOutcomeType::kCommit,
-               {block_height, ordering::kFirstRejectRound},
-               *initial_ledger_state});
+        auto maybe_synchronizer = synchronizer.lock();
+        auto maybe_ordering_init = ordering_init.lock();
+        auto maybe_yac_init = yac_init.lock();
+        auto maybe_log = log.lock();
+        auto maybe_subscription = subscription.lock();
+        if (maybe_synchronizer and maybe_ordering_init and maybe_yac_init
+            and maybe_log and maybe_subscription) {
+          ProcessGateObjectContext context{std::move(maybe_synchronizer),
+                                           std::move(maybe_ordering_init),
+                                           std::move(maybe_yac_init),
+                                           std::move(maybe_log),
+                                           std::move(maybe_subscription)};
+          consensus::Round initial_round{block_height,
+                                         ordering::kFirstRejectRound};
+          auto round_switch =
+              context.ordering_init->processSynchronizationEvent(
+                  {SynchronizationOutcomeType::kCommit,
+                   initial_round,
+                   *initial_ledger_state});
+          if (auto maybe_object = context.yac_init->processRoundSwitch(
+                  round_switch.next_round, round_switch.ledger_state)) {
+            auto round = [](auto &object) { return object.round; };
+            context.log->info("Ignoring object with {} because {} is newer",
+                              initial_round,
+                              std::visit(round, *maybe_object));
+            return processGateObject(std::move(context), *maybe_object);
+          }
+          context.ordering_init->processRoundSwitch(round_switch);
         }
       });
 

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -230,7 +230,6 @@ class Irohad {
   virtual RunResult initWsvRestorer();
 
   // constructor dependencies
-  std::shared_ptr<iroha::Subscription> se_;
   IrohadConfig config_;
   const std::string listen_ip_;
   boost::optional<shared_model::crypto::Keypair> keypair_;
@@ -268,7 +267,7 @@ class Irohad {
 
   // initialization objects
   std::shared_ptr<iroha::ordering::OnDemandOrderingInit> ordering_init;
-  std::unique_ptr<iroha::consensus::yac::YacInit> yac_init;
+  std::shared_ptr<iroha::consensus::yac::YacInit> yac_init;
   iroha::network::BlockLoaderInit loader_init;
 
   // IR-907 14.09.2020 @lebdron: remove it from here

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -20,53 +20,46 @@
 #include "main/subscription.hpp"
 #include "network/impl/client_factory_impl.hpp"
 
-using namespace iroha::consensus;
-using namespace iroha::consensus::yac;
+using iroha::consensus::yac::YacInit;
 
 namespace {
-  auto createPeerOrderer(
-      std::shared_ptr<iroha::ametsuchi::PeerQueryFactory> peer_query_factory) {
-    return std::make_shared<PeerOrdererImpl>(peer_query_factory);
-  }
-
   auto createCryptoProvider(const shared_model::crypto::Keypair &keypair,
                             logger::LoggerPtr log) {
-    auto crypto = std::make_shared<CryptoProviderImpl>(keypair, std::move(log));
+    auto crypto = std::make_shared<iroha::consensus::yac::CryptoProviderImpl>(
+        keypair, std::move(log));
 
     return crypto;
   }
 
   auto createHashProvider() {
-    return std::make_shared<YacHashProviderImpl>();
+    return std::make_shared<iroha::consensus::yac::YacHashProviderImpl>();
   }
 
   auto createNetwork(
-      std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-          async_call,
       std::shared_ptr<iroha::network::GenericClientFactory> client_factory,
       logger::LoggerPtr log) {
-    return std::make_shared<NetworkImpl>(
-        async_call,
-        std::make_unique<
-            iroha::network::ClientFactoryImpl<NetworkImpl::Service>>(
+    return std::make_shared<iroha::consensus::yac::NetworkImpl>(
+        std::make_unique<iroha::network::ClientFactoryImpl<
+            iroha::consensus::yac::NetworkImpl::Service>>(
             std::move(client_factory)),
         log);
   }
 
-  std::shared_ptr<Yac> createYac(
-      ClusterOrdering initial_order,
-      Round initial_round,
+  std::shared_ptr<iroha::consensus::yac::Yac> createYac(
+      shared_model::interface::types::PeerList initial_order,
+      iroha::consensus::Round initial_round,
       const shared_model::crypto::Keypair &keypair,
-      std::shared_ptr<Timer> timer,
-      std::shared_ptr<YacNetwork> network,
-      ConsistencyModel consistency_model,
+      std::shared_ptr<iroha::consensus::yac::Timer> timer,
+      std::shared_ptr<iroha::consensus::yac::YacNetwork> network,
+      iroha::consensus::yac::ConsistencyModel consistency_model,
       const logger::LoggerManagerTreePtr &consensus_log_manager) {
     std::shared_ptr<iroha::consensus::yac::CleanupStrategy> cleanup_strategy =
         std::make_shared<iroha::consensus::yac::BufferedCleanupStrategy>();
-    return Yac::create(
-        YacVoteStorage(cleanup_strategy,
-                       getSupermajorityChecker(consistency_model),
-                       consensus_log_manager->getChild("VoteStorage")),
+    return iroha::consensus::yac::Yac::create(
+        iroha::consensus::yac::YacVoteStorage(
+            cleanup_strategy,
+            getSupermajorityChecker(consistency_model),
+            consensus_log_manager->getChild("VoteStorage")),
         std::move(network),
         createCryptoProvider(
             keypair, consensus_log_manager->getChild("Crypto")->getLogger()),
@@ -77,105 +70,90 @@ namespace {
   }
 }  // namespace
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
+std::shared_ptr<iroha::consensus::yac::ServiceImpl>
+YacInit::getConsensusNetwork() const {
+  BOOST_ASSERT_MSG(initialized_,
+                   "YacInit::initConsensusGate(...) must be called prior "
+                   "to YacInit::getConsensusNetwork()!");
+  return consensus_network_;
+}
 
-      std::shared_ptr<ServiceImpl> YacInit::getConsensusNetwork() const {
-        BOOST_ASSERT_MSG(initialized_,
-                         "YacInit::initConsensusGate(...) must be called prior "
-                         "to YacInit::getConsensusNetwork()!");
-        return consensus_network_;
-      }
+void YacInit::subscribe(std::function<void(GateObject const &)> callback) {
+  BOOST_ASSERT_MSG(initialized_,
+                   "YacInit::initConsensusGate(...) must be called prior "
+                   "to YacInit::subscribe()!");
+  states_subscription_ =
+      SubscriberCreator<bool, std::vector<VoteMessage>>::template create<
+          EventTypes::kOnState>(
+          iroha::SubscriptionEngineHandlers::kYac,
+          [yac(utils::make_weak(yac_)),
+           yac_gate(utils::make_weak(yac_gate_)),
+           callback(std::move(callback))](auto, auto state) {
+            auto maybe_yac = yac.lock();
+            auto maybe_yac_gate = yac_gate.lock();
+            if (not(maybe_yac and maybe_yac_gate)) {
+              return;
+            }
+            auto maybe_answer = maybe_yac->onState(std::move(state));
+            if (not maybe_answer) {
+              return;
+            }
+            auto maybe_outcome =
+                maybe_yac_gate->processOutcome(*std::move(maybe_answer));
+            if (maybe_outcome) {
+              callback(*std::move(maybe_outcome));
+            }
+          });
+}
 
-      void YacInit::subscribe(
-          std::function<void(GateObject const &)> callback) {
-        BOOST_ASSERT_MSG(initialized_,
-                         "YacInit::initConsensusGate(...) must be called prior "
-                         "to YacInit::subscribe()!");
-        states_subscription_ =
-            SubscriberCreator<bool, std::vector<VoteMessage>>::template create<
-                EventTypes::kOnState>(
-                iroha::SubscriptionEngineHandlers::kYac,
-                [yac(utils::make_weak(yac_)),
-                 yac_gate(utils::make_weak(yac_gate_)),
-                 callback(std::move(callback))](auto, auto state) {
-                  auto maybe_yac = yac.lock();
-                  auto maybe_yac_gate = yac_gate.lock();
-                  if (not(maybe_yac and maybe_yac_gate)) {
-                    return;
-                  }
-                  auto maybe_answer = maybe_yac->onState(std::move(state));
-                  if (not maybe_answer) {
-                    return;
-                  }
-                  auto maybe_outcome =
-                      maybe_yac_gate->processOutcome(*std::move(maybe_answer));
-                  if (maybe_outcome) {
-                    callback(*std::move(maybe_outcome));
-                  }
-                });
-      }
+std::optional<iroha::consensus::GateObject> YacInit::processRoundSwitch(
+    consensus::Round const &round,
+    std::shared_ptr<LedgerState const> ledger_state) {
+  return yac_gate_->processRoundSwitch(round, std::move(ledger_state));
+}
 
-      auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
-        return std::make_shared<TimerImpl>(delay_milliseconds);
-      }
+auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
+  return std::make_shared<TimerImpl>(delay_milliseconds);
+}
 
-      std::shared_ptr<YacGate> YacInit::initConsensusGate(
-          Round initial_round,
-          std::shared_ptr<iroha::ametsuchi::PeerQueryFactory>
-              peer_query_factory,
-          boost::optional<shared_model::interface::types::PeerList>
-              alternative_peers,
-          std::shared_ptr<const LedgerState> ledger_state,
-          std::shared_ptr<network::BlockLoader> block_loader,
-          const shared_model::crypto::Keypair &keypair,
-          std::shared_ptr<consensus::ConsensusResultCache>
-              consensus_result_cache,
-          std::chrono::milliseconds vote_delay_milliseconds,
-          std::shared_ptr<
-              iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
-          ConsistencyModel consistency_model,
-          const logger::LoggerManagerTreePtr &consensus_log_manager,
-          std::shared_ptr<iroha::network::GenericClientFactory>
-              client_factory) {
-        auto peer_orderer = createPeerOrderer(peer_query_factory);
-        auto peers = peer_query_factory->createPeerQuery() |
-            [](auto &&peer_query) { return peer_query->getLedgerPeers(); };
+std::shared_ptr<iroha::consensus::yac::YacGate> YacInit::initConsensusGate(
+    Round initial_round,
+    std::optional<shared_model::interface::types::PeerList> alternative_peers,
+    std::shared_ptr<const LedgerState> ledger_state,
+    std::shared_ptr<network::BlockLoader> block_loader,
+    const shared_model::crypto::Keypair &keypair,
+    std::shared_ptr<consensus::ConsensusResultCache> consensus_result_cache,
+    std::chrono::milliseconds vote_delay_milliseconds,
+    ConsistencyModel consistency_model,
+    const logger::LoggerManagerTreePtr &consensus_log_manager,
+    std::shared_ptr<iroha::network::GenericClientFactory> client_factory) {
+  consensus_network_ = std::make_shared<ServiceImpl>(
+      consensus_log_manager->getChild("Service")->getLogger(),
+      [](std::vector<VoteMessage> state) {
+        getSubscription()->notify(EventTypes::kOnState, std::move(state));
+      });
 
-        consensus_network_ = std::make_shared<ServiceImpl>(
-            consensus_log_manager->getChild("Service")->getLogger(),
-            [](std::vector<VoteMessage> state) {
-              getSubscription()->notify(EventTypes::kOnState, std::move(state));
-            });
+  yac_ = createYac(
+      ledger_state->ledger_peers,
+      initial_round,
+      keypair,
+      createTimer(vote_delay_milliseconds),
+      createNetwork(client_factory,
+                    consensus_log_manager->getChild("Network")->getLogger()),
+      consistency_model,
+      consensus_log_manager);
+  auto hash_provider = createHashProvider();
 
-        yac_ = createYac(
-            *ClusterOrdering::create(peers.value()),
-            initial_round,
-            keypair,
-            createTimer(vote_delay_milliseconds),
-            createNetwork(
-                async_call,
-                client_factory,
-                consensus_log_manager->getChild("Network")->getLogger()),
-            consistency_model,
-            consensus_log_manager);
-        auto hash_provider = createHashProvider();
+  initialized_ = true;
 
-        initialized_ = true;
-
-        yac_gate_ = std::make_shared<YacGateImpl>(
-            yac_,
-            std::move(peer_orderer),
-            alternative_peers |
-                [](auto &peers) { return ClusterOrdering::create(peers); },
-            std::move(ledger_state),
-            hash_provider,
-            std::move(consensus_result_cache),
-            consensus_log_manager->getChild("Gate")->getLogger());
-        return yac_gate_;
-      }
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+  yac_gate_ = std::make_shared<YacGateImpl>(
+      yac_,
+      std::make_shared<PeerOrdererImpl>(),
+      alternative_peers |
+          [](auto &peers) { return ClusterOrdering::create(peers); },
+      std::move(ledger_state),
+      hash_provider,
+      std::move(consensus_result_cache),
+      consensus_log_manager->getChild("Gate")->getLogger());
+  return yac_gate_;
+}

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include "ametsuchi/peer_query_factory.hpp"
 #include "consensus/consensus_block_cache.hpp"
 #include "consensus/gate_object.hpp"
 #include "consensus/yac/consensus_outcome_type.hpp"
@@ -23,54 +22,48 @@
 #include "logger/logger_manager_fwd.hpp"
 #include "main/subscription_fwd.hpp"
 #include "network/block_loader.hpp"
-#include "network/impl/async_grpc_client.hpp"
 
-namespace iroha {
-  namespace network {
-    class GenericClientFactory;
-  }
-  namespace consensus {
-    namespace yac {
-      class Yac;
-      class YacGateImpl;
+namespace iroha::network {
+  class GenericClientFactory;
+}
 
-      class YacInit {
-       public:
-        std::shared_ptr<YacGate> initConsensusGate(
-            Round initial_round,
-            // TODO 30.01.2019 lebdron: IR-262 Remove PeerQueryFactory
-            std::shared_ptr<ametsuchi::PeerQueryFactory> peer_query_factory,
-            boost::optional<shared_model::interface::types::PeerList>
-                alternative_peers,
-            std::shared_ptr<const LedgerState> ledger_state,
-            std::shared_ptr<network::BlockLoader> block_loader,
-            const shared_model::crypto::Keypair &keypair,
-            std::shared_ptr<consensus::ConsensusResultCache> block_cache,
-            std::chrono::milliseconds vote_delay_milliseconds,
-            std::shared_ptr<
-                iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
-            ConsistencyModel consistency_model,
-            const logger::LoggerManagerTreePtr &consensus_log_manager,
-            std::shared_ptr<iroha::network::GenericClientFactory>
-                client_factory);
+namespace iroha::consensus::yac {
+  class Yac;
+  class YacGateImpl;
 
-        std::shared_ptr<ServiceImpl> getConsensusNetwork() const;
+  class YacInit {
+   public:
+    std::shared_ptr<YacGate> initConsensusGate(
+        Round initial_round,
+        std::optional<shared_model::interface::types::PeerList>
+            alternative_peers,
+        std::shared_ptr<const LedgerState> ledger_state,
+        std::shared_ptr<network::BlockLoader> block_loader,
+        const shared_model::crypto::Keypair &keypair,
+        std::shared_ptr<consensus::ConsensusResultCache> block_cache,
+        std::chrono::milliseconds vote_delay_milliseconds,
+        ConsistencyModel consistency_model,
+        const logger::LoggerManagerTreePtr &consensus_log_manager,
+        std::shared_ptr<iroha::network::GenericClientFactory> client_factory);
 
-        void subscribe(std::function<void(GateObject const &)> callback);
+    std::shared_ptr<ServiceImpl> getConsensusNetwork() const;
 
-       private:
-        auto createTimer(std::chrono::milliseconds delay_milliseconds);
+    void subscribe(std::function<void(GateObject const &)> callback);
 
-        bool initialized_{false};
-        std::shared_ptr<ServiceImpl> consensus_network_;
-        std::shared_ptr<Yac> yac_;
-        std::shared_ptr<YacGateImpl> yac_gate_;
-        std::shared_ptr<BaseSubscriber<bool, std::vector<VoteMessage>>>
-            states_subscription_;
-      };
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+    std::optional<GateObject> processRoundSwitch(
+        consensus::Round const &round,
+        std::shared_ptr<LedgerState const> ledger_state);
+
+   private:
+    auto createTimer(std::chrono::milliseconds delay_milliseconds);
+
+    bool initialized_{false};
+    std::shared_ptr<ServiceImpl> consensus_network_;
+    std::shared_ptr<Yac> yac_;
+    std::shared_ptr<YacGateImpl> yac_gate_;
+    std::shared_ptr<BaseSubscriber<bool, std::vector<VoteMessage>>>
+        states_subscription_;
+  };
+}  // namespace iroha::consensus::yac
 
 #endif  // IROHA_CONSENSUS_INIT_HPP

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -19,7 +19,7 @@
 #include "ordering/impl/on_demand_os_server_grpc.hpp"
 #include "synchronizer/synchronizer_common.hpp"
 
-using namespace iroha::ordering;
+using iroha::ordering::OnDemandOrderingInit;
 
 namespace {
   /// indexes to permutations for corresponding rounds
@@ -37,38 +37,33 @@ OnDemandOrderingInit::OnDemandOrderingInit(logger::LoggerPtr log)
  * gRPC backend. \see initOrderingGate for parameters
  */
 auto createNotificationFactory(
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
     std::shared_ptr<OnDemandOrderingInit::TransportFactoryType>
         proposal_transport_factory,
     std::chrono::milliseconds delay,
     const logger::LoggerManagerTreePtr &ordering_log_manager,
     std::shared_ptr<iroha::network::GenericClientFactory> client_factory) {
-  return std::make_shared<transport::OnDemandOsClientGrpcFactory>(
-      std::move(async_call),
+  return std::make_shared<
+      iroha::ordering::transport::OnDemandOsClientGrpcFactory>(
       std::move(proposal_transport_factory),
       [] { return std::chrono::system_clock::now(); },
       delay,
       ordering_log_manager->getChild("NetworkClient")->getLogger(),
       std::make_unique<iroha::network::ClientFactoryImpl<
-          transport::OnDemandOsClientGrpcFactory::Service>>(
+          iroha::ordering::transport::OnDemandOsClientGrpcFactory::Service>>(
           std::move(client_factory)),
-      [](ProposalEvent event) {
+      [](iroha::ordering::ProposalEvent event) {
         iroha::getSubscription()->notify(iroha::EventTypes::kOnProposalResponse,
                                          std::move(event));
       });
 }
 
 auto OnDemandOrderingInit::createConnectionManager(
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
     std::shared_ptr<TransportFactoryType> proposal_transport_factory,
     std::chrono::milliseconds delay,
     const logger::LoggerManagerTreePtr &ordering_log_manager,
     std::shared_ptr<iroha::network::GenericClientFactory> client_factory) {
   connection_manager_ = std::make_unique<OnDemandConnectionManager>(
-      createNotificationFactory(std::move(async_call),
-                                std::move(proposal_transport_factory),
+      createNotificationFactory(std::move(proposal_transport_factory),
                                 delay,
                                 ordering_log_manager,
                                 std::move(client_factory)),
@@ -117,8 +112,6 @@ OnDemandOrderingInit::initOrderingGate(
         batch_parser,
     std::shared_ptr<shared_model::interface::TransactionBatchFactory>
         transaction_batch_factory,
-    std::shared_ptr<iroha::network::AsyncGrpcClient<google::protobuf::Empty>>
-        async_call,
     std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
         proposal_factory,
     std::shared_ptr<TransportFactoryType> proposal_transport_factory,
@@ -139,8 +132,7 @@ OnDemandOrderingInit::initOrderingGate(
       proposal_creation_timeout);
   ordering_gate_ =
       createGate(ordering_service,
-                 createConnectionManager(std::move(async_call),
-                                         std::move(proposal_transport_factory),
+                 createConnectionManager(std::move(proposal_transport_factory),
                                          delay,
                                          ordering_log_manager,
                                          std::move(client_factory)),
@@ -151,7 +143,7 @@ OnDemandOrderingInit::initOrderingGate(
   return ordering_gate_;
 }
 
-void OnDemandOrderingInit::processSynchronizationEvent(
+iroha::ordering::RoundSwitch OnDemandOrderingInit::processSynchronizationEvent(
     synchronizer::SynchronizationEvent event) {
   iroha::consensus::Round current_round = event.round;
 
@@ -224,8 +216,12 @@ void OnDemandOrderingInit::processSynchronizationEvent(
 
   connection_manager_->initializeConnections(peers);
 
-  ordering_gate_->processRoundSwitch(
-      {std::move(current_round), event.ledger_state});
+  return {std::move(current_round), event.ledger_state};
+}
+
+void OnDemandOrderingInit::processRoundSwitch(
+    iroha::ordering::RoundSwitch const &event) {
+  ordering_gate_->processRoundSwitch(event);
 }
 
 void OnDemandOrderingInit::processCommittedBlock(

--- a/irohad/main/impl/on_demand_ordering_init.hpp
+++ b/irohad/main/impl/on_demand_ordering_init.hpp
@@ -14,12 +14,7 @@
 #include "logger/logger_fwd.hpp"
 #include "logger/logger_manager_fwd.hpp"
 #include "main/subscription_fwd.hpp"
-
-namespace google {
-  namespace protobuf {
-    class Empty;
-  }
-}  // namespace google
+#include "ordering/impl/round_switch.hpp"
 
 namespace grpc {
   class Service;
@@ -41,8 +36,6 @@ namespace shared_model {
 namespace iroha {
   namespace network {
     class GenericClientFactory;
-    template <typename Response>
-    class AsyncGrpcClient;
     class OrderingEvent;
     class OrderingGate;
   }  // namespace network
@@ -56,130 +49,127 @@ namespace iroha {
   namespace synchronizer {
     struct SynchronizationEvent;
   }
-  namespace ordering {
-    class OnDemandConnectionManager;
-    class OnDemandOrderingGate;
-    class OnDemandOrderingService;
-    class ProposalCreationStrategy;
-    struct ProposalEvent;
-    namespace transport {
-      class OdOsNotification;
-    }
+}  // namespace iroha
+
+namespace iroha::ordering {
+  class OnDemandConnectionManager;
+  class OnDemandOrderingGate;
+  class OnDemandOrderingService;
+  class ProposalCreationStrategy;
+  struct ProposalEvent;
+  namespace transport {
+    class OdOsNotification;
+  }
+
+  /**
+   * Encapsulates initialization logic for on-demand ordering gate and service
+   */
+  class OnDemandOrderingInit {
+   public:
+    using TransportFactoryType =
+        shared_model::interface::AbstractTransportFactory<
+            shared_model::interface::Proposal,
+            iroha::protocol::Proposal>;
+
+   private:
+    /**
+     * Creates connection manager which redirects requests to appropriate
+     * ordering services in the current round. \see initOrderingGate for
+     * parameters
+     */
+    auto createConnectionManager(
+        std::shared_ptr<TransportFactoryType> proposal_transport_factory,
+        std::chrono::milliseconds delay,
+        const logger::LoggerManagerTreePtr &ordering_log_manager,
+        std::shared_ptr<iroha::network::GenericClientFactory> client_factory);
 
     /**
-     * Encapsulates initialization logic for on-demand ordering gate and service
+     * Creates on-demand ordering gate. \see initOrderingGate for parameters
+     * TODO andrei 31.10.18 IR-1825 Refactor ordering gate observable
      */
-    class OnDemandOrderingInit {
-     public:
-      using TransportFactoryType =
-          shared_model::interface::AbstractTransportFactory<
-              shared_model::interface::Proposal,
-              iroha::protocol::Proposal>;
+    auto createGate(
+        std::shared_ptr<OnDemandOrderingService> ordering_service,
+        std::shared_ptr<transport::OdOsNotification> network_client,
+        std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
+            proposal_factory,
+        std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        size_t max_number_of_transactions,
+        const logger::LoggerManagerTreePtr &ordering_log_manager);
 
-     private:
-      /**
-       * Creates connection manager which redirects requests to appropriate
-       * ordering services in the current round. \see initOrderingGate for
-       * parameters
-       */
-      auto createConnectionManager(
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
-          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
-          std::chrono::milliseconds delay,
-          const logger::LoggerManagerTreePtr &ordering_log_manager,
-          std::shared_ptr<iroha::network::GenericClientFactory> client_factory);
+    /**
+     * Creates on-demand ordering service. \see initOrderingGate for
+     * parameters
+     */
+    auto createService(
+        size_t max_number_of_transactions,
+        std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
+            proposal_factory,
+        std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        const logger::LoggerManagerTreePtr &ordering_log_manager);
 
-      /**
-       * Creates on-demand ordering gate. \see initOrderingGate for parameters
-       * TODO andrei 31.10.18 IR-1825 Refactor ordering gate observable
-       */
-      auto createGate(
-          std::shared_ptr<OnDemandOrderingService> ordering_service,
-          std::shared_ptr<transport::OdOsNotification> network_client,
-          std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
-              proposal_factory,
-          std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          size_t max_number_of_transactions,
-          const logger::LoggerManagerTreePtr &ordering_log_manager);
+   public:
+    /// Constructor.
+    /// @param log - the logger to use for internal messages.
+    OnDemandOrderingInit(logger::LoggerPtr log);
 
-      /**
-       * Creates on-demand ordering service. \see initOrderingGate for
-       * parameters
-       */
-      auto createService(
-          size_t max_number_of_transactions,
-          std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
-              proposal_factory,
-          std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          const logger::LoggerManagerTreePtr &ordering_log_manager);
+    /**
+     * Initializes on-demand ordering gate and ordering sevice components
+     *
+     * @param max_number_of_transactions maximum number of transactions in a
+     * proposal
+     * @param delay timeout for ordering service response on proposal request
+     * @param transaction_factory transport factory for transactions required
+     * by ordering service network endpoint
+     * @param batch_parser transaction batch parser required by ordering
+     * service network endpoint
+     * @param transaction_batch_factory transport factory for transaction
+     * batch candidates produced by parser
+     * @param proposal_factory factory required by ordering service to produce
+     * proposals
+     * @param client_factory - a factory of client stubs
+     * @return initialized ordering gate
+     */
+    std::shared_ptr<network::OrderingGate> initOrderingGate(
+        size_t max_number_of_transactions,
+        std::chrono::milliseconds delay,
+        std::shared_ptr<shared_model::interface::AbstractTransportFactory<
+            shared_model::interface::Transaction,
+            iroha::protocol::Transaction>> transaction_factory,
+        std::shared_ptr<shared_model::interface::TransactionBatchParser>
+            batch_parser,
+        std::shared_ptr<shared_model::interface::TransactionBatchFactory>
+            transaction_batch_factory,
+        std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
+            proposal_factory,
+        std::shared_ptr<TransportFactoryType> proposal_transport_factory,
+        std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
+        logger::LoggerManagerTreePtr ordering_log_manager,
+        std::shared_ptr<iroha::network::GenericClientFactory> client_factory,
+        std::chrono::milliseconds proposal_creation_timeout);
 
-     public:
-      /// Constructor.
-      /// @param log - the logger to use for internal messages.
-      OnDemandOrderingInit(logger::LoggerPtr log);
+    iroha::ordering::RoundSwitch processSynchronizationEvent(
+        synchronizer::SynchronizationEvent event);
 
-      /**
-       * Initializes on-demand ordering gate and ordering sevice components
-       *
-       * @param max_number_of_transactions maximum number of transactions in a
-       * proposal
-       * @param delay timeout for ordering service response on proposal request
-       * @param transaction_factory transport factory for transactions required
-       * by ordering service network endpoint
-       * @param batch_parser transaction batch parser required by ordering
-       * service network endpoint
-       * @param transaction_batch_factory transport factory for transaction
-       * batch candidates produced by parser
-       * @param async_call asynchronous gRPC client required for sending batches
-       * requests to ordering service and processing responses
-       * @param proposal_factory factory required by ordering service to produce
-       * proposals
-       * @param client_factory - a factory of client stubs
-       * @return initialized ordering gate
-       */
-      std::shared_ptr<network::OrderingGate> initOrderingGate(
-          size_t max_number_of_transactions,
-          std::chrono::milliseconds delay,
-          std::shared_ptr<shared_model::interface::AbstractTransportFactory<
-              shared_model::interface::Transaction,
-              iroha::protocol::Transaction>> transaction_factory,
-          std::shared_ptr<shared_model::interface::TransactionBatchParser>
-              batch_parser,
-          std::shared_ptr<shared_model::interface::TransactionBatchFactory>
-              transaction_batch_factory,
-          std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-              async_call,
-          std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
-              proposal_factory,
-          std::shared_ptr<TransportFactoryType> proposal_transport_factory,
-          std::shared_ptr<ametsuchi::TxPresenceCache> tx_cache,
-          logger::LoggerManagerTreePtr ordering_log_manager,
-          std::shared_ptr<iroha::network::GenericClientFactory> client_factory,
-          std::chrono::milliseconds proposal_creation_timeout);
+    void processRoundSwitch(iroha::ordering::RoundSwitch const &event);
 
-      void processSynchronizationEvent(
-          synchronizer::SynchronizationEvent event);
+    void processCommittedBlock(
+        std::shared_ptr<shared_model::interface::Block const> block);
 
-      void processCommittedBlock(
-          std::shared_ptr<shared_model::interface::Block const> block);
+    void subscribe(
+        std::function<void(network::OrderingEvent const &)> callback);
 
-      void subscribe(
-          std::function<void(network::OrderingEvent const &)> callback);
+    /// gRPC service for ordering service
+    std::shared_ptr<grpc::Service> service;
 
-      /// gRPC service for ordering service
-      std::shared_ptr<grpc::Service> service;
-
-     private:
-      shared_model::crypto::Hash previous_hash_, current_hash_;
-      logger::LoggerPtr log_;
-      std::shared_ptr<OnDemandOrderingService> ordering_service_;
-      std::shared_ptr<OnDemandConnectionManager> connection_manager_;
-      std::shared_ptr<OnDemandOrderingGate> ordering_gate_;
-      std::shared_ptr<BaseSubscriber<bool, ProposalEvent>>
-          proposals_subscription_;
-    };
-  }  // namespace ordering
-}  // namespace iroha
+   private:
+    shared_model::crypto::Hash previous_hash_, current_hash_;
+    logger::LoggerPtr log_;
+    std::shared_ptr<OnDemandOrderingService> ordering_service_;
+    std::shared_ptr<OnDemandConnectionManager> connection_manager_;
+    std::shared_ptr<OnDemandOrderingGate> ordering_gate_;
+    std::shared_ptr<BaseSubscriber<bool, ProposalEvent>>
+        proposals_subscription_;
+  };
+}  // namespace iroha::ordering
 
 #endif  // IROHA_ON_DEMAND_ORDERING_INIT_HPP

--- a/irohad/main/iroha_conf_loader.hpp
+++ b/irohad/main/iroha_conf_loader.hpp
@@ -64,7 +64,7 @@ struct IrohadConfig {
   boost::optional<uint32_t> proposal_creation_timeout;
   boost::optional<uint32_t> stale_stream_max_rounds;
   boost::optional<logger::LoggerManagerTreePtr> logger_manager;
-  boost::optional<shared_model::interface::types::PeerList> initial_peers;
+  std::optional<shared_model::interface::types::PeerList> initial_peers;
   boost::optional<UtilityService> utility_service;
 
   // This is a part of cryto providers feature:

--- a/irohad/main/subscription_fwd.hpp
+++ b/irohad/main/subscription_fwd.hpp
@@ -37,6 +37,7 @@ namespace iroha {
     kOnNeedProposal,
     kOnNewProposal,
     kOnNewBatchInCache,
+    kOnPackProposal,
     kOnProposalResponse,
     kOnTransactionResponse,
     kOnConsensusGateEvent,

--- a/irohad/network/impl/async_grpc_client.hpp
+++ b/irohad/network/impl/async_grpc_client.hpp
@@ -37,7 +37,9 @@ namespace iroha {
         while (cq_.Next(&got_tag, &ok)) {
           auto call = static_cast<AsyncClientCall *>(got_tag);
           if (not call->status.ok()) {
-            log_->warn("RPC failed: {}", call->status.error_message());
+            log_->warn("RPC failed: {} {}",
+                       call->context.peer(),
+                       call->status.error_message());
           }
           if (call->on_response) {
             call->on_response(call->status, call->reply);

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -15,6 +15,7 @@
 #include "interfaces/iroha_internal/unsafe_proposal_factory.hpp"
 #include "logger/logger_fwd.hpp"
 #include "ordering/impl/on_demand_common.hpp"
+#include "ordering/impl/round_switch.hpp"
 #include "ordering/on_demand_ordering_service.hpp"
 #include "ordering/on_demand_os_transport.hpp"
 
@@ -31,16 +32,6 @@ namespace iroha {
      */
     class OnDemandOrderingGate : public network::OrderingGate {
      public:
-      struct RoundSwitch {
-        consensus::Round next_round;
-        std::shared_ptr<const LedgerState> ledger_state;
-
-        RoundSwitch(consensus::Round next_round,
-                    std::shared_ptr<const LedgerState> ledger_state)
-            : next_round(std::move(next_round)),
-              ledger_state(std::move(ledger_state)) {}
-      };
-
       OnDemandOrderingGate(
           std::shared_ptr<OnDemandOrderingService> ordering_service,
           std::shared_ptr<transport::OdOsNotification> network_client,

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -64,6 +64,8 @@ namespace iroha {
         removeFromBatchesCache(hashes);
       }
 
+      void processReceivedProposal(CollectionType batches) override;
+
      private:
       /**
        * Packs new proposals and creates new rounds
@@ -132,7 +134,7 @@ namespace iroha {
       mutable std::mutex proposals_mutex_;
 
       mutable std::shared_timed_mutex batches_cache_cs_;
-      BatchesSetType batches_cache_;
+      BatchesSetType batches_cache_, used_batches_cache_;
 
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -11,7 +11,6 @@
 #include "common/result.hpp"
 #include "interfaces/iroha_internal/abstract_transport_factory.hpp"
 #include "logger/logger_fwd.hpp"
-#include "network/impl/async_grpc_client.hpp"
 #include "ordering.grpc.pb.h"
 #include "ordering/impl/on_demand_common.hpp"
 
@@ -41,8 +40,6 @@ namespace iroha {
          */
         OnDemandOsClientGrpc(
             std::shared_ptr<proto::OnDemandOrdering::StubInterface> stub,
-            std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<TimepointType()> time_provider,
             std::chrono::milliseconds proposal_request_timeout,
@@ -56,8 +53,6 @@ namespace iroha {
        private:
         logger::LoggerPtr log_;
         std::shared_ptr<proto::OnDemandOrdering::StubInterface> stub_;
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call_;
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;
@@ -72,8 +67,6 @@ namespace iroha {
 
         using TransportFactoryType = OnDemandOsClientGrpc::TransportFactoryType;
         OnDemandOsClientGrpcFactory(
-            std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-                async_call,
             std::shared_ptr<TransportFactoryType> proposal_factory,
             std::function<OnDemandOsClientGrpc::TimepointType()> time_provider,
             OnDemandOsClientGrpc::TimeoutType proposal_request_timeout,
@@ -85,8 +78,6 @@ namespace iroha {
         create(const shared_model::interface::Peer &to) override;
 
        private:
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call_;
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;
         std::chrono::milliseconds proposal_request_timeout_;

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -52,6 +52,10 @@ grpc::Status OnDemandOsServerGrpc::SendBatches(
     return ::grpc::Status::OK;
   }
 
+  log_->info("Received SendBatches with {} from {}",
+             *batches.assumeValue().front(),
+             context->peer());
+
   ordering_service_->onBatches(std::move(batches).assumeValue());
 
   return ::grpc::Status::OK;
@@ -75,9 +79,18 @@ grpc::Status OnDemandOsServerGrpc::RequestProposal(
         template create<EventTypes::kOnNewBatchInCache>(
             static_cast<iroha::SubscriptionEngineHandlers>(*tid),
             [scheduler(utils::make_weak(scheduler))](auto, auto) {
-              if (auto maybe_scheduler = scheduler.lock()) {
+              if (auto maybe_scheduler = scheduler.lock())
                 maybe_scheduler->dispose();
-              }
+            });
+    auto proposals_subscription =
+        SubscriberCreator<bool, consensus::Round>::template create<
+            EventTypes::kOnPackProposal>(
+            static_cast<iroha::SubscriptionEngineHandlers>(*tid),
+            [round, scheduler(utils::make_weak(scheduler))](auto,
+                                                            auto packed_round) {
+              if (auto maybe_scheduler = scheduler.lock();
+                  maybe_scheduler and round == packed_round)
+                maybe_scheduler->dispose();
             });
     scheduler->addDelayed(delay_, [scheduler(utils::make_weak(scheduler))] {
       if (auto maybe_scheduler = scheduler.lock()) {

--- a/irohad/ordering/impl/round_switch.hpp
+++ b/irohad/ordering/impl/round_switch.hpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_ROUND_SWITCH_HPP
+#define IROHA_ROUND_SWITCH_HPP
+
+#include <memory>
+
+#include "consensus/round.hpp"
+
+namespace iroha {
+  struct LedgerState;
+}
+
+namespace iroha::ordering {
+  struct RoundSwitch {
+    consensus::Round next_round;
+    std::shared_ptr<const LedgerState> ledger_state;
+
+    RoundSwitch(consensus::Round next_round,
+                std::shared_ptr<const LedgerState> ledger_state)
+        : next_round(std::move(next_round)),
+          ledger_state(std::move(ledger_state)) {}
+  };
+}  // namespace iroha::ordering
+
+#endif  // IROHA_ROUND_SWITCH_HPP

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -94,6 +94,8 @@ namespace iroha {
       virtual bool isEmptyBatchesCache() const = 0;
 
       virtual bool hasProposal(consensus::Round round) const = 0;
+
+      virtual void processReceivedProposal(CollectionType batches) = 0;
     };
 
   }  // namespace ordering

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -117,7 +117,6 @@ FakePeer::FakePeer(
           iroha::network::makeTransportClientFactory<MstTransport>(
               client_factory_))),
       yac_transport_client_(std::make_shared<YacTransportClient>(
-          async_call_,
           iroha::network::makeTransportClientFactory<YacTransportClient>(
               client_factory_),
           consensus_log_manager_->getChild("Transport")->getLogger())),

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -10,69 +10,67 @@
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
 #include "framework/integration_framework/fake_peer/proposal_storage.hpp"
 
-namespace integration_framework {
-  namespace fake_peer {
+using integration_framework::fake_peer::OnDemandOsNetworkNotifier;
 
-    OnDemandOsNetworkNotifier::OnDemandOsNetworkNotifier(
-        const std::shared_ptr<FakePeer> &fake_peer)
-        : fake_peer_wptr_(fake_peer) {}
+OnDemandOsNetworkNotifier::OnDemandOsNetworkNotifier(
+    const std::shared_ptr<FakePeer> &fake_peer)
+    : fake_peer_wptr_(fake_peer) {}
 
-    void OnDemandOsNetworkNotifier::onBatches(CollectionType batches) {
-      std::lock_guard<std::mutex> guard(batches_subject_mutex_);
-      batches_subject_.get_subscriber().on_next(
-          std::make_shared<BatchesCollection>(std::move(batches)));
+void OnDemandOsNetworkNotifier::onBatches(CollectionType batches) {
+  std::lock_guard<std::mutex> guard(batches_subject_mutex_);
+  batches_subject_.get_subscriber().on_next(
+      std::make_shared<BatchesCollection>(std::move(batches)));
+}
+
+std::optional<std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>>
+OnDemandOsNetworkNotifier::onRequestProposal(iroha::consensus::Round round) {
+  {
+    std::lock_guard<std::mutex> guard(rounds_subject_mutex_);
+    rounds_subject_.get_subscriber().on_next(round);
+  }
+  auto fake_peer = fake_peer_wptr_.lock();
+  BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
+  const auto behaviour = fake_peer->getBehaviour();
+  if (behaviour) {
+    auto opt_proposal = behaviour->processOrderingProposalRequest(round);
+    if (opt_proposal) {
+      return std::shared_ptr<const shared_model::interface::Proposal>(
+          std::static_pointer_cast<const shared_model::proto::Proposal>(
+              *opt_proposal));
     }
+  }
+  return {};
+}
 
-    std::optional<
-        std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>>
-    OnDemandOsNetworkNotifier::onRequestProposal(
-        iroha::consensus::Round round) {
-      {
-        std::lock_guard<std::mutex> guard(rounds_subject_mutex_);
-        rounds_subject_.get_subscriber().on_next(round);
-      }
-      auto fake_peer = fake_peer_wptr_.lock();
-      BOOST_ASSERT_MSG(fake_peer, "Fake peer shared pointer is not set!");
-      const auto behaviour = fake_peer->getBehaviour();
-      if (behaviour) {
-        auto opt_proposal = behaviour->processOrderingProposalRequest(round);
-        if (opt_proposal) {
-          return std::shared_ptr<const shared_model::interface::Proposal>(
-              std::static_pointer_cast<const shared_model::proto::Proposal>(
-                  *opt_proposal));
-        }
-      }
-      return {};
-    }
+void OnDemandOsNetworkNotifier::onCollaborationOutcome(
+    iroha::consensus::Round round) {}
 
-    void OnDemandOsNetworkNotifier::onCollaborationOutcome(
-        iroha::consensus::Round round) {}
+void OnDemandOsNetworkNotifier::onTxsCommitted(const HashesSetType &hashes) {}
 
-    void OnDemandOsNetworkNotifier::onTxsCommitted(
-        const HashesSetType &hashes) {}
+void OnDemandOsNetworkNotifier::forCachedBatches(
+    std::function<void(
+        const iroha::ordering::OnDemandOrderingService::BatchesSetType &)> const
+        &f) {}
 
-    void OnDemandOsNetworkNotifier::forCachedBatches(
-        std::function<void(const iroha::ordering::OnDemandOrderingService::
-                               BatchesSetType &)> const &f) {}
+bool OnDemandOsNetworkNotifier::isEmptyBatchesCache() const {
+  return true;
+}
 
-    bool OnDemandOsNetworkNotifier::isEmptyBatchesCache() const {
-      return true;
-    }
+bool OnDemandOsNetworkNotifier::hasProposal(
+    iroha::consensus::Round round) const {
+  return false;
+}
 
-    bool OnDemandOsNetworkNotifier::hasProposal(
-        iroha::consensus::Round round) const {
-      return false;
-    }
+void OnDemandOsNetworkNotifier::processReceivedProposal(
+    CollectionType batches) {}
 
-    rxcpp::observable<iroha::consensus::Round>
-    OnDemandOsNetworkNotifier::getProposalRequestsObservable() {
-      return rounds_subject_.get_observable();
-    }
+rxcpp::observable<iroha::consensus::Round>
+OnDemandOsNetworkNotifier::getProposalRequestsObservable() {
+  return rounds_subject_.get_observable();
+}
 
-    rxcpp::observable<std::shared_ptr<BatchesCollection>>
-    OnDemandOsNetworkNotifier::getBatchesObservable() {
-      return batches_subject_.get_observable();
-    }
-
-  }  // namespace fake_peer
-}  // namespace integration_framework
+rxcpp::observable<
+    std::shared_ptr<integration_framework::fake_peer::BatchesCollection>>
+OnDemandOsNetworkNotifier::getBatchesObservable() {
+  return batches_subject_.get_observable();
+}

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -14,47 +14,46 @@
 #include "framework/integration_framework/fake_peer/types.hpp"
 #include "ordering/on_demand_ordering_service.hpp"
 
-namespace integration_framework {
-  namespace fake_peer {
+namespace integration_framework::fake_peer {
 
-    class OnDemandOsNetworkNotifier final
-        : public iroha::ordering::OnDemandOrderingService {
-     public:
-      OnDemandOsNetworkNotifier(const std::shared_ptr<FakePeer> &fake_peer);
+  class OnDemandOsNetworkNotifier final
+      : public iroha::ordering::OnDemandOrderingService {
+   public:
+    OnDemandOsNetworkNotifier(const std::shared_ptr<FakePeer> &fake_peer);
 
-      void onBatches(CollectionType batches) override;
+    void onBatches(CollectionType batches) override;
 
-      std::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
-          iroha::consensus::Round round) override;
+    std::optional<std::shared_ptr<const ProposalType>> onRequestProposal(
+        iroha::consensus::Round round) override;
 
-      void onCollaborationOutcome(iroha::consensus::Round round) override;
+    void onCollaborationOutcome(iroha::consensus::Round round) override;
 
-      void onTxsCommitted(const HashesSetType &hashes) override;
+    void onTxsCommitted(const HashesSetType &hashes) override;
 
-      void forCachedBatches(
-          std::function<void(const iroha::ordering::OnDemandOrderingService::
-                                 BatchesSetType &)> const &f) override;
+    void forCachedBatches(
+        std::function<void(const iroha::ordering::OnDemandOrderingService::
+                               BatchesSetType &)> const &f) override;
 
-      bool isEmptyBatchesCache() const override;
+    bool isEmptyBatchesCache() const override;
 
-      bool hasProposal(iroha::consensus::Round round) const override;
+    bool hasProposal(iroha::consensus::Round round) const override;
 
-      rxcpp::observable<iroha::consensus::Round>
-      getProposalRequestsObservable();
+    void processReceivedProposal(CollectionType batches) override;
 
-      rxcpp::observable<std::shared_ptr<BatchesCollection>>
-      getBatchesObservable();
+    rxcpp::observable<iroha::consensus::Round> getProposalRequestsObservable();
 
-     private:
-      std::weak_ptr<FakePeer> fake_peer_wptr_;
-      rxcpp::subjects::subject<iroha::consensus::Round> rounds_subject_;
-      std::mutex rounds_subject_mutex_;
-      rxcpp::subjects::subject<std::shared_ptr<BatchesCollection>>
-          batches_subject_;
-      std::mutex batches_subject_mutex_;
-    };
+    rxcpp::observable<std::shared_ptr<BatchesCollection>>
+    getBatchesObservable();
 
-  }  // namespace fake_peer
-}  // namespace integration_framework
+   private:
+    std::weak_ptr<FakePeer> fake_peer_wptr_;
+    rxcpp::subjects::subject<iroha::consensus::Round> rounds_subject_;
+    std::mutex rounds_subject_mutex_;
+    rxcpp::subjects::subject<std::shared_ptr<BatchesCollection>>
+        batches_subject_;
+    std::mutex batches_subject_mutex_;
+  };
+
+}  // namespace integration_framework::fake_peer
 
 #endif /* FAKE_PEER_ODOS_NETWORK_NOTIFIER_HPP_ */

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -223,7 +223,6 @@ IntegrationTestFramework::IntegrationTestFramework(
       client_factory_(
           iroha::network::getTestInsecureClientFactory(std::nullopt)),
       yac_transport_(std::make_shared<iroha::consensus::yac::NetworkImpl>(
-          async_call_,
           makeTransportClientFactory<iroha::consensus::yac::NetworkImpl>(
               client_factory_),
           log_manager_->getChild("ConsensusTransport")->getLogger())),
@@ -237,7 +236,7 @@ IntegrationTestFramework::IntegrationTestFramework(
   // amount of minutes in a day
   config_.mst_expiration_time = 24 * 60;
   config_.max_round_delay_ms = 0;
-  config_.proposal_creation_timeout = 0;
+  config_.proposal_creation_timeout = 1000;
   config_.stale_stream_max_rounds = 2;
   config_.max_proposal_size = 10;
   config_.mst_support = mst_support;
@@ -262,8 +261,7 @@ IntegrationTestFramework::~IntegrationTestFramework() {
   }
   // the code below should be executed anyway in order to prevent app hang
   if (iroha_instance_ and iroha_instance_->getIrohaInstance()) {
-    iroha_instance_->getIrohaInstance()->terminate(
-        std::chrono::system_clock::now());
+    iroha_instance_->getIrohaInstance()->terminate();
   }
 }
 

--- a/test/fuzzing/consensus_fuzz.cpp
+++ b/test/fuzzing/consensus_fuzz.cpp
@@ -78,7 +78,7 @@ namespace fuzzing {
           network_,
           crypto_provider_,
           timer_,
-          *initial_order,
+          initial_order->getPeers(),
           initial_round_,
           getTestLoggerManager(logger::LogLevel::kCritical)
               ->getChild("Yac")

--- a/test/integration/acceptance/hex_keys_test.cpp
+++ b/test/integration/acceptance/hex_keys_test.cpp
@@ -128,16 +128,8 @@ TEST_P(HexKeys, AddSignatory) {
   auto hash1 = tx1.hash();
   auto hash2 = tx2.hash();
 
-  itf.sendTx(tx1)
-      .checkStatus(hash1, CHECK_STATELESS_VALID)
-      .checkStatus(hash1, CHECK_ENOUGH_SIGNATURES)
-      .checkStatus(hash1, CHECK_STATEFUL_VALID)
-      .checkStatus(hash1, CHECK_COMMITTED)
-      .sendTx(tx2)
-      .checkStatus(hash2, CHECK_STATELESS_VALID)
-      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
-      .checkStatus(hash2, CHECK_STATEFUL_INVALID)
-      .checkStatus(hash2, CHECK_REJECTED);
+  itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
+      .sendTxAwait(tx2, CHECK_TXS_QUANTITY(0));
 }
 
 /**
@@ -151,11 +143,7 @@ TEST_P(HexKeys, RemoveSignatory) {
   auto hash2 = tx2.hash();
 
   itf.sendTxAwait(tx1, CHECK_TXS_QUANTITY(1))
-      .sendTx(tx2)
-      .checkStatus(hash2, CHECK_STATELESS_VALID)
-      .checkStatus(hash2, CHECK_ENOUGH_SIGNATURES)
-      .checkStatus(hash2, CHECK_STATEFUL_VALID)
-      .checkStatus(hash2, CHECK_COMMITTED);
+      .sendTxAwait(tx2, CHECK_TXS_QUANTITY(1));
 }
 
 /**
@@ -203,11 +191,7 @@ TEST_P(HexKeys, AddPeerSameKeyDifferentCase) {
       complete(addPeer(PublicKeyHexStringView{same_key_transformed}, kNow));
   auto hash = tx.hash();
 
-  itf.sendTx(tx)
-      .checkStatus(hash, CHECK_STATELESS_VALID)
-      .checkStatus(hash, CHECK_ENOUGH_SIGNATURES)
-      .checkStatus(hash, CHECK_STATEFUL_INVALID)
-      .checkStatus(hash, CHECK_REJECTED);
+  itf.sendTxAwait(tx, CHECK_TXS_QUANTITY(0));
 }
 
 /**

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <grpc++/grpc++.h>
 
@@ -75,11 +77,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
     subscription = iroha::getSubscription();
     cleanup_strategy =
         std::make_shared<iroha::consensus::yac::BufferedCleanupStrategy>();
-    auto async_call = std::make_shared<
-        iroha::network::AsyncGrpcClient<google::protobuf::Empty>>(
-        getTestLogger("AsyncCall"));
     network = std::make_shared<NetworkImpl>(
-        async_call,
         std::make_unique<
             iroha::network::ClientFactoryImpl<NetworkImpl::Service>>(
             iroha::network::getTestInsecureClientFactory(std::nullopt)),
@@ -98,7 +96,7 @@ class ConsensusSunnyDayTest : public ::testing::Test {
         network,
         crypto,
         timer,
-        order.value(),
+        order->getPeers(),
         initial_round,
         getTestLogger("Yac"));
 

--- a/test/module/irohad/consensus/yac/CMakeLists.txt
+++ b/test/module/irohad/consensus/yac/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(yac_network_test
     yac
     yac_transport
     test_logger
+    sync_subscription
     )
 
 addtest(yac_peer_orderer_test peer_orderer_test.cpp)

--- a/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_hash_gate.hpp
@@ -16,10 +16,16 @@ namespace iroha {
 
       class MockHashGate : public HashGate {
        public:
-        MOCK_METHOD3(vote,
-                     void(YacHash,
-                          ClusterOrdering,
-                          boost::optional<ClusterOrdering>));
+        MOCK_METHOD(void,
+                    vote,
+                    (YacHash, ClusterOrdering, std::optional<ClusterOrdering>),
+                    (override));
+
+        MOCK_METHOD((std::optional<Answer>),
+                    processRoundSwitch,
+                    (consensus::Round const &,
+                     shared_model::interface::types::PeerList const &),
+                    (override));
 
         MOCK_METHOD0(stop, void());
       };

--- a/test/module/irohad/consensus/yac/mock_yac_peer_orderer.hpp
+++ b/test/module/irohad/consensus/yac/mock_yac_peer_orderer.hpp
@@ -10,32 +10,26 @@
 
 #include "consensus/yac/yac_peer_orderer.hpp"
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
+namespace iroha::consensus::yac {
+  class MockYacPeerOrderer : public YacPeerOrderer {
+   public:
+    MOCK_METHOD2(
+        getOrdering,
+        std::optional<ClusterOrdering>(
+            const YacHash &,
+            std::vector<std::shared_ptr<shared_model::interface::Peer>> const
+                &));
 
-      class MockYacPeerOrderer : public YacPeerOrderer {
-       public:
-        MOCK_METHOD2(
-            getOrdering,
-            boost::optional<ClusterOrdering>(
-                const YacHash &,
-                std::vector<
-                    std::shared_ptr<shared_model::interface::Peer>> const &));
+    MockYacPeerOrderer() = default;
 
-        MockYacPeerOrderer() = default;
+    MockYacPeerOrderer(const MockYacPeerOrderer &rhs){};
 
-        MockYacPeerOrderer(const MockYacPeerOrderer &rhs){};
+    MockYacPeerOrderer(MockYacPeerOrderer &&rhs){};
 
-        MockYacPeerOrderer(MockYacPeerOrderer &&rhs){};
-
-        MockYacPeerOrderer &operator=(const MockYacPeerOrderer &rhs) {
-          return *this;
-        }
-      };
-
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+    MockYacPeerOrderer &operator=(const MockYacPeerOrderer &rhs) {
+      return *this;
+    }
+  };
+}  // namespace iroha::consensus::yac
 
 #endif  // IROHA_MOCK_YAC_PEER_ORDERER_HPP

--- a/test/module/irohad/consensus/yac/network_test.cpp
+++ b/test/module/irohad/consensus/yac/network_test.cpp
@@ -23,107 +23,94 @@ using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 using ::testing::SaveArg;
 
-namespace iroha {
-  namespace consensus {
-    namespace yac {
-      class YacNetworkTest : public ::testing::Test {
-       public:
-        static constexpr auto default_ip = "0.0.0.0";
-        static constexpr auto default_address = "0.0.0.0:0";
+namespace iroha::consensus::yac {
+  class YacNetworkTest : public ::testing::Test {
+   public:
+    static constexpr auto default_ip = "0.0.0.0";
+    static constexpr auto default_address = "0.0.0.0:0";
 
-        template <typename ExpectationsSetter>
-        auto expectConnection(const shared_model::interface::Peer &peer,
-                              ExpectationsSetter &&set_expectations) {
-          using namespace ::testing;
-          auto stub =
-              std::make_unique<iroha::consensus::yac::proto::MockYacStub>();
-          std::forward<ExpectationsSetter>(set_expectations)(*stub);
-          EXPECT_CALL(*mock_client_factory_, createClient(Ref(peer)))
-              .WillOnce(Return(ByMove(std::move(stub))));
-        }
+    template <typename ExpectationsSetter>
+    auto expectConnection(const shared_model::interface::Peer &peer,
+                          ExpectationsSetter &&set_expectations) {
+      using namespace ::testing;
+      auto stub = std::make_unique<iroha::consensus::yac::proto::MockYacStub>();
+      std::forward<ExpectationsSetter>(set_expectations)(*stub);
+      EXPECT_CALL(*mock_client_factory_, createClient(Ref(peer)))
+          .WillOnce(Return(ByMove(std::move(stub))));
+    }
 
-        void SetUp() override {
-          async_call = std::make_shared<
-              network::AsyncGrpcClient<google::protobuf::Empty>>(
-              getTestLogger("AsyncCall"));
-          mock_client_factory_ =
-              new iroha::network::MockClientFactory<NetworkImpl::Service>();
-          network = std::make_shared<NetworkImpl>(
-              async_call,
-              std::unique_ptr<NetworkImpl::ClientFactory>(mock_client_factory_),
-              getTestLogger("YacNetwork"));
-          service = std::make_shared<ServiceImpl>(getTestLogger("Service"),
-                                                  [](auto) {});
+    void SetUp() override {
+      mock_client_factory_ =
+          new iroha::network::MockClientFactory<NetworkImpl::Service>();
+      network = std::make_shared<NetworkImpl>(
+          std::unique_ptr<NetworkImpl::ClientFactory>(mock_client_factory_),
+          getTestLogger("YacNetwork"));
+      service =
+          std::make_shared<ServiceImpl>(getTestLogger("Service"), [](auto) {});
 
-          message.hash.vote_hashes.proposal_hash = "proposal";
-          message.hash.vote_hashes.block_hash = "block";
+      message.hash.vote_hashes.proposal_hash = "proposal";
+      message.hash.vote_hashes.block_hash = "block";
 
-          // getTransport is not used in network at the moment, please check if
-          // test fails
-          message.hash.block_signature = createSig();
-          message.signature = createSig();
-          message.hash.vote_round = {};
+      // getTransport is not used in network at the moment, please check if
+      // test fails
+      message.hash.block_signature = createSig();
+      message.signature = createSig();
+      message.hash.vote_round = {};
 
-          int port = 0;
-          peer = makePeer(std::string(default_ip) + ":" + std::to_string(port));
-        }
+      int port = 0;
+      peer = makePeer(std::string(default_ip) + ":" + std::to_string(port));
+    }
 
-        iroha::network::MockClientFactory<NetworkImpl::Service>
-            *mock_client_factory_;
-        std::shared_ptr<network::AsyncGrpcClient<google::protobuf::Empty>>
-            async_call;
-        std::shared_ptr<NetworkImpl> network;
-        std::shared_ptr<ServiceImpl> service;
-        std::shared_ptr<shared_model::interface::Peer> peer;
-        VoteMessage message;
-      };
+    iroha::network::MockClientFactory<NetworkImpl::Service>
+        *mock_client_factory_;
+    std::shared_ptr<NetworkImpl> network;
+    std::shared_ptr<ServiceImpl> service;
+    std::shared_ptr<shared_model::interface::Peer> peer;
+    VoteMessage message;
+  };
 
-      /**
-       * @given initialized network
-       * @when send vote to itself
-       * @then vote handled
-       */
-      TEST_F(YacNetworkTest, MessageHandledWhenMessageSent) {
-        proto::State request;
-        auto r = std::make_unique<grpc::testing::MockClientAsyncResponseReader<
-            google::protobuf::Empty>>();
-        expectConnection(*peer, [&request, &r](auto &stub) {
-          EXPECT_CALL(stub, AsyncSendStateRaw(_, _, _))
-              .WillOnce(DoAll(SaveArg<1>(&request), Return(r.get())));
-        });
+  /**
+   * @given initialized network
+   * @when send vote to itself
+   * @then vote handled
+   */
+  TEST_F(YacNetworkTest, MessageHandledWhenMessageSent) {
+    proto::State request;
+    expectConnection(*peer, [&request](auto &stub) {
+      EXPECT_CALL(stub, SendState(_, _, _))
+          .WillOnce(DoAll(SaveArg<1>(&request), Return(grpc::Status::OK)));
+    });
 
-        network->sendState(*peer, {message});
+    network->sendState(*peer, {message});
 
-        ASSERT_EQ(request.votes_size(), 1);
-      }
+    ASSERT_EQ(request.votes_size(), 1);
+  }
 
-      /**
-       * @given initialized network
-       * @when send request with one vote
-       * @then status OK
-       */
-      TEST_F(YacNetworkTest, SendMessage) {
-        proto::State request;
-        grpc::ServerContext context;
+  /**
+   * @given initialized network
+   * @when send request with one vote
+   * @then status OK
+   */
+  TEST_F(YacNetworkTest, SendMessage) {
+    proto::State request;
+    grpc::ServerContext context;
 
-        auto pb_vote = request.add_votes();
-        *pb_vote = PbConverters::serializeVote(message);
+    auto pb_vote = request.add_votes();
+    *pb_vote = PbConverters::serializeVote(message);
 
-        auto response = service->SendState(&context, &request, nullptr);
-        ASSERT_EQ(response.error_code(), grpc::StatusCode::OK);
-      }
+    auto response = service->SendState(&context, &request, nullptr);
+    ASSERT_EQ(response.error_code(), grpc::StatusCode::OK);
+  }
 
-      /**
-       * @given initialized network
-       * @when send request with no votes
-       * @then status CANCELLED
-       */
-      TEST_F(YacNetworkTest, SendMessageEmptyKeys) {
-        proto::State request;
-        grpc::ServerContext context;
-        auto response = service->SendState(&context, &request, nullptr);
-        ASSERT_EQ(response.error_code(), grpc::StatusCode::CANCELLED);
-      }
-    }  // namespace yac
-  }    // namespace consensus
-}  // namespace iroha
+  /**
+   * @given initialized network
+   * @when send request with no votes
+   * @then status CANCELLED
+   */
+  TEST_F(YacNetworkTest, SendMessageEmptyKeys) {
+    proto::State request;
+    grpc::ServerContext context;
+    auto response = service->SendState(&context, &request, nullptr);
+    ASSERT_EQ(response.error_code(), grpc::StatusCode::CANCELLED);
+  }
+}  // namespace iroha::consensus::yac

--- a/test/module/irohad/consensus/yac/peer_orderer_test.cpp
+++ b/test/module/irohad/consensus/yac/peer_orderer_test.cpp
@@ -15,13 +15,10 @@
 #include <boost/range/numeric.hpp>
 #include "consensus/yac/storage/yac_proposal_storage.hpp"
 #include "framework/crypto_literals.hpp"
-#include "module/irohad/ametsuchi/mock_peer_query.hpp"
-#include "module/irohad/ametsuchi/mock_peer_query_factory.hpp"
 #include "module/irohad/consensus/yac/yac_test_util.hpp"
 #include "module/shared_model/interface_mocks.hpp"
 
 using namespace boost::adaptors;
-using namespace iroha::ametsuchi;
 using namespace iroha::consensus::yac;
 
 using namespace std;
@@ -33,17 +30,6 @@ const size_t kPeersQuantity = 4;
 
 class YacPeerOrdererTest : public ::testing::Test {
  public:
-  YacPeerOrdererTest() : orderer(make_shared<MockPeerQueryFactory>()) {}
-
-  void SetUp() override {
-    wsv = make_shared<MockPeerQuery>();
-    pbfactory = make_shared<MockPeerQueryFactory>();
-    EXPECT_CALL(*pbfactory, createPeerQuery())
-        .WillRepeatedly(testing::Return(boost::make_optional(
-            std::shared_ptr<iroha::ametsuchi::PeerQuery>(wsv))));
-    orderer = PeerOrdererImpl(pbfactory);
-  }
-
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers = [] {
     std::vector<std::shared_ptr<shared_model::interface::Peer>> result;
     for (size_t i = 1; i <= kPeersQuantity; ++i) {
@@ -65,8 +51,6 @@ class YacPeerOrdererTest : public ::testing::Test {
     return result;
   }();
 
-  shared_ptr<MockPeerQuery> wsv;
-  shared_ptr<MockPeerQueryFactory> pbfactory;
   PeerOrdererImpl orderer;
 };
 
@@ -77,7 +61,7 @@ TEST_F(YacPeerOrdererTest, PeerOrdererOrderingWhenInvokeNormalCase) {
 
 TEST_F(YacPeerOrdererTest, PeerOrdererOrderingWhenEmptyPeerList) {
   auto order = orderer.getOrdering(YacHash(), {});
-  ASSERT_EQ(order, boost::none);
+  ASSERT_EQ(order, std::nullopt);
 }
 
 /**

--- a/test/module/irohad/consensus/yac/yac_fixture.hpp
+++ b/test/module/irohad/consensus/yac/yac_fixture.hpp
@@ -66,7 +66,7 @@ namespace iroha {
               network,
               crypto,
               timer,
-              ordering,
+              ordering.getPeers(),
               initial_round,
               getTestLogger("Yac"));
         }

--- a/test/module/irohad/consensus/yac/yac_gate_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_gate_test.cpp
@@ -109,7 +109,7 @@ class YacGateTest : public ::testing::Test {
   }
 
   iroha::consensus::Round round{2, 1};
-  boost::optional<ClusterOrdering> alternative_order;
+  std::optional<ClusterOrdering> alternative_order;
   std::string expected_signed{"expected_signed"};
   Hash prev_hash{std::string{"prev hash"}};
   YacHash expected_hash;
@@ -148,6 +148,7 @@ TEST_F(YacGateTest, YacGateSubscriptionTest) {
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 
@@ -189,12 +190,14 @@ TEST_F(YacGateTest, CacheReleased) {
       .WillOnce(Return(expected_hash))
       .WillOnce(Return(empty_hash));
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 
   gate->processOutcome(expected_commit);
   round.reject_round++;
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote({boost::none, round, ledger_state});
 
   ASSERT_EQ(block_cache->get(), nullptr);
@@ -210,11 +213,12 @@ TEST_F(YacGateTest, YacGateSubscribtionTestFailCase) {
   EXPECT_CALL(*hash_gate, vote(_, _, _)).Times(0);
 
   // generate order of peers
-  EXPECT_CALL(*peer_orderer, getOrdering(_, _)).WillOnce(Return(boost::none));
+  EXPECT_CALL(*peer_orderer, getOrdering(_, _)).WillOnce(Return(std::nullopt));
 
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 }
@@ -235,6 +239,7 @@ TEST_F(YacGateTest, AgreementOnNone) {
 
   ASSERT_EQ(block_cache->get(), nullptr);
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote({boost::none, round, ledger_state});
 
   ASSERT_EQ(block_cache->get(), nullptr);
@@ -255,6 +260,7 @@ TEST_F(YacGateTest, DifferentCommit) {
 
   EXPECT_CALL(*hash_gate, vote(expected_hash, _, _)).Times(1);
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 
@@ -305,6 +311,7 @@ TEST_F(YacGateTest, Future) {
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 
@@ -341,6 +348,7 @@ TEST_F(YacGateTest, OutdatedFuture) {
   // make hash from block
   EXPECT_CALL(*hash_provider, makeHash(_)).WillOnce(Return(expected_hash));
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 
@@ -369,6 +377,7 @@ class CommitFromTheFuture : public YacGateTest {
 
     EXPECT_CALL(*hash_gate, vote(expected_hash, _, _)).Times(1);
 
+    gate->processRoundSwitch(round, ledger_state);
     gate->vote(BlockCreatorEvent{
         RoundData{expected_proposal, expected_block}, round, ledger_state});
 
@@ -461,6 +470,7 @@ class YacGateOlderTest : public YacGateTest {
     // make hash from block
     ON_CALL(*hash_provider, makeHash(_)).WillByDefault(Return(expected_hash));
 
+    gate->processRoundSwitch(round, ledger_state);
     gate->vote(BlockCreatorEvent{
         RoundData{expected_proposal, expected_block}, round, ledger_state});
   }
@@ -478,8 +488,10 @@ TEST_F(YacGateOlderTest, OlderVote) {
 
   EXPECT_CALL(*hash_provider, makeHash(_)).Times(0);
 
-  gate->vote(BlockCreatorEvent{
-      boost::none, {round.block_round - 1, round.reject_round}, ledger_state});
+  gate->processRoundSwitch(round, ledger_state);
+
+  --round.block_round;
+  gate->vote(BlockCreatorEvent{boost::none, round, ledger_state});
 }
 
 /**
@@ -567,6 +579,7 @@ TEST_F(YacGateAlternativeOrderTest, AlternativeOrderUsed) {
   // yac consensus
   EXPECT_CALL(*hash_gate, vote(expected_hash, _, alternative_order)).Times(1);
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
 }
@@ -582,13 +595,15 @@ TEST_F(YacGateAlternativeOrderTest, AlternativeOrderUsedOnce) {
     InSequence s;  // ensures the call order
     EXPECT_CALL(*hash_gate, vote(expected_hash, _, alternative_order)).Times(1);
     EXPECT_CALL(*hash_gate,
-                vote(expected_hash, _, boost::optional<ClusterOrdering>{}))
+                vote(expected_hash, _, std::optional<ClusterOrdering>{}))
         .Times(1);
   }
 
+  gate->processRoundSwitch(round, ledger_state);
   gate->vote(BlockCreatorEvent{
       RoundData{expected_proposal, expected_block}, round, ledger_state});
-  gate->vote(BlockCreatorEvent{RoundData{expected_proposal, expected_block},
-                               {round.block_round + 1, 0},
-                               ledger_state});
+  iroha::consensus::Round next_round{round.block_round + 1, 0};
+  gate->processRoundSwitch(next_round, ledger_state);
+  gate->vote(BlockCreatorEvent{
+      RoundData{expected_proposal, expected_block}, next_round, ledger_state});
 }

--- a/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_rainy_day_test.cpp
@@ -155,6 +155,7 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
   setNetworkOrderCheckerSingleVote(
       my_order.value(), testing::AnyOf(next_reject_hash), kFixedRandomNumber);
 
+  yac->processRoundSwitch(next_reject_hash.vote_round, my_order->getPeers());
   yac->vote(next_reject_hash, my_order.value());
 
   // -- now yac receives a vote from another peer when we already have a reject
@@ -164,7 +165,6 @@ TEST_F(YacTest, ValidCaseWhenReceiveOnVoteAfterReject) {
       iroha::hexstringToBytestringResult(peer->pubkey()).assumeValue();
   const auto slowpoke_hash = makeYacHash(peers_number);
 
-  vote_matchers.emplace_back(makeVoteMatcher(slowpoke_hash));
   EXPECT_CALL(*network,
               sendState(_, ::testing::UnorderedElementsAreArray(vote_matchers)))
       .Times(1);

--- a/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
+++ b/test/module/irohad/consensus/yac/yac_synchronization_test.cpp
@@ -57,7 +57,7 @@ class NetworkUtil {
   }
 
   std::vector<std::shared_ptr<shared_model::interface::Peer>> peers_;
-  boost::optional<ClusterOrdering> order_;
+  std::optional<ClusterOrdering> order_;
 };
 
 class YacSynchronizationTest : public YacTest {
@@ -76,14 +76,19 @@ class YacSynchronizationTest : public YacTest {
     initYac(order);
     EXPECT_CALL(*crypto, verify(_)).WillRepeatedly(Return(true));
 
-    for (auto i = 0u; i < number_of_committed_rounds_; i++) {
+    for (auto i = initial_round.block_round;
+         i < initial_round.block_round + number_of_committed_rounds_;
+         i++) {
       top_hash_ = createHash(Round{i, 0});
       setNetworkOrderCheckerSingleVote(order, top_hash_.value(), 2);
+      yac->processRoundSwitch(top_hash_->vote_round, order.getPeers());
       yac->vote(top_hash_.value(), order);
       yac->onState(network_util.createVotes(voters_, top_hash_.value()));
     }
-    const YacHash next_hash = createHash({number_of_committed_rounds_, 0});
+    const YacHash next_hash = createHash(
+        {initial_round.block_round + number_of_committed_rounds_, 0});
     setNetworkOrderCheckerSingleVote(order, next_hash, 2);
+    yac->processRoundSwitch(next_hash.vote_round, order.getPeers());
     yac->vote(next_hash, order);
   }
 
@@ -109,7 +114,7 @@ class YacSynchronizationTest : public YacTest {
  * @when  Vote from known peer from old round which was presented in the cache
  * @then  Yac sends commit for the last round
  */
-TEST_F(YacSynchronizationTest, SynchronizationOncommitInTheCahe) {
+TEST_F(YacSynchronizationTest, SynchronizationOnCommitInTheCache) {
   expectSendTopCommitTo(0);
   yac->onState(network_util_.createVotes({0}, createHash(Round{1, 0})));
 }
@@ -119,7 +124,7 @@ TEST_F(YacSynchronizationTest, SynchronizationOncommitInTheCahe) {
  * @when  Vote from known peer from old round which presents in a cache
  * @then  Yac sends commit for the last round
  */
-TEST_F(YacSynchronizationTest, SynchronizationOnCommitOutOfTheCahe) {
+TEST_F(YacSynchronizationTest, SynchronizationOnCommitOutOfTheCache) {
   expectSendTopCommitTo(0);
   yac->onState(network_util_.createVotes({0}, createHash(Round{9, 0})));
 }
@@ -129,7 +134,7 @@ TEST_F(YacSynchronizationTest, SynchronizationOnCommitOutOfTheCahe) {
  * @when  Vote from known peer from old round which doesn't present in the cache
  * @then  Yac sends last commit
  */
-TEST_F(YacSynchronizationTest, SynchronizationRejectOutOfTheCahe) {
+TEST_F(YacSynchronizationTest, SynchronizationRejectOutOfTheCache) {
   expectSendTopCommitTo(0);
   yac->onState(network_util_.createVotes({0}, createHash(Round{5, 5})));
 }

--- a/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
@@ -105,7 +105,8 @@ TEST_F(OnDemandOsServerGrpcTest, SendBatches) {
       ->mutable_reduced_payload()
       ->set_creator_account_id(creator);
 
-  server->SendBatches(nullptr, &request, nullptr);
+  grpc::ServerContext context;
+  server->SendBatches(&context, &request, nullptr);
 
   ASSERT_EQ(collection.at(0)->transactions().at(0)->creatorAccountId(),
             creator);

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -13,37 +13,36 @@
 #include "ordering/on_demand_ordering_service.hpp"
 #include "ordering/on_demand_os_transport.hpp"
 
-namespace iroha {
-  namespace ordering {
-    namespace transport {
+namespace iroha::ordering::transport {
+  struct MockOdOsNotificationFactory : public OdOsNotificationFactory {
+    MOCK_METHOD((iroha::expected::Result<std::unique_ptr<OdOsNotification>,
+                                         std::string>),
+                create,
+                (const shared_model::interface::Peer &),
+                (override));
+  };
+}  // namespace iroha::ordering::transport
 
-      struct MockOdOsNotificationFactory : public OdOsNotificationFactory {
-        MOCK_METHOD1(create,
-                     iroha::expected::Result<std::unique_ptr<OdOsNotification>,
-                                             std::string>(
-                         const shared_model::interface::Peer &));
-      };
+namespace iroha::ordering {
+  struct MockOnDemandOrderingService : public OnDemandOrderingService {
+    MOCK_METHOD(void, onBatches, (CollectionType), (override));
 
-    }  // namespace transport
+    MOCK_METHOD((std::optional<std::shared_ptr<const ProposalType>>),
+                onRequestProposal,
+                (consensus::Round),
+                (override));
 
-    struct MockOnDemandOrderingService : public OnDemandOrderingService {
-      MOCK_METHOD1(onBatches, void(CollectionType));
-
-      MOCK_METHOD1(
-          onRequestProposal,
-          std::optional<std::shared_ptr<const ProposalType>>(consensus::Round));
-
-      MOCK_METHOD1(onCollaborationOutcome, void(consensus::Round));
-      MOCK_METHOD1(onTxsCommitted, void(const HashesSetType &));
-      MOCK_METHOD1(
-          forCachedBatches,
-          void(std::function<
-               void(const OnDemandOrderingService::BatchesSetType &)> const &));
-      MOCK_METHOD(bool, isEmptyBatchesCache, (), (const, override));
-      MOCK_METHOD(bool, hasProposal, (consensus::Round), (const, override));
-    };
-
-  }  // namespace ordering
-}  // namespace iroha
+    MOCK_METHOD(void, onCollaborationOutcome, (consensus::Round), (override));
+    MOCK_METHOD(void, onTxsCommitted, (const HashesSetType &), (override));
+    MOCK_METHOD(void,
+                forCachedBatches,
+                (std::function<void(
+                     const OnDemandOrderingService::BatchesSetType &)> const &),
+                (override));
+    MOCK_METHOD(bool, isEmptyBatchesCache, (), (const, override));
+    MOCK_METHOD(bool, hasProposal, (consensus::Round), (const, override));
+    MOCK_METHOD(void, processReceivedProposal, (CollectionType), (override));
+  };
+}  // namespace iroha::ordering
 
 #endif  // IROHA_ORDERING_MOCKS_HPP

--- a/test/module/irohad/torii/torii_transport_command_test.cpp
+++ b/test/module/irohad/torii/torii_transport_command_test.cpp
@@ -354,10 +354,11 @@ TEST_F(CommandServiceTransportGrpcTest, StatusStreamEmpty) {
  */
 TEST_F(CommandServiceTransportGrpcTest, StatusStreamOnStatelessValid) {
   grpc::ServerContext context;
+  shared_model::crypto::Hash hash("1");
   iroha::protocol::TxStatusRequest request;
+  request.set_tx_hash(hash.hex());
   iroha::MockServerWriter<iroha::protocol::ToriiResponse> response_writer;
 
-  shared_model::crypto::Hash hash("1");
   TestDispatcher<iroha::SubscriptionEngineHandlers::kTotalCount,
                  iroha::kThreadPoolSize>::responses
       .emplace_back(status_factory->makeStatelessValid(hash, {}));


### PR DESCRIPTION
Closes https://github.com/hyperledger/iroha/issues/960

- Prevent infinite vote sending when the round is pruned
- Prevent sending redundant replies with last committed round
- Notify YAC of the latest ledger state to account for asynchronous proposal request
- Notify ordering service clients of packed proposals to prevent delays

Individual commits pass build and tests, so squash is not required