### PR TITLE
Remove queue actor. Substitute with lock free queue

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -70,7 +70,7 @@ jobs:
             clang \
             llvm-dev
       - name: Run tests
-        run: cargo test --workspace -- --test-threads=1
+        run: cargo test --workspace --no-fail-fast -- --test-threads=1
 
   test-iroha_network-mock:
     runs-on: [self-hosted, Linux] #ubuntu-latest

--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -29,7 +29,7 @@ jobs:
             clang \
             llvm-dev
       - name: Run long tests
-        run: cargo test --workspace --verbose -- --ignored --test-threads=1 long
+        run: cargo test --workspace --verbose --no-fail-fast -- --ignored --test-threads=1 long
   test-docker:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1348,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "criterion",
+ "crossbeam-queue",
  "dashmap",
  "futures",
  "hex",
@@ -2814,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2906,18 +2917,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3022,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",

--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = "1.0"
 tokio = { version = "1.6.0", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"]}
 tokio-stream = { version = "0.1.6", features = ["fs"]}
 tracing = "0.1"
+crossbeam-queue = "0.3"
 warp = "0.3"
 ursa = "=0.3.6"
 structopt = { version = "0.3", optional = true }

--- a/iroha/src/genesis.rs
+++ b/iroha/src/genesis.rs
@@ -13,7 +13,6 @@ use tokio::{time, time::Duration};
 
 use self::config::GenesisConfiguration;
 use crate::{
-    queue::QueueTrait,
     sumeragi::{
         network_topology::{GenesisBuilder as GenesisTopologyBuilder, Topology},
         Sumeragi,
@@ -58,9 +57,9 @@ pub trait GenesisNetworkTrait:
     ///
     /// # Errors
     /// Returns error if waiting for peers or genesis round itself fails
-    async fn submit_transactions<Q: QueueTrait, W: WorldTrait>(
+    async fn submit_transactions<W: WorldTrait>(
         &self,
-        sumeragi: &mut Sumeragi<Q, Self, W>,
+        sumeragi: &mut Sumeragi<Self, W>,
         network: Addr<IrohaNetwork>,
     ) -> Result<()> {
         let genesis_topology = self

--- a/iroha/src/queue.rs
+++ b/iroha/src/queue.rs
@@ -1,216 +1,174 @@
 //! Module with queue actor
 
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    fmt::Debug,
-    sync::Arc,
-    time::Duration,
-};
+use std::time::Duration;
 
-use iroha_actor::{broker::*, prelude::*, Context as ActorContext};
+use crossbeam_queue::ArrayQueue;
+use dashmap::{mapref::entry::Entry, DashMap};
 use iroha_data_model::prelude::*;
-use iroha_error::{error, Result};
+use iroha_error::Result;
 
 use self::config::QueueConfiguration;
 use crate::{prelude::*, wsv::WorldTrait};
 
-/// Transaction queue
+/// Lockfree queue for transactions
+///
+/// Multiple producers, single consumer
 #[derive(Debug)]
-pub struct Queue<W: WorldTrait> {
-    pending_tx_hash_queue: VecDeque<Hash>,
-    pending_tx_by_hash: BTreeMap<Hash, VersionedAcceptedTransaction>,
-    max_txs_in_block: usize,
-    max_txs_in_queue: usize,
-    tx_time_to_live: Duration,
-    wsv: Arc<WorldStateView<W>>,
-    broker: Broker,
+pub struct Queue {
+    queue: ArrayQueue<Hash>,
+    txs: DashMap<Hash, VersionedAcceptedTransaction>,
+    /// Length of dashmap.
+    ///
+    /// DashMap right now just iterates over itself and calculates its length like this:
+    /// self.txs.iter().len()
+    txs_in_block: usize,
+    max_txs: usize,
+    ttl: Duration,
 }
 
-/// Queue trait
-pub trait QueueTrait:
-    Actor
-    + Handler<PopPendingTransactions, Result = Vec<VersionedAcceptedTransaction>>
-    + Handler<VersionedAcceptedTransaction, Result = ()>
-    + Handler<GetPendingTransactions, Result = PendingTransactions>
-    + Debug
-{
-    /// World for checking if tx is in blockchain and for checking signatures
-    type World: WorldTrait;
-
-    /// Makes queue from configuration and WSV
-    fn from_configuration(
-        cfg: &QueueConfiguration,
-        wsv: Arc<WorldStateView<Self::World>>,
-        broker: Broker,
-    ) -> Self;
-}
-
-impl<W: WorldTrait> QueueTrait for Queue<W> {
-    type World = W;
-
-    fn from_configuration(
-        cfg: &QueueConfiguration,
-        wsv: Arc<WorldStateView<W>>,
-        broker: Broker,
-    ) -> Self {
+impl Queue {
+    /// Makes queue from configuration
+    pub fn from_configuration(cfg: &QueueConfiguration) -> Self {
         Self {
-            pending_tx_hash_queue: VecDeque::new(),
-            pending_tx_by_hash: BTreeMap::new(),
-            max_txs_in_block: cfg.maximum_transactions_in_block as usize,
-            max_txs_in_queue: cfg.maximum_transactions_in_queue as usize,
-            tx_time_to_live: Duration::from_millis(cfg.transaction_time_to_live_ms),
-            wsv,
-            broker,
+            queue: ArrayQueue::new(cfg.maximum_transactions_in_queue as usize),
+            txs: DashMap::new(),
+            max_txs: cfg.maximum_transactions_in_queue as usize,
+            txs_in_block: cfg.maximum_transactions_in_block as usize,
+            ttl: Duration::from_millis(cfg.transaction_time_to_live_ms),
         }
     }
-}
 
-/// Pops pending transactions from queue
-#[derive(Debug, Clone, Copy, Message)]
-#[message(result = "Vec<VersionedAcceptedTransaction>")]
-pub struct PopPendingTransactions {
-    /// Is peer leader?
-    pub is_leader: bool,
-}
-
-/// Gets pending txs without modifying a queue
-#[derive(Debug, Clone, Copy, Default, Message)]
-#[message(result = "PendingTransactions")]
-pub struct GetPendingTransactions;
-
-#[async_trait::async_trait]
-impl<W: WorldTrait> Actor for Queue<W> {
-    async fn on_start(&mut self, ctx: &mut ActorContext<Self>) {
-        self.broker
-            .subscribe::<VersionedAcceptedTransaction, _>(ctx);
-    }
-}
-
-#[async_trait::async_trait]
-impl<W: WorldTrait> Handler<PopPendingTransactions> for Queue<W> {
-    type Result = Vec<VersionedAcceptedTransaction>;
-    async fn handle(
-        &mut self,
-        PopPendingTransactions { is_leader }: PopPendingTransactions,
-    ) -> Self::Result {
-        self.get_pending_txs(is_leader)
-    }
-}
-
-#[async_trait::async_trait]
-impl<W: WorldTrait> Handler<VersionedAcceptedTransaction> for Queue<W> {
-    type Result = ();
-    #[iroha_logger::log(skip(self, tx))]
-    async fn handle(&mut self, tx: VersionedAcceptedTransaction) {
-        if let Err(error) = self.push_pending_tx(tx) {
-            iroha_logger::error!(%error, "Failed to put tx into queue of pending tx")
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl<W: WorldTrait> Handler<GetPendingTransactions> for Queue<W> {
-    type Result = PendingTransactions;
-    async fn handle(
-        &mut self,
-        GetPendingTransactions: GetPendingTransactions,
-    ) -> PendingTransactions {
-        self.pending_txs()
-    }
-}
-
-impl<W: WorldTrait> Queue<W> {
-    /// Get cloned txs that are currently in a queue.
-    pub fn pending_txs(&self) -> PendingTransactions {
-        self.pending_tx_by_hash
-            .values()
-            .cloned()
+    /// Returns all pending transactions paginated
+    pub fn waiting(&'_ self) -> impl Iterator<Item = Transaction> + '_ {
+        self.txs
+            .iter()
+            .map(|e| e.value().clone())
             .map(VersionedAcceptedTransaction::into_inner_v1)
             .map(Transaction::from)
-            .collect()
     }
 
-    /// Puts new tx into queue.
+    /// Pushes transaction into queue
     /// # Errors
-    /// Returns error if queue is full.
-    pub fn push_pending_tx(&mut self, tx: VersionedAcceptedTransaction) -> Result<()> {
-        if let Some(transaction) = self.pending_tx_by_hash.get_mut(&tx.hash()) {
-            let mut signatures: BTreeSet<_> = transaction
-                .as_inner_v1()
-                .signatures
-                .iter()
-                .cloned()
-                .collect();
-            let mut new_signatures: BTreeSet<_> =
-                tx.into_inner_v1().signatures.into_iter().collect();
-            signatures.append(&mut new_signatures);
-            transaction.as_mut_inner_v1().signatures = signatures.into_iter().collect();
-            Ok(())
-        } else if self.pending_tx_hash_queue.len() < self.max_txs_in_queue {
-            self.pending_tx_hash_queue.push_back(tx.hash());
-            let _result = self.pending_tx_by_hash.insert(tx.hash(), tx);
-            Ok(())
-        } else {
-            Err(error!("The queue is full."))
+    /// Returns transaction if queue is full
+    #[allow(
+        clippy::unwrap_in_result,
+        clippy::expect_used,
+        clippy::missing_panics_doc
+    )]
+    pub fn push<W: WorldTrait>(
+        &self,
+        tx: VersionedAcceptedTransaction,
+        wsv: &WorldStateView<W>,
+    ) -> Result<(), VersionedAcceptedTransaction> {
+        if tx.is_expired(self.ttl) {
+            iroha_logger::warn!("Transaction expired");
+            return Err(tx);
         }
+        if tx.is_in_blockchain(wsv) {
+            iroha_logger::warn!("Transaction is already applied");
+            return Err(tx);
+        }
+
+        if self.txs.len() >= self.max_txs {
+            iroha_logger::warn!("Transaction queue is full");
+            return Err(tx);
+        }
+
+        let hash = tx.hash();
+        let entry = match self.txs.entry(hash) {
+            Entry::Occupied(mut old_tx) => {
+                // MST case
+                old_tx
+                    .get_mut()
+                    .as_mut_inner_v1()
+                    .signatures
+                    .append(&mut tx.into_inner_v1().signatures);
+                return Ok(());
+            }
+            Entry::Vacant(entry) => entry,
+        };
+
+        entry.insert(tx);
+        self.queue.push(hash).map_err(|hash| {
+            self.txs
+                .remove(&hash)
+                .expect("Inserted just before match")
+                .1
+        })
     }
 
-    /// Gets at most `max_txs_in_block` number of transactions, but does not drop them out of the queue.
-    /// Drops only the transactions that have reached their TTL or are already in blockchain.
-    /// For MST transactions if on leader, waits for them to gather enough signatures before, showing them as output of this function.
+    /// Pops single transaction.
     ///
-    /// The reason for not dropping transaction when getting them, is that in the case of a view change this peer might become a leader,
-    /// or might need to forward transaction to the leader to check if the leader is not faulty.
-    /// If there is no view change and the block is committed then the transactions will simply drop because they are in a blockchain already.
-    #[allow(clippy::expect_used)]
-    pub fn get_pending_txs(&mut self, is_leader: bool) -> Vec<VersionedAcceptedTransaction> {
-        let mut output_txs = Vec::new();
-        let mut left_behind_txs = VecDeque::new();
-        let mut counter = self.max_txs_in_block;
+    /// Records unsigned transaction in seen.
+    #[allow(clippy::expect_used, clippy::unwrap_in_result)]
+    fn pop<W: WorldTrait>(
+        &self,
+        is_leader: bool,
+        wsv: &WorldStateView<W>,
+        seen: &mut Vec<Hash>,
+    ) -> Option<VersionedAcceptedTransaction> {
+        loop {
+            let hash = self.queue.pop()?;
+            let entry = match self.txs.entry(hash) {
+                Entry::Occupied(entry) => entry,
+                Entry::Vacant(_) => unreachable!(),
+            };
 
-        while counter > 0 && !self.pending_tx_hash_queue.is_empty() {
-            let tx_hash = self
-                .pending_tx_hash_queue
-                .pop_front()
-                .expect("Unreachable, as queue not empty");
-            let tx = &self.pending_tx_by_hash[&tx_hash];
-
-            let expired = tx.is_expired(self.tx_time_to_live);
-
-            if expired {
-                iroha_logger::warn!("Transaction with hash {} dropped due to expired TTL. This can happen either due to signature condition being not satisfied in time or too many transactions in the queue.", tx_hash)
+            if entry.get().is_expired(self.ttl) {
+                iroha_logger::warn!("Transaction expired");
+                entry.remove_entry();
+                continue;
             }
-
-            if expired || tx.is_in_blockchain(&*self.wsv) {
-                self.pending_tx_by_hash
-                    .remove(&tx_hash)
-                    .expect("Should always be present, as contained in queue");
+            if entry.get().is_in_blockchain(wsv) {
+                entry.remove_entry();
                 continue;
             }
 
-            let signature_condition_passed = match tx.check_signature_condition(&*self.wsv) {
-                Ok(passed) => passed,
-                Err(e) => {
-                    iroha_logger::error!(%e, "Not passed signature");
-                    self.pending_tx_by_hash
-                        .remove(&tx_hash)
-                        .expect("Should always be present, as contained in queue");
+            let sig_condition = match entry.get().check_signature_condition(wsv) {
+                Ok(condition) => condition,
+                Err(error) => {
+                    iroha_logger::error!(%error, "Not passed signature condition");
+                    entry.remove_entry();
                     continue;
                 }
             };
 
-            if !is_leader || signature_condition_passed {
-                output_txs.push(self.pending_tx_by_hash[&tx_hash].clone());
-                counter -= 1;
+            if !is_leader || sig_condition {
+                return Some(entry.remove());
             }
 
-            left_behind_txs.push_back(tx_hash);
+            // MST case:
+            // if signature is not passed, put it to behind
+            seen.push(hash);
         }
+    }
 
-        left_behind_txs.append(&mut self.pending_tx_hash_queue);
-        self.pending_tx_hash_queue = left_behind_txs;
+    /// Pops transactions till it fills whole block or till the end of queue.
+    ///
+    /// `is_leader` is neaded for checking whether we can transmit transaction which do not pass
+    /// signature condition.
+    ///
+    /// BEWARE: Shouldn't be called concurently, as it can become inconsistent
+    #[allow(clippy::missing_panics_doc, clippy::unwrap_in_result)]
+    pub fn pop_avaliable<W: WorldTrait>(
+        &self,
+        is_leader: bool,
+        wsv: &WorldStateView<W>,
+    ) -> Vec<VersionedAcceptedTransaction> {
+        let mut seen = Vec::new();
 
-        output_txs
+        let out = std::iter::repeat_with(|| self.pop(is_leader, wsv, &mut seen))
+            .take_while(Option::is_some)
+            .map(Option::unwrap)
+            .take(self.txs_in_block)
+            .collect::<Vec<_>>();
+
+        #[allow(clippy::expect_used)]
+        seen.into_iter()
+            .try_for_each(|hash| self.queue.push(hash))
+            .expect("As we never exceed the number of transactions pending");
+
+        out
     }
 }
 
@@ -251,10 +209,16 @@ pub mod config {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::restriction)]
+    #![allow(clippy::restriction, clippy::all, clippy::pedantic)]
 
-    use std::{thread, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+        thread,
+        time::Duration,
+    };
 
+    use dashmap::DashSet;
     use iroha_data_model::{domain::DomainsMap, peer::PeersIds};
 
     use super::*;
@@ -270,8 +234,11 @@ mod tests {
             .cloned()
             .unwrap_or_else(|| KeyPair::generate().expect("Failed to generate keypair."));
 
+        let message = std::iter::repeat_with(rand::random::<char>)
+            .take(16)
+            .collect();
         let tx = Transaction::new(
-            Vec::new(),
+            vec![FailBox { message }.into()],
             <Account as Identifiable>::Id::new(account, domain),
             proposed_ttl_ms,
         )
@@ -293,57 +260,52 @@ mod tests {
     }
 
     #[test]
-    fn push_pending_tx() {
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: 2,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::default(),
-            Broker::new(),
-        );
+    fn push_available_tx() {
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: 2,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: 100,
+        });
+        let wsv = WorldStateView::new(world_with_test_domains(
+            KeyPair::generate().unwrap().public_key,
+        ));
 
         queue
-            .push_pending_tx(accepted_tx("account", "domain", 100_000, None))
+            .push(accepted_tx("account", "domain", 100_000, None), &wsv)
             .expect("Failed to push tx into queue");
     }
 
     #[test]
-    fn push_pending_tx_overflow() {
-        let max_txs_in_queue = 10;
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: 2,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: max_txs_in_queue,
-            },
-            Arc::default(),
-            Broker::new(),
-        );
-        for _ in 0..max_txs_in_queue {
+    fn push_available_tx_overflow() {
+        let max_max_txs = 10;
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: 2,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: max_max_txs,
+        });
+        let wsv = WorldStateView::new(world_with_test_domains(
+            KeyPair::generate().unwrap().public_key,
+        ));
+
+        for _ in 0..max_max_txs {
             queue
-                .push_pending_tx(accepted_tx("account", "domain", 100_000, None))
+                .push(accepted_tx("account", "domain", 100_000, None), &wsv)
                 .expect("Failed to push tx into queue");
             thread::sleep(Duration::from_millis(10));
         }
 
         assert!(queue
-            .push_pending_tx(accepted_tx("account", "domain", 100_000, None))
+            .push(accepted_tx("account", "domain", 100_000, None), &wsv)
             .is_err());
     }
 
     #[test]
     fn push_multisignature_tx() {
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: 2,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::default(),
-            Broker::new(),
-        );
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: 2,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: 100,
+        });
         let tx = Transaction::new(
             Vec::new(),
             <Account as Identifiable>::Id::new("account", "domain"),
@@ -358,25 +320,18 @@ mod tests {
             )
             .expect("Failed to accept Transaction.")
         };
+        let wsv = WorldStateView::new(world_with_test_domains(
+            KeyPair::generate().unwrap().public_key,
+        ));
 
-        queue
-            .push_pending_tx(get_tx())
-            .expect("Failed to push tx into queue");
+        queue.push(get_tx(), &wsv).unwrap();
+        queue.push(get_tx(), &wsv).unwrap();
 
-        queue
-            .push_pending_tx(get_tx())
-            .expect("Failed to push tx into queue");
-
-        assert_eq!(queue.pending_tx_hash_queue.len(), 1);
+        assert_eq!(queue.queue.len(), 1);
         let signature_count = queue
-            .pending_tx_by_hash
-            .get(
-                queue
-                    .pending_tx_hash_queue
-                    .front()
-                    .expect("Failed to get first tx."),
-            )
-            .expect("Failed to get tx by hash.")
+            .txs
+            .get(&queue.queue.pop().unwrap())
+            .unwrap()
             .as_inner_v1()
             .signatures
             .len();
@@ -384,96 +339,88 @@ mod tests {
     }
 
     #[test]
-    fn get_pending_txs() {
+    fn get_available_txs() {
         let max_block_tx = 2;
         let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: max_block_tx,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::new(WorldStateView::new(world_with_test_domains(
-                alice_key.public_key.clone(),
-            ))),
-            Broker::new(),
-        );
+        let wsv = WorldStateView::new(world_with_test_domains(alice_key.public_key.clone()));
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: max_block_tx,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: 100,
+        });
         for _ in 0..5 {
             queue
-                .push_pending_tx(accepted_tx(
-                    "alice",
-                    "wonderland",
-                    100_000,
-                    Some(&alice_key),
-                ))
+                .push(
+                    accepted_tx("alice", "wonderland", 100_000, Some(&alice_key)),
+                    &wsv,
+                )
                 .expect("Failed to push tx into queue");
             thread::sleep(Duration::from_millis(10));
         }
-        assert_eq!(queue.get_pending_txs(false).len(), max_block_tx as usize)
+
+        let available = queue.pop_avaliable(false, &wsv);
+        assert_eq!(available.len(), max_block_tx as usize);
     }
 
     #[test]
     fn drop_tx_if_in_blockchain() {
         let max_block_tx = 2;
         let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
-        let world_state_view =
-            WorldStateView::new(world_with_test_domains(alice_key.public_key.clone()));
+        let wsv = WorldStateView::new(world_with_test_domains(alice_key.public_key.clone()));
         let tx = accepted_tx("alice", "wonderland", 100_000, Some(&alice_key));
-        let _ = world_state_view.transactions.insert(tx.hash());
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: max_block_tx,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::new(world_state_view),
-            Broker::new(),
-        );
-        queue
-            .push_pending_tx(tx)
-            .expect("Failed to push tx into queue");
-        assert_eq!(queue.get_pending_txs(false).len(), 0);
+        wsv.transactions.insert(tx.hash());
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: max_block_tx,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: 100,
+        });
+        queue.push(tx, &wsv).expect("Failed to push tx into queue");
+        assert_eq!(queue.pop_avaliable(false, &wsv).len(), 0);
     }
 
     #[test]
-    fn get_pending_txs_with_timeout() {
+    fn get_available_txs_with_timeout() {
         let max_block_tx = 6;
         let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
-        let mut queue = Queue::<World>::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: max_block_tx,
-                transaction_time_to_live_ms: 200,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::new(WorldStateView::new(world_with_test_domains(
-                alice_key.public_key.clone(),
-            ))),
-            Broker::new(),
-        );
+        let wsv = WorldStateView::new(world_with_test_domains(alice_key.public_key.clone()));
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: max_block_tx,
+            transaction_time_to_live_ms: 200,
+            maximum_transactions_in_queue: 100,
+        });
         for _ in 0..(max_block_tx - 1) {
             queue
-                .push_pending_tx(accepted_tx("alice", "wonderland", 100, Some(&alice_key)))
+                .push(
+                    accepted_tx("alice", "wonderland", 100, Some(&alice_key)),
+                    &wsv,
+                )
                 .expect("Failed to push tx into queue");
             thread::sleep(Duration::from_millis(10));
         }
 
         queue
-            .push_pending_tx(accepted_tx("alice", "wonderland", 200, Some(&alice_key)))
+            .push(
+                accepted_tx("alice", "wonderland", 200, Some(&alice_key)),
+                &wsv,
+            )
             .expect("Failed to push tx into queue");
         std::thread::sleep(Duration::from_millis(101));
-        assert_eq!(queue.get_pending_txs(false).len(), 1);
+        assert_eq!(queue.pop_avaliable(false, &wsv).len(), 1);
 
-        queue.wsv = Arc::new(WorldStateView::new(World::new()));
+        let wsv = WorldStateView::new(World::new());
 
         queue
-            .push_pending_tx(accepted_tx("alice", "wonderland", 300, Some(&alice_key)))
+            .push(
+                accepted_tx("alice", "wonderland", 300, Some(&alice_key)),
+                &wsv,
+            )
             .expect("Failed to push tx into queue");
         std::thread::sleep(Duration::from_millis(101));
-        assert_eq!(queue.get_pending_txs(false).len(), 0);
+        assert_eq!(queue.pop_avaliable(false, &wsv).len(), 0);
     }
 
     #[test]
-    fn get_pending_txs_on_leader() {
+    fn get_available_txs_on_leader() {
         let max_block_tx = 2;
 
         let alice_key_1 = KeyPair::generate().expect("Failed to generate keypair.");
@@ -483,20 +430,16 @@ mod tests {
         let mut account = Account::new(account_id.clone());
         account.signatories.push(alice_key_1.public_key.clone());
         account.signatories.push(alice_key_2.public_key.clone());
-        let _result = domain.accounts.insert(account_id, account);
+        domain.accounts.insert(account_id, account);
         let mut domains = BTreeMap::new();
-        let _result = domains.insert("wonderland".to_string(), domain);
+        domains.insert("wonderland".to_string(), domain);
 
-        let world_state_view = WorldStateView::new(World::with(domains, BTreeSet::new()));
-        let mut queue = Queue::from_configuration(
-            &QueueConfiguration {
-                maximum_transactions_in_block: max_block_tx,
-                transaction_time_to_live_ms: 100_000,
-                maximum_transactions_in_queue: 100,
-            },
-            Arc::new(world_state_view),
-            Broker::new(),
-        );
+        let wsv = WorldStateView::new(World::with(domains, BTreeSet::new()));
+        let queue = Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block: max_block_tx,
+            transaction_time_to_live_ms: 100_000,
+            maximum_transactions_in_queue: 100,
+        });
 
         let bob_key = KeyPair::generate().expect("Failed to generate keypair.");
         let alice_tx_1 = accepted_tx("alice", "wonderland", 100_000, Some(&alice_key_1));
@@ -506,24 +449,66 @@ mod tests {
         let alice_tx_3 = accepted_tx("alice", "wonderland", 100_000, Some(&bob_key));
         thread::sleep(Duration::from_millis(10));
         let alice_tx_4 = accepted_tx("alice", "wonderland", 100_000, Some(&alice_key_1));
-        queue
-            .push_pending_tx(alice_tx_1.clone())
-            .expect("Failed to push tx into queue");
-        queue
-            .push_pending_tx(alice_tx_2.clone())
-            .expect("Failed to push tx into queue");
-        queue
-            .push_pending_tx(alice_tx_3)
-            .expect("Failed to push tx into queue");
-        queue
-            .push_pending_tx(alice_tx_4)
-            .expect("Failed to push tx into queue");
+        queue.push(alice_tx_1.clone(), &wsv).unwrap();
+        queue.push(alice_tx_2.clone(), &wsv).unwrap();
+        queue.push(alice_tx_3, &wsv).unwrap();
+        queue.push(alice_tx_4, &wsv).unwrap();
         let output_txs: Vec<_> = queue
-            .get_pending_txs(true)
+            .pop_avaliable(true, &wsv)
             .into_iter()
             .map(|tx| tx.hash())
             .collect();
         assert_eq!(output_txs, vec![alice_tx_1.hash(), alice_tx_2.hash()]);
-        assert_eq!(queue.pending_tx_hash_queue.len(), 4);
+        assert_eq!(queue.queue.len(), 2);
+    }
+
+    #[test]
+    fn test_multithreaded() {
+        let maximum_transactions_in_block = 100;
+        let maximum_transactions_in_queue = 10_000;
+        let transaction_time_to_live_ms = 10_000_000;
+        let producer_threads = 8;
+        let produce_txs_per_thread = 1000;
+
+        let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
+        let wsv = Arc::new(WorldStateView::new(world_with_test_domains(
+            alice_key.public_key.clone(),
+        )));
+        let q = Arc::new(Queue::from_configuration(&QueueConfiguration {
+            maximum_transactions_in_block,
+            maximum_transactions_in_queue,
+            transaction_time_to_live_ms,
+        }));
+        let hashes = Arc::new(DashSet::new());
+
+        let handles = std::iter::repeat_with(|| {
+            let q = Arc::clone(&q);
+            let hashes = Arc::clone(&hashes);
+            let wsv = Arc::clone(&wsv);
+            let alice = alice_key.clone();
+
+            std::thread::spawn(move || {
+                for _ in 0..produce_txs_per_thread {
+                    let tx = accepted_tx("alice", "wonderland", 10_000_000, Some(&alice));
+                    assert!(hashes.insert(tx.hash()));
+                    q.push(tx, &wsv).unwrap();
+                }
+            })
+        })
+        .take(producer_threads as usize)
+        .collect::<Vec<_>>();
+
+        let mut cnt = producer_threads * produce_txs_per_thread;
+
+        while cnt > 0 {
+            q.pop_avaliable(true, &wsv)
+                .iter()
+                .map(VersionedAcceptedTransaction::hash)
+                .for_each(|hash| {
+                    hashes.remove(&hash).unwrap();
+                    cnt -= 1;
+                });
+        }
+        handles.into_iter().for_each(|h| h.join().unwrap());
     }
 }

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -4,10 +4,10 @@
 
 use std::{
     cmp::min,
+    collections::BTreeSet,
     time::{Duration, SystemTime},
 };
 
-use iroha_actor::Message;
 pub use iroha_data_model::prelude::*;
 use iroha_derive::Io;
 use iroha_error::{Result, WrapErr};
@@ -24,9 +24,6 @@ use crate::{
 };
 
 declare_versioned_with_scale!(VersionedAcceptedTransaction 1..2, Debug, Clone, iroha_derive::FromVariant);
-impl Message for VersionedAcceptedTransaction {
-    type Result = ();
-}
 
 impl VersionedAcceptedTransaction {
     /// Same as [`as_v1`](`VersionedAcceptedTransaction::as_v1()`) but also does conversion
@@ -136,7 +133,7 @@ pub struct AcceptedTransaction {
     /// Payload of this transaction.
     pub payload: Payload,
     /// Signatures for this transaction.
-    pub signatures: Vec<Signature>,
+    pub signatures: BTreeSet<Signature>,
 }
 
 impl AcceptedTransaction {
@@ -443,7 +440,7 @@ impl VersionedValidTransaction {
 #[derive(Clone, Debug, Io, Encode, Decode)]
 pub struct ValidTransaction {
     payload: Payload,
-    signatures: Vec<Signature>,
+    signatures: BTreeSet<Signature>,
 }
 
 impl ValidTransaction {

--- a/iroha_client/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
+++ b/iroha_client/tests/asset_amount_should_be_the_same_on_a_recently_added_peer.rs
@@ -16,7 +16,8 @@ mod tests {
         let (rt, network, mut iroha_client) = <Network>::start_test_with_runtime(4, 1);
         let pipeline_time = Configuration::pipeline_time();
 
-        thread::sleep(pipeline_time * 3);
+        thread::sleep(pipeline_time * 2);
+        iroha_logger::info!("Started");
 
         let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
         let account_id = AccountId::new("account", "domain");
@@ -32,7 +33,9 @@ mod tests {
             create_account.into(),
             create_asset.into(),
         ])?;
-        thread::sleep(pipeline_time * 5);
+        thread::sleep(pipeline_time * 2);
+        iroha_logger::info!("Init");
+
         //When
         let quantity: u32 = 200;
         let mint_asset = MintBox::new(
@@ -44,6 +47,7 @@ mod tests {
         );
         iroha_client.submit(mint_asset)?;
         thread::sleep(pipeline_time * 5);
+        iroha_logger::info!("Mint");
 
         let (_peer, mut iroha_client) = rt.block_on(network.add_peer());
 

--- a/iroha_client/tests/multisignature_transaction.rs
+++ b/iroha_client/tests/multisignature_transaction.rs
@@ -54,6 +54,7 @@ mod tests {
             ])
             .expect("Failed to prepare state.");
         thread::sleep(pipeline_time * 2);
+
         //When
         let quantity: u32 = 200;
         let mint_asset = MintBox::new(
@@ -75,6 +76,7 @@ mod tests {
             )
             .expect("Failed to submit transaction.");
         thread::sleep(pipeline_time);
+
         //Then
         client_configuration.torii_api_url = network.peers.last().unwrap().api_address.clone();
         let mut iroha_client_1 = Client::new(&client_configuration);

--- a/iroha_p2p/src/peer.rs
+++ b/iroha_p2p/src/peer.rs
@@ -32,7 +32,7 @@ use crate::{
     Error, Message, MessageResult,
 };
 
-const MAX_MESSAGE_LENGTH: usize = 2 * 1024 * 1024;
+const MAX_MESSAGE_LENGTH: usize = 16 * 1024 * 1024;
 const MAX_HANDSHAKE_LENGTH: usize = 255;
 /// Default associated data for AEAD
 /// [`Authenticated encryption`](https://en.wikipedia.org/wiki/Authenticated_encryption)
@@ -578,7 +578,7 @@ impl Display for State {
 /// If reading encounters IO-error
 pub async fn read_client_hello(stream: &mut OwnedReadHalf) -> Result<PublicKey, Error> {
     stream.as_ref().readable().await?;
-    let _garbage = Garbage::read(stream).await?;
+    Garbage::read(stream).await?;
     // And then we have clients public key
     stream.as_ref().readable().await?;
     let mut key = [0_u8; 32];
@@ -601,7 +601,7 @@ pub async fn send_client_hello(stream: &mut OwnedWriteHalf, key: &[u8]) -> io::R
 /// If reading encounters IO-error
 pub async fn read_server_hello(stream: &mut OwnedReadHalf) -> Result<PublicKey, Error> {
     stream.as_ref().readable().await?;
-    let _garbage = Garbage::read(stream).await?;
+    Garbage::read(stream).await?;
     // Then we have servers public key
     stream.as_ref().readable().await?;
     let mut key = [0_u8; 32];


### PR DESCRIPTION
https://jira.hyperledger.org/browse/IR-1149

### Description of the Change

#### Making torii lockfree and updating iroha_network for that

We only read state in torii, so we can safely remove rwlock from there

#### Removing queue actor

Removing queue actor in favor of multi producer single consumer queue from crossbeam.

### Benefits

It will be faster and always available in contrast to actor. It will also remove congestions because there will be by one actor less.

### Possible Drawbacks 

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
