### PR TITLE
Add wsv_checker and migration-tool to docker image

### DIFF
--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -49,6 +49,7 @@ jobs:
   ## anyway please read .github/README.md
   check_workflow_yaml_coressponds_to_src_yaml:
     runs-on: ubuntu-latest
+    container: ubuntu:latest  ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
     name: Check if github workflows were properly made from sources
     steps:
       - &step_detect_commented_pr
@@ -79,6 +80,7 @@ jobs:
   pr_comment_reaction_rocket:
     ## Just to react to valid comment with rocket
     runs-on: ubuntu-latest
+    container: ubuntu:latest
     if: ${{ github.event.comment &&
           github.event.issue.pull_request &&
           startsWith(github.event.comment.body, '/build') }}
@@ -115,6 +117,7 @@ jobs:
   ## - on schedule '/build all'
   generate_matrixes:
     runs-on: ubuntu-latest
+    container: ubuntu:latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment &&
           github.event.issue.pull_request &&
           startsWith(github.event.comment.body, '/build') ) }}
@@ -783,8 +786,8 @@ jobs:
       - generate_matrixes
     runs-on: [ self-hosted, Linux ]  ## or ubuntu-latest
     strategy: *strategy_ubuntu_release
-    #if: *if_ubuntu_release
-    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    if: *if_ubuntu_release
+    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
     env: &env_dockerhub_release
       <<: *env_dockerhub
       IMAGE_NAME: iroha
@@ -834,7 +837,7 @@ jobs:
         with:
           <<: *step_docker_build_and_push_with
           context: docker/release/
-          push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+          push: ${{ steps.docker_login.outcome == 'success' && matrix.CC == 'gcc-9' }}
       - <<: *step_docker_build_and_push_ghcr
         with:
           <<: *step_docker_build_and_push_ghcr-with
@@ -847,5 +850,5 @@ jobs:
       - build-UD
       - generate_matrixes
     strategy: *strategy_ubuntu_debug
