### PR TITLE
[SE] atomic task upload to external handler

### DIFF
--- a/irohad/subscription/scheduler.hpp
+++ b/irohad/subscription/scheduler.hpp
@@ -23,8 +23,10 @@ namespace iroha::subscription {
     /// Checks if current scheduler executes task
     virtual bool isBusy() const = 0;
 
-    /// Adds task to execution queue
-    virtual void add(Task &&t) = 0;
+    /// If scheduller is not busy it takes task for execution. Otherwise it
+    /// returns it back.
+    virtual std::optional<Task> uploadIfFree(std::chrono::microseconds timeout,
+                                             Task &&task) = 0;
 
     /// Adds delayed task to execution queue
     virtual void addDelayed(std::chrono::microseconds timeout, Task &&t) = 0;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Adds atomic busy check. Minor refactoring.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
