### PR TITLE
[fix] #1715: Consensus fixes to handle high load

### DIFF
--- a/configs/peer/config.json
+++ b/configs/peer/config.json
@@ -3,11 +3,7 @@
     "P2P_ADDR": "127.0.0.1:1337",
     "API_URL": "http://127.0.0.1:8080"
   },
-  "SUMERAGI": {
-    "BLOCK_TIME_MS": 1000,
-    "COMMIT_TIME_MS": 1000,
-    "TX_RECEIPT_TIME_MS": 100
-  },
+  "SUMERAGI": {},
   "KURA": {
     "INIT_MODE": "strict",
     "BLOCK_STORE_PATH": "./blocks"

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -62,6 +62,7 @@ pub trait GenesisNetworkTrait:
         &self,
         sumeragi: &mut Sumeragi<Self, K, W>,
         network: Addr<IrohaNetwork>,
+        ctx: &mut iroha_actor::Context<Sumeragi<Self, K, W>>,
     ) -> Result<()> {
         let genesis_topology = self
             .wait_for_peers(sumeragi.peer_id.clone(), sumeragi.topology.clone(), network)
@@ -69,7 +70,7 @@ pub trait GenesisNetworkTrait:
         time::sleep(Duration::from_millis(self.genesis_submission_delay_ms())).await;
         iroha_logger::info!("Initializing iroha using the genesis block.");
         sumeragi
-            .start_genesis_round(self.deref().clone(), genesis_topology)
+            .start_genesis_round(self.deref().clone(), genesis_topology, ctx)
             .await
     }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -16,7 +16,7 @@ use crate::{
     kura::KuraTrait,
     sumeragi::{
         network_topology::{GenesisBuilder as GenesisTopologyBuilder, Topology},
-        Sumeragi,
+        FaultInjection, SumeragiWithFault,
     },
     tx::VersionedAcceptedTransaction,
     wsv::WorldTrait,
@@ -54,15 +54,19 @@ pub trait GenesisNetworkTrait:
         network: Addr<IrohaNetwork>,
     ) -> Result<Topology>;
 
+    // FIXME: Having `ctx` reference and `sumaregi` reference here is not ideal.
+    // The way it is currently designed, this function is called from sumeragi and then calls sumeragi, while being in an unrelated module.
+    // This needs to be restructured.
+
     /// Submits genesis transactions.
     ///
     /// # Errors
     /// Returns error if waiting for peers or genesis round itself fails
