### PR TITLE
[GHA] faster with caches, enable github docker registry ghcr.io

### DIFF
--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -134,12 +134,10 @@ jobs:
           set -x
           git fetch origin ${{github.event.after}} --depth=2
           git log -1 FETCH_HEAD
-          #test ${{github.event.after}} = $(git rev-parse HEAD)
           commit_message_body_build_spec(){
             git log -n1 $1 --format=%B | grep '^/build '
           }
           git_is_merge_commit(){
-            #test $(git rev-list $1^..$1 -1 --merges) = $1
             git rev-parse ${1:-HEAD}^2 &>/dev/null
           }
           commit_was_merged_build_spec(){
@@ -613,10 +611,10 @@ jobs:
               comma=', '
             done
           }
-          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_module.out \
             || true
-          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_integration.out \
             || true
           tests_passed=true

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -622,11 +622,13 @@ jobs:
           for t in module integration ;do
             f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::error::The following $t tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::warning::The following $t tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -407,28 +407,29 @@ jobs:
           $(realpath $CCACHE_PATH/gcc) --show-config
           echo >>$GITHUB_ENV _CCACHE_DIR=$($(realpath $CCACHE_PATH/gcc) --show-config | sed -nE 's,.*cache_dir = ,,p')
           echo >>$GITHUB_ENV NPROC=$(nproc | awk '{printf("%.0f",$1*0.77)}')
+          echo >>$GITHUB_ENV HOME=$HOME
       - &step_restore_ccache
-        name: Restore cache ccache
+        name: Restore cache CCache
         uses: actions/cache@v2
         with:
           path: ${{ env._CCACHE_DIR }}
-          key:  ${{ runner.os }}-ccache
+          key:          ${{runner.os}}-ccache-${{matrix.CC}}.${{ github.event.after }}
+          restore-keys: ${{runner.os}}-ccache-${{matrix.CC}}.
       - &step_store_ccache_stats
         run: ccache --show-stats | tee /tmp/ccache-stats
       - &step_vcpkg_cache
-        if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
+        #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
         name: Restore cache vcpkg
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.cache/vcpkg/archives
-          #  $HOME/.cache/vcpkg
+            ${{env.HOME}}/.cache/vcpkg/archives
           #  build-vcpkg/installed
           #  build/vcpkg_installed    ## This is default folder for manual installation in manifest mode
-          key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
-          # key:          ${{ runner.os }}-vcpkg-${{matrix.CC}}-${{ hashFiles('build-vcpkg/installed/vcpkg/status') }}
-          # restore-keys: ${{ runner.os }}-vcpkg-${{matrix.CC}}-
+          # key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
+          key:          ${{runner.os}}-vcpkg-${{matrix.CC}}.${{ hashFiles('vcpkg/**') }}
+          restore-keys: ${{runner.os}}-vcpkg-${{matrix.CC}}.
       - &step_vcpkg_build
         name: Build iroha vcpkg dependancies
         run: ./vcpkg/build_iroha_deps.sh $PWD/build-vcpkg; test -f $PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -449,7 +450,8 @@ jobs:
         ## Takes 13s on regular GitHub runner
         run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake
           -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
-          -GNinja ${{ matrix.CMAKE_USE }}
+          -GNinja
+          ${{ matrix.CMAKE_USE }}
           -DTESTING=ON
           -DPACKAGE_DEB=ON
           #-DCMAKE_VERBOSE_MAKEFILE=ON
@@ -801,6 +803,3 @@ jobs:
       - generate_matrixes
     strategy: *strategy_ubuntu_debug
     if: *if_ubuntu_debug
-    # env:
-    #   <<: *env_dockerhub_release
-    #   IMAGE_NAME: iroha-debug

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -594,6 +594,7 @@ jobs:
           module_rocksdb_executor_test
           module_gossip_propagation_strategy_test
           integration_queries_acceptance_test
+          integration_fake_peer_example_test
           END
           grep_failed_tests(){
             grep 'The following tests FAILED:' -A10000 "$@" | tail +2 #| cut -d- -f2 | cut -d' ' -f2 | sort
@@ -618,13 +619,14 @@ jobs:
             | tee ctest_integration.out \
             || true
           tests_passed=true
-          for f in $(ls -rt ctest_*.out) ;do
+          for t in module integration ;do
+            f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following tests FAILED and ALLOWED TO FAIL: $o"
+              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -87,13 +87,13 @@ jobs:
         name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       -
@@ -124,21 +124,33 @@ jobs:
       - *step_checkout
       -
         name: Generate matrix for build triggered by chat-ops - comment to PR
-        if: github.event.comment && github.event.issue.pull_request
+        if: github.event.issue.pull_request && github.event.comment
         id: comment_body
         run: echo "${{github.event.comment.body}}" >/tmp/comment_body
       -
         name: Generate default matrix for regular builds
-        if: ${{ steps.comment_body.outcome == 'skipped' }}
+        if: ${{ steps.comment_body.outcome == 'skipped' }}  ## i.e. not github.event.issue.pull_request
         run: |
           set -x
+          git fetch origin ${{github.event.after}} --depth=2
+          git log -1 FETCH_HEAD
+          #test ${{github.event.after}} = $(git rev-parse HEAD)
           commit_message_body_build_spec(){
-            git fetch origin ${{github.event.after}} --depth=1
-            git log --format=%B -n1 ${{github.event.after}} | grep '^/build '
+            git log -n1 $1 --format=%B | grep '^/build '
+          }
+          git_is_merge_commit(){
+            #test $(git rev-list $1^..$1 -1 --merges) = $1
+            git rev-parse ${1:-HEAD}^2 &>/dev/null
+          }
+          commit_was_merged_build_spec(){
+            git_is_merge_commit $1 &&
+              git log -n1 $1 --format=%s | grep -q '^Merge branch' &&
+              echo "/build before-merge"
           }
           case ${{github.event_name}} in
-            pull_request)       commit_message_body_build_spec >/tmp/comment_body ||
-                                  echo  >/tmp/comment_body "/build debug" ;;
+            pull_request)       commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ||
+                                commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ||
+                                  echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal" ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release"
                                   echo "/build macos debug"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -254,6 +254,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - &step_docker_login_ghcr
