### PR TITLE
[fix] #1742: Concrete errors returned in `core` instructions.

### DIFF
--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -10,11 +10,12 @@ use super::*;
 impl<W: WorldTrait> ValidQuery<W> for FindTransactionsByAccountId {
     #[log]
     #[metrics(+"find_transactions_by_account_id")]
-    fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
+    fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output, query::Error> {
         let id = self
             .account_id
             .evaluate(wsv, &Context::default())
-            .wrap_err("Failed to get id")?;
+            .wrap_err("Failed to get account id")
+            .map_err(query::Error::Evaluate)?;
         Ok(wsv.transactions_values_by_account_id(&id))
     }
 }
@@ -22,16 +23,17 @@ impl<W: WorldTrait> ValidQuery<W> for FindTransactionsByAccountId {
 impl<W: WorldTrait> ValidQuery<W> for FindTransactionByHash {
     #[log]
     #[metrics(+"find_transaction_by_hash")]
-    fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output> {
+    fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output, query::Error> {
         let hash = self
             .hash
             .evaluate(wsv, &Context::default())
-            .wrap_err("Failed to get hash")?;
+            .wrap_err("Failed to get hash")
+            .map_err(query::Error::Evaluate)?;
         let hash = HashOf::from_hash(hash);
         if !wsv.has_transaction(&hash) {
-            return Err(eyre!("Transaction not found"));
+            return Err(FindError::Transaction(hash).into());
         };
         wsv.transaction_value_by_hash(&hash)
-            .ok_or_else(|| eyre!("Failed to fetch transaction"))
+            .ok_or_else(|| FindError::Transaction(hash).into())
     }
 }

--- a/core/src/smartcontracts/mod.rs
+++ b/core/src/smartcontracts/mod.rs
@@ -4,8 +4,6 @@
 
 pub mod isi;
 
-use std::error::Error;
-
 use iroha_data_model::prelude::*;
 pub use isi::*;
 
@@ -16,7 +14,7 @@ use crate::wsv::WorldTrait;
 #[allow(clippy::missing_errors_doc)]
 pub trait Execute<W: WorldTrait> {
     /// Error type returned by execute function
-    type Error: Error;
+    type Error: std::error::Error;
 
     /// Apply actions to `wsv` on behalf of `authority`.
     fn execute(
@@ -31,9 +29,15 @@ pub trait Execute<W: WorldTrait> {
 pub trait Evaluate<W: WorldTrait> {
     /// The resulting type of the expression.
     type Value;
+    /// Error type returned if the evaluation fails. Typically just [`isi::error::Error`].
+    type Error: std::error::Error;
 
     /// Calculates result.
-    fn evaluate(&self, wsv: &WorldStateView<W>, context: &Context) -> eyre::Result<Self::Value>;
+    fn evaluate(
+        &self,
+        wsv: &WorldStateView<W>,
+        context: &Context,
+    ) -> Result<Self::Value, Self::Error>;
 }
 
 /// This trait should be implemented for all Iroha Queries.
@@ -43,10 +47,10 @@ pub trait ValidQuery<W: WorldTrait>: Query {
     /// Should not mutate [`WorldStateView`]!
     ///
     /// Returns Ok(QueryResult) if succeeded and Err(String) if failed.
-    fn execute(&self, wsv: &WorldStateView<W>) -> eyre::Result<Self::Output>;
+    fn execute(&self, wsv: &WorldStateView<W>) -> eyre::Result<Self::Output, query::Error>;
 
     /// Executes query and maps it into value
-    fn execute_into_value(&self, wsv: &WorldStateView<W>) -> eyre::Result<Value> {
+    fn execute_into_value(&self, wsv: &WorldStateView<W>) -> eyre::Result<Value, query::Error> {
         self.execute(wsv).map(Into::into)
     }
 }

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -387,7 +387,7 @@ async fn handle_queries<W: WorldTrait>(
     request: VerifiedQueryRequest,
 ) -> Result<Scale<VersionedQueryResult>, query::Error> {
     let valid_request = request.validate(&wsv, &query_validator)?;
-    let result = valid_request.execute(&wsv).map_err(query::Error::Find)?;
+    let result = valid_request.execute(&wsv)?;
     let result = QueryResult(if let Value::Vec(value) = result {
         Value::Vec(value.into_iter().paginate(pagination).collect())
     } else {

--- a/data_model/src/fixed.rs
+++ b/data_model/src/fixed.rs
@@ -98,15 +98,29 @@ pub enum FixedPointOperationError {
     /// Conversion failed.
     #[error("Failed to produce fixed point number")]
     Conversion(#[source] ConvertError),
-    /// The arithmetic operation failed.
-    #[error("Arithmetic error")]
-    Arithmetic(#[source] ArithmeticError),
+    /// Overflow
+    #[error("Overflow")]
+    Overflow,
+    /// Division by zero
+    #[error("Division by zero")]
+    DivideByZero,
+    /// Domain violation. E.g. computing `sqrt(-1)`
+    #[error("Domain violation")]
+    DomainViolation,
+    /// Arithmetic
+    #[error("Unknown Arithmetic error")]
+    Arithmetic,
 }
 
 impl From<ArithmeticError> for FixedPointOperationError {
     #[inline]
     fn from(err: ArithmeticError) -> Self {
-        Self::Arithmetic(err)
+        match err {
+            ArithmeticError::Overflow => Self::Overflow,
+            ArithmeticError::DivisionByZero => Self::DivideByZero,
+            ArithmeticError::DomainViolation => Self::DomainViolation,
+            _ => Self::Arithmetic,
+        }
     }
 }
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -31,8 +31,9 @@ pub mod metadata;
 pub mod query;
 pub mod transaction;
 
-/// `Name` struct represents type for Iroha Entities names, like [`Domain`](`domain::Domain`)'s name or [`Account`](`account::Account`)'s
-/// name.
+/// `Name` struct represents type for Iroha Entities names, like
+/// [`Domain`](`domain::Domain`)'s name or
+/// [`Account`](`account::Account`)'s name.
 #[derive(
     Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode, Deserialize, Serialize, IntoSchema,
 )]
@@ -111,7 +112,7 @@ pub trait TryAsMut<T> {
     /// The type returned in the event of a conversion error.
     type Error;
 
-    /// Performs the conversion.
+    /// Perform the conversion.
     fn try_as_mut(&mut self) -> Result<&mut T, Self::Error>;
 }
 
@@ -121,7 +122,7 @@ pub trait TryAsRef<T> {
     /// The type returned in the event of a conversion error.
     type Error;
 
-    /// Performs the conversion.
+    /// Perform the conversion.
     fn try_as_ref(&self) -> Result<&T, Self::Error>;
 }
 
@@ -413,7 +414,7 @@ where
                 .collect::<Result<Vec<_>, _>>()
                 .wrap_err("Failed to convert to vector")
         } else {
-            Err(eyre!("Expected vector, but found something else"))
+            Err(eyre::eyre!("Expected vector, but found something else"))
         }
     }
 }
@@ -1767,7 +1768,7 @@ pub mod domain {
 pub mod peer {
     //! This module contains [`Peer`] structure and related implementations and traits implementations.
 
-    use std::hash::Hash;
+    use std::{fmt, hash::Hash};
 
     use dashmap::DashSet;
     use iroha_schema::IntoSchema;
@@ -1820,6 +1821,12 @@ pub mod peer {
         pub public_key: PublicKey,
     }
 
+    impl fmt::Display for Id {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt::Debug::fmt(self, f)
+        }
+    }
+
     impl Peer {
         /// Construct `Peer` given `id`.
         #[inline]
@@ -1847,7 +1854,7 @@ pub mod peer {
         fn from_iter<T: IntoIterator<Item = Id>>(iter: T) -> Self {
             iter.into_iter()
                 .map(Into::into)
-                .collect::<Vec<Self>>()
+                .collect::<Vec<Value>>()
                 .into()
         }
     }
@@ -2111,7 +2118,11 @@ pub mod prelude {
         Bytes, IdBox, Identifiable, IdentifiableBox, Name, Parameter, TryAsMut, TryAsRef, Value,
     };
     pub use crate::{
-        events::prelude::*, expression::prelude::*, isi::prelude::*, metadata::prelude::*,
-        permissions::prelude::*, query::prelude::*,
+        events::prelude::*,
+        expression::prelude::*,
+        isi::prelude::*,
+        metadata::{self, prelude::*},
+        permissions::prelude::*,
+        query::prelude::*,
     };
 }

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -513,7 +513,7 @@ impl Display for InstructionExecutionFail {
             Register(_) => "register",
             Sequence(_) => "sequence",
             Transfer(_) => "transfer",
-            Unregister(_) => "unregister",
+            Unregister(_) => "un-register",
             SetKeyValue(_) => "set key-value pair",
             RemoveKeyValue(_) => "remove key-value pair",
             Grant(_) => "grant",
@@ -530,7 +530,7 @@ impl StdError for InstructionExecutionFail {}
 /// Transaction was reject because of low authority
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, Deserialize, Serialize, IntoSchema)]
 pub struct NotPermittedFail {
-    /// Reason of failure
+    /// The cause of failure.
     pub reason: String,
 }
 


### PR DESCRIPTION
Signed-off-by: Aleksandr <a-p-petrosyan@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Opaque `eyre::Report`s have been replaced with specific `Error` enums. 

### Issue

Closes #1742 

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Opaque error types that could only have been printed are now also possible to handle and match. 


### Possible Drawbacks

None