-    async fn submit_transactions<K: KuraTrait, W: WorldTrait>(
+    async fn submit_transactions<K: KuraTrait, W: WorldTrait, F: FaultInjection>(
         &self,
-        sumeragi: &mut Sumeragi<Self, K, W>,
+        sumeragi: &mut SumeragiWithFault<Self, K, W, F>,
         network: Addr<IrohaNetwork>,
-        ctx: &mut iroha_actor::Context<Sumeragi<Self, K, W>>,
+        ctx: &mut iroha_actor::Context<SumeragiWithFault<Self, K, W, F>>,
     ) -> Result<()> {
         let genesis_topology = self
             .wait_for_peers(sumeragi.peer_id.clone(), sumeragi.topology.clone(), network)

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -7,6 +7,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use eyre::{Report, Result};
 use iroha_crypto::HashOf;
 use iroha_data_model::transaction::prelude::*;
+use rand::seq::IteratorRandom;
 use thiserror::Error;
 
 pub use self::config::Configuration;
@@ -84,6 +85,19 @@ impl Queue {
             .filter(|e| self.is_pending(e.value(), wsv))
             .map(|e| e.value().clone())
             .collect()
+    }
+
+    /// Returns `n` randomly selected transaction from the queue.
+    pub fn n_random_transactions<W: WorldTrait>(
+        &self,
+        wsv: &WorldStateView<W>,
+        n: usize,
+    ) -> Vec<VersionedAcceptedTransaction> {
+        self.txs
+            .iter()
+            .filter(|e| self.is_pending(e.value(), wsv))
+            .map(|e| e.value().clone())
+            .choose_multiple(&mut rand::thread_rng(), n)
     }
 
     fn check_tx<W: WorldTrait>(

--- a/core/src/samples.rs
+++ b/core/src/samples.rs
@@ -81,6 +81,7 @@ pub fn get_config(trusted_peers: HashSet<PeerId>, key_pair: Option<KeyPair>) -> 
             trusted_peers: TrustedPeers {
                 peers: trusted_peers,
             },
+            gossip_period_ms: 500,
             ..SumeragiConfiguration::default()
         },
         torii: ToriiConfiguration {

--- a/core/src/sumeragi/view_change.rs
+++ b/core/src/sumeragi/view_change.rs
@@ -5,12 +5,11 @@ use std::{collections::HashSet, fmt::Display};
 
 use eyre::{Context, Result};
 use iroha_crypto::{HashOf, KeyPair, PublicKey, SignatureOf, SignaturesOf};
-use iroha_data_model::{prelude::PeerId, transaction::VersionedTransaction};
+use iroha_data_model::prelude::PeerId;
 use iroha_macro::*;
 use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode};
 
-use super::message::TransactionReceipt;
 use crate::block::{EmptyChainHash, VersionedCommittedBlock, VersionedValidBlock};
 
 /// The proof of a view change. It needs to be signed by f+1 peers for proof to be valid and view change to happen.
@@ -21,7 +20,7 @@ pub struct Proof {
 }
 
 impl Proof {
-    fn hash(&self) -> HashOf<Self> {
+    pub fn hash(&self) -> HashOf<Self> {
         HashOf::new(&self.payload).transmute()
     }
 
@@ -56,15 +55,12 @@ impl Proof {
     /// # Errors
     /// Can fail due to signing
     pub fn block_creation_timeout(
-        transaction_receipt: TransactionReceipt,
         previous_proof: HashOf<Self>,
         latest_block: HashOf<VersionedCommittedBlock>,
         key_pair: KeyPair,
     ) -> Result<Self> {
         let payload = ProofPayload {
-            reason: Reason::from(BlockCreationTimeout {
-                transaction_receipt,
-            }),
+            reason: Reason::from(BlockCreationTimeout),
             previous_proof,
             latest_block,
         };
@@ -75,15 +71,12 @@ impl Proof {
     /// # Errors
     /// Can fail due to signing
     pub fn no_transaction_receipt_received(
-        transaction_hash: HashOf<VersionedTransaction>,
         previous_proof: HashOf<Self>,
         latest_block: HashOf<VersionedCommittedBlock>,
         key_pair: KeyPair,
     ) -> Result<Self> {
         let payload = ProofPayload {
-            reason: Reason::NoTransactionReceiptReceived(NoTransactionReceiptReceived {
-                transaction_hash,
-            }),
+            reason: Reason::NoTransactionReceiptReceived(NoTransactionReceiptReceived),
             previous_proof,
             latest_block,
         };
@@ -99,6 +92,13 @@ impl Proof {
         let signature = SignatureOf::new(key_pair, &self.payload)?.transmute();
         self.signatures.add(signature);
         Ok(self)
+    }
+
+    /// Adds verified signatures of `other` to self.
+    pub fn merge_signatures(&mut self, mut other: Proof) {
+        self.signatures.merge(SignaturesOf::from_iter_unchecked(
+            other.signatures.verified_by_hash(self.hash()).cloned(),
+        ));
     }
 
     /// Verify if the proof is valid, given the peers in `topology`.
@@ -143,11 +143,11 @@ impl Proof {
 /// Payload of [`Proof`]
 #[derive(Clone, Debug, Io, Encode, Decode, IntoSchema)]
 pub struct ProofPayload {
-    ///
+    /// Hash os the previous view change proof.
     previous_proof: HashOf<Proof>,
     /// Latest committed block hash.
     latest_block: HashOf<VersionedCommittedBlock>,
-    ///
+    /// Reason for a view change.
     reason: Reason,
 }
 
@@ -181,17 +181,11 @@ pub struct CommitTimeout {
 
 /// `NoTransactionReceiptReceived` (from leader) reason for a view change.
 #[derive(Clone, Debug, Io, Encode, Decode, Copy, IntoSchema)]
-pub struct NoTransactionReceiptReceived {
-    /// The hash of the transaction for which there was no `TransactionReceipt`.
-    pub transaction_hash: HashOf<VersionedTransaction>,
-}
+pub struct NoTransactionReceiptReceived;
 
 /// `BlockCreationTimeout` reason for a view change.
 #[derive(Clone, Debug, Io, Encode, Decode, IntoSchema)]
-pub struct BlockCreationTimeout {
-    /// A proof of the leader receiving and accepting a transaction.
-    pub transaction_receipt: TransactionReceipt,
-}
+pub struct BlockCreationTimeout;
 
 /// A chain of view change proofs. Stored in block for roles to be known at that point in history.
 #[derive(Clone, Debug, Io, Encode, Decode, Default, IntoSchema)]

--- a/core/src/sumeragi/view_change.rs
+++ b/core/src/sumeragi/view_change.rs
@@ -20,6 +20,7 @@ pub struct Proof {
 }
 
 impl Proof {
+    /// Hash of this proof.
     pub fn hash(&self) -> HashOf<Self> {
         HashOf::new(&self.payload).transmute()
     }
@@ -95,7 +96,7 @@ impl Proof {
     }
 
     /// Adds verified signatures of `other` to self.
-    pub fn merge_signatures(&mut self, mut other: Proof) {
+    pub fn merge_signatures(&mut self, other: &Proof) {
         self.signatures.merge(SignaturesOf::from_iter_unchecked(
             other.signatures.verified_by_hash(self.hash()).cloned(),
         ));
@@ -184,7 +185,7 @@ pub struct CommitTimeout {
 pub struct NoTransactionReceiptReceived;
 
 /// `BlockCreationTimeout` reason for a view change.
-#[derive(Clone, Debug, Io, Encode, Decode, IntoSchema)]
+#[derive(Copy, Clone, Debug, Io, Encode, Decode, IntoSchema)]
 pub struct BlockCreationTimeout;
 
 /// A chain of view change proofs. Stored in block for roles to be known at that point in history.

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -176,8 +176,8 @@ impl<W: WorldTrait> WorldStateView<W> {
         for tx in &block.as_inner_v1().rejected_transactions {
             self.transactions.insert(tx.hash());
         }
-        self.tx_metric_update();
         self.blocks.push(block);
+        self.tx_metric_update();
         Ok(())
     }
 

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -15,8 +15,8 @@ use iroha_core::{
     kura::KuraTrait,
     prelude::*,
     sumeragi::{
-        network_topology::Topology, Gossip, IsLeader, Sumeragi, SumeragiTrait, SumeragiWithFault,
-        Voting,
+        network_topology::Topology, Gossip, IsLeader, RetrieveTransactions, Sumeragi,
+        SumeragiTrait, SumeragiWithFault,
     },
     wsv::WorldTrait,
 };
@@ -314,7 +314,12 @@ where
     B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
 {
     for peer in network.peers() {
-        peer.iroha.as_ref().unwrap().sumeragi.do_send(Voting).await;
+        peer.iroha
+            .as_ref()
+            .unwrap()
+            .sumeragi
+            .do_send(RetrieveTransactions)
+            .await;
     }
 }
 
@@ -392,6 +397,7 @@ async fn change_view_on_tx_receipt_timeout() {
             _,
             _,
             _,
+            // FIXME: Leader gets gossip
             sumeragi::Skip<sumeragi::TransactionForwarded, sumeragi::Leader>,
         >,
         BlockSynchronizer<_, _>,
@@ -411,7 +417,12 @@ async fn change_view_on_tx_receipt_timeout() {
 
     // Let peers retrieve the gossiped tx and send to leader, so they can all understand the leader is unresponsive.
     for peer in network.peers() {
-        peer.iroha.as_ref().unwrap().sumeragi.do_send(Voting).await;
+        peer.iroha
+            .as_ref()
+            .unwrap()
+            .sumeragi
+            .do_send(RetrieveTransactions)
+            .await;
     }
 
     time::sleep(Duration::from_secs(3)).await;

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -5,35 +5,28 @@
     clippy::pedantic
 )]
 
-use std::{fmt::Debug, num::NonZeroU64, ops::Deref, path::Path, sync::Arc, time::Duration};
+use std::{fmt::Debug, ops::Deref, time::Duration};
 
-use async_trait::async_trait;
 use eyre::Result;
-use iroha_actor::{broker::*, prelude::*, Context};
+use iroha_actor::prelude::*;
 use iroha_core::{
-    block_sync::{BlockSynchronizer, BlockSynchronizerTrait, ContinueSync},
-    event::EventsSender,
+    block_sync::{BlockSynchronizer, BlockSynchronizerTrait},
     genesis::{config::GenesisConfiguration, GenesisNetworkTrait},
-    kura::{KuraTrait, StoreBlock},
+    kura::KuraTrait,
     prelude::*,
-    queue::Queue,
-    smartcontracts::permissions::IsInstructionAllowedBoxed,
     sumeragi::{
-        message::Message as SumeragiMessage,
-        network_topology::{Role, Topology},
-        *,
+        network_topology::Topology, Gossip, IsLeader, Sumeragi, SumeragiTrait, SumeragiWithFault,
+        Voting,
     },
     wsv::WorldTrait,
 };
 use iroha_data_model::prelude::*;
-use iroha_p2p::network::StopSelf;
 use test_network::*;
-use tokio::{sync::mpsc, time};
-use utils::{genesis, kura, kura::*, sumeragi, world};
+use tokio::time;
+use utils::{genesis, sumeragi, world};
 
 pub mod utils {
     use iroha_core::genesis::RawGenesisBlock;
-    use iroha_crypto::HashOf;
 
     use super::*;
 
@@ -78,93 +71,18 @@ pub mod utils {
         }
     }
 
-    pub mod kura {
-        use iroha_core::{
-            kura::{GetBlockHash, Mode},
-            sumeragi,
-        };
-
-        use super::*;
-
-        #[derive(Debug)]
-        pub struct CountStored<W: WorldTrait> {
-            pub broker: Broker,
-            pub wsv: Arc<WorldStateView<W>>,
-        }
-
-        #[async_trait]
-        impl<W: WorldTrait> KuraTrait for CountStored<W> {
-            type World = W;
-
-            async fn new(
-                _: Mode,
-                _: &Path,
-                _: NonZeroU64,
-                wsv: Arc<WorldStateView<W>>,
-                broker: Broker,
-                _: usize,
-            ) -> Result<Self, iroha_core::kura::Error> {
-                Ok(Self { broker, wsv })
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<W: WorldTrait> Actor for CountStored<W> {
-            async fn on_start(&mut self, ctx: &mut Context<Self>) {
-                self.broker.subscribe::<StoreBlock, _>(ctx);
-                self.broker
-                    .issue_send(sumeragi::Init {
-                        last_block: HashOf::from_hash(Hash([0; 32])),
-                        height: 0,
-                    })
-                    .await;
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<W: WorldTrait> Handler<StoreBlock> for CountStored<W> {
-            type Result = ();
-
-            async fn handle(&mut self, StoreBlock(block): StoreBlock) -> Self::Result {
-                self.broker.issue_send(Stored(block.hash())).await;
-                self.wsv.apply(block).await.unwrap();
-                self.broker.issue_send(UpdateNetworkTopology).await;
-                self.broker.issue_send(ContinueSync).await;
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<W: WorldTrait> Handler<GetBlockHash> for CountStored<W> {
-            type Result = Option<HashOf<VersionedCommittedBlock>>;
-            async fn handle(&mut self, _: GetBlockHash) -> Self::Result {
-                panic!("Shouldn't be called here!")
-            }
-        }
-
-        #[derive(Debug, iroha_actor::Message, Clone, PartialEq, Eq, Copy)]
-        pub struct Stored(pub HashOf<VersionedCommittedBlock>);
-    }
-
     pub mod sumeragi {
-        use std::{fmt::Debug, marker::PhantomData, ops::DerefMut};
+        use std::{fmt::Debug, marker::PhantomData};
 
-        use iroha_actor::Message;
         use iroha_core::{
-            smartcontracts::permissions::IsQueryAllowedBoxed, IrohaNetwork, NetworkMessage,
+            genesis::GenesisNetworkTrait,
+            kura::KuraTrait,
+            sumeragi::{
+                message::Message as SumeragiMessage, network_topology::Role, FaultInjection,
+                SumeragiWithFault,
+            },
+            wsv::WorldTrait,
         };
-
-        use super::*;
-
-        #[async_trait::async_trait]
-        pub trait FaultBehaviour: Debug + Send + 'static {
-            /// Does some bad stuff instead of message handling
-            async fn fault<G, W, K, S>(sumeragi: &mut S, m: SumeragiMessage)
-            where
-                G: GenesisNetworkTrait,
-                W: WorldTrait,
-                K: KuraTrait<World = W>,
-                S: Deref<Target = Sumeragi<G, K, W>> + DerefMut + Send;
-        }
 
         pub trait ConstRoleTrait: Debug + Send + 'static {
             /// Returns true if we indead is that role
@@ -204,16 +122,17 @@ pub mod utils {
         }
 
         #[derive(Debug, Clone, Copy, Default)]
-        pub struct Empty<A>(PhantomData<A>);
+        pub struct EmptyBlockCreated;
 
-        #[async_trait::async_trait]
-        impl FaultBehaviour for Empty<BlockCreated> {
-            async fn fault<G, W, K, S>(sumeragi: &mut S, msg: SumeragiMessage)
+        impl FaultInjection for EmptyBlockCreated {
+            fn faulty_message<G, K, W>(
+                _: &SumeragiWithFault<G, K, W, Self>,
+                msg: SumeragiMessage,
+            ) -> Option<SumeragiMessage>
             where
                 G: GenesisNetworkTrait,
-                W: WorldTrait,
                 K: KuraTrait,
-                S: Deref<Target = Sumeragi<G, K, W>> + DerefMut + Send,
+                W: WorldTrait,
             {
                 let msg = if let SumeragiMessage::BlockCreated(mut block) = msg {
                     block.block.as_mut_inner_v1().transactions = Vec::new();
@@ -221,31 +140,38 @@ pub mod utils {
                 } else {
                     msg
                 };
-                drop(msg.handle(sumeragi).await);
+                Some(msg)
             }
         }
 
         #[derive(Debug, Clone, Copy, Default)]
-        pub struct Skip<A>(PhantomData<A>);
+        pub struct Skip<M, R>(PhantomData<M>, PhantomData<R>);
 
         macro_rules! impl_skip {
             ( $($name:ident),* $(,)? ) => {$(
                 #[derive(Debug, Clone, Copy, Default)]
                 pub struct $name;
-                #[async_trait::async_trait]
-                impl FaultBehaviour for Skip<$name> {
-                    async fn fault<G, W, K, S>(sumeragi: &mut S, m: SumeragiMessage)
+
+                impl<R: ConstRoleTrait + Send + Sync> FaultInjection for Skip<$name, R> {
+                    fn faulty_message<G, K, W>(
+                        sumeragi: &SumeragiWithFault<G, K, W, Self>,
+                        msg: SumeragiMessage,
+                    ) -> Option<SumeragiMessage>
                     where
                         G: GenesisNetworkTrait,
-                        W: WorldTrait,
                         K: KuraTrait,
-                        S: Deref<Target = Sumeragi<G, K, W>> + DerefMut + Send,
+                        W: WorldTrait,
                     {
-                        if let SumeragiMessage::$name(..) = m {
-                            iroha_logger::error!("Fault behaviour: Skipping {}", stringify!($name));
-                            return;
+                        if let SumeragiMessage::$name(..) = msg {
+                            if R::role(sumeragi.role()) {
+                                iroha_logger::error!("Fault behaviour: Skipping {}", stringify!($name));
+                                None
+                            } else {
+                                Some(msg)
+                            }
+                        } else {
+                            Some(msg)
                         }
-                        drop(m.handle(&mut *sumeragi).await);
                     }
                 }
             )*};
@@ -259,269 +185,6 @@ pub mod utils {
             TransactionForwarded,
             ViewChangeSuggested
         );
-
-        macro_rules! impl_handler_proxy(
-            ( $name:ident : $( Handler< $msg:ty, Result = $ret:ty> $(+)? )* ) => {$(
-                #[async_trait::async_trait]
-                impl<R, F, G, K, W> Handler<$msg> for $name<R, F, G, K, W>
-                where
-                    R: ConstRoleTrait,
-                    F: FaultBehaviour,
-                    G: GenesisNetworkTrait,
-                    K: KuraTrait<World = W>,
-                    W: WorldTrait
-                {
-                    type Result = $ret;
-                    async fn handle(&mut self, msg: $msg) -> Self::Result {
-                        <Sumeragi<_, _, _> as Handler<$msg>>::handle(&mut *self, msg).await
-                    }
-                }
-            )*}
-        );
-
-        #[derive(Debug)]
-        pub struct Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait,
-            W: WorldTrait,
-        {
-            sumeragi: Sumeragi<G, K, W>,
-            _faulty: PhantomData<(R, F)>,
-        }
-
-        impl<R, F, G, K, W> Deref for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait,
-            W: WorldTrait,
-        {
-            type Target = Sumeragi<G, K, W>;
-            fn deref(&self) -> &Self::Target {
-                &self.sumeragi
-            }
-        }
-
-        impl<R, F, G, K, W> DerefMut for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait,
-            W: WorldTrait,
-        {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.sumeragi
-            }
-        }
-
-        impl<R, F, G, K, W> Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait,
-            W: WorldTrait,
-        {
-            pub fn new(sumeragi: Sumeragi<G, K, W>) -> Self {
-                Self {
-                    sumeragi,
-                    _faulty: PhantomData::default(),
-                }
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Actor for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            async fn on_start(&mut self, ctx: &mut Context<Self>) {
-                self.broker.subscribe::<UpdateNetworkTopology, _>(ctx);
-                self.broker.subscribe::<sumeragi::message::Message, _>(ctx);
-                self.broker.subscribe::<Init, _>(ctx);
-                self.broker.subscribe::<CommitBlock, _>(ctx);
-                self.broker.subscribe::<NetworkMessage, _>(ctx);
-                self.broker.subscribe::<Voting, _>(ctx);
-                self.broker.subscribe::<Gossip, _>(ctx);
-                ctx.notify_every::<ConnectPeers>(PEERS_CONNECT_INTERVAL);
-            }
-        }
-
-        impl<R, F, G, K, W> SumeragiTrait for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type GenesisNetwork = G;
-            type Kura = K;
-            type World = W;
-
-            fn from_configuration(
-                configuration: &config::SumeragiConfiguration,
-                events_sender: EventsSender,
-                wsv: Arc<WorldStateView<W>>,
-                is_instruction_allowed: IsInstructionAllowedBoxed<W>,
-                is_query_allowed: Arc<IsQueryAllowedBoxed<W>>,
-                telemetry_enabled: bool,
-                genesis_network: Option<Self::GenesisNetwork>,
-                queue: Arc<Queue>,
-                broker: Broker,
-                kura: AlwaysAddr<K>,
-                network: Addr<IrohaNetwork>,
-            ) -> Result<Self> {
-                Sumeragi::from_configuration(
-                    configuration,
-                    events_sender,
-                    wsv,
-                    is_instruction_allowed,
-                    is_query_allowed,
-                    telemetry_enabled,
-                    genesis_network,
-                    queue,
-                    broker,
-                    kura,
-                    network,
-                )
-                .map(Self::new)
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Handler<Init> for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type Result = ();
-            async fn handle(&mut self, Init { last_block, height }: Init) {
-                self.connect_peers().await;
-
-                if height != 0 && *last_block != Hash([0; 32]) {
-                    self.init(last_block, height);
-                } else if let Some(genesis_network) = self.genesis_network.take() {
-                    let addr = self.network.clone();
-                    if let Err(error) = genesis_network.submit_transactions(self, addr).await {
-                        iroha_logger::error!(%error, "Failed to submit genesis transactions")
-                    }
-                }
-                self.update_network_topology().await;
-            }
-        }
-
-        impl_handler_proxy!(
-            Faulty: Handler<UpdateNetworkTopology, Result = ()>
-                     + Handler<CommitBlock, Result = ()>
-                     + Handler<GetNetworkTopology, Result = Topology>
-                     + Handler<IsLeader, Result = bool>
-                     + Handler<GetLeader, Result = PeerId>
-                     + Handler<Voting, Result = ()>
-                     + Handler<ConnectPeers, Result = ()>
-                     + Handler<NetworkMessage, Result = ()>
-                     + Handler<Gossip, Result = ()>
-        );
-
-        #[derive(Debug, Clone, Copy, Default, Message)]
-        #[message(result = "Topology")]
-        pub struct NetworkTopology;
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Handler<NetworkTopology> for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type Result = Topology;
-            async fn handle(&mut self, _: NetworkTopology) -> Self::Result {
-                self.topology.clone()
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Handler<SumeragiMessage> for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type Result = ();
-            async fn handle(&mut self, msg: SumeragiMessage) -> Self::Result {
-                if R::role(self.topology.role(&self.peer_id)) {
-                    F::fault(&mut *self, msg).await;
-                } else {
-                    drop(msg.handle(&mut *self).await);
-                }
-            }
-        }
-
-        #[derive(Debug, Clone, Copy, Message)]
-        #[message(result = "Vec<HashOf<VersionedValidBlock>>")]
-        pub struct InvalidBlocks;
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Handler<InvalidBlocks> for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type Result = Vec<HashOf<VersionedValidBlock>>;
-            async fn handle(&mut self, _: InvalidBlocks) -> Self::Result {
-                self.invalidated_blocks_hashes.clone()
-            }
-        }
-
-        #[derive(Debug, Clone, Message)]
-        pub struct Round(pub Vec<VersionedAcceptedTransaction>);
-
-        #[async_trait::async_trait]
-        impl<R, F, G, K, W> Handler<Round> for Faulty<R, F, G, K, W>
-        where
-            R: ConstRoleTrait,
-            F: FaultBehaviour,
-            G: GenesisNetworkTrait,
-            K: KuraTrait<World = W>,
-            W: WorldTrait,
-        {
-            type Result = ();
-            async fn handle(&mut self, Round(txs): Round) -> Self::Result {
-                drop(self.round(txs).await);
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl<G, K, W> Handler<Round> for Sumeragi<G, K, W>
-        where
-            G: GenesisNetworkTrait,
-            K: KuraTrait,
-            W: WorldTrait,
-        {
-            type Result = ();
-            async fn handle(&mut self, Round(txs): Round) -> Self::Result {
-                drop(self.round(txs).await);
-            }
-        }
     }
 
     pub mod world {
@@ -532,42 +195,42 @@ pub mod utils {
         use once_cell::sync::Lazy;
 
         #[derive(Debug, Clone, Default)]
-        pub struct WithRoot(World);
+        pub struct WithAlice(World);
 
-        impl Deref for WithRoot {
+        impl Deref for WithAlice {
             type Target = World;
             fn deref(&self) -> &Self::Target {
                 &self.0
             }
         }
 
-        impl DerefMut for WithRoot {
+        impl DerefMut for WithAlice {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
             }
         }
 
-        pub static ROOT_KEYS: Lazy<KeyPair> = Lazy::new(|| KeyPair::generate().unwrap());
-        pub static ROOT_ID: Lazy<AccountId> = Lazy::new(|| AccountId::new("root", "global"));
-        pub static ROOT: Lazy<Account> = Lazy::new(|| {
-            let mut account = Account::new(ROOT_ID.clone());
-            account.signatories.push(ROOT_KEYS.public_key.clone());
+        pub static ALICE_KEYS: Lazy<KeyPair> = Lazy::new(|| KeyPair::generate().unwrap());
+        pub static ALICE_ID: Lazy<AccountId> = Lazy::new(|| AccountId::new("alice", "wonderland"));
+        pub static ALICE: Lazy<Account> = Lazy::new(|| {
+            let mut account = Account::new(ALICE_ID.clone());
+            account.signatories.push(ALICE_KEYS.public_key.clone());
             account
         });
-        pub static GLOBAL: Lazy<Domain> = Lazy::new(|| {
-            let mut domain = Domain::new("global");
-            domain.accounts.insert(ROOT_ID.clone(), ROOT.clone());
+        pub static WONDERLAND: Lazy<Domain> = Lazy::new(|| {
+            let mut domain = Domain::new("wonderland");
+            domain.accounts.insert(ALICE_ID.clone(), ALICE.clone());
             domain
         });
 
-        impl WorldTrait for WithRoot {
+        impl WorldTrait for WithAlice {
             /// Creates `World` with these `domains` and `trusted_peers_ids`
             fn with(
                 domains: impl IntoIterator<Item = (Name, Domain)>,
                 trusted_peers_ids: impl IntoIterator<Item = PeerId>,
             ) -> Self {
                 Self(World::with(
-                    vec![(GLOBAL.name.clone(), GLOBAL.clone())]
+                    vec![(WONDERLAND.name.clone(), WONDERLAND.clone())]
                         .into_iter()
                         .chain(domains),
                     trusted_peers_ids,
@@ -576,72 +239,34 @@ pub mod utils {
         }
 
         pub fn sign_tx(isi: impl IntoIterator<Item = Instruction>) -> VersionedAcceptedTransaction {
-            let tx = Transaction::new(isi.into_iter().collect(), ROOT_ID.clone(), 100_000)
-                .sign(&ROOT_KEYS)
+            let tx = Transaction::new(isi.into_iter().collect(), ALICE_ID.clone(), 100_000)
+                .sign(&ALICE_KEYS)
                 .unwrap();
             VersionedAcceptedTransaction::from_transaction(tx, 4096).unwrap()
         }
     }
 }
 
-/// Checks if blocks are applied on single peer
-async fn blocks_applied_peer(channel: &mut mpsc::Receiver<Stored>, n: usize) -> usize {
-    for i in 0..n {
-        let timeout = time::timeout(Duration::from_millis(100), channel.recv())
-            .await
-            .map(|o| o.is_none())
-            .unwrap_or(true);
-        if timeout {
-            return i;
-        }
-    }
-    n
-}
-
 /// Checks if blocks applied on all peers
-async fn blocks_applied(channels: &mut [mpsc::Receiver<Stored>], n: usize) {
-    let mut out = Vec::new();
-    for chan in channels.iter_mut() {
-        // Blocks number is increased by one in order to remove false positives,
-        // when peer actually accepted more blocks than needed.
-        out.push(blocks_applied_peer(chan, n + 1).await);
-    }
-    assert_eq!(out, vec![n; channels.len()]);
-}
-
-async fn start_round_with_tx<W, G, S, K, B>(network: &Network<W, G, K, S, B>, to_leader: bool)
+async fn blocks_applied<W, G, S, K, B>(network: &Network<W, G, K, S, B>, n_blocks: usize)
 where
     W: WorldTrait,
     G: GenesisNetworkTrait,
     K: KuraTrait<World = W>,
-    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W> + Handler<sumeragi::Round>,
+    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
     B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
 {
-    let tx = world::sign_tx(vec![]);
-    let leader = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, IsLeader)
-        .await;
-    let (_, peer) = leader
-        .into_iter()
-        .find(|(leader, _)| if to_leader { *leader } else { !*leader })
-        .unwrap();
-    network
-        .peer_by_id(&peer)
-        .unwrap()
-        .iroha
-        .as_ref()
-        .unwrap()
-        .sumeragi
-        .do_send(sumeragi::Round(vec![tx]))
-        .await;
+    for peer in network.peers() {
+        assert_eq!(peer.iroha.as_ref().unwrap().wsv.height(), n_blocks as u64)
+    }
 }
 
-async fn put_tx_in_queue<W, G, S, K, B>(network: &Network<W, G, K, S, B>, to_leader: bool)
+async fn put_tx_in_queue_to_peer<W, G, S, K, B>(network: &Network<W, G, K, S, B>, to_leader: bool)
 where
     W: WorldTrait,
     G: GenesisNetworkTrait,
     K: KuraTrait<World = W>,
-    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W> + Handler<sumeragi::Round>,
+    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
     B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
 {
     let tx = world::sign_tx(vec![]);
@@ -661,29 +286,57 @@ where
         .unwrap();
 }
 
+async fn put_tx_in_queue_to_all<W, G, S, K, B>(network: &Network<W, G, K, S, B>)
+where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+    K: KuraTrait<World = W>,
+    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
+    B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
+{
+    let tx = world::sign_tx(vec![]);
+    for peer in network.peers() {
+        peer.iroha
+            .as_ref()
+            .unwrap()
+            .queue
+            .push(tx.clone(), &*peer.iroha.as_ref().unwrap().wsv)
+            .unwrap();
+    }
+}
+
+async fn round<W, G, S, K, B>(network: &Network<W, G, K, S, B>)
+where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+    K: KuraTrait<World = W>,
+    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
+    B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
+{
+    for peer in network.peers() {
+        peer.iroha.as_ref().unwrap().sumeragi.do_send(Voting).await;
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "mock"]
 async fn all_peers_commit_block() {
     iroha_logger::install_panic_hook().unwrap();
     let (network, _) = <Network<
-        world::WithRoot,
+        world::WithAlice,
         genesis::NoGenesis,
-        kura::CountStored<_>,
+        iroha_core::kura::Kura<_>,
         Sumeragi<_, _, _>,
         BlockSynchronizer<_, _>,
     >>::start_test(10, 1)
     .await;
 
-    let mut channels = network
-        .peers()
-        .map(|peer| peer.broker.subscribe_with_channel::<Stored>())
-        .collect::<Vec<_>>();
-
     // Send tx to leader
-    start_round_with_tx(&network, true).await;
+    put_tx_in_queue_to_peer(&network, true).await;
+    round(&network).await;
     time::sleep(Duration::from_secs(2)).await;
 
-    blocks_applied(&mut channels, 1).await;
+    blocks_applied(&network, 1).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -691,33 +344,33 @@ async fn all_peers_commit_block() {
 async fn change_view_on_commit_timeout() {
     iroha_logger::install_panic_hook().unwrap();
     let (network, _) = <Network<
-        world::WithRoot,
+        world::WithAlice,
         genesis::NoGenesis,
-        kura::CountStored<_>,
-        sumeragi::Faulty<sumeragi::ProxyTail, sumeragi::Skip<sumeragi::BlockSigned>, _, _, _>,
+        iroha_core::kura::Kura<_>,
+        SumeragiWithFault<_, _, _, sumeragi::Skip<sumeragi::BlockSigned, sumeragi::ProxyTail>>,
         BlockSynchronizer<_, _>,
     >>::start_test(10, 1)
     .await;
 
-    let mut channels = network
-        .peers()
-        .map(|peer| peer.broker.subscribe_with_channel::<Stored>())
-        .collect::<Vec<_>>();
+    // Send tx to leader
+    put_tx_in_queue_to_peer(&network, true).await;
+    round(&network).await;
+    time::sleep(Duration::from_secs(4)).await;
 
-    // send to leader
-    start_round_with_tx(&network, true).await;
-    time::sleep(Duration::from_secs(2)).await;
-
-    blocks_applied(&mut channels, 0).await;
+    blocks_applied(&network, 0).await;
 
     let topologies = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::NetworkTopology)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::CurrentNetworkTopology,
+        )
         .await;
     let invalid_block_hashes = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::InvalidBlocks)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::InvalidatedBlockHashes,
+        )
         .await;
-
-    network.send_all(StopSelf::Network).await;
 
     for (topology, _) in topologies {
         assert_eq!(topology.view_change_proofs().len(), 1);
@@ -732,21 +385,21 @@ async fn change_view_on_commit_timeout() {
 async fn change_view_on_tx_receipt_timeout() {
     iroha_logger::install_panic_hook().unwrap();
     let (network, _) = <Network<
-        world::WithRoot,
+        world::WithAlice,
         genesis::NoGenesis,
-        kura::CountStored<_>,
-        sumeragi::Faulty<sumeragi::Leader, sumeragi::Skip<sumeragi::TransactionForwarded>, _, _, _>,
+        iroha_core::kura::Kura<_>,
+        SumeragiWithFault<
+            _,
+            _,
+            _,
+            sumeragi::Skip<sumeragi::TransactionForwarded, sumeragi::Leader>,
+        >,
         BlockSynchronizer<_, _>,
     >>::start_test(10, 1)
     .await;
 
-    let mut channels = network
-        .peers()
-        .map(|peer| peer.broker.subscribe_with_channel::<Stored>())
-        .collect::<Vec<_>>();
-
     // send to not leader
-    put_tx_in_queue(&network, false).await;
+    put_tx_in_queue_to_peer(&network, false).await;
 
     // Let peers gossip tx.
     for peer in network.peers() {
@@ -763,10 +416,13 @@ async fn change_view_on_tx_receipt_timeout() {
 
     time::sleep(Duration::from_secs(3)).await;
 
-    blocks_applied(&mut channels, 0).await;
+    blocks_applied(&network, 0).await;
 
     let topologies = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::NetworkTopology)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::CurrentNetworkTopology,
+        )
         .await;
     for (topology, _) in topologies {
         assert_eq!(topology.view_change_proofs().len(), 1);
@@ -778,27 +434,26 @@ async fn change_view_on_tx_receipt_timeout() {
 async fn change_view_on_block_creation_timeout() {
     iroha_logger::install_panic_hook().unwrap();
     let (network, _) = <Network<
-        world::WithRoot,
+        world::WithAlice,
         genesis::NoGenesis,
-        kura::CountStored<_>,
-        sumeragi::Faulty<sumeragi::Any, sumeragi::Skip<sumeragi::BlockCreated>, _, _, _>,
+        iroha_core::kura::Kura<_>,
+        SumeragiWithFault<_, _, _, sumeragi::Skip<sumeragi::BlockCreated, sumeragi::Any>>,
         BlockSynchronizer<_, _>,
     >>::start_test(10, 1)
     .await;
 
-    let mut channels = network
-        .peers()
-        .map(|peer| peer.broker.subscribe_with_channel::<Stored>())
-        .collect::<Vec<_>>();
-
     // send to not leader
-    start_round_with_tx(&network, false).await;
-    time::sleep(Duration::from_secs(2)).await;
+    put_tx_in_queue_to_all(&network).await;
+    round(&network).await;
+    time::sleep(Duration::from_secs(3)).await;
 
-    blocks_applied(&mut channels, 0).await;
+    blocks_applied(&network, 0).await;
 
     let topologies = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::NetworkTopology)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::CurrentNetworkTopology,
+        )
         .await;
 
     for (topology, _) in topologies {
@@ -811,29 +466,31 @@ async fn change_view_on_block_creation_timeout() {
 async fn not_enough_votes() {
     iroha_logger::install_panic_hook().unwrap();
     let (network, _) = <Network<
-        world::WithRoot,
+        world::WithAlice,
         genesis::NoGenesis,
-        kura::CountStored<_>,
-        sumeragi::Faulty<sumeragi::Any, sumeragi::Empty<sumeragi::BlockCreated>, _, _, _>,
+        iroha_core::kura::Kura<_>,
+        SumeragiWithFault<_, _, _, sumeragi::EmptyBlockCreated>,
         BlockSynchronizer<_, _>,
     >>::start_test(10, 1)
     .await;
 
-    let mut channels = network
-        .peers()
-        .map(|peer| peer.broker.subscribe_with_channel::<Stored>())
-        .collect::<Vec<_>>();
+    put_tx_in_queue_to_peer(&network, true).await;
+    round(&network).await;
+    time::sleep(Duration::from_secs(4)).await;
 
-    start_round_with_tx(&network, true).await;
-    time::sleep(Duration::from_secs(2)).await;
-
-    blocks_applied(&mut channels, 0).await;
+    blocks_applied(&network, 0).await;
 
     let topologies = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::NetworkTopology)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::CurrentNetworkTopology,
+        )
         .await;
     let invalid_block_hashes = network
-        .send_to_actor_on_peers(|iroha| &iroha.sumeragi, sumeragi::InvalidBlocks)
+        .send_to_actor_on_peers(
+            |iroha| &iroha.sumeragi,
+            iroha_core::sumeragi::InvalidatedBlockHashes,
+        )
         .await;
 
     for (topology, _) in topologies {

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -30,7 +30,9 @@ The following is the default configuration used by Iroha.
     "TX_RECEIPT_TIME_MS": 500,
     "N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE": 1,
     "MAX_INSTRUCTION_NUMBER": 4096,
-    "MAILBOX": 100
+    "MAILBOX": 100,
+    "GOSSIP_BATCH_SIZE": 500,
+    "GOSSIP_PERIOD_MS": 1000
   },
   "TORII": {
     "P2P_ADDR": "127.0.0.1:1337",
@@ -429,6 +431,8 @@ Has type `SumeragiConfiguration`. Can be configured via environment variable `IR
 {
   "BLOCK_TIME_MS": 1000,
   "COMMIT_TIME_MS": 2000,
+  "GOSSIP_BATCH_SIZE": 500,
+  "GOSSIP_PERIOD_MS": 1000,
   "MAILBOX": 100,
   "MAX_INSTRUCTION_NUMBER": 4096,
   "N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE": 1,
@@ -459,6 +463,26 @@ Has type `u64`. Can be configured via environment variable `SUMERAGI_COMMIT_TIME
 
 ```json
 2000
+```
+
+### `sumeragi.gossip_batch_size`
+
+Maximum number of transactions in tx gossip batch message.
+
+Has type `usize`. Can be configured via environment variable `SUMERAGI_GOSSIP_BATCH_SIZE`
+
+```json
+500
+```
+
+### `sumeragi.gossip_period_ms`
+
+Maximum number of transactions in tx gossip batch message.
+
+Has type `u64`. Can be configured via environment variable `SUMERAGI_GOSSIP_PERIOD_MS`
+
+```json
+1000
 ```
 
 ### `sumeragi.key_pair`

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -467,7 +467,7 @@ Has type `u64`. Can be configured via environment variable `SUMERAGI_COMMIT_TIME
 
 ### `sumeragi.gossip_batch_size`
 
-Maximum number of transactions in tx gossip batch message.
+Maximum number of transactions in tx gossip batch message. While configuring this, attention should be payed to `p2p` max message size.
 
 Has type `usize`. Can be configured via environment variable `SUMERAGI_GOSSIP_BATCH_SIZE`
 
@@ -477,7 +477,7 @@ Has type `usize`. Can be configured via environment variable `SUMERAGI_GOSSIP_BA
 
 ### `sumeragi.gossip_period_ms`
 
-Maximum number of transactions in tx gossip batch message.
+Period in milliseconds for pending transaction gossiping between peers.
 
 Has type `u64`. Can be configured via environment variable `SUMERAGI_GOSSIP_PERIOD_MS`
 

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -32,6 +32,7 @@ use crate::{
     Error, Message, MessageResult,
 };
 
+/// Max message length in bytes.
 const MAX_MESSAGE_LENGTH: usize = 16 * 1024 * 1024;
 const MAX_HANDSHAKE_LENGTH: usize = 255;
 /// Default associated data for AEAD

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -719,7 +719,7 @@ async fn read_message(stream: &mut OwnedReadHalf) -> Result<Message, Error> {
 /// message length is more than `MAX_MESSAGE_LENGTH`.
 pub async fn send_message(stream: &mut OwnedWriteHalf, data: &[u8]) -> Result<(), Error> {
     if data.len() > MAX_MESSAGE_LENGTH {
-        warn!(
+        error!(
             max_msg_len = MAX_MESSAGE_LENGTH,
             "Message length exceeds maximum length!",
         );


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

View change handling fixes

- View change proofs made independent of particular transaction hashes
- Reduced message passing
- Collect view change votes instead of sending messages right away (improves network resilience)
- Fully use Actor framework in Sumeragi (schedule messages to self instead of task spawns)

Improves fault injection for tests with Sumeragi

- Brings testing code closer to production code
- Removes overcomplicated wrappers
- Allows Sumeragi use actor Context in test code

Batch transaction gossiping

Significantly reduces message passing

Also fixes transaction count metric calculation, which previously was providing results delayed by 1 block.

### Issue
#1715
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

- Network is more resilient - will recover in cases of faulty peers or after high load (when the load normalizes)
- Network is more performant: about 2 TPS previously, now 100 TPS

For measuring TPS:
- Python script was used
- Timeouts in config were increased
- Logging level was set to `ERROR`
- 4 peers through docker compose were ran locally on a machine with 16 GB or RAM, i7 8th gen.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