+        name: Log in to the Container registry GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - &step_warn_docker_no_push
         name: Possible WARNING
         if: ${{ steps.docker_login.outcome == 'skipped' }}
@@ -285,6 +292,13 @@ jobs:
         ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
         ##  - tag 'edge' when branch support/1.2.x is pushed
         ##  - schedule, see the docs
+      - &step_docker_meta_ghcr
+        <<: *step_docker_meta
+        name: Docker meta GHCR
+        id: meta_ghcr
+        with:
+          <<: *step_docker_meta_with
+          images: ghcr.io/${{ github.repository }}-builder
       - &step_docker_buildx
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -306,6 +320,15 @@ jobs:
           push: ${{ steps.docker_login.outcome == 'success' }}
           tags:   ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - &step_docker_build_and_push_ghcr
+        <<: *step_docker_build_and_push
+        id: build_and_push_ghcr
+        name: Build and push to GHCR
+        with: &step_docker_build_and_push_ghcr-with
+          <<: *step_docker_build_and_push_with
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo == github.event.pull_request.base.repo }}
+          tags:   ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}
       - &step_docker_move_cache
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
@@ -432,7 +455,7 @@ jobs:
       - &step_vcpkg_cache
         #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
-        name: Restore cache vcpkg
+        name: Restore cache Vcpkg binarycache ## NOTE not useng NuGet because on ubuntu nuget needs mono of 433MB, unusable.
         uses: actions/cache@v2
         with:
           path: |
@@ -788,12 +811,19 @@ jobs:
         env:
           dockertag: ${{ hashFiles('docker/release/**') }}
       - <<: *step_docker_meta
-        with:
+        with: &step_docker_release_meta_with
           <<: *step_docker_meta_with
-          images: ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}  ## uses suffics could be empty, -burrow, -ursa
+          images: |
+            ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}
+            ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
           flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
           #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
+      - <<: *step_docker_meta_ghcr
+        with:
+          <<: *step_docker_release_meta_with
+          images: ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
       - *step_docker_login
+      - *step_docker_login_ghcr
       - *step_warn_docker_no_push
       - *step_docker_buildx
       - <<: *step_docker_cache
@@ -806,6 +836,10 @@ jobs:
           <<: *step_docker_build_and_push_with
           context: docker/release/
           push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+      - <<: *step_docker_build_and_push_ghcr
+        with:
+          <<: *step_docker_build_and_push_ghcr-with
+          context: docker/release/
       - *step_docker_move_cache
 
   docker-D:

--- a/.github/chatops-gen-matrix.sh
+++ b/.github/chatops-gen-matrix.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 shopt -s lastpipe
 
+if test $(uname) = Darwin ;then
+   set -a # export the following funcs instead of aliases
+   sed() { gsed "$@"; }
+   grep() { ggrep "$@"; }
+   set +a # stop exporting
+fi
+
 echowarn(){
    echo >&2 '::warning::'"$@"
 }
@@ -21,6 +28,8 @@ EXAMPLE build_spec:
    /build ubuntu release gcc10
    /build macos llvm release
    /build all
+   /build ubuntu all              ## build all possible configurations on Ubuntu
+   /build ubuntu burrow all       ## build all possible configurations on Ubuntu with Burrow
 AVAILABLE build_spec keywords:
 END
    awk '/^\s*## BUILDSPEC ARGUMENTS/,/^\s*## END BUILDSPEC ARGUMENTS/ ' $0 | sed -n 's,).*,,gp' | sed -E 's,^ +,   ,'
@@ -66,6 +75,7 @@ generate(){
       used_compilers+=$cc' '
       for bt in $build_types ;do
          for co in $cmake_opts ;do
+            if test $os = macos -a $co = burrow; then continue; fi
             MATRIX+="$os $cc $bt $co"$'\n'
          done
       done
@@ -102,16 +112,19 @@ handle_user_line(){
          gcc-10|gcc10)              compilers+=" gcc-10 " ;;
          clang|clang-10|clang10)    compilers+=" clang clang-10"  ;;
          llvm)                      compilers+=" $1 " ;;
-         clang)                     compilers+=" $1 " ;;
          msvc)                      compilers+=" $1 " ;;
-         mingw)                     compilers+=" $1 " ;;
-         cygwin)                    compilers+=" $1 " ;;
          dockerpush)                dockerpush=yes ;;
          nodockerpush)              dockerpush=no ;;
          all|everything|beforemerge|before_merge|before-merge|readytomerge|ready-to-merge|ready_to_merge)
-            oses="$ALL_oses" build_types="$ALL_build_types" cmake_opts="$ALL_cmake_opts" compilers="$ALL_compilers"
+            oses=${oses:-"$ALL_oses"}
+            build_types=${build_types:-"$ALL_build_types"}
+            cmake_opts=${cmake_opts:-"$ALL_cmake_opts"}
+            compilers=${compilers:-"$ALL_compilers"}
             ;;
          ## END BUILDSPEC ARGUMENTS
+         \#*)
+            break  ## stop parsing buildspec
+            ;;
          *)
             echoerr "Unknown /build argument '$1'"
             return 1
@@ -142,9 +155,17 @@ test -n "${MATRIX:-}" ||
 
 
 ############# FIXME remove this after build fixed #############
-echo "$MATRIX" | awk -v IGNORECASE=1 '!/gcc-9/ && /release/' | while read line ;do echo "'$line'" ;done |
-   echowarn "FIXME At the moment we are able to build Release only with GCC-9, other buildspecs are dropped: "$(cat)
-MATRIX="$(echo "$MATRIX" | awk -v IGNORECASE=1 '!(!/gcc-9/ && /release/)' )"  ##FIXME lifehack to disable always failing build during linkage
+quoted(){
+   while read line ;do echo -n "'$line' " ;done
+}
+ignored=$(mktemp)
+echo "$MATRIX" | awk -v IGNORECASE=1 '/clang-10/ && /release/' >$ignored
+MATRIX="$( grep -Fvx -f $ignored <<<"$MATRIX" )"
+if test -s $ignored
+then cat $ignored | quoted | echowarn "FIXME At the moment NOT able to build Release with Clang-10," \
+                                      "because civetweb-cpp from vcpkg. Buildspecs are dropped: $(cat)"
+fi
+rm -f $ignored
 ############# END fixme remove this after build fixed #########
 
 

