### PR TITLE
Added `RawGenesisBlock` to schema introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,7 @@ dependencies = [
  "iroha_macro",
  "iroha_network",
  "iroha_p2p",
+ "iroha_schema",
  "iroha_telemetry",
  "iroha_version",
  "maplit",
@@ -1738,6 +1739,7 @@ dependencies = [
 name = "iroha_schema_bin"
 version = "0.1.0"
 dependencies = [
+ "iroha",
  "iroha_data_model",
  "iroha_error",
  "iroha_schema",

--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -39,6 +39,7 @@ iroha_actor = { path = "../iroha_actor" }
 iroha_config = { version = "=0.1.0", path = "../iroha_config" }
 iroha_futures = { path = "../iroha_futures" }
 iroha_telemetry = { path = "../iroha_telemetry", optional = true }
+iroha_schema = { path = "../iroha_schema"}
 
 async-trait = "0.1"
 chrono = "0.4"

--- a/iroha/src/genesis.rs
+++ b/iroha/src/genesis.rs
@@ -7,6 +7,7 @@ use iroha_actor::Addr;
 use iroha_crypto::KeyPair;
 use iroha_data_model::{account::Account, isi::Instruction, prelude::*};
 use iroha_error::{error, Result, WrapErr};
+use iroha_schema::prelude::*;
 use serde::Deserialize;
 use tokio::{time, time::Duration};
 
@@ -204,13 +205,15 @@ impl GenesisNetworkTrait for GenesisNetwork {
     }
 }
 
-#[derive(Clone, Deserialize, Debug)]
-struct RawGenesisBlock {
+/// `RawGenesisBlock` is an initial block of the network
+#[derive(Clone, Deserialize, Debug, IntoSchema)]
+pub struct RawGenesisBlock {
+    /// Transactions
     pub transactions: Vec<GenesisTransaction>,
 }
 
-/// `GenesisTransaction` is a transaction for inisialize settings.
-#[derive(Clone, Deserialize, Debug)]
+/// `GenesisTransaction` is a transaction for initialize settings.
+#[derive(Clone, Deserialize, Debug, IntoSchema)]
 pub struct GenesisTransaction {
     /// Instructions
     pub isi: Vec<Instruction>,

--- a/iroha_schema/iroha_schema_bin/Cargo.toml
+++ b/iroha_schema/iroha_schema_bin/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2018"
 [dependencies]
 iroha_schema = { path = "../../iroha_schema" }
 iroha_data_model = { path = "../../iroha_data_model" }
+iroha = { path = "../../iroha" }
 iroha_error = { path = "../../iroha_error" }
 serde_json = "1"

--- a/iroha_schema/iroha_schema_bin/src/main.rs
+++ b/iroha_schema/iroha_schema_bin/src/main.rs
@@ -15,6 +15,7 @@ macro_rules! to_json {
 }
 
 fn main() {
+    use iroha::genesis::RawGenesisBlock;
     use iroha_data_model::{
         expression::*,
         isi::{If, *},
@@ -74,6 +75,8 @@ fn main() {
         VersionedSignedQueryRequest,
         VersionedQueryResult,
         VersionedEventSocketMessage,
+
+        RawGenesisBlock
     };
 
     println!("{}", json)


### PR DESCRIPTION
Signed-off-by: rkharisov <rinat@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Added RawGenesisBlock to schema introspection

### Benefits

Clients will be aware of Iroha2 genesis format. It is very useful for integration tests - allows to specify initial state of the blockchain. Also knowing of genesis format helps for deployment configuration due Genesis in client's code can be serialised and shared

