### PR TITLE
Removal of arguments from test_network crate

### DIFF
--- a/iroha/src/init.rs
+++ b/iroha/src/init.rs
@@ -1,20 +1,20 @@
 use std::collections::BTreeMap;
 
 use iroha_data_model::prelude::*;
+use iroha_error::{error, Result};
 
 use crate::config::Configuration;
 
 /// Returns the a map of a form `domain_name -> domain`, for initial domains.
-#[allow(clippy::expect_used)]
-pub fn domains(configuration: &Configuration) -> BTreeMap<String, Domain> {
+pub fn domains(configuration: &Configuration) -> Result<BTreeMap<String, Domain>> {
     let key = configuration
         .genesis_configuration
         .genesis_account_public_key
         .clone()
-        .expect("Genesis account public key is not specified.");
-    std::iter::once((
+        .ok_or_else(|| error!("Genesis account public key is not specified."))?;
+    Ok(std::iter::once((
         GENESIS_DOMAIN_NAME.to_owned(),
         Domain::from(GenesisDomain::new(key)),
     ))
-    .collect()
+    .collect())
 }

--- a/iroha/src/tx.rs
+++ b/iroha/src/tx.rs
@@ -553,7 +553,10 @@ mod tests {
         let accepted_tx_hash = accepted_tx.hash();
         let valid_tx_hash = accepted_tx
             .validate(
-                &WorldStateView::new(World::with(init::domains(&config), BTreeSet::new())),
+                &WorldStateView::new(World::with(
+                    init::domains(&config).unwrap(),
+                    BTreeSet::new(),
+                )),
                 &AllowAll.into(),
                 &AllowAll.into(),
                 true,

--- a/iroha_dsl/tests/dsl.rs
+++ b/iroha_dsl/tests/dsl.rs
@@ -2,7 +2,10 @@
 
 use std::{thread, time::Duration};
 
-use iroha::{config::Configuration, Arguments};
+use iroha::{
+    config::Configuration,
+    genesis::{GenesisNetwork, GenesisNetworkTrait},
+};
 use iroha_client::{client::Client, config::Configuration as ClientConfiguration};
 use iroha_dsl::prelude::*;
 use test_network::{Peer as TestPeer, TestRuntime};
@@ -112,15 +115,15 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         Duration::from_millis(configuration.sumeragi_configuration.pipeline_time_ms());
 
     // Given
+    let genesis = GenesisNetwork::from_configuration(
+        true,
+        GENESIS_PATH,
+        &configuration.genesis_configuration,
+        configuration.sumeragi_configuration.max_instruction_number,
+    )
+    .unwrap();
     let rt = Runtime::test();
-    rt.block_on(peer.start_with_config(
-        Arguments {
-            submit_genesis: true,
-            genesis_path: GENESIS_PATH.into(),
-            ..Arguments::default()
-        },
-        configuration,
-    ));
+    rt.block_on(peer.start_with_config(genesis, configuration));
     thread::sleep(pipeline_time);
 
     let mut configuration = ClientConfiguration::from_path(CLIENT_CONFIGURATION_PATH)

--- a/iroha_p2p/src/network.rs
+++ b/iroha_p2p/src/network.rs
@@ -44,7 +44,7 @@ where
     K: KeyExchangeScheme + Send + 'static,
     E: Encryptor + Send + 'static,
 {
-    /// Listening to this address for incoming connections. Must parse into [`SocketAddr`].
+    /// Listening to this address for incoming connections. Must parse into [`std::net::SocketAddr`].
     listen_addr: String,
     /// Peers that are doing handshakes for the moment
     pub new_peers: HashMap<ConnectionId, Addr<Peer<T, K, E>>>,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Removal of arguments from test_network crate

### Issue

It is a failure point for us to have arguments in tests, as they force us to read from disk. Also that forces us to take with us 3 configs and put them everywhere in tests.

### Benefits

Less errors due to disk failures. Easier genesis usage in tests.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