--- a/.github/chatops-gen-matrix.sh
+++ b/.github/chatops-gen-matrix.sh
@@ -142,16 +142,13 @@ handle_user_line(){
    done
 }
 
-if test -z "$cmdline" ;then
-   while read input_line ;do
+{ test -n "$cmdline" && echo "$cmdline" || cat; } |
+   tr ';' '\n' | while read input_line ;do
       handle_user_line $input_line || continue
    done
-else
-   handle_user_line $cmdline || true
-fi
 
 test -n "${MATRIX:-}" ||
-   { echoerr "MATRIX is empty!"; --help-buildspec >&2; exit 1; }
+   { echoerr "MATRIX is empty!"$'\n'; --help-buildspec >&2; exit 1; }
 
 
 ############# FIXME remove this after build fixed #############

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -637,6 +637,7 @@ jobs:
           module_rocksdb_executor_test
           module_gossip_propagation_strategy_test
           integration_queries_acceptance_test
+          integration_fake_peer_example_test
           END
           grep_failed_tests(){
             grep 'The following tests FAILED:' -A10000 "$@" | tail +2 #| cut -d- -f2 | cut -d' ' -f2 | sort
@@ -661,13 +662,14 @@ jobs:
             | tee ctest_integration.out \
             || true
           tests_passed=true
-          for f in $(ls -rt ctest_*.out) ;do
+          for t in module integration ;do
+            f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following tests FAILED and ALLOWED TO FAIL: $o"
+              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed
@@ -911,6 +913,7 @@ jobs:
           module_rocksdb_executor_test
           module_gossip_propagation_strategy_test
           integration_queries_acceptance_test
+          integration_fake_peer_example_test
           END
           grep_failed_tests(){
             grep 'The following tests FAILED:' -A10000 "$@" | tail +2 #| cut -d- -f2 | cut -d' ' -f2 | sort
@@ -935,13 +938,14 @@ jobs:
             | tee ctest_integration.out \
             || true
           tests_passed=true
-          for f in $(ls -rt ctest_*.out) ;do
+          for t in module integration ;do
+            f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following tests FAILED and ALLOWED TO FAIL: $o"
+              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed
@@ -1179,6 +1183,7 @@ jobs:
           module_rocksdb_executor_test
           module_gossip_propagation_strategy_test
           integration_queries_acceptance_test
+          integration_fake_peer_example_test
           END
           grep_failed_tests(){
             grep 'The following tests FAILED:' -A10000 "$@" | tail +2 #| cut -d- -f2 | cut -d' ' -f2 | sort
@@ -1203,13 +1208,14 @@ jobs:
             | tee ctest_integration.out \
             || true
           tests_passed=true
-          for f in $(ls -rt ctest_*.out) ;do
+          for t in module integration ;do
+            f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following tests FAILED and ALLOWED TO FAIL: $o"
+              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -270,6 +270,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to the Container registry GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Possible WARNING
         if: ${{ steps.docker_login.outcome == 'skipped' }}
         run: echo "::warning::DOCKERHUB_TOKEN and DOCKERHUB_USERNAME are empty. Will build but NOT push."
@@ -299,6 +305,33 @@ jobs:
           ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
           ##  - tag 'edge' when branch support/1.2.x is pushed
           ##  - schedule, see the docs
+      - uses: docker/metadata-action@v3
+        name: Docker meta GHCR
+        id: meta_ghcr
+        with:
+          tags: |
+            type=raw,value=${{env.dockertag}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=schedule
+            type=edge,branch=support/1.2.x
+            type=edge,branch=develop
+            type=edge,branch=test-ci
+            type=sha,prefix=commit-,format=short
+            type=sha,prefix=commit-,format=long
+          ## Docker image will be pushed with tags:
+          ##  - hash of file Dockerfile.builder
+          ##  - branchname, when branch is pushed
+          ##  - pr-NUMBER, when pushed to PR
+          ##  - git tag when tag is pushed
+          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
+          ##  - tag 'edge' when branch support/1.2.x is pushed
+          ##  - schedule, see the docs
+
+          images: ghcr.io/${{ github.repository }}-builder
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
@@ -317,6 +350,16 @@ jobs:
           push: ${{ steps.docker_login.outcome == 'success' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - uses: docker/build-push-action@v2
+        id: build_and_push_ghcr
+        name: Build and push to GHCR
+        with:
+          context: docker/iroha-builder/
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo == github.event.pull_request.base.repo }}
+          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
@@ -471,7 +514,7 @@ jobs:
       - run: ccache --show-stats | tee /tmp/ccache-stats
       - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
-        name: Restore cache vcpkg
+        name: Restore cache Vcpkg binarycache ## NOTE not useng NuGet because on ubuntu nuget needs mono of 433MB, unusable.
         uses: actions/cache@v2
         with:
           path: |
@@ -745,7 +788,7 @@ jobs:
       - run: ccache --show-stats | tee /tmp/ccache-stats
       - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
-        name: Restore cache vcpkg
+        name: Restore cache Vcpkg binarycache ## NOTE not useng NuGet because on ubuntu nuget needs mono of 433MB, unusable.
         uses: actions/cache@v2
         with:
           path: |
@@ -1017,7 +1060,7 @@ jobs:
       - run: ccache --show-stats | tee /tmp/ccache-stats
       - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
-        name: Restore cache vcpkg
+        name: Restore cache Vcpkg binarycache ## NOTE not useng NuGet because on ubuntu nuget needs mono of 433MB, unusable.
         uses: actions/cache@v2
         with:
           path: |
@@ -1403,9 +1446,41 @@ jobs:
           ##  - tag 'edge' when branch support/1.2.x is pushed
           ##  - schedule, see the docs
 
-          images: ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }} ## uses suffics could be empty, -burrow, -ursa
+          images: |
+            ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}
+            ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
           flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
           #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
+      - uses: docker/metadata-action@v3
+        name: Docker meta GHCR
+        id: meta_ghcr
+        with:
+          tags: |
+            type=raw,value=${{env.dockertag}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=schedule
+            type=edge,branch=support/1.2.x
+            type=edge,branch=develop
+            type=edge,branch=test-ci
+            type=sha,prefix=commit-,format=short
+            type=sha,prefix=commit-,format=long
+          ## Docker image will be pushed with tags:
+          ##  - hash of file Dockerfile.builder
+          ##  - branchname, when branch is pushed
+          ##  - pr-NUMBER, when pushed to PR
+          ##  - git tag when tag is pushed
+          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
+          ##  - tag 'edge' when branch support/1.2.x is pushed
+          ##  - schedule, see the docs
+
+          flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
+          #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
+
+          images: ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
       - name: Login to DockerHub
         if: ${{ env.DOCKERHUB_TOKEN != '' && env.DOCKERHUB_USERNAME != '' }}
         id: docker_login
@@ -1413,6 +1488,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to the Container registry GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Possible WARNING
         if: ${{ steps.docker_login.outcome == 'skipped' }}
         run: echo "::warning::DOCKERHUB_TOKEN and DOCKERHUB_USERNAME are empty. Will build but NOT push."
@@ -1434,6 +1515,16 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           context: docker/release/
           push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+      - uses: docker/build-push-action@v2
+        id: build_and_push_ghcr
+        name: Build and push to GHCR
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo == github.event.pull_request.base.repo }}
+          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}
+          context: docker/release/
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
@@ -1557,9 +1648,41 @@ jobs:
           ##  - tag 'edge' when branch support/1.2.x is pushed
           ##  - schedule, see the docs
 
