### PR TITLE
[feature] #1734: Validate `Name` to exclude whitespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "iroha_core",
  "iroha_data_model",
  "iroha_macro",
+ "once_cell",
 ]
 
 [[package]]

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -38,7 +38,7 @@ fn query_requests(criterion: &mut Criterion) {
     let domain_name = "domain";
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test(domain_name).into()));
     let account_name = "account";
-    let account_id = AccountId::new(account_name, domain_name);
+    let account_id = AccountId::test(account_name, domain_name);
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
             account_id.clone(),
@@ -48,7 +48,7 @@ fn query_requests(criterion: &mut Criterion) {
         )
         .into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
+    let asset_definition_id = AssetDefinitionId::test("xor", domain_name);
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));
@@ -119,7 +119,7 @@ fn instruction_submits(criterion: &mut Criterion) {
     let domain_name = "domain";
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test(domain_name).into()));
     let account_name = "account";
-    let account_id = AccountId::new(account_name, domain_name);
+    let account_id = AccountId::test(account_name, domain_name);
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
             account_id.clone(),
@@ -129,7 +129,7 @@ fn instruction_submits(criterion: &mut Criterion) {
         )
         .into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
+    let asset_definition_id = AssetDefinitionId::test("xor", domain_name);
     let mut client_config = iroha_client::samples::get_client_config(&get_key_pair());
     client_config.torii_api_url = peer.api_address.clone();
     let mut iroha_client = Client::new(&client_config);

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -36,7 +36,7 @@ fn query_requests(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("query-reqeuests");
     let domain_name = "domain";
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new(domain_name).into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test(domain_name).into()));
     let account_name = "account";
     let account_id = AccountId::new(account_name, domain_name);
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
@@ -117,7 +117,7 @@ fn instruction_submits(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("instruction-requests");
     let domain_name = "domain";
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new(domain_name).into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test(domain_name).into()));
     let account_name = "account";
     let account_id = AccountId::new(account_name, domain_name);
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -25,7 +25,8 @@ fn query_requests(criterion: &mut Criterion) {
     let rt = Runtime::test();
     let genesis = GenesisNetwork::from_configuration(
         true,
-        RawGenesisBlock::new("alice", "wonderland", &get_key_pair().public_key),
+        RawGenesisBlock::new("alice", "wonderland", &get_key_pair().public_key)
+            .expect("Valid names never fail to parse"),
         &configuration.genesis,
         configuration.sumeragi.max_instruction_number,
     )
@@ -107,7 +108,8 @@ fn instruction_submits(criterion: &mut Criterion) {
     );
     let genesis = GenesisNetwork::from_configuration(
         true,
-        RawGenesisBlock::new("alice", "wonderland", &configuration.public_key),
+        RawGenesisBlock::new("alice", "wonderland", &configuration.public_key)
+            .expect("Valid names never fail to parse"),
         &configuration.genesis,
         configuration.sumeragi.max_instruction_number,
     )

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -662,9 +662,9 @@ pub mod domain {
         FindAllDomains::new()
     }
 
-    /// Get query to get all domain by name
-    pub fn by_name(domain_name: impl Into<EvaluatesTo<Name>>) -> FindDomainByName {
-        FindDomainByName::new(domain_name)
+    /// Get query to get all domain by id
+    pub fn by_id(domain_id: impl Into<EvaluatesTo<DomainId>>) -> FindDomainById {
+        FindDomainById::new(domain_id)
     }
 }
 

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -48,7 +48,7 @@ impl Default for Configuration {
         Self {
             public_key: PublicKey::default(),
             private_key: PrivateKey::default(),
-            account_id: AccountId::new("", ""),
+            account_id: AccountId::test("", ""),
             torii_api_url: uri::DEFAULT_API_URL.to_owned(),
             torii_status_url: DEFAULT_TORII_STATUS_URL.to_owned(),
             transaction_time_to_live_ms: DEFAULT_TRANSACTION_TIME_TO_LIVE_MS,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -21,7 +21,7 @@ pub mod samples {
             private_key,
             account_id: iroha_data_model::prelude::AccountId {
                 name: "alice".to_owned(),
-                domain_name: "wonderland".to_owned(),
+                domain_id: iroha_data_model::prelude::DomainId::new("wonderland"),
             },
             torii_api_url: uri::DEFAULT_API_URL.to_owned(),
             ..Configuration::default()

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,10 +19,7 @@ pub mod samples {
         Configuration {
             public_key,
             private_key,
-            account_id: iroha_data_model::prelude::AccountId {
-                name: "alice".to_owned(),
-                domain_id: iroha_data_model::prelude::DomainId::new("wonderland"),
-            },
+            account_id: iroha_data_model::prelude::AccountId::new("alice", "wonderland"),
             torii_api_url: uri::DEFAULT_API_URL.to_owned(),
             ..Configuration::default()
         }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,7 +19,7 @@ pub mod samples {
         Configuration {
             public_key,
             private_key,
-            account_id: iroha_data_model::prelude::AccountId::new("alice", "wonderland"),
+            account_id: iroha_data_model::prelude::AccountId::test("alice", "wonderland"),
             torii_api_url: uri::DEFAULT_API_URL.to_owned(),
             ..Configuration::default()
         }

--- a/client/tests/integration_tests/add_account.rs
+++ b/client/tests/integration_tests/add_account.rs
@@ -16,14 +16,14 @@ fn client_add_account_with_name_length_more_than_limit_should_not_commit_transac
 
     let pipeline_time = Configuration::pipeline_time();
 
-    let normal_account_id = AccountId::new("bob", "wonderland");
+    let normal_account_id = AccountId::test("bob", "wonderland");
     let create_account = RegisterBox::new(IdentifiableBox::from(NewAccount::new(
         normal_account_id.clone(),
     )));
     test_client.submit(create_account)?;
 
     let too_long_account_name = "0".repeat(2_usize.pow(14));
-    let incorrect_account_id = AccountId::new(&too_long_account_name, "wonderland");
+    let incorrect_account_id = AccountId::test(&too_long_account_name, "wonderland");
     let create_account = RegisterBox::new(IdentifiableBox::from(NewAccount::new(
         incorrect_account_id.clone(),
     )));

--- a/client/tests/integration_tests/add_asset.rs
+++ b/client/tests/integration_tests/add_asset.rs
@@ -15,8 +15,8 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
     let pipeline_time = Configuration::pipeline_time();
 
     // Given
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         asset_definition_id.clone(),
     )));
@@ -50,8 +50,8 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
     // Given
     thread::sleep(pipeline_time);
 
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_big_quantity(
         asset_definition_id.clone(),
     )));
@@ -85,8 +85,8 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
     // Given
     thread::sleep(pipeline_time);
 
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let identifiable_box =
         IdentifiableBox::from(AssetDefinition::with_precision(asset_definition_id.clone()));
     let create_asset = RegisterBox::new(identifiable_box);
@@ -141,7 +141,7 @@ fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transacti
     // Given
     thread::sleep(pipeline_time);
 
-    let normal_asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let normal_asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         normal_asset_definition_id.clone(),
     )));
@@ -149,7 +149,7 @@ fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transacti
     iroha_logger::info!("Creating asset");
 
     let too_long_asset_name = "0".repeat(2_usize.pow(14));
-    let incorrect_asset_definition_id = AssetDefinitionId::new(&too_long_asset_name, "wonderland");
+    let incorrect_asset_definition_id = AssetDefinitionId::test(&too_long_asset_name, "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         incorrect_asset_definition_id.clone(),
     )));

--- a/client/tests/integration_tests/add_domain.rs
+++ b/client/tests/integration_tests/add_domain.rs
@@ -18,20 +18,20 @@ fn client_add_domain_with_name_length_more_than_limit_should_not_commit_transact
     // Given
 
     let normal_domain_name = "sora";
-    let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::new(normal_domain_name)));
+    let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::test(normal_domain_name)));
     test_client.submit(create_domain)?;
 
     let too_long_domain_name = &"0".repeat(2_usize.pow(14));
-    let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::new(too_long_domain_name)));
+    let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::test(too_long_domain_name)));
     test_client.submit(create_domain)?;
 
     thread::sleep(pipeline_time * 2);
 
     assert!(test_client
-        .request(client::domain::by_name(normal_domain_name.to_string()))
+        .request(client::domain::by_id(DomainId::new(normal_domain_name)))
         .is_ok());
     assert!(test_client
-        .request(client::domain::by_name(too_long_domain_name.to_string()))
+        .request(client::domain::by_id(DomainId::new(too_long_domain_name)))
         .is_err());
 
     Ok(())

--- a/client/tests/integration_tests/add_domain.rs
+++ b/client/tests/integration_tests/add_domain.rs
@@ -28,10 +28,10 @@ fn client_add_domain_with_name_length_more_than_limit_should_not_commit_transact
     thread::sleep(pipeline_time * 2);
 
     assert!(test_client
-        .request(client::domain::by_id(DomainId::new(normal_domain_name)))
+        .request(client::domain::by_id(DomainId::test(normal_domain_name)))
         .is_ok());
     assert!(test_client
-        .request(client::domain::by_id(DomainId::new(too_long_domain_name)))
+        .request(client::domain::by_id(DomainId::test(too_long_domain_name)))
         .is_err());
 
     Ok(())

--- a/client/tests/integration_tests/asset_propagation.rs
+++ b/client/tests/integration_tests/asset_propagation.rs
@@ -16,7 +16,7 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
     wait_for_genesis_committed(network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
     let account_id = AccountId::new("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(account_id.clone(), KeyPair::generate()?.public_key).into(),

--- a/client/tests/integration_tests/asset_propagation.rs
+++ b/client/tests/integration_tests/asset_propagation.rs
@@ -17,11 +17,11 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
     let pipeline_time = Configuration::pipeline_time();
 
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
-    let account_id = AccountId::new("account", "domain");
+    let account_id = AccountId::test("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(account_id.clone(), KeyPair::generate()?.public_key).into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", "domain");
+    let asset_definition_id = AssetDefinitionId::test("xor", "domain");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));

--- a/client/tests/integration_tests/multiple_blocks_created.rs
+++ b/client/tests/integration_tests/multiple_blocks_created.rs
@@ -18,7 +18,7 @@ fn long_multiple_blocks_created() {
     let pipeline_time = Configuration::pipeline_time();
 
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
-    let account_id = AccountId::new("account", "domain");
+    let account_id = AccountId::test("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
             account_id.clone(),
@@ -28,7 +28,7 @@ fn long_multiple_blocks_created() {
         )
         .into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", "domain");
+    let asset_definition_id = AssetDefinitionId::test("xor", "domain");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));

--- a/client/tests/integration_tests/multiple_blocks_created.rs
+++ b/client/tests/integration_tests/multiple_blocks_created.rs
@@ -17,7 +17,7 @@ fn long_multiple_blocks_created() {
     wait_for_genesis_committed(network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
     let account_id = AccountId::new("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(

--- a/client/tests/integration_tests/multisignature_account.rs
+++ b/client/tests/integration_tests/multisignature_account.rs
@@ -15,8 +15,8 @@ fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
     let pipeline_time = Configuration::pipeline_time();
 
     // Given
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));

--- a/client/tests/integration_tests/multisignature_transaction.rs
+++ b/client/tests/integration_tests/multisignature_transaction.rs
@@ -18,14 +18,14 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     let pipeline_time = Configuration::pipeline_time();
 
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
-    let account_id = AccountId::new("account", "domain");
+    let account_id = AccountId::test("account", "domain");
     let key_pair_1 = KeyPair::generate().expect("Failed to generate KeyPair.");
     let key_pair_2 = KeyPair::generate().expect("Failed to generate KeyPair.");
     let create_account = RegisterBox::new(IdentifiableBox::from(NewAccount::with_signatory(
         account_id.clone(),
         key_pair_1.public_key.clone(),
     )));
-    let asset_definition_id = AssetDefinitionId::new("xor", "domain");
+    let asset_definition_id = AssetDefinitionId::test("xor", "domain");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         asset_definition_id.clone(),
     )));

