### PR TITLE
Feature/rdb block store

### DIFF
--- a/example/config.sample
+++ b/example/config.sample
@@ -1,5 +1,4 @@
 {
-  "block_store_path" : "/tmp/block_store/",
   "torii_port" : 50051,
   "internal_port" : 10001,
   "database": {

--- a/irohad/ametsuchi/CMakeLists.txt
+++ b/irohad/ametsuchi/CMakeLists.txt
@@ -23,6 +23,19 @@ target_link_libraries(pool_wrapper
     SOCI::core
     )
 
+add_library(rocksdb_block_storage
+    impl/rocksdb_block_storage.cpp
+    impl/rocksdb_block_storage_factory.cpp
+    )
+
+target_link_libraries(rocksdb_block_storage
+    libs_files
+    shared_model_proto_backend
+    logger
+    Boost::boost
+    RocksDB::rocksdb
+    )
+
 add_library(flat_file_storage
     impl/flat_file/flat_file.cpp
     impl/flat_file_block_storage.cpp
@@ -201,6 +214,7 @@ target_link_libraries(ametsuchi
     rdb_connection_init
     ametsuchi_rocksdb
     flat_file_storage
+    rocksdb_block_storage
     postgres_indexer
     postgres_storage
     logger

--- a/irohad/ametsuchi/impl/rocksdb_block_storage.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_block_storage.cpp
@@ -1,0 +1,135 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/rocksdb_block_storage.hpp"
+
+#include "ametsuchi/impl/rocksdb_common.hpp"
+#include "backend/protobuf/block.hpp"
+#include "common/byteutils.hpp"
+#include "logger/logger.hpp"
+
+using namespace iroha::ametsuchi;
+
+#define CHECK_OPERATION(command, ...)                                          \
+  if (auto result = (__VA_ARGS__); expected::hasError(result)) {               \
+    log_->error("Error while block {} " command ". Code: {}. Description: {}", \
+                block->height(),                                               \
+                result.assumeError().code,                                     \
+                result.assumeError().description);                             \
+    return false;                                                              \
+  }
+
+namespace {
+  inline iroha::expected::Result<void, DbError> incrementTotalBlocksCount(
+      iroha::ametsuchi::RocksDbCommon &common) {
+    RDB_TRY_GET_VALUE(
+        opt_count,
+        forBlocksTotalCount<kDbOperation::kGet, kDbEntry::kCanExist>(common));
+
+    common.encode(opt_count ? *opt_count + 1ull : 1ull);
+    RDB_ERROR_CHECK(
+        forBlocksTotalCount<kDbOperation::kPut, kDbEntry::kMustExist>(common));
+
+    return {};
+  }
+}  // namespace
+
+RocksDbBlockStorage::RocksDbBlockStorage(
+    std::shared_ptr<RocksDBContext> db_context,
+    std::shared_ptr<shared_model::interface::BlockJsonConverter> json_converter,
+    logger::LoggerPtr log)
+    : db_context_(std::move(db_context)),
+      json_converter_(std::move(json_converter)),
+      log_(std::move(log)) {}
+
+bool RocksDbBlockStorage::insert(
+    std::shared_ptr<const shared_model::interface::Block> block) {
+  return json_converter_->serialize(*block).match(
+      [&](const auto &block_json) {
+        RocksDbCommon common(db_context_);
+        CHECK_OPERATION("insertion",
+                        forBlock<kDbOperation::kCheck, kDbEntry::kMustNotExist>(
+                            common, block->height()));
+
+        common.valueBuffer() = block_json.value;
+        CHECK_OPERATION("storing",
+                        forBlock<kDbOperation::kPut>(common, block->height()));
+
+        CHECK_OPERATION("total count storing",
+                        incrementTotalBlocksCount(common));
+        return true;
+      },
+      [this](const auto &error) {
+        log_->warn("Error while block serialization: {}", error.error);
+        return false;
+      });
+}
+
+boost::optional<std::unique_ptr<shared_model::interface::Block>>
+RocksDbBlockStorage::fetch(
+    shared_model::interface::types::HeightType height) const {
+  RocksDbCommon common(db_context_);
+  if (auto result =
+          forBlock<kDbOperation::kGet, kDbEntry::kMustExist>(common, height);
+      expected::hasError(result)) {
+    log_->error("Error while block {} reading. Code: {}. Description: {}",
+                height,
+                result.assumeError().code,
+                result.assumeError().description);
+    return boost::none;
+  }
+
+  return json_converter_->deserialize(common.valueBuffer())
+      .match(
+          [&](auto &&block) {
+            return boost::make_optional<
+                std::unique_ptr<shared_model::interface::Block>>(
+                std::move(block.value));
+          },
+          [&](const auto &error)
+              -> boost::optional<
+                  std::unique_ptr<shared_model::interface::Block>> {
+            log_->warn("Error while block deserialization: {}", error.error);
+            return boost::none;
+          });
+}
+
+size_t RocksDbBlockStorage::size() const {
+  RocksDbCommon common(db_context_);
+  if (auto result =
+          forBlocksTotalCount<kDbOperation::kGet, kDbEntry::kMustExist>(common);
+      expected::hasValue(result))
+    return *result.assumeValue();
+  return 0ull;
+}
+
+void RocksDbBlockStorage::reload() {}
+
+void RocksDbBlockStorage::clear() {
+  RocksDbCommon common(db_context_);
+
+  if (auto status = common.filterDelete(fmtstrings::kPathWsv); !status.ok())
+    log_->error("Unable to delete WSV. Description: {}", status.ToString());
+
+  if (auto status = common.filterDelete(fmtstrings::kPathStore); !status.ok())
+    log_->error("Unable to delete STORE. Description: {}", status.ToString());
+}
+
+iroha::expected::Result<void, std::string> RocksDbBlockStorage::forEach(
+    iroha::ametsuchi::BlockStorage::FunctionType function) const {
+  uint64_t const blocks_count = size();
+  for (uint64_t ix = 1; ix <= blocks_count; ++ix) {
+    auto maybe_block = fetch(ix);
+    if (maybe_block) {
+      auto maybe_error = function(std::move(maybe_block).value());
+      if (iroha::expected::hasError(maybe_error)) {
+        return maybe_error.assumeError();
+      }
+    } else {
+      return fmt::format("Failed to fetch block {}", ix);
+    }
+  }
+  return {};
+}

--- a/irohad/ametsuchi/impl/rocksdb_block_storage.hpp
+++ b/irohad/ametsuchi/impl/rocksdb_block_storage.hpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_ROCKSDB_BLOCK_STORAGE_HPP
+#define IROHA_ROCKSDB_BLOCK_STORAGE_HPP
+
+#include "ametsuchi/block_storage.hpp"
+
+#include "interfaces/iroha_internal/block_json_converter.hpp"
+#include "logger/logger_fwd.hpp"
+
+namespace iroha::ametsuchi {
+  struct RocksDBContext;
+
+  class RocksDbBlockStorage : public BlockStorage {
+   public:
+    RocksDbBlockStorage(
+        std::shared_ptr<RocksDBContext> db_context,
+        std::shared_ptr<shared_model::interface::BlockJsonConverter>
+            json_converter,
+        logger::LoggerPtr log);
+
+    bool insert(
+        std::shared_ptr<const shared_model::interface::Block> block) override;
+
+    boost::optional<std::unique_ptr<shared_model::interface::Block>> fetch(
+        shared_model::interface::types::HeightType height) const override;
+
+    size_t size() const override;
+
+    void reload() override;
+
+    void clear() override;
+
+    expected::Result<void, std::string> forEach(
+        FunctionType function) const override;
+
+   private:
+    std::shared_ptr<RocksDBContext> db_context_;
+    std::shared_ptr<shared_model::interface::BlockJsonConverter>
+        json_converter_;
+    logger::LoggerPtr log_;
+  };
+
+}  // namespace iroha::ametsuchi
+
+#endif  // IROHA_ROCKSDB_BLOCK_STORAGE_HPP

--- a/irohad/ametsuchi/impl/rocksdb_block_storage_factory.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_block_storage_factory.cpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/rocksdb_block_storage_factory.hpp"
+
+#include "ametsuchi/impl/rocksdb_block_storage.hpp"
+#include "ametsuchi/impl/rocksdb_common.hpp"
+
+using namespace iroha::ametsuchi;
+
+RocksDbBlockStorageFactory::RocksDbBlockStorageFactory(
+    std::shared_ptr<RocksDBContext> db_context,
+    std::shared_ptr<shared_model::interface::BlockJsonConverter>
+        json_block_converter,
+    logger::LoggerManagerTreePtr log_manager)
+    : db_context_(std::move(db_context)),
+      json_block_converter_(std::move(json_block_converter)),
+      log_manager_(std::move(log_manager)) {}
+
+iroha::expected::Result<std::unique_ptr<BlockStorage>, std::string>
+RocksDbBlockStorageFactory::create() {
+  return std::make_unique<RocksDbBlockStorage>(
+      db_context_,
+      json_block_converter_,
+      log_manager_->getChild("RocksDbBlockFactory")->getLogger());
+}

--- a/irohad/ametsuchi/impl/rocksdb_block_storage_factory.hpp
+++ b/irohad/ametsuchi/impl/rocksdb_block_storage_factory.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_ROCKSDB_BLOCK_STORAGE_FACTORY_HPP
+#define IROHA_ROCKSDB_BLOCK_STORAGE_FACTORY_HPP
+
+#include "ametsuchi/block_storage_factory.hpp"
+
+#include "interfaces/iroha_internal/block_json_converter.hpp"
+#include "logger/logger_manager.hpp"
+
+namespace iroha::ametsuchi {
+  struct RocksDBContext;
+
+  class RocksDbBlockStorageFactory : public BlockStorageFactory {
+   public:
+    RocksDbBlockStorageFactory(
+        std::shared_ptr<RocksDBContext> db_context,
+        std::shared_ptr<shared_model::interface::BlockJsonConverter>
+            json_block_converter,
+        logger::LoggerManagerTreePtr log_manager);
+
+    iroha::expected::Result<std::unique_ptr<BlockStorage>, std::string> create()
+        override;
+
+   private:
+    std::shared_ptr<RocksDBContext> db_context_;
+    std::shared_ptr<shared_model::interface::BlockJsonConverter>
+        json_block_converter_;
+    logger::LoggerManagerTreePtr log_manager_;
+  };
+
+}  // namespace iroha::ametsuchi
+
+#endif  // IROHA_ROCKSDB_BLOCK_STORAGE_FACTORY_HPP

--- a/irohad/ametsuchi/impl/rocksdb_command_executor.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_command_executor.cpp
@@ -752,10 +752,7 @@ RocksDbCommandExecutor::ExecutionResult RocksDbCommandExecutor::operator()(
     bool do_validation,
     shared_model::interface::RolePermissionSet const &creator_permissions) {
   auto const &[account_name, domain_id] = staticSplitId<2>(command.accountId());
-
   auto const revoked_perm = command.permissionName();
-  auto const required_perm =
-      shared_model::interface::permissions::permissionFor(revoked_perm);
 
   if (do_validation) {
     // check if account exists

--- a/test/module/irohad/ametsuchi/CMakeLists.txt
+++ b/test/module/irohad/ametsuchi/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(ametsuchi_test
     ametsuchi_fixture
     common_test_constants
     flat_file_storage
+    rocksdb_block_storage
     shared_model_stateless_validation
     test_logger
     sync_subscription
@@ -157,6 +158,13 @@ target_link_libraries(in_memory_block_storage_test
 
 addtest(flat_file_block_storage_test flat_file_block_storage_test.cpp)
 target_link_libraries(flat_file_block_storage_test
+    ametsuchi
+    test_logger
+    sync_subscription
+    )
+
+addtest(rocksdb_block_storage_test rocksdb_block_storage_test.cpp)
+target_link_libraries(rocksdb_block_storage_test
     ametsuchi
     test_logger
     sync_subscription

--- a/test/module/irohad/ametsuchi/rocksdb_block_storage_test.cpp
+++ b/test/module/irohad/ametsuchi/rocksdb_block_storage_test.cpp
@@ -1,0 +1,202 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ametsuchi/impl/rocksdb_block_storage.hpp"
+#include "ametsuchi/impl/rocksdb_block_storage_factory.hpp"
+
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include "ametsuchi/impl/rocksdb_common.hpp"
+#include "framework/result_gtest_checkers.hpp"
+#include "framework/test_logger.hpp"
+#include "module/shared_model/interface_mocks.hpp"
+
+using namespace iroha::ametsuchi;
+using namespace boost::filesystem;
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+class RocksDbBlockStorageTest : public ::testing::Test {
+ public:
+  RocksDbBlockStorageTest() {
+    ON_CALL(*block_, height()).WillByDefault(Return(height_));
+  }
+
+ protected:
+  void SetUp() override {
+    create_directory(path_provider_());
+  }
+
+  void TearDown() override {
+    remove_all(path_provider_());
+  }
+
+  std::shared_ptr<RocksDBContext> makeContext() {
+    auto db_port = std::make_shared<RocksDBPort>();
+    db_port->initialize(path_provider_());
+    return std::make_shared<RocksDBContext>(db_port);
+  }
+
+  const std::string block_store_path_ =
+      (temp_directory_path() / unique_path()).string();
+
+  std::function<std::string()> path_provider_ = [&]() {
+    return block_store_path_;
+  };
+
+  std::shared_ptr<MockBlockJsonConverter> converter_ =
+      std::make_shared<NiceMock<MockBlockJsonConverter>>();
+  logger::LoggerManagerTreePtr log_manager_ = getTestLoggerManager();
+  std::shared_ptr<MockBlock> block_ = std::make_shared<NiceMock<MockBlock>>();
+  shared_model::interface::types::HeightType height_ = 1;
+};
+
+/**
+ * @given block storage factory
+ * @when create is called
+ * @then block storage is created
+ */
+TEST_F(RocksDbBlockStorageTest, Creation) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create();
+  IROHA_ASSERT_RESULT_VALUE(block_storage);
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when another block with height_ is inserted
+ * @then second insertion fails
+ */
+TEST_F(RocksDbBlockStorageTest, Insert) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  ASSERT_TRUE(block_storage->insert(block_));
+  ASSERT_FALSE(block_storage->insert(block_));
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when block with height_ is fetched
+ * @then it is returned
+ */
+TEST_F(RocksDbBlockStorageTest, FetchExisting) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  ASSERT_TRUE(block_storage->insert(block_));
+
+  shared_model::interface::Block *raw_block;
+
+  EXPECT_CALL(*converter_, deserialize(_))
+      .WillOnce(Invoke([&](const shared_model::interface::types::JsonType &)
+                           -> iroha::expected::Result<
+                               std::unique_ptr<shared_model::interface::Block>,
+                               std::string> {
+        auto return_block = std::make_unique<MockBlock>();
+        raw_block = return_block.get();
+        return iroha::expected::makeValue<
+            std::unique_ptr<shared_model::interface::Block>>(
+            std::move(return_block));
+      }));
+  std::shared_ptr<const shared_model::interface::Block> block_var =
+      *(block_storage->fetch(height_));
+
+  ASSERT_EQ(raw_block, block_var.get());
+}
+
+/**
+ * @given initialized block storage without blocks
+ * @when block with height_ is fetched
+ * @then nothing is returned
+ */
+TEST_F(RocksDbBlockStorageTest, FetchNonexistent) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  auto block_var = block_storage->fetch(height_);
+  ASSERT_FALSE(block_var);
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when size is fetched
+ * @then 1 is returned
+ */
+TEST_F(RocksDbBlockStorageTest, Size) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  ASSERT_TRUE(block_storage->insert(block_));
+
+  ASSERT_EQ(1, block_storage->size());
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when storage is cleared with clear
+ * @then no blocks are left in storage
+ */
+TEST_F(RocksDbBlockStorageTest, Clear) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  ASSERT_TRUE(block_storage->insert(block_));
+
+  block_storage->clear();
+
+  auto block_var = block_storage->fetch(height_);
+
+  ASSERT_FALSE(block_var);
+}
+
+/**
+ * @given initialized block storage, single block with height_ inserted
+ * @when forEach is called
+ * @then block with height_ is visited, lambda is invoked once
+ */
+TEST_F(RocksDbBlockStorageTest, ForEach) {
+  auto block_storage =
+      RocksDbBlockStorageFactory(makeContext(), converter_, log_manager_)
+          .create()
+          .assumeValue();
+  ASSERT_TRUE(block_storage->insert(block_));
+
+  shared_model::interface::Block *raw_block;
+
+  EXPECT_CALL(*converter_, deserialize(_))
+      .WillOnce(Invoke([&](const shared_model::interface::types::JsonType &)
+                           -> iroha::expected::Result<
+                               std::unique_ptr<shared_model::interface::Block>,
+                               std::string> {
+        auto return_block = std::make_unique<MockBlock>();
+        raw_block = return_block.get();
+        return iroha::expected::makeValue<
+            std::unique_ptr<shared_model::interface::Block>>(
+            std::move(return_block));
+      }));
+
+  size_t count = 0;
+
+  block_storage->forEach([&count, &raw_block](const auto &block)
+                             -> iroha::expected::Result<void, std::string> {
+    [&] {
+      ++count;
+      ASSERT_EQ(raw_block, block.get());
+    }();
+    return {};
+  });
+
+  ASSERT_EQ(1, count);
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Adds block store based on ```RocksDB```.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