-          images: ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }} ## uses suffics could be empty, -burrow, -ursa
+          images: |
+            ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}
+            ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
           flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
           #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
+      - uses: docker/metadata-action@v3
+        name: Docker meta GHCR
+        id: meta_ghcr
+        with:
+          tags: |
+            type=raw,value=${{env.dockertag}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=schedule
+            type=edge,branch=support/1.2.x
+            type=edge,branch=develop
+            type=edge,branch=test-ci
+            type=sha,prefix=commit-,format=short
+            type=sha,prefix=commit-,format=long
+          ## Docker image will be pushed with tags:
+          ##  - hash of file Dockerfile.builder
+          ##  - branchname, when branch is pushed
+          ##  - pr-NUMBER, when pushed to PR
+          ##  - git tag when tag is pushed
+          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
+          ##  - tag 'edge' when branch support/1.2.x is pushed
+          ##  - schedule, see the docs
+
+          flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
+          #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
+
+          images: ghcr.io/${{ github.repository }}${{ env._uses_suffix }}
       - name: Login to DockerHub
         if: ${{ env.DOCKERHUB_TOKEN != '' && env.DOCKERHUB_USERNAME != '' }}
         id: docker_login
@@ -1567,6 +1690,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to the Container registry GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Possible WARNING
         if: ${{ steps.docker_login.outcome == 'skipped' }}
         run: echo "::warning::DOCKERHUB_TOKEN and DOCKERHUB_USERNAME are empty. Will build but NOT push."
@@ -1588,6 +1717,16 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           context: docker/release/
           push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+      - uses: docker/build-push-action@v2
+        id: build_and_push_ghcr
+        name: Build and push to GHCR
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo == github.event.pull_request.base.repo }}
+          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}
+          context: docker/release/
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -665,11 +665,13 @@ jobs:
           for t in module integration ;do
             f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::error::The following $t tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::warning::The following $t tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed
@@ -941,11 +943,13 @@ jobs:
           for t in module integration ;do
             f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::error::The following $t tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::warning::The following $t tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed
@@ -1211,11 +1215,13 @@ jobs:
           for t in module integration ;do
             f=ctest_$t.out
             if a=$(grep_failed_tests $f | exclude_allowed_to_fail | list_to_line) ;then
-              echo "::error::The following ${t^^} tests FAILED but not in list ALLOW_TO_FAIL: $a"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::error::The following $t tests FAILED but not in list ALLOW_TO_FAIL: $a"
               tests_passed=false
             fi
             if o=$(grep_failed_tests $f | only_allowed_to_fail | list_to_line) ;then
-              echo "::warning::The following ${t^^} tests FAILED and ALLOWED TO FAIL: $o"
+              #${t^^}  ## FixMe install bash 5.0 on macos
+              echo "::warning::The following $t tests FAILED and ALLOWED TO FAIL: $o"
             fi
           done
           $tests_passed

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -79,13 +79,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: Reaction
@@ -111,13 +111,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: Checkout
@@ -126,20 +126,32 @@ jobs:
           ref: ${{env.PR_REF}} ## not empty on issue_comment, else default value GITHUB_REF
           repository: ${{env.PR_REPO}} ## not empty on issue_comment, else default value github.repository, required by forks
       - name: Generate matrix for build triggered by chat-ops - comment to PR
-        if: github.event.comment && github.event.issue.pull_request
+        if: github.event.issue.pull_request && github.event.comment
         id: comment_body
         run: echo "${{github.event.comment.body}}" >/tmp/comment_body
       - name: Generate default matrix for regular builds
-        if: ${{ steps.comment_body.outcome == 'skipped' }}
+        if: ${{ steps.comment_body.outcome == 'skipped' }} ## i.e. not github.event.issue.pull_request
         run: |
           set -x
+          git fetch origin ${{github.event.after}} --depth=2
+          git log -1 FETCH_HEAD
+          #test ${{github.event.after}} = $(git rev-parse HEAD)
           commit_message_body_build_spec(){
-            git fetch origin ${{github.event.after}} --depth=1
-            git log --format=%B -n1 ${{github.event.after}} | grep '^/build '
+            git log -n1 $1 --format=%B | grep '^/build '
+          }
+          git_is_merge_commit(){
+            #test $(git rev-list $1^..$1 -1 --merges) = $1
+            git rev-parse ${1:-HEAD}^2 &>/dev/null
+          }
+          commit_was_merged_build_spec(){
+            git_is_merge_commit $1 &&
+              git log -n1 $1 --format=%s | grep -q '^Merge branch' &&
+              echo "/build before-merge"
           }
           case ${{github.event_name}} in
