### PR TITLE
[feature] #1678: `try_allocate`

### DIFF
--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -310,14 +310,14 @@ pub enum Error {
     Codec(
         #[from]
         #[source]
-        iroha_version::error::Error
+        iroha_version::error::Error,
     ),
     /// Allocation error
     #[error("Failed to allocate buffer")]
     Alloc(
         #[from]
         #[source]
-        std::collections::TryReserveError
+        std::collections::TryReserveError,
     ),
     /// Zero-height block was provided
     #[error("An attempt to write zero-height block.")]

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -415,8 +415,8 @@ impl<IO: DiskIO> BlockStore<IO> {
             return Ok(None);
         }
         let len = file_stream.read_u64_le().await?;
-        // #[allow(clippy::cast_possible_truncation)]
         let mut buffer = Vec::new();
+        #[allow(clippy::cast_possible_truncation)]
         buffer.try_reserve(len as usize)?;
         let _len = file_stream.read_exact(&mut buffer).await?;
         Ok(Some(VersionedCommittedBlock::decode_versioned(&buffer)?))


### PR DESCRIPTION

### Description of the Change

There is a chance to fail to allocate buffer for block deserialization if its size was corrupted.
At the time try_allocate was still experimental and I coudn't use it. Now it's stable, so this is a planned enchancement.

### Benefits

We no longer depend on some particular "max buffer size" constant.

### Possible Drawbacks 


### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
