### PR TITLE
[feature] #1216: Add Prometheus endpoint. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "int_traits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1579,7 @@ dependencies = [
  "iroha_schema",
  "iroha_version",
  "parity-scale-codec",
+ "prometheus",
  "serde",
  "serde_json",
  "test_network",
@@ -1853,6 +1863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2138,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2343,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -2835,6 +2893,12 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ cp configs/client_config.json target/debug/config.json
 cd target/debug
 ./iroha_client_cli --help
 ```
-
 More details about Iroha Client CLI can be found [here](./client_cli/README.md).
 
 # Integration
@@ -142,6 +141,14 @@ Optional JSON formatted logging can be saved to the [logging file](./docs/source
 ## Monitoring
 
 The details of the `Health` endpoint can be found [here](./docs/source/references/api_spec.md#health). 
+
+Iroha is instrumented to produce both JSON-formatted as well as `prometheus`-readable metrics at the `status` and `metrics` endpoints respectively. More information is found in the [API specifications](./docs/source/references/api_spec.md).
+
+The [`prometheus`](https://prometheus.io/docs/introduction/overview/) monitoring system is the de-factor standard for monitoring long-running services such as an Iroha peer. In order to get started, please [install `prometheus`](https://prometheus.io/docs/introduction/first_steps/), and execute the following in the project root. 
+
+```
+prometheus --config.file=configs/prometheus.yml
+```
 
 ## Storage
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1,6 +1,5 @@
-//! Contains the end-point querying logic building on top of
-//! [`crate::http_client`].  This is where you need to add any custom
-//! end-point related logic.
+//! Contains the end-point querying logic.  This is where you need to
+//! add any custom end-point related logic.
 use std::{
     collections::HashMap,
     convert::TryFrom,

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+rule_files:
+  # - "first.rules"
+  # - "second.rules"
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:8180']

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -51,13 +51,14 @@ pub struct Chain {
 
 impl Chain {
     /// Constructor.
+    #[inline]
     pub fn new() -> Self {
         Chain {
             blocks: DashMap::new(),
         }
     }
 
-    /// Put latest block.
+    /// Push latest block.
     pub fn push(&self, block: VersionedCommittedBlock) {
         let height = block.as_inner_v1().header.height;
         self.blocks.insert(height, block);
@@ -74,11 +75,13 @@ impl Chain {
     }
 
     /// Length of the blockchain.
+    #[inline]
     pub fn len(&self) -> usize {
         self.blocks.len()
     }
 
     /// Whether blockchain is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.blocks.is_empty()
     }
@@ -171,6 +174,7 @@ pub struct PendingBlock {
 
 impl PendingBlock {
     /// Create a new `PendingBlock` from transactions.
+    #[inline]
     pub fn new(transactions: Vec<VersionedAcceptedTransaction>) -> PendingBlock {
         #[allow(clippy::expect_used)]
         let timestamp = current_time().as_millis();
@@ -271,6 +275,7 @@ pub struct BlockHeader {
 
 impl BlockHeader {
     /// Checks if it's a header of a genesis block.
+    #[inline]
     pub const fn is_genesis(&self) -> bool {
         self.height == 1
     }
@@ -336,6 +341,7 @@ declare_versioned_with_scale!(VersionedValidBlock 1..2, Debug, Clone, iroha_macr
 
 impl VersionedValidBlock {
     /// Same as [`as_v1`](`VersionedValidBlock::as_v1()`) but also does conversion
+    #[inline]
     pub const fn as_inner_v1(&self) -> &ValidBlock {
         match self {
             Self::V1(v1) => &v1.0,
@@ -343,6 +349,7 @@ impl VersionedValidBlock {
     }
 
     /// Same as [`as_inner_v1`](`VersionedValidBlock::as_inner_v1()`) but returns mutable reference
+    #[inline]
     pub fn as_mut_inner_v1(&mut self) -> &mut ValidBlock {
         match self {
             Self::V1(v1) => &mut v1.0,
@@ -350,6 +357,7 @@ impl VersionedValidBlock {
     }
 
     /// Same as [`into_v1`](`VersionedValidBlock::into_v1()`) but also does conversion
+    #[inline]
     pub fn into_inner_v1(self) -> ValidBlock {
         match self {
             Self::V1(v1) => v1.0,
@@ -357,6 +365,7 @@ impl VersionedValidBlock {
     }
 
     /// Returns header of valid block
+    #[inline]
     pub const fn header(&self) -> &BlockHeader {
         &self.as_inner_v1().header
     }
@@ -713,12 +722,14 @@ impl From<CommittedBlock> for ValidBlock {
 }
 
 impl From<VersionedCommittedBlock> for VersionedValidBlock {
+    #[inline]
     fn from(block: VersionedCommittedBlock) -> Self {
         ValidBlock::from(block.into_inner_v1()).into()
     }
 }
 
 impl From<&VersionedCommittedBlock> for Vec<Event> {
+    #[inline]
     fn from(block: &VersionedCommittedBlock) -> Self {
         block.as_inner_v1().into()
     }

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -104,7 +104,7 @@ impl Queue {
     /// Pushes transaction into queue.
     ///
     /// # Errors
-    /// See [`Error`]
+    /// See [`enum@Error`]
     #[allow(
         clippy::unwrap_in_result,
         clippy::expect_used,

--- a/core/src/samples.rs
+++ b/core/src/samples.rs
@@ -51,7 +51,7 @@ pub fn get_trusted_peers(public_key: Option<&PublicKey>) -> HashSet<PeerId> {
 
 #[allow(clippy::implicit_hasher)]
 /// Get a sample Iroha configuration. Trusted peers must either be
-/// specified in this function, including the current peer. Use [`samples::get_trusted_peers`]
+/// specified in this function, including the current peer. Use [`get_trusted_peers`]
 /// to populate `trusted_peers` if in doubt.
 ///
 /// # Panics

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -124,7 +124,7 @@ where
     pub genesis_network: Option<G>,
     /// Broker
     pub broker: Broker,
-    /// [`Kura`] actor address
+    /// [`Kura`](crate::kura) actor address
     pub kura: AlwaysAddr<K>,
     /// [`iroha_p2p::Network`] actor address
     pub network: Addr<IrohaNetwork>,

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Network<
 {
     /// Genesis peer which sends genesis block to everyone
     pub genesis: Peer<W, G, K, S, B>,
-    /// Peers excluding the `genesis` peer. Use [`peers()`] function to get all instead.
+    /// Peers excluding the `genesis` peer. Use [`Network::peers`] function to get all instead.
     pub peers: HashMap<PeerId, Peer<W, G, K, S, B>>,
 }
 

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -34,6 +34,7 @@ parity-scale-codec = { version = "2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.28"
+prometheus = { version = "0.13.0", default-features = false }
 
 warp = { version = "0.3", default-features = false, optional = true }
 

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -173,12 +173,49 @@ Also returns current status of peer in json string:
 **Responses**:
 - 200 OK - reports status:
   + Number of connected peers, except for the reporting peer itself
-  + Number of committed blocks
+  + Number of committed blocks (block height)
+  + Total number of transactions
+  + `uptime` since creation of the genesis block in milliseconds.
   ```json
   {
       "peers": 3,
-      "blocks": 1
+      "blocks": 1,
+      "txs": 3,
+      "uptime": 3200,
   }