-            pull_request)       commit_message_body_build_spec >/tmp/comment_body ||
-                                  echo  >/tmp/comment_body "/build debug" ;;
+            pull_request)       commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ||
+                                commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ||
+                                  echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal" ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release"
                                   echo "/build macos debug"
@@ -199,13 +211,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: System info
@@ -361,13 +373,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: Show needs
@@ -635,13 +647,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: Show needs
@@ -904,13 +916,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
   build-M:
@@ -926,13 +938,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: System info
@@ -1169,13 +1181,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
     defaults:
@@ -1286,13 +1298,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: System info
@@ -1440,13 +1452,13 @@ jobs:
       - name: Show context
         run: |
           echo "::group::GitHub context"
-          cat >/dev/null <<'END'
-            ${{ toJson(github) }}
+          cat <<'END'
+          ${{ toJson(github) }}
           END
           echo "::endgroup::"
           echo "::group::GitHub needs"
-          cat >/dev/null <<'END'
-            ${{ toJson(needs) }}
+          cat <<'END'
+          ${{ toJson(needs) }}
           END
           echo "::endgroup::"
       - name: System info

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -135,12 +135,10 @@ jobs:
           set -x
           git fetch origin ${{github.event.after}} --depth=2
           git log -1 FETCH_HEAD
-          #test ${{github.event.after}} = $(git rev-parse HEAD)
           commit_message_body_build_spec(){
             git log -n1 $1 --format=%B | grep '^/build '
           }
           git_is_merge_commit(){
-            #test $(git rev-list $1^..$1 -1 --merges) = $1
             git rev-parse ${1:-HEAD}^2 &>/dev/null
           }
           commit_was_merged_build_spec(){
@@ -656,10 +654,10 @@ jobs:
               comma=', '
             done
           }
-          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_module.out \
             || true
-          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_integration.out \
             || true
           tests_passed=true
@@ -930,10 +928,10 @@ jobs:
               comma=', '
             done
           }
-          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_module.out \
             || true
-          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_integration.out \
             || true
           tests_passed=true
@@ -1198,10 +1196,10 @@ jobs:
               comma=', '
             done
           }
-          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -R '^module_' --parallel 4 --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_module.out \
             || true
-          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 40 --repeat until-pass:3 \
+          ctest -E '^module_'              --output-on-failure --no-tests=error --timeout 80 --repeat until-pass:3 \
             | tee ctest_integration.out \
             || true
           tests_passed=true

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -449,25 +449,26 @@ jobs:
           $(realpath $CCACHE_PATH/gcc) --show-config
           echo >>$GITHUB_ENV _CCACHE_DIR=$($(realpath $CCACHE_PATH/gcc) --show-config | sed -nE 's,.*cache_dir = ,,p')
           echo >>$GITHUB_ENV NPROC=$(nproc | awk '{printf("%.0f",$1*0.77)}')
-      - name: Restore cache ccache
+          echo >>$GITHUB_ENV HOME=$HOME
+      - name: Restore cache CCache
         uses: actions/cache@v2
         with:
           path: ${{ env._CCACHE_DIR }}
-          key: ${{ runner.os }}-ccache
+          key: ${{runner.os}}-ccache-${{matrix.CC}}.${{ github.event.after }}
+          restore-keys: ${{runner.os}}-ccache-${{matrix.CC}}.
       - run: ccache --show-stats | tee /tmp/ccache-stats
-      - if: ${{false}} ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
+      - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
         name: Restore cache vcpkg
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.cache/vcpkg/archives
-          #  $HOME/.cache/vcpkg
+            ${{env.HOME}}/.cache/vcpkg/archives
           #  build-vcpkg/installed
           #  build/vcpkg_installed    ## This is default folder for manual installation in manifest mode
-          key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
-          # key:          ${{ runner.os }}-vcpkg-${{matrix.CC}}-${{ hashFiles('build-vcpkg/installed/vcpkg/status') }}
-          # restore-keys: ${{ runner.os }}-vcpkg-${{matrix.CC}}-
+          # key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
+          key: ${{runner.os}}-vcpkg-${{matrix.CC}}.${{ hashFiles('vcpkg/**') }}
+          restore-keys: ${{runner.os}}-vcpkg-${{matrix.CC}}.
       - name: Build iroha vcpkg dependancies
         run: ./vcpkg/build_iroha_deps.sh $PWD/build-vcpkg; test -f $PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake
         ## Takes 48m16s on default GitHub runner with 2 cores
@@ -722,25 +723,26 @@ jobs:
           $(realpath $CCACHE_PATH/gcc) --show-config
           echo >>$GITHUB_ENV _CCACHE_DIR=$($(realpath $CCACHE_PATH/gcc) --show-config | sed -nE 's,.*cache_dir = ,,p')
           echo >>$GITHUB_ENV NPROC=$(nproc | awk '{printf("%.0f",$1*0.77)}')
-      - name: Restore cache ccache
+          echo >>$GITHUB_ENV HOME=$HOME
+      - name: Restore cache CCache
         uses: actions/cache@v2
         with:
           path: ${{ env._CCACHE_DIR }}
-          key: ${{ runner.os }}-ccache
+          key: ${{runner.os}}-ccache-${{matrix.CC}}.${{ github.event.after }}
+          restore-keys: ${{runner.os}}-ccache-${{matrix.CC}}.
       - run: ccache --show-stats | tee /tmp/ccache-stats
-      - if: ${{false}} ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
+      - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
         name: Restore cache vcpkg
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.cache/vcpkg/archives
-          #  $HOME/.cache/vcpkg
+            ${{env.HOME}}/.cache/vcpkg/archives
           #  build-vcpkg/installed
           #  build/vcpkg_installed    ## This is default folder for manual installation in manifest mode
