### PR TITLE
Altered  representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
 name = "iroha_schema"
 version = "0.1.0"
 dependencies = [
+ "fixnum",
  "iroha_schema_derive",
  "parity-scale-codec",
  "serde",

--- a/iroha_data_model/src/lib.rs
+++ b/iroha_data_model/src/lib.rs
@@ -1080,7 +1080,7 @@ pub mod fixed {
     pub type FixNum = FixedPoint<Base, U9>;
 
     /// An encapsulation of [`Fixed`] in encodable form.
-    #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Copy, Debug, Serialize, Deserialize, IntoSchema)]
     pub struct Fixed(FixNum);
 
     impl Fixed {
@@ -1162,12 +1162,6 @@ pub mod fixed {
 
         fn encoded_fixed_size() -> Option<usize> {
             Some(std::mem::size_of::<Base>())
-        }
-    }
-
-    impl IntoSchema for Fixed {
-        fn schema(map: &mut MetaMap) {
-            let _ = map.entry(Self::type_name()).or_insert(Metadata::Fixed);
         }
     }
 

--- a/iroha_schema/Cargo.toml
+++ b/iroha_schema/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 parity-scale-codec = { version = "2", features = ["derive"] }
 iroha_schema_derive = { path = "iroha_schema_derive" }
+fixnum = { version = "0.6", features = ["i64"]}


### PR DESCRIPTION
Signed-off-by: rkharisov <rinat@soramitsu.co.jp>

### Description of the Change

Altered representation of fixed point

Previously was: 
```json
  "iroha_schema::iroha_data_model::fixed::Fixed": "Fixed",
```

Now will be:
```json
 "iroha_data_model::fixed::Fixed": {
    "TupleStruct": {
      "types": [
        "FixedPoint<i64>"
      ]
    }
  },
"FixedPoint<i64>": {
    "FixedPoint": {
      "base": "i64",
      "decimal_places": 9
    }
  }
```
