### PR TITLE
Reconnect telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ name = "iroha_telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "eyre",
  "futures",

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -83,6 +83,8 @@ Configuration of iroha is done via options in the following document. Here is de
   "TELEMETRY": {
     "NAME": null,
     "URL": null,
+    "MIN_PERIOD": 1,
+    "MAX_EXPONENT": 4,
     "FILE": null
   },
   "NETWORK": {
@@ -530,6 +532,8 @@ Has type `iroha_telemetry::Configuration`. Can be configured via environment var
 ```json
 {
   "FILE": null,
+  "MAX_EXPONENT": 4,
+  "MIN_PERIOD": 1,
   "NAME": null,
   "URL": null
 }
@@ -543,6 +547,26 @@ Has type `Option<PathBuf>`. Can be configured via environment variable `TELEMETR
 
 ```json
 null
+```
+
+### `telemetry.max_exponent`
+
+The maximum exponent of 2 that is used for increasing delay between reconnections
+
+Has type `u8`. Can be configured via environment variable `TELEMETRY_MAX_EXPONENT`
+
+```json
+4
+```
+
+### `telemetry.min_period`
+
+The minimum period of time in seconds to wait before reconnecting
+
+Has type `u64`. Can be configured via environment variable `TELEMETRY_MIN_PERIOD`
+
+```json
+1
 ```
 
 ### `telemetry.name`

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 dev-telemetry = []
 
 [dependencies]
+async-trait = "0.1"
 chrono = "0.4"
 eyre = "0.6.5"
 futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }

--- a/telemetry/src/config.rs
+++ b/telemetry/src/config.rs
@@ -5,9 +5,12 @@ use iroha_config::derive::Configurable;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::retry_period::RetryPeriod;
+
 /// Configuration parameters container
-#[derive(Clone, Default, Deserialize, Serialize, Debug, Configurable, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, Debug, Configurable, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
+#[serde(default)]
 #[config(env_prefix = "TELEMETRY_")]
 pub struct Configuration {
     /// The node's name to be seen on the telemetry
@@ -16,8 +19,35 @@ pub struct Configuration {
     /// The url of the telemetry, e.g., ws://127.0.0.1:8001/submit
     #[config(serde_as_str)]
     pub url: Option<Url>,
+    /// The minimum period of time in seconds to wait before reconnecting
+    #[serde(default = "default_min_period")]
+    pub min_period: u64,
+    /// The maximum exponent of 2 that is used for increasing delay between reconnections
+    #[serde(default = "default_max_exponent")]
+    pub max_exponent: u8,
     /// The filepath that to write dev-telemetry to
     #[cfg(feature = "dev-telemetry")]
     #[config(serde_as_str)]
     pub file: Option<PathBuf>,
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Self {
+            name: None,
+            url: None,
+            min_period: RetryPeriod::DEFAULT_MIN_PERIOD,
+            max_exponent: RetryPeriod::DEFAULT_MAX_EXPONENT,
+            #[cfg(feature = "dev-telemetry")]
+            file: None,
+        }
+    }
+}
+
+fn default_min_period() -> u64 {
+    RetryPeriod::DEFAULT_MIN_PERIOD
+}
+
+fn default_max_exponent() -> u8 {
+    RetryPeriod::DEFAULT_MAX_EXPONENT
 }

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 #[cfg(feature = "dev-telemetry")]
 pub mod dev;
 pub mod futures;
+mod retry_period;
 pub mod ws;
 
 pub use config::Configuration;

--- a/telemetry/src/retry_period.rs
+++ b/telemetry/src/retry_period.rs
@@ -1,0 +1,42 @@
+/// Encapsulates the retry period that is calculated as `min_period * 2 ^ min(exponent, max_exponent)`
+pub struct RetryPeriod {
+    /// The minimum period
+    min_period: u64,
+    /// The maximum exponent
+    max_exponent: u8,
+    /// The current exponent
+    exponent: u8,
+}
+
+impl RetryPeriod {
+    pub const DEFAULT_MIN_PERIOD: u64 = 1;
+    pub const DEFAULT_MAX_EXPONENT: u8 = 4;
+
+    /// Constructs a new object
+    pub fn new(min_period: u64, max_exponent: u8) -> Self {
+        Self {
+            min_period,
+            max_exponent,
+            exponent: 0,
+        }
+    }
+
+    /// Increases the exponent if it isn't at its maximum
+    pub fn increase_exponent(&mut self) {
+        if self.exponent < self.max_exponent {
+            self.exponent += 1;
+        }
+    }
+
+    /// Returns the period
+    pub fn period(&mut self) -> u64 {
+        let mult = 2_u64.saturating_pow(self.exponent.into());
+        self.min_period.saturating_mul(mult)
+    }
+}
+
+impl Default for RetryPeriod {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MIN_PERIOD, Self::DEFAULT_MAX_EXPONENT)
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alexey Kalita <kalita.alexey@outlook.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
If telemetry fails to send a message, the node is going to reconnect in a few seconds.
While the telemetry is down, messages are skipped.
The period between reconnects can be customized with MIN_PERIOD and MAX_POWER
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #1546 

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