-          key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
-          # key:          ${{ runner.os }}-vcpkg-${{matrix.CC}}-${{ hashFiles('build-vcpkg/installed/vcpkg/status') }}
-          # restore-keys: ${{ runner.os }}-vcpkg-${{matrix.CC}}-
+          # key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
+          key: ${{runner.os}}-vcpkg-${{matrix.CC}}.${{ hashFiles('vcpkg/**') }}
+          restore-keys: ${{runner.os}}-vcpkg-${{matrix.CC}}.
       - name: Build iroha vcpkg dependancies
         run: ./vcpkg/build_iroha_deps.sh $PWD/build-vcpkg; test -f $PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake
         ## Takes 48m16s on default GitHub runner with 2 cores
@@ -990,28 +992,29 @@ jobs:
           $(realpath $CCACHE_PATH/gcc) --show-config
           echo >>$GITHUB_ENV _CCACHE_DIR=$($(realpath $CCACHE_PATH/gcc) --show-config | sed -nE 's,.*cache_dir = ,,p')
           echo >>$GITHUB_ENV NPROC=$(nproc | awk '{printf("%.0f",$1*0.77)}')
+          echo >>$GITHUB_ENV HOME=$HOME
         env:
           CC: ${{matrix.CC}}
           CCACHE_PATH: /usr/local/opt/ccache/libexec
-      - name: Restore cache ccache
+      - name: Restore cache CCache
         uses: actions/cache@v2
         with:
           path: ${{ env._CCACHE_DIR }}
-          key: ${{ runner.os }}-ccache
+          key: ${{runner.os}}-ccache-${{matrix.CC}}.${{ github.event.after }}
+          restore-keys: ${{runner.os}}-ccache-${{matrix.CC}}.
       - run: ccache --show-stats | tee /tmp/ccache-stats
-      - if: ${{false}} ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
+      - #if: ${{false}}  ## This works bad when something patched or something updated, seems they does not recalc hash of changed packages. See todos in the begining of file.
         ## Read the docs https://vcpkg.readthedocs.io/en/latest/users/binarycaching/ https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md
         name: Restore cache vcpkg
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.cache/vcpkg/archives
-          #  $HOME/.cache/vcpkg
+            ${{env.HOME}}/.cache/vcpkg/archives
           #  build-vcpkg/installed
           #  build/vcpkg_installed    ## This is default folder for manual installation in manifest mode
-          key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
-          # key:          ${{ runner.os }}-vcpkg-${{matrix.CC}}-${{ hashFiles('build-vcpkg/installed/vcpkg/status') }}
-          # restore-keys: ${{ runner.os }}-vcpkg-${{matrix.CC}}-
+          # key: ${{ runner.os }}-${{matrix.CC}}-vcpkg
+          key: ${{runner.os}}-vcpkg-${{matrix.CC}}.${{ hashFiles('vcpkg/**') }}
+          restore-keys: ${{runner.os}}-vcpkg-${{matrix.CC}}.
       - name: Build iroha vcpkg dependancies
         run: ./vcpkg/build_iroha_deps.sh $PWD/build-vcpkg; test -f $PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake
         ## Takes 48m16s on default GitHub runner with 2 cores
@@ -1587,6 +1590,3 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ) }}
     if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
-    # env:
-    #   <<: *env_dockerhub_release
-    #   IMAGE_NAME: iroha-debug

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
             postgresql postgresql-contrib; \
     if [ $(uname -m) = "x86_64" ] ;then \
         apt-get -y --no-install-recommends install \
