### PR TITLE
[feature] #1331: Implement more `Prometheus` metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ dependencies = [
  "iroha_client",
  "iroha_core",
  "iroha_crypto",
+ "iroha_data_model_derive",
  "iroha_macro",
  "iroha_schema",
  "iroha_version",
@@ -1564,6 +1565,17 @@ dependencies = [
  "tokio",
  "trybuild",
  "warp",
+]
+
+[[package]]
+name = "iroha_data_model_derive"
+version = "2.0.0-pre.1"
+dependencies = [
+ "iroha_core",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "iroha_data_model",
  "iroha_logger",
  "iroha_permissions_validators",
+ "iroha_telemetry",
  "iroha_version",
  "rand 0.8.4",
  "serde",
@@ -1552,12 +1553,10 @@ dependencies = [
  "iroha_client",
  "iroha_core",
  "iroha_crypto",
- "iroha_data_model_derive",
  "iroha_macro",
  "iroha_schema",
  "iroha_version",
  "parity-scale-codec",
- "prometheus",
  "serde",
  "serde_json",
  "test_network",
@@ -1565,17 +1564,6 @@ dependencies = [
  "tokio",
  "trybuild",
  "warp",
-]
-
-[[package]]
-name = "iroha_data_model_derive"
-version = "2.0.0-pre.1"
-dependencies = [
- "iroha_core",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1725,6 +1713,8 @@ dependencies = [
  "iroha_config",
  "iroha_futures",
  "iroha_logger",
+ "iroha_telemetry_derive",
+ "prometheus",
  "serde",
  "serde_json",
  "streaming-stats",
@@ -1733,6 +1723,18 @@ dependencies = [
  "tokio-tungstenite 0.16.0",
  "url",
  "vergen",
+]
+
+[[package]]
+name = "iroha_telemetry_derive"
+version = "2.0.0-pre.1"
+dependencies = [
+ "iroha_core",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
 ]
 
 [[package]]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,17 +14,18 @@ RUN set -eux; \
         ca-certificates \
         gcc \
         curl \
-        clang \
-        llvm-dev \
-        libc6-dev \
-        wget \
-        git \
-        cmake \
-        libstdc++-10-dev \
-        libssl-dev \
-        zlib1g-dev \
-        libxxhash-dev \
-        build-essential \
+		clang \
+		llvm-dev \
+		libc6-dev \
+		wget \
+		git \
+		cmake \
+		libstdc++-10-dev \
+		libssl-dev \
+		zlib1g-dev \
+		libxxhash-dev \
+		build-essential \
+		pkg-config \
         ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ iroha_config = { version = "=2.0.0-pre.1", path = "../config" }
 iroha_crypto = { version = "=2.0.0-pre.1", path = "../crypto" }
 iroha_data_model = { version = "=2.0.0-pre.1", path = "../data_model" }
 iroha_logger = { version = "=2.0.0-pre.1", path = "../logger"}
+iroha_telemetry = { version ="=2.0.0-pre.1", path = "../telemetry" }
 iroha_version = { version = "=2.0.0-pre.1", path = "../version" }
 
 attohttpc = "0.18"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,6 +14,7 @@ use iroha_config::{GetConfiguration, PostConfiguration};
 use iroha_crypto::{HashOf, KeyPair};
 use iroha_data_model::prelude::*;
 use iroha_logger::prelude::*;
+use iroha_telemetry::metrics::Status;
 use iroha_version::prelude::*;
 use rand::Rng;
 use serde::de::DeserializeOwned;

--- a/config/src/runtime_upgrades.rs
+++ b/config/src/runtime_upgrades.rs
@@ -43,7 +43,7 @@ impl<T> From<PoisonErr<'_, T>> for ReloadError {
 
 /// The field needs to be mutably borrowed to be reloaded.
 pub trait ReloadMut<T>: Debug {
-    // TODO: When negative traits/specialisation stabilises, Debug ought not to be a requirement.
+    // TODO: When negative traits/specialisation, remove Debug
 
     /// Reload `self` using provided `item`.
     ///
@@ -218,13 +218,14 @@ pub mod handle {
         }
     }
 
-    // -----------------------------------------------------------------
+    // ---------------------------------------------------------------
 
-    /// A run-time reloadable configuration option with value-semantics.  This
-    /// means that reloading a [`Value`] only affects the [`Value`] itself. It's
-    /// useful when you want to keep a configuration immutable, but retain
-    /// thread-safe interior mutability, which is preferable to making the
-    /// entire configuration `mut`.
+    /// A run-time reloadable configuration option with
+    /// value-semantics.  This means that reloading a [`Value`] only
+    /// affects the [`Value`] itself. It's useful when you want to
+    /// keep a configuration immutable, but retain thread-safe
+    /// interior mutability, which is preferable to making the entire
+    /// configuration `mut`.
     ///
     /// # Examples
     /// ```
@@ -233,7 +234,7 @@ pub mod handle {
     ///
     /// #[derive(iroha_config::derive::Configurable, Serialize, Deserialize)]
     /// pub struct Config { option: Value<bool> };
-
+    ///
     /// fn main() {
     ///    let c = Config { option: true.into() };
     ///
@@ -241,8 +242,8 @@ pub mod handle {
     /// }
     /// ```
     ///
-    /// If you wish to perform validation on the value, consider using a thin
-    /// wrapper `tuple` struct.
+    /// If you wish to perform validation on the value, consider using
+    /// a thin wrapper `tuple` struct.
     ///
     #[derive(Debug)]
     pub struct Value<T: Clone + Copy>(pub AtomicCell<T>);
@@ -292,9 +293,9 @@ pub mod handle {
 
     // -----------------------------------------------------------------------
 
-    /// Structure that encapsulates a configuration value as well as a handle
-    /// for reloading other parts of the program.  This is the `struct` that you
-    /// want to use 99% of the time.
+    /// Structure that encapsulates a configuration value as well as a
+    /// handle for reloading other parts of the program.  This is the
+    /// `struct` that you want to use 99% of the time.
     ///
     /// It handles automatic synchronisation of the current value from
     /// the reload, as well as proper (de)serialization: namely the

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ roles = ["iroha_data_model/roles"]
 telemetry = []
 cli = ["structopt"]
 dev-telemetry = ["telemetry", "iroha_telemetry/dev-telemetry"]
+expensive-telemetry = ["iroha_telemetry/metric-instrumentation"]
 default = ["bridge", "cli"]
 
 [badges]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography::cryptocurrencies"]
 bridge = []
 dex = []
 roles = ["iroha_data_model/roles"]
-telemetry = ["iroha_telemetry"]
+telemetry = []
 cli = ["structopt"]
 dev-telemetry = ["telemetry", "iroha_telemetry/dev-telemetry"]
 default = ["bridge", "cli"]
@@ -35,7 +35,7 @@ iroha_version = { version = "=2.0.0-pre.1", path = "../version", features = ["wa
 iroha_actor = { path = "../actor" }
 iroha_config = { version = "=2.0.0-pre.1", path = "../config" }
 iroha_futures = { path = "../futures" }
-iroha_telemetry = { path = "../telemetry", optional = true }
+iroha_telemetry = { path = "../telemetry" }
 iroha_schema = { path = "../schema" }
 
 async-trait = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,7 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_data_model = { path = "../data_model", features = ["warp"] }
+iroha_data_model = { version = "=2.0.0-pre.1", path = "../data_model", features = ["warp"] }
 iroha_macro = { version = "=2.0.0-pre.1", path = "../macro" }
 iroha_p2p = { version = "=2.0.0-pre.1", path = "../p2p" }
 iroha_logger = { version = "=2.0.0-pre.1", path = "../logger"}

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -5,17 +5,19 @@ use iroha_data_model::prelude::*;
 
 use crate::prelude::*;
 
-/// ISI module contains all instructions related to accounts:
+/// All instructions related to accounts:
 /// - minting/burning public key into account signatories
 /// - minting/burning signature condition check
 /// - update metadata
 /// - grant permissions and roles
+/// - TODO Revoke permissions or roles
 pub mod isi {
     use super::{super::prelude::*, *};
 
     impl<W: WorldTrait> Execute<W> for Mint<Account, PublicKey> {
         type Error = Error;
 
+        #[metrics(+"mint_account_pubkey")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -33,6 +35,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Mint<Account, SignatureCheckCondition> {
         type Error = Error;
 
+        #[metrics(+"mint_account_signature_check_condition")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -50,6 +53,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Burn<Account, PublicKey> {
         type Error = Error;
 
+        #[metrics(+"burn_account_pubkey")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -73,6 +77,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for SetKeyValue<Account, String, Value> {
         type Error = Error;
 
+        #[metrics(+"set_key_value_account_string_value")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -95,6 +100,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Account, String> {
         type Error = Error;
 
+        #[metrics(+"remove_account_key_value")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -114,6 +120,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Grant<Account, PermissionToken> {
         type Error = Error;
 
+        #[metrics(+"grant_account_permission_token")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -132,6 +139,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Grant<Account, RoleId> {
         type Error = Error;
 
+        #[metrics(+"grant_account_role")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -152,7 +160,7 @@ pub mod isi {
     }
 }
 
-/// Query module provides [`Query`] Account related implementations.
+/// Account-related [`Query`] instructions.
 pub mod query {
 
     use eyre::{eyre, Result, WrapErr};
@@ -164,25 +172,19 @@ pub mod query {
     #[cfg(feature = "roles")]
     impl<W: WorldTrait> ValidQuery<W> for FindRolesByAccountId {
         #[log]
+        #[metrics(+"find_roles_by_account_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
-            wsv.metrics
-                .queries
-                .with_label_values(&["find_roles_by_account_id", "submission"])
-                .inc();
             let account_id = self.id.evaluate(wsv, &Context::new())?;
             let roles = wsv.map_account(&account_id, |account| {
                 account.roles.iter().cloned().collect::<Vec<_>>()
             })?;
-            wsv.metrics
-                .queries
-                .with_label_values(&["find_roles_by_account_id", "success"])
-                .inc();
             Ok(roles)
         }
     }
 
     impl<W: WorldTrait> ValidQuery<W> for FindPermissionTokensByAccountId {
         #[log]
+        #[metrics(+"find_permission_tokens_by_account_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let account_id = self.id.evaluate(wsv, &Context::new())?;
             let tokens = wsv.map_account(&account_id, |account| {
@@ -197,6 +199,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAllAccounts {
         #[log]
+        #[metrics(+"find_all_accounts")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -210,6 +213,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAccountById {
         #[log]
+        #[metrics(+"find_account_by_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .id
@@ -221,6 +225,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAccountsByName {
         #[log]
+        #[metrics(+"find_account_by_name")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .name
@@ -240,6 +245,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAccountsByDomainName {
         #[log]
+        #[metrics(+"find_accounts_by_domain_name")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .domain_name
@@ -256,6 +262,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAccountKeyValueByIdAndKey {
         #[log]
+        #[metrics(+"find_account_key_value_by_id_and_key")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .id

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -165,10 +165,18 @@ pub mod query {
     impl<W: WorldTrait> ValidQuery<W> for FindRolesByAccountId {
         #[log]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
+            wsv.metrics
+                .queries
+                .with_label_values(&["find_roles_by_account_id", "submission"])
+                .inc();
             let account_id = self.id.evaluate(wsv, &Context::new())?;
             let roles = wsv.map_account(&account_id, |account| {
                 account.roles.iter().cloned().collect::<Vec<_>>()
             })?;
+            wsv.metrics
+                .queries
+                .with_label_values(&["find_roles_by_account_id", "success"])
+                .inc();
             Ok(roles)
         }
     }

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -2,6 +2,7 @@
 //! and implementations of [`Query`]'s to [`WorldStateView<W>`] about [`Account`].
 
 use iroha_data_model::prelude::*;
+use iroha_telemetry::metrics;
 
 use crate::prelude::*;
 

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -2,6 +2,7 @@
 //! instructions implementations.
 
 use iroha_data_model::prelude::*;
+use iroha_telemetry::metrics;
 
 use super::prelude::*;
 use crate::prelude::*;
@@ -67,7 +68,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
-                wsv.metrics.tx_amounts.observe(*quantity as f64);
+                wsv.metrics.tx_amounts.observe(f64::from(*quantity));
                 Ok(())
             })
             .map_err(Into::into)
@@ -94,6 +95,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
+                #[allow(clippy::cast_precision_loss)]
                 wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
@@ -170,7 +172,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
-                wsv.metrics.tx_amounts.observe(*quantity as f64);
+                wsv.metrics.tx_amounts.observe(f64::from(*quantity));
                 Ok(())
             })
             .map_err(Into::into)
@@ -196,6 +198,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
+                #[allow(clippy::cast_precision_loss)]
                 wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
@@ -281,7 +284,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
-                wsv.metrics.tx_amounts.observe(*quantity as f64);
+                wsv.metrics.tx_amounts.observe(f64::from(*quantity));
                 Ok(())
             })
             .map_err(Into::into)

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -34,6 +34,7 @@ pub mod isi {
         }
     }
 
+    /// Assert that this asset is `mintable`.
     fn assert_can_mint<W: WorldTrait>(
         definition_id: &AssetDefinitionId,
         wsv: &WorldStateView<W>,
@@ -49,6 +50,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Mint<Asset, u32> {
         type Error = Error;
 
+        #[metrics(+"mint_qty")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -65,6 +67,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
+                wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
             .map_err(Into::into)
@@ -74,6 +77,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Mint<Asset, u128> {
         type Error = Error;
 
+        #[metrics(+"mint_big_qty")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -90,6 +94,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
+                wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
             .map_err(Into::into)
@@ -99,6 +104,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Mint<Asset, Fixed> {
         type Error = Error;
 
+        #[metrics(+"mint_fixed")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -113,6 +119,7 @@ pub mod isi {
             wsv.modify_asset(&self.destination_id, |asset| {
                 let quantity: &mut Fixed = asset.try_as_mut()?;
                 *quantity = quantity.checked_add(self.object)?;
+                wsv.metrics.tx_amounts.observe((*quantity).into());
                 Ok(())
             })
             .map_err(Into::into)
@@ -122,6 +129,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for SetKeyValue<Asset, String, Value> {
         type Error = Error;
 
+        #[metrics(+"asset_set_key_value")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -146,6 +154,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Burn<Asset, u32> {
         type Error = Error;
 
+        #[metrics(+"burn_qty")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -161,6 +170,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
+                wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
             .map_err(Into::into)
@@ -170,6 +180,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Burn<Asset, u128> {
         type Error = Error;
 
+        #[metrics(+"burn_big_qty")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -185,6 +196,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
+                wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
             .map_err(Into::into)
@@ -194,6 +206,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Burn<Asset, Fixed> {
         type Error = Error;
 
+        #[metrics(+"burn_fixed")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -207,6 +220,8 @@ pub mod isi {
             wsv.modify_asset(&self.destination_id, |asset| {
                 let quantity: &mut Fixed = asset.try_as_mut()?;
                 *quantity = quantity.checked_sub(self.object)?;
+                // Careful if `Fixed` stops being `Copy`.
+                wsv.metrics.tx_amounts.observe((*quantity).into());
                 Ok(())
             })
             .map_err(Into::into)
@@ -216,6 +231,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Asset, String> {
         type Error = Error;
 
+        #[metrics(+"asset_remove_key_value")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -237,6 +253,7 @@ pub mod isi {
         type Error = Error;
 
         #[log(skip(_authority))]
+        #[metrics(+"transfer_qty_asset")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -264,6 +281,7 @@ pub mod isi {
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::OverflowError)?;
+                wsv.metrics.tx_amounts.observe(*quantity as f64);
                 Ok(())
             })
             .map_err(Into::into)
@@ -271,7 +289,7 @@ pub mod isi {
     }
 }
 
-/// Query module provides [`Query`] Asset related implementations.
+/// Asset-related query implementations.
 pub mod query {
     use eyre::{eyre, Result, WrapErr};
     use iroha_logger::prelude::*;
@@ -280,6 +298,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAllAssets {
         #[log]
+        #[metrics(+"find_all_assets")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -295,6 +314,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAllAssetsDefinitions {
         #[log]
+        #[metrics(+"find_all_asset_definitions")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -308,6 +328,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetById {
         #[log]
+        #[metrics(+"find_asset_by_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .id
@@ -323,6 +344,8 @@ pub mod query {
     }
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetsByName {
+        #[log]
+        #[metrics(+"find_assets_by_name")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .name
@@ -344,6 +367,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetsByAccountId {
         #[log]
+        #[metrics(+"find_assets_by_account_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .account_id
@@ -355,6 +379,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetsByAssetDefinitionId {
         #[log]
+        #[metrics(+"find_assets_by_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .asset_definition_id
@@ -376,6 +401,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainName {
         #[log]
+        #[metrics(+"find_assets_by_domain_name")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .domain_name
@@ -393,6 +419,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainNameAndAssetDefinitionId {
         #[log]
+        #[metrics(+"find_assets_by_domain_name_and_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .domain_name
@@ -423,6 +450,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetQuantityById {
         #[log]
+        #[metrics(+"find_asset_quantity_by_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<u32> {
             let id = self
                 .id
@@ -443,6 +471,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetKeyValueByIdAndKey {
         #[log]
+        #[metrics(+"find_asset_key_value_by_id_and_key")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Value> {
             let id = self
                 .id

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -18,6 +18,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Register<NewAccount> {
         type Error = Error;
 
+        #[metrics(+"register_account")]
         fn execute(
             self,
             _authority: <NewAccount as Identifiable>::Id,
@@ -45,6 +46,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Unregister<Account> {
         type Error = Error;
 
+        #[metrics(+"unregister_account")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -61,6 +63,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Register<AssetDefinition> {
         type Error = Error;
 
+        #[metrics(+"register_asset_def")]
         fn execute(
             self,
             authority: <Account as Identifiable>::Id,
@@ -92,6 +95,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Unregister<AssetDefinition> {
         type Error = Error;
 
+        #[metrics(+"unregister_asset_def")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -121,6 +125,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for SetKeyValue<AssetDefinition, String, Value> {
         type Error = Error;
 
+        #[metrics(+"set_key_value_asset_def")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -141,6 +146,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for RemoveKeyValue<AssetDefinition, String> {
         type Error = Error;
 
+        #[metrics(+"remove_key_value_asset_def")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -161,6 +167,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for SetKeyValue<Domain, String, Value> {
         type Error = Error;
 
+        #[metrics(+"set_key_value_domain")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -183,6 +190,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Domain, String> {
         type Error = Error;
 
+        #[metrics(+"remove_key_value_domain")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -210,6 +218,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindAllDomains {
         #[log]
+        #[metrics(+"find_all_domains")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             Ok(wsv
                 .domains()
@@ -220,6 +229,7 @@ pub mod query {
     }
 
     impl<W: WorldTrait> ValidQuery<W> for FindDomainByName {
+        #[metrics(+"find_domain_by_name")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .name
@@ -231,6 +241,7 @@ pub mod query {
 
     impl<W: WorldTrait> ValidQuery<W> for FindDomainKeyValueByIdAndKey {
         #[log]
+        #[metrics(+"find_domain_key_value_by_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let name = self
                 .name
@@ -246,6 +257,7 @@ pub mod query {
     }
 
     impl<W: WorldTrait> ValidQuery<W> for FindAssetDefinitionKeyValueByIdAndKey {
+        #[metrics(+"find_asset_definition_key_value_by_id_and_key")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
             let id = self
                 .id

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -3,6 +3,7 @@ use std::collections::btree_map::Entry;
 
 use eyre::{eyre, Result};
 use iroha_data_model::prelude::*;
+use iroha_telemetry::metrics;
 
 use super::super::isi::prelude::*;
 use crate::prelude::*;

--- a/core/src/smartcontracts/isi/permissions.rs
+++ b/core/src/smartcontracts/isi/permissions.rs
@@ -49,7 +49,8 @@ pub type IsInstructionAllowedBoxed<W> = IsAllowedBoxed<W, Instruction>;
 /// Box with permissions validator for `Query`.
 pub type IsQueryAllowedBoxed<W> = IsAllowedBoxed<W, QueryBox>;
 
-/// Trait for joining validators with `or` method, autoimplemented for all types which convert to [`IsAllowedBoxed`].
+/// Trait for joining validators with `or` method, auto-implemented
+/// for all types which convert to [`IsAllowedBoxed`].
 pub trait ValidatorApplyOr<W: WorldTrait, O: NeedsPermission> {
     /// Combines two validators into [`Or`].
     fn or(self, another: impl Into<IsAllowedBoxed<W, O>>) -> Or<W, O>;

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -45,7 +45,7 @@ impl VerifiedQueryRequest {
             .map_err(Error::Find)?;
         if !account_has_public_key {
             return Err(Error::Signature(eyre!(
-                "Public key used for the signature does not correspond to the account."
+                "Signature public key doesn't correspond to the account."
             )));
         }
         query_validator

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -1,4 +1,4 @@
-//! This module contains query related Iroha functionality.
+//! Query related Iroha functionality.
 
 use std::{error::Error as StdError, fmt};
 
@@ -29,10 +29,12 @@ pub struct VerifiedQueryRequest {
 
 impl VerifiedQueryRequest {
     /// Statefully validate query.
-    /// Checks whether account exists and has the corresponding public key, also check permissions based on this account.
     ///
     /// # Errors
-    /// Returns and error if one of the previously mentioned checks did not pass.
+    /// if:
+    /// - Account doesn't exist.
+    /// - Account doesn't have the correct public key.
+    /// - Account has the correct permissions.
     pub fn validate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,
@@ -82,7 +84,8 @@ impl ValidQueryRequest {
     /// Execute contained query on the [`WorldStateView`].
     ///
     /// # Errors
-    /// Returns an error if the query execution fails.
+    /// Forwards `self.query.execute` error.
+    #[inline]
     pub fn execute<W: WorldTrait>(&self, wsv: &WorldStateView<W>) -> Result<Value> {
         self.query.execute(wsv)
     }
@@ -148,6 +151,7 @@ impl Error {
 }
 
 impl Reply for Error {
+    #[inline]
     fn into_response(self) -> Response {
         reply::with_status(self.to_string(), self.status_code()).into_response()
     }

--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -8,6 +8,7 @@ use super::*;
 
 impl<W: WorldTrait> ValidQuery<W> for FindTransactionsByAccountId {
     #[log]
+    #[metrics(+"find_transactions_by_account_id")]
     fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
         let id = self
             .account_id
@@ -19,6 +20,7 @@ impl<W: WorldTrait> ValidQuery<W> for FindTransactionsByAccountId {
 
 impl<W: WorldTrait> ValidQuery<W> for FindTransactionByHash {
     #[log]
+    #[metrics(+"find_transaction_by_hash")]
     fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
         let hash = self
             .hash

--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -3,6 +3,7 @@
 use eyre::{Result, WrapErr};
 use iroha_data_model::prelude::*;
 use iroha_logger::prelude::*;
+use iroha_telemetry::metrics;
 
 use super::*;
 

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -1,4 +1,4 @@
-//! This module contains `World` related ISI implementations.
+//! `World`-related ISI implementations.
 
 use super::prelude::*;
 use crate::prelude::*;
@@ -13,6 +13,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Register<Peer> {
         type Error = Error;
 
+        #[metrics(+"register_peer")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -29,6 +30,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Unregister<Peer> {
         type Error = Error;
 
+        #[metrics(+"unregister_peer")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -45,6 +47,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Register<Domain> {
         type Error = Error;
 
+        #[metrics("register_domain")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -61,6 +64,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Unregister<Domain> {
         type Error = Error;
 
+        #[metrics("unregister_domain")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -77,6 +81,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Register<Role> {
         type Error = Error;
 
+        #[metrics(+"register_role")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,
@@ -92,6 +97,7 @@ pub mod isi {
     impl<W: WorldTrait> Execute<W> for Unregister<Role> {
         type Error = Error;
 
+        #[metrics("unregister_peer")]
         fn execute(
             self,
             _authority: <Account as Identifiable>::Id,

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 pub mod isi {
     use eyre::{eyre, Result};
     use iroha_data_model::prelude::*;
+    use iroha_telemetry::metrics;
 
     use super::*;
 

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -53,6 +53,7 @@ pub mod isi {
             let domain = self.object;
             domain.validate_len(wsv.config.ident_length_limits)?;
             wsv.domains().insert(domain.name.clone(), domain);
+            wsv.metrics.domains.inc();
             Ok(())
         }
     }
@@ -67,6 +68,7 @@ pub mod isi {
         ) -> Result<(), Error> {
             // TODO: Should we fail if no domain found?
             wsv.domains().remove(&self.object_id);
+            wsv.metrics.domains.dec();
             Ok(())
         }
     }

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -486,7 +486,15 @@ async fn update_metrics<W: WorldTrait>(
         wsv.metrics
             .uptime_since_genesis_ms
             .set((current_time().as_millis() - timestamp) as u64)
-    }
+    };
+    let domains = wsv.domains();
+    wsv.metrics.domains.set(domains.len() as u64);
+    wsv.metrics.users.set(
+        domains
+            .iter()
+            .map(|d| d.accounts.values().len() as u64)
+            .sum(),
+    );
     wsv.metrics.connected_peers.set(peers);
     Ok(())
 }

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -7,6 +7,7 @@ use eyre::Context;
 use futures::stream::{FuturesUnordered, StreamExt};
 use iroha_config::{Configurable, GetConfiguration, PostConfiguration};
 use iroha_data_model::prelude::*;
+use iroha_telemetry::metrics::Status;
 use serde::Serialize;
 use thiserror::Error;
 use utils::*;

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -18,7 +18,6 @@ use warp::{
     Filter, Reply,
 };
 
-#[macro_use]
 mod utils;
 
 use crate::{

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -16,6 +16,7 @@ use eyre::Result;
 use iroha_crypto::HashOf;
 use iroha_data_model::{domain::DomainsMap, peer::PeersIds, prelude::*};
 use iroha_logger::prelude::*;
+use iroha_telemetry::metrics::Metrics;
 use tokio::task;
 
 use crate::{

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -22,10 +22,11 @@ roles = []
 test = []
 
 [dependencies]
-iroha_crypto = { version = "=2.0.0-pre.1",path = "../crypto" }
+iroha_crypto = { version = "=2.0.0-pre.1", path = "../crypto" }
 iroha_macro = { version = "=2.0.0-pre.1", path = "../macro" }
 iroha_schema = { version = "=2.0.0-pre.1", path = "../schema"}
 iroha_version = { version = "=2.0.0-pre.1", path = "../version", features = ["warp", "derive"] }
+iroha_data_model_derive = { version = "=2.0.0-pre.1", path = "derive" }
 
 eyre = "0.6.5"
 fixnum = { version = "0.6", features = ["i64"]}

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -26,7 +26,6 @@ iroha_crypto = { version = "=2.0.0-pre.1", path = "../crypto" }
 iroha_macro = { version = "=2.0.0-pre.1", path = "../macro" }
 iroha_schema = { version = "=2.0.0-pre.1", path = "../schema"}
 iroha_version = { version = "=2.0.0-pre.1", path = "../version", features = ["warp", "derive"] }
-iroha_data_model_derive = { version = "=2.0.0-pre.1", path = "derive" }
 
 eyre = "0.6.5"
 fixnum = { version = "0.6", features = ["i64"]}
@@ -35,7 +34,6 @@ parity-scale-codec = { version = "2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.28"
-prometheus = { version = "0.13.0", default-features = false }
 
 warp = { version = "0.3", default-features = false, optional = true }
 

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "iroha_data_model_derive"
+version = "2.0.0-pre.1"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+description = "Tracking metrics in iroha_core, requires some instrumentation that is most conveniently expressed as attribute-like macros."
+edition = "2021"
+homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+repository = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
+license = "Apache-2.0"
+keywords = ["crypto", "blockchain", "ledger", "iroha", "model"]
+categories = ["cryptography::cryptocurrencies", "api-bindings"]
+
+[lib]
+proc-macro = true
+
+[badges]
+is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledger/iroha" }
+is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/iroha" }
+maintenance = { status = "actively-developed" }
+
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = { version = "1.0" }
+proc-macro2 = "1.0"
+proc-macro-error = "1.0"
+
+[dev-dependencies]
+iroha_core = { path = "../../core" } 

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -1,0 +1,199 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::{abort, proc_macro_error};
+use quote::{quote, ToTokens};
+use syn::{
+    parse::Parse, parse_macro_input, punctuated::Punctuated, token::Comma, FnArg, ItemFn, LitStr,
+    Path, Type,
+};
+
+fn type_has_metrics_field(ty: &Type) -> bool {
+    match ty {
+        // This may seem fragile, but it isn't. We use the same
+        // convention everywhere in the code base, and if you follow
+        // `CONTRIBUTING.md` you'll likely have `use
+        // iroha_data_model::WorldStateView` somewhere.
+        Type::Path(pth) => {
+            let Path {
+                leading_colon: _,
+                segments,
+            } = pth.path.clone();
+            let type_name = &segments[0].ident;
+            type_name.to_string() == "WorldStateView"
+        }
+        _ => false,
+    }
+}
+
+/// The identifier of the first argument that has a type which has
+/// metrics.
+///
+/// # Errors
+/// If no argument has type which has a metrics field.
+fn arg_metrics(input: &Punctuated<FnArg, Comma>) -> Result<syn::Ident, &Punctuated<FnArg, Comma>> {
+    input
+        .iter()
+        .find(|arg| match arg {
+            FnArg::Typed(typ) => match &*typ.ty {
+                syn::Type::Reference(typ) => type_has_metrics_field(&typ.elem),
+                _ => false,
+            },
+            _ => false,
+        })
+        .map_or(None, |arg| match arg {
+            FnArg::Typed(typ) => match *typ.pat.clone() {
+                syn::Pat::Ident(ident) => Some(ident.ident),
+                _ => None,
+            },
+            _ => None,
+        })
+        .ok_or(input)
+}
+
+struct MetricSpecs(Vec<MetricSpec>); // `HashSet` — idiomatic; slow
+
+impl Parse for MetricSpecs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let vars = Punctuated::<MetricSpec, Comma>::parse_terminated(input)?;
+        Ok(Self(vars.into_iter().collect()))
+    }
+}
+
+struct MetricSpec {
+    timing: bool,
+    metric_name: LitStr,
+}
+
+impl Parse for MetricSpec {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let timing = <syn::Token![+]>::parse(input).is_ok();
+        let metric_name_lit = syn::Lit::parse(input.clone())?;
+        let metric_name = match metric_name_lit {
+            syn::Lit::Str(lit_str) => lit_str,
+            _ => {
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "Must be a string literal. Format `[+]\"name_of_metric\"`.",
+                ))
+            }
+        };
+        Ok(Self {
+            metric_name,
+            timing,
+        })
+    }
+}
+
+impl ToTokens for MetricSpec {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.metric_name.to_tokens(tokens)
+    }
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn metrics(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    }: ItemFn = parse_macro_input!(item as ItemFn);
+
+    // This is a good sanity check. Possibly redundant.
+    if sig.ident.to_string() != "execute" {
+        abort!(sig.ident, "Function should be an `impl execute`");
+    }
+    match sig.output.clone() {
+        syn::ReturnType::Default => abort!(
+            sig.output,
+            "`Fn` must return `Result`. Returns nothing instead. "
+        ),
+        syn::ReturnType::Type(_, typ) => match *typ {
+            Type::Path(pth) => {
+                let Path {
+                    leading_colon: _,
+                    segments,
+                } = pth.path;
+                let type_name = &segments[0].ident;
+                if type_name.to_string() != "Result" {
+                    abort!(
+                        type_name,
+                        format!("Should return `Result`. Found {}", type_name)
+                    );
+                }
+            }
+            _ => abort!(
+                typ,
+                "Should return `Result`. Non-path result type specification found"
+            ),
+        },
+    }
+    if sig.inputs.is_empty() {
+        abort!(
+            sig,
+            "Function must have at least one argument of type `WorldStateView`."
+        );
+    }
+    let specs = parse_macro_input!(attr as MetricSpecs);
+    let metric_arg_ident = arg_metrics(&sig.inputs)
+        .unwrap_or_else(|args| abort!(args, "At least one argument must contain a metrics field"));
+    // Again this may seem fragile, but if we move the metrics from
+    // the `WorldStateView`, we'd need to refactor many things anyway.
+    let inc_metric = |spec: &MetricSpec, kind: &str| {
+        quote!(
+            #metric_arg_ident
+                .metrics
+                .isi
+                .with_label_values( &[#spec, #kind ]).inc();
+        )
+    };
+    // I agree that casting this to `f64` is not the best
+    // idea. However, 1) Prometheus doesn't record more precise data
+    // anyway, 2) if the time to handle requests is a sufficiently
+    // large `u128` that it **cannot** be a represented as `f64` then
+    // we have bigger problems than imprecise metrics. 3) This is way
+    // shorter.
+    let track_time = |spec: &MetricSpec| {
+        quote!(
+            #metric_arg_ident
+                .metrics
+                .isi_times
+                .with_label_values( &[#spec])
+                .observe((end_time.as_millis() - start_time.as_millis()) as f64);
+        )
+    };
+    let totals: TokenStream2 = specs
+        .0
+        .iter()
+        .map(|spec| inc_metric(spec, "total"))
+        .collect();
+    let successes: TokenStream2 = specs
+        .0
+        .iter()
+        .map(|spec| inc_metric(spec, "success"))
+        .collect();
+    let times: TokenStream2 = specs
+        .0
+        .iter()
+        .filter(|spec| spec.timing)
+        .map(track_time)
+        .collect();
+
+    quote!(
+        #(#attrs)* #vis #sig {
+            let _closure = || #block;
+
+            let start_time = #metric_arg_ident.metrics.current_time();
+            #totals
+            let res = _closure();
+            let end_time = #metric_arg_ident.metrics.current_time();
+            #times
+            if let Ok(_) = res {
+                #successes
+            };
+            res
+        }
+    )
+    .into()
+}

--- a/data_model/derive/tests/instrument_query.rs
+++ b/data_model/derive/tests/instrument_query.rs
@@ -1,7 +1,0 @@
-use iroha_core::wsv::{World, WorldStateView};
-use iroha_data_model_derive::metrics;
-
-#[metrics(+"test_query", +"another_test_query")]
-fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
-    Ok(())
-}

--- a/data_model/derive/tests/instrument_query.rs
+++ b/data_model/derive/tests/instrument_query.rs
@@ -1,0 +1,7 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_data_model_derive::metrics;
+
+#[metrics(+"test_query", +"another_test_query")]
+fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
+    Ok(())
+}

--- a/data_model/src/fixed.rs
+++ b/data_model/src/fixed.rs
@@ -122,6 +122,14 @@ impl TryFrom<f64> for Fixed {
     }
 }
 
+impl From<Fixed> for f64 {
+    #[inline]
+    fn from(val: Fixed) -> Self {
+        let Fixed(fix_num) = val;
+        fix_num.into()
+    }
+}
+
 impl Encode for Fixed {
     #[inline]
     fn size_hint(&self) -> usize {

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -26,7 +26,6 @@ pub mod expression;
 pub mod fixed;
 pub mod isi;
 pub mod merkle;
-pub mod metrics;
 pub mod query;
 pub mod transaction;
 
@@ -2150,22 +2149,13 @@ pub mod uri {
 
 /// The prelude re-exports most commonly used traits, structs and macros from this crate.
 pub mod prelude {
-    pub use iroha_data_model_derive::metrics;
 
     #[cfg(feature = "roles")]
     pub use super::role::prelude::*;
     pub use super::{
-        account::prelude::*,
-        asset::prelude::*,
-        current_time,
-        domain::prelude::*,
-        fixed::prelude::*,
-        metrics::{Metrics, Status},
-        pagination::prelude::*,
-        peer::prelude::*,
-        transaction::prelude::*,
-        uri, Bytes, IdBox, Identifiable, IdentifiableBox, Name, Parameter, TryAsMut, TryAsRef,
-        Value,
+        account::prelude::*, asset::prelude::*, current_time, domain::prelude::*,
+        fixed::prelude::*, pagination::prelude::*, peer::prelude::*, transaction::prelude::*, uri,
+        Bytes, IdBox, Identifiable, IdentifiableBox, Name, Parameter, TryAsMut, TryAsRef, Value,
     };
     pub use crate::{
         events::prelude::*, expression::prelude::*, isi::prelude::*, metadata::prelude::*,

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -7,7 +7,6 @@ use std::{
     error,
     fmt::Debug,
     ops::RangeInclusive,
-    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -16,10 +15,6 @@ use iroha_crypto::{Hash, PublicKey};
 use iroha_macro::{error::ErrorTryFromEnum, FromVariant};
 use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode};
-use prometheus::{
-    core::{AtomicU64, GenericGauge},
-    Encoder, IntCounter, Registry,
-};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -31,6 +26,7 @@ pub mod expression;
 pub mod fixed;
 pub mod isi;
 pub mod merkle;
+pub mod metrics;
 pub mod query;
 pub mod transaction;
 
@@ -386,110 +382,6 @@ pub fn current_time() -> Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("Failed to get the current system time")
-}
-
-/// Thin wrapper around duration that `impl`s [`Default`]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Uptime(Duration);
-
-impl Default for Uptime {
-    fn default() -> Self {
-        Self(Duration::from_millis(0))
-    }
-}
-
-/// Response body for GET status request
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct Status {
-    /// Number of connected peers, except for the reporting peer itself
-    pub peers: u64,
-    /// Number of committed blocks
-    pub blocks: u64,
-    /// Number of transactions committed in the last block
-    pub txs: u64,
-    /// Uptime since genesis block creation
-    pub uptime: Uptime,
-}
-
-impl From<&Arc<Metrics>> for Status {
-    fn from(val: &Arc<Metrics>) -> Self {
-        Self {
-            peers: val.connected_peers.get(),
-            blocks: val.block_height.get(),
-            txs: val.txs.get(),
-            uptime: Uptime(Duration::from_millis(val.uptime_since_genesis_ms.get())),
-        }
-    }
-}
-
-/// A strict superset of [`Status`].
-#[derive(Debug)]
-pub struct Metrics {
-    /// Transactions in the last committed block
-    pub txs: IntCounter,
-    /// Current block height
-    pub block_height: IntCounter,
-    /// Total number of currently connected peers
-    pub connected_peers: GenericGauge<AtomicU64>,
-    /// Uptime of the network, starting from commit of the genesis block
-    pub uptime_since_genesis_ms: GenericGauge<AtomicU64>,
-    // Internal use only.
-    registry: Registry,
-}
-
-impl Default for Metrics {
-    // The constructors either always fail, or never.
-    #[allow(clippy::expect_used)]
-    fn default() -> Self {
-        let txs = IntCounter::new("txs", "Transactions committed").expect("Infallible");
-        let block_height =
-            IntCounter::new("block_height", "Current block height").expect("Infallible");
-        let connected_peers = GenericGauge::new(
-            "connected_peers",
-            "Total number of currently connected peers",
-        )
-        .expect("Infallible");
-        let uptime_since_genesis_ms = GenericGauge::new(
-            "uptime_since_genesis_ms",
-            "Uptime of the network, starting from creation of the genesis block",
-        )
-        .expect("Infallible");
-        let registry = Registry::new();
-        registry
-            .register(Box::new(txs.clone()))
-            .expect("register txs should not fail");
-        registry
-            .register(Box::new(block_height.clone()))
-            .expect("register block_height should not fail");
-        registry
-            .register(Box::new(connected_peers.clone()))
-            .expect("register connected_peers should not fail");
-        registry
-            .register(Box::new(uptime_since_genesis_ms.clone()))
-            .expect("register uptime should not fail");
-        Self {
-            txs,
-            block_height,
-            connected_peers,
-            uptime_since_genesis_ms,
-            registry,
-        }
-    }
-}
-
-impl Metrics {
-    /// Convert the current [`Metrics`] into a Prometheus-readable format.
-    ///
-    /// # Errors
-    /// - If [`Encoder`] fails to encode the data
-    /// - If the buffer produced by [`Encoder`] causes [`String::from_utf8`] to fail.
-    pub fn try_to_string(&self) -> eyre::Result<String> {
-        let mut buffer = vec![];
-        let encoder = prometheus::TextEncoder::new();
-        let metric_families = self.registry.gather();
-        Encoder::encode(&encoder, &metric_families, &mut buffer)?;
-        Ok(String::from_utf8(buffer)?)
-    }
 }
 
 #[cfg(feature = "roles")]
@@ -2233,7 +2125,6 @@ pub mod uri {
 
     /// Default socket for listening on external requests
     pub const DEFAULT_API_URL: &str = "127.0.0.1:8080";
-
     /// Query URI is used to handle incoming Query requests.
     pub const QUERY: &str = "query";
     /// Transaction URI is used to handle incoming ISI requests.
@@ -2262,9 +2153,16 @@ pub mod prelude {
     #[cfg(feature = "roles")]
     pub use super::role::prelude::*;
     pub use super::{
-        account::prelude::*, asset::prelude::*, current_time, domain::prelude::*,
-        fixed::prelude::*, pagination::prelude::*, peer::prelude::*, transaction::prelude::*, uri,
-        Bytes, IdBox, Identifiable, IdentifiableBox, Name, Parameter, Status, TryAsMut, TryAsRef,
+        account::prelude::*,
+        asset::prelude::*,
+        current_time,
+        domain::prelude::*,
+        fixed::prelude::*,
+        metrics::{Metrics, Status},
+        pagination::prelude::*,
+        peer::prelude::*,
+        transaction::prelude::*,
+        uri, Bytes, IdBox, Identifiable, IdentifiableBox, Name, Parameter, TryAsMut, TryAsRef,
         Value,
     };
     pub use crate::{

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -2150,6 +2150,8 @@ pub mod uri {
 
 /// The prelude re-exports most commonly used traits, structs and macros from this crate.
 pub mod prelude {
+    pub use iroha_data_model_derive::metrics;
+
     #[cfg(feature = "roles")]
     pub use super::role::prelude::*;
     pub use super::{

--- a/data_model/src/metrics.rs
+++ b/data_model/src/metrics.rs
@@ -87,28 +87,29 @@ impl Default for Metrics {
         .expect("Infallible");
         let domains = GenericGauge::new("domains", "Total number of domains").expect("Infallible");
         let users = GenericGauge::new("users", "Total number of users").expect("Infallible");
+
         let registry = Registry::new();
-        registry
-            .register(Box::new(txs.clone()))
-            .expect("register txs should not fail");
-        registry
-            .register(Box::new(block_height.clone()))
-            .expect("register block_height should not fail");
-        registry
-            .register(Box::new(connected_peers.clone()))
-            .expect("register connected_peers should not fail");
-        registry
-            .register(Box::new(uptime_since_genesis_ms.clone()))
-            .expect("register uptime should not fail");
-        registry
-            .register(Box::new(domains.clone()))
-            .expect("register domains counter should not fail");
-        registry
-            .register(Box::new(users.clone()))
-            .expect("register users should not fail");
-        registry
-            .register(Box::new(queries.clone()))
-            .expect("register queries should not fail");
+
+        macro_rules! register {
+			($metric:expr)=> {
+				registry.register(Box::new($metric.clone())).expect("Infallible");
+			};
+			($metric:expr,$($metrics:expr),+)=>{
+				register!($metric);
+				register!($($metrics),+);
+			}
+		}
+
+        register!(
+            txs,
+            block_height,
+            connected_peers,
+            uptime_since_genesis_ms,
+            domains,
+            users,
+            queries
+        );
+
         Self {
             txs,
             block_height,

--- a/data_model/src/metrics.rs
+++ b/data_model/src/metrics.rs
@@ -1,0 +1,138 @@
+//! [`Metrics`] and [`Status`]-related logic and functions.
+use std::{sync::Arc, time::Duration};
+
+use prometheus::{
+    core::{AtomicU64, GenericGauge},
+    Encoder, IntCounter, IntCounterVec, Opts, Registry,
+};
+use serde::{Deserialize, Serialize};
+
+/// Thin wrapper around duration that `impl`s [`Default`]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Uptime(Duration);
+
+impl Default for Uptime {
+    fn default() -> Self {
+        Self(Duration::from_millis(0))
+    }
+}
+
+/// Response body for GET status request
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+pub struct Status {
+    /// Number of connected peers, except for the reporting peer itself
+    pub peers: u64,
+    /// Number of committed blocks
+    pub blocks: u64,
+    /// Number of transactions committed in the last block
+    pub txs: u64,
+    /// Uptime since genesis block creation
+    pub uptime: Uptime,
+}
+
+impl From<&Arc<Metrics>> for Status {
+    fn from(val: &Arc<Metrics>) -> Self {
+        Self {
+            peers: val.connected_peers.get(),
+            blocks: val.block_height.get(),
+            txs: val.txs.with_label_values(&["total"]).get(),
+            uptime: Uptime(Duration::from_millis(val.uptime_since_genesis_ms.get())),
+        }
+    }
+}
+
+/// A strict superset of [`Status`].
+#[derive(Debug)]
+pub struct Metrics {
+    /// Transactions in the last committed block
+    pub txs: IntCounterVec,
+    /// Current block height
+    pub block_height: IntCounter,
+    /// Total number of currently connected peers
+    pub connected_peers: GenericGauge<AtomicU64>,
+    /// Uptime of the network, starting from commit of the genesis block
+    pub uptime_since_genesis_ms: GenericGauge<AtomicU64>,
+    /// Number of domains.
+    pub domains: GenericGauge<AtomicU64>,
+    /// Number of users with non-zero assets.
+    pub users: GenericGauge<AtomicU64>,
+    /// Queries handled by this peer
+    pub queries: IntCounterVec,
+    // Internal use only.
+    registry: Registry,
+}
+
+impl Default for Metrics {
+    // The constructors either always fail, or never.
+    #[allow(clippy::expect_used)]
+    fn default() -> Self {
+        let txs = IntCounterVec::new(Opts::new("txs", "Transactions committed"), &["type"])
+            .expect("Infallible");
+        let queries = IntCounterVec::new(
+            Opts::new("queries", "Queries handled by this peer"),
+            &["type", "success_status"],
+        )
+        .expect("Infallible");
+        let block_height =
+            IntCounter::new("block_height", "Current block height").expect("Infallible");
+        let connected_peers = GenericGauge::new(
+            "connected_peers",
+            "Total number of currently connected peers",
+        )
+        .expect("Infallible");
+        let uptime_since_genesis_ms = GenericGauge::new(
+            "uptime_since_genesis_ms",
+            "Network uptime, from creation of the genesis block",
+        )
+        .expect("Infallible");
+        let domains = GenericGauge::new("domains", "Total number of domains").expect("Infallible");
+        let users = GenericGauge::new("users", "Total number of users").expect("Infallible");
+        let registry = Registry::new();
+        registry
+            .register(Box::new(txs.clone()))
+            .expect("register txs should not fail");
+        registry
+            .register(Box::new(block_height.clone()))
+            .expect("register block_height should not fail");
+        registry
+            .register(Box::new(connected_peers.clone()))
+            .expect("register connected_peers should not fail");
+        registry
+            .register(Box::new(uptime_since_genesis_ms.clone()))
+            .expect("register uptime should not fail");
+        registry
+            .register(Box::new(domains.clone()))
+            .expect("register domains counter should not fail");
+        registry
+            .register(Box::new(users.clone()))
+            .expect("register users should not fail");
+        registry
+            .register(Box::new(queries.clone()))
+            .expect("register queries should not fail");
+        Self {
+            txs,
+            block_height,
+            connected_peers,
+            uptime_since_genesis_ms,
+            registry,
+            domains,
+            users,
+            queries,
+        }
+    }
+}
+
+impl Metrics {
+    /// Convert the current [`Metrics`] into a Prometheus-readable format.
+    ///
+    /// # Errors
+    /// - If [`Encoder`] fails to encode the data
+    /// - If the buffer produced by [`Encoder`] causes [`String::from_utf8`] to fail.
+    pub fn try_to_string(&self) -> eyre::Result<String> {
+        let mut buffer = vec![];
+        let encoder = prometheus::TextEncoder::new();
+        let metric_families = self.registry.gather();
+        Encoder::encode(&encoder, &metric_families, &mut buffer)?;
+        Ok(String::from_utf8(buffer)?)
+    }
+}

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -12,6 +12,8 @@ dev-telemetry = []
 iroha_config = { version = "=2.0.0-pre.1", path = "../config" }
 iroha_logger = { version = "=2.0.0-pre.1", path = "../logger" }
 iroha_futures = { version = "=2.0.0-pre.1", path = "../futures", features = ["telemetry"] }
+iroha_telemetry_derive = { version = "=2.0.0-pre.1", path = "derive" }
+
 
 async-trait = "0.1"
 chrono = "0.4"
@@ -24,6 +26,8 @@ tokio = { version = "1.6.0", features = ["rt", "rt-multi-thread", "macros"]}
 tokio-stream = { version = "0.1.6", features = ["fs"]}
 tokio-tungstenite = { version = "0.16" }
 url = { version = "2.2.2", features = ["serde"] }
+prometheus = { version = "0.13.0", default-features = false }
+
 
 [build-dependencies]
 anyhow = "1.0"

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 
 [features]
 dev-telemetry = []
+metric-instrumentation = []
 
 [dependencies]
 iroha_config = { version = "=2.0.0-pre.1", path = "../config" }

--- a/telemetry/derive/Cargo.toml
+++ b/telemetry/derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "iroha_data_model_derive"
+name = "iroha_telemetry_derive"
 version = "2.0.0-pre.1"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 description = "Tracking metrics in iroha_core, requires some instrumentation that is most conveniently expressed as attribute-like macros."
@@ -26,4 +26,6 @@ proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 
 [dev-dependencies]
-iroha_core = { path = "../../core" } 
+iroha_core = { path = "../../core" }
+
+trybuild = "1.0.53"

--- a/telemetry/derive/tests/ui.rs
+++ b/telemetry/derive/tests/ui.rs
@@ -1,0 +1,8 @@
+use trybuild::TestCases;
+
+#[test]
+fn ui() {
+    let test_cases = TestCases::new();
+    test_cases.pass("tests/ui_pass/*.rs");
+    test_cases.compile_fail("tests/ui_fail/*.rs");
+}

--- a/telemetry/derive/tests/ui_fail/args_no_wsv.rs
+++ b/telemetry/derive/tests/ui_fail/args_no_wsv.rs
@@ -2,7 +2,7 @@ use iroha_core::wsv::{World, WorldStateView};
 use iroha_telemetry_derive::metrics;
 
 #[metrics(+"test_query", "another_test_query_without_timing")]
-fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+fn execute(_wsv: &World) -> Result<(), ()> {
 	Ok(())
 }
 

--- a/telemetry/derive/tests/ui_fail/args_no_wsv.rs
+++ b/telemetry/derive/tests/ui_fail/args_no_wsv.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing")]
+fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/args_no_wsv.stderr
+++ b/telemetry/derive/tests/ui_fail/args_no_wsv.stderr
@@ -1,0 +1,5 @@
+error: At least one argument must be a `WorldStateView`. Path specifications currently aren't parsed.
+ --> tests/ui_fail/args_no_wsv.rs:5:12
+  |
+5 | fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/telemetry/derive/tests/ui_fail/args_no_wsv.stderr
+++ b/telemetry/derive/tests/ui_fail/args_no_wsv.stderr
@@ -1,5 +1,5 @@
-error: At least one argument must be a `WorldStateView`. Path specifications currently aren't parsed.
+error: At least one argument must be a `WorldStateView`.
  --> tests/ui_fail/args_no_wsv.rs:5:12
   |
-5 | fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | fn execute(_wsv: &World) -> Result<(), ()> {
+  |            ^^^^^^^^^^^^

--- a/telemetry/derive/tests/ui_fail/bare_spec.rs
+++ b/telemetry/derive/tests/ui_fail/bare_spec.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(test_query, "another_test_query_without_timing")]
+fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/bare_spec.stderr
+++ b/telemetry/derive/tests/ui_fail/bare_spec.stderr
@@ -1,0 +1,5 @@
+error: expected literal
+ --> tests/ui_fail/bare_spec.rs:4:11
+  |
+4 | #[metrics(test_query, "another_test_query_without_timing")]
+  |           ^^^^^^^^^^

--- a/telemetry/derive/tests/ui_fail/doubled_plus.rs
+++ b/telemetry/derive/tests/ui_fail/doubled_plus.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", ++"another_test_query_without_timing")]
+fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/doubled_plus.stderr
+++ b/telemetry/derive/tests/ui_fail/doubled_plus.stderr
@@ -1,0 +1,5 @@
+error: expected literal
+ --> tests/ui_fail/doubled_plus.rs:4:27
+  |
+4 | #[metrics(+"test_query", ++"another_test_query_without_timing")]
+  |                           ^

--- a/telemetry/derive/tests/ui_fail/no_args.rs
+++ b/telemetry/derive/tests/ui_fail/no_args.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing")]
+fn execute() -> Result<(), ()> {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/no_args.stderr
+++ b/telemetry/derive/tests/ui_fail/no_args.stderr
@@ -1,0 +1,5 @@
+error: Function must have at least one argument of type `WorldStateView`.
+ --> tests/ui_fail/no_args.rs:5:1
+  |
+5 | fn execute() -> Result<(), ()> {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/telemetry/derive/tests/ui_fail/non_snake_case_name.rs
+++ b/telemetry/derive/tests/ui_fail/non_snake_case_name.rs
@@ -1,16 +1,12 @@
+#![allow(unused_imports)]
 use iroha_core::wsv::{World, WorldStateView};
 use iroha_telemetry_derive::metrics;
 
 #[metrics(+"test query", "another_test_query_without_timing")]
 fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
-	// TODO: AFAIK prometheus is fine with spaces in names, but
-	// enforcing a consistent style might be a good idea long-term.
-
-	// Uncomment this, when the test can be un-ignored
-	
-	// Ok(())
+	Ok(())
 }
 
 fn main() {
-	
+
 }

--- a/telemetry/derive/tests/ui_fail/non_snake_case_name.rs
+++ b/telemetry/derive/tests/ui_fail/non_snake_case_name.rs
@@ -1,0 +1,16 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test query", "another_test_query_without_timing")]
+fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
+	// TODO: AFAIK prometheus is fine with spaces in names, but
+	// enforcing a consistent style might be a good idea long-term.
+
+	// Uncomment this, when the test can be un-ignored
+	
+	// Ok(())
+}
+
+fn main() {
+	
+}

--- a/telemetry/derive/tests/ui_fail/non_snake_case_name.stderr
+++ b/telemetry/derive/tests/ui_fail/non_snake_case_name.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+ --> tests/ui_fail/non_snake_case_name.rs:4:1
+  |
+4 | #[metrics(+"test query", "another_test_query_without_timing")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected `()`, found enum `Result`
+  | this expression has type `()`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<_, _>`
+  = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/ui_fail/non_snake_case_name.rs:4:1
+  |
+4 | #[metrics(+"test query", "another_test_query_without_timing")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Result`, found `()`
+5 | fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
+  |                                            -------------- expected `Result<(), ()>` because of return type
+  |
+  = note:   expected enum `Result<(), ()>`
+          found unit type `()`
+  = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try using a variant of the expected enum
+  |
+4 | Ok(#[metrics(+"test query", "another_test_query_without_timing")])
+  |
+4 | Err(#[metrics(+"test query", "another_test_query_without_timing")])
+  |

--- a/telemetry/derive/tests/ui_fail/non_snake_case_name.stderr
+++ b/telemetry/derive/tests/ui_fail/non_snake_case_name.stderr
@@ -1,30 +1,7 @@
-error[E0308]: mismatched types
- --> tests/ui_fail/non_snake_case_name.rs:4:1
+error: Spaces are not allowed. Use underscores '_'
+ --> tests/ui_fail/non_snake_case_name.rs:5:1
   |
-4 | #[metrics(+"test query", "another_test_query_without_timing")]
+5 | #[metrics(+"test query", "another_test_query_without_timing")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  | |
-  | expected `()`, found enum `Result`
-  | this expression has type `()`
   |
-  = note: expected unit type `()`
-                  found enum `Result<_, _>`
   = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> tests/ui_fail/non_snake_case_name.rs:4:1
-  |
-4 | #[metrics(+"test query", "another_test_query_without_timing")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Result`, found `()`
-5 | fn execute(wsv: &WorldStateView<World>) -> Result<(), ()> {
-  |                                            -------------- expected `Result<(), ()>` because of return type
-  |
-  = note:   expected enum `Result<(), ()>`
-          found unit type `()`
-  = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: try using a variant of the expected enum
-  |
-4 | Ok(#[metrics(+"test query", "another_test_query_without_timing")])
-  |
-4 | Err(#[metrics(+"test query", "another_test_query_without_timing")])
-  |

--- a/telemetry/derive/tests/ui_fail/not_execute.rs
+++ b/telemetry/derive/tests/ui_fail/not_execute.rs
@@ -7,5 +7,6 @@ fn exequte(wsv: &WorldStateView<World>) -> Result<(), ()> {
 }
 
 fn main() {
-	
+	let _something: World = World::default();
+	let _something_else = WorldStateView::<World>::default();
 }

--- a/telemetry/derive/tests/ui_fail/not_execute.rs
+++ b/telemetry/derive/tests/ui_fail/not_execute.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing")]
+fn exequte(wsv: &WorldStateView<World>) -> Result<(), ()> {
+		Ok(())
+}
+
+fn main() {
+	
+}

--- a/telemetry/derive/tests/ui_fail/not_execute.stderr
+++ b/telemetry/derive/tests/ui_fail/not_execute.stderr
@@ -1,0 +1,13 @@
+error: Function should be an `impl execute`
+ --> tests/ui_fail/not_execute.rs:5:4
+  |
+5 | fn exequte(wsv: &WorldStateView<World>) -> Result<(), ()> {
+  |    ^^^^^^^
+
+warning: unused imports: `WorldStateView`, `World`
+ --> tests/ui_fail/not_execute.rs:1:23
+  |
+1 | use iroha_core::wsv::{World, WorldStateView};
+  |                       ^^^^^  ^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/telemetry/derive/tests/ui_fail/not_execute.stderr
+++ b/telemetry/derive/tests/ui_fail/not_execute.stderr
@@ -3,11 +3,3 @@ error: Function should be an `impl execute`
   |
 5 | fn exequte(wsv: &WorldStateView<World>) -> Result<(), ()> {
   |    ^^^^^^^
-
-warning: unused imports: `WorldStateView`, `World`
- --> tests/ui_fail/not_execute.rs:1:23
-  |
-1 | use iroha_core::wsv::{World, WorldStateView};
-  |                       ^^^^^  ^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` on by default

--- a/telemetry/derive/tests/ui_fail/not_return_result.rs
+++ b/telemetry/derive/tests/ui_fail/not_return_result.rs
@@ -1,0 +1,7 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing")]
+fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
+
+}

--- a/telemetry/derive/tests/ui_fail/not_return_result.rs
+++ b/telemetry/derive/tests/ui_fail/not_return_result.rs
@@ -2,6 +2,12 @@ use iroha_core::wsv::{World, WorldStateView};
 use iroha_telemetry_derive::metrics;
 
 #[metrics(+"test_query", "another_test_query_without_timing")]
-fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
-
+fn execute(_wsv: &WorldStateView<World>) -> iroha_core::RESULT {
+	Ok(())
 }
+
+fn main() {
+	let _something: World = World::default();
+	let _something_else = WorldStateView::<World>::default();
+}
+

--- a/telemetry/derive/tests/ui_fail/not_return_result.stderr
+++ b/telemetry/derive/tests/ui_fail/not_return_result.stderr
@@ -1,0 +1,25 @@
+error: Should return `Result`. Found iroha_core
+ --> tests/ui_fail/not_return_result.rs:5:44
+  |
+5 | fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
+  |                                            ^^^^^^^^^^
+
+warning: unused imports: `WorldStateView`, `World`
+ --> tests/ui_fail/not_return_result.rs:1:23
+  |
+1 | use iroha_core::wsv::{World, WorldStateView};
+  |                       ^^^^^  ^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui_fail/not_return_result.rs:1:1
+  |
+1 | / use iroha_core::wsv::{World, WorldStateView};
+2 | | use iroha_telemetry_derive::metrics;
+3 | |
+4 | | #[metrics(+"test_query", "another_test_query_without_timing")]
+5 | | fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
+6 | |
+7 | | }
+  | |_^ consider adding a `main` function to `$DIR/tests/ui_fail/not_return_result.rs`

--- a/telemetry/derive/tests/ui_fail/not_return_result.stderr
+++ b/telemetry/derive/tests/ui_fail/not_return_result.stderr
@@ -1,25 +1,5 @@
-error: Should return `Result`. Found iroha_core
- --> tests/ui_fail/not_return_result.rs:5:44
+error: Should return `Result`. Found RESULT
+ --> tests/ui_fail/not_return_result.rs:5:57
   |
-5 | fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
-  |                                            ^^^^^^^^^^
-
-warning: unused imports: `WorldStateView`, `World`
- --> tests/ui_fail/not_return_result.rs:1:23
-  |
-1 | use iroha_core::wsv::{World, WorldStateView};
-  |                       ^^^^^  ^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` on by default
-
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui_fail/not_return_result.rs:1:1
-  |
-1 | / use iroha_core::wsv::{World, WorldStateView};
-2 | | use iroha_telemetry_derive::metrics;
-3 | |
-4 | | #[metrics(+"test_query", "another_test_query_without_timing")]
-5 | | fn execute(wsv: &WorldStateView<World>) -> iroha_core::Result {
-6 | |
-7 | | }
-  | |_^ consider adding a `main` function to `$DIR/tests/ui_fail/not_return_result.rs`
+5 | fn execute(_wsv: &WorldStateView<World>) -> iroha_core::RESULT {
+  |                                                         ^^^^^^

--- a/telemetry/derive/tests/ui_fail/return_nothing.rs
+++ b/telemetry/derive/tests/ui_fail/return_nothing.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing")]
+fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/return_nothing.stderr
+++ b/telemetry/derive/tests/ui_fail/return_nothing.stderr
@@ -1,0 +1,7 @@
+error: `Fn` must return `Result`. Returns nothing instead.
+ --> tests/ui_fail/return_nothing.rs:4:1
+  |
+4 | #[metrics(+"test_query", "another_test_query_without_timing")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/telemetry/derive/tests/ui_fail/trailing_plus.rs
+++ b/telemetry/derive/tests/ui_fail/trailing_plus.rs
@@ -1,0 +1,11 @@
+use iroha_core::wsv::{World, WorldStateView};
+use iroha_telemetry_derive::metrics;
+
+#[metrics(+"test_query", "another_test_query_without_timing"+)]
+fn execute(wsv: &iroha_core::wsv::WorldStateView<World>) -> Result<(), ()> {
+	Ok(())
+}
+
+fn main() {
+	let _world = WorldStateView::<World>::default();
+}

--- a/telemetry/derive/tests/ui_fail/trailing_plus.stderr
+++ b/telemetry/derive/tests/ui_fail/trailing_plus.stderr
@@ -1,0 +1,5 @@
+error: expected `,`
+ --> tests/ui_fail/trailing_plus.rs:4:61
+  |
+4 | #[metrics(+"test_query", "another_test_query_without_timing"+)]
+  |                                                             ^

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -4,10 +4,12 @@ mod config;
 #[cfg(feature = "dev-telemetry")]
 pub mod dev;
 pub mod futures;
+pub mod metrics;
 mod retry_period;
 pub mod ws;
 
 pub use config::Configuration;
+pub use iroha_telemetry_derive::metrics;
 
 pub mod msg {
     //! Messages that can be sent to the telemetry

--- a/telemetry/src/metrics.rs
+++ b/telemetry/src/metrics.rs
@@ -1,6 +1,6 @@
 //! [`Metrics`] and [`Status`]-related logic and functions.
 use std::{
-    sync::Arc,
+    ops::Deref,
     time::{Duration, SystemTime},
 };
 
@@ -33,8 +33,9 @@ pub struct Status {
     pub uptime: Uptime,
 }
 
-impl From<&Arc<Metrics>> for Status {
-    fn from(val: &Arc<Metrics>) -> Self {
+impl<T: Deref<Target = Metrics>> From<&T> for Status {
+    fn from(value: &T) -> Self {
+        let val: &Metrics = &*value;
         Self {
             peers: val.connected_peers.get(),
             blocks: val.block_height.get(),

--- a/telemetry/src/metrics.rs
+++ b/telemetry/src/metrics.rs
@@ -161,6 +161,11 @@ impl Metrics {
         Ok(String::from_utf8(buffer)?)
     }
 
+    /// Get time elapsed since Unix epoch.
+    ///
+    /// # Panics
+    /// Never
+    #[allow(clippy::unused_self, clippy::expect_used)]
     pub fn current_time(&self) -> Duration {
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION

### Description of the Change

- Refactored metric storage. 
- Added more metrics. 
- Added instrumentation for easily tracking `query` and `isi` execution and timing, via `iroha_telemetry_derive` procedural macro crate. 
- Full metrics are hidden behind the `expensive-telemetry` feature flag for core. Without this flag the `metrics` macro checks, if it's properly applied, but doesn't record the metrics. 


### Issue

Resolves #1331 


### Benefits

More metrics

### Possible Drawbacks
Tracking `expensive-telemetry` metrics slows down all instrumented `isi` and `query` implementations. 

### Usage Examples or Tests *[optional]*

```rust
#[metrics(
   "a", 
   "bunch_of_metrics",
   "ordered_freely", 
   "only_the_timed", 
  +"have_a_plus", 
  +"which_looks_like_a_t"
)]
```

### Alternate Designs *[optional]*

Instrumentation can be added by changing the trait topology for Queries and ISI. 