+  ```
+
+## Metrics Endpoint
+
+**Protocol**: HTTP
+
+**Encoding**: Prometheus
+
+**Endpoint**: `/metrics`
+
+**Method**: `GET`
+
+**Expects**: -
+
+**Responses**:
+- 200 OK - currently mirrors status:
+  + Number of connected peers, except for the reporting peer itself
+  + Number of committed blocks (block height)
+  + Total number of transactions
+  + `uptime` since creation of the genesis block in milliseconds.
+  ```bash
+  # HELP block_height Current block height
+  # TYPE block_height counter
+  block_height 0
+  # HELP connected_peers Total number of currently connected peers
+  # TYPE connected_peers gauge
+  connected_peers 0
+  # HELP txs Transactions committed
+  # TYPE txs counter
+  txs 0
+  # HELP uptime_since_genesis_ms Uptime of the network, starting from creation of the genesis block
+  # TYPE uptime_since_genesis_ms gauge
+  uptime_since_genesis_ms 0
   ```
 
 ## Parity Scale Codec

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -37,7 +37,7 @@ The following is the default configuration used by Iroha.
     "API_URL": "127.0.0.1:8080",
     "STATUS_URL": "127.0.0.1:8180",
     "MAX_TRANSACTION_SIZE": 32768,
-    "MAX_SUMERAGI_MESSAGE_SIZE": 16384000,
+    "MAX_CONTENT_LEN": 16384000,
     "MAX_INSTRUCTION_NUMBER": 4096
   },
   "BLOCK_SYNC": {
@@ -603,8 +603,8 @@ Has type `ToriiConfiguration`. Can be configured via environment variable `IROHA
 ```json
 {
   "API_URL": "127.0.0.1:8080",
+  "MAX_CONTENT_LEN": 16384000,
   "MAX_INSTRUCTION_NUMBER": 4096,
-  "MAX_SUMERAGI_MESSAGE_SIZE": 16384000,
   "MAX_TRANSACTION_SIZE": 32768,
   "P2P_ADDR": "127.0.0.1:1337",
   "STATUS_URL": "127.0.0.1:8180"
@@ -621,6 +621,16 @@ Has type `String`. Can be configured via environment variable `TORII_API_URL`
 "127.0.0.1:8080"
 ```
 