-            clang-10 lldb-10 lld-10 libc++-10-dev libc++abi-10-dev clang-format; \
+            clang-10 lldb-10 lld-10 libc++-10-dev libc++abi-10-dev clang-format clang-format-7 clang-format-12; \
     fi; \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -38,8 +38,8 @@ SynchronizerImpl::processOutcome(consensus::GateObject object) {
   log_->info("processing consensus outcome");
 
   auto process_reject =
-      [this](auto outcome_type,
-             const auto &msg) -> std::optional<SynchronizationEvent> {
+      [](auto outcome_type,
+         const auto &msg) -> std::optional<SynchronizationEvent> {
     assert(msg.ledger_state->top_block_info.height + 1
            == msg.round.block_round);
     return SynchronizationEvent{outcome_type, msg.round, msg.ledger_state};

--- a/libs/common/permutation_generator.cpp
+++ b/libs/common/permutation_generator.cpp
@@ -60,7 +60,7 @@ Seeder &Seeder::feed(const char *seed_start, size_t seed_length) {
   return *this;
 }
 
-inline Seeder &Seeder::feed(ValueType value) {
+Seeder &Seeder::feed(ValueType value) {
   // like CBC
   current_seed_ = RandomEngine{current_seed_ ^ value}();
   return *this;

--- a/test/integration/acceptance/get_transactions_test.cpp
+++ b/test/integration/acceptance/get_transactions_test.cpp
@@ -4,7 +4,9 @@
  */
 
 #include <gtest/gtest.h>
+
 #include <boost/variant.hpp>
+
 #include "backend/protobuf/query_responses/proto_query_response.hpp"
 #include "backend/protobuf/transaction.hpp"
 #include "builders/protobuf/queries.hpp"
@@ -18,11 +20,11 @@ using namespace integration_framework;
 using namespace shared_model;
 using namespace common_constants;
 
-class GetTransactions : public AcceptanceFixture, public testing::WithParamInterface<iroha::StorageType> {
- public:
-  static constexpr iroha::StorageType storage_types[] = {
-      iroha::StorageType::kPostgres};//, iroha::StorageType::kRocksDb};
+using iroha::StorageType;
 
+class GetTransactions : public AcceptanceFixture,
+                        public testing::WithParamInterface<iroha::StorageType> {
+ public:
   /**
    * Creates the transaction with the user creation commands
    * @param perms are the permissions of the user
@@ -66,7 +68,7 @@ class GetTransactions : public AcceptanceFixture, public testing::WithParamInter
  * @when query GetTransactions of existing transaction of the user
  * @then stateful validation fail returned
  */
-TEST_F(GetTransactions, HaveNoGetPerms) {
+TEST_P(GetTransactions, HaveNoGetPerms) {
   auto check = [](auto &status) {
     ASSERT_TRUE(
         boost::apply_visitor(interface::QueryErrorResponseChecker<
@@ -74,18 +76,16 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
                              status.get()));
   };
 
-  for (auto const type : storage_types) {
-    auto dummy_tx = dummyTx();
-    IntegrationTestFramework(1, type)
-        .setInitialState(kAdminKeypair)
-        .sendTx(makeUserWithPerms({interface::permissions::Role::kReadAssets}))
-        .skipProposal()
-        .skipBlock()
-        .sendTxAwait(
-            dummy_tx,
-            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendQuery(makeQuery(dummy_tx.hash()), check);
-  }
+  auto dummy_tx = dummyTx();
+  IntegrationTestFramework(1, GetParam())
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kReadAssets}))
+      .skipProposal()
+      .skipBlock()
+      .sendTxAwait(
+          dummy_tx,
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(dummy_tx.hash()), check);
 }
 
 /**
@@ -98,30 +98,27 @@ TEST_F(GetTransactions, HaveNoGetPerms) {
  * @then receive TransactionsResponse with the transaction hash
  */
 TEST_P(GetTransactions, HaveGetAllTx) {
-  //for (auto const type : storage_types) {
-    auto dummy_tx = dummyTx();
-    auto check = [&dummy_tx](auto &status) {
-      ASSERT_NO_THROW({
-        const auto &resp =
-            boost::get<const shared_model::interface::TransactionsResponse &>(
-                status.get());
-        ASSERT_EQ(resp.transactions().size(), 1);
-        ASSERT_EQ(resp.transactions().front(), dummy_tx);
-      });
-    };
+  auto dummy_tx = dummyTx();
+  auto check = [&dummy_tx](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &resp =
+          boost::get<const shared_model::interface::TransactionsResponse &>(
+              status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(resp.transactions().front(), dummy_tx);
+    });
+  };
 
-    IntegrationTestFramework(1, GetParam())
-        .setInitialState(kAdminKeypair)
-        .sendTx(makeUserWithPerms({interface::permissions::Role::kGetAllTxs}))
-        .skipProposal()
-        .skipBlock()
-        .sendTxAwait(
-            dummy_tx,
-            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendQuery(makeQuery(dummy_tx.hash()), check);
-  //}
+  IntegrationTestFramework(1, GetParam())
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms({interface::permissions::Role::kGetAllTxs}))
+      .skipProposal()
+      .skipBlock()
+      .sendTxAwait(
+          dummy_tx,
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(dummy_tx.hash()), check);
 }
-INSTANTIATE_TEST_SUITE_P(GetTransactions_PostgresAndRocksdb, GetTransactions, testing::ValuesIn(GetTransactions::storage_types));
 
 /**
  * TODO mboldyrev 18.01.2019 IR-215 remove, covered by
@@ -132,29 +129,27 @@ INSTANTIATE_TEST_SUITE_P(GetTransactions_PostgresAndRocksdb, GetTransactions, te
  * @when query GetTransactions of existing transaction of the user
  * @then receive TransactionsResponse with the transaction hash
  */
-TEST_F(GetTransactions, HaveGetMyTx) {
-  for (auto const type : storage_types) {
-    auto dummy_tx = dummyTx();
-    auto check = [&dummy_tx](auto &status) {
-      ASSERT_NO_THROW({
-        const auto &resp =
-            boost::get<const shared_model::interface::TransactionsResponse &>(
-                status.get());
-        ASSERT_EQ(resp.transactions().size(), 1);
-        ASSERT_EQ(resp.transactions().front(), dummy_tx);
-      });
-    };
+TEST_P(GetTransactions, HaveGetMyTx) {
+  auto dummy_tx = dummyTx();
+  auto check = [&dummy_tx](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &resp =
+          boost::get<const shared_model::interface::TransactionsResponse &>(
+              status.get());
+      ASSERT_EQ(resp.transactions().size(), 1);
+      ASSERT_EQ(resp.transactions().front(), dummy_tx);
+    });
+  };
 
-    IntegrationTestFramework(1, type)
-        .setInitialState(kAdminKeypair)
-        .sendTx(makeUserWithPerms())
-        .skipProposal()
-        .skipBlock()
-        .sendTxAwait(
-            dummy_tx,
-            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendQuery(makeQuery(dummy_tx.hash()), check);
-  }
+  IntegrationTestFramework(1, GetParam())
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipBlock()
+      .sendTxAwait(
+          dummy_tx,
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(dummy_tx.hash()), check);
 }
 
 /**
@@ -166,37 +161,33 @@ TEST_F(GetTransactions, HaveGetMyTx) {
  * invalid signatures
  * @then receive StatefullErrorResponse
  */
-TEST_F(GetTransactions, InvalidSignatures) {
-  for (auto const type : storage_types) {
-    auto dummy_tx = dummyTx();
-    auto check = [](auto &status) {
-      ASSERT_NO_THROW({
-        const auto &error_rsp =
-            boost::get<const shared_model::interface::ErrorQueryResponse &>(
-                status.get());
-        boost::get<
-            const shared_model::interface::StatefulFailedErrorResponse &>(
-            error_rsp.get());
-      });
-    };
+TEST_P(GetTransactions, InvalidSignatures) {
+  auto dummy_tx = dummyTx();
+  auto check = [](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &error_rsp =
+          boost::get<const shared_model::interface::ErrorQueryResponse &>(
+              status.get());
+      boost::get<const shared_model::interface::StatefulFailedErrorResponse &>(
+          error_rsp.get());
+    });
+  };
 
-    auto query =
-        baseQry()
-            .queryCounter(1)
-            .getTransactions(std::vector<crypto::Hash>{dummy_tx.hash()})
-            .build()
-            .signAndAddSignature(
-                crypto::DefaultCryptoAlgorithmType::generateKeypair())
-            .finish();
+  auto query = baseQry()
+                   .queryCounter(1)
+                   .getTransactions(std::vector<crypto::Hash>{dummy_tx.hash()})
+                   .build()
+                   .signAndAddSignature(
+                       crypto::DefaultCryptoAlgorithmType::generateKeypair())
+                   .finish();
 
-    IntegrationTestFramework(1, type)
-        .setInitialState(kAdminKeypair)
-        .sendTx(makeUserWithPerms())
-        .skipProposal()
-        .skipVerifiedProposal()
-        .skipBlock()
-        .sendQuery(query, check);
-  }
+  IntegrationTestFramework(1, GetParam())
+      .setInitialState(kAdminKeypair)
+      .sendTx(makeUserWithPerms())
+      .skipProposal()
+      .skipVerifiedProposal()
+      .skipBlock()
+      .sendQuery(query, check);
 }
 
 /**
@@ -207,31 +198,28 @@ TEST_F(GetTransactions, InvalidSignatures) {
  * @when query GetTransactions with nonexistent hash
  * @then Stateful invalid query response
  */
-TEST_F(GetTransactions, NonexistentHash) {
-  for (auto const type : storage_types) {
-    auto check = [](auto &status) {
-      ASSERT_NO_THROW({
-        const auto &resp =
-            boost::get<const shared_model::interface::ErrorQueryResponse &>(
-                status.get());
-        // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 4
-        // with a named constant
-        ASSERT_EQ(resp.errorCode(), 4);
-        boost::get<
-            const shared_model::interface::StatefulFailedErrorResponse &>(
-            resp.get());
-      });
-    };
+TEST_P(GetTransactions, NonexistentHash) {
+  auto check = [](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &resp =
+          boost::get<const shared_model::interface::ErrorQueryResponse &>(
+              status.get());
+      // TODO [IR-1816] Akvinikym 03.12.18: replace magic number 4
+      // with a named constant
+      ASSERT_EQ(resp.errorCode(), 4);
+      boost::get<const shared_model::interface::StatefulFailedErrorResponse &>(
+          resp.get());
+    });
+  };
 
-    IntegrationTestFramework(1, type)
-        .setInitialState(kAdminKeypair)
-        .sendTxAwait(
-            makeUserWithPerms(),
-            [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendQuery(makeQuery(crypto::Hash(std::string(
-                       crypto::DefaultCryptoAlgorithmType::kHashLength, '0'))),
-                   check);
-  }
+  IntegrationTestFramework(1, GetParam())
+      .setInitialState(kAdminKeypair)
+      .sendTxAwait(
+          makeUserWithPerms(),
+          [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(crypto::Hash(std::string(
+                     crypto::DefaultCryptoAlgorithmType::kHashLength, '0'))),
+                 check);
 }
 
 /**
@@ -243,22 +231,33 @@ TEST_F(GetTransactions, NonexistentHash) {
  * @when query GetTransactions of existing transaction of the other user
  * @then TransactionsResponse with no transactions
  */
-TEST_F(GetTransactions, OtherUserTx) {
-  for (auto const type : storage_types) {
-    auto check = [](auto &status) {
-      ASSERT_NO_THROW({
-        const auto &resp =
-            boost::get<const shared_model::interface::TransactionsResponse &>(
-                status.get());
-        ASSERT_EQ(resp.transactions().size(), 0);
-      });
-    };
+TEST_P(GetTransactions, OtherUserTx) {
+  auto check = [](auto &status) {
+    ASSERT_NO_THROW({
+      const auto &resp =
+          boost::get<const shared_model::interface::TransactionsResponse &>(
+              status.get());
+      ASSERT_EQ(resp.transactions().size(), 0);
+    });
+  };
 
-    auto tx = makeUserWithPerms();
-    IntegrationTestFramework(1, type)
-        .setInitialState(kAdminKeypair)
-        .sendTxAwait(
-            tx, [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
-        .sendQuery(makeQuery(tx.hash()), check);
-  }
+  iroha::StorageType type = GetParam();
+  auto tx = makeUserWithPerms();
+  IntegrationTestFramework(1, type)
+      .setInitialState(kAdminKeypair)
+      .sendTxAwait(
+          tx, [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); })
+      .sendQuery(makeQuery(tx.hash()), check);
 }
+
+INSTANTIATE_TEST_SUITE_P(DifferentStorageType,
+                         GetTransactions,
+                         testing::Values(StorageType::kPostgres,
+                                         StorageType::kRocksDb),
+                         [](const testing::TestParamInfo<StorageType> &info) {
+                           return info.param == StorageType::kPostgres
+                               ? "kPostgres"
+                               : info.param == StorageType::kRocksDb
+                               ? "kRocksDb"
+                               : "UNKNOWN";
+                         });


### PR DESCRIPTION
* Now **build** takes **much less time** 🕰, with vcpkg binarycaching and ccache shared between workflow runs and jobs: no need to build vcpkg deps (minus 24..30 mins on every run), ccache hit rate is about 15-20% so it saves up to 6 minutes on each debug build, and about 10 mins on release build.
* After pressing button `Update branch`(i.e. merge base branch into PR head) now triggers `/build before-merge` buildspec, so **will be able to merge after CI passed**. Earlier we have had to push a commit with message `/build ...` (it is still best way to tell CI about it is ready to merge). Try it yourself `.github/chatops-gen-matrix.sh --help`
* **Release** build on MacOS and Ubuntu GCC-10 is **fixed**
* **Docker** images iroha-builder, iroha, iroha-burrow, iroha-ursa are pushed to **ghcr.io** and could be found by link https://github.com/hyperledger/iroha/pkgs/container/iroha
  <img width="1257" alt="изображение" src="https://user-images.githubusercontent.com/47349143/130365943-889e3430-b904-4929-ab29-892ee2ad6dc3.png">
* slightly reorganize tests - now GTest reports against which database type (postgres or rocks) it is tested.
* buildspec `macos burrow` disabled because it fails on Ry's macos self-hosted runner, and because it is inpoppular and have no reason, except of scientific.

--------------------
Remarks
- chat-ops with comments to PR works restricted - cannot report their statuses to PR. Still in progress because of security reasons and restrictions. There is a way to do, but it is long and hard enough.
  We can trigger CI with message `/build before-merge` in PR comments, and it will build and report status to that comment, but at the moment it cannot report statuses to PR as GitHub Actions do.
- GitHub Actions provide 5GB storage for caches, it would be enough if our caches were incremental, but they are simply tar archives, so they are rotated by GitHub and periodically we build from scratch. ToDo caches with rsync, rclone or restic. Or even better let's rent normal full-time VPS, or install physical server in office.