### PR TITLE
add commit-msg git hook to include signoff

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,7 @@
 # Iroha hooks
 
-For easy development you can copy(or link) those hooks after you clone repo. This way you won't forget to generate docs if anything is changed:
+For easy development you can copy(or link) those hooks after you clone repo. This way you won't forget to generate docs if anything is changed.
 ```sh
 $ cp hooks/pre-commit.sample .git/hooks/pre-commit
+$ cp hooks/commit-msg.sample .git/hooks/commit-msg
 ```

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -5,3 +5,6 @@ For easy development you can copy(or link) those hooks after you clone repo. Thi
 $ cp hooks/pre-commit.sample .git/hooks/pre-commit
 $ cp hooks/commit-msg.sample .git/hooks/commit-msg
 ```
+
+# LEGAL DISCLAIMER
+commit-msg hook will automatically sign-off your commits, to learn more about why we require the `signed-off-by:` line, please consult [this question](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for). By signing off your commits, you certify that you have the right to contribute the code within the signed-off commits, i.e. that you are not violating copyright law, DMCA, or any software patent.

--- a/hooks/commit-msg.sample
+++ b/hooks/commit-msg.sample
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "ERROR: Set user name with 'git config user.name \"<name>\"'"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "ERROR: Set user email with 'git config user.email \"<email>\"'"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer "Signed-off-by: $NAME <$EMAIL>" --in-place "$1"


### PR DESCRIPTION
Signed-off-by: Marin Veršić <marin.versic101@gmail.com>



### Description of the Change

* add commit-msg hook which ensures signoff is included

### Issue

Sometimes dev might forget to include signoff in the commit, this hook will automatically add signoff if missing

### Benefits

Developer has the option to automatically sign-off their commits. 


### Possible Drawbacks

The developer must understand what `sign-off` means in order to use the feature. And can unwittingly, commit code that they cannot. 

### Usage Examples or Tests 

```
$ cp hooks/commit-msg.sample .git/hooks/commit-msg
```

### Alternate Designs *[optional]*

Encouraging the developer to create an alias for commit. Also encouraging the developer to create GPG-signed commits. 