+### `torii.max_content_len`
+
+Maximum number of bytes in raw message. Used to prevent from DOS attacks.
+
+Has type `usize`. Can be configured via environment variable `TORII_MAX_CONTENT_LEN`
+
+```json
+16384000
+```
+
 ### `torii.max_instruction_number`
 
 Maximum number of instruction per transaction. Used to prevent from DOS attacks.
@@ -629,16 +639,6 @@ Has type `u64`. Can be configured via environment variable `TORII_MAX_INSTRUCTIO
 
 ```json
 4096
-```
-
-### `torii.max_sumeragi_message_size`
-
-Maximum number of bytes in raw message. Used to prevent from DOS attacks.
-
-Has type `usize`. Can be configured via environment variable `TORII_MAX_SUMERAGI_MESSAGE_SIZE`
-
-```json
-16384000
 ```
 
 ### `torii.max_transaction_size`

--- a/logger/src/config.rs
+++ b/logger/src/config.rs
@@ -51,7 +51,7 @@ impl<T: Subscriber + Debug> ReloadMut<Level> for Handle<LevelFilter, T> {
     }
 }
 
-/// Configuration for [`Logger`].
+/// Configuration for [`crate`].
 #[derive(Clone, Deserialize, Serialize, Debug, Configurable)]
 #[serde(rename_all = "UPPERCASE")]
 #[serde(default)]

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -39,7 +39,7 @@ pub type Telemetries = (SubstrateTelemetry, FutureTelemetry);
 
 static LOGGER_SET: AtomicBool = AtomicBool::new(false);
 
-/// Initializes `Logger` with given [`LoggerConfiguration`](`config::LoggerConfiguration`).
+/// Initializes `Logger` with given [`Configuration`].
 /// After the initialization `log` macros will print with the use of this `Logger`.
 /// Returns the receiving side of telemetry channels (regular telemetry, future telemetry)
 ///

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -19,8 +19,9 @@ pub mod peer;
 /// The main type to use for secure communication.
 pub type Network<T> = NetworkBase<T, X25519Sha256, ChaCha20Poly1305>;
 
-/// Errors used in the [`iroha_p2p`] crate.
-#[derive(Clone, Debug, Error, iroha_macro::FromVariant, iroha_actor::Message)]
+
+/// Errors used in [`crate`].
+#[derive(Clone, Debug, iroha_macro::FromVariant, Error, iroha_actor::Message)]
 pub enum Error {
     /// Failed to read or write
     #[error("Failed IO operation.")]
@@ -70,7 +71,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Clone, Encode, Decode, iroha_actor::Message)]
 pub struct Message(pub Vec<u8>);
 
-/// Result of reading from [`Peer`]
+/// Result of reading from [`peer::Peer`]
 #[derive(Debug, iroha_actor::Message)]
 pub struct MessageResult(pub Result<Message, Error>);
 

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -51,13 +51,13 @@ where
     K: KeyExchangeScheme + Send + 'static,
     E: Encryptor + Send + 'static,
 {
-    /// Listening address for incoming connections. Must parse into [`std::net::SocketAddr`].
+    /// Listening address for incoming connections. Must parse into [`std::net::SocketAddr`]
     listen_addr: String,
-    /// [`Peer`]s performing [`Peer::handshake`]
+    /// [`Peer`]s performing a `handshake`
     pub new_peers: HashMap<ConnectionId, Addr<Peer<T, K, E>>>,
-    /// Current [`Peer`]s in `Ready` state.
+    /// Current [`Peer`]s in [`Peer::Ready`] state.
     pub peers: HashMap<PublicKey, RefPeer<T, K, E>>,
-    /// Untrusted hostnames or [`IpAddr`]s of remote peers: inserted by [`DisconnectPeer`] and removed by [`ConnectPeer`] from Sumeragi
+    /// a [`HashSet`] of [`String`]s representing the hostnames and/or [`std::net::IpAddr`]s of untrusted remote [`Peer`]s: inserted by [`DisconnectPeer`] and removed by [`ConnectPeer`] from Sumeragi
     untrusted_peers: HashSet<String>,
     /// [`TcpListener`] that is accepting [`Peer`]s' connections
     pub listener: Option<TcpListener>,
@@ -426,7 +426,7 @@ pub struct ConnectedPeers {
     pub peers: HashSet<PublicKey>,
 }
 
-/// The [`Connection`]'s `id`.
+/// An identification for [`Peer`] connections.
 pub type ConnectionId = u64;
 
 /// Variants of messages from [`Peer`] - connection state changes and data messages

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -160,7 +160,7 @@ where
 }
 
 /// An endpoint, that juggles messages between [`crate::Network`] and another connected node.
-/// Until the [`crate::Peer`] is in the `Ready` state, it doesn't have a fully set up
+/// Until the [`Peer`] is in the `Ready` state, it doesn't have a fully set up
 pub enum Peer<T, K, E>
 where
     T: Encode + Decode + Send + Clone + 'static,


### PR DESCRIPTION
### Description of the Change

Added a [`prometheus`](https://prometheus.io/docs/introduction/overview/) end-point to iroha2. 

### Issue

Closes #1216 

### Benefits

Prometheus Monitoring is possible. 
 
The following metrics are gathered:
- uptime since genesis. 
- currently connected peers
- block height
- total transactions

### Possible Drawbacks
Small overhead to block commit. 

### Usage Examples or Tests 

Install `prometheus`. 

Run an iroha peer (or network) using either 
`docker compose up`
or directly. 

run 
```bash
prometheus --config.file=configs/prometheus.yml
```
to scrape for the metric. 

Transactions per second should be handled by prometheus. 


### Alternate Designs 

Could compute a running average of TPS and send it to the status endpoint. 

This is error-prone and unnecessary, since the TPS can be computed while processing the `prometheus` data. 