--- a/client/tests/integration_tests/multisignature_transaction.rs
+++ b/client/tests/integration_tests/multisignature_transaction.rs
@@ -17,7 +17,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     wait_for_genesis_committed(network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
     let account_id = AccountId::new("account", "domain");
     let key_pair_1 = KeyPair::generate().expect("Failed to generate KeyPair.");
     let key_pair_2 = KeyPair::generate().expect("Failed to generate KeyPair.");

--- a/client/tests/integration_tests/offline_peers.rs
+++ b/client/tests/integration_tests/offline_peers.rs
@@ -13,7 +13,7 @@ fn genesis_block_is_commited_with_some_offline_peers() {
     wait_for_genesis_committed(network.clients(), 1);
 
     //When
-    let alice_id = AccountId::new("alice", "wonderland");
+    let alice_id = AccountId::test("alice", "wonderland");
     let alice_has_roses = 13;
 
     //Then
@@ -22,7 +22,7 @@ fn genesis_block_is_commited_with_some_offline_peers() {
         .expect("Failed to execute request.");
     let asset = assets
         .iter()
-        .find(|asset| asset.id.definition_id == AssetDefinitionId::new("rose", "wonderland"))
+        .find(|asset| asset.id.definition_id == AssetDefinitionId::test("rose", "wonderland"))
         .unwrap();
     assert_eq!(AssetValue::Quantity(alice_has_roses), asset.value);
 }

--- a/client/tests/integration_tests/pagination.rs
+++ b/client/tests/integration_tests/pagination.rs
@@ -15,7 +15,7 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() {
 
     let register = ('a'..'z')
         .map(|c| c.to_string())
-        .map(|name| AssetDefinitionId::new(&name, "wonderland"))
+        .map(|name| AssetDefinitionId::test(&name, "wonderland"))
         .map(AssetDefinition::new_quantity)
         .map(IdentifiableBox::from)
         .map(RegisterBox::new)

--- a/client/tests/integration_tests/permissions.rs
+++ b/client/tests/integration_tests/permissions.rs
@@ -12,12 +12,12 @@ use tokio::runtime::Runtime;
 const BURN_REJECTION_REASON: &str = "Failed to pass first check with Can\'t burn assets from another account. \
     and second check with Account does not have the needed permission token: \
     PermissionToken { name: \"can_burn_user_assets\", params: {\"asset_id\": Id(AssetId(Id { definition_id: \
-    DefinitionId { name: \"xor\", domain_name: \"wonderland\" }, account_id: Id { name: \"bob\", domain_name: \"wonderland\" } }))} }..";
+    DefinitionId { name: \"xor\", domain_id: Id { name: \"wonderland\" } }, account_id: Id { name: \"bob\", domain_id: Id { name: \"wonderland\" } } }))} }..";
 
 const MINT_REJECTION_REASON: &str = "Failed to pass first check with Can\'t transfer assets of the other account. \
     and second check with Account does not have the needed permission token: \
     PermissionToken { name: \"can_transfer_user_assets\", params: {\"asset_id\": Id(AssetId(Id { definition_id: \
-    DefinitionId { name: \"xor\", domain_name: \"wonderland\" }, account_id: Id { name: \"bob\", domain_name: \"wonderland\" } }))} }..";
+    DefinitionId { name: \"xor\", domain_id: Id { name: \"wonderland\" } }, account_id: Id { name: \"bob\", domain_id: Id { name: \"wonderland\" } } }))} }..";
 
 fn get_assets(iroha_client: &mut Client, id: &AccountId) -> Vec<Asset> {
     iroha_client

--- a/client/tests/integration_tests/permissions.rs
+++ b/client/tests/integration_tests/permissions.rs
@@ -36,9 +36,9 @@ fn permissions_disallow_asset_transfer() {
     let pipeline_time = Configuration::pipeline_time();
 
     // Given
-    let alice_id = AccountId::new("alice", "wonderland");
-    let bob_id = AccountId::new("bob", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let alice_id = AccountId::test("alice", "wonderland");
+    let bob_id = AccountId::test("bob", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         asset_definition_id.clone(),
     )));
@@ -98,9 +98,9 @@ fn permissions_disallow_asset_burn() {
     thread::sleep(pipeline_time * 5);
 
     let domain_name = "wonderland";
-    let alice_id = AccountId::new("alice", domain_name);
-    let bob_id = AccountId::new("bob", domain_name);
-    let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
+    let alice_id = AccountId::test("alice", domain_name);
+    let bob_id = AccountId::test("bob", domain_name);
+    let asset_definition_id = AssetDefinitionId::test("xor", domain_name);
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         asset_definition_id.clone(),
     )));
@@ -173,11 +173,11 @@ fn account_can_query_only_its_own_domain() {
 
     // Alice can query the domain in which her account exists.
     assert!(iroha_client
-        .request(client::domain::by_id(DomainId::new(domain_name)))
+        .request(client::domain::by_id(DomainId::test(domain_name)))
         .is_ok());
 
     // Alice can not query other domains.
     assert!(iroha_client
-        .request(client::domain::by_id(DomainId::new(new_domain_name)))
+        .request(client::domain::by_id(DomainId::test(new_domain_name)))
         .is_err());
 }

--- a/client/tests/integration_tests/permissions.rs
+++ b/client/tests/integration_tests/permissions.rs
@@ -163,7 +163,7 @@ fn account_can_query_only_its_own_domain() {
 
     let domain_name = "wonderland";
     let new_domain_name = "wonderland2";
-    let register_domain = RegisterBox::new(IdentifiableBox::from(Domain::new(new_domain_name)));
+    let register_domain = RegisterBox::new(IdentifiableBox::from(Domain::test(new_domain_name)));
 
     iroha_client
         .submit(register_domain)
@@ -173,11 +173,11 @@ fn account_can_query_only_its_own_domain() {
 
     // Alice can query the domain in which her account exists.
     assert!(iroha_client
-        .request(client::domain::by_name(domain_name.to_owned()))
+        .request(client::domain::by_id(DomainId::new(domain_name)))
         .is_ok());
 
     // Alice can not query other domains.
     assert!(iroha_client
-        .request(client::domain::by_name(new_domain_name.to_owned()))
+        .request(client::domain::by_id(DomainId::new(new_domain_name)))
         .is_err());
 }

--- a/client/tests/integration_tests/transfer_asset.rs
+++ b/client/tests/integration_tests/transfer_asset.rs
@@ -13,7 +13,7 @@ fn client_can_transfer_asset_to_another_account() {
     wait_for_genesis_committed(vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
     let account1_id = AccountId::new("account1", "domain");
     let account2_id = AccountId::new("account2", "domain");
     let create_account1 = RegisterBox::new(IdentifiableBox::NewAccount(

--- a/client/tests/integration_tests/transfer_asset.rs
+++ b/client/tests/integration_tests/transfer_asset.rs
@@ -14,8 +14,8 @@ fn client_can_transfer_asset_to_another_account() {
     let pipeline_time = Configuration::pipeline_time();
 
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
-    let account1_id = AccountId::new("account1", "domain");
-    let account2_id = AccountId::new("account2", "domain");
+    let account1_id = AccountId::test("account1", "domain");
+    let account2_id = AccountId::test("account2", "domain");
     let create_account1 = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
             account1_id.clone(),
@@ -34,7 +34,7 @@ fn client_can_transfer_asset_to_another_account() {
         )
         .into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", "domain");
+    let asset_definition_id = AssetDefinitionId::test("xor", "domain");
     let quantity: u32 = 200;
     let create_asset = RegisterBox::new(IdentifiableBox::from(AssetDefinition::new_quantity(
         asset_definition_id.clone(),

--- a/client/tests/integration_tests/tx_history.rs
+++ b/client/tests/integration_tests/tx_history.rs
@@ -15,8 +15,8 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
     let pipeline_time = Configuration::pipeline_time();
 
     // Given
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));
@@ -33,7 +33,7 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
     let mint_not_existed_asset = MintBox::new(
         Value::U32(quantity),
         IdBox::AssetId(AssetId::new(
-            AssetDefinitionId::new("foo", "wonderland"),
+            AssetDefinitionId::test("foo", "wonderland"),
             account_id.clone(),
         )),
     );

--- a/client/tests/integration_tests/tx_rollback.rs
+++ b/client/tests/integration_tests/tx_rollback.rs
@@ -15,9 +15,9 @@ fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes(
     let pipeline_time = Configuration::pipeline_time();
 
     //When
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland");
-    let wrong_asset_definition_id = AssetDefinitionId::new("ksor", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("xor", "wonderland");
+    let wrong_asset_definition_id = AssetDefinitionId::test("ksor", "wonderland");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id).into(),
     ));

--- a/client/tests/integration_tests/unregister_peer.rs
+++ b/client/tests/integration_tests/unregister_peer.rs
@@ -95,11 +95,11 @@ fn init() -> Result<(
     thread::sleep(pipeline_time * 2);
     iroha_logger::info!("Started");
     let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
-    let account_id = AccountId::new("account", "domain");
+    let account_id = AccountId::test("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(account_id.clone(), KeyPair::generate()?.public_key).into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", "domain");
+    let asset_definition_id = AssetDefinitionId::test("xor", "domain");
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));

--- a/client/tests/integration_tests/unregister_peer.rs
+++ b/client/tests/integration_tests/unregister_peer.rs
@@ -94,7 +94,7 @@ fn init() -> Result<(
     let pipeline_time = Configuration::pipeline_time();
     thread::sleep(pipeline_time * 2);
     iroha_logger::info!("Started");
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new("domain").into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test("domain").into()));
     let account_id = AccountId::new("account", "domain");
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(account_id.clone(), KeyPair::generate()?.public_key).into(),

--- a/client/tests/integration_tests/unstable_network.rs
+++ b/client/tests/integration_tests/unstable_network.rs
@@ -79,8 +79,8 @@ fn unstable_network(
 
     let pipeline_time = Configuration::pipeline_time();
 
-    let account_id = AccountId::new("alice", "wonderland");
-    let asset_definition_id = AssetDefinitionId::new("rose", "wonderland");
+    let account_id = AccountId::test("alice", "wonderland");
+    let asset_definition_id = AssetDefinitionId::test("rose", "wonderland");
     // Initially there are 13 roses.
     let mut account_has_quantity = 13;
 

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -43,7 +43,7 @@ impl FromStr for Metadata {
     }
 }
 
-/// Client configuration wrapper. Allows getting itself from arguments from cli (from user suplied file).
+/// Client configuration wrapper. Allows getting itself from arguments from cli (from user supplied file).
 #[derive(Debug, Clone)]
 pub struct Configuration(pub ClientConfiguration);
 
@@ -125,12 +125,12 @@ fn main() -> Result<()> {
     println!("Iroha Client CLI: build v0.0.1 [release]");
     println!(
         "User: {}@{}",
-        config.account_id.name, config.account_id.domain_name
+        config.account_id.name, config.account_id.domain_id
     );
     #[cfg(debug_assertions)]
     eprintln!(
         "{}",
-        &serde_json::to_string(&config).wrap_err("Failed to serialize configuraiton.")?
+        &serde_json::to_string(&config).wrap_err("Failed to serialize configuration.")?
     );
     #[cfg(not(debug_assertions))]
     eprintln!("This is a release build, debug information omitted from messages");
@@ -248,7 +248,7 @@ mod domain {
     pub struct Register {
         /// Domain's name as double-quoted string
         #[structopt(short, long)]
-        pub id: Domain,
+        pub id: DomainId,
         /// The filename with key-value metadata pairs in JSON
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
@@ -260,7 +260,7 @@ mod domain {
                 id,
                 metadata: Metadata(metadata),
             } = self;
-            let create_domain = RegisterBox::new(IdentifiableBox::from(id));
+            let create_domain = RegisterBox::new(IdentifiableBox::from(Domain::new(id)));
             submit(create_domain, cfg, metadata).wrap_err("Failed to create domain")
         }
     }

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -15,8 +15,8 @@ use tokio::{fs, runtime::Runtime};
 
 async fn measure_block_size_for_n_validators(n_validators: u32) {
     let dir = tempfile::tempdir().unwrap();
-    let alice_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-    let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
+    let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+    let bob_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "bob", "test");
     let transfer = Instruction::Transfer(TransferBox {
         source_id: IdBox::AssetId(alice_xor_id).into(),
         object: Value::U32(10).into(),
@@ -25,7 +25,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
     let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
     let tx = Transaction::new(
         vec![transfer],
-        <Account as Identifiable>::Id::new("alice", "wonderland"),
+        <Account as Identifiable>::Id::test("alice", "wonderland"),
         1000,
     )
     .sign(&keypair)

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -22,14 +22,14 @@ fn build_test_transaction(keys: &KeyPair) -> Transaction {
     let account_name = "account";
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
-            AccountId::new(account_name, domain_name),
+            AccountId::test(account_name, domain_name),
             KeyPair::generate()
                 .expect("Failed to generate KeyPair.")
                 .public_key,
         )
         .into(),
     ));
-    let asset_definition_id = AssetDefinitionId::new("xor", domain_name);
+    let asset_definition_id = AssetDefinitionId::test("xor", domain_name);
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new(asset_definition_id, AssetValueType::Quantity, true).into(),
     ));
@@ -39,7 +39,7 @@ fn build_test_transaction(keys: &KeyPair) -> Transaction {
             create_account.into(),
             create_asset.into(),
         ],
-        AccountId::new(START_ACCOUNT, START_DOMAIN),
+        AccountId::test(START_ACCOUNT, START_DOMAIN),
         TRANSACTION_TIME_TO_LIVE_MS,
     )
     .sign(keys)
@@ -50,11 +50,11 @@ fn build_test_wsv(keys: &KeyPair) -> WorldStateView<World> {
     WorldStateView::new({
         let mut domains = BTreeMap::new();
         let mut domain = Domain::test(START_DOMAIN);
-        let account_id = AccountId::new(START_ACCOUNT, START_DOMAIN);
+        let account_id = AccountId::test(START_ACCOUNT, START_DOMAIN);
         let mut account = Account::new(account_id.clone());
         account.signatories.push(keys.public_key.clone());
         domain.accounts.insert(account_id, account);
-        domains.insert(DomainId::new(START_DOMAIN), domain);
+        domains.insert(DomainId::test(START_DOMAIN), domain);
         World::with(domains, BTreeSet::new())
     })
 }
@@ -170,11 +170,11 @@ fn validate_blocks(criterion: &mut Criterion) {
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
     let domain_name = "global";
     let asset_definitions = BTreeMap::new();
-    let account_id = AccountId::new("root", domain_name);
+    let account_id = AccountId::test("root", domain_name);
     let account = Account::with_signatory(account_id.clone(), key_pair.public_key);
     let mut accounts = BTreeMap::new();
     accounts.insert(account_id, account);
-    let domain_id = DomainId::new(domain_name);
+    let domain_id = DomainId::test(domain_name);
     let domain = Domain {
         id: domain_id.clone(),
         accounts,

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -18,7 +18,7 @@ const START_ACCOUNT: &str = "starter";
 
 fn build_test_transaction(keys: &KeyPair) -> Transaction {
     let domain_name = "domain";
-    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::new(domain_name).into()));
+    let create_domain = RegisterBox::new(IdentifiableBox::Domain(Domain::test(domain_name).into()));
     let account_name = "account";
     let create_account = RegisterBox::new(IdentifiableBox::NewAccount(
         NewAccount::with_signatory(
@@ -49,12 +49,12 @@ fn build_test_transaction(keys: &KeyPair) -> Transaction {
 fn build_test_wsv(keys: &KeyPair) -> WorldStateView<World> {
     WorldStateView::new({
         let mut domains = BTreeMap::new();
-        let mut domain = Domain::new(START_DOMAIN);
+        let mut domain = Domain::test(START_DOMAIN);
         let account_id = AccountId::new(START_ACCOUNT, START_DOMAIN);
         let mut account = Account::new(account_id.clone());
         account.signatories.push(keys.public_key.clone());
         domain.accounts.insert(account_id, account);
-        domains.insert(START_DOMAIN.to_string(), domain);
+        domains.insert(DomainId::new(START_DOMAIN), domain);
         World::with(domains, BTreeSet::new())
     })
 }
@@ -168,20 +168,21 @@ fn sign_blocks(criterion: &mut Criterion) {
 fn validate_blocks(criterion: &mut Criterion) {
     // Prepare WSV
     let key_pair = KeyPair::generate().expect("Failed to generate KeyPair.");
-    let domain_name = "global".to_string();
+    let domain_name = "global";
     let asset_definitions = BTreeMap::new();
-    let account_id = AccountId::new("root", &domain_name);
+    let account_id = AccountId::new("root", domain_name);
     let account = Account::with_signatory(account_id.clone(), key_pair.public_key);
     let mut accounts = BTreeMap::new();
     accounts.insert(account_id, account);
+    let domain_id = DomainId::new(domain_name);
     let domain = Domain {
-        name: domain_name.clone(),
+        id: domain_id.clone(),
         accounts,
         asset_definitions,
         metadata: Metadata::new(),
     };
     let mut domains = BTreeMap::new();
-    domains.insert(domain_name, domain);
+    domains.insert(domain_id, domain);
     let wsv = WorldStateView::new(World::with(domains, BTreeSet::new()));
     // Pepare test transaction
     let keys = KeyPair::generate().expect("Failed to generate keys");

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -234,16 +234,23 @@ impl RawGenesisBlock {
         let file = File::open(&path).wrap_err(format!("Failed to open {:?}", &path))?;
         let reader = BufReader::new(file);
         serde_json::from_reader(reader).wrap_err(format!(
-            "Failed to deserialise raw genesis block from {:?}",
+            "Failed to deserialize raw genesis block from {:?}",
             &path
         ))
     }
 
     /// Create a [`RawGenesisBlock`] with specified [`Domain`] and [`NewAccount`].
-    pub fn new(name: &str, domain_name: &str, public_key: &PublicKey) -> Self {
-        RawGenesisBlock {
-            transactions: vec![GenesisTransaction::new(name, domain_name, public_key)],
-        }
+    ///
+    /// # Errors
+    /// Fails if `account_name` or `domain_name` is invalid
+    pub fn new(account_name: &str, domain_name: &str, public_key: &PublicKey) -> Result<Self> {
+        Ok(RawGenesisBlock {
+            transactions: vec![GenesisTransaction::new(
+                account_name,
+                domain_name,
+                public_key,
+            )?],
+        })
     }
 }
 
@@ -274,23 +281,26 @@ impl GenesisTransaction {
     }
 
     /// Create a [`GenesisTransaction`] with the specified [`Domain`] and [`NewAccount`].
-    pub fn new(account_name: &str, domain_name: &str, public_key: &PublicKey) -> Self {
-        Self {
+    ///
+    /// # Errors
+    /// Fails if `account_name` or `domain_name` is invalid
+    pub fn new(account_name: &str, domain_name: &str, public_key: &PublicKey) -> Result<Self> {
+        Ok(Self {
             isi: vec![
-                RegisterBox::new(IdentifiableBox::from(Domain::new(DomainId::test(
+                RegisterBox::new(IdentifiableBox::from(Domain::new(DomainId::new(
                     domain_name,
-                ))))
+                )?)))
                 .into(),
                 RegisterBox::new(IdentifiableBox::NewAccount(
                     NewAccount::with_signatory(
-                        iroha_data_model::account::Id::test(account_name, domain_name),
+                        iroha_data_model::account::Id::new(account_name, domain_name)?,
                         public_key.clone(),
                     )
                     .into(),
                 ))
                 .into(),
             ],
-        }
+        })
     }
 }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -277,13 +277,13 @@ impl GenesisTransaction {
     pub fn new(account_name: &str, domain_name: &str, public_key: &PublicKey) -> Self {
         Self {
             isi: vec![
-                RegisterBox::new(IdentifiableBox::from(Domain::new(DomainId::new(
+                RegisterBox::new(IdentifiableBox::from(Domain::new(DomainId::test(
                     domain_name,
                 ))))
                 .into(),
                 RegisterBox::new(IdentifiableBox::NewAccount(
                     NewAccount::with_signatory(
-                        iroha_data_model::account::Id::new(account_name, domain_name),
+                        iroha_data_model::account::Id::test(account_name, domain_name),
                         public_key.clone(),
                     )
                     .into(),

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -266,7 +266,7 @@ impl GenesisTransaction {
     ) -> Result<VersionedAcceptedTransaction> {
         let transaction = Transaction::new(
             self.isi.clone(),
-            <Account as Identifiable>::Id::genesis_account(),
+            <Account as Identifiable>::Id::genesis(),
             GENESIS_TRANSACTIONS_TTL_MS,
         )
         .sign(genesis_key_pair)?;
@@ -274,14 +274,17 @@ impl GenesisTransaction {
     }
 
     /// Create a [`GenesisTransaction`] with the specified [`Domain`] and [`NewAccount`].
-    pub fn new(name: &str, domain: &str, pubkey: &PublicKey) -> Self {
+    pub fn new(account_name: &str, domain_name: &str, public_key: &PublicKey) -> Self {
         Self {
             isi: vec![
-                RegisterBox::new(IdentifiableBox::Domain(Domain::new(domain).into())).into(),
+                RegisterBox::new(IdentifiableBox::from(Domain::new(DomainId::new(
+                    domain_name,
+                ))))
+                .into(),
                 RegisterBox::new(IdentifiableBox::NewAccount(
                     NewAccount::with_signatory(
-                        iroha_data_model::account::Id::new(name, domain),
-                        pubkey.clone(),
+                        iroha_data_model::account::Id::new(account_name, domain_name),
+                        public_key.clone(),
                     )
                     .into(),
                 ))

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -6,14 +6,14 @@ use iroha_data_model::prelude::*;
 use crate::config::Configuration;
 
 /// Returns the a map of a form `domain_name -> domain`, for initial domains.
-pub fn domains(configuration: &Configuration) -> Result<BTreeMap<String, Domain>> {
+pub fn domains(configuration: &Configuration) -> Result<BTreeMap<DomainId, Domain>> {
     let key = configuration
         .genesis
         .account_public_key
         .clone()
         .ok_or_else(|| eyre!("Genesis account public key is not specified."))?;
     Ok(std::iter::once((
-        GENESIS_DOMAIN_NAME.to_owned(),
+        DomainId::new(GENESIS_DOMAIN_NAME),
         Domain::from(GenesisDomain::new(key)),
     ))
     .collect())

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -13,7 +13,7 @@ pub fn domains(configuration: &Configuration) -> Result<BTreeMap<DomainId, Domai
         .clone()
         .ok_or_else(|| eyre!("Genesis account public key is not specified."))?;
     Ok(std::iter::once((
-        DomainId::new(GENESIS_DOMAIN_NAME),
+        DomainId::test(GENESIS_DOMAIN_NAME),
         Domain::from(GenesisDomain::new(key)),
     ))
     .collect())

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -289,7 +289,7 @@ mod tests {
             .collect();
         let tx = Transaction::new(
             vec![FailBox { message }.into()],
-            <Account as Identifiable>::Id::new(account, domain),
+            <Account as Identifiable>::Id::test(account, domain),
             proposed_ttl_ms,
         )
         .sign(&key)
@@ -301,11 +301,11 @@ mod tests {
     pub fn world_with_test_domains(public_key: PublicKey) -> World {
         let domains = DomainsMap::new();
         let mut domain = Domain::test("wonderland");
-        let account_id = AccountId::new("alice", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
         let mut account = Account::new(account_id.clone());
         account.signatories.push(public_key);
         domain.accounts.insert(account_id, account);
-        domains.insert(DomainId::new("wonderland"), domain);
+        domains.insert(DomainId::test("wonderland"), domain);
         World::with(domains, PeersIds::new())
     }
 
@@ -364,10 +364,10 @@ mod tests {
         let wsv = WorldStateView::new(world_with_test_domains(
             KeyPair::generate().unwrap().public_key,
         ));
-        let mut domain = wsv.domain_mut(&DomainId::new("wonderland")).unwrap();
+        let mut domain = wsv.domain_mut(&DomainId::test("wonderland")).unwrap();
         domain
             .accounts
-            .get_mut(&<Account as Identifiable>::Id::new("alice", "wonderland"))
+            .get_mut(&<Account as Identifiable>::Id::test("alice", "wonderland"))
             .unwrap()
             .signature_check_condition = SignatureCheckCondition(0_u32.into());
         drop(domain);
@@ -388,7 +388,7 @@ mod tests {
         });
         let tx = Transaction::new(
             Vec::new(),
-            <Account as Identifiable>::Id::new("alice", "wonderland"),
+            <Account as Identifiable>::Id::test("alice", "wonderland"),
             100_000,
         );
         let get_tx = || {

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -300,12 +300,12 @@ mod tests {
 
     pub fn world_with_test_domains(public_key: PublicKey) -> World {
         let domains = DomainsMap::new();
-        let mut domain = Domain::new("wonderland");
+        let mut domain = Domain::test("wonderland");
         let account_id = AccountId::new("alice", "wonderland");
         let mut account = Account::new(account_id.clone());
         account.signatories.push(public_key);
         domain.accounts.insert(account_id, account);
-        domains.insert("wonderland".to_string(), domain);
+        domains.insert(DomainId::new("wonderland"), domain);
         World::with(domains, PeersIds::new())
     }
 
@@ -364,7 +364,7 @@ mod tests {
         let wsv = WorldStateView::new(world_with_test_domains(
             KeyPair::generate().unwrap().public_key,
         ));
-        let mut domain = wsv.domain_mut("wonderland").unwrap();
+        let mut domain = wsv.domain_mut(&DomainId::new("wonderland")).unwrap();
         domain
             .accounts
             .get_mut(&<Account as Identifiable>::Id::new("alice", "wonderland"))

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -244,16 +244,16 @@ pub mod query {
         }
     }
 
-    impl<W: WorldTrait> ValidQuery<W> for FindAccountsByDomainName {
+    impl<W: WorldTrait> ValidQuery<W> for FindAccountsByDomainId {
         #[log]
-        #[metrics(+"find_accounts_by_domain_name")]
+        #[metrics(+"find_accounts_by_domain_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
-            let name = self
-                .domain_name
+            let id = self
+                .domain_id
                 .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain name")?;
+                .wrap_err("Failed to get domain id")?;
             Ok(wsv
-                .domain(&name)?
+                .domain(&id)?
                 .accounts
                 .values()
                 .cloned()

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -75,7 +75,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for SetKeyValue<Account, String, Value> {
+    impl<W: WorldTrait> Execute<W> for SetKeyValue<Account, Name, Value> {
         type Error = Error;
 
         #[metrics(+"set_key_value_account_string_value")]
@@ -98,7 +98,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Account, String> {
+    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Account, Name> {
         type Error = Error;
 
         #[metrics(+"remove_account_key_value")]

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -402,16 +402,16 @@ pub mod query {
         }
     }
 
-    impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainName {
+    impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainId {
         #[log]
-        #[metrics(+"find_assets_by_domain_name")]
+        #[metrics(+"find_assets_by_domain_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
-            let name = self
-                .domain_name
+            let id = self
+                .domain_id
                 .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain name")?;
+                .wrap_err("Failed to get domain id")?;
             let mut vec = Vec::new();
-            for account in wsv.domain(&name)?.accounts.values() {
+            for account in wsv.domain(&id)?.accounts.values() {
                 for asset in account.assets.values() {
                     vec.push(asset.clone())
                 }
@@ -420,19 +420,19 @@ pub mod query {
         }
     }
 
-    impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainNameAndAssetDefinitionId {
+    impl<W: WorldTrait> ValidQuery<W> for FindAssetsByDomainIdAndAssetDefinitionId {
         #[log]
-        #[metrics(+"find_assets_by_domain_name_and_asset_definition_id")]
+        #[metrics(+"find_assets_by_domain_id_and_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
-            let name = self
-                .domain_name
+            let domain_id = self
+                .domain_id
                 .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain name")?;
+                .wrap_err("Failed to get domain id")?;
             let asset_definition_id = self
                 .asset_definition_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset definition id")?;
-            let domain = wsv.domain(&name)?;
+            let domain = wsv.domain(&domain_id)?;
             let _definition = domain
                 .asset_definitions
                 .get(&asset_definition_id)
@@ -440,7 +440,7 @@ pub mod query {
             let mut assets = Vec::new();
             for account in domain.accounts.values() {
                 for asset in account.assets.values() {
-                    if asset.id.account_id.domain_name == name
+                    if asset.id.account_id.domain_id == domain_id
                         && asset.id.definition_id == asset_definition_id
                     {
                         assets.push(asset.clone())

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -128,7 +128,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for SetKeyValue<Asset, String, Value> {
+    impl<W: WorldTrait> Execute<W> for SetKeyValue<Asset, Name, Value> {
         type Error = Error;
 
         #[metrics(+"asset_set_key_value")]
@@ -231,7 +231,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Asset, String> {
+    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Asset, Name> {
         type Error = Error;
 
         #[metrics(+"asset_remove_key_value")]

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -26,7 +26,10 @@ pub mod isi {
             wsv: &WorldStateView<W>,
         ) -> Result<(), Error> {
             let account = self.object;
-            account.validate_len(wsv.config.ident_length_limits)?;
+            account
+                .id
+                .name
+                .validate_len(wsv.config.ident_length_limits)?;
             let domain_id = account.id.domain_id.clone();
             match wsv
                 .domain_mut(&domain_id)?
@@ -75,7 +78,10 @@ pub mod isi {
             wsv: &WorldStateView<W>,
         ) -> Result<(), Error> {
             let asset_definition = self.object;
-            asset_definition.validate_len(wsv.config.ident_length_limits)?;
+            asset_definition
+                .id
+                .name
+                .validate_len(wsv.config.ident_length_limits)?;
             let domain_id = asset_definition.id.domain_id.clone();
             let mut domain = wsv.domain_mut(&domain_id)?;
             match domain.asset_definitions.entry(asset_definition.id.clone()) {

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -123,7 +123,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for SetKeyValue<AssetDefinition, String, Value> {
+    impl<W: WorldTrait> Execute<W> for SetKeyValue<AssetDefinition, Name, Value> {
         type Error = Error;
 
         #[metrics(+"set_key_value_asset_def")]
@@ -144,7 +144,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<AssetDefinition, String> {
+    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<AssetDefinition, Name> {
         type Error = Error;
 
         #[metrics(+"remove_key_value_asset_def")]
@@ -165,7 +165,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for SetKeyValue<Domain, String, Value> {
+    impl<W: WorldTrait> Execute<W> for SetKeyValue<Domain, Name, Value> {
         type Error = Error;
 
         #[metrics(+"set_key_value_domain")]
@@ -188,7 +188,7 @@ pub mod isi {
         }
     }
 
-    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Domain, String> {
+    impl<W: WorldTrait> Execute<W> for RemoveKeyValue<Domain, Name> {
         type Error = Error;
 
         #[metrics(+"remove_key_value_domain")]

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -496,7 +496,7 @@ mod tests {
         let asset_id = AssetId::new(asset_definition_id, account_id.clone());
         SetKeyValueBox::new(
             IdBox::from(asset_id.clone()),
-            "Bytes".to_owned(),
+            Name::test("Bytes"),
             vec![1_u32, 2_u32, 3_u32],
         )
         .execute(account_id, &wsv)?;
@@ -520,7 +520,7 @@ mod tests {
         let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(account_id.clone()),
-            "Bytes".to_owned(),
+            Name::test("Bytes"),
             vec![1_u32, 2_u32, 3_u32],
         )
         .execute(account_id.clone(), &wsv)?;
@@ -545,7 +545,7 @@ mod tests {
         let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(definition_id.clone()),
-            "Bytes".to_owned(),
+            Name::test("Bytes"),
             vec![1_u32, 2_u32, 3_u32],
         )
         .execute(account_id, &wsv)?;
@@ -573,7 +573,7 @@ mod tests {
         let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(domain_id.clone()),
-            "Bytes".to_owned(),
+            Name::test("Bytes"),
             vec![1_u32, 2_u32, 3_u32],
         )
         .execute(account_id, &wsv)?;

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -321,19 +321,19 @@ impl<W: WorldTrait> Execute<W> for SetKeyValueBox {
         let value = self.value.evaluate(wsv, &context)?;
         match self.object_id.evaluate(wsv, &context)? {
             IdBox::AssetId(asset_id) => {
-                SetKeyValue::<Asset, String, Value>::new(asset_id, key, value)
+                SetKeyValue::<Asset, Name, Value>::new(asset_id, key, value)
                     .execute(authority, wsv)
             }
             IdBox::AssetDefinitionId(definition_id) => {
-                SetKeyValue::<AssetDefinition, String, Value>::new(definition_id, key, value)
+                SetKeyValue::<AssetDefinition, Name, Value>::new(definition_id, key, value)
                     .execute(authority, wsv)
             }
             IdBox::AccountId(account_id) => {
-                SetKeyValue::<Account, String, Value>::new(account_id, key, value)
+                SetKeyValue::<Account, Name, Value>::new(account_id, key, value)
                     .execute(authority, wsv)
             }
             IdBox::DomainName(name) => {
-                SetKeyValue::<Domain, String, Value>::new(name, key, value).execute(authority, wsv)
+                SetKeyValue::<Domain, Name, Value>::new(name, key, value).execute(authority, wsv)
             }
             _ => Err(eyre!("Unsupported set key-value instruction.").into()),
         }
@@ -353,14 +353,14 @@ impl<W: WorldTrait> Execute<W> for RemoveKeyValueBox {
         let key = self.key.evaluate(wsv, &context)?;
         match self.object_id.evaluate(wsv, &context)? {
             IdBox::AssetId(asset_id) => {
-                RemoveKeyValue::<Asset, String>::new(asset_id, key).execute(authority, wsv)
+                RemoveKeyValue::<Asset, Name>::new(asset_id, key).execute(authority, wsv)
             }
             IdBox::AssetDefinitionId(definition_id) => {
-                RemoveKeyValue::<AssetDefinition, String>::new(definition_id, key)
+                RemoveKeyValue::<AssetDefinition, Name>::new(definition_id, key)
                     .execute(authority, wsv)
             }
             IdBox::AccountId(account_id) => {
-                RemoveKeyValue::<Account, String>::new(account_id, key).execute(authority, wsv)
+                RemoveKeyValue::<Account, Name>::new(account_id, key).execute(authority, wsv)
             }
             _ => Err(eyre!("Unsupported remove key-value instruction.").into()),
         }

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -474,25 +474,25 @@ mod tests {
     fn world_with_test_domains() -> Result<World> {
         let domains = DomainsMap::new();
         let mut domain = Domain::test("wonderland");
-        let account_id = AccountId::new("alice", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
         let mut account = Account::new(account_id.clone());
         let key_pair = KeyPair::generate()?;
         account.signatories.push(key_pair.public_key);
         domain.accounts.insert(account_id.clone(), account);
-        let asset_definition_id = AssetDefinitionId::new("rose", "wonderland");
+        let asset_definition_id = AssetDefinitionId::test("rose", "wonderland");
         domain.asset_definitions.insert(
             asset_definition_id.clone(),
             AssetDefinitionEntry::new(AssetDefinition::new_store(asset_definition_id), account_id),
         );
-        domains.insert(DomainId::new("wonderland"), domain);
+        domains.insert(DomainId::test("wonderland"), domain);
         Ok(World::with(domains, PeersIds::new()))
     }
 
     #[test]
     fn asset_store() -> Result<()> {
         let wsv = WorldStateView::<World>::new(world_with_test_domains()?);
-        let account_id = AccountId::new("alice", "wonderland");
-        let asset_definition_id = AssetDefinitionId::new("rose", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
+        let asset_definition_id = AssetDefinitionId::test("rose", "wonderland");
         let asset_id = AssetId::new(asset_definition_id, account_id.clone());
         SetKeyValueBox::new(
             IdBox::from(asset_id.clone()),
@@ -502,7 +502,7 @@ mod tests {
         .execute(account_id, &wsv)?;
         let asset = wsv.asset(&asset_id)?;
         let metadata: &Metadata = asset.try_as_ref()?;
-        let bytes = metadata.get(&Name::new("Bytes")).cloned();
+        let bytes = metadata.get(&Name::test("Bytes")).cloned();
         assert_eq!(
             bytes,
             Some(Value::Vec(vec![
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn account_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains()?);
-        let account_id = AccountId::new("alice", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(account_id.clone()),
             "Bytes".to_owned(),
@@ -525,7 +525,7 @@ mod tests {
         )
         .execute(account_id.clone(), &wsv)?;
         let bytes = wsv.map_account(&account_id, |account| {
-            account.metadata.get(&Name::new("Bytes")).cloned()
+            account.metadata.get(&Name::test("Bytes")).cloned()
         })?;
         assert_eq!(
             bytes,
@@ -541,8 +541,8 @@ mod tests {
     #[test]
     fn asset_definition_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains()?);
-        let definition_id = AssetDefinitionId::new("rose", "wonderland");
-        let account_id = AccountId::new("alice", "wonderland");
+        let definition_id = AssetDefinitionId::test("rose", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(definition_id.clone()),
             "Bytes".to_owned(),
@@ -553,7 +553,7 @@ mod tests {
             .asset_definition_entry(&definition_id)?
             .definition
             .metadata
-            .get(&Name::new("Bytes"))
+            .get(&Name::test("Bytes"))
             .cloned();
         assert_eq!(
             bytes,
@@ -569,8 +569,8 @@ mod tests {
     #[test]
     fn domain_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains()?);
-        let domain_id = DomainId::new("wonderland");
-        let account_id = AccountId::new("alice", "wonderland");
+        let domain_id = DomainId::test("wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
         SetKeyValueBox::new(
             IdBox::from(domain_id.clone()),
             "Bytes".to_owned(),
@@ -580,7 +580,7 @@ mod tests {
         let bytes = wsv
             .domain(&domain_id)?
             .metadata
-            .get(&Name::new("Bytes"))
+            .get(&Name::test("Bytes"))
             .cloned();
         assert_eq!(
             bytes,

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -502,7 +502,7 @@ mod tests {
         .execute(account_id, &wsv)?;
         let asset = wsv.asset(&asset_id)?;
         let metadata: &Metadata = asset.try_as_ref()?;
-        let bytes = metadata.get("Bytes").cloned();
+        let bytes = metadata.get(&Name::new("Bytes")).cloned();
         assert_eq!(
             bytes,
             Some(Value::Vec(vec![
@@ -525,7 +525,7 @@ mod tests {
         )
         .execute(account_id.clone(), &wsv)?;
         let bytes = wsv.map_account(&account_id, |account| {
-            account.metadata.get("Bytes").cloned()
+            account.metadata.get(&Name::new("Bytes")).cloned()
         })?;
         assert_eq!(
             bytes,
@@ -553,7 +553,7 @@ mod tests {
             .asset_definition_entry(&definition_id)?
             .definition
             .metadata
-            .get("Bytes")
+            .get(&Name::new("Bytes"))
             .cloned();
         assert_eq!(
             bytes,
@@ -577,7 +577,11 @@ mod tests {
             vec![1_u32, 2_u32, 3_u32],
         )
         .execute(account_id, &wsv)?;
-        let bytes = wsv.domain(&domain_id)?.metadata.get("Bytes").cloned();
+        let bytes = wsv
+            .domain(&domain_id)?
+            .metadata
+            .get(&Name::new("Bytes"))
+            .cloned();
         assert_eq!(
             bytes,
             Some(Value::Vec(vec![

--- a/core/src/smartcontracts/isi/permissions.rs
+++ b/core/src/smartcontracts/isi/permissions.rs
@@ -779,13 +779,13 @@ mod tests {
         let bob_id = <Account as Identifiable>::Id::new("bob", "test");
         let alice_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
         let instruction_burn: Instruction = BurnBox::new(Value::U32(10), alice_xor_id).into();
-        let mut domain = Domain::new("test");
+        let mut domain = Domain::test("test");
         let mut bob_account = Account::new(bob_id.clone());
         let _ = bob_account
             .permission_tokens
             .insert(PermissionToken::new("token", BTreeMap::default()));
         domain.accounts.insert(bob_id.clone(), bob_account);
-        let domains = vec![("test".to_string(), domain)];
+        let domains = vec![(DomainId::new("test"), domain)];
         let wsv = WorldStateView::new(World::with(domains, BTreeSet::new()));
         let validator: HasTokenBoxed<_> = Box::new(GrantedToken);
         assert!(validator.check(&alice_id, &instruction_burn, &wsv).is_err());

--- a/core/src/smartcontracts/isi/permissions.rs
+++ b/core/src/smartcontracts/isi/permissions.rs
@@ -693,7 +693,7 @@ mod tests {
             _instruction: &Instruction,
             _wsv: &WorldStateView<W>,
         ) -> Result<(), super::DenialReason> {
-            if authority.name.inner() == "alice" {
+            if authority.name.as_ref() == "alice" {
                 Err("Alice account is denied.".to_owned())
             } else {
                 Ok(())

--- a/core/src/smartcontracts/isi/permissions.rs
+++ b/core/src/smartcontracts/isi/permissions.rs
@@ -693,7 +693,7 @@ mod tests {
             _instruction: &Instruction,
             _wsv: &WorldStateView<W>,
         ) -> Result<(), super::DenialReason> {
-            if authority.name == "alice" {
+            if authority.name.inner() == "alice" {
                 Err("Alice account is denied.".to_owned())
             } else {
                 Ok(())
@@ -710,7 +710,7 @@ mod tests {
             _instruction: &Instruction,
             _wsv: &WorldStateView<W>,
         ) -> Result<PermissionToken, String> {
-            Ok(PermissionToken::new("token", BTreeMap::new()))
+            Ok(PermissionToken::new(Name::new("token"), BTreeMap::new()))
         }
     }
 
@@ -781,9 +781,10 @@ mod tests {
         let instruction_burn: Instruction = BurnBox::new(Value::U32(10), alice_xor_id).into();
         let mut domain = Domain::test("test");
         let mut bob_account = Account::new(bob_id.clone());
-        let _ = bob_account
-            .permission_tokens
-            .insert(PermissionToken::new("token", BTreeMap::default()));
+        let _ = bob_account.permission_tokens.insert(PermissionToken::new(
+            Name::new("token"),
+            BTreeMap::default(),
+        ));
         domain.accounts.insert(bob_id.clone(), bob_account);
         let domains = vec![(DomainId::new("test"), domain)];
         let wsv = WorldStateView::new(World::with(domains, BTreeSet::new()));

--- a/core/src/smartcontracts/isi/permissions.rs
+++ b/core/src/smartcontracts/isi/permissions.rs
@@ -710,7 +710,7 @@ mod tests {
             _instruction: &Instruction,
             _wsv: &WorldStateView<W>,
         ) -> Result<PermissionToken, String> {
-            Ok(PermissionToken::new(Name::new("token"), BTreeMap::new()))
+            Ok(PermissionToken::new(Name::test("token"), BTreeMap::new()))
         }
     }
 
@@ -722,14 +722,14 @@ mod tests {
             .all_should_succeed();
         let instruction_burn: Instruction = BurnBox::new(
             Value::U32(10),
-            IdBox::AssetId(AssetId::from_names("xor", "test", "alice", "test")),
+            IdBox::AssetId(AssetId::test("xor", "test", "alice", "test")),
         )
         .into();
         let instruction_fail = Instruction::Fail(FailBox {
             message: "fail message".to_owned(),
         });
-        let account_bob = <Account as Identifiable>::Id::new("bob", "test");
-        let account_alice = <Account as Identifiable>::Id::new("alice", "test");
+        let account_bob = <Account as Identifiable>::Id::test("bob", "test");
+        let account_alice = <Account as Identifiable>::Id::test("alice", "test");
         let wsv = WorldStateView::new(World::new());
         assert!(permissions_validator
             .check(&account_bob, &instruction_burn, &wsv)
@@ -752,7 +752,7 @@ mod tests {
             .all_should_succeed();
         let instruction_burn: Instruction = BurnBox::new(
             Value::U32(10),
-            IdBox::AssetId(AssetId::from_names("xor", "test", "alice", "test")),
+            IdBox::AssetId(AssetId::test("xor", "test", "alice", "test")),
         )
         .into();
         let instruction_fail = Instruction::Fail(FailBox {
@@ -760,7 +760,7 @@ mod tests {
         });
         let nested_instruction_sequence =
             Instruction::If(If::new(true, instruction_burn.clone()).into());
-        let account_alice = <Account as Identifiable>::Id::new("alice", "test");
+        let account_alice = <Account as Identifiable>::Id::test("alice", "test");
         let wsv = WorldStateView::new(World::new());
         assert!(permissions_validator
             .check(&account_alice, &instruction_fail, &wsv)
@@ -775,18 +775,18 @@ mod tests {
 
     #[test]
     pub fn granted_permission() {
-        let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-        let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-        let alice_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+        let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+        let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+        let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
         let instruction_burn: Instruction = BurnBox::new(Value::U32(10), alice_xor_id).into();
         let mut domain = Domain::test("test");
         let mut bob_account = Account::new(bob_id.clone());
         let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-            Name::new("token"),
+            Name::test("token"),
             BTreeMap::default(),
         ));
         domain.accounts.insert(bob_id.clone(), bob_account);
-        let domains = vec![(DomainId::new("test"), domain)];
+        let domains = vec![(DomainId::test("test"), domain)];
         let wsv = WorldStateView::new(World::with(domains, BTreeSet::new()));
         let validator: HasTokenBoxed<_> = Box::new(GrantedToken);
         assert!(validator.check(&alice_id, &instruction_burn, &wsv).is_err());
@@ -797,10 +797,10 @@ mod tests {
     pub fn check_query_permissions_nested() {
         let instruction: Instruction = Pair::new(
             TransferBox::new(
-                IdBox::AssetId(AssetId::from_names("btc", "crypto", "seller", "company")),
+                IdBox::AssetId(AssetId::test("btc", "crypto", "seller", "company")),
                 Expression::Add(Add::new(
                     Expression::Query(
-                        FindAssetQuantityById::new(AssetId::from_names(
+                        FindAssetQuantityById::new(AssetId::test(
                             "btc2eth_rate",
                             "exchange",
                             "dex",
@@ -810,17 +810,17 @@ mod tests {
                     ),
                     10_u32,
                 )),
-                IdBox::AssetId(AssetId::from_names("btc", "crypto", "buyer", "company")),
+                IdBox::AssetId(AssetId::test("btc", "crypto", "buyer", "company")),
             ),
             TransferBox::new(
-                IdBox::AssetId(AssetId::from_names("eth", "crypto", "buyer", "company")),
+                IdBox::AssetId(AssetId::test("eth", "crypto", "buyer", "company")),
                 15_u32,
-                IdBox::AssetId(AssetId::from_names("eth", "crypto", "seller", "company")),
+                IdBox::AssetId(AssetId::test("eth", "crypto", "seller", "company")),
             ),
         )
         .into();
         let wsv = WorldStateView::new(World::new());
-        let alice_id = <Account as Identifiable>::Id::new("alice", "test");
+        let alice_id = <Account as Identifiable>::Id::test("alice", "test");
         assert!(check_query_in_instruction(&alice_id, &instruction, &wsv, &DenyAll.into()).is_err())
     }
 }

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -176,18 +176,18 @@ impl<W: WorldTrait> ValidQuery<W> for QueryBox {
             FindAllAccounts(query) => query.execute_into_value(wsv),
             FindAccountById(query) => query.execute_into_value(wsv),
             FindAccountsByName(query) => query.execute_into_value(wsv),
-            FindAccountsByDomainName(query) => query.execute_into_value(wsv),
+            FindAccountsByDomainId(query) => query.execute_into_value(wsv),
             FindAllAssets(query) => query.execute_into_value(wsv),
             FindAllAssetsDefinitions(query) => query.execute_into_value(wsv),
             FindAssetById(query) => query.execute_into_value(wsv),
             FindAssetsByName(query) => query.execute_into_value(wsv),
             FindAssetsByAccountId(query) => query.execute_into_value(wsv),
             FindAssetsByAssetDefinitionId(query) => query.execute_into_value(wsv),
-            FindAssetsByDomainName(query) => query.execute_into_value(wsv),
-            FindAssetsByDomainNameAndAssetDefinitionId(query) => query.execute_into_value(wsv),
+            FindAssetsByDomainId(query) => query.execute_into_value(wsv),
+            FindAssetsByDomainIdAndAssetDefinitionId(query) => query.execute_into_value(wsv),
             FindAssetQuantityById(query) => query.execute_into_value(wsv),
             FindAllDomains(query) => query.execute_into_value(wsv),
-            FindDomainByName(query) => query.execute_into_value(wsv),
+            FindDomainById(query) => query.execute_into_value(wsv),
             FindDomainKeyValueByIdAndKey(query) => query.execute_into_value(wsv),
             FindAllPeers(query) => query.execute_into_value(wsv),
             FindAssetKeyValueByIdAndKey(query) => query.execute_into_value(wsv),
@@ -221,7 +221,7 @@ mod tests {
 
     fn world_with_test_domains() -> World {
         let domains = DomainsMap::new();
-        let mut domain = Domain::new("wonderland");
+        let mut domain = Domain::test("wonderland");
         let mut account = Account::new(ALICE_ID.clone());
         account.signatories.push(ALICE_KEYS.public_key.clone());
         domain.accounts.insert(ALICE_ID.clone(), account);
@@ -233,7 +233,7 @@ mod tests {
                 ALICE_ID.clone(),
             ),
         );
-        domains.insert("wonderland".to_string(), domain);
+        domains.insert(DomainId::new("wonderland"), domain);
         World::with(domains, PeersIds::new())
     }
 
@@ -315,9 +315,9 @@ mod tests {
     #[test]
     fn domain_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains());
-        let domain_name = "wonderland".to_owned();
+        let domain_id = DomainId::new("wonderland");
         let key = "Bytes".to_owned();
-        wsv.modify_domain(&domain_name, |domain| {
+        wsv.modify_domain(&domain_id, |domain| {
             domain.metadata.insert_with_limits(
                 key.clone(),
                 Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
@@ -325,7 +325,7 @@ mod tests {
             )?;
             Ok(())
         })?;
-        let bytes = FindDomainKeyValueByIdAndKey::new(domain_name, key).execute(&wsv)?;
+        let bytes = FindDomainKeyValueByIdAndKey::new(domain_id, key).execute(&wsv)?;
         assert_eq!(
             bytes,
             Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)])

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::wsv::World;
 
     static ALICE_KEYS: Lazy<KeyPair> = Lazy::new(|| KeyPair::generate().unwrap());
-    static ALICE_ID: Lazy<AccountId> = Lazy::new(|| AccountId::new("alice", "wonderland"));
+    static ALICE_ID: Lazy<AccountId> = Lazy::new(|| AccountId::test("alice", "wonderland"));
 
     fn world_with_test_domains() -> World {
         let domains = DomainsMap::new();
@@ -225,7 +225,7 @@ mod tests {
         let mut account = Account::new(ALICE_ID.clone());
         account.signatories.push(ALICE_KEYS.public_key.clone());
         domain.accounts.insert(ALICE_ID.clone(), account);
-        let asset_definition_id = AssetDefinitionId::new("rose", "wonderland");
+        let asset_definition_id = AssetDefinitionId::test("rose", "wonderland");
         domain.asset_definitions.insert(
             asset_definition_id.clone(),
             AssetDefinitionEntry::new(
@@ -233,26 +233,27 @@ mod tests {
                 ALICE_ID.clone(),
             ),
         );
-        domains.insert(DomainId::new("wonderland"), domain);
+        domains.insert(DomainId::test("wonderland"), domain);
         World::with(domains, PeersIds::new())
     }
 
     #[test]
     fn asset_store() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains());
-        let account_id = AccountId::new("alice", "wonderland");
-        let asset_definition_id = AssetDefinitionId::new("rose", "wonderland");
+        let account_id = AccountId::test("alice", "wonderland");
+        let asset_definition_id = AssetDefinitionId::test("rose", "wonderland");
         let asset_id = AssetId::new(asset_definition_id, account_id);
         let mut store = Metadata::new();
         store
             .insert_with_limits(
-                Name::new("Bytes"),
+                Name::test("Bytes"),
                 Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
                 MetadataLimits::new(10, 100),
             )
             .unwrap();
         wsv.add_asset(Asset::new(asset_id.clone(), AssetValue::Store(store)))?;
-        let bytes = FindAssetKeyValueByIdAndKey::new(asset_id, Name::new("Bytes")).execute(&wsv)?;
+        let bytes =
+            FindAssetKeyValueByIdAndKey::new(asset_id, Name::test("Bytes")).execute(&wsv)?;
         assert_eq!(
             bytes,
             Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)])
@@ -265,7 +266,7 @@ mod tests {
         let wsv = WorldStateView::new(world_with_test_domains());
         wsv.modify_account(&ALICE_ID, |account| {
             account.metadata.insert_with_limits(
-                Name::new("Bytes"),
+                Name::test("Bytes"),
                 Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
                 MetadataLimits::new(10, 100),
             )?;
@@ -315,8 +316,8 @@ mod tests {
     #[test]
     fn domain_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains());
-        let domain_id = DomainId::new("wonderland");
-        let key = Name::new("Bytes");
+        let domain_id = DomainId::test("wonderland");
+        let key = Name::test("Bytes");
         wsv.modify_domain(&domain_id, |domain| {
             domain.metadata.insert_with_limits(
                 key.clone(),

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -272,7 +272,7 @@ mod tests {
             )?;
             Ok(())
         })?;
-        let bytes = FindAccountKeyValueByIdAndKey::new(ALICE_ID.clone(), "Bytes".to_owned())
+        let bytes = FindAccountKeyValueByIdAndKey::new(ALICE_ID.clone(), Name::test("Bytes"))
             .execute(&wsv)?;
         assert_eq!(
             bytes,

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -246,13 +246,13 @@ mod tests {
         let mut store = Metadata::new();
         store
             .insert_with_limits(
-                "Bytes".to_owned(),
+                Name::new("Bytes"),
                 Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
                 MetadataLimits::new(10, 100),
             )
             .unwrap();
         wsv.add_asset(Asset::new(asset_id.clone(), AssetValue::Store(store)))?;
-        let bytes = FindAssetKeyValueByIdAndKey::new(asset_id, "Bytes".to_owned()).execute(&wsv)?;
+        let bytes = FindAssetKeyValueByIdAndKey::new(asset_id, Name::new("Bytes")).execute(&wsv)?;
         assert_eq!(
             bytes,
             Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)])
@@ -265,7 +265,7 @@ mod tests {
         let wsv = WorldStateView::new(world_with_test_domains());
         wsv.modify_account(&ALICE_ID, |account| {
             account.metadata.insert_with_limits(
-                "Bytes".to_string(),
+                Name::new("Bytes"),
                 Value::Vec(vec![Value::U32(1), Value::U32(2), Value::U32(3)]),
                 MetadataLimits::new(10, 100),
             )?;
@@ -316,7 +316,7 @@ mod tests {
     fn domain_metadata() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains());
         let domain_id = DomainId::new("wonderland");
-        let key = "Bytes".to_owned();
+        let key = Name::new("Bytes");
         wsv.modify_domain(&domain_id, |domain| {
             domain.metadata.insert_with_limits(
                 key.clone(),

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -56,7 +56,7 @@ pub mod isi {
         ) -> Result<(), Error> {
             let domain = self.object;
             domain.validate_len(wsv.config.ident_length_limits)?;
-            wsv.domains().insert(domain.name.clone(), domain);
+            wsv.domains().insert(domain.id.clone(), domain);
             wsv.metrics.domains.inc();
             Ok(())
         }

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -55,7 +55,10 @@ pub mod isi {
             wsv: &WorldStateView<W>,
         ) -> Result<(), Error> {
             let domain = self.object;
-            domain.validate_len(wsv.config.ident_length_limits)?;
+            domain
+                .id
+                .name
+                .validate_len(wsv.config.ident_length_limits)?;
             wsv.domains().insert(domain.id.clone(), domain);
             wsv.metrics.domains.inc();
             Ok(())

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -568,7 +568,7 @@ async fn update_metrics<W: WorldTrait>(
     for domain in domains {
         wsv.metrics
             .accounts
-            .get_metric_with_label_values(&[domain.id.name.inner()])
+            .get_metric_with_label_values(&[domain.id.name.as_ref()])
             .wrap_err("Failed to compose domains")
             .map_err(Error::Prometheus)?
             .set(domain.accounts.values().len() as u64);

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -568,7 +568,7 @@ async fn update_metrics<W: WorldTrait>(
     for domain in domains {
         wsv.metrics
             .accounts
-            .get_metric_with_label_values(&[&domain.id.name])
+            .get_metric_with_label_values(&[domain.id.name.inner()])
             .wrap_err("Failed to compose domains")
             .map_err(Error::Prometheus)?
             .set(domain.accounts.values().len() as u64);

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -565,13 +565,13 @@ async fn update_metrics<W: WorldTrait>(
     let domains = wsv.domains();
     wsv.metrics.domains.set(domains.len() as u64);
     wsv.metrics.connected_peers.set(peers);
-    for d in domains {
+    for domain in domains {
         wsv.metrics
             .accounts
-            .get_metric_with_label_values(&[&d.name])
+            .get_metric_with_label_values(&[&domain.id.name])
             .wrap_err("Failed to compose domains")
             .map_err(Error::Prometheus)?
-            .set(d.accounts.values().len() as u64);
+            .set(domain.accounts.values().len() as u64);
     }
     Ok(())
 }

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -27,12 +27,12 @@ async fn create_torii() -> (Torii<World>, KeyPair) {
     let wsv = Arc::new(WorldStateView::new(World::with(
         ('a'..'z')
             .map(|name| name.to_string())
-            .map(|name| (name.clone(), Domain::new(&name))),
+            .map(|name| (DomainId::new(&name), Domain::test(&name))),
         vec![],
     )));
     let keys = KeyPair::generate().expect("Failed to generate keys");
     wsv.world.domains.insert(
-        "wonderland".to_owned(),
+        DomainId::new("wonderland"),
         Domain::with_accounts(
             "wonderland",
             std::iter::once(Account::with_signatory(
@@ -242,7 +242,7 @@ impl AssertReady {
 const DOMAIN: &str = "desert";
 
 fn register_domain() -> Instruction {
-    Instruction::Register(RegisterBox::new(Domain::new(DOMAIN)))
+    Instruction::Register(RegisterBox::new(Domain::test(DOMAIN)))
 }
 fn register_account(name: &str) -> Instruction {
     Instruction::Register(RegisterBox::new(NewAccount::with_signatory(
@@ -389,8 +389,8 @@ async fn find_account_with_no_domain() {
 async fn find_domain() {
     AssertSet::new()
         .given(register_domain())
-        .query(QueryBox::FindDomainByName(FindDomainByName::new(
-            DOMAIN.to_string(),
+        .query(QueryBox::FindDomainById(FindDomainById::new(
+            DomainId::new(DOMAIN),
         )))
         .status(StatusCode::OK)
         .assert()
@@ -400,7 +400,7 @@ async fn find_domain() {
 async fn find_domain_with_no_domain() {
     AssertSet::new()
     // .given(register_domain())
-        .query(QueryBox::FindDomainByName(FindDomainByName::new(
+        .query(QueryBox::FindDomainById(FindDomainById::new(
             DOMAIN.to_string(),
         )))
         .status(StatusCode::NOT_FOUND)

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -27,16 +27,16 @@ async fn create_torii() -> (Torii<World>, KeyPair) {
     let wsv = Arc::new(WorldStateView::new(World::with(
         ('a'..'z')
             .map(|name| name.to_string())
-            .map(|name| (DomainId::new(&name), Domain::test(&name))),
+            .map(|name| (DomainId::test(&name), Domain::test(&name))),
         vec![],
     )));
     let keys = KeyPair::generate().expect("Failed to generate keys");
     wsv.world.domains.insert(
-        DomainId::new("wonderland"),
+        DomainId::test("wonderland"),
         Domain::with_accounts(
             "wonderland",
             std::iter::once(Account::with_signatory(
-                AccountId::new("alice", "wonderland"),
+                AccountId::test("alice", "wonderland"),
                 keys.public_key.clone(),
             )),
         ),
@@ -82,7 +82,7 @@ async fn torii_pagination() {
     let get_domains = |start, limit| {
         let query: VerifiedQueryRequest = QueryRequest::new(
             QueryBox::FindAllDomains(Default::default()),
-            AccountId::new("alice", "wonderland"),
+            AccountId::test("alice", "wonderland"),
         )
         .sign(keys.clone())
         .expect("Failed to sign query with keys")
@@ -187,7 +187,7 @@ impl AssertReady {
             torii.query_validator = Arc::new(DenyAll.into());
         }
 
-        let authority = AccountId::new("alice", "wonderland");
+        let authority = AccountId::test("alice", "wonderland");
         for instruction in self.instructions {
             instruction
                 .execute(authority.clone(), &torii.wsv)
@@ -246,19 +246,19 @@ fn register_domain() -> Instruction {
 }
 fn register_account(name: &str) -> Instruction {
     Instruction::Register(RegisterBox::new(NewAccount::with_signatory(
-        AccountId::new(name, DOMAIN),
+        AccountId::test(name, DOMAIN),
         KeyPair::generate().unwrap().public_key,
     )))
 }
 fn register_asset_definition(name: &str) -> Instruction {
     Instruction::Register(RegisterBox::new(AssetDefinition::new_quantity(
-        AssetDefinitionId::new(name, DOMAIN),
+        AssetDefinitionId::test(name, DOMAIN),
     )))
 }
 fn mint_asset(quantity: u32, asset: &str, account: &str) -> Instruction {
     Instruction::Mint(MintBox::new(
         Value::U32(quantity),
-        AssetId::from_names(asset, DOMAIN, account, DOMAIN),
+        AssetId::test(asset, DOMAIN, account, DOMAIN),
     ))
 }
 #[tokio::test]
@@ -268,9 +268,9 @@ async fn find_asset() {
         .given(register_account("alice"))
         .given(register_asset_definition("rose"))
         .given(mint_asset(99, "rose", "alice"))
-        .query(QueryBox::FindAssetById(FindAssetById::new(
-            AssetId::from_names("rose", DOMAIN, "alice", DOMAIN),
-        )))
+        .query(QueryBox::FindAssetById(FindAssetById::new(AssetId::test(
+            "rose", DOMAIN, "alice", DOMAIN,
+        ))))
         .status(StatusCode::OK)
         .hint("Quantity")
         .hint("99")
@@ -285,7 +285,7 @@ async fn find_asset_with_no_mint() {
         .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            AssetId::from_names("rose", DOMAIN, "alice", DOMAIN),
+            AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .assert()
@@ -299,7 +299,7 @@ async fn find_asset_with_no_asset_definition() {
     // .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            AssetId::from_names("rose", DOMAIN, "alice", DOMAIN),
+            AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .hint("definition")
@@ -314,7 +314,7 @@ async fn find_asset_with_no_account() {
         .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            AssetId::from_names("rose", DOMAIN, "alice", DOMAIN),
+            AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .hint("account")
@@ -329,7 +329,7 @@ async fn find_asset_with_no_domain() {
     // .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            AssetId::from_names("rose", DOMAIN, "alice", DOMAIN),
+            AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .hint("domain")
@@ -354,7 +354,7 @@ async fn find_account() {
         .given(register_domain())
         .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
-            AccountId::new("alice", DOMAIN),
+            AccountId::test("alice", DOMAIN),
         )))
         .status(StatusCode::OK)
         .assert()
@@ -366,7 +366,7 @@ async fn find_account_with_no_account() {
         .given(register_domain())
     // .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
-            AccountId::new("alice", DOMAIN),
+            AccountId::test("alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .assert()
@@ -378,7 +378,7 @@ async fn find_account_with_no_domain() {
     // .given(register_domain())
     // .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
-            AccountId::new("alice", DOMAIN),
+            AccountId::test("alice", DOMAIN),
         )))
         .status(StatusCode::NOT_FOUND)
         .hint("domain")
@@ -390,7 +390,7 @@ async fn find_domain() {
     AssertSet::new()
         .given(register_domain())
         .query(QueryBox::FindDomainById(FindDomainById::new(
-            DomainId::new(DOMAIN),
+            DomainId::test(DOMAIN),
         )))
         .status(StatusCode::OK)
         .assert()
@@ -408,14 +408,14 @@ async fn find_domain_with_no_domain() {
         .await
 }
 fn query() -> QueryBox {
-    QueryBox::FindAccountById(FindAccountById::new(AccountId::new("alice", DOMAIN)))
+    QueryBox::FindAccountById(FindAccountById::new(AccountId::test("alice", DOMAIN)))
 }
 #[tokio::test]
 async fn query_with_wrong_signatory() {
     AssertSet::new()
         .given(register_domain())
         .given(register_account("alice"))
-        .account(AccountId::new("alice", DOMAIN))
+        .account(AccountId::test("alice", DOMAIN))
     // .deny_all()
         .query(query())
         .status(StatusCode::UNAUTHORIZED)

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -161,7 +161,7 @@ impl AcceptedTransaction {
     ) -> Result<(), TransactionRejectionReason> {
         let wsv_temp = wsv.clone();
         let account_id = self.payload.account_id.clone();
-        if !is_genesis && account_id == <Account as Identifiable>::Id::genesis_account() {
+        if !is_genesis && account_id == <Account as Identifiable>::Id::genesis() {
             return Err(TransactionRejectionReason::UnexpectedGenesisAccountSignature);
         }
 

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -388,7 +388,7 @@ mod tests {
 
         let tx = Transaction::new(
             vec![],
-            AccountId::new(GENESIS_ACCOUNT_NAME, GENESIS_DOMAIN_NAME),
+            AccountId::test(GENESIS_ACCOUNT_NAME, GENESIS_DOMAIN_NAME),
             1000,
         );
         let tx_hash = tx.hash();
@@ -422,7 +422,7 @@ mod tests {
         };
         let tx = Transaction::new(
             vec![inst.into(); DEFAULT_MAX_INSTRUCTION_NUMBER as usize + 1],
-            AccountId::new("root", "global"),
+            AccountId::test("root", "global"),
             1000,
         );
         let result: Result<AcceptedTransaction> = AcceptedTransaction::from_transaction(tx, 4096);

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -128,7 +128,8 @@ pub trait TestGenesis: Sized {
 impl<G: GenesisNetworkTrait> TestGenesis for G {
     fn test(submit_genesis: bool) -> Option<Self> {
         let cfg = Configuration::test();
-        let mut genesis = RawGenesisBlock::new("alice", "wonderland", &get_key_pair().public_key);
+        let mut genesis = RawGenesisBlock::new("alice", "wonderland", &get_key_pair().public_key)
+            .expect("Valid names never fail to parse");
         genesis.transactions[0].isi.push(
             RegisterBox::new(IdentifiableBox::AssetDefinition(
                 AssetDefinition::new_quantity(AssetDefinitionId::test("rose", "wonderland")).into(),

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -131,13 +131,14 @@ impl<G: GenesisNetworkTrait> TestGenesis for G {
         let mut genesis = RawGenesisBlock::new("alice", "wonderland", &get_key_pair().public_key);
         genesis.transactions[0].isi.push(
             RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new_quantity(AssetDefinitionId::new("rose", "wonderland")).into(),
+                AssetDefinition::new_quantity(AssetDefinitionId::test("rose", "wonderland")).into(),
             ))
             .into(),
         );
         genesis.transactions[0].isi.push(
             RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new_quantity(AssetDefinitionId::new("tulip", "wonderland")).into(),
+                AssetDefinition::new_quantity(AssetDefinitionId::test("tulip", "wonderland"))
+                    .into(),
             ))
             .into(),
         );
@@ -145,8 +146,8 @@ impl<G: GenesisNetworkTrait> TestGenesis for G {
             MintBox::new(
                 Value::U32(13),
                 IdBox::AssetId(AssetId::new(
-                    AssetDefinitionId::new("rose", "wonderland"),
-                    AccountId::new("alice", "wonderland"),
+                    AssetDefinitionId::test("rose", "wonderland"),
+                    AccountId::test("alice", "wonderland"),
                 )),
             )
             .into(),

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -555,7 +555,7 @@ pub mod utils {
             account
         });
         pub static GLOBAL: Lazy<Domain> = Lazy::new(|| {
-            let mut domain = Domain::new("global");
+            let mut domain = Domain::new(DomainId::new("global"));
             domain.accounts.insert(ROOT_ID.clone(), ROOT.clone());
             domain
         });
@@ -563,11 +563,11 @@ pub mod utils {
         impl WorldTrait for WithRoot {
             /// Creates `World` with these `domains` and `trusted_peers_ids`
             fn with(
-                domains: impl IntoIterator<Item = (Name, Domain)>,
+                domains: impl IntoIterator<Item = (DomainId, Domain)>,
                 trusted_peers_ids: impl IntoIterator<Item = PeerId>,
             ) -> Self {
                 Self(World::with(
-                    vec![(GLOBAL.name.clone(), GLOBAL.clone())]
+                    vec![(GLOBAL.id.clone(), GLOBAL.clone())]
                         .into_iter()
                         .chain(domains),
                     trusted_peers_ids,

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -555,7 +555,7 @@ pub mod utils {
             account
         });
         pub static GLOBAL: Lazy<Domain> = Lazy::new(|| {
-            let mut domain = Domain::new(DomainId::test("global"));
+            let mut domain = Domain::test("global");
             domain.accounts.insert(ROOT_ID.clone(), ROOT.clone());
             domain
         });

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -548,14 +548,14 @@ pub mod utils {
         }
 
         pub static ROOT_KEYS: Lazy<KeyPair> = Lazy::new(|| KeyPair::generate().unwrap());
-        pub static ROOT_ID: Lazy<AccountId> = Lazy::new(|| AccountId::new("root", "global"));
+        pub static ROOT_ID: Lazy<AccountId> = Lazy::new(|| AccountId::test("root", "global"));
         pub static ROOT: Lazy<Account> = Lazy::new(|| {
             let mut account = Account::new(ROOT_ID.clone());
             account.signatories.push(ROOT_KEYS.public_key.clone());
             account
         });
         pub static GLOBAL: Lazy<Domain> = Lazy::new(|| {
-            let mut domain = Domain::new(DomainId::new("global"));
+            let mut domain = Domain::new(DomainId::test("global"));
             domain.accounts.insert(ROOT_ID.clone(), ROOT.clone());
             domain
         });

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -633,9 +633,10 @@ impl FailBox {
     }
 }
 
-impl Identifiable for Instruction {
-    type Id = Name;
-}
+// SATO
+// impl Identifiable for Instruction {
+//     type Id = Name;
+// }
 
 #[cfg(test)]
 mod tests {

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -633,11 +633,6 @@ impl FailBox {
     }
 }
 
-// SATO
-// impl Identifiable for Instruction {
-//     type Id = Name;
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -34,18 +34,7 @@ pub mod transaction;
 /// `Name` struct represents type for Iroha Entities names, like [`Domain`](`domain::Domain`)'s name or [`Account`](`account::Account`)'s
 /// name.
 #[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Decode,
-    Encode,
-    Deserialize,
-    Serialize,
-    IntoSchema,
+    Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode, Deserialize, Serialize, IntoSchema,
 )]
 pub struct Name(String);
 
@@ -97,6 +86,12 @@ impl str::FromStr for Name {
             return Err(eyre!("Name must have no whitespaces"));
         }
         Ok(Self(str.to_owned()))
+    }
+}
+
+impl Debug for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
     }
 }
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -71,6 +71,23 @@ impl Name {
     pub fn inner(&self) -> &String {
         &self.0
     }
+
+    /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
+    ///
+    /// # Errors
+    /// Fails if `range` does not
+    pub fn validate_len(&self, range: impl Into<RangeInclusive<usize>>) -> Result<()> {
+        let range = range.into();
+        if range.contains(&self.inner().chars().count()) {
+            Ok(())
+        } else {
+            Err(eyre!(
+                "The number of chars in the name must be {} to {}",
+                &range.start(),
+                &range.end()
+            ))
+        }
+    }
 }
 
 impl str::FromStr for Name {
@@ -644,7 +661,6 @@ pub mod account {
     use std::{
         collections::{BTreeMap, BTreeSet},
         fmt,
-        ops::RangeInclusive,
     };
 
     use eyre::{eyre, Error, Result};
@@ -813,23 +829,6 @@ pub mod account {
                 id,
                 signatories,
                 metadata: Metadata::default(),
-            }
-        }
-
-        /// Checks the length of the id in bytes is in a valid range
-        ///
-        /// # Errors
-        /// Fails if limit check fails
-        pub fn validate_len(&self, range: impl Into<RangeInclusive<usize>>) -> Result<()> {
-            let range = range.into();
-            if range.contains(&self.id.name.inner().chars().count()) {
-                Ok(())
-            } else {
-                Err(eyre!(
-                    "Length of the account name must be in range {}-{}",
-                    &range.start(),
-                    &range.end()
-                ))
             }
         }
     }
@@ -1047,7 +1046,6 @@ pub mod asset {
         cmp::Ordering,
         collections::BTreeMap,
         fmt::{self, Display, Formatter},
-        ops::RangeInclusive,
         str::FromStr,
     };
 
@@ -1388,23 +1386,6 @@ pub mod asset {
         pub fn new_store_token(id: DefinitionId) -> Self {
             AssetDefinition::new(id, AssetValueType::Store, false)
         }
-
-        /// Checks the length of the id in bytes is in a valid range
-        ///
-        /// # Errors
-        /// Fails if limit check fails
-        pub fn validate_len(&self, range: impl Into<RangeInclusive<usize>>) -> Result<()> {
-            let range = range.into();
-            if range.contains(&self.id.name.inner().len()) {
-                Ok(())
-            } else {
-                Err(eyre!(
-                    "Length of the asset defenition name must be in range {}-{}",
-                    &range.start(),
-                    &range.end()
-                ))
-            }
-        }
     }
 
     impl Asset {
@@ -1601,10 +1582,10 @@ pub mod asset {
 pub mod domain {
     //! This module contains [`Domain`](`crate::domain::Domain`) structure and related implementations and trait implementations.
 
-    use std::{cmp::Ordering, collections::BTreeMap, fmt, iter, ops::RangeInclusive, str::FromStr};
+    use std::{cmp::Ordering, collections::BTreeMap, fmt, iter, str::FromStr};
 
     use dashmap::DashMap;
-    use eyre::{eyre, Error, Result};
+    use eyre::{Error, Result};
     use iroha_crypto::PublicKey;
     use iroha_schema::IntoSchema;
     use parity_scale_codec::{Decode, Encode};
@@ -1698,23 +1679,6 @@ pub mod domain {
                 accounts: AccountsMap::new(),
                 asset_definitions: AssetDefinitionsMap::new(),
                 metadata: Metadata::new(),
-            }
-        }
-
-        /// Checks the length of the id in bytes is in a valid range
-        ///
-        /// # Errors
-        /// Fails if limit check fails
-        pub fn validate_len(&self, range: impl Into<RangeInclusive<usize>>) -> Result<()> {
-            let range = range.into();
-            if range.contains(&self.id.name.inner().len()) {
-                Ok(())
-            } else {
-                Err(eyre!(
-                    "Length of the domain name must be in range {}-{}",
-                    &range.start(),
-                    &range.end()
-                ))
             }
         }
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -53,7 +53,7 @@ impl Name {
     /// Constructor.
     #[inline]
     #[allow(clippy::expect_used)]
-    pub fn new(valid_str: &str) -> Self {
+    pub fn test(valid_str: &str) -> Self {
         valid_str
             .parse::<Self>()
             .expect("Valid names never fail to parse")
@@ -956,10 +956,10 @@ pub mod account {
         /// `Id` constructor used to easily create an `Id` from two string slices - one for the
         /// account's name, another one for the container's name.
         #[inline]
-        pub fn new(name: &str, domain_name: &str) -> Self {
+        pub fn test(name: &str, domain_name: &str) -> Self {
             Id {
-                name: Name::new(name),
-                domain_id: DomainId::new(domain_name),
+                name: Name::test(name),
+                domain_id: DomainId::test(domain_name),
             }
         }
 
@@ -967,8 +967,8 @@ pub mod account {
         #[inline]
         pub fn genesis() -> Self {
             Id {
-                name: Name::new(GENESIS_ACCOUNT_NAME),
-                domain_id: DomainId::new(GENESIS_DOMAIN_NAME),
+                name: Name::test(GENESIS_ACCOUNT_NAME),
+                domain_id: DomainId::test(GENESIS_DOMAIN_NAME),
             }
         }
     }
@@ -1000,8 +1000,8 @@ pub mod account {
                 return Err(eyre!("Id should have format `name@domain_name`"));
             }
             Ok(Id {
-                name: Name::new(vector[0]),
-                domain_id: DomainId::new(vector[1]),
+                name: Name::test(vector[0]),
+                domain_id: DomainId::test(vector[1]),
             })
         }
     }
@@ -1465,10 +1465,10 @@ pub mod asset {
         /// [`Id`] constructor used to easily create an [`Id`] from three string slices - one for the
         /// asset definition's name, another one for the domain's name.
         #[inline]
-        pub fn new(name: &str, domain_name: &str) -> Self {
+        pub fn test(name: &str, domain_name: &str) -> Self {
             DefinitionId {
-                name: Name::new(name),
-                domain_id: DomainId::new(domain_name),
+                name: Name::test(name),
+                domain_id: DomainId::test(domain_name),
             }
         }
     }
@@ -1477,18 +1477,20 @@ pub mod asset {
         /// [`Id`] constructor used to easily create an [`Id`] from an names of asset definition and
         /// account.
         #[inline]
-        pub fn from_names(
+        // SATO
+        // pub fn from_names(
+        pub fn test(
             asset_definition_name: &str,
             asset_definition_domain_name: &str,
             account_name: &str,
             account_domain_name: &str,
         ) -> Self {
             Id {
-                definition_id: DefinitionId::new(
+                definition_id: DefinitionId::test(
                     asset_definition_name,
                     asset_definition_domain_name,
                 ),
-                account_id: AccountId::new(account_name, account_domain_name),
+                account_id: AccountId::test(account_name, account_domain_name),
             }
         }
 
@@ -1541,8 +1543,8 @@ pub mod asset {
                 ));
             }
             Ok(DefinitionId {
-                name: Name::new(vector[0]),
-                domain_id: DomainId::new(vector[1]),
+                name: Name::test(vector[0]),
+                domain_id: DomainId::test(vector[1]),
             })
         }
     }
@@ -1614,7 +1616,7 @@ pub mod domain {
     impl From<GenesisDomain> for Domain {
         fn from(domain: GenesisDomain) -> Self {
             Self {
-                id: Id::new(GENESIS_DOMAIN_NAME),
+                id: Id::test(GENESIS_DOMAIN_NAME),
                 accounts: iter::once((
                     <Account as Identifiable>::Id::genesis(),
                     GenesisAccount::new(domain.genesis_key).into(),
@@ -1655,9 +1657,9 @@ pub mod domain {
 
     impl Domain {
         /// Test `Domain` constructor.
-        pub fn test(valid_name: &str) -> Self {
+        pub fn test(name: &str) -> Self {
             Domain {
-                id: Id::new(valid_name),
+                id: Id::test(name),
                 accounts: AccountsMap::new(),
                 asset_definitions: AssetDefinitionsMap::new(),
                 metadata: Metadata::new(),
@@ -1698,7 +1700,7 @@ pub mod domain {
                 .map(|account| (account.id.clone(), account))
                 .collect();
             Domain {
-                id: Id::new(name),
+                id: Id::test(name),
                 accounts: accounts_map,
                 asset_definitions: AssetDefinitionsMap::new(),
                 metadata: Metadata::new(),
@@ -1742,9 +1744,9 @@ pub mod domain {
     impl Id {
         /// Constructor.
         #[inline]
-        pub fn new(name: &str) -> Self {
+        pub fn test(name: &str) -> Self {
             Id {
-                name: Name::new(name),
+                name: Name::test(name),
             }
         }
     }
@@ -1752,7 +1754,7 @@ pub mod domain {
     impl FromStr for Id {
         type Err = Infallible;
         fn from_str(name: &str) -> Result<Self, Self::Err> {
-            Ok(Self::new(name))
+            Ok(Self::test(name))
         }
     }
 

--- a/data_model/src/metadata.rs
+++ b/data_model/src/metadata.rs
@@ -217,16 +217,16 @@ mod tests {
         let limits = Limits::new(1024, 1024);
         // TODO: If we allow a `unsafe`, we could create the path.
         metadata
-            .insert_with_limits(Name::new("0"), Metadata::new().into(), limits)
+            .insert_with_limits(Name::test("0"), Metadata::new().into(), limits)
             .unwrap();
         metadata
             .nested_insert_with_limits(
-                &[Name::new("0"), Name::new("1")],
+                &[Name::test("0"), Name::test("1")],
                 Metadata::new().into(),
                 limits,
             )
             .unwrap();
-        let path = [Name::new("0"), Name::new("1"), Name::new("2")];
+        let path = [Name::test("0"), Name::test("1"), Name::test("2")];
         metadata
             .nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits)
             .unwrap();
@@ -245,20 +245,20 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 15);
         metadata
-            .insert_with_limits(Name::new("0"), Metadata::new().into(), limits)
+            .insert_with_limits(Name::test("0"), Metadata::new().into(), limits)
             .unwrap();
         metadata
             .nested_insert_with_limits(
-                &[Name::new("0"), Name::new("1")],
+                &[Name::test("0"), Name::test("1")],
                 Metadata::new().into(),
                 limits,
             )
             .unwrap();
-        let path = vec![Name::new("0"), Name::new("1"), Name::new("2")];
+        let path = vec![Name::test("0"), Name::test("1"), Name::test("2")];
         metadata
             .nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits)
             .unwrap();
-        let bad_path = vec![Name::new("0"), Name::new("3"), Name::new("2")];
+        let bad_path = vec![Name::test("0"), Name::test("3"), Name::test("2")];
         assert!(metadata
             .nested_insert_with_limits(&bad_path, "Hello World".to_owned().into(), limits)
             .is_err());
@@ -271,13 +271,13 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 14);
         // TODO: If we allow a `unsafe`, we could create the path.
-        metadata.insert_with_limits(Name::new("0"), Metadata::new().into(), limits)?;
+        metadata.insert_with_limits(Name::test("0"), Metadata::new().into(), limits)?;
         metadata.nested_insert_with_limits(
-            &[Name::new("0"), Name::new("1")],
+            &[Name::test("0"), Name::test("1")],
             Metadata::new().into(),
             limits,
         )?;
-        let path = vec![Name::new("0"), Name::new("1"), Name::new("2")];
+        let path = vec![Name::test("0"), Name::test("1"), Name::test("2")];
         let failing_insert =
             metadata.nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits);
         match failing_insert {
@@ -291,10 +291,10 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 5);
         assert!(metadata
-            .insert_with_limits(Name::new("1"), "2".to_owned().into(), limits)
+            .insert_with_limits(Name::test("1"), "2".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits(Name::new("1"), "23456".to_owned().into(), limits)
+            .insert_with_limits(Name::test("1"), "23456".to_owned().into(), limits)
             .is_err());
     }
 
@@ -303,16 +303,16 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(2, 5);
         assert!(metadata
-            .insert_with_limits(Name::new("1"), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::test("1"), "0".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits(Name::new("2"), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::test("2"), "0".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits(Name::new("2"), "1".to_owned().into(), limits)
+            .insert_with_limits(Name::test("2"), "1".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits(Name::new("3"), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::test("3"), "0".to_owned().into(), limits)
             .is_err());
     }
 }

--- a/data_model/src/metadata.rs
+++ b/data_model/src/metadata.rs
@@ -135,7 +135,7 @@ impl Metadata {
             };
         }
         check_size_limits(key, value.clone(), limits)?;
-        layer.insert_with_limits(key.to_string(), value, limits)
+        layer.insert_with_limits(key.clone(), value, limits)
     }
 
     /// Insert [`Value`] under the given key.  Returns `Some(value)`
@@ -181,7 +181,7 @@ impl Metadata {
     }
 }
 
-fn check_size_limits(key: &str, value: Value, limits: Limits) -> Result<()> {
+fn check_size_limits(key: &Name, value: Value, limits: Limits) -> Result<()> {
     let entry_bytes: Vec<u8> = (key, value).encode();
     let byte_size = entry_bytes.len();
     if byte_size > limits.max_entry_byte_size as usize {
@@ -197,7 +197,7 @@ pub mod prelude {
 
 #[cfg(test)]
 mod tests {
-    use super::{Limits, Metadata, Value};
+    use super::{Limits, Metadata, Name, Value};
 
     #[test]
     fn nested_fns_ignore_empty_path() {
@@ -217,16 +217,16 @@ mod tests {
         let limits = Limits::new(1024, 1024);
         // TODO: If we allow a `unsafe`, we could create the path.
         metadata
-            .insert_with_limits("0".to_owned(), Metadata::new().into(), limits)
+            .insert_with_limits(Name::new("0"), Metadata::new().into(), limits)
             .unwrap();
         metadata
             .nested_insert_with_limits(
-                &["0".to_owned(), "1".to_owned()],
+                &[Name::new("0"), Name::new("1")],
                 Metadata::new().into(),
                 limits,
             )
             .unwrap();
-        let path = ["0".to_owned(), "1".to_owned(), "2".to_owned()];
+        let path = [Name::new("0"), Name::new("1"), Name::new("2")];
         metadata
             .nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits)
             .unwrap();
@@ -245,20 +245,20 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 15);
         metadata
-            .insert_with_limits("0".to_owned(), Metadata::new().into(), limits)
+            .insert_with_limits(Name::new("0"), Metadata::new().into(), limits)
             .unwrap();
         metadata
             .nested_insert_with_limits(
-                &["0".to_owned(), "1".to_owned()],
+                &[Name::new("0"), Name::new("1")],
                 Metadata::new().into(),
                 limits,
             )
             .unwrap();
-        let path = vec!["0".to_owned(), "1".to_owned(), "2".to_owned()];
+        let path = vec![Name::new("0"), Name::new("1"), Name::new("2")];
         metadata
             .nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits)
             .unwrap();
-        let bad_path = vec!["0".to_owned(), "3".to_owned(), "2".to_owned()];
+        let bad_path = vec![Name::new("0"), Name::new("3"), Name::new("2")];
         assert!(metadata
             .nested_insert_with_limits(&bad_path, "Hello World".to_owned().into(), limits)
             .is_err());
@@ -271,13 +271,13 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 14);
         // TODO: If we allow a `unsafe`, we could create the path.
-        metadata.insert_with_limits("0".to_owned(), Metadata::new().into(), limits)?;
+        metadata.insert_with_limits(Name::new("0"), Metadata::new().into(), limits)?;
         metadata.nested_insert_with_limits(
-            &["0".to_owned(), "1".to_owned()],
+            &[Name::new("0"), Name::new("1")],
             Metadata::new().into(),
             limits,
         )?;
-        let path = vec!["0".to_owned(), "1".to_owned(), "2".to_owned()];
+        let path = vec![Name::new("0"), Name::new("1"), Name::new("2")];
         let failing_insert =
             metadata.nested_insert_with_limits(&path, "Hello World".to_owned().into(), limits);
         match failing_insert {
@@ -291,10 +291,10 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(10, 5);
         assert!(metadata
-            .insert_with_limits("1".to_owned(), "2".to_owned().into(), limits)
+            .insert_with_limits(Name::new("1"), "2".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits("1".to_owned(), "23456".to_owned().into(), limits)
+            .insert_with_limits(Name::new("1"), "23456".to_owned().into(), limits)
             .is_err());
     }
 
@@ -303,16 +303,16 @@ mod tests {
         let mut metadata = Metadata::new();
         let limits = Limits::new(2, 5);
         assert!(metadata
-            .insert_with_limits("1".to_owned(), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::new("1"), "0".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits("2".to_owned(), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::new("2"), "0".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits("2".to_owned(), "1".to_owned().into(), limits)
+            .insert_with_limits(Name::new("2"), "1".to_owned().into(), limits)
             .is_ok());
         assert!(metadata
-            .insert_with_limits("3".to_owned(), "0".to_owned().into(), limits)
+            .insert_with_limits(Name::new("3"), "0".to_owned().into(), limits)
             .is_err());
     }
 }

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -40,8 +40,8 @@ pub enum QueryBox {
     FindAccountKeyValueByIdAndKey(FindAccountKeyValueByIdAndKey),
     /// `FindAccountsByName` variant.
     FindAccountsByName(FindAccountsByName),
-    /// `FindAccountsByDomainName` variant.
-    FindAccountsByDomainName(FindAccountsByDomainName),
+    /// `FindAccountsByDomainId` variant.
+    FindAccountsByDomainId(FindAccountsByDomainId),
     /// `FindAllAssets` variant.
     FindAllAssets(FindAllAssets),
     /// `FindAllAssetsDefinitions` variant.
@@ -54,10 +54,10 @@ pub enum QueryBox {
     FindAssetsByAccountId(FindAssetsByAccountId),
     /// `FindAssetsByAssetDefinitionId` variant.
     FindAssetsByAssetDefinitionId(FindAssetsByAssetDefinitionId),
-    /// `FindAssetsByDomainName` variant.
-    FindAssetsByDomainName(FindAssetsByDomainName),
-    /// `FindAssetsByDomainNameAndAssetDefinitionId` variant.
-    FindAssetsByDomainNameAndAssetDefinitionId(FindAssetsByDomainNameAndAssetDefinitionId),
+    /// `FindAssetsByDomainId` variant.
+    FindAssetsByDomainId(FindAssetsByDomainId),
+    /// `FindAssetsByDomainIdAndAssetDefinitionId` variant.
+    FindAssetsByDomainIdAndAssetDefinitionId(FindAssetsByDomainIdAndAssetDefinitionId),
     /// `FindAssetQuantityById` variant.
     FindAssetQuantityById(FindAssetQuantityById),
     /// `FindAssetKeyValueByIdAndKey` variant.
@@ -66,8 +66,8 @@ pub enum QueryBox {
     FindAssetDefinitionKeyValueByIdAndKey(FindAssetDefinitionKeyValueByIdAndKey),
     /// `FindAllDomains` variant.
     FindAllDomains(FindAllDomains),
-    /// `FindDomainByName` variant.
-    FindDomainByName(FindDomainByName),
+    /// `FindDomainById` variant.
+    FindDomainById(FindDomainById),
     /// `FindDomainKeyValueByIdAndKey` variant.
     FindDomainKeyValueByIdAndKey(FindDomainKeyValueByIdAndKey),
     /// `FindAllPeers` variant.
@@ -372,7 +372,7 @@ pub mod account {
         type Output = Vec<Account>;
     }
 
-    /// `FindAccountsByDomainName` Iroha Query will get `Domain`s name as input and
+    /// `FindAccountsByDomainId` Iroha Query will get `Domain`s id as input and
     /// find all `Account`s under this `Domain`.
     #[derive(
         Debug,
@@ -387,12 +387,12 @@ pub mod account {
         Serialize,
         IntoSchema,
     )]
-    pub struct FindAccountsByDomainName {
-        /// `domain_name` under which accounts should be found.
-        pub domain_name: EvaluatesTo<Name>,
+    pub struct FindAccountsByDomainId {
+        /// `Id` of the domain under which accounts should be found.
+        pub domain_id: EvaluatesTo<DomainId>,
     }
 
-    impl Query for FindAccountsByDomainName {
+    impl Query for FindAccountsByDomainId {
         type Output = Vec<Account>;
     }
 
@@ -431,18 +431,18 @@ pub mod account {
         }
     }
 
-    impl FindAccountsByDomainName {
-        /// Default `FindAccountsByDomainName` constructor.
-        pub fn new(domain_name: impl Into<EvaluatesTo<Name>>) -> Self {
-            let domain_name = domain_name.into();
-            FindAccountsByDomainName { domain_name }
+    impl FindAccountsByDomainId {
+        /// Default `FindAccountsByDomainId` constructor.
+        pub fn new(domain_id: impl Into<EvaluatesTo<DomainId>>) -> Self {
+            let domain_id = domain_id.into();
+            FindAccountsByDomainId { domain_id }
         }
     }
 
     /// The prelude re-exports most commonly used traits, structs and macros from this crate.
     pub mod prelude {
         pub use super::{
-            FindAccountById, FindAccountKeyValueByIdAndKey, FindAccountsByDomainName,
+            FindAccountById, FindAccountKeyValueByIdAndKey, FindAccountsByDomainId,
             FindAccountsByName, FindAllAccounts,
         };
     }
@@ -599,7 +599,7 @@ pub mod asset {
         type Output = Vec<Asset>;
     }
 
-    /// `FindAssetsByDomainName` Iroha Query will get `Domain`s name as input and
+    /// `FindAssetsByDomainId` Iroha Query will get `Domain`s id as input and
     /// find all `Asset`s under this `Domain` in Iroha `Peer`.
     #[derive(
         Debug,
@@ -614,16 +614,16 @@ pub mod asset {
         Serialize,
         IntoSchema,
     )]
-    pub struct FindAssetsByDomainName {
-        /// `Name` of the domain under which assets should be found.
-        pub domain_name: EvaluatesTo<Name>,
+    pub struct FindAssetsByDomainId {
+        /// `Id` of the domain under which assets should be found.
+        pub domain_id: EvaluatesTo<DomainId>,
     }
 
-    impl Query for FindAssetsByDomainName {
+    impl Query for FindAssetsByDomainId {
         type Output = Vec<Asset>;
     }
 
-    /// `FindAssetsByDomainNameAndAssetDefinitionId` Iroha Query will get `Domain`'s name and
+    /// `FindAssetsByDomainIdAndAssetDefinitionId` Iroha Query will get `Domain`'s id and
     /// `AssetDefinitionId` as inputs and find all `Asset`s under the `Domain`
     /// with this `AssetDefinition` in Iroha `Peer`.
     #[derive(
@@ -639,14 +639,14 @@ pub mod asset {
         Serialize,
         IntoSchema,
     )]
-    pub struct FindAssetsByDomainNameAndAssetDefinitionId {
-        /// `Name` of the domain under which assets should be found.
-        pub domain_name: EvaluatesTo<Name>,
+    pub struct FindAssetsByDomainIdAndAssetDefinitionId {
+        /// `Id` of the domain under which assets should be found.
+        pub domain_id: EvaluatesTo<DomainId>,
         /// `AssetDefinitionId` assets of which type should be found.
         pub asset_definition_id: EvaluatesTo<AssetDefinitionId>,
     }
 
-    impl Query for FindAssetsByDomainNameAndAssetDefinitionId {
+    impl Query for FindAssetsByDomainIdAndAssetDefinitionId {
         type Output = Vec<Asset>;
     }
 
@@ -774,24 +774,24 @@ pub mod asset {
         }
     }
 
-    impl FindAssetsByDomainName {
+    impl FindAssetsByDomainId {
         /// Default `FindAssetsByDomainName` constructor
-        pub fn new(domain_name: impl Into<EvaluatesTo<Name>>) -> Self {
-            let domain_name = domain_name.into();
-            Self { domain_name }
+        pub fn new(domain_id: impl Into<EvaluatesTo<DomainId>>) -> Self {
+            let domain_id = domain_id.into();
+            Self { domain_id }
         }
     }
 
-    impl FindAssetsByDomainNameAndAssetDefinitionId {
+    impl FindAssetsByDomainIdAndAssetDefinitionId {
         /// Default `FindAssetsByDomainNameAndAssetDefinitionId` constructor
         pub fn new(
-            domain_name: impl Into<EvaluatesTo<Name>>,
+            domain_id: impl Into<EvaluatesTo<DomainId>>,
             asset_definition_id: impl Into<EvaluatesTo<AssetDefinitionId>>,
         ) -> Self {
-            let domain_name = domain_name.into();
+            let domain_id = domain_id.into();
             let asset_definition_id = asset_definition_id.into();
             Self {
-                domain_name,
+                domain_id,
                 asset_definition_id,
             }
         }
@@ -820,7 +820,7 @@ pub mod asset {
             FindAllAssets, FindAllAssetsDefinitions, FindAssetById,
             FindAssetDefinitionKeyValueByIdAndKey, FindAssetKeyValueByIdAndKey,
             FindAssetQuantityById, FindAssetsByAccountId, FindAssetsByAssetDefinitionId,
-            FindAssetsByDomainName, FindAssetsByDomainNameAndAssetDefinitionId, FindAssetsByName,
+            FindAssetsByDomainId, FindAssetsByDomainIdAndAssetDefinitionId, FindAssetsByName,
         };
     }
 }
@@ -858,7 +858,7 @@ pub mod domain {
         type Output = Vec<Domain>;
     }
 
-    /// `FindDomainByName` Iroha Query will find a `Domain` by it's identification in Iroha `Peer`.
+    /// `FindDomainById` Iroha Query will find a `Domain` by it's identification in Iroha `Peer`.
     #[derive(
         Debug,
         Clone,
@@ -872,12 +872,12 @@ pub mod domain {
         Serialize,
         IntoSchema,
     )]
-    pub struct FindDomainByName {
-        /// Name of the domain to find.
-        pub name: EvaluatesTo<Name>,
+    pub struct FindDomainById {
+        /// `Id` of the domain to find.
+        pub id: EvaluatesTo<DomainId>,
     }
 
-    impl Query for FindDomainByName {
+    impl Query for FindDomainById {
         type Output = Domain;
     }
 
@@ -888,11 +888,11 @@ pub mod domain {
         }
     }
 
-    impl FindDomainByName {
-        /// Default `FindDomainByName` constructor.
-        pub fn new(name: impl Into<EvaluatesTo<Name>>) -> Self {
-            let name = name.into();
-            FindDomainByName { name }
+    impl FindDomainById {
+        /// Default `FindDomainById` constructor.
+        pub fn new(id: impl Into<EvaluatesTo<DomainId>>) -> Self {
+            let id = id.into();
+            FindDomainById { id }
         }
     }
 
@@ -912,18 +912,21 @@ pub mod domain {
         IntoSchema,
     )]
     pub struct FindDomainKeyValueByIdAndKey {
-        /// `Name` of an domain to find.
-        pub name: EvaluatesTo<Name>,
+        /// `Id` of an domain to find.
+        pub id: EvaluatesTo<DomainId>,
         /// Key of the specific key-value in the domain's metadata.
         pub key: EvaluatesTo<Name>,
     }
 
     impl FindDomainKeyValueByIdAndKey {
         /// Default `FindDomainKeyValueByIdAndKey` constructor.
-        pub fn new(name: impl Into<EvaluatesTo<Name>>, key: impl Into<EvaluatesTo<Name>>) -> Self {
-            let name = name.into();
+        pub fn new(
+            id: impl Into<EvaluatesTo<DomainId>>,
+            key: impl Into<EvaluatesTo<Name>>,
+        ) -> Self {
+            let id = id.into();
             let key = key.into();
-            FindDomainKeyValueByIdAndKey { name, key }
+            FindDomainKeyValueByIdAndKey { id, key }
         }
     }
 
@@ -933,7 +936,7 @@ pub mod domain {
 
     /// The prelude re-exports most commonly used traits, structs and macros from this crate.
     pub mod prelude {
-        pub use super::{FindAllDomains, FindDomainByName, FindDomainKeyValueByIdAndKey};
+        pub use super::{FindAllDomains, FindDomainById, FindDomainKeyValueByIdAndKey};
     }
 }
 

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -131,9 +131,9 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
     let mut iroha_client = Client::new(&client_configuration);
     iroha_client
         .submit_all(vec![
-            RegisterBox::new(IdentifiableBox::Domain(Domain::new("exchange").into())).into(),
-            RegisterBox::new(IdentifiableBox::Domain(Domain::new("company").into())).into(),
-            RegisterBox::new(IdentifiableBox::Domain(Domain::new("crypto").into())).into(),
+            RegisterBox::new(IdentifiableBox::Domain(Domain::test("exchange").into())).into(),
+            RegisterBox::new(IdentifiableBox::Domain(Domain::test("company").into())).into(),
+            RegisterBox::new(IdentifiableBox::Domain(Domain::test("crypto").into())).into(),
             RegisterBox::new(IdentifiableBox::NewAccount(
                 NewAccount::new(AccountId::new("seller", "company")).into(),
             ))

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -116,7 +116,8 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
     // Given
     let genesis = GenesisNetwork::from_configuration(
         true,
-        RawGenesisBlock::new("alice", "wonderland", &kp.public_key),
+        RawGenesisBlock::new("alice", "wonderland", &kp.public_key)
+            .expect("Valid names never fail to parse"),
         &configuration.genesis,
         configuration.sumeragi.max_instruction_number,
     )

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -16,9 +16,9 @@ use tokio::runtime::Runtime;
 fn find_rate_and_make_exchange_isi_should_be_valid() {
     let _instruction = Pair::new(
         TransferBox::new(
-            IdBox::AssetId(AssetId::from_names("btc", "crypto", "seller", "company")),
+            IdBox::AssetId(AssetId::test("btc", "crypto", "seller", "company")),
             Expression::Query(
-                FindAssetQuantityById::new(AssetId::from_names(
+                FindAssetQuantityById::new(AssetId::test(
                     "btc2eth_rate",
                     "exchange",
                     "dex",
@@ -26,12 +26,12 @@ fn find_rate_and_make_exchange_isi_should_be_valid() {
                 ))
                 .into(),
             ),
-            IdBox::AssetId(AssetId::from_names("btc", "crypto", "buyer", "company")),
+            IdBox::AssetId(AssetId::test("btc", "crypto", "buyer", "company")),
         ),
         TransferBox::new(
-            IdBox::AssetId(AssetId::from_names("btc", "crypto", "buyer", "company")),
+            IdBox::AssetId(AssetId::test("btc", "crypto", "buyer", "company")),
             Expression::Query(
-                FindAssetQuantityById::new(AssetId::from_names(
+                FindAssetQuantityById::new(AssetId::test(
                     "btc2eth_rate",
                     "exchange",
                     "dex",
@@ -39,7 +39,7 @@ fn find_rate_and_make_exchange_isi_should_be_valid() {
                 ))
                 .into(),
             ),
-            IdBox::AssetId(AssetId::from_names("btc", "crypto", "seller", "company")),
+            IdBox::AssetId(AssetId::test("btc", "crypto", "seller", "company")),
         ),
     );
 }
@@ -48,7 +48,7 @@ fn find_rate_and_make_exchange_isi_should_be_valid() {
 fn find_rate_and_check_it_greater_than_value_isi_should_be_valid() {
     let _instruction = IfInstruction::new(
         Not::new(Greater::new(
-            QueryBox::from(FindAssetQuantityById::new(AssetId::from_names(
+            QueryBox::from(FindAssetQuantityById::new(AssetId::test(
                 "btc2eth_rate",
                 "exchange",
                 "dex",
@@ -78,7 +78,7 @@ impl FindRateAndCheckItGreaterThanValue {
     pub fn into_isi(self) -> IfInstruction {
         IfInstruction::new(
             Not::new(Greater::new(
-                QueryBox::from(FindAssetQuantityById::new(AssetId::from_names(
+                QueryBox::from(FindAssetQuantityById::new(AssetId::test(
                     &format!("{}2{}_rate", self.from_currency, self.to_currency),
                     "exchange",
                     "dex",
@@ -135,59 +135,59 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
             RegisterBox::new(IdentifiableBox::Domain(Domain::test("company").into())).into(),
             RegisterBox::new(IdentifiableBox::Domain(Domain::test("crypto").into())).into(),
             RegisterBox::new(IdentifiableBox::NewAccount(
-                NewAccount::new(AccountId::new("seller", "company")).into(),
+                NewAccount::new(AccountId::test("seller", "company")).into(),
             ))
             .into(),
             RegisterBox::new(IdentifiableBox::NewAccount(
-                NewAccount::new(AccountId::new("buyer", "company")).into(),
+                NewAccount::new(AccountId::test("buyer", "company")).into(),
             ))
             .into(),
             RegisterBox::new(IdentifiableBox::NewAccount(
-                NewAccount::new(AccountId::new("dex", "exchange")).into(),
+                NewAccount::new(AccountId::test("dex", "exchange")).into(),
             ))
             .into(),
             RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new_quantity(AssetDefinitionId::new("btc", "crypto")).into(),
+                AssetDefinition::new_quantity(AssetDefinitionId::test("btc", "crypto")).into(),
             ))
             .into(),
             RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new_quantity(AssetDefinitionId::new("eth", "crypto")).into(),
+                AssetDefinition::new_quantity(AssetDefinitionId::test("eth", "crypto")).into(),
             ))
             .into(),
             RegisterBox::new(IdentifiableBox::AssetDefinition(
-                AssetDefinition::new_quantity(AssetDefinitionId::new("btc2eth_rate", "exchange"))
+                AssetDefinition::new_quantity(AssetDefinitionId::test("btc2eth_rate", "exchange"))
                     .into(),
             ))
             .into(),
             MintBox::new(
                 Value::U32(200),
                 IdBox::AssetId(AssetId::new(
-                    AssetDefinitionId::new("eth", "crypto"),
-                    AccountId::new("buyer", "company"),
+                    AssetDefinitionId::test("eth", "crypto"),
+                    AccountId::test("buyer", "company"),
                 )),
             )
             .into(),
             MintBox::new(
                 Value::U32(20),
                 IdBox::AssetId(AssetId::new(
-                    AssetDefinitionId::new("btc", "crypto"),
-                    AccountId::new("seller", "company"),
+                    AssetDefinitionId::test("btc", "crypto"),
+                    AccountId::test("seller", "company"),
                 )),
             )
             .into(),
             MintBox::new(
                 Value::U32(20),
                 IdBox::AssetId(AssetId::new(
-                    AssetDefinitionId::new("btc2eth_rate", "exchange"),
-                    AccountId::new("dex", "exchange"),
+                    AssetDefinitionId::test("btc2eth_rate", "exchange"),
+                    AccountId::test("dex", "exchange"),
                 )),
             )
             .into(),
             Pair::new(
                 TransferBox::new(
-                    IdBox::AssetId(AssetId::from_names("btc", "crypto", "seller", "company")),
+                    IdBox::AssetId(AssetId::test("btc", "crypto", "seller", "company")),
                     Expression::Query(
-                        FindAssetQuantityById::new(AssetId::from_names(
+                        FindAssetQuantityById::new(AssetId::test(
                             "btc2eth_rate",
                             "exchange",
                             "dex",
@@ -195,12 +195,12 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
                         ))
                         .into(),
                     ),
-                    IdBox::AssetId(AssetId::from_names("btc", "crypto", "buyer", "company")),
+                    IdBox::AssetId(AssetId::test("btc", "crypto", "buyer", "company")),
                 ),
                 TransferBox::new(
-                    IdBox::AssetId(AssetId::from_names("eth", "crypto", "buyer", "company")),
+                    IdBox::AssetId(AssetId::test("eth", "crypto", "buyer", "company")),
                     Expression::Query(
-                        FindAssetQuantityById::new(AssetId::from_names(
+                        FindAssetQuantityById::new(AssetId::test(
                             "btc2eth_rate",
                             "exchange",
                             "dex",
@@ -208,7 +208,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
                         ))
                         .into(),
                     ),
-                    IdBox::AssetId(AssetId::from_names("eth", "crypto", "seller", "company")),
+                    IdBox::AssetId(AssetId::test("eth", "crypto", "seller", "company")),
                 ),
             )
             .into(),
@@ -220,7 +220,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
     let expected_buyer_btc = 20;
 
     let eth_quantity = iroha_client
-        .request(FindAssetQuantityById::new(AssetId::from_names(
+        .request(FindAssetQuantityById::new(AssetId::test(
             "eth", "crypto", "seller", "company",
         )))
         .expect("Failed to execute Iroha Query");
@@ -228,20 +228,20 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
 
     // For the btc amount we expect an error, as zero assets are purged from accounts
     iroha_client
-        .request(FindAssetQuantityById::new(AssetId::from_names(
+        .request(FindAssetQuantityById::new(AssetId::test(
             "btc", "crypto", "seller", "company",
         )))
         .expect_err("Failed to execute Iroha Query");
 
     let buyer_eth_quantity = iroha_client
-        .request(FindAssetQuantityById::new(AssetId::from_names(
+        .request(FindAssetQuantityById::new(AssetId::test(
             "eth", "crypto", "buyer", "company",
         )))
         .expect("Failed to execute Iroha Query");
     assert_eq!(expected_buyer_eth, buyer_eth_quantity);
 
     let buyer_btc_quantity = iroha_client
-        .request(FindAssetQuantityById::new(AssetId::from_names(
+        .request(FindAssetQuantityById::new(AssetId::test(
             "btc", "crypto", "buyer", "company",
         )))
         .expect("Failed to execute Iroha Query");

--- a/permissions_validators/Cargo.toml
+++ b/permissions_validators/Cargo.toml
@@ -13,3 +13,5 @@ roles = ["iroha_core/roles"]
 iroha_core = { version = "=2.0.0-pre.1", path = "../core"}
 iroha_data_model = { version = "=2.0.0-pre.1", path = "../data_model" }
 iroha_macro = { version = "=2.0.0-pre.1", path = "../macro" }
+
+once_cell = "1.8.0"

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -17,6 +17,7 @@ use iroha_core::{
 };
 use iroha_data_model::{isi::*, prelude::*};
 use iroha_macro::error::ErrorTryFromEnum;
+use once_cell::sync::Lazy;
 
 macro_rules! impl_from_item_for_instruction_validator_box {
     ( $ty:ty ) => {
@@ -127,7 +128,8 @@ pub mod private_blockchain {
         use super::*;
 
         /// Can register domains permission token name.
-        pub const CAN_REGISTER_DOMAINS_TOKEN: &str = "can_register_domains";
+        pub static CAN_REGISTER_DOMAINS_TOKEN: Lazy<Name> =
+            Lazy::new(|| Name::new("can_register_domains"));
 
         /// Prohibits registering domains.
         #[derive(Debug, Copy, Clone)]
@@ -165,7 +167,7 @@ pub mod private_blockchain {
                 _wsv: &WorldStateView<W>,
             ) -> Result<PermissionToken, String> {
                 Ok(PermissionToken::new(
-                    CAN_REGISTER_DOMAINS_TOKEN,
+                    CAN_REGISTER_DOMAINS_TOKEN.clone(),
                     BTreeMap::new(),
                 ))
             }
@@ -579,11 +581,12 @@ pub mod public_blockchain {
     use super::*;
 
     /// Origin asset id param used in permission tokens.
-    pub const ASSET_ID_TOKEN_PARAM_NAME: &str = "asset_id";
+    pub static ASSET_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("asset_id"));
     /// Origin account id param used in permission tokens.
-    pub const ACCOUNT_ID_TOKEN_PARAM_NAME: &str = "account_id";
+    pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("account_id"));
     /// Origin asset definition param used in permission tokens.
-    pub const ASSET_DEFINITION_ID_TOKEN_PARAM_NAME: &str = "asset_definition_id";
+    pub static ASSET_DEFINITION_ID_TOKEN_PARAM_NAME: Lazy<Name> =
+        Lazy::new(|| Name::new("asset_definition_id"));
 
     /// A preconfigured set of permissions for simple use cases.
     pub fn default_permissions<W: WorldTrait>() -> IsInstructionAllowedBoxed<W> {
@@ -649,16 +652,16 @@ pub mod public_blockchain {
     ) -> Result<(), String> {
         let account_id = if let Value::Id(IdBox::AccountId(account_id)) = permission_token
             .params
-            .get(ACCOUNT_ID_TOKEN_PARAM_NAME)
+            .get(&ACCOUNT_ID_TOKEN_PARAM_NAME.clone())
             .ok_or(format!(
                 "Failed to find permission param {}.",
-                ACCOUNT_ID_TOKEN_PARAM_NAME
+                ACCOUNT_ID_TOKEN_PARAM_NAME.clone()
             ))? {
             account_id
         } else {
             return Err(format!(
                 "Permission param {} is not an AccountId.",
-                ACCOUNT_ID_TOKEN_PARAM_NAME
+                ACCOUNT_ID_TOKEN_PARAM_NAME.clone()
             ));
         };
         if account_id != authority {
@@ -678,16 +681,16 @@ pub mod public_blockchain {
     ) -> Result<(), String> {
         let asset_id = if let Value::Id(IdBox::AssetId(asset_id)) = permission_token
             .params
-            .get(ASSET_ID_TOKEN_PARAM_NAME)
+            .get(&ASSET_ID_TOKEN_PARAM_NAME.clone())
             .ok_or(format!(
                 "Failed to find permission param {}.",
-                ASSET_ID_TOKEN_PARAM_NAME
+                ASSET_ID_TOKEN_PARAM_NAME.clone()
             ))? {
             asset_id
         } else {
             return Err(format!(
                 "Permission param {} is not an AssetId.",
-                ASSET_ID_TOKEN_PARAM_NAME
+                ASSET_ID_TOKEN_PARAM_NAME.clone()
             ));
         };
         if &asset_id.account_id != authority {
@@ -709,16 +712,16 @@ pub mod public_blockchain {
         let definition_id = if let Value::Id(IdBox::AssetDefinitionId(definition_id)) =
             permission_token
                 .params
-                .get(ASSET_DEFINITION_ID_TOKEN_PARAM_NAME)
+                .get(&ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone())
                 .ok_or(format!(
                     "Failed to find permission param {}.",
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone()
                 ))? {
             definition_id
         } else {
             return Err(format!(
                 "Permission param {} is not an AssetDefinitionId.",
-                ASSET_DEFINITION_ID_TOKEN_PARAM_NAME
+                ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone()
             ));
         };
         let registered_by_signer_account = wsv
@@ -739,7 +742,8 @@ pub mod public_blockchain {
         use super::*;
 
         /// Can transfer user's assets permission token name.
-        pub const CAN_TRANSFER_USER_ASSETS_TOKEN: &str = "can_transfer_user_assets";
+        pub static CAN_TRANSFER_USER_ASSETS_TOKEN: Lazy<Name> =
+            Lazy::new(|| Name::new("can_transfer_user_assets"));
 
         /// Checks that account transfers only the assets that he owns.
         #[derive(Debug, Copy, Clone)]
@@ -801,7 +805,10 @@ pub mod public_blockchain {
                 };
                 let mut params = BTreeMap::new();
                 params.insert(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), source_id.into());
-                Ok(PermissionToken::new(CAN_TRANSFER_USER_ASSETS_TOKEN, params))
+                Ok(PermissionToken::new(
+                    CAN_TRANSFER_USER_ASSETS_TOKEN.clone(),
+                    params,
+                ))
             }
         }
 
@@ -825,7 +832,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_TRANSFER_USER_ASSETS_TOKEN {
+                if permission_token.name != CAN_TRANSFER_USER_ASSETS_TOKEN.clone() {
                     return Err("Grant instruction is not for transfer permission.".to_owned());
                 }
                 check_asset_owner_for_token(&permission_token, authority)
@@ -839,8 +846,8 @@ pub mod public_blockchain {
         use super::*;
 
         /// Can unregister asset with the corresponding asset definition.
-        pub const CAN_UNREGISTER_ASSET_WITH_DEFINITION: &str =
-            "can_unregister_asset_with_definition";
+        pub static CAN_UNREGISTER_ASSET_WITH_DEFINITION: Lazy<Name> =
+            Lazy::new(|| Name::new("can_unregister_asset_with_definition"));
 
         /// Checks that account can unregister only the assets which were registered by this account in the first place.
         #[derive(Debug, Copy, Clone)]
@@ -908,11 +915,11 @@ pub mod public_blockchain {
                 };
                 let mut params = BTreeMap::new();
                 params.insert(
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone(),
                     object_id.into(),
                 );
                 Ok(PermissionToken::new(
-                    CAN_UNREGISTER_ASSET_WITH_DEFINITION,
+                    CAN_UNREGISTER_ASSET_WITH_DEFINITION.clone(),
                     params,
                 ))
             }
@@ -938,7 +945,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_UNREGISTER_ASSET_WITH_DEFINITION {
+                if permission_token.name != CAN_UNREGISTER_ASSET_WITH_DEFINITION.clone() {
                     return Err("Grant instruction is not for unregister permission.".to_owned());
                 }
                 check_asset_creator_for_token(&permission_token, authority, wsv)
@@ -952,7 +959,8 @@ pub mod public_blockchain {
         use super::*;
 
         /// Can mint asset with the corresponding asset definition.
-        pub const CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN: &str = "can_mint_user_asset_definitions";
+        pub static CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN: Lazy<Name> =
+            Lazy::new(|| Name::new("can_mint_user_asset_definitions"));
 
         /// Checks that account can mint only the assets which were registered by this account.
         #[derive(Debug, Copy, Clone)]
@@ -1024,7 +1032,7 @@ pub mod public_blockchain {
                     asset_id.definition_id.into(),
                 );
                 Ok(PermissionToken::new(
-                    CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
+                    CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN.clone(),
                     params,
                 ))
             }
@@ -1050,7 +1058,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN {
+                if permission_token.name != CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN.clone() {
                     return Err("Grant instruction is not for mint permission.".to_owned());
                 }
                 check_asset_creator_for_token(&permission_token, authority, wsv)
@@ -1064,9 +1072,11 @@ pub mod public_blockchain {
         use super::*;
 
         /// Can burn asset with the corresponding asset definition.
-        pub const CAN_BURN_ASSET_WITH_DEFINITION: &str = "can_burn_asset_with_definition";
+        pub static CAN_BURN_ASSET_WITH_DEFINITION: Lazy<Name> =
+            Lazy::new(|| Name::new("can_burn_asset_with_definition"));
         /// Can burn user's assets permission token name.
-        pub const CAN_BURN_USER_ASSETS_TOKEN: &str = "can_burn_user_assets";
+        pub static CAN_BURN_USER_ASSETS_TOKEN: Lazy<Name> =
+            Lazy::new(|| Name::new("can_burn_user_assets"));
 
         /// Checks that account can burn only the assets which were registered by this account.
         #[derive(Debug, Copy, Clone)]
@@ -1137,7 +1147,10 @@ pub mod public_blockchain {
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
                     asset_id.definition_id.into(),
                 );
-                Ok(PermissionToken::new(CAN_BURN_ASSET_WITH_DEFINITION, params))
+                Ok(PermissionToken::new(
+                    CAN_BURN_ASSET_WITH_DEFINITION.clone(),
+                    params,
+                ))
             }
         }
 
@@ -1161,7 +1174,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_BURN_ASSET_WITH_DEFINITION {
+                if permission_token.name != CAN_BURN_ASSET_WITH_DEFINITION.clone() {
                     return Err("Grant instruction is not for burn permission.".to_owned());
                 }
                 check_asset_creator_for_token(&permission_token, authority, wsv)
@@ -1227,7 +1240,10 @@ pub mod public_blockchain {
                 };
                 let mut params = BTreeMap::new();
                 params.insert(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), destination_id.into());
-                Ok(PermissionToken::new(CAN_BURN_USER_ASSETS_TOKEN, params))
+                Ok(PermissionToken::new(
+                    CAN_BURN_USER_ASSETS_TOKEN.clone(),
+                    params,
+                ))
             }
         }
 
@@ -1251,7 +1267,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_BURN_USER_ASSETS_TOKEN {
+                if permission_token.name != CAN_BURN_USER_ASSETS_TOKEN.clone() {
                     return Err("Grant instruction is not for burn permission.".to_owned());
                 }
                 check_asset_owner_for_token(&permission_token, authority)?;
@@ -1266,22 +1282,25 @@ pub mod public_blockchain {
         use super::*;
 
         /// Can set key value in user's assets permission token name.
-        pub const CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN: &str = "can_set_key_value_in_user_assets";
+        pub static CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN: Lazy<Name> =
+            Lazy::new(|| Name::new("can_set_key_value_in_user_assets"));
         /// Can remove key value in user's assets permission token name.
-        pub const CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS: &str = "can_remove_key_value_in_user_assets";
+        pub static CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS: Lazy<Name> =
+            Lazy::new(|| Name::new("can_remove_key_value_in_user_assets"));
         /// Can burn user's assets permission token name.
-        pub const CAN_SET_KEY_VALUE_IN_USER_METADATA: &str = "can_set_key_value_in_user_metadata";
+        pub static CAN_SET_KEY_VALUE_IN_USER_METADATA: Lazy<Name> =
+            Lazy::new(|| Name::new("can_set_key_value_in_user_metadata"));
         /// Can burn user's assets permission token name.
-        pub const CAN_REMOVE_KEY_VALUE_IN_USER_METADATA: &str =
-            "can_remove_key_value_in_user_metadata";
+        pub static CAN_REMOVE_KEY_VALUE_IN_USER_METADATA: Lazy<Name> =
+            Lazy::new(|| Name::new("can_remove_key_value_in_user_metadata"));
         /// Can set key value in the corresponding asset definition.
-        pub const CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION: &str =
-            "can_set_key_value_in_asset_definition";
+        pub static CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION: Lazy<Name> =
+            Lazy::new(|| Name::new("can_set_key_value_in_asset_definition"));
         /// Can remove key value in the corresponding asset definition.
-        pub const CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION: &str =
-            "can_remove_key_value_in_asset_definition";
+        pub static CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION: Lazy<Name> =
+            Lazy::new(|| Name::new("can_remove_key_value_in_asset_definition"));
         /// Target account id for setting and removing key value permission tokens.
-        pub const ACCOUNT_ID_TOKEN_PARAM_NAME: &str = "account_id";
+        pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("account_id"));
 
         /// Checks that account can set keys for assets only for the signer account.
         #[derive(Debug, Copy, Clone)]
@@ -1346,7 +1365,7 @@ pub mod public_blockchain {
                 let mut params = BTreeMap::new();
                 params.insert(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), object_id.into());
                 Ok(PermissionToken::new(
-                    CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN,
+                    CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN.clone(),
                     params,
                 ))
             }
@@ -1372,7 +1391,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN {
+                if permission_token.name != CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN.clone() {
                     return Err("Grant instruction is not for set permission.".to_owned());
                 }
                 check_asset_owner_for_token(&permission_token, authority)?;
@@ -1442,7 +1461,7 @@ pub mod public_blockchain {
                 let mut params = BTreeMap::new();
                 params.insert(ACCOUNT_ID_TOKEN_PARAM_NAME.to_owned(), object_id.into());
                 Ok(PermissionToken::new(
-                    CAN_SET_KEY_VALUE_IN_USER_METADATA,
+                    CAN_SET_KEY_VALUE_IN_USER_METADATA.clone(),
                     params,
                 ))
             }
@@ -1468,7 +1487,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_SET_KEY_VALUE_IN_USER_METADATA {
+                if permission_token.name != CAN_SET_KEY_VALUE_IN_USER_METADATA.clone() {
                     return Err("Grant instruction is not for set permission.".to_owned());
                 }
                 check_account_owner_for_token(&permission_token, authority)?;
@@ -1537,7 +1556,7 @@ pub mod public_blockchain {
                 let mut params = BTreeMap::new();
                 params.insert(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), object_id.into());
                 Ok(PermissionToken::new(
-                    CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS,
+                    CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS.clone(),
                     params,
                 ))
             }
@@ -1563,7 +1582,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS {
+                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS.clone() {
                     return Err("Grant instruction is not for set permission.".to_owned());
                 }
                 check_asset_owner_for_token(&permission_token, authority)?;
@@ -1633,7 +1652,7 @@ pub mod public_blockchain {
                 let mut params = BTreeMap::new();
                 params.insert(ACCOUNT_ID_TOKEN_PARAM_NAME.to_owned(), object_id.into());
                 Ok(PermissionToken::new(
-                    CAN_REMOVE_KEY_VALUE_IN_USER_METADATA,
+                    CAN_REMOVE_KEY_VALUE_IN_USER_METADATA.clone(),
                     params,
                 ))
             }
@@ -1659,7 +1678,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_USER_METADATA {
+                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_USER_METADATA.clone() {
                     return Err("Grant instruction is not for remove permission.".to_owned());
                 }
                 check_account_owner_for_token(&permission_token, authority)?;
@@ -1687,7 +1706,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION {
+                if permission_token.name != CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION.clone() {
                     return Err(
                         "Grant instruction is not for set key value in asset definition permission."
                             .to_owned(),
@@ -1717,7 +1736,7 @@ pub mod public_blockchain {
                     .map_err(|e| e.to_string())?
                     .try_into()
                     .map_err(|e: ErrorTryFromEnum<_, _>| e.to_string())?;
-                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION {
+                if permission_token.name != CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION.clone() {
                     return Err(
                         "Grant instruction is not for remove key value in asset definition permission."
                             .to_owned(),
@@ -1840,7 +1859,7 @@ pub mod public_blockchain {
                     object_id.into(),
                 );
                 Ok(PermissionToken::new(
-                    CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION,
+                    CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION.clone(),
                     params,
                 ))
             }
@@ -1879,7 +1898,7 @@ pub mod public_blockchain {
                     object_id.into(),
                 );
                 Ok(PermissionToken::new(
-                    CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION,
+                    CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION.clone(),
                     params,
                 ))
             }
@@ -1931,9 +1950,9 @@ pub mod public_blockchain {
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-                transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
+                transfer::CAN_TRANSFER_USER_ASSETS_TOKEN.clone(),
                 [(
-                    ASSET_ID_TOKEN_PARAM_NAME.to_string(),
+                    ASSET_ID_TOKEN_PARAM_NAME.clone(),
                     alice_xor_id.clone().into(),
                 )],
             ));
@@ -1959,7 +1978,7 @@ pub mod public_blockchain {
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
-                transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
+                transfer::CAN_TRANSFER_USER_ASSETS_TOKEN.clone(),
                 [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
             );
             let wsv = WorldStateView::<World>::new(World::new());
@@ -2016,9 +2035,9 @@ pub mod public_blockchain {
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-                unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
+                unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION.clone(),
                 [(
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone(),
                     xor_id.clone().into(),
                 )],
             ));
@@ -2045,7 +2064,7 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
-                unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
+                unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION.clone(),
                 [(
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
                     xor_id.clone().into(),
@@ -2119,9 +2138,9 @@ pub mod public_blockchain {
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-                mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
+                mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN.clone(),
                 [(
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone(),
                     xor_id.clone().into(),
                 )],
             ));
@@ -2150,7 +2169,7 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
-                mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
+                mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN.clone(),
                 [(
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
                     xor_id.clone().into(),
@@ -2223,9 +2242,9 @@ pub mod public_blockchain {
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-                burn::CAN_BURN_ASSET_WITH_DEFINITION,
+                burn::CAN_BURN_ASSET_WITH_DEFINITION.clone(),
                 [(
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.clone(),
                     xor_id.clone().into(),
                 )],
             ));
@@ -2254,7 +2273,7 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
-                burn::CAN_BURN_ASSET_WITH_DEFINITION,
+                burn::CAN_BURN_ASSET_WITH_DEFINITION.clone(),
                 [(
                     ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
                     xor_id.clone().into(),
@@ -2301,9 +2320,9 @@ pub mod public_blockchain {
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
-                burn::CAN_BURN_USER_ASSETS_TOKEN,
+                burn::CAN_BURN_USER_ASSETS_TOKEN.clone(),
                 [(
-                    ASSET_ID_TOKEN_PARAM_NAME.to_string(),
+                    ASSET_ID_TOKEN_PARAM_NAME.clone(),
                     alice_xor_id.clone().into(),
                 )],
             ));
@@ -2328,7 +2347,7 @@ pub mod public_blockchain {
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
-                burn::CAN_BURN_USER_ASSETS_TOKEN,
+                burn::CAN_BURN_USER_ASSETS_TOKEN.clone(),
                 [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
             );
             let wsv = WorldStateView::<World>::new(World::new());

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -129,7 +129,7 @@ pub mod private_blockchain {
 
         /// Can register domains permission token name.
         pub static CAN_REGISTER_DOMAINS_TOKEN: Lazy<Name> =
-            Lazy::new(|| Name::new("can_register_domains"));
+            Lazy::new(|| Name::test("can_register_domains"));
 
         /// Prohibits registering domains.
         #[derive(Debug, Copy, Clone)]
@@ -581,12 +581,12 @@ pub mod public_blockchain {
     use super::*;
 
     /// Origin asset id param used in permission tokens.
-    pub static ASSET_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("asset_id"));
+    pub static ASSET_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::test("asset_id"));
     /// Origin account id param used in permission tokens.
-    pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("account_id"));
+    pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::test("account_id"));
     /// Origin asset definition param used in permission tokens.
     pub static ASSET_DEFINITION_ID_TOKEN_PARAM_NAME: Lazy<Name> =
-        Lazy::new(|| Name::new("asset_definition_id"));
+        Lazy::new(|| Name::test("asset_definition_id"));
 
     /// A preconfigured set of permissions for simple use cases.
     pub fn default_permissions<W: WorldTrait>() -> IsInstructionAllowedBoxed<W> {
@@ -743,7 +743,7 @@ pub mod public_blockchain {
 
         /// Can transfer user's assets permission token name.
         pub static CAN_TRANSFER_USER_ASSETS_TOKEN: Lazy<Name> =
-            Lazy::new(|| Name::new("can_transfer_user_assets"));
+            Lazy::new(|| Name::test("can_transfer_user_assets"));
 
         /// Checks that account transfers only the assets that he owns.
         #[derive(Debug, Copy, Clone)]
@@ -847,7 +847,7 @@ pub mod public_blockchain {
 
         /// Can unregister asset with the corresponding asset definition.
         pub static CAN_UNREGISTER_ASSET_WITH_DEFINITION: Lazy<Name> =
-            Lazy::new(|| Name::new("can_unregister_asset_with_definition"));
+            Lazy::new(|| Name::test("can_unregister_asset_with_definition"));
 
         /// Checks that account can unregister only the assets which were registered by this account in the first place.
         #[derive(Debug, Copy, Clone)]
@@ -960,7 +960,7 @@ pub mod public_blockchain {
 
         /// Can mint asset with the corresponding asset definition.
         pub static CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN: Lazy<Name> =
-            Lazy::new(|| Name::new("can_mint_user_asset_definitions"));
+            Lazy::new(|| Name::test("can_mint_user_asset_definitions"));
 
         /// Checks that account can mint only the assets which were registered by this account.
         #[derive(Debug, Copy, Clone)]
@@ -1073,10 +1073,10 @@ pub mod public_blockchain {
 
         /// Can burn asset with the corresponding asset definition.
         pub static CAN_BURN_ASSET_WITH_DEFINITION: Lazy<Name> =
-            Lazy::new(|| Name::new("can_burn_asset_with_definition"));
+            Lazy::new(|| Name::test("can_burn_asset_with_definition"));
         /// Can burn user's assets permission token name.
         pub static CAN_BURN_USER_ASSETS_TOKEN: Lazy<Name> =
-            Lazy::new(|| Name::new("can_burn_user_assets"));
+            Lazy::new(|| Name::test("can_burn_user_assets"));
 
         /// Checks that account can burn only the assets which were registered by this account.
         #[derive(Debug, Copy, Clone)]
@@ -1283,24 +1283,24 @@ pub mod public_blockchain {
 
         /// Can set key value in user's assets permission token name.
         pub static CAN_SET_KEY_VALUE_USER_ASSETS_TOKEN: Lazy<Name> =
-            Lazy::new(|| Name::new("can_set_key_value_in_user_assets"));
+            Lazy::new(|| Name::test("can_set_key_value_in_user_assets"));
         /// Can remove key value in user's assets permission token name.
         pub static CAN_REMOVE_KEY_VALUE_IN_USER_ASSETS: Lazy<Name> =
-            Lazy::new(|| Name::new("can_remove_key_value_in_user_assets"));
+            Lazy::new(|| Name::test("can_remove_key_value_in_user_assets"));
         /// Can burn user's assets permission token name.
         pub static CAN_SET_KEY_VALUE_IN_USER_METADATA: Lazy<Name> =
-            Lazy::new(|| Name::new("can_set_key_value_in_user_metadata"));
+            Lazy::new(|| Name::test("can_set_key_value_in_user_metadata"));
         /// Can burn user's assets permission token name.
         pub static CAN_REMOVE_KEY_VALUE_IN_USER_METADATA: Lazy<Name> =
-            Lazy::new(|| Name::new("can_remove_key_value_in_user_metadata"));
+            Lazy::new(|| Name::test("can_remove_key_value_in_user_metadata"));
         /// Can set key value in the corresponding asset definition.
         pub static CAN_SET_KEY_VALUE_IN_ASSET_DEFINITION: Lazy<Name> =
-            Lazy::new(|| Name::new("can_set_key_value_in_asset_definition"));
+            Lazy::new(|| Name::test("can_set_key_value_in_asset_definition"));
         /// Can remove key value in the corresponding asset definition.
         pub static CAN_REMOVE_KEY_VALUE_IN_ASSET_DEFINITION: Lazy<Name> =
-            Lazy::new(|| Name::new("can_remove_key_value_in_asset_definition"));
+            Lazy::new(|| Name::test("can_remove_key_value_in_asset_definition"));
         /// Target account id for setting and removing key value permission tokens.
-        pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::new("account_id"));
+        pub static ACCOUNT_ID_TOKEN_PARAM_NAME: Lazy<Name> = Lazy::new(|| Name::test("account_id"));
 
         /// Checks that account can set keys for assets only for the signer account.
         #[derive(Debug, Copy, Clone)]
@@ -1921,11 +1921,10 @@ pub mod public_blockchain {
 
         #[test]
         fn transfer_only_owned_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "bob", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let transfer = Instruction::Transfer(TransferBox {
                 source_id: IdBox::AssetId(alice_xor_id).into(),
@@ -1942,11 +1941,10 @@ pub mod public_blockchain {
 
         #[test]
         fn transfer_granted_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "bob", "test");
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
@@ -1957,7 +1955,7 @@ pub mod public_blockchain {
                 )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = vec![(DomainId::new("test"), domain)];
+            let domains = vec![(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, BTreeSet::new()));
             let transfer = Instruction::Transfer(TransferBox {
                 source_id: IdBox::AssetId(alice_xor_id).into(),
@@ -1973,10 +1971,9 @@ pub mod public_blockchain {
 
         #[test]
         fn grant_transfer_of_my_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
                 transfer::CAN_TRANSFER_USER_ASSETS_TOKEN.clone(),
                 [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
@@ -1993,16 +1990,16 @@ pub mod public_blockchain {
 
         #[test]
         fn unregister_only_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    DomainId::new("test"),
+                    DomainId::test("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        id: DomainId::new("test"),
+                        id: DomainId::test("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {
@@ -2028,9 +2025,9 @@ pub mod public_blockchain {
 
         #[test]
         fn unregister_granted_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
@@ -2046,7 +2043,7 @@ pub mod public_blockchain {
                 xor_id.clone(),
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Unregister(UnregisterBox::new(xor_id));
             let validator: IsInstructionAllowedBoxed<World> =
@@ -2059,9 +2056,9 @@ pub mod public_blockchain {
 
         #[test]
         fn grant_unregister_of_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION.clone(),
@@ -2075,7 +2072,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
 
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let grant = Instruction::Grant(GrantBox {
@@ -2090,18 +2087,17 @@ pub mod public_blockchain {
 
         #[test]
         fn mint_only_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    DomainId::new("test"),
+                    DomainId::test("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        id: DomainId::new("test"),
+                        id: DomainId::test("test"),
                         asset_definitions: [(
                             xor_id,
                             AssetDefinitionEntry {
@@ -2129,11 +2125,10 @@ pub mod public_blockchain {
 
         #[test]
         fn mint_granted_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
@@ -2149,7 +2144,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Mint(MintBox {
                 object: Value::U32(100).into(),
@@ -2164,9 +2159,9 @@ pub mod public_blockchain {
 
         #[test]
         fn grant_mint_of_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN.clone(),
@@ -2180,7 +2175,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2194,18 +2189,17 @@ pub mod public_blockchain {
 
         #[test]
         fn burn_only_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    DomainId::new("test"),
+                    DomainId::test("test"),
                     Domain {
                         accounts: [].into(),
-                        id: DomainId::new("test"),
+                        id: DomainId::test("test"),
                         asset_definitions: [(
                             xor_id,
                             AssetDefinitionEntry {
@@ -2233,11 +2227,10 @@ pub mod public_blockchain {
 
         #[test]
         fn burn_granted_asset_definition() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
@@ -2253,7 +2246,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let instruction = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -2268,9 +2261,9 @@ pub mod public_blockchain {
 
         #[test]
         fn grant_burn_of_assets_created_by_this_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 burn::CAN_BURN_ASSET_WITH_DEFINITION.clone(),
@@ -2284,7 +2277,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [(DomainId::new("test"), domain)];
+            let domains = [(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2298,10 +2291,9 @@ pub mod public_blockchain {
 
         #[test]
         fn burn_only_owned_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let burn = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -2313,10 +2305,9 @@ pub mod public_blockchain {
 
         #[test]
         fn burn_granted_assets() -> Result<(), String> {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
@@ -2327,7 +2318,7 @@ pub mod public_blockchain {
                 )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = vec![(DomainId::new("test"), domain)];
+            let domains = vec![(DomainId::test("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let transfer = Instruction::Burn(BurnBox {
                 object: Value::U32(10).into(),
@@ -2342,10 +2333,9 @@ pub mod public_blockchain {
 
         #[test]
         fn grant_burn_of_my_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
                 burn::CAN_BURN_USER_ASSETS_TOKEN.clone(),
                 [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
@@ -2362,10 +2352,9 @@ pub mod public_blockchain {
 
         #[test]
         fn set_to_only_owned_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let set = Instruction::SetKeyValue(SetKeyValueBox::new(
                 IdBox::AssetId(alice_xor_id),
@@ -2382,10 +2371,9 @@ pub mod public_blockchain {
 
         #[test]
         fn remove_to_only_owned_assets() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let alice_xor_id =
-                <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let alice_xor_id = <Asset as Identifiable>::Id::test("xor", "test", "alice", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
                 IdBox::AssetId(alice_xor_id),
@@ -2401,8 +2389,8 @@ pub mod public_blockchain {
 
         #[test]
         fn set_to_only_owned_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let set = Instruction::SetKeyValue(SetKeyValueBox::new(
                 IdBox::AccountId(alice_id.clone()),
@@ -2419,8 +2407,8 @@ pub mod public_blockchain {
 
         #[test]
         fn remove_to_only_owned_account() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
             let wsv = WorldStateView::<World>::new(World::new());
             let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
                 IdBox::AccountId(alice_id.clone()),
@@ -2436,16 +2424,16 @@ pub mod public_blockchain {
 
         #[test]
         fn set_to_only_owned_asset_definition() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    DomainId::new("test"),
+                    DomainId::test("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        id: DomainId::new("test"),
+                        id: DomainId::test("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {
@@ -2474,16 +2462,16 @@ pub mod public_blockchain {
 
         #[test]
         fn remove_to_only_owned_asset_definition() {
-            let alice_id = <Account as Identifiable>::Id::new("alice", "test");
-            let bob_id = <Account as Identifiable>::Id::new("bob", "test");
-            let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
+            let alice_id = <Account as Identifiable>::Id::test("alice", "test");
+            let bob_id = <Account as Identifiable>::Id::test("bob", "test");
+            let xor_id = <AssetDefinition as Identifiable>::Id::test("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    DomainId::new("test"),
+                    DomainId::test("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        id: DomainId::new("test"),
+                        id: DomainId::test("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -384,7 +384,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -212,7 +212,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -226,7 +226,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -235,17 +235,17 @@ pub mod private_blockchain {
                             ))
                         }
                     }
-                    FindAccountsByDomainName(query) => {
-                        let domain_name = query
-                            .domain_name
+                    FindAccountsByDomainId(query) => {
+                        let domain_id = query
+                            .domain_id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if domain_name == authority.domain_name {
+                        if domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
                                 "Cannot access accounts from a different domain with name {}.",
-                                domain_name
+                                domain_id
                             ))
                         }
                     }
@@ -254,7 +254,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if asset_id.account_id.domain_name == authority.domain_name {
+                        if asset_id.account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -268,7 +268,7 @@ pub mod private_blockchain {
                             .account_id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -277,31 +277,31 @@ pub mod private_blockchain {
                             ))
                         }
                     }
-                    FindAssetsByDomainName(query) => {
-                        let domain_name = query
-                            .domain_name
+                    FindAssetsByDomainId(query) => {
+                        let domain_id = query
+                            .domain_id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if domain_name == authority.domain_name {
+                        if domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
                                 "Cannot access assets from a different domain with name {}.",
-                                domain_name
+                                domain_id
                             ))
                         }
                     }
-                    FindAssetsByDomainNameAndAssetDefinitionId(query) => {
-                        let domain_name = query
-                            .domain_name
+                    FindAssetsByDomainIdAndAssetDefinitionId(query) => {
+                        let domain_id = query
+                            .domain_id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if domain_name == authority.domain_name {
+                        if domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
                                 "Cannot access assets from a different domain with name {}.",
-                                domain_name
+                                domain_id
                             ))
                         }
                     }
@@ -310,13 +310,13 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if asset_definition_id.domain_name == authority.domain_name {
+                        if asset_definition_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
                                 "Cannot access asset definition from a different domain. Asset definition domain: {}. Signers account domain {}.",
-                                asset_definition_id.domain_name,
-                                authority.domain_name
+                                asset_definition_id.domain_id,
+                                authority.domain_id
                             ))
                         }
                     }
@@ -325,7 +325,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if asset_id.account_id.domain_name == authority.domain_name {
+                        if asset_id.account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -339,7 +339,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if asset_id.account_id.domain_name == authority.domain_name {
+                        if asset_id.account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -348,21 +348,17 @@ pub mod private_blockchain {
                             ))
                         }
                     }
-                    FindDomainByName(query::FindDomainByName { name })
+                    FindDomainById(query::FindDomainById { id })
                     | FindDomainKeyValueByIdAndKey(query::FindDomainKeyValueByIdAndKey {
-                        name,
+                        id,
                         ..
                     }) => {
-                        let domain_name = name
-                            .evaluate(wsv, &context)
-                            .map_err(|err| err.to_string())?;
-                        if domain_name == authority.domain_name {
+                        let domain_id =
+                            id.evaluate(wsv, &context).map_err(|err| err.to_string())?;
+                        if domain_id == authority.domain_id {
                             Ok(())
                         } else {
-                            Err(format!(
-                                "Cannot access a different domain: {}.",
-                                domain_name
-                            ))
+                            Err(format!("Cannot access a different domain: {}.", domain_id))
                         }
                     }
                     FindTransactionsByAccountId(query) => {
@@ -370,7 +366,7 @@ pub mod private_blockchain {
                             .account_id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -400,7 +396,7 @@ pub mod private_blockchain {
                             .id
                             .evaluate(wsv, &context)
                             .map_err(|err| err.to_string())?;
-                        if account_id.domain_name == authority.domain_name {
+                        if account_id.domain_id == authority.domain_id {
                             Ok(())
                         } else {
                             Err(format!(
@@ -432,16 +428,16 @@ pub mod private_blockchain {
                 let context = Context::new();
                 match query {
                     FindAccountsByName(_)
-                    | FindAccountsByDomainName(_)
+                    | FindAccountsByDomainId(_)
                     | FindAllAccounts(_)
                     | FindAllAssetsDefinitions(_)
                     | FindAssetsByAssetDefinitionId(_)
-                    | FindAssetsByDomainName(_)
+                    | FindAssetsByDomainId(_)
                     | FindAssetsByName(_)
                     | FindAllDomains(_)
-                    | FindDomainByName(_)
+                    | FindDomainById(_)
                     | FindDomainKeyValueByIdAndKey(_)
-                    | FindAssetsByDomainNameAndAssetDefinitionId(_)
+                    | FindAssetsByDomainIdAndAssetDefinitionId(_)
                     | FindAssetDefinitionKeyValueByIdAndKey(_)
                     | FindAllAssets(_) => {
                         Err("Only access to the assets of the same domain is permitted.".to_owned())
@@ -1932,7 +1928,7 @@ pub mod public_blockchain {
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let bob_xor_id = <Asset as Identifiable>::Id::from_names("xor", "test", "bob", "test");
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
@@ -1942,7 +1938,7 @@ pub mod public_blockchain {
                 )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = vec![("test".to_string(), domain)];
+            let domains = vec![(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, BTreeSet::new()));
             let transfer = Instruction::Transfer(TransferBox {
                 source_id: IdBox::AssetId(alice_xor_id).into(),
@@ -1984,10 +1980,10 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    "test".to_owned(),
+                    DomainId::new("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        name: "test".to_owned(),
+                        id: DomainId::new("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {
@@ -2017,7 +2013,7 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
@@ -2031,7 +2027,7 @@ pub mod public_blockchain {
                 xor_id.clone(),
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Unregister(UnregisterBox::new(xor_id));
             let validator: IsInstructionAllowedBoxed<World> =
@@ -2055,12 +2051,12 @@ pub mod public_blockchain {
                     xor_id.clone().into(),
                 )],
             );
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
 
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let grant = Instruction::Grant(GrantBox {
@@ -2083,10 +2079,10 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    "test".to_string(),
+                    DomainId::new("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        name: "test".to_string(),
+                        id: DomainId::new("test"),
                         asset_definitions: [(
                             xor_id,
                             AssetDefinitionEntry {
@@ -2120,7 +2116,7 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
@@ -2134,7 +2130,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Mint(MintBox {
                 object: Value::U32(100).into(),
@@ -2160,12 +2156,12 @@ pub mod public_blockchain {
                     xor_id.clone().into(),
                 )],
             );
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2187,10 +2183,10 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    "test".to_string(),
+                    DomainId::new("test"),
                     Domain {
                         accounts: [].into(),
-                        name: "test".to_string(),
+                        id: DomainId::new("test"),
                         asset_definitions: [(
                             xor_id,
                             AssetDefinitionEntry {
@@ -2224,7 +2220,7 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 burn::CAN_BURN_ASSET_WITH_DEFINITION,
@@ -2238,7 +2234,7 @@ pub mod public_blockchain {
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let instruction = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -2264,12 +2260,12 @@ pub mod public_blockchain {
                     xor_id.clone().into(),
                 )],
             );
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = [("test".to_owned(), domain)];
+            let domains = [(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2302,7 +2298,7 @@ pub mod public_blockchain {
             let bob_id = <Account as Identifiable>::Id::new("bob", "test");
             let alice_xor_id =
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
-            let mut domain = Domain::new("test");
+            let mut domain = Domain::test("test");
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 burn::CAN_BURN_USER_ASSETS_TOKEN,
@@ -2312,7 +2308,7 @@ pub mod public_blockchain {
                 )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
-            let domains = vec![("test".to_string(), domain)];
+            let domains = vec![(DomainId::new("test"), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let transfer = Instruction::Burn(BurnBox {
                 object: Value::U32(10).into(),
@@ -2427,10 +2423,10 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    "test".to_string(),
+                    DomainId::new("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        name: "test".to_string(),
+                        id: DomainId::new("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {
@@ -2465,10 +2461,10 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
                 [(
-                    "test".to_string(),
+                    DomainId::new("test"),
                     Domain {
                         accounts: BTreeMap::new(),
-                        name: "test".to_string(),
+                        id: DomainId::new("test"),
                         asset_definitions: [(
                             xor_id.clone(),
                             AssetDefinitionEntry {


### PR DESCRIPTION
### Description of the Change
- Prohibit a whitespace from getting into a `Name` of domain, account, asset, metadata key, and permission token.
- Identify `Domain` by `Id` instead of `Name`

Now `Id::new`s return `Result<Self>`, while previous implementations are left as `Id::test`s for usability

### Issue
Close #1734

### Benefits
Type level guarantee of no whitespaces in `Name` 

### Possible Drawbacks
There might be a better error handling for `Name` validation