### PR TITLE
[ci] #1630: Move back to self-hosted runners.

### DIFF
--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -16,14 +16,7 @@ jobs:
       image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.CARGO_HOME }}
-            target/
-          key: iroha2-rust-check-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            iroha2-rust-check
+      - uses: Swatinem/rust-cache@v1
       - name: Print all info
         run: |
           cargo version

--- a/.github/workflows/iroha2-dev-pr-unstable.yml
+++ b/.github/workflows/iroha2-dev-pr-unstable.yml
@@ -20,13 +20,6 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ${{ env.CARGO_HOME }}
-      #       target/
-      #     key: iroha2-rust-test-${{ hashFiles('Cargo.lock') }}
-      #     restore-keys: |
-      #       iroha2-rust-test
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: cargo test -p iroha_client --tests unstable_network --quiet

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -20,14 +20,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ${{ env.CARGO_HOME }}
-      #       target/
-      #     key: iroha2-rust-test-${{ hashFiles('Cargo.lock') }}
-      #     restore-keys: |
-      #       iroha2-rust-test
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: mold -run cargo test --quiet --workspace --no-fail-fast -- --skip unstable_network --test-threads 2 
         env:
@@ -53,14 +46,7 @@ jobs:
       image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ${{ env.CARGO_HOME }}
-      #       target/
-      #     key: iroha2-rust-test-coverage-${{ hashFiles('Cargo.lock') }}
-      #     restore-keys: |
-      #       iroha2-rust-test-coverage
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: mold -run cargo test --quiet --workspace --no-fail-fast -- --skip  unstable_network --test-threads 2 || true
         env:

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -14,6 +14,7 @@ jobs:
       image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: set up buildx
         uses: docker/setup-buildx-action@v1
         id: buildx
@@ -59,8 +60,11 @@ jobs:
 
   build-ci-image:
     runs-on: ubuntu-latest
+    container:
+      image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -75,9 +79,11 @@ jobs:
 
   archive-and-publish-schema:
     runs-on: ubuntu-latest
-    container: rust:1.56-buster
+    container:
+      image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
         run: |
           apt-get update
@@ -115,18 +121,11 @@ jobs:
 
   print-telemetry:
     runs-on: ubuntu-latest
-    container: rust:1.56-buster
+    container:
+      image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.CARGO_HOME }}
-            target/
-          key: iroha2-rust-telemetry-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            iroha2-rust-telemetry-
-
+      - uses: Swatinem/rust-cache@v1
       - name: Run debug tests and save telemetry
         env:
           TELEMETRY_FILE: ../target/telemetry/debug.json.lz4
@@ -175,19 +174,11 @@ jobs:
   # 2  Coverage bot can have results from `iroha2-dev` to report coverage changes.
   coverage:
     runs-on: ubuntu-latest
-    #container: rust:1.56-buster
     container:
       image: 7272721/i2-ci:latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.CARGO_HOME }}
-            target/
-          key: iroha2-rust-test-coverage-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            iroha2-rust-test-coverage
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: mold -run cargo test --workspace --no-fail-fast -- --skip  unstable_network || true
         env:

--- a/.github/workflows/iroha2-pr-heavy.yml
+++ b/.github/workflows/iroha2-pr-heavy.yml
@@ -19,18 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: 7272721/i2-ci:latest
-    # container: rust:1.56-buster
-    # timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo
-            target/
-          key: iroha2-rust-docker-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            iroha2-rust-docker-
+      - uses: Swatinem/rust-cache@v1
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -58,14 +49,7 @@ jobs:
     container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.CARGO_HOME }}
-            target/
-          key: iroha2-rust-bench-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            iroha2-rust-bench-
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Description of the Change

Moved back to self-hosted runners with a smarter cache. 

### Issue

closes #1630 

### Benefits

Faster CI time. 

### Possible Drawbacks

Self hosted runners could be unstable. 

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
