### PR TITLE
Feature/[RDB] cache

### DIFF
--- a/irohad/ametsuchi/impl/database_cache/cache.hpp
+++ b/irohad/ametsuchi/impl/database_cache/cache.hpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AMETSUCHI_DATABASE_CACHE_HPP
+#define AMETSUCHI_DATABASE_CACHE_HPP
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "common/common.hpp"
+#include "common/radix_tree.hpp"
+
+namespace iroha::ametsuchi {
+
+  template <typename Type>
+  class DatabaseCache {
+    using CachebleSetType = std::vector<std::string>;
+
+    CachebleSetType cacheable_paths_;
+    std::unique_ptr<iroha::RadixTree<Type>> cache_;
+
+    auto cachebleSearch(std::string_view key) const {
+      auto it = std::lower_bound(
+          cacheable_paths_.begin(), cacheable_paths_.end(), key);
+      return it != cacheable_paths_.begin() ? --it : it;
+    }
+
+   public:
+    DatabaseCache(DatabaseCache const &) = delete;
+    DatabaseCache &operator=(DatabaseCache const &) = delete;
+
+    DatabaseCache() {
+      drop();
+    }
+
+    void addCacheblePath(std::string const &path) {
+      auto it = cachebleSearch(path);
+      auto insert = [&]() {
+        cacheable_paths_.emplace_back(path);
+        std::sort(cacheable_paths_.begin(), cacheable_paths_.end());
+      };
+
+      if (it == cacheable_paths_.end())
+        insert();
+      else if (it->find(path) == 0ull) {
+        cacheable_paths_.erase(it);
+        insert();
+      } else if (path.find(*it) != 0ull)
+        insert();
+    }
+
+    bool isCacheable(std::string_view key) const {
+      auto it = cachebleSearch(key);
+      return (key.find(*it) == 0ull);
+    }
+
+    template <typename Func>
+    bool get(std::string_view key, Func &&func) {
+      if (auto *ptr = cache_->find(key.data(), key.size()))
+        return std::forward<Func>(func)(*ptr);
+      return false;
+    }
+
+    void set(std::string_view key, std::string_view const &value) {
+      cache_->template insert(key.data(), key.size(), value);
+    }
+
+    auto erase(std::string_view key) {
+      return cache_->erase(key.data(), key.size());
+    }
+
+    auto filterDelete(std::string_view key) {
+      return cache_->filterDelete(key.data(), key.size());
+    }
+
+    void drop() {
+      cache_ = std::make_unique<iroha::RadixTree<Type>>();
+    }
+  };
+
+}  // namespace iroha::ametsuchi
+
+#endif  // AMETSUCHI_DATABASE_CACHE_HPP

--- a/irohad/ametsuchi/impl/rocksdb_common.hpp
+++ b/irohad/ametsuchi/impl/rocksdb_common.hpp
@@ -16,6 +16,7 @@
 #include <rocksdb/db.h>
 #include <rocksdb/utilities/optimistic_transaction_db.h>
 #include <rocksdb/utilities/transaction.h>
+#include "ametsuchi/impl/database_cache/cache.hpp"
 #include "ametsuchi/impl/executor_common.hpp"
 #include "common/irohad_version.hpp"
 #include "common/result.hpp"
@@ -376,7 +377,6 @@ namespace iroha::ametsuchi::fmtstrings {
 
 }  // namespace iroha::ametsuchi::fmtstrings
 
-
 namespace {
   auto constexpr kValue{FMT_STRING("{}")};
 }
