### PR TITLE
Gossip and queue fixes

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -56,9 +56,9 @@ jobs:
           context: .
           push: true
           tags: iroha1/iroha:iroha2-dev
-          build-args:
-            - TARGET_DIR=release
-            - PROFILE=--release
+          build-args: |
+            TARGET_DIR=release
+            PROFILE=--release
 
       - name: Build and push Iroha client cli Docker image
         uses: docker/build-push-action@v2
@@ -66,10 +66,10 @@ jobs:
           context: .
           push: true
           tags: iroha1/iroha:iroha2-client-cli-dev
-          build-args:
-            - TARGET_DIR=release
-            - PROFILE=--release
-            - BIN=iroha_client_cli
+          build-args: |
+            TARGET_DIR=release
+            PROFILE=--release
+            BIN=iroha_client_cli
 
       - name: Build and push Iroha Crypto CLI Docker image
         uses: docker/build-push-action@v2
@@ -77,10 +77,10 @@ jobs:
           context: .
           push: true
           tags: iroha1/iroha:iroha2-crypto-cli-dev
-          build-args:
-            - TARGET_DIR=release
-            - PROFILE=--release
-            - BIN=iroha_crypto_cli
+          build-args: |
+            TARGET_DIR=release
+            PROFILE=--release
+            BIN=iroha_crypto_cli
 
   # Coverage is both in PR and in push pipelines so that:
   # 1. PR can get coverage report from bot.

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,58 @@
+version: "3.3"
+services:
+  iroha:
+    build:
+      context: .
+    image: iroha:debug
+    environment:
+      TORII_P2P_ADDR: iroha:1337
+      TORII_API_URL: iroha:8080
+      IROHA_PUBLIC_KEY: "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
+      IROHA_PRIVATE_KEY: '{"digest_function": "ed25519", "payload": "9ac47abf59b356e0bd7dcbbbb4dec080e302156a48ca907e47cb6aea1d32719e7233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"}'
+      SUMERAGI_TRUSTED_PEERS: '[{"address":"iroha:1337", "public_key": "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"}, {"address":"iroha2:1338", "public_key": "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"}, {"address": "iroha3:1339", "public_key": "ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"}, {"address": "iroha4:1340", "public_key": "ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"}]'
+    ports:
+      - "1337:1337"
+      - "8080:8080"
+    command: ./iroha_cli --submit-genesis
+
+  iroha2:
+    depends_on:
+      - iroha
+    image: iroha:debug
+    environment:
+      TORII_P2P_ADDR: iroha2:1338
+      TORII_API_URL: iroha2:8081
+      IROHA_PUBLIC_KEY: "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"
+      IROHA_PRIVATE_KEY: '{"digest_function": "ed25519", "payload": "3bac34cda9e3763fa069c1198312d1ec73b53023b8180c822ac355435edc4a24cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"}'
+      SUMERAGI_TRUSTED_PEERS: '[{"address":"iroha:1337", "public_key": "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"}, {"address":"iroha2:1338", "public_key": "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"}, {"address": "iroha3:1339", "public_key": "ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"}, {"address": "iroha4:1340", "public_key": "ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"}]'
+    ports:
+      - "1338:1338"
+      - "8081:8081"
+
+  iroha3:
+    depends_on:
+      - iroha
+    image: iroha:debug
+    environment:
+      TORII_P2P_ADDR: iroha3:1339
+      TORII_API_URL: iroha3:8082
+      IROHA_PUBLIC_KEY: "ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"
+      IROHA_PRIVATE_KEY: '{"digest_function": "ed25519", "payload": "1261a436d36779223d7d6cf20e8b644510e488e6a50bafd77a7485264d27197dfaca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"}'
+      SUMERAGI_TRUSTED_PEERS: '[{"address":"iroha:1337", "public_key": "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"}, {"address":"iroha2:1338", "public_key": "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"}, {"address": "iroha3:1339", "public_key": "ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"}, {"address": "iroha4:1340", "public_key": "ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"}]'
+    ports:
+      - "1339:1339"
+      - "8082:8082"
+
+  iroha4:
+    depends_on:
+      - iroha
+    image: iroha:debug
+    environment:
+      TORII_P2P_ADDR: iroha4:1340
+      TORII_API_URL: iroha4:8083
+      IROHA_PUBLIC_KEY: "ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"
+      IROHA_PRIVATE_KEY: '{"digest_function": "ed25519", "payload": "a70dab95c7482eb9f159111b65947e482108cfe67df877bd8d3b9441a781c7c98e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"}'
+      SUMERAGI_TRUSTED_PEERS: '[{"address":"iroha:1337", "public_key": "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"}, {"address":"iroha2:1338", "public_key": "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"}, {"address": "iroha3:1339", "public_key": "ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020"}, {"address": "iroha4:1340", "public_key": "ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f"}]'
+    ports:
+      - "1340:1340"
+      - "8083:8083"