-    #if: *if_ubuntu_debug
-    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+    if: *if_ubuntu_debug
+    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -27,7 +27,7 @@ name: Iroha1
 on:
   push:
     branches: [ main, support/1.*, edge, develop, test-ci, gha, gha/*, gha-*, \*-with-gha ]
-    tags: [ 'v*' ]
+    tags:
   pull_request:
     branches: [ main, support/1.*, edge, develop ]  ## target branches
   workflow_dispatch:
@@ -111,8 +111,8 @@ jobs:
   ## At the moment there are several options:
   ## - default on pushes, pull requests
   ## - on comment to pull request according to comment message (chat-ops)
-  ## - TODO on workflow_dispatch according to its build_spec
-  ## - TODO all on schedule
+  ## - on workflow_dispatch according to its build_spec
+  ## - on schedule '/build all'
   generate_matrixes:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment &&
@@ -280,14 +280,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
         ## Docker image will be pushed with tags:
         ##  - hash of file Dockerfile.builder
         ##  - branchname, when branch is pushed
@@ -492,6 +490,7 @@ jobs:
           -GNinja
           ${{ matrix.CMAKE_USE }}
           -DTESTING=ON
+          -DBENCHMARKING=ON
           -DPACKAGE_DEB=ON
           #-DCMAKE_VERBOSE_MAKEFILE=ON
       - &step_cmake_build
@@ -784,7 +783,8 @@ jobs:
       - generate_matrixes
     runs-on: [ self-hosted, Linux ]  ## or ubuntu-latest
     strategy: *strategy_ubuntu_release
-    if: *if_ubuntu_release
+    #if: *if_ubuntu_release
+    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
     env: &env_dockerhub_release
       <<: *env_dockerhub
       IMAGE_NAME: iroha
@@ -847,4 +847,5 @@ jobs:
       - build-UD
       - generate_matrixes
     strategy: *strategy_ubuntu_debug
-    if: *if_ubuntu_debug
+    #if: *if_ubuntu_debug
+    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -48,8 +48,8 @@ jobs:
   ## You should `pre-commit install` or use `pre-commit-hook.sh`,
   ## anyway please read .github/README.md
   check_workflow_yaml_coressponds_to_src_yaml:
-    runs-on: ubuntu-latest
-    container: ubuntu:latest  ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest  ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
     name: Check if github workflows were properly made from sources
     steps:
       - &step_detect_commented_pr
@@ -79,8 +79,8 @@ jobs:
 
   pr_comment_reaction_rocket:
     ## Just to react to valid comment with rocket
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest
     if: ${{ github.event.comment &&
           github.event.issue.pull_request &&
           startsWith(github.event.comment.body, '/build') }}
@@ -116,8 +116,8 @@ jobs:
   ## - on workflow_dispatch according to its build_spec
   ## - on schedule '/build all'
   generate_matrixes:
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment &&
           github.event.issue.pull_request &&
           startsWith(github.event.comment.body, '/build') ) }}
@@ -212,7 +212,7 @@ jobs:
   ## Note: image is push only when DockerHub login-token pair available - not to PRs from forks
   Docker-iroha-builder:
     needs: check_workflow_yaml_coressponds_to_src_yaml
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: ubuntu-20.04 #ubuntu-latest #[ self-hosted, Linux ]
     env: &env_dockerhub
       DOCKERHUB_ORG:      hyperledger   ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -37,8 +37,8 @@ on:
         description: 'See chatops-gen-matrix.sh, example "/build ubuntu macos gcc-9 burrow"'
         required: false
         default: '/build'
-  issue_comment:
-    types: [created, edited]
+  # issue_comment:
+  #   types: [created, edited]
   schedule:
     - cron: '12 22 * * *'
 

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -377,7 +377,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: [ self-hosted, Linux ]
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     ## Container is taken from previous job
     container: #&container
       image: &container_image ${{needs.Docker-iroha-builder.outputs.container}}
@@ -784,7 +784,7 @@ jobs:
     needs:
       - build-UR
       - generate_matrixes
-    runs-on: [ self-hosted, Linux ]  ## or ubuntu-latest
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     strategy: *strategy_ubuntu_release
     if: *if_ubuntu_release
     # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -178,7 +178,9 @@ jobs:
           echo "::set-output name=matrix_ubuntu_debug::$(cat matrix_ubuntu_debug)"
           echo "::set-output name=matrix_macos::$(cat matrix_macos)"
           echo "::set-output name=matrix_windows::$(cat matrix_windows)"
-      ##TODO report errors and warnings as answer as issue comment (chat-ops)
+          echo "::set-output name=matrix_dockerimage_release::$(cat matrix_dockerimage_release)"
+          echo "::set-output name=matrix_dockerimage_debug::$(cat matrix_dockerimage_debug)"
+      ##TODO report errors and warnings as answer to issue comment (chat-ops)
       -
         name: Reaction confused
         if: failure() && github.event.comment
@@ -205,6 +207,8 @@ jobs:
       matrix_ubuntu_debug:   ${{steps.matrixes.outputs.matrix_ubuntu_debug}}
       matrix_macos:          ${{steps.matrixes.outputs.matrix_macos}}
       matrix_windows:        ${{steps.matrixes.outputs.matrix_windows}}
+      matrix_dockerimage_release: ${{steps.matrixes.outputs.matrix_dockerimage_release}}
+      matrix_dockerimage_debug:   ${{steps.matrixes.outputs.matrix_dockerimage_debug}}
 
   ## Build docker image named 'hyperledger/iroha-builder' with all stuff to compile iroha and its dependancies
   ## The result docker image is pushed with tags :pr-NUMBER, :commit-HASH, :branch-name, :tag-name,
@@ -785,9 +789,12 @@ jobs:
       - build-UR
       - generate_matrixes
     runs-on: ubuntu-latest #[ self-hosted, Linux ]
-    strategy: *strategy_ubuntu_release
-    if: *if_ubuntu_release
-    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    # strategy: *strategy_ubuntu_release
+    # if: *if_ubuntu_release
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_release ) }}
+    if:       ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_release ).include[0] }}
     env: &env_dockerhub_release
       <<: *env_dockerhub
       IMAGE_NAME: iroha
@@ -849,6 +856,9 @@ jobs:
     needs:
       - build-UD
       - generate_matrixes
-    strategy: *strategy_ubuntu_debug
-    if: *if_ubuntu_debug
-    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+    # strategy: *strategy_ubuntu_debug
+    # if: *if_ubuntu_debug
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_debug ) }}
+    if:       ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_debug ).include[0] }}

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -381,7 +381,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [ self-hosted, Linux ] #ubuntu-latest
     ## Container is taken from previous job
     container: #&container
       image: &container_image ${{needs.Docker-iroha-builder.outputs.container}}
@@ -788,7 +788,7 @@ jobs:
     needs:
       - build-UR
       - generate_matrixes
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [ self-hosted, Linux ] #ubuntu-latest
     # strategy: *strategy_ubuntu_release
     # if: *if_ubuntu_release
     strategy:

--- a/.github/chatops-gen-matrix.sh
+++ b/.github/chatops-gen-matrix.sh
@@ -189,3 +189,6 @@ echo "$MATRIX" | awk -v IGNORECASE=1 '/ubuntu/ && /release/' | json_include >mat
 echo "$MATRIX" | awk -v IGNORECASE=1 '/ubuntu/ && /debug/'   | json_include >matrix_ubuntu_debug
 echo "$MATRIX" | awk -v IGNORECASE=1 '/macos/'               | json_include >matrix_macos
 echo "$MATRIX" | awk -v IGNORECASE=1 '/windows/'             | json_include >matrix_windows
+
+echo "$MATRIX" | awk -v IGNORECASE=1 '/ubuntu/ && /release/ && /gcc-9/' | json_include >matrix_dockerimage_release
+echo "$MATRIX" | awk -v IGNORECASE=1 '/ubuntu/ && /debug/   && /gcc-9/' | json_include >matrix_dockerimage_debug

--- a/.github/chatops-gen-matrix.sh
+++ b/.github/chatops-gen-matrix.sh
@@ -73,7 +73,6 @@ handle_user_line(){
    fi
    shift
    local oses compilers cmake_opts build_types
-   dockerpush=yes
 
    while [[ $# > 0 ]] ;do
       case "$1" in
@@ -91,8 +90,6 @@ handle_user_line(){
          clang|clang-10|clang10)    compilers+=" clang clang-10"  ;;
          llvm)                      compilers+=" $1 " ;;
          msvc)                      compilers+=" $1 " ;;
-         dockerpush)                dockerpush=yes ;;
-         nodockerpush)              dockerpush=no ;;
          all|everything|beforemerge|before_merge|before-merge|readytomerge|ready-to-merge|ready_to_merge)
             oses=${oses:-"$ALL_oses"}
             build_types=${build_types:-"$ALL_build_types"}
@@ -167,8 +164,7 @@ to_json(){
          os:\"$1\",
          cc:\"$2\",
          BuildType:\"$3\",
-         CMAKE_USE:\"$( [[ "$4" = normal ]] || echo "-DUSE_${4^^}=ON" )\",
-         dockerpush: \"$dockerpush\"
+         CMAKE_USE:\"$( [[ "$4" = normal ]] || echo "-DUSE_${4^^}=ON" )\"
       }"
 }
 to_json_multiline(){

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -50,6 +50,7 @@ jobs:
   ## anyway please read .github/README.md
   check_workflow_yaml_coressponds_to_src_yaml:
     runs-on: ubuntu-latest
+    container: ubuntu:latest ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
     name: Check if github workflows were properly made from sources
     steps:
       - name: REF and SHA of commented PR to ENV
@@ -74,6 +75,7 @@ jobs:
   pr_comment_reaction_rocket:
     ## Just to react to valid comment with rocket
     runs-on: ubuntu-latest
+    container: ubuntu:latest
     if: ${{ github.event.comment && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build') }}
     steps:
       - name: Show context
@@ -105,6 +107,7 @@ jobs:
   ## - on schedule '/build all'
   generate_matrixes:
     runs-on: ubuntu-latest
+    container: ubuntu:latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build') ) }}
     # needs: check_workflow_yaml_coressponds_to_src_yaml
     steps:
@@ -1308,8 +1311,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ) }}
-    #if: *if_ubuntu_release
-    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1472,7 +1475,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: docker/release/
-          push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+          push: ${{ steps.docker_login.outcome == 'success' && matrix.CC == 'gcc-9' }}
       - uses: docker/build-push-action@v2
         id: build_and_push_ghcr
         name: Build and push to GHCR
@@ -1492,6 +1495,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   docker-D:
     runs-on: [self-hosted, Linux] ## or ubuntu-latest
+    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1654,7 +1658,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: docker/release/
-          push: ${{ steps.docker_login.outcome == 'success' && ( matrix.dockerpush == '' || matrix.dockerpush == 'yes' ) }}
+          push: ${{ steps.docker_login.outcome == 'success' && matrix.CC == 'gcc-9' }}
       - uses: docker/build-push-action@v2
         id: build_and_push_ghcr
         name: Build and push to GHCR
@@ -1678,5 +1682,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ) }}
-    #if: *if_ubuntu_debug
-    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -29,7 +29,7 @@ name: Iroha1
 on:
   push:
     branches: [main, support/1.*, edge, develop, test-ci, gha, gha/*, gha-*, \*-with-gha]
-    tags: ['v*']
+    tags:
   pull_request:
     branches: [main, support/1.*, edge, develop] ## target branches
   workflow_dispatch:
@@ -101,8 +101,8 @@ jobs:
   ## At the moment there are several options:
   ## - default on pushes, pull requests
   ## - on comment to pull request according to comment message (chat-ops)
-  ## - TODO on workflow_dispatch according to its build_spec
-  ## - TODO all on schedule
+  ## - on workflow_dispatch according to its build_spec
+  ## - on schedule '/build all'
   generate_matrixes:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build') ) }}
@@ -293,22 +293,20 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
+        ## Docker image will be pushed with tags:
+        ##  - hash of file Dockerfile.builder
+        ##  - branchname, when branch is pushed
+        ##  - pr-NUMBER, when pushed to PR
+        ##  - git tag when tag is pushed
+        ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
+        ##  - tag 'edge' when branch support/1.2.x is pushed
+        ##  - schedule, see the docs
       - uses: docker/metadata-action@v3
         name: Docker meta GHCR
         id: meta_ghcr
@@ -318,22 +316,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
 
           images: ghcr.io/${{ github.repository }}-builder
       - name: Set up Docker Buildx
@@ -544,7 +532,7 @@ jobs:
         #    sys time    0,70 secs  575,00 micros    0,70 secs
       - name: CMake configure
         ## Takes 13s on regular GitHub runner
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DPACKAGE_DEB=ON
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DBENCHMARKING=ON -DPACKAGE_DEB=ON
         #-DCMAKE_VERBOSE_MAKEFILE=ON
       - name: CMake build
         run: |
@@ -813,7 +801,7 @@ jobs:
         #    sys time    0,70 secs  575,00 micros    0,70 secs
       - name: CMake configure
         ## Takes 13s on regular GitHub runner
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DPACKAGE_DEB=ON
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DBENCHMARKING=ON -DPACKAGE_DEB=ON
         #-DCMAKE_VERBOSE_MAKEFILE=ON
       - name: CMake build
         run: |
@@ -1080,7 +1068,7 @@ jobs:
         #    sys time    0,70 secs  575,00 micros    0,70 secs
       - name: CMake configure
         ## Takes 13s on regular GitHub runner
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DPACKAGE_DEB=ON
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DBENCHMARKING=ON -DPACKAGE_DEB=ON
         #-DCMAKE_VERBOSE_MAKEFILE=ON
       - name: CMake build
         run: |
@@ -1288,7 +1276,7 @@ jobs:
         #    sys time    0,70 secs  575,00 micros    0,70 secs
       - name: CMake configure
         ## Takes 13s on regular GitHub runner
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DPACKAGE_DEB=ON
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/build-vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }} -GNinja ${{ matrix.CMAKE_USE }} -DTESTING=ON -DBENCHMARKING=ON -DPACKAGE_DEB=ON
         #-DCMAKE_VERBOSE_MAKEFILE=ON
       - name: CMake build
         run: |
@@ -1320,7 +1308,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ) }}
-    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    #if: *if_ubuntu_release
+    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1418,22 +1407,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
 
           images: |
             ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}
@@ -1449,22 +1428,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
 
           flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
           #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
@@ -1620,22 +1589,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
 
           images: |
             ${{ env.DOCKERHUB_ORG }}/${{ env.IMAGE_NAME }}${{ env._uses_suffix }}
@@ -1651,22 +1610,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=schedule
-            type=edge,branch=support/1.2.x
             type=edge,branch=develop
-            type=edge,branch=test-ci
-            type=sha,prefix=commit-,format=short
-            type=sha,prefix=commit-,format=long
-          ## Docker image will be pushed with tags:
-          ##  - hash of file Dockerfile.builder
-          ##  - branchname, when branch is pushed
-          ##  - pr-NUMBER, when pushed to PR
-          ##  - git tag when tag is pushed
-          ##  - semver like 1.2.3 and 1.2 when tag vX.X.X is pushed
-          ##  - tag 'edge' when branch support/1.2.x is pushed
-          ##  - schedule, see the docs
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=sha,prefix=commit-,format=short
+          #  type=sha,prefix=commit-,format=long
 
           flavor: suffix=${{env._compiler_suffix}}${{env._debug_suffix}}
           #maybetodo flavor: prefix=${{ env.USES_PREFIX }}  ## In case creating repository hyperledger/iroha-burrow denied, Use tag prefix hyperledger/iroha:burrow-xxxx
@@ -1729,4 +1678,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ) }}
-    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+    #if: *if_ubuntu_debug
+    if: ${{ matrix.CC = 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -49,8 +49,8 @@ jobs:
   ## You should `pre-commit install` or use `pre-commit-hook.sh`,
   ## anyway please read .github/README.md
   check_workflow_yaml_coressponds_to_src_yaml:
-    runs-on: ubuntu-latest
-    container: ubuntu:latest ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest  ## This is required as barrier between AWS-hosted runners and GitHub-hosted runners - they have different set of software, so run in container
     name: Check if github workflows were properly made from sources
     steps:
       - name: REF and SHA of commented PR to ENV
@@ -74,8 +74,8 @@ jobs:
           [[ $(./.github/make-workflows.sh -x --worktree) = *"everything is up to date" ]]
   pr_comment_reaction_rocket:
     ## Just to react to valid comment with rocket
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest
     if: ${{ github.event.comment && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build') }}
     steps:
       - name: Show context
@@ -106,8 +106,8 @@ jobs:
   ## - on workflow_dispatch according to its build_spec
   ## - on schedule '/build all'
   generate_matrixes:
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04 #ubuntu-latest
+    #container: ubuntu:latest
     if: ${{ (github.event_name != 'comment') || ( github.event.comment && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build') ) }}
     # needs: check_workflow_yaml_coressponds_to_src_yaml
     steps:
@@ -209,7 +209,7 @@ jobs:
   ## Note: image is push only when DockerHub login-token pair available - not to PRs from forks
   Docker-iroha-builder:
     needs: check_workflow_yaml_coressponds_to_src_yaml
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: ubuntu-20.04 #ubuntu-latest #[ self-hosted, Linux ]
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -399,7 +399,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [self-hosted, Linux] #ubuntu-latest
     ## Container is taken from previous job
     container: #&container
       image: ${{needs.Docker-iroha-builder.outputs.container}}
@@ -672,7 +672,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [self-hosted, Linux] #ubuntu-latest
     ## Container is taken from previous job
     container: #&container
       image: ${{needs.Docker-iroha-builder.outputs.container}}
@@ -1311,7 +1311,7 @@ jobs:
     needs:
       - build-UR
       - generate_matrixes
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [self-hosted, Linux] #ubuntu-latest
     # strategy: *strategy_ubuntu_release
     # if: *if_ubuntu_release
     strategy:
@@ -1499,7 +1499,7 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   docker-D:
-    runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    runs-on: [self-hosted, Linux] #ubuntu-latest
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -178,7 +178,9 @@ jobs:
           echo "::set-output name=matrix_ubuntu_debug::$(cat matrix_ubuntu_debug)"
           echo "::set-output name=matrix_macos::$(cat matrix_macos)"
           echo "::set-output name=matrix_windows::$(cat matrix_windows)"
-      ##TODO report errors and warnings as answer as issue comment (chat-ops)
+          echo "::set-output name=matrix_dockerimage_release::$(cat matrix_dockerimage_release)"
+          echo "::set-output name=matrix_dockerimage_debug::$(cat matrix_dockerimage_debug)"
+      ##TODO report errors and warnings as answer to issue comment (chat-ops)
       - name: Reaction confused
         if: failure() && github.event.comment
         run: |
@@ -203,6 +205,8 @@ jobs:
       matrix_ubuntu_debug: ${{steps.matrixes.outputs.matrix_ubuntu_debug}}
       matrix_macos: ${{steps.matrixes.outputs.matrix_macos}}
       matrix_windows: ${{steps.matrixes.outputs.matrix_windows}}
+      matrix_dockerimage_release: ${{steps.matrixes.outputs.matrix_dockerimage_release}}
+      matrix_dockerimage_debug: ${{steps.matrixes.outputs.matrix_dockerimage_debug}}
   ## Build docker image named 'hyperledger/iroha-builder' with all stuff to compile iroha and its dependancies
   ## The result docker image is pushed with tags :pr-NUMBER, :commit-HASH, :branch-name, :tag-name,
   ## and conditional tags :edge (for development branches) and :latest (for git-tags)
@@ -1308,11 +1312,12 @@ jobs:
       - build-UR
       - generate_matrixes
     runs-on: ubuntu-latest #[ self-hosted, Linux ]
+    # strategy: *strategy_ubuntu_release
+    # if: *if_ubuntu_release
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ) }}
-    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
-    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_release ) }}
+    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_release ).include[0] }}
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1678,8 +1683,9 @@ jobs:
     needs:
       - build-UD
       - generate_matrixes
+    # strategy: *strategy_ubuntu_debug
+    # if: *if_ubuntu_debug
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ) }}
-    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
-    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_debug ).include[0] }}
+      matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_debug ) }}
+    if: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_dockerimage_debug ).include[0] }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -395,7 +395,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     ## Container is taken from previous job
     container: #&container
       image: ${{needs.Docker-iroha-builder.outputs.container}}
@@ -668,7 +668,7 @@ jobs:
     needs:
       - Docker-iroha-builder
       - generate_matrixes
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     ## Container is taken from previous job
     container: #&container
       image: ${{needs.Docker-iroha-builder.outputs.container}}
@@ -1307,7 +1307,7 @@ jobs:
     needs:
       - build-UR
       - generate_matrixes
-    runs-on: [self-hosted, Linux] ## or ubuntu-latest
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ) }}
@@ -1494,8 +1494,7 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   docker-D:
-    runs-on: [self-hosted, Linux] ## or ubuntu-latest
-    # if: ${{ matrix.CC == 'gcc-9' && fromJSON( needs.generate_matrixes.outputs.matrix_ubuntu_release ).include[0] }}
+    runs-on: ubuntu-latest #[ self-hosted, Linux ]
     env:
       DOCKERHUB_ORG: hyperledger ## Must be hyperledger, also can use iroha1, cannot use ${{ secrets.DOCKERHUB_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -39,8 +39,8 @@ on:
         description: 'See chatops-gen-matrix.sh, example "/build ubuntu macos gcc-9 burrow"'
         required: false
         default: '/build'
-  issue_comment:
-    types: [created, edited]
+  # issue_comment:
+  #   types: [created, edited]
   schedule:
     - cron: '12 22 * * *'
 jobs:

--- a/irohad/migration-tool/CMakeLists.txt
+++ b/irohad/migration-tool/CMakeLists.txt
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+
 set(CMAKE_CXX_STANDARD 20)
 add_executable(migration-tool migration-tool.cpp ../main/impl/storage_init.cpp)
 #target_compile_features(migration-tool PUBLIC cxx_std_20)
@@ -19,3 +21,5 @@ target_link_libraries(migration-tool PRIVATE
 
 find_package(nlohmann_json CONFIG REQUIRED)
 target_link_libraries(migration-tool PRIVATE nlohmann_json nlohmann_json::nlohmann_json)
+
+add_install_step_for_bin(migration-tool)

--- a/irohad/wsv_checker/CMakeLists.txt
+++ b/irohad/wsv_checker/CMakeLists.txt
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+
 set(CMAKE_CXX_STANDARD 20)
 add_executable(wsv_checker wsv_checker.cpp)
 #target_compile_features(wsv_checker PUBLIC cxx_std_20)
@@ -15,3 +17,5 @@ target_link_libraries(wsv_checker PRIVATE
 
 find_package(nlohmann_json CONFIG REQUIRED)
 target_link_libraries(wsv_checker PRIVATE nlohmann_json nlohmann_json::nlohmann_json)
+
+add_install_step_for_bin(wsv_checker)


### PR DESCRIPTION
## Closes #1415
### engulfs #1411

 * push docker images only with gcc-9 builds
 * enable 'latest' for all tags, earlier were 'v*'
 * reduce number of docker tags: remove commit-*
 * `-DBENCHMARKING=ON`
