### PR TITLE
Store proof of view changes

### DIFF
--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -389,7 +389,7 @@ Has type `u32`. Can be configured via environment variable `SUMERAGI_MAX_FAULTY_
 
 Maximum instruction number per transaction
 
-Has type `usize`. Can be configured via environment variable `SUMERAGI_MAX_INSTRUCTION_NUMBER`
+Has type `u64`. Can be configured via environment variable `SUMERAGI_MAX_INSTRUCTION_NUMBER`
 
 ```json
 4096
@@ -399,7 +399,7 @@ Has type `usize`. Can be configured via environment variable `SUMERAGI_MAX_INSTR
 
 After N view changes topology will change tactic from shifting by one, to reshuffle.
 
-Has type `u32`. Can be configured via environment variable `SUMERAGI_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE`
+Has type `u64`. Can be configured via environment variable `SUMERAGI_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE`
 
 ```json
 1
@@ -488,7 +488,7 @@ Has type `String`. Can be configured via environment variable `TORII_API_URL`
 
 Maximum number of instruction per transaction. Used to prevent from DOS attacks.
 
-Has type `usize`. Can be configured via environment variable `TORII_MAX_INSTRUCTION_NUMBER`
+Has type `u64`. Can be configured via environment variable `TORII_MAX_INSTRUCTION_NUMBER`
 
 ```json
 4096

--- a/iroha/benches/validation.rs
+++ b/iroha/benches/validation.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha::{
     prelude::*,
+    sumeragi::view_change,
     tx::AcceptedTransaction,
     wsv::{World, WorldTrait},
 };
@@ -126,9 +127,12 @@ fn chain_blocks(criterion: &mut Criterion) {
     let _ = criterion.bench_function("chain_block", |b| {
         b.iter(|| {
             success_count += 1;
-            let new_block = block
-                .clone()
-                .chain(success_count, previous_block_hash, 0, Vec::new());
+            let new_block = block.clone().chain(
+                success_count,
+                previous_block_hash,
+                view_change::ProofChain::empty(),
+                Vec::new(),
+            );
             previous_block_hash = new_block.hash();
         });
     });

--- a/iroha/src/block_sync.rs
+++ b/iroha/src/block_sync.rs
@@ -37,7 +37,7 @@ pub struct BlockSynchronizer<S: SumeragiTrait, W: WorldTrait> {
     state: State,
     gossip_period: Duration,
     batch_size: u32,
-    n_topology_shifts_before_reshuffle: u32,
+    n_topology_shifts_before_reshuffle: u64,
     broker: Broker,
 }
 
@@ -54,7 +54,7 @@ pub trait BlockSynchronizerTrait: Actor + Handler<ContinueSync> + Handler<Messag
         wsv: Arc<WorldStateView<Self::World>>,
         sumeragi: AlwaysAddr<Self::Sumeragi>,
         peer_id: PeerId,
-        n_topology_shifts_before_reshuffle: u32,
+        n_topology_shifts_before_reshuffle: u64,
         broker: Broker,
     ) -> Self;
 }
@@ -68,7 +68,7 @@ impl<S: SumeragiTrait, W: WorldTrait> BlockSynchronizerTrait for BlockSynchroniz
         wsv: Arc<WorldStateView<W>>,
         sumeragi: AlwaysAddr<S>,
         peer_id: PeerId,
-        n_topology_shifts_before_reshuffle: u32,
+        n_topology_shifts_before_reshuffle: u64,
         broker: Broker,
     ) -> Self {
         Self {
@@ -182,7 +182,7 @@ impl<S: SumeragiTrait + Debug, W: WorldTrait> BlockSynchronizer<S, W> {
         if !block.header().is_genesis() {
             network_topology = network_topology
                 .into_builder()
-                .with_view_changes(block.header().number_of_view_changes)
+                .with_view_changes(block.header().view_change_proofs.clone())
                 .build()
                 .expect(
                     "Unreachable as doing view changes on valid topology will not raise an error.",

--- a/iroha/src/genesis.rs
+++ b/iroha/src/genesis.rs
@@ -44,7 +44,7 @@ pub trait GenesisNetworkTrait:
     /// Fail if genesis block loading fails
     fn from_configuration(
         genesis_config: &GenesisConfiguration,
-        max_instructions_number: usize,
+        max_instructions_number: u64,
     ) -> Result<Option<Self>>;
 
     /// Waits for a minimum number of `peers` needed for consensus to be online.
@@ -170,7 +170,7 @@ async fn check_peers_status(
 impl GenesisNetworkTrait for GenesisNetwork {
     fn from_configuration(
         genesis_config: &GenesisConfiguration,
-        max_instructions_number: usize,
+        max_instructions_number: u64,
     ) -> Result<Option<GenesisNetwork>> {
         if let Some(genesis_block_path) = &genesis_config.genesis_block_path {
             let file = File::open(Path::new(&genesis_block_path))
@@ -240,7 +240,7 @@ impl GenesisTransaction {
     pub fn sign_and_accept(
         &self,
         genesis_key_pair: &KeyPair,
-        max_instruction_number: usize,
+        max_instruction_number: u64,
     ) -> Result<VersionedAcceptedTransaction> {
         let transaction = Transaction::new(
             self.isi.clone(),

--- a/iroha/src/kura.rs
+++ b/iroha/src/kura.rs
@@ -313,7 +313,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::wsv::World;
+    use crate::{sumeragi::view_change, wsv::World};
 
     #[tokio::test]
     async fn strict_init_kura() {
@@ -380,7 +380,7 @@ mod tests {
                 .await
                 .expect("Failed to write block to file.");
             block = PendingBlock::new(Vec::new())
-                .chain(height, hash, 0, Vec::new())
+                .chain(height, hash, view_change::ProofChain::empty(), Vec::new())
                 .validate(&WorldStateView::new(World::new()), &AllowAll.into())
                 .sign(&keypair)
                 .expect("Failed to sign blocks.")

--- a/iroha/src/sumeragi/view_change.rs
+++ b/iroha/src/sumeragi/view_change.rs
@@ -1,0 +1,326 @@
+//! Structures related to proofs and reasons of view changes.
+//! Where view change is a process of changing topology due to some faulty network behavior.
+
+use std::{collections::HashSet, fmt::Display};
+
+use iroha_crypto::{Hash, KeyPair, PublicKey, Signature, Signatures};
+use iroha_data_model::prelude::PeerId;
+use iroha_derive::*;
+use iroha_error::Result;
+use parity_scale_codec::{Decode, Encode};
+
+use super::message::TransactionReceipt;
+use crate::block::EmptyChainHash;
+
+/// The proof of a view change. It needs to be signed by f+1 peers for proof to be valid and view change to happen.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct Proof {
+    payload: ProofPayload,
+    signatures: Signatures,
+}
+
+impl Proof {
+    /// Constructor for `CommitTimeout` view change suggestion.
+    pub fn commit_timeout(
+        voting_block_hash: Hash,
+        previous_proof: Hash,
+        latest_block: Hash,
+    ) -> Self {
+        Self {
+            signatures: Signatures::default(),
+            payload: ProofPayload {
+                reason: Reason::CommitTimeout(CommitTimeout { voting_block_hash }),
+                previous_proof,
+                latest_block,
+            },
+        }
+    }
+
+    /// Constructor for `BlockCreationTimeout` view change suggestion.
+    pub fn block_creation_timeout(
+        transaction_receipt: TransactionReceipt,
+        previous_proof: Hash,
+        latest_block: Hash,
+    ) -> Self {
+        Self {
+            signatures: Signatures::default(),
+            payload: ProofPayload {
+                reason: Reason::BlockCreationTimeout(BlockCreationTimeout {
+                    transaction_receipt,
+                }),
+                previous_proof,
+                latest_block,
+            },
+        }
+    }
+
+    /// Constructor for `NoTransactionReceiptReceived` view change suggestion.
+    pub fn no_transaction_receipt_received(
+        transaction_hash: Hash,
+        previous_proof: Hash,
+        latest_block: Hash,
+    ) -> Self {
+        Self {
+            signatures: Signatures::default(),
+            payload: ProofPayload {
+                reason: Reason::NoTransactionReceiptReceived(NoTransactionReceiptReceived {
+                    transaction_hash,
+                }),
+                previous_proof,
+                latest_block,
+            },
+        }
+    }
+
+    /// Hash of the proof `payload`.
+    pub fn hash(&self) -> Hash {
+        let bytes: Vec<u8> = self.payload.clone().into();
+        Hash::new(&bytes)
+    }
+    /// Signs this message with the peer's public and private key.
+    /// This way peers vote for changing the view - changing the roles of peers.
+    ///
+    /// # Errors
+    /// Can fail during creation of signature
+    pub fn sign(mut self, key_pair: &KeyPair) -> Result<Proof> {
+        let signature = Signature::new(key_pair.clone(), self.hash().as_ref())?;
+        self.signatures.add(signature);
+        Ok(self)
+    }
+
+    /// Verify if the proof is valid, given the peers in `topology`.
+    pub fn verify(&self, peers: &HashSet<PeerId>, max_faults: u32) -> bool {
+        let peer_public_keys: HashSet<PublicKey> = peers
+            .iter()
+            .map(|peer_id| peer_id.public_key.clone())
+            .collect();
+        let n_signatures = self
+            .signatures
+            .verified(self.hash().as_ref())
+            .iter()
+            .filter(|signature| peer_public_keys.contains(&signature.public_key))
+            .count();
+        // See Whitepaper for the information on this limit.
+        #[allow(clippy::int_plus_one)]
+        {
+            n_signatures >= max_faults as usize + 1
+        }
+    }
+
+    /// Should be checked by validators before signing the proof.
+    pub fn has_same_state(&self, latest_block: Hash, latest_view_change: Hash) -> bool {
+        self.payload.latest_block == latest_block
+            && self.payload.previous_proof == latest_view_change
+    }
+
+    /// The `Reason` of this view change. Why should topology change?
+    pub const fn reason(&self) -> &Reason {
+        &self.payload.reason
+    }
+
+    /// Signatures of peers who signed this proof - therefore voting for this view change.
+    pub const fn signatures(&self) -> &Signatures {
+        &self.signatures
+    }
+}
+
+/// Payload of [`Proof`]
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct ProofPayload {
+    ///
+    previous_proof: Hash,
+    /// Latest committed block hash.
+    latest_block: Hash,
+    ///
+    reason: Reason,
+}
+
+/// Reason for a view change.
+#[allow(variant_size_differences)]
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub enum Reason {
+    /// Proxy tail have not committed a block in time.
+    CommitTimeout(CommitTimeout),
+    /// Transaction was sent to leader, but no corresponding receipt was received from the leader for it.
+    NoTransactionReceiptReceived(NoTransactionReceiptReceived),
+    /// Transaction reached leader but no block was created.
+    BlockCreationTimeout(BlockCreationTimeout),
+}
+
+impl Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Reason::CommitTimeout(_) => write!(f, "Commit Timeout"),
+            Reason::NoTransactionReceiptReceived(_) => write!(f, "No Transaction Receipt Received"),
+            Reason::BlockCreationTimeout(_) => write!(f, "Block Creation Timeout"),
+        }
+    }
+}
+
+/// Block `CommitTimeout` reason for a view change.
+#[derive(Clone, Debug, Io, Encode, Decode, Copy)]
+pub struct CommitTimeout {
+    /// The hash of the block in discussion in this round.
+    pub voting_block_hash: Hash,
+}
+
+/// `NoTransactionReceiptReceived` (from leader) reason for a view change.
+#[derive(Clone, Debug, Io, Encode, Decode, Copy)]
+pub struct NoTransactionReceiptReceived {
+    /// The hash of the transaction for which there was no `TransactionReceipt`.
+    pub transaction_hash: Hash,
+}
+
+/// `BlockCreationTimeout` reason for a view change.
+#[derive(Clone, Debug, Io, Encode, Decode)]
+pub struct BlockCreationTimeout {
+    /// A proof of the leader receiving and accepting a transaction.
+    pub transaction_receipt: TransactionReceipt,
+}
+
+/// A chain of view change proofs. Stored in block for roles to be known at that point in history.
+#[derive(Clone, Debug, Io, Encode, Decode, Default)]
+pub struct ProofChain {
+    proofs: Vec<Proof>,
+}
+
+impl ProofChain {
+    /// Initialize an empty proof chain.
+    pub const fn empty() -> ProofChain {
+        Self { proofs: Vec::new() }
+    }
+
+    /// Verify the view change proof chain.
+    pub fn verify_with_state(
+        &self,
+        peers: &HashSet<PeerId>,
+        max_faults: u32,
+        latest_block: Hash,
+    ) -> bool {
+        let mut previous_proof: Hash = EmptyChainHash.into();
+        for proof in &self.proofs {
+            if proof.has_same_state(latest_block, previous_proof) && proof.verify(peers, max_faults)
+            {
+                previous_proof = proof.hash();
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Add a latest change proof on top.
+    pub fn push(&mut self, proof: Proof) {
+        self.proofs.push(proof)
+    }
+
+    /// The number of view change proofs in this proof chain.
+    pub fn len(&self) -> usize {
+        self.proofs.len()
+    }
+
+    /// Is proof chain empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The hash of the latest view change.
+    pub fn latest_hash(&self) -> Hash {
+        self.proofs
+            .last()
+            .map_or(EmptyChainHash.into(), Proof::hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic_in_result_fn)]
+
+    use super::*;
+
+    #[test]
+    fn proof_is_valid() -> Result<()> {
+        let proof = Proof::commit_timeout(Hash([1_u8; 32]), Hash([2_u8; 32]), Hash([3_u8; 32]));
+        let key_pair_1 = KeyPair::generate()?;
+        let key_pair_2 = KeyPair::generate()?;
+        let proof = proof.sign(&key_pair_1)?;
+        let proof = proof.sign(&key_pair_2)?;
+        let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
+        let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
+        let peers = maplit::hashset![peer_1, peer_2];
+        assert!(proof.verify(&peers, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn proof_has_not_enough_signatures() -> Result<()> {
+        let proof = Proof::commit_timeout(Hash([1_u8; 32]), Hash([2_u8; 32]), Hash([3_u8; 32]));
+        let key_pair_1 = KeyPair::generate()?;
+        let key_pair_2 = KeyPair::generate()?;
+        let proof = proof.sign(&key_pair_1)?;
+        let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
+        let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
+        let peers = maplit::hashset![peer_1, peer_2];
+        assert!(!proof.verify(&peers, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn proof_has_not_enough_valid_signatures() -> Result<()> {
+        let proof = Proof::commit_timeout(Hash([1_u8; 32]), Hash([2_u8; 32]), Hash([3_u8; 32]));
+        let key_pair_1 = KeyPair::generate()?;
+        let key_pair_2 = KeyPair::generate()?;
+        let key_pair_3 = KeyPair::generate()?;
+        let proof = proof.sign(&key_pair_1)?;
+        let proof = proof.sign(&key_pair_3)?;
+        let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
+        let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
+        let peers = maplit::hashset![peer_1, peer_2];
+        assert!(!proof.verify(&peers, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn proof_chain_is_valid() -> Result<()> {
+        let mut proof_chain = ProofChain::empty();
+        let key_pair_1 = KeyPair::generate()?;
+        let key_pair_2 = KeyPair::generate()?;
+        let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
+        let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
+        let latest_block = Hash([3_u8; 32]);
+        for i in 0..10 {
+            let proof =
+                Proof::commit_timeout(Hash([i; 32]), proof_chain.latest_hash(), latest_block);
+            let proof = proof.sign(&key_pair_1)?;
+            let proof = proof.sign(&key_pair_2)?;
+            proof_chain.push(proof);
+        }
+        let peers = maplit::hashset![peer_1, peer_2];
+        assert!(proof_chain.verify_with_state(&peers, 1, latest_block));
+        Ok(())
+    }
+
+    #[test]
+    fn proof_chain_is_not_valid() -> Result<()> {
+        let mut proof_chain = ProofChain::empty();
+        let key_pair_1 = KeyPair::generate()?;
+        let key_pair_2 = KeyPair::generate()?;
+        let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
+        let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
+        let latest_block = Hash([3_u8; 32]);
+        for i in 0..10 {
+            let latest_proof_hash = if i == 2 {
+                Hash([0_u8; 32])
+            } else {
+                proof_chain.latest_hash()
+            };
+            let proof = Proof::commit_timeout(Hash([i; 32]), latest_proof_hash, latest_block);
+            let proof = proof.sign(&key_pair_1)?;
+            let proof = proof.sign(&key_pair_2)?;
+            proof_chain.push(proof);
+        }
+        let peers = maplit::hashset![peer_1, peer_2];
+        assert!(!proof_chain.verify_with_state(&peers, 1, latest_block));
+        Ok(())
+    }
+}

--- a/iroha/src/torii.rs
+++ b/iroha/src/torii.rs
@@ -516,7 +516,7 @@ pub mod config {
     const DEFAULT_TORII_P2P_URL: &str = "127.0.0.1:1337";
     const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
     const DEFAULT_TORII_MAX_TRANSACTION_SIZE: usize = 2_usize.pow(15);
-    const DEFAULT_TORII_MAX_INSTRUCTION_NUMBER: usize = 2_usize.pow(12);
+    const DEFAULT_TORII_MAX_INSTRUCTION_NUMBER: u64 = 2_u64.pow(12);
     const DEFAULT_TORII_MAX_SUMERAGI_MESSAGE_SIZE: usize = 2_usize.pow(12) * 4000;
 
     /// `ToriiConfiguration` provides an ability to define parameters such as `TORII_URL`.
@@ -533,7 +533,7 @@ pub mod config {
         /// Maximum number of bytes in raw message. Used to prevent from DOS attacks.
         pub torii_max_sumeragi_message_size: usize,
         /// Maximum number of instruction per transaction. Used to prevent from DOS attacks.
-        pub torii_max_instruction_number: usize,
+        pub torii_max_instruction_number: u64,
     }
 
     impl Default for ToriiConfiguration {

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -56,7 +56,7 @@ impl VersionedAcceptedTransaction {
     /// Accepts transaction
     pub fn from_transaction(
         transaction: Transaction,
-        max_instruction_number: usize,
+        max_instruction_number: u64,
     ) -> Result<VersionedAcceptedTransaction> {
         AcceptedTransaction::from_transaction(transaction, max_instruction_number).map(Into::into)
     }
@@ -111,7 +111,7 @@ impl VersionedAcceptedTransaction {
 
     /// # Errors
     /// Asserts specific instruction number of instruction in transaction constraint
-    pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+    pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
         self.as_inner_v1()
             .check_instruction_len(max_instruction_len)
     }
@@ -140,7 +140,7 @@ pub struct AcceptedTransaction {
 impl AcceptedTransaction {
     /// # Errors
     /// Asserts specific instruction number of instruction in transaction constraint
-    pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+    pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
         self.payload.check_instruction_len(max_instruction_len)
     }
 
@@ -150,7 +150,7 @@ impl AcceptedTransaction {
     /// Can fail if verification of some signature fails
     pub fn from_transaction(
         transaction: Transaction,
-        max_instruction_number: usize,
+        max_instruction_number: u64,
     ) -> Result<AcceptedTransaction> {
         transaction
             .check_instruction_len(max_instruction_number)
@@ -413,7 +413,7 @@ impl VersionedValidTransaction {
 
     /// # Errors
     /// Asserts specific instruction number of instruction in transaction constraint
-    pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+    pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
         self.as_inner_v1()
             .check_instruction_len(max_instruction_len)
     }
@@ -439,7 +439,7 @@ pub struct ValidTransaction {
 impl ValidTransaction {
     /// # Errors
     /// Asserts specific instruction number of instruction in transaction constraint
-    pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+    pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
         self.payload.check_instruction_len(max_instruction_len)
     }
 

--- a/iroha_client/src/client.rs
+++ b/iroha_client/src/client.rs
@@ -24,7 +24,7 @@ use crate::{
 pub struct Client {
     /// Url for accessing iroha node
     pub torii_url: String,
-    max_instruction_number: usize,
+    max_instruction_number: u64,
     key_pair: KeyPair,
     proposed_transaction_ttl_ms: u64,
     transaction_status_timout: Duration,

--- a/iroha_client/src/config.rs
+++ b/iroha_client/src/config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
 const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
 const DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS: u64 = 10_000;
-const DEFAULT_MAX_INSTRUCTION_NUMBER: usize = 2_usize.pow(12);
+const DEFAULT_MAX_INSTRUCTION_NUMBER: u64 = 2_u64.pow(12);
 
 /// `Configuration` provides an ability to define client parameters such as `TORII_URL`.
 // TODO: design macro to load config from env.
@@ -36,7 +36,7 @@ pub struct Configuration {
     /// Transaction status wait timeout in milliseconds.
     pub transaction_status_timeout_ms: u64,
     /// Maximum number of instructions per transaction
-    pub max_instruction_number: usize,
+    pub max_instruction_number: u64,
 }
 
 impl Default for Configuration {

--- a/iroha_crypto/src/lib.rs
+++ b/iroha_crypto/src/lib.rs
@@ -516,6 +516,18 @@ impl Signatures {
             .cloned()
             .collect()
     }
+
+    /// Number of signatures.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn len(&self) -> usize {
+        self.signatures.len()
+    }
+
+    /// Checks if there is no signatures.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn is_empty(&self) -> bool {
+        self.signatures.is_empty()
+    }
 }
 
 /// The prelude re-exports most commonly used traits, structs and macros from this crate.

--- a/iroha_data_model/src/lib.rs
+++ b/iroha_data_model/src/lib.rs
@@ -1891,7 +1891,7 @@ pub mod transaction {
         ///
         /// # Errors
         /// Fails if instruction length exceeds maximum instruction number
-        pub fn check_instruction_len(&self, max_instruction_number: usize) -> Result<()> {
+        pub fn check_instruction_len(&self, max_instruction_number: u64) -> Result<()> {
             self.as_inner_v1()
                 .check_instruction_len(max_instruction_number)
         }
@@ -1960,7 +1960,7 @@ pub mod transaction {
         ///
         /// # Errors
         /// Fails if instruction length exceeds maximum instruction number
-        pub fn check_instruction_len(&self, max_instruction_number: usize) -> Result<()> {
+        pub fn check_instruction_len(&self, max_instruction_number: u64) -> Result<()> {
             self.payload.check_instruction_len(max_instruction_number)
         }
 
@@ -1989,12 +1989,12 @@ pub mod transaction {
 
         /// # Errors
         /// Asserts specific instruction number of instruction constraint
-        pub fn check_instruction_len(&self, max_instruction_number: usize) -> Result<()> {
+        pub fn check_instruction_len(&self, max_instruction_number: u64) -> Result<()> {
             if self
                 .instructions
                 .iter()
                 .map(Instruction::len)
-                .sum::<usize>()
+                .sum::<usize>() as u64
                 > max_instruction_number
             {
                 return Err(error!("Too many instructions in payload"));
@@ -2141,7 +2141,7 @@ pub mod transaction {
 
         /// # Errors
         /// Asserts specific instruction number of instruction in transaction constraint
-        pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+        pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
             self.as_inner_v1()
                 .check_instruction_len(max_instruction_len)
         }
@@ -2195,7 +2195,7 @@ pub mod transaction {
     impl RejectedTransaction {
         /// # Errors
         /// Asserts specific instruction number of instruction in transaction constraint
-        pub fn check_instruction_len(&self, max_instruction_len: usize) -> Result<()> {
+        pub fn check_instruction_len(&self, max_instruction_len: u64) -> Result<()> {
             self.payload.check_instruction_len(max_instruction_len)
         }
 


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->
Closes #1123 

### Description of the Change
- Store proofs
- Use these proofs in BlockCreated to be up to date
- Refactor view change handling logic (now it is universal)
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

If several peers join the network late they will not only get blocks, but also view changes on top of these blocks. This will help them with syncing.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