--- a/iroha/src/torii/mod.rs
+++ b/iroha/src/torii/mod.rs
@@ -70,9 +70,10 @@ pub enum Error {
     /// Error while getting or setting configuration
     #[error("Configuration error")]
     Config(#[source] ConfigError),
-    /// Queue is full
-    #[error("Queue is full")]
-    FullQueue,
+    //TODO: Have specific errors for each case in queue push failure
+    /// Failed to push into queue.
+    #[error("Failed to push into queue")]
+    PushIntoQueue,
 }
 
 impl Reply for Error {
@@ -84,7 +85,7 @@ impl Reply for Error {
                 ExecuteQuery(_)
                 | RequestPendingTransactions(_)
                 | DecodeRequestPendingTransactions(_)
-                | FullQueue
+                | PushIntoQueue
                 | EncodePendingTransactions(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 TxTooBig | VersionedTransaction(_) | AcceptTransaction(_) | ValidateQuery(_) => {
                     StatusCode::BAD_REQUEST
@@ -242,7 +243,7 @@ async fn handle_instructions<W: WorldTrait>(
     state
         .queue
         .push(transaction, &*state.wsv)
-        .map_err(|_| Error::FullQueue)
+        .map_err(|_| Error::PushIntoQueue)
         .map(|()| Empty)
 }
 

--- a/iroha/src/torii/mod.rs
+++ b/iroha/src/torii/mod.rs
@@ -282,7 +282,16 @@ async fn handle_pending_transactions<W: WorldTrait>(
     state: ToriiState<W>,
     pagination: Pagination,
 ) -> Result<Scale<VersionedPendingTransactions>> {
-    Ok(Scale(state.queue.waiting().paginate(pagination).collect()))
+    Ok(Scale(
+        state
+            .queue
+            .all_transactions()
+            .into_iter()
+            .map(VersionedAcceptedTransaction::into_inner_v1)
+            .map(Transaction::from)
+            .paginate(pagination)
+            .collect(),
+    ))
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/iroha_client/tests/tests/multisignature_transaction.rs
+++ b/iroha_client/tests/tests/multisignature_transaction.rs
@@ -12,7 +12,6 @@ use test_network::*;
 
 #[allow(clippy::too_many_lines)]
 #[test]
-#[ignore = "FIXME"]
 fn multisignature_transactions_should_wait_for_all_signatures() {
     let (_rt, network, _) = <Network>::start_test_with_runtime(4, 1);
     let pipeline_time = Configuration::pipeline_time();
@@ -77,7 +76,8 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     thread::sleep(pipeline_time);
 
     //Then
-    client_configuration.torii_api_url = network.peers.last().unwrap().api_address.clone();
+    client_configuration.torii_api_url =
+        "http://".to_owned() + &network.peers.last().unwrap().api_address;
     let mut iroha_client_1 = Client::new(&client_configuration);
     let request = client::asset::by_account_id(account_id);
     assert!(iroha_client_1


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
- Separates gossiping from round in Sumeragi (therefore fixing MST edge case) see #1433
- Fixes a `panic` in queue on `unreachble()!` macro. It seems it is quite reachable :) Under high load and due to parallelism it can be invoked. We might improve the design here later. But for now it can be just replaced with `continue`
- Adds a docker-compose-local.yml setup to build and start containers locally for testing.
### Queue Bug
#### Setup
Local machine, docker compose with local images on latest dev commit
#### Steps
Submit txs with high frequency manually through iroha_client_cli
#### Result
Several peers stop doing anything, invalid state is reported by tokio due to `unreachable` macro in queue

After fix I tested locally with the same setup to verify that it is working. Later we can try to come up with appropriate test. See next steps.
### Next Steps
This bug fixup is urgent so some of the things that might have been included in this PR were moved to separate issues:
- #1480
- #1479 