### PR TITLE
GaroRobe/issue1465

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha3",
+ "sha3 0.8.2",
  "subtle-encoding",
  "zeroize",
 ]
@@ -235,23 +235,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium 0.3.0",
- "wyz",
-]
-
-[[package]]
-name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -285,6 +274,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -508,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
 name = "core-foundation"
@@ -643,13 +633,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.7.0"
+name = "crypto-bigint"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
 dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
+ "generic-array 0.14.4",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -659,17 +651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -712,7 +704,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -728,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
 dependencies = [
  "const-oid",
 ]
@@ -784,12 +776,13 @@ checksum = "fc4b29f4b9bb94bf267d57269fd0706d343a160937108e9619fe380645428abb"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
- "hmac 0.10.1",
+ "hmac",
  "signature",
 ]
 
@@ -812,7 +805,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2",
  "zeroize",
 ]
 
@@ -824,19 +817,17 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "bitvec 0.18.5",
- "digest 0.9.0",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array 0.14.4",
  "group",
  "pkcs8",
- "rand_core 0.5.1",
- "subtle 2.4.1",
+ "rand_core 0.6.3",
+ "subtle",
  "zeroize",
 ]
 
@@ -879,20 +870,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec 0.18.5",
- "rand_core 0.5.1",
- "subtle 2.4.1",
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
@@ -1134,13 +1118,13 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core 0.5.1",
- "subtle 2.4.1",
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
@@ -1244,31 +1228,21 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
- "digest 0.8.1",
- "hmac 0.7.1",
+ "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
+ "crypto-mac 0.11.1",
  "digest 0.9.0",
 ]
 
@@ -1421,7 +1395,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "unique_port",
- "ursa",
  "warp",
 ]
 
@@ -1485,7 +1458,6 @@ dependencies = [
  "tracing",
  "tungstenite",
  "unique_port",
- "ursa",
 ]
 
 [[package]]
@@ -1566,7 +1538,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "ursa",
  "warp",
 ]
 
@@ -1665,7 +1636,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "unique_port",
- "ursa",
 ]
 
 [[package]]
@@ -1789,14 +1759,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.7.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.6",
+ "sha2",
 ]
 
 [[package]]