@@ -393,8 +393,10 @@ namespace iroha::ametsuchi {
     RocksDBContext(RocksDBContext const &) = delete;
     RocksDBContext &operator=(RocksDBContext const &) = delete;
 
-    explicit RocksDBContext(std::shared_ptr<RocksDBPort> dbp)
-        : db_port(std::move(dbp)) {
+    explicit RocksDBContext(
+        std::shared_ptr<RocksDBPort> dbp,
+        std::shared_ptr<DatabaseCache<std::string>> cache = nullptr)
+        : cache_(std::move(cache)), db_port(std::move(dbp)) {
       assert(db_port);
     }
 
@@ -411,6 +413,9 @@ namespace iroha::ametsuchi {
     /// Buffer for value data
     std::string value_buffer;
 
+    /// Cache with extra loaded values
+    std::shared_ptr<DatabaseCache<std::string>> cache_;
+
     /// Database port
     std::shared_ptr<RocksDBPort> db_port;
 
@@ -419,12 +424,10 @@ namespace iroha::ametsuchi {
   };
 
   enum DbErrorCode {
-    kOk = 0,
     kErrorNoPermissions = 2,
     kNotFound = 3,
     kNoAccount = 3,
     kMustNotExist = 4,
-    kNoRoles = 4,
     kInvalidPagination = 4,
     kInvalidStatus = 12,
     kInitializeFailed = 15,
@@ -550,6 +553,10 @@ namespace iroha::ametsuchi {
       return tx_context_->transaction;
     }
 
+    auto &cache() {
+      return tx_context_->cache_;
+    }
+
     [[nodiscard]] bool isTransaction() const {
       return tx_context_->transaction != nullptr;
     }
@@ -562,8 +569,10 @@ namespace iroha::ametsuchi {
       if (!it->status().ok())
         return it->status();
 
-      static_assert(std::is_convertible_v<std::result_of_t<F&(decltype(it),size_t)>, bool>,
-                    "Required F(unique_ptr<rocksdb::Iterator>,size_t) -> bool");
+      static_assert(
+          std::is_convertible_v<std::result_of_t<F &(decltype(it), size_t)>,
+                                bool>,
+          "Required F(unique_ptr<rocksdb::Iterator>,size_t) -> bool");
 
       rocksdb::Slice const key(keyBuffer().data(), keyBuffer().size());
       for (; it->Valid() && it->key().starts_with(key); it->Next())
@@ -571,6 +580,16 @@ namespace iroha::ametsuchi {
           break;
 
       return it->status();
+    }
+
+    void storeInCache(std::string_view key) {
+      if (auto c = cache(); c && c->isCacheable(key))
+        c->set(key, valueBuffer());
+    }
+
+    void dropCache() {
+      if (auto c = cache())
+        c->drop();
     }
 
    public:
@@ -590,6 +609,7 @@ namespace iroha::ametsuchi {
       if (isTransaction())
         status = transaction()->Rollback();
 
+      dropCache();
       transaction().reset();
       return status;
     }
@@ -613,6 +633,8 @@ namespace iroha::ametsuchi {
     void skip() {
       if (isTransaction())
         transaction().reset();
+
+      dropCache();
     }
 
     /// Saves current state of a transaction
@@ -626,6 +648,8 @@ namespace iroha::ametsuchi {
       rocksdb::Status status;
       if (isTransaction())
         status = transaction()->RollbackToSavePoint();
+
+      dropCache();
       return status;
     }
 
@@ -649,10 +673,22 @@ namespace iroha::ametsuchi {
       fmt::format_to(keyBuffer(), fmtstring, std::forward<Args>(args)...);
 
       valueBuffer().clear();
-      return transaction()->Get(
-          rocksdb::ReadOptions(),
-          rocksdb::Slice(keyBuffer().data(), keyBuffer().size()),
-          &valueBuffer());
+      rocksdb::Slice const slice(keyBuffer().data(), keyBuffer().size());
+
+      if (auto c = cache(); c && c->isCacheable(slice.ToStringView())
+          && c->get(slice.ToStringView(), [&](auto const &str) {
+               valueBuffer() = str;
+               return true;
+             })) {
+        return rocksdb::Status();
+      }
+
+      auto status =
+          transaction()->Get(rocksdb::ReadOptions(), slice, &valueBuffer());
+      if (status.ok())
+        storeInCache(slice.ToStringView());
+
+      return status;
     }
 
     /// Put data from @see valueBuffer to database
@@ -661,9 +697,13 @@ namespace iroha::ametsuchi {
       keyBuffer().clear();
       fmt::format_to(keyBuffer(), fmtstring, std::forward<Args>(args)...);
 
-      return transaction()->Put(
-          rocksdb::Slice(keyBuffer().data(), keyBuffer().size()),
-          valueBuffer());
+      rocksdb::Slice const slice(keyBuffer().data(), keyBuffer().size());
+      auto status = transaction()->Put(slice, valueBuffer());
+
+      if (status.ok())
+        storeInCache(slice.ToStringView());
+
+      return status;
     }
 
     /// Delete database entry by the key
@@ -672,8 +712,11 @@ namespace iroha::ametsuchi {
       keyBuffer().clear();
       fmt::format_to(keyBuffer(), fmtstring, std::forward<Args>(args)...);
 
-      return transaction()->Delete(
-          rocksdb::Slice(keyBuffer().data(), keyBuffer().size()));
+      rocksdb::Slice const slice(keyBuffer().data(), keyBuffer().size());
+      if (auto c = cache(); c && c->isCacheable(slice.ToStringView()))
+        c->erase(slice.ToStringView());
+
+      return transaction()->Delete(slice);
     }
 
     /// Searches for the first key that matches a prefix
@@ -717,6 +760,9 @@ namespace iroha::ametsuchi {
         return it->status();
 
       rocksdb::Slice const key(keyBuffer().data(), keyBuffer().size());
+      if (auto c = cache(); c && c->isCacheable(key.ToStringView()))
+        c->filterDelete(key.ToStringView());
+
       for (; it->Valid() && it->key().starts_with(key); it->Next())
         if (auto status = transaction()->Delete(it->key()); !status.ok())
           return status;
@@ -757,8 +803,9 @@ namespace iroha::ametsuchi {
                             F &&func,
                             S const &strformat,
                             Args &&... args) {
-    static_assert(std::is_convertible_v<std::result_of_t<F&(rocksdb::Slice)>, bool>,
-                  "Must F(rocksdb::Slice) -> bool");
+    static_assert(
+        std::is_convertible_v<std::result_of_t<F &(rocksdb::Slice)>, bool>,
+        "Must F(rocksdb::Slice) -> bool");
     return rdb.enumerate(
         [func{std::forward<F>(func)}](auto const &it,
                                       auto const prefix_size) mutable {
@@ -1019,7 +1066,7 @@ namespace iroha::ametsuchi {
             typename T,
             typename = std::enable_if_t<std::is_same<T, bool>::value>>
   inline std::optional<bool> loadValue(
-      RocksDbCommon&,
+      RocksDbCommon &,
       expected::Result<rocksdb::Status, DbError> const &status) {
     std::optional<bool> value;
     if constexpr (kOp == kDbOperation::kGet) {

--- a/irohad/main/application.cpp
+++ b/irohad/main/application.cpp
@@ -324,8 +324,15 @@ Irohad::RunResult Irohad::initStorage(
           rdb_port,
           RdbConnectionInit::init(
               startup_wsv_data_policy, *rdb_opt_, log_manager_));
-      db_context_ =
-          std::make_shared<ametsuchi::RocksDBContext>(std::move(rdb_port));
+
+      auto cache = std::make_shared<DatabaseCache<std::string>>();
+      cache->addCacheblePath(RDB_ROOT /**/ RDB_WSV /**/ RDB_NETWORK);
+      cache->addCacheblePath(RDB_ROOT /**/ RDB_WSV /**/ RDB_SETTINGS);
+      cache->addCacheblePath(RDB_ROOT /**/ RDB_WSV /**/ RDB_ROLES);
+      cache->addCacheblePath(RDB_ROOT /**/ RDB_WSV /**/ RDB_DOMAIN);
+
+      db_context_ = std::make_shared<ametsuchi::RocksDBContext>(
+          std::move(rdb_port), std::move(cache));
     } break;
 
     default:

--- a/libs/common/radix_tree.hpp
+++ b/libs/common/radix_tree.hpp
@@ -1,0 +1,415 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_RADIX_TREE_HPP
+#define IROHA_RADIX_TREE_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace iroha {
+
+  /**
+   * Determines the permitted symbols
+   * [0-9]
+   * [A-Z]
+   * [a-z]
+   * /
+   * #
+   * @
+   */
+  struct Alphabet {
+    static constexpr uint32_t f0 = 'z' - '_' + 1ul;
+    static constexpr uint32_t f1 = '9' - '.' + 1ul;
+    static constexpr uint32_t f2 = 'Z' - '@' + 1ul;
+
+    static uint32_t position(char d) {
+      assert((d >= '_' && d <= 'z') || (d >= '.' && d <= '9')
+             || (d >= '@' && d <= 'Z') || d == '#');
+
+      return ((uint32_t)d - uint32_t('_')) < f0
+          ? uint32_t(d) - uint32_t('_')
+          : ((uint32_t)d - uint32_t('.')) < f1
+              ? uint32_t(d) - uint32_t('.') + f0
+              : ((uint32_t)d - uint32_t('@')) < f2
+                  ? uint32_t(d) - uint32_t('@') + f0 + f1
+                  : d == '#' ? f2 + f1 + f0 : (uint32_t)-1;
+    }
+
+    static constexpr uint32_t size() {
+      return f2 + f1 + f0 + 1ul;
+    }
+  };
+
+  template <typename Type,
+            typename AlphabetT = Alphabet,
+            typename CharT = char,
+            uint32_t KeySz = 16ul,
+            typename AllocT = std::allocator<void>>
+  class RadixTree {
+    struct NodeContext {
+      NodeContext *parent;
+      NodeContext *children[AlphabetT::size()];
+      CharT key[KeySz];
+      uint32_t children_count;
+      uint32_t key_sz;
+
+      NodeContext() : parent(nullptr), children_count(0ul), key_sz(0ul) {
+        std::memset(key, 0, sizeof(key));
+        std::memset(children, 0, sizeof(children));
+      }
+    };
+    struct Node {
+      NodeContext context;
+      std::optional<Type> data;
+
+      template <typename... Args>
+      explicit Node(Args &&... args) : data(std::forward<Args>(args)...) {}
+    };
+    static_assert(offsetof(Node, context) == 0ul,
+                  "Context must be with 0 offset.");
+    using Alloc =
+        typename std::allocator_traits<AllocT>::template rebind_alloc<Node>;
+
+    mutable NodeContext root_;
+    Alloc alloc_;
+
+    template <typename... Args>
+    Node *allocate(Args &&... args) {
+      auto ptr = (Node *)alloc_.allocate(1);
+      return new (ptr) Node(std::forward<Args>(args)...);
+    }
+
+    void deallocate(Node *node) {
+      node->~Node();
+      alloc_.deallocate(node, 1);
+    }
+
+    template <typename... Args>
+    Node *create(CharT const *key, uint32_t len, Args &&... args) {
+      Node *const created = allocate(std::forward<Args>(args)...);
+      memcpy(created->context.key, key, len * sizeof(CharT));
+      created->context.key_sz = len;
+      return created;
+    }
+
+    template <typename... Args>
+    Node *reinit(Node *const what, Args &&... args) const {
+      what->data.template emplace(std::forward<Args>(args)...);
+      return what;
+    }
+
+    NodeContext *&getFromKey(NodeContext *const parent,
+                             CharT const *key) const {
+      return parent->children[AlphabetT::position(key[0ul])];
+    }
+
+    NodeContext *&getFromKey(Node *const parent, CharT const *key) const {
+      return getFromKey(nodeToNodeContext(parent), key);
+    }
+
+    void chain(NodeContext *const what, NodeContext *const parent) {
+      assert(what->key_sz != 0ul);
+      getFromKey(parent, what->key) = what;
+      what->parent = parent;
+    }
+
+    void unchain(NodeContext *const what) {
+      assert(what->children_count == 0ul);
+
+      assert(what->key_sz != 0ul);
+      getFromKey(what->parent, what->key) = nullptr;
+
+      assert(what->parent->children_count > 0ul);
+      --what->parent->children_count;
+    }
+
+    void chain(Node *const what, Node *const where) {
+      chain(nodeToNodeContext(what), nodeToNodeContext(where));
+    }
+
+    void chain(NodeContext *const what, Node *const where) {
+      chain(what, nodeToNodeContext(where));
+    }
+
+    void chain(Node *const what, NodeContext *const where) {
+      chain(nodeToNodeContext(what), where);
+    }
+
+    void adjustKey(CharT const *&key,
+                   CharT const *const end,
+                   CharT const *&target,
+                   CharT const *const target_end) const {
+      while (key != end && target != target_end && *key == *target) {
+        ++key;
+        ++target;
+      }
+    }
+
+    struct SearchContext {
+      NodeContext *node;
+
+      char const *prefix_remains;
+      uint32_t prefix_remains_len;
+
+      char const *target;
+      char const *target_begin;
+      char const *target_end;
+    };
+
+    void findNearest(NodeContext *const from,
+                     CharT const *&key,
+                     uint32_t len,
+                     SearchContext &sc) const {
+      CharT const *const end = key + len;
+      sc.node = from;
+      sc.target = nullptr;
+      sc.target_end = nullptr;
+      sc.target_begin = nullptr;
+
+      while (key != end)
+        if (NodeContext *child = getFromKey(sc.node, key)) {
+          sc.target = child->key;
+          sc.target_begin = child->key;
+          sc.target_end = child->key + child->key_sz;
+          if (adjustKey(key, end, sc.target, sc.target_end);
+              0ul == sc.target_end - sc.target)
+            sc.node = child;
+          else
+            break;
+        } else
+          break;
+
+      sc.prefix_remains = key;
+      sc.prefix_remains_len = end - key;
+    }
+
+    Node *nodeContextToNode(NodeContext *const context) const {
+      assert(context != &root_);
+      return (Node *)context;
+    }
+
+    NodeContext *nodeToNodeContext(Node *const node) const {
+      return &node->context;
+    }
+
+    NodeContext *getFirstChild(NodeContext const *const from) {
+      assert(from->children_count != 0ul);
+      for (auto &child : from->children)
+        if (child != nullptr)
+          return child;
+      return nullptr;
+    }
+
+    bool compress(NodeContext *const parent,
+                  NodeContext *const target,
+                  NodeContext *const child) {
+      if (child->key_sz + target->key_sz <= KeySz) {
+        CharT tmp[KeySz];
+        std::memcpy(tmp, target->key, target->key_sz * sizeof(CharT));
+        std::memcpy(
+            tmp + target->key_sz, child->key, child->key_sz * sizeof(CharT));
+        std::memcpy(
+            child->key, tmp, (target->key_sz + child->key_sz) * sizeof(CharT));
+        child->key_sz += target->key_sz;
+        chain(child, parent);
+        child->parent = parent;
+        deallocate(nodeContextToNode(target));
+        return true;
+      }
+      return false;
+    }
+
+    void tryCompressDown(NodeContext *const target) {
+      if (target != &root_ && !nodeContextToNode(target)->data
+          && target->children_count == 1ull
+          && compress(target->parent, target, getFirstChild(target))) {
+      }
+    }
+
+    void tryCompressUp(NodeContext *const child) {
+      while (child->parent && child->parent != &root_
+             && child->parent->children_count == 1ull
+             && !nodeContextToNode(child->parent)->data
+             && compress(child->parent->parent, child->parent, child))
+        ;
+    }
+
+    template <typename... Args>
+    NodeContext *breakPath(NodeContext *const parent,
+                           CharT const *target_key,
+                           uint32_t middle_key_len,
+                           uint32_t target_key_len,
+                           Args &&... args) {
+      assert(middle_key_len < target_key_len);
+
+      Node *const middle =
+          create(target_key, middle_key_len, std::forward<Args>(args)...);
+
+      NodeContext *const target = getFromKey(parent, target_key);
+      std::memcpy(target->key,
+                  target->key + middle_key_len,
+                  (target->key_sz - middle_key_len) * sizeof(CharT));
+
+      target->key_sz -= middle_key_len;
+      chain(target, middle);
+      chain(middle, parent);
+
+      ++middle->context.children_count;
+      tryCompressDown(target);
+
+      return nodeToNodeContext(middle);
+    }
+
+    template <typename... Args>
+    NodeContext *processLeaf(SearchContext const &context, Args &&... args) {
+      Node *const created = create(context.prefix_remains,
+                                   std::min(context.prefix_remains_len, KeySz),
+                                   std::forward<Args>(args)...);
+      chain(&created->context, context.node);
+      ++context.node->children_count;
+
+      return nodeToNodeContext(created);
+    }
+
+    template <typename... Args>
+    NodeContext *processMiddle(SearchContext const &context, Args &&... args) {
+      return breakPath(context.node,
+                       context.target_begin,
+                       context.target - context.target_begin,
+                       context.target_end - context.target_begin,
+                       std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    NodeContext *processBranch(SearchContext const &context, Args &&... args) {
+      NodeContext *const base =
+          breakPath(context.node,
+                    context.target_begin,
+                    context.target - context.target_begin,
+                    context.target_end - context.target_begin,
+                    std::nullopt);
+
+      Node *const created = create(context.prefix_remains,
+                                   std::min(context.prefix_remains_len, KeySz),
+                                   std::forward<Args>(args)...);
+
+      chain(created, base);
+      ++base->children_count;
+
+      tryCompressUp(base);
+      return nodeToNodeContext(created);
+    }
+
+    NodeContext *safeDelete(NodeContext *node) {
+      NodeContext *const parent = node->parent;
+      unchain(node);
+      deallocate(nodeContextToNode(node));
+      return parent;
+    }
+
+    void eraseWithChildren(NodeContext *const from) {
+      NodeContext *node = from;
+      NodeContext *parent = from->parent;
+      while (node != parent)
+        node = (node->children_count != 0ul)
+            ? getFirstChild(node)
+            : (node != &root_) ? safeDelete(node) : node->parent;
+
+      if (node && node != &root_) {
+        while (canSafeDelete(node)) node = safeDelete(node);
+        tryCompressUp(node);
+        tryCompressDown(node);
+      }
+    }
+
+    bool canSafeDelete(NodeContext *node) {
+      return node != &root_ && node->children_count == 0ull
+          && !nodeContextToNode(node)->data;
+    }
+
+   public:
+    RadixTree() = default;
+    explicit RadixTree(AllocT &alloc) : alloc_(alloc) {}
+
+    ~RadixTree() {
+      eraseWithChildren(&root_);
+    }
+
+    template <typename... Args>
+    void insert(CharT const *key, uint32_t len, Args &&... args) {
+      SearchContext context;
+      NodeContext *from = &root_;
+      CharT const *const end = key + len;
+
+      do {
+        findNearest(from, key, end - key, context);
+        auto const target_remains_len = context.target_end - context.target;
+
+        from = (context.prefix_remains_len == 0ul && target_remains_len == 0ul)
+            ? context.node
+            : (target_remains_len == 0ull) ? processLeaf(context, std::nullopt)
+                                           : (context.prefix_remains_len == 0ul)
+                    ? processMiddle(context, std::nullopt)
+                    : processBranch(context, std::nullopt);
+
+        key += std::min(context.prefix_remains_len, KeySz);
+      } while (key != end);
+
+      reinit(nodeContextToNode(from), std::forward<Args>(args)...);
+    }
+
+    Type *find(CharT const *key, uint32_t len) const {
+      SearchContext context;
+      findNearest(&root_, key, len, context);
+      auto const target_remains_len = context.target_end - context.target;
+
+      if (context.prefix_remains_len == 0ul && target_remains_len == 0ul)
+        if (Node *const node = nodeContextToNode(context.node); node->data)
+          return &(*node->data);
+
+      return nullptr;
+    }
+
+    uint32_t erase(CharT const *key, uint32_t len) {
+      SearchContext context;
+      findNearest(&root_, key, len, context);
+
+      auto const target_remains_len = context.target_end - context.target;
+      if (context.prefix_remains_len == 0ul && target_remains_len == 0ul) {
+        NodeContext *node = context.node;
+        uint32_t const result = nodeContextToNode(node)->data ? 1ull : 0ull;
+        if (node->children_count)
+          nodeContextToNode(node)->data.reset();
+        else
+          do {
+            node = safeDelete(node);
+          } while (canSafeDelete(node));
+
+        tryCompressUp(node);
+        tryCompressDown(node);
+        return result;
+      }
+      return 0ul;
+    }
+
+    void filterDelete(CharT const *key, uint32_t len) {
+      SearchContext context;
+      findNearest(&root_, key, len, context);
+
+      if (context.prefix_remains_len == 0ul) {
+        auto const target_remains_len = context.target_end - context.target;
+        if (target_remains_len == 0ul)
+          eraseWithChildren(context.node);
+        else
+          eraseWithChildren(getFromKey(context.node, context.target_begin));
+      }
+    }
+  };
+
+}  // namespace iroha
+#endif  // IROHA_RADIX_TREE_HPP

--- a/test/module/irohad/ametsuchi/rocksdb_common_test.cpp
+++ b/test/module/irohad/ametsuchi/rocksdb_common_test.cpp
@@ -4,11 +4,27 @@
  */
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
+#include <iostream>
 
+#include "ametsuchi/impl/database_cache/cache.hpp"
 #include "ametsuchi/impl/rocksdb_common.hpp"
+#include "common/radix_tree.hpp"
 
 namespace fs = boost::filesystem;
 using namespace iroha::ametsuchi;
+
+struct QQQ {
+  std::string s;
+  QQQ(std::string const &p) : s(p) {
+    std::cout << "CTOR" << std::endl;
+  }
+  QQQ(char const *p) : s(p) {
+    std::cout << "CTOR" << std::endl;
+  }
+  ~QQQ() {
+    std::cout << "~CTOR" << std::endl;
+  }
+};
 
 class RocksDBTest : public ::testing::Test {
  public:
@@ -16,7 +32,10 @@ class RocksDBTest : public ::testing::Test {
     db_name_ = (fs::temp_directory_path() / fs::unique_path()).string();
     db_port_ = std::make_shared<RocksDBPort>();
     db_port_->initialize(db_name_);
-    tx_context_ = std::make_shared<RocksDBContext>(db_port_);
+
+    auto dbc = std::make_shared<DatabaseCache<std::string>>();
+    dbc->addCacheblePath("k");
+    tx_context_ = std::make_shared<RocksDBContext>(db_port_, dbc);
 
     insertDb(key1_, value1_);
     insertDb(key2_, value2_);
@@ -60,6 +79,209 @@ class RocksDBTest : public ::testing::Test {
   std::string const value4_ = "vaLUe4";
   std::string const value5_ = "vaLUe5";
 };
+
+TEST_F(RocksDBTest, DatabaseCacheTest) {
+  iroha::ametsuchi::DatabaseCache<std::string> dbc;
+  dbc.addCacheblePath("wSc");
+  dbc.addCacheblePath("wScq");
+  dbc.addCacheblePath("bps");
+  dbc.addCacheblePath("bps");
+  dbc.addCacheblePath("bpsQ");
+  dbc.addCacheblePath("bpsQ0");
+  dbc.addCacheblePath("bpm");
+
+  dbc.addCacheblePath("12");
+  dbc.addCacheblePath("1");
+
+  std::string src[] = {"bps1", "1jg", "0pp", "2"};
+
+  {
+    size_t counter = 0ull;
+    for (auto &s : src)
+      if (dbc.isCacheable(s)) {
+        dbc.set(s, s + "_value");
+        ++counter;
+      }
+    ASSERT_EQ(counter, 2ull);
+  }
+
+  auto check = [](auto const &str1, auto const &str2) {
+    ASSERT_EQ(str1, str2);
+  };
+
+  size_t counter = 0ull;
+  for (auto &s : src)
+    if (dbc.get(s, [&](auto const &str) {
+          check(str, s + "_value");
+          return true;
+        }))
+      ++counter;
+  ASSERT_EQ(counter, 2ull);
+}
+
+TEST_F(RocksDBTest, RadixTreeTest) {
+  iroha::RadixTree<QQQ, iroha::Alphabet, char, 2ul> rt;
+
+  rt.insert("123", 3, "d");
+  rt.filterDelete("12", 2);
+  ASSERT_TRUE(rt.find("1", 1) == nullptr);
+  ASSERT_TRUE(rt.find("12", 2) == nullptr);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+
+  rt.insert("123", 3, "d");
+  rt.filterDelete("1", 1);
+  ASSERT_TRUE(rt.find("1", 1) == nullptr);
+  ASSERT_TRUE(rt.find("12", 2) == nullptr);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+
+  rt.insert("123", 3, "d");
+  rt.filterDelete("123", 3);
+  ASSERT_TRUE(rt.find("1", 1) == nullptr);
+  ASSERT_TRUE(rt.find("12", 2) == nullptr);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+
+  rt.insert("123", 3, "q");
+  rt.filterDelete("1234", 4);
+  ASSERT_TRUE(rt.find("1", 1) == nullptr);
+  ASSERT_TRUE(rt.find("12", 2) == nullptr);
+  ASSERT_TRUE(rt.find("123", 3)->s == "q");
+
+  rt.insert("123", 3, "q");
+  rt.insert("11", 2, "1");
+  rt.filterDelete("12", 2);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+  ASSERT_TRUE(rt.find("11", 2)->s == "1");
+
+  rt.insert("123", 3, "q");
+  rt.insert("11", 2, "1");
+  rt.filterDelete("1", 1);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+  ASSERT_TRUE(rt.find("11", 2) == nullptr);
+
+  rt.insert("123", 3, "q");
+  rt.insert("11", 2, "1");
+  rt.insert("124", 3, "d");
+
+  rt.filterDelete("123", 3);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+  ASSERT_TRUE(rt.find("124", 3)->s == "d");
+  ASSERT_TRUE(rt.find("11", 2)->s == "1");
+
+  rt.filterDelete("12", 2);
+  ASSERT_TRUE(rt.find("123", 3) == nullptr);
+  ASSERT_TRUE(rt.find("124", 3) == nullptr);
+  ASSERT_TRUE(rt.find("11", 2)->s == "1");
+
+  rt.insert("7123", 4, "d");
+  rt.insert("711", 3, "q");
+  rt.insert("7124", 4, "a");
+
+  ASSERT_TRUE(rt.find("7123", 4)->s == "d");
+  ASSERT_TRUE(rt.find("711", 3)->s == "q");
+  ASSERT_TRUE(rt.find("7124", 4)->s == "a");
+  ASSERT_TRUE(rt.find("7", 1) == nullptr);
+  ASSERT_TRUE(rt.find("71", 2) == nullptr);
+  ASSERT_TRUE(rt.find("72", 2) == nullptr);
+
+  ASSERT_EQ(rt.erase("7123", 4), 1ull);
+  ASSERT_TRUE(rt.find("7123", 4) == nullptr);
+  ASSERT_TRUE(rt.find("711", 3)->s == "q");
+  ASSERT_TRUE(rt.find("7124", 4)->s == "a");
+
+  ASSERT_EQ(rt.erase("7124", 4), 1ull);
+  ASSERT_TRUE(rt.find("711", 3)->s == "q");
+  ASSERT_TRUE(rt.find("7124", 4) == nullptr);
+
+  ASSERT_EQ(rt.erase("7123", 4), 0ull);
+  ASSERT_TRUE(rt.find("711", 3)->s == "q");
+  ASSERT_TRUE(rt.find("7123", 4) == nullptr);
+
+  ASSERT_EQ(rt.erase("711", 3), 1ull);
+  ASSERT_TRUE(rt.find("711", 3) == nullptr);
+
+  rt.insert("1345", 4, "l");
+  rt.insert("1346", 4, "lll");
+  rt.insert("1444", 4, "ll");
+
+  ASSERT_TRUE(rt.find("1345", 4)->s == "l");
+  ASSERT_TRUE(rt.find("1346", 4)->s == "lll");
+  ASSERT_TRUE(rt.find("1444", 4)->s == "ll");
+
+  rt.insert("1444", 4, "dd");
+  ASSERT_TRUE(rt.find("1444", 4)->s == "dd");
+
+  ASSERT_EQ(rt.erase("1444", 4), 1ull);
+  ASSERT_TRUE(rt.find("1444", 4) == nullptr);
+
+  rt.insert("1444", 4, "m");
+  ASSERT_TRUE(rt.find("1444", 4)->s == "m");
+  ASSERT_TRUE(rt.find("1345", 4)->s == "l");
+  ASSERT_TRUE(rt.find("1346", 4)->s == "lll");
+
+  rt.insert("1100123", 7, "123");
+  ASSERT_TRUE(rt.find("1100123", 7)->s == "123");
+
+  ASSERT_EQ(rt.erase("110", 3), 0ull);
+  ASSERT_TRUE(rt.find("110", 3) == nullptr);
+  ASSERT_TRUE(rt.find("1100123", 7)->s == "123");
+
+  rt.insert("1100123456", 10, "123456");
+  rt.insert("110012345", 9, "12345");
+  rt.insert("11001234567", 11, "1234567");
+  rt.insert("1100123455", 10, "123455");
+  rt.insert("1100123456", 10, "111");
+  rt.insert("1100120", 7, "120");
+  rt.insert("0011890", 7, "890");
+  rt.insert("0011897", 7, "897");
+  rt.insert("00118", 5, "8");
+
+  ASSERT_TRUE(rt.find("1100123456", 10)->s == "111");
+  ASSERT_TRUE(rt.find("110012345", 9)->s == "12345");
+  ASSERT_TRUE(rt.find("11001234567", 11)->s == "1234567");
+  ASSERT_TRUE(rt.find("1100123455", 10)->s == "123455");
+  ASSERT_TRUE(rt.find("1100120", 7)->s == "120");
+  ASSERT_TRUE(rt.find("0011890", 7)->s == "890");
+  ASSERT_TRUE(rt.find("0011897", 7)->s == "897");
+  ASSERT_TRUE(rt.find("00118", 5)->s == "8");
+
+  ASSERT_EQ(rt.erase("1100123456", 10), 1ull);
+  ASSERT_EQ(rt.erase("11001234567", 11), 1ull);
+  ASSERT_EQ(rt.erase("1100120", 7), 1ull);
+  ASSERT_EQ(rt.erase("0011890", 7), 1ull);
+  ASSERT_EQ(rt.erase("1100sg3456", 10), 0ull);
+  ASSERT_EQ(rt.erase("1103242556#", 11), 0ull);
+  ASSERT_EQ(rt.erase("1d100120", 8), 0ull);
+  ASSERT_EQ(rt.erase("1100123456", 10), 0ull);
+  ASSERT_EQ(rt.erase("11001234567", 11), 0ull);
+  ASSERT_EQ(rt.erase("1100120", 7), 0ull);
+
+  ASSERT_TRUE(rt.find("1100123456", 10) == nullptr);
+  ASSERT_TRUE(rt.find("11001234567", 11) == nullptr);
+  ASSERT_TRUE(rt.find("1100120", 7) == nullptr);
+  ASSERT_TRUE(rt.find("0011890", 7) == nullptr);
+  ASSERT_TRUE(rt.find("110012345", 9)->s == "12345");
+  ASSERT_TRUE(rt.find("1100123455", 10)->s == "123455");
+  ASSERT_TRUE(rt.find("0011897", 7)->s == "897");
+  ASSERT_TRUE(rt.find("00118", 5)->s == "8");
+  ASSERT_TRUE(rt.find("1444", 4)->s == "m");
+  ASSERT_TRUE(rt.find("1345", 4)->s == "l");
+  ASSERT_TRUE(rt.find("1346", 4)->s == "lll");
+  ASSERT_TRUE(rt.find("1100123", 7)->s == "123");
+  ASSERT_TRUE(rt.find("110", 3) == nullptr);
+  ASSERT_TRUE(rt.find("7123", 4) == nullptr);
+  ASSERT_TRUE(rt.find("711", 3) == nullptr);
+  ASSERT_TRUE(rt.find("7124", 4) == nullptr);
+
+  rt.filterDelete("11", 2);
+  ASSERT_TRUE(rt.find("110012345", 9) == nullptr);
+  ASSERT_TRUE(rt.find("1100123455", 10) == nullptr);
+  ASSERT_TRUE(rt.find("0011897", 7)->s == "897");
+  ASSERT_TRUE(rt.find("00118", 5)->s == "8");
+  ASSERT_TRUE(rt.find("1444", 4)->s == "m");
+  ASSERT_TRUE(rt.find("1345", 4)->s == "l");
+  ASSERT_TRUE(rt.find("1346", 4)->s == "lll");
+  ASSERT_TRUE(rt.find("1100123", 7) == nullptr);
+}
 
 TEST_F(RocksDBTest, SimpleOperation) {
   ASSERT_TRUE(readDb(key1_) == value1_);


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Adds cache based on radix tree.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
