### PR TITLE
Feature: ordering service cache size limit + metrics

### DIFF
--- a/irohad/main/subscription_fwd.hpp
+++ b/irohad/main/subscription_fwd.hpp
@@ -41,6 +41,7 @@ namespace iroha {
     kOnProposalResponse,
     kOnTransactionResponse,
     kOnConsensusGateEvent,
+    kOdOsCachedTxsSizeChanged,
 
     // MST
     kOnStateUpdate,

--- a/irohad/maintenance/metrics.hpp
+++ b/irohad/maintenance/metrics.hpp
@@ -23,18 +23,16 @@
 #include "network/ordering_gate_common.hpp"
 
 class Metrics : public std::enable_shared_from_this<Metrics> {
-  using OnProposalSubscription = iroha::BaseSubscriber<
-      bool,
-      iroha::network::OrderingEvent>;  // FixMe subscribtion ≠ subscriber
   using BlockPtr = std::shared_ptr<const shared_model::interface::Block>;
   using BlockSubscriber = iroha::BaseSubscriber<bool, BlockPtr>;
+  using TxsCacheSubscriber = iroha::BaseSubscriber<bool, uint64_t>;
 
   std::string listen_addr_port_;
   std::shared_ptr<prometheus::Exposer> exposer_;
   std::shared_ptr<prometheus::Registry> registry_;
   std::shared_ptr<iroha::ametsuchi::Storage> storage_;
   std::shared_ptr<BlockSubscriber> block_subscriber_;
-  std::shared_ptr<OnProposalSubscription> on_proposal_subscription_;
+  std::shared_ptr<TxsCacheSubscriber> txs_cache_size_subscriber_;
   logger::LoggerPtr logger_;
 
   Metrics(std::string const &listen_addr,

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -19,6 +19,7 @@
 #include "logger/logger.hpp"
 #include "main/subscription.hpp"
 
+
 using iroha::ordering::OnDemandOrderingServiceImpl;
 
 OnDemandOrderingServiceImpl::OnDemandOrderingServiceImpl(
@@ -30,6 +31,7 @@ OnDemandOrderingServiceImpl::OnDemandOrderingServiceImpl(
     size_t number_of_proposals)
     : transaction_limit_(transaction_limit),
       number_of_proposals_(number_of_proposals),
+
       cached_txs_size_(0ull),
       proposal_factory_(std::move(proposal_factory)),
       tx_cache_(std::move(tx_cache)),
@@ -70,6 +72,10 @@ bool OnDemandOrderingServiceImpl::insertBatchToCache(
     cached_txs_size_ += boost::size(batch->transactions());
     getSubscription()->notify(EventTypes::kOnNewBatchInCache,
                               std::shared_ptr(batch));
+    cached_txs_size_ += boost::size(batch->transactions());
+    getSubscription()->notify(
+        EventTypes::kOdOsCachedTxsSizeChanged,
+        cached_txs_size_);
   }
   return true;
 }
@@ -88,6 +94,9 @@ void OnDemandOrderingServiceImpl::removeFromBatchesCache(
       auto const erased_size = boost::size((*it)->transactions());
       it = batches_cache_.erase(it);
       cached_txs_size_ -= erased_size;
+      getSubscription()->notify(
+          EventTypes::kOdOsCachedTxsSizeChanged,
+          cached_txs_size_);
     } else {
       ++it;
     }

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -96,7 +96,7 @@ namespace iroha {
       bool batchAlreadyProcessed(
           const shared_model::interface::TransactionBatch &batch);
 
-      void insertBatchToCache(
+      bool insertBatchToCache(
           std::shared_ptr<shared_model::interface::TransactionBatch> const
               &batch);
 
@@ -135,6 +135,7 @@ namespace iroha {
 
       mutable std::shared_timed_mutex batches_cache_cs_;
       BatchesSetType batches_cache_, used_batches_cache_;
+      uint64_t cached_txs_size_;
 
       std::shared_ptr<shared_model::interface::UnsafeProposalFactory>
           proposal_factory_;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Adds Ordering Service cache size limitation.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