@@ -2070,7 +2040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
 dependencies = [
  "arrayvec",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -2139,11 +2109,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -2282,12 +2253,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
@@ -2715,18 +2680,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
@@ -2752,6 +2705,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,12 +2727,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest 0.9.0",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2784,6 +2749,15 @@ checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -2830,12 +2804,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -3269,7 +3237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3286,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "ursa"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3a5042fd816173a9992637b8ed2bc7028ea7f469c0a55e4de07e83da56688b"
+checksum = "8760a62e18e4d3e3f599e15c09a9f9567fd9d4a90594d45166162be8d232e63b"
 dependencies = [
  "aead",
  "aes",
@@ -3305,7 +3273,7 @@ dependencies = [
  "failure",
  "hex",
  "hkdf",
- "hmac 0.7.1",
+ "hmac",
  "int_traits",
  "k256",
  "lazy_static",
@@ -3315,9 +3283,9 @@ dependencies = [
  "rand_chacha 0.2.1",
  "secp256k1",
  "serde",
- "sha2 0.8.2",
- "sha3",
- "subtle 2.4.1",
+ "sha2",
+ "sha3 0.9.1",
+ "subtle",
  "time",
  "x25519-dalek",
  "zeroize",

--- a/iroha/Cargo.toml
+++ b/iroha/Cargo.toml
@@ -53,7 +53,6 @@ tokio-stream = { version = "0.1.6", features = ["fs"]}
 tracing = "0.1"
 crossbeam-queue = "0.3"
 warp = "0.3"
-ursa = "=0.3.6"
 structopt = { version = "0.3", optional = true }
 thiserror = "1.0.28"
 

--- a/iroha_client/Cargo.toml
+++ b/iroha_client/Cargo.toml
@@ -25,7 +25,6 @@ iroha_crypto = { version = "=0.1.0", path = "../iroha_crypto" }
 iroha_config = { path = "../iroha_config" }
 iroha_version = { version = "=0.1.0", path = "../iroha_version" }
 eyre = "0.6.5"
-ursa = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 attohttpc = "0.16.3"

--- a/iroha_crypto/Cargo.toml
+++ b/iroha_crypto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 eyre = "0.6.5"
-ursa = "=0.3.6"
+ursa = "=0.3.7"
 openssl-sys = { version = "0", features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/iroha_crypto/src/lib.rs
+++ b/iroha_crypto/src/lib.rs
@@ -1,5 +1,7 @@
 //! This module contains structures and implementations related to the cryptographic parts of the Iroha.
 
+pub use ursa;
+
 pub mod multihash;
 mod varint;
 

--- a/iroha_data_model/Cargo.toml
+++ b/iroha_data_model/Cargo.toml
@@ -34,7 +34,6 @@ dashmap = { version = "4.0" }
 parity-scale-codec = { version = "2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-ursa = "0.3.2"
 thiserror = "1.0.28"
 
 warp = { version = "0.3", default-features = false, optional = true }

--- a/iroha_p2p/Cargo.toml
+++ b/iroha_p2p/Cargo.toml
@@ -27,7 +27,6 @@ futures = { version = "0.3" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 parity-scale-codec = { version = "2", features = ["derive"] }
-ursa = "=0.3.6"
 aead = "0.3.2"
 thiserror = "1.0.28"
 

--- a/iroha_p2p/src/lib.rs
+++ b/iroha_p2p/src/lib.rs
@@ -4,11 +4,11 @@
 
 use std::{io, net::AddrParseError};
 
+use iroha_crypto::ursa::{encryption::symm::prelude::ChaCha20Poly1305, kex::x25519::X25519Sha256};
 use iroha_derive::FromVariant;
 pub use network::{ConnectPeer, NetworkBase, Post};
 use parity_scale_codec::{Decode, Encode};
 use thiserror::Error;
-use ursa::{encryption::symm::prelude::ChaCha20Poly1305, kex::x25519::X25519Sha256};
 
 /// Network is a main p2p start point.
 pub mod network;

--- a/iroha_p2p/src/network.rs
+++ b/iroha_p2p/src/network.rs
@@ -10,7 +10,10 @@ use iroha_actor::{
     broker::{Broker, BrokerMessage},
     Actor, Addr, Context, ContextHandler, Handler,
 };
-use iroha_crypto::PublicKey;
+use iroha_crypto::{
+    ursa::{encryption::symm::Encryptor, kex::KeyExchangeScheme},
+    PublicKey,
+};
 use iroha_logger::{debug, info, warn};
 use parity_scale_codec::{Decode, Encode};
 use rand::prelude::SliceRandom;
@@ -21,7 +24,6 @@ use tokio::{
         oneshot::{Receiver, Sender},
     },
 };
-use ursa::{encryption::symm::Encryptor, kex::KeyExchangeScheme};
 
 use crate::{
     peer::{Peer, PeerId},

--- a/iroha_p2p/src/peer.rs
+++ b/iroha_p2p/src/peer.rs
@@ -6,6 +6,11 @@ use std::{
 use async_stream::stream;
 use futures::Stream;
 use iroha_actor::{broker::Broker, Actor, Context, ContextHandler, Handler};
+use iroha_crypto::ursa::{
+    encryption::symm::{Encryptor, SymmetricEncryptor},
+    kex::KeyExchangeScheme,
+    keys::{PrivateKey, PublicKey},
+};
 use iroha_logger::{debug, info, warn};
 use parity_scale_codec::{Decode, Encode};
 use rand::{Rng, RngCore};
@@ -20,11 +25,6 @@ use tokio::{
         oneshot,
         oneshot::{Receiver, Sender},
     },
-};
-use ursa::{
-    encryption::symm::{Encryptor, SymmetricEncryptor},
-    kex::KeyExchangeScheme,
-    keys::{PrivateKey, PublicKey},
 };
 
 use crate::{

--- a/iroha_p2p/tests/mod.rs
+++ b/iroha_p2p/tests/mod.rs
@@ -296,7 +296,7 @@ async fn start_network(
 
 #[test]
 fn test_encryption() {
-    use ursa::encryption::symm::prelude::*;
+    use iroha_crypto::ursa::encryption::symm::prelude::*;
 
     const TEST_KEY: [u8; 32] = [
         5, 87, 82, 183, 220, 57, 107, 49, 227, 4, 96, 231, 198, 88, 153, 11, 22, 65, 56, 45, 237,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Initially, the task was to migrate to HL Ursa portable, to sever dependency on C libraries. 
Unfortunately, it turned out to be not the time yet, so I simply upgraded ursa version to 0.3.7 and removed all direct dependencies on ursa except for one in iroha_crypto.

### Benefits

iroha_crypto now encapsulates functionality provided by ursa (re-exports it actually) and we have a single point to set ursa version.

### Possible Drawbacks 

We should get back to the question of Rust-only solution later, possibly when Ursa will support it better.