### PR TITLE
Detect future timestamp on queue push

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -3,12 +3,12 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::{collections::BTreeSet, iter, marker::PhantomData, time::SystemTime};
+use std::{collections::BTreeSet, iter, marker::PhantomData};
 
 use dashmap::{iter::Iter as MapIter, mapref::one::Ref as MapRef, DashMap};
 use eyre::{Context, Result};
 use iroha_crypto::{HashOf, KeyPair, SignatureOf, SignaturesOf};
-use iroha_data_model::{events::prelude::*, transaction::prelude::*};
+use iroha_data_model::{current_time, events::prelude::*, transaction::prelude::*};
 use iroha_derive::Io;
 use iroha_version::{declare_versioned_with_scale, version_with_scale};
 use parity_scale_codec::{Decode, Encode};
@@ -100,10 +100,7 @@ impl PendingBlock {
     /// Create a new `PendingBlock` from transactions.
     pub fn new(transactions: Vec<VersionedAcceptedTransaction>) -> PendingBlock {
         #[allow(clippy::expect_used)]
-        let timestamp = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Failed to get System Time.")
-            .as_millis();
+        let timestamp = current_time().as_millis();
         PendingBlock {
             timestamp,
             transactions,

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -65,6 +65,11 @@ impl VersionedAcceptedTransaction {
         self.as_inner_v1().is_expired(transaction_time_to_live)
     }
 
+    /// If `true`, this transaction is regarded to have been tampered to have a future timestamp.
+    pub fn is_in_future(&self, threshold: Duration) -> bool {
+        self.as_inner_v1().is_in_future(threshold)
+    }
+
     /// Move transaction lifecycle forward by checking an ability to apply instructions to the
     /// `WorldStateView<W>`.
     /// # Errors
@@ -168,11 +173,18 @@ impl AcceptedTransaction {
     /// Checks if this transaction is waiting longer than specified in `transaction_time_to_live` from `QueueConfiguration` or `time_to_live_ms` of this transaction.
     /// Meaning that the transaction will be expired as soon as the lesser of the specified TTLs was reached.
     pub fn is_expired(&self, transaction_time_to_live: Duration) -> bool {
-        current_time().saturating_sub(Duration::from_millis(self.payload.creation_time))
+        let tx_timestamp = Duration::from_millis(self.payload.creation_time);
+        current_time().saturating_sub(tx_timestamp)
             > min(
-                Duration::from_millis(self.payload.time_to_live_ms),
                 transaction_time_to_live,
+                Duration::from_millis(self.payload.time_to_live_ms),
             )
+    }
+
+    /// If `true`, this transaction is regarded to have been tampered to have a future timestamp.
+    pub fn is_in_future(&self, threshold: Duration) -> bool {
+        let tx_timestamp = Duration::from_millis(self.payload.creation_time);
+        tx_timestamp.saturating_sub(current_time()) > threshold
     }
 
     #[allow(clippy::unwrap_in_result)]

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -2,11 +2,7 @@
 //!
 //! `Transaction` is the start of the Transaction lifecycle.
 
-use std::{
-    cmp::min,
-    collections::BTreeSet,
-    time::{Duration, SystemTime},
-};
+use std::{cmp::min, collections::BTreeSet, time::Duration};
 
 use eyre::{Result, WrapErr};
 use iroha_crypto::{HashOf, SignaturesOf};
@@ -172,12 +168,7 @@ impl AcceptedTransaction {
     /// Checks if this transaction is waiting longer than specified in `transaction_time_to_live` from `QueueConfiguration` or `time_to_live_ms` of this transaction.
     /// Meaning that the transaction will be expired as soon as the lesser of the specified TTLs was reached.
     pub fn is_expired(&self, transaction_time_to_live: Duration) -> bool {
-        #[allow(clippy::expect_used)]
-        let current_time = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Failed to get System Time.");
-
-        current_time.saturating_sub(Duration::from_millis(self.payload.creation_time))
+        current_time().saturating_sub(Duration::from_millis(self.payload.creation_time))
             > min(
                 Duration::from_millis(self.payload.time_to_live_ms),
                 transaction_time_to_live,

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::missing_inline_in_public_items)]
 
-use std::{convert::TryFrom, time::SystemTime};
+use std::convert::TryFrom;
 
 use eyre::Result;
 use iroha_crypto::{prelude::*, SignatureOf};
@@ -17,7 +17,7 @@ use warp::{reply::Response, Reply};
 #[cfg(feature = "roles")]
 use self::role::*;
 use self::{account::*, asset::*, domain::*, peer::*, permissions::*, transaction::*};
-use crate::{account::Account, Identifiable, Value};
+use crate::{account::Account, current_time, Identifiable, Value};
 
 /// Sized container for all possible Queries.
 #[allow(clippy::enum_variant_names)]
@@ -173,10 +173,7 @@ impl QueryRequest {
     /// Constructs a new request with the `query`.
     #[allow(clippy::expect_used)]
     pub fn new(query: QueryBox, account_id: <Account as Identifiable>::Id) -> Self {
-        let timestamp_ms = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Failed to get System Time.")
-            .as_millis();
+        let timestamp_ms = current_time().as_millis();
         QueryRequest {
             payload: Payload {
                 timestamp_ms,

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -43,7 +43,8 @@ Configuration of iroha is done via options in the following document. Here is de
   "QUEUE": {
     "MAXIMUM_TRANSACTIONS_IN_BLOCK": 8192,
     "MAXIMUM_TRANSACTIONS_IN_QUEUE": 65536,
-    "TRANSACTION_TIME_TO_LIVE_MS": 86400000
+    "TRANSACTION_TIME_TO_LIVE_MS": 86400000,
+    "FUTURE_THRESHOLD_MS": 1000
   },
   "LOGGER": {
     "MAX_LOG_LEVEL": "DEBUG",
@@ -352,10 +353,21 @@ Has type `QueueConfiguration`. Can be configured via environment variable `IROHA
 
 ```json
 {
+  "FUTURE_THRESHOLD_MS": 1000,
   "MAXIMUM_TRANSACTIONS_IN_BLOCK": 8192,
   "MAXIMUM_TRANSACTIONS_IN_QUEUE": 65536,
   "TRANSACTION_TIME_TO_LIVE_MS": 86400000
 }
+```
+
+### `queue.future_threshold_ms`
+
+The threshold to determine if a transaction has been tampered to have a future timestamp.
+
+Has type `u64`. Can be configured via environment variable `QUEUE_FUTURE_THRESHOLD_MS`
+
+```json
+1000
 ```
 
 ### `queue.maximum_transactions_in_block`


### PR DESCRIPTION
### Description of the Change
Make `Queue` determine if a transaction has been tampered to have a future timestamp,
based on configurable threshold

### Issue
Close #1494

### Benefits
Prevent future timestamps and make transaction TTLs work well

### Possible Drawbacks
`DEFAULT_FUTURE_THRESHOLD_MS` may be debatable
