### PR TITLE
[fix] #1751: Sumeragi awaits wsv block commit

### DIFF
--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -27,11 +27,7 @@ use tokio::{
 use tokio_stream::wrappers::ReadDirStream;
 
 use crate::{
-    block::VersionedCommittedBlock,
-    block_sync::ContinueSync,
-    prelude::*,
-    sumeragi::{self, UpdateNetworkTopology},
-    wsv::WorldTrait,
+    block::VersionedCommittedBlock, block_sync::ContinueSync, prelude::*, sumeragi, wsv::WorldTrait,
 };
 
 /// Message for storing committed block
@@ -246,10 +242,6 @@ impl<W: WorldTrait, IO: DiskIO> KuraWithIO<W, IO> {
         match self.block_store.write(&block).await {
             Ok(block_hash) => {
                 self.merkle_tree = self.merkle_tree.add(block_hash);
-                if let Err(error) = self.wsv.apply(block).await {
-                    warn!(%error, %block_hash, "Failed to apply block on WSV");
-                }
-                self.broker.issue_send(UpdateNetworkTopology).await;
                 self.broker.issue_send(ContinueSync).await;
                 Ok(block_hash)
             }


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
- Sumeragi awaits wsv block commit
- Update for network topology now directly from sumeragi
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue
#1751
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Fixes double spend attack, and general bug with same transaction being committed more than once. For more detailed overview please read the issue.

Previously wsv was updated after kura when it received the message from sumeragi. The bug was in the fact that sumeragi assumed it committed the block and updated its state, therefore able to approve next blocks, but the message might arrive to Kura a lot later. This made possible for the `is_in_blockchain` checks for transactions to pass sometimes even as some of them were in previous block. And therefore leaders could create blocks with same txs and other peers might approve it.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
