### PR TITLE
Log level fix

### DIFF
--- a/iroha_logger/src/lib.rs
+++ b/iroha_logger/src/lib.rs
@@ -27,8 +27,12 @@ pub fn init(configuration: config::LoggerConfiguration) -> Option<Receiver<Telem
     {
         return None;
     }
+
     let level = configuration.max_log_level.into();
-    let subscriber_builder = tracing_subscriber::fmt().with_test_writer();
+    let subscriber_builder = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_max_level(tracing_subscriber::filter::LevelFilter::TRACE);
+
     if configuration.compact_mode {
         let subscriber = subscriber_builder.compact().finish();
         let (subscriber, receiver) = TelemetryLayer::from_capacity(

--- a/iroha_logger/tests/log_level.rs
+++ b/iroha_logger/tests/log_level.rs
@@ -1,0 +1,63 @@
+#![allow(clippy::restriction, clippy::all)]
+
+use std::time::Duration;
+
+use iroha_logger::{
+    debug, info,
+    layer::{EventInspectorTrait, EventSubscriber, LevelFilter},
+    trace,
+};
+use tokio::{sync::mpsc, time};
+use tracing::{Event, Level, Subscriber};
+
+struct SenderFilter<S> {
+    sender: mpsc::UnboundedSender<()>,
+    sub: S,
+}
+
+impl<S: Subscriber> SenderFilter<S> {
+    pub fn new(sub: S) -> (impl Subscriber, mpsc::UnboundedReceiver<()>) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (EventSubscriber(Self { sender, sub }), receiver)
+    }
+}
+
+impl<S: Subscriber> EventInspectorTrait for SenderFilter<S> {
+    type Subscriber = S;
+
+    fn inner_subscriber(&self) -> &Self::Subscriber {
+        &self.sub
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        self.sender.send(()).unwrap();
+        self.sub.event(event)
+    }
+}
+
+#[tokio::test]
+async fn test() {
+    let (sub, mut rcv) = SenderFilter::new(
+        tracing_subscriber::fmt()
+            .with_max_level(tracing_subscriber::filter::LevelFilter::TRACE)
+            .finish(),
+    );
+    let sub = LevelFilter::new(Level::DEBUG, sub);
+    tracing::subscriber::set_global_default(sub).unwrap();
+
+    trace!(a = 2, c = true);
+    debug!(a = 2, c = true);
+    info!(a = 2, c = true);
+
+    time::timeout(Duration::from_millis(10), rcv.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    time::timeout(Duration::from_millis(10), rcv.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(time::timeout(Duration::from_millis(10), rcv.recv())
+        .await
+        .is_err());
+}

--- a/iroha_macro/iroha_derive/tests/from_variant/03-container-enums.rs
+++ b/iroha_macro/iroha_derive/tests/from_variant/03-container-enums.rs
@@ -1,6 +1,8 @@
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
-use std::sync::{Arc, Mutex, RwLock};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+    sync::{Arc, Mutex, RwLock},
+};
 
 struct Variant1;
 struct Variant2;

--- a/iroha_macro/iroha_derive/tests/from_variant/04-container-from.stderr
+++ b/iroha_macro/iroha_derive/tests/from_variant/04-container-from.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `std::convert::From<Variant1>` for type `Enum`
-  --> $DIR/03-container-enums.rs:14:10
+  --> $DIR/03-container-enums.rs:16:10
    |
-14 | #[derive(iroha_derive::FromVariant)]
+16 | #[derive(iroha_derive::FromVariant)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Enum`
    |
   ::: $WORKSPACE/iroha_macro/iroha_derive/tests/from_variant/04-container-from.rs


### PR DESCRIPTION
### Description of the Change

closes #1484

Fix display of logs with log level less than info.

### Issue

Beforehand maximum log level withing tracing was set to `INFO`, now we override it with minimum.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
