### PR TITLE
[feature] #1425: add wasm runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 3
 
 [[package]]
 name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli 0.25.0",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli",
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -69,6 +78,15 @@ checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -199,12 +217,12 @@ version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
- "addr2line",
+ "addr2line 0.17.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -213,6 +231,15 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -515,6 +542,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +564,101 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.25.0",
+ "log",
+ "regalloc",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c04d1fe6a5abb5bb0edc78baa8ef238370fb8e389cc88b6d153f7c3e9680425"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d260ad44f6fd2c91f7f5097191a2a9e3edcbb36df1fb787b600dad5ea148ec"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools",
+ "log",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "wasmparser",
+]
 
 [[package]]
 name = "crc32fast"
@@ -779,6 +910,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1014,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1093,16 @@ checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
+]
+
+[[package]]
+name = "file-per-thread-logger"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+dependencies = [
+ "env_logger",
+ "log",
 ]
 
 [[package]]
@@ -1124,6 +1326,17 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
@@ -1299,6 +1512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1580,7 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1479,6 +1702,7 @@ dependencies = [
 name = "iroha_core"
 version = "2.0.0-pre.1"
 dependencies = [
+ "anyhow",
  "async-stream",
  "async-trait",
  "byte-unit",
@@ -1511,6 +1735,7 @@ dependencies = [
  "tokio-stream",
  "unique_port",
  "warp",
+ "wasmtime",
 ]
 
 [[package]]
@@ -1823,6 +2048,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1946,6 +2186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4330eca86d39f2b52d0481aa1e90fe21bfa61f11b0bf9b48ab95595013cefe48"
 
 [[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
 name = "multipart"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2263,17 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -2141,6 +2398,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "percent-encoding"
@@ -2316,6 +2579,15 @@ dependencies = [
  "memchr",
  "parking_lot",
  "thiserror",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2546,11 +2818,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2567,6 +2863,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2888,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2638,6 +2952,26 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "secp256k1"
@@ -2852,6 +3186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +3279,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempfile"
@@ -3626,6 +3972,236 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
+name = "wasmparser"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5894be15a559c85779254700e1d35f02f843b5a69152e5c82c626d9fd66c0e"
+
+[[package]]
+name = "wasmtime"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbb8a082a8ef50f7eeb8b82dda9709ef1e68963ea3c94e45581644dd4041835"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "log",
+ "paste",
+ "psm",
+ "region",
+ "rustc-demangle",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-cache",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73391579ca7f24573138ef768b73b2aed5f9d542385c64979b65d60d0912399"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "directories-next",
+ "errno",
+ "file-per-thread-logger",
+ "libc",
+ "log",
+ "serde",
+ "sha2",
+ "toml",
+ "winapi",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81c6f5ae9205382345c7cd7454932a906186836999a2161c385e38a15f52e1fe"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-wasm",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-debug"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69e08f55e12f15f50b1b533bc3626723e7224254a065de6576934c86258c9e8"
+dependencies = [
+ "anyhow",
+ "gimli 0.25.0",
+ "more-asserts",
+ "object 0.26.2",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005d93174040af37fb8625f891cd9827afdad314261f7ec4ee61ec497d6e9d3c"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-wasm",
+ "gimli 0.25.0",
+ "indexmap",
+ "log",
+ "more-asserts",
+ "serde",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa8d00a477a43848dc84cb83f097e8dc8aacd57fd4e763f232416aa27cb137c"
+dependencies = [
+ "cc",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bf1dfb213a35d8f21aefae40e597fe72778a907011ffdff7affb029a02af9a"
+dependencies = [
+ "addr2line 0.16.0",
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.25.0",
+ "log",
+ "more-asserts",
+ "object 0.26.2",
+ "rayon",
+ "region",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-cranelift",
+ "wasmtime-debug",
+ "wasmtime-environ",
+ "wasmtime-obj",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "winapi",
+]
+
+[[package]]
+name = "wasmtime-obj"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231491878e710c68015228c9f9fc5955fe5c96dbf1485c15f7bed55b622c83c"
+dependencies = [
+ "anyhow",
+ "more-asserts",
+ "object 0.26.2",
+ "target-lexicon",
+ "wasmtime-debug",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-profiling"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21486cfb5255c2069666c1f116f9e949d4e35c9a494f11112fa407879e42198d"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "gimli 0.25.0",
+ "lazy_static",
+ "libc",
+ "object 0.26.2",
+ "scroll",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ",
+ "wasmtime-runtime",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ddfdf32e0a20d81f48be9dacd31612bc61de5a174d1356fef806d300f507de"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "log",
+ "mach",
+ "memoffset",
+ "more-asserts",
+ "rand 0.8.4",
+ "region",
+ "thiserror",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "winapi",
+]
+
+[[package]]
+name = "wast"
+version = "38.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0d7b256bef26c898fa7344a2d627e8499f5a749432ce0a05eae1a64ff0c271"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,4 +4284,33 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.9.0+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -644,9 +644,7 @@ pub mod asset {
     }
 
     /// Get query to get all assets by account id
-    pub fn by_account_id(
-        account_id: impl Into<EvaluatesTo<<Account as Identifiable>::Id>>,
-    ) -> FindAssetsByAccountId {
+    pub fn by_account_id(account_id: impl Into<EvaluatesTo<AccountId>>) -> FindAssetsByAccountId {
         FindAssetsByAccountId::new(account_id)
     }
 

--- a/client/tests/integration_tests/add_asset.rs
+++ b/client/tests/integration_tests/add_asset.rs
@@ -29,7 +29,8 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
             account_id.clone(),
         )),
     );
-    let tx = test_client.build_transaction(vec![create_asset.into(), mint.into()], metadata)?;
+    let instructions: Vec<Instruction> = vec![create_asset.into(), mint.into()];
+    let tx = test_client.build_transaction(instructions.into(), metadata)?;
     test_client.submit_transaction(tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
         result.iter().any(|asset| {
@@ -61,7 +62,8 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
             account_id.clone(),
         )),
     );
-    let tx = test_client.build_transaction(vec![create_asset.into(), mint.into()], metadata)?;
+    let instructions: Vec<Instruction> = vec![create_asset.into(), mint.into()];
+    let tx = test_client.build_transaction(instructions.into(), metadata)?;
     test_client.submit_transaction(tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
         result.iter().any(|asset| {
@@ -93,7 +95,8 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
             account_id.clone(),
         )),
     );
-    let tx = test_client.build_transaction(vec![create_asset.into(), mint.into()], metadata)?;
+    let instructions: Vec<Instruction> = vec![create_asset.into(), mint.into()];
+    let tx = test_client.build_transaction(instructions.into(), metadata)?;
     test_client.submit_transaction(tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id.clone()), |result| {
         result.iter().any(|asset| {

--- a/client/tests/integration_tests/events/pipeline.rs
+++ b/client/tests/integration_tests/events/pipeline.rs
@@ -40,10 +40,9 @@ fn test_with_instruction_and_status(
             &peers[submitting_peer].api_address,
             &peers[submitting_peer].telemetry_address,
         );
-        let transaction = submitter_client.build_transaction(
-            instruction.clone().into_iter().collect(),
-            UnlimitedMetadata::new(),
-        )?;
+        let instructions: Vec<Instruction> = instruction.clone().into_iter().collect();
+        let transaction =
+            submitter_client.build_transaction(instructions.into(), UnlimitedMetadata::new())?;
         for receiving_peer in 0..PEER_COUNT {
             let committed_event_received_clone = committed_event_received.clone();
             let validating_event_received_clone = validating_event_received.clone();

--- a/client/tests/integration_tests/multisignature_transaction.rs
+++ b/client/tests/integration_tests/multisignature_transaction.rs
@@ -65,8 +65,9 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     client_configuration.public_key = key_pair_1.public_key;
     client_configuration.private_key = key_pair_1.private_key;
     let mut iroha_client = Client::new(&client_configuration);
+    let instructions: Vec<Instruction> = vec![mint_asset.clone().into()];
     let transaction = iroha_client
-        .build_transaction(vec![mint_asset.clone().into()], UnlimitedMetadata::new())
+        .build_transaction(instructions.into(), UnlimitedMetadata::new())
         .expect("Failed to create transaction.");
     iroha_client
         .submit_transaction(
@@ -89,8 +90,9 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     client_configuration.public_key = key_pair_2.public_key;
     client_configuration.private_key = key_pair_2.private_key;
     let mut iroha_client_2 = Client::new(&client_configuration);
+    let instructions: Vec<Instruction> = vec![mint_asset.into()];
     let transaction = iroha_client_2
-        .build_transaction(vec![mint_asset.into()], UnlimitedMetadata::new())
+        .build_transaction(instructions.into(), UnlimitedMetadata::new())
         .expect("Failed to create transaction.");
     let transaction = iroha_client_2
         .get_original_transaction(&transaction, 3, Duration::from_millis(100))

--- a/client/tests/integration_tests/tx_history.rs
+++ b/client/tests/integration_tests/tx_history.rs
@@ -46,8 +46,9 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
         } else {
             &mint_not_existed_asset
         };
+        let instructions: Vec<Instruction> = vec![mint_asset.clone().into()];
         let transaction = iroha_client
-            .build_transaction(vec![mint_asset.clone().into()], UnlimitedMetadata::new())
+            .build_transaction(instructions.into(), UnlimitedMetadata::new())
             .expect("Failed to create transaction");
         iroha_client
             .submit_transaction(transaction)

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -158,7 +158,7 @@ pub fn submit(
     #[cfg(not(debug_assertions))]
     let err_msg = "Failed to build transaction.";
     let tx = iroha_client
-        .build_transaction(vec![instruction], metadata)
+        .build_transaction(vec![instruction].into(), metadata)
         .wrap_err(err_msg)?;
     let tx = match iroha_client.get_original_transaction(
         &tx,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,6 +54,10 @@ crossbeam-queue = "0.3"
 warp = "0.3"
 thiserror = "1.0.28"
 pin-project = "1"
+wasmtime = "0.29.0"
+
+# transitive dependencies
+anyhow = ">= 1.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -24,8 +24,8 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
     });
     let keypair = KeyPair::generate().expect("Failed to generate KeyPair.");
     let tx = Transaction::new(
-        vec![transfer],
-        <Account as Identifiable>::Id::test("alice", "wonderland"),
+        AccountId::test("alice", "wonderland"),
+        vec![transfer].into(),
         1000,
     )
     .sign(&keypair)

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -33,13 +33,14 @@ fn build_test_transaction(keys: &KeyPair) -> Transaction {
     let create_asset = RegisterBox::new(IdentifiableBox::AssetDefinition(
         AssetDefinition::new(asset_definition_id, AssetValueType::Quantity, true).into(),
     ));
+    let instructions: Vec<Instruction> = vec![
+        create_domain.into(),
+        create_account.into(),
+        create_asset.into(),
+    ];
     Transaction::new(
-        vec![
-            create_domain.into(),
-            create_account.into(),
-            create_asset.into(),
-        ],
         AccountId::test(START_ACCOUNT, START_DOMAIN),
+        instructions.into(),
         TRANSACTION_TIME_TO_LIVE_MS,
     )
     .sign(keys)

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::{collections::BTreeSet, iter, marker::PhantomData};
+use std::{collections::BTreeSet, error::Error, iter, marker::PhantomData};
 
 use dashmap::{mapref::one::Ref as MapRef, DashMap};
 use eyre::{Context, Result};
@@ -279,8 +279,6 @@ impl BlockHeader {
         self.height == 1
     }
 }
-
-use std::error::Error;
 
 impl ChainedBlock {
     /// Validate block transactions against current state of the world.

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, fmt::Debug, fs::File, io::BufReader, ops::Deref,
 use eyre::{eyre, Result, WrapErr};
 use iroha_actor::Addr;
 use iroha_crypto::{KeyPair, PublicKey};
-use iroha_data_model::{account::Account, isi::Instruction, prelude::*};
+use iroha_data_model::prelude::*;
 use iroha_schema::prelude::*;
 use serde::{Deserialize, Serialize};
 use tokio::{time, time::Duration};
@@ -20,7 +20,7 @@ use crate::{
     },
     tx::VersionedAcceptedTransaction,
     wsv::WorldTrait,
-    Identifiable, IrohaNetwork,
+    IrohaNetwork,
 };
 
 type Online = Vec<PeerId>;
@@ -277,8 +277,8 @@ impl GenesisTransaction {
         max_instruction_number: u64,
     ) -> Result<VersionedAcceptedTransaction> {
         let transaction = Transaction::new(
-            self.isi.clone(),
-            <Account as Identifiable>::Id::genesis(),
+            AccountId::genesis(),
+            self.isi.clone().into(),
             GENESIS_TRANSACTIONS_TTL_MS,
         )
         .sign(genesis_key_pair)?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,6 @@ pub mod stream;
 pub mod sumeragi;
 pub mod torii;
 pub mod tx;
-mod wasm;
 pub mod wsv;
 
 use std::{path::PathBuf, sync::Arc, time::Duration};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod stream;
 pub mod sumeragi;
 pub mod torii;
 pub mod tx;
+mod wasm;
 pub mod wsv;
 
 use std::{path::PathBuf, sync::Arc, time::Duration};

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -382,7 +382,7 @@ mod tests {
         let mut domain = wsv.domain_mut(&DomainId::test("wonderland")).unwrap();
         domain
             .accounts
-            .get_mut(&<Account as Identifiable>::Id::test("alice", "wonderland"))
+            .get_mut(&AccountId::test("alice", "wonderland"))
             .unwrap()
             .signature_check_condition = SignatureCheckCondition(0_u32.into());
         drop(domain);

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -301,9 +301,10 @@ mod tests {
         let message = std::iter::repeat_with(rand::random::<char>)
             .take(16)
             .collect();
+        let instructions: Vec<Instruction> = vec![FailBox { message }.into()];
         let tx = Transaction::new(
-            vec![FailBox { message }.into()],
-            <Account as Identifiable>::Id::test(account, domain),
+            AccountId::test(account, domain),
+            instructions.into(),
             proposed_ttl_ms,
         )
         .sign(&key)
@@ -401,8 +402,8 @@ mod tests {
             ..Configuration::default()
         });
         let tx = Transaction::new(
-            Vec::new(),
-            <Account as Identifiable>::Id::test("alice", "wonderland"),
+            AccountId::test("alice", "wonderland"),
+            Vec::<Instruction>::new().into(),
             100_000,
         );
         let get_tx = || {

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -301,7 +301,7 @@ impl<W: WorldTrait> Execute<W> for RegisterBox {
     #[log]
     fn execute(
         self,
-        authority: <Account as Identifiable>::Id,
+        authority: AccountId,
         wsv: &WorldStateView<W>,
     ) -> Result<Self::Diff, Self::Error> {
         let context = Context::new();
@@ -328,7 +328,7 @@ impl<W: WorldTrait> Execute<W> for UnregisterBox {
     #[log]
     fn execute(
         self,
-        authority: <Account as Identifiable>::Id,
+        authority: AccountId,
         wsv: &WorldStateView<W>,
     ) -> Result<Self::Diff, Self::Error> {
         let context = Context::new();

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -295,7 +295,7 @@ mod tests {
     async fn find_transaction() -> Result<()> {
         let wsv = WorldStateView::new(world_with_test_domains());
 
-        let tx = Transaction::new(vec![], ALICE_ID.clone(), 4000);
+        let tx = Transaction::new(ALICE_ID.clone(), Vec::<Instruction>::new().into(), 4000);
         let signed_tx = tx.sign(&ALICE_KEYS)?;
         let va_tx = VersionedAcceptedTransaction::from_transaction(signed_tx.clone(), 4096)?;
 

--- a/core/src/smartcontracts/mod.rs
+++ b/core/src/smartcontracts/mod.rs
@@ -21,7 +21,7 @@ pub trait Execute<W: WorldTrait> {
     /// Apply actions to `wsv` on behalf of `authority`.
     fn execute(
         self,
-        authority: <Account as Identifiable>::Id,
+        authority: AccountId,
         wsv: &WorldStateView<W>,
     ) -> Result<Self::Diff, Self::Error>;
 }

--- a/core/src/smartcontracts/mod.rs
+++ b/core/src/smartcontracts/mod.rs
@@ -3,6 +3,7 @@
 //! Currently supported only Iroha instructions
 
 pub mod isi;
+pub mod wasm;
 
 use iroha_data_model::prelude::*;
 pub use isi::*;

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -173,9 +173,8 @@ impl AcceptedTransaction {
         is_query_allowed: &IsQueryAllowedBoxed<W>,
         is_genesis: bool,
     ) -> Result<(), TransactionRejectionReason> {
-        let wsv_temp = wsv.clone();
-        let account_id = self.payload.account_id.clone();
-        if !is_genesis && account_id == <Account as Identifiable>::Id::genesis() {
+        let account_id = &self.payload.account_id;
+        if !is_genesis && *account_id == AccountId::genesis() {
             return Err(TransactionRejectionReason::UnexpectedGenesisAccountSignature);
         }
 
@@ -195,46 +194,66 @@ impl AcceptedTransaction {
             return Err(reason);
         }
 
-        for instruction in &self.payload.instructions {
-            instruction
-                .clone()
-                .execute(account_id.clone(), &wsv_temp)
-                .map_err(|reason| InstructionExecutionFail {
-                    instruction: instruction.clone(),
-                    reason: reason.to_string(),
-                })
-                .map_err(TransactionRejectionReason::InstructionExecution)?;
+        // WSV is cloned here so that instructions don't get applied to the blockchain
+        // Therefore, this instruction execution validates before actually executing
+        let wsv_temp = wsv.clone();
+        match &self.payload.instructions {
+            Executable::Instructions(instructions) => {
+                for instruction in instructions {
+                    instruction
+                        .clone()
+                        .execute(account_id.clone(), &wsv_temp)
+                        .map_err(|reason| InstructionExecutionFail {
+                            instruction: instruction.clone(),
+                            reason: reason.to_string(),
+                        })
+                        .map_err(TransactionRejectionReason::InstructionExecution)?;
 
-            // Permission validation is skipped for genesis.
-            if !is_genesis {
-                #[cfg(feature = "roles")]
-                {
-                    let instructions = permissions::unpack_if_role_grant(instruction.clone(), wsv)
+                    // Permission validation is skipped for genesis.
+                    if !is_genesis {
+                        #[cfg(feature = "roles")]
+                        {
+                            let granted_instructions = permissions::unpack_if_role_grant(instruction.clone(), wsv)
                         .expect(
                             "Infallible. Evaluations have been checked by instruction execution.",
                         );
-                    for isi in &instructions {
-                        is_instruction_allowed
-                            .check(&account_id, isi, wsv)
-                            .map_err(|reason| NotPermittedFail { reason })
-                            .map_err(TransactionRejectionReason::NotPermitted)?;
-                    }
-                }
-                #[cfg(not(feature = "roles"))]
-                {
-                    is_instruction_allowed
-                        .check(&account_id, instruction, wsv)
+                            for isi in &granted_instructions {
+                                is_instruction_allowed
+                                    .check(account_id, isi, wsv)
+                                    .map_err(|reason| NotPermittedFail { reason })
+                                    .map_err(TransactionRejectionReason::NotPermitted)?;
+                            }
+                        }
+                        #[cfg(not(feature = "roles"))]
+                        {
+                            is_instruction_allowed
+                                .check(account_id, instruction, wsv)
+                                .map_err(|reason| NotPermittedFail { reason })
+                                .map_err(TransactionRejectionReason::NotPermitted)?;
+                        }
+                        permissions::check_query_in_instruction(
+                            account_id,
+                            instruction,
+                            wsv,
+                            is_query_allowed,
+                        )
                         .map_err(|reason| NotPermittedFail { reason })
                         .map_err(TransactionRejectionReason::NotPermitted)?;
+                    }
                 }
-                permissions::check_query_in_instruction(
-                    &account_id,
-                    instruction,
-                    wsv,
-                    is_query_allowed,
-                )
-                .map_err(|reason| NotPermittedFail { reason })
-                .map_err(TransactionRejectionReason::NotPermitted)?;
+            }
+            Executable::Wasm(bytes) => {
+                let mut wasm_runtime = crate::wasm::Runtime::new()
+                    .map_err(|reason| WasmExecutionFail {
+                        reason: reason.to_string(),
+                    })
+                    .map_err(TransactionRejectionReason::WasmExecution)?;
+                wasm_runtime
+                    .execute(wsv, account_id.clone(), bytes)
+                    .map_err(|reason| WasmExecutionFail {
+                        reason: reason.to_string(),
+                    })
+                    .map_err(TransactionRejectionReason::WasmExecution)?;
             }
         }
 
@@ -402,8 +421,8 @@ mod tests {
         config.genesis.account_public_key = Some(key_pair.public_key.clone());
 
         let tx = Transaction::new(
-            vec![],
             AccountId::test(GENESIS_ACCOUNT_NAME, GENESIS_DOMAIN_NAME),
+            Vec::<Instruction>::new().into(),
             1000,
         );
         let tx_hash = tx.hash();
@@ -432,12 +451,13 @@ mod tests {
 
     #[test]
     fn transaction_not_accepted() {
-        let inst = FailBox {
+        let inst: Instruction = FailBox {
             message: "Will fail".to_owned(),
-        };
+        }
+        .into();
         let tx = Transaction::new(
-            vec![inst.into(); DEFAULT_MAX_INSTRUCTION_NUMBER as usize + 1],
             AccountId::test("root", "global"),
+            vec![inst; DEFAULT_MAX_INSTRUCTION_NUMBER as usize + 1].into(),
             1000,
         );
         let result: Result<AcceptedTransaction> = AcceptedTransaction::from_transaction(tx, 4096);

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -1,0 +1,384 @@
+//! This module contains logic related to executing smartcontracts via `WebAssembly` VM
+//! Smartcontracts can be written in Rust, compiled to wasm format and submitted in a transaction
+
+use eyre::WrapErr;
+use iroha_data_model::prelude::*;
+use iroha_logger::prelude::*;
+use parity_scale_codec::{Decode, Encode};
+use wasmtime::{Caller, Config, Engine, Linker, Module, Store, Trap, TypedFunc};
+
+use crate::{
+    smartcontracts::{Execute, ValidQuery},
+    wsv::{WorldStateView, WorldTrait},
+};
+
+const WASM_ALLOC_FN: &str = "alloc";
+const WASM_MEMORY_NAME: &str = "memory";
+const WASM_MAIN_FN_NAME: &str = "main";
+const EXECUTE_ISI_FN_NAME: &str = "execute_isi";
+const EXECUTE_QUERY_FN_NAME: &str = "execute_query";
+
+/// `WebAssembly` execution error type
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Runtime initialization failure")]
+    Initialization(#[source] anyhow::Error),
+    #[error("Module instantiation failure")]
+    Instantiation(#[source] anyhow::Error),
+    #[error("Named export not found")]
+    ExportNotFound(#[source] anyhow::Error),
+    #[error("Fn call failed")]
+    FnCall(#[source] Trap),
+    /// Some other error happened
+    #[error("Some other error happened")]
+    Other(#[source] eyre::Error),
+}
+
+struct State<'a, W: WorldTrait> {
+    wsv: &'a WorldStateView<W>,
+    account_id: AccountId,
+
+    /// Number of instructions in the smartcontract
+    instruction_count: u64,
+}
+
+impl<'a, W: WorldTrait> State<'a, W> {
+    fn new(wsv: &'a WorldStateView<W>, account_id: AccountId) -> Self {
+        Self {
+            wsv,
+            account_id,
+            instruction_count: 0,
+        }
+    }
+}
+
+/// `WebAssembly` virtual machine
+pub struct Runtime<'a, W: WorldTrait> {
+    engine: Engine,
+    linker: Linker<State<'a, W>>,
+}
+
+impl<'a, W: WorldTrait> Runtime<'a, W> {
+    /// Every WASM instruction costs approximately 1 unit of fuel. See
+    /// [`wasmtime` reference](https://docs.rs/wasmtime/0.29.0/wasmtime/struct.Store.html#method.add_fuel)
+    const FUEL_LIMIT: u64 = 10_000;
+
+    fn create_config() -> Config {
+        let mut config = Config::new();
+        config.consume_fuel(true);
+        //config.cache_config_load_default();
+        config
+    }
+
+    fn create_engine(config: &Config) -> Result<Engine, Error> {
+        Engine::new(config).map_err(Error::Initialization)
+    }
+
+    fn create_linker(engine: &Engine) -> Result<Linker<State<'a, W>>, Error> {
+        let mut linker = Linker::new(engine);
+
+        linker
+            .func_wrap(
+                "iroha",
+                EXECUTE_ISI_FN_NAME,
+                |mut caller: Caller<State<_>>, offset: u32, len: u32| {
+                    let memory = Self::get_memory(&mut caller)?;
+
+                    // Accessing memory as a byte slice to avoid the use of unsafe
+                    let isi_mem_range = offset as usize..(offset + len) as usize;
+                    let mut isi_bytes = &memory.data(&caller)[isi_mem_range];
+                    let instruction = Instruction::decode(&mut isi_bytes)
+                        .map_err(|error| Trap::new(error.to_string()))?;
+
+                    instruction
+                        .execute(caller.data().account_id.clone(), caller.data().wsv)
+                        .map_err(|error| Trap::new(error.to_string()))?;
+
+                    caller.data_mut().instruction_count += 1;
+                    Ok(())
+                },
+            )
+            .map_err(Error::Initialization)?;
+
+        linker
+            .func_wrap(
+                "iroha",
+                EXECUTE_QUERY_FN_NAME,
+                |mut caller: Caller<State<_>>, offset: u32, len: u32| {
+                    let alloc_fn = Self::get_alloc_fn(&mut caller)?;
+                    let memory = Self::get_memory(&mut caller)?;
+
+                    // Accessing memory as a byte slice to avoid the use of unsafe
+                    let query_mem_range = offset as usize..(offset + len) as usize;
+                    let mut query_bytes = &memory.data(&caller)[query_mem_range];
+                    let query = QueryBox::decode(&mut query_bytes)
+                        .map_err(|error| Trap::new(error.to_string()))?;
+
+                    let res_bytes = query
+                        .execute(caller.data().wsv)
+                        .map_err(|e| Trap::new(e.to_string()))?
+                        .encode();
+
+                    let res_bytes_len: u32 = {
+                        let res_bytes_len: Result<u32, _> = res_bytes.len().try_into();
+                        res_bytes_len.map_err(|error| Trap::new(error.to_string()))?
+                    };
+
+                    let res_offset = {
+                        let res_offset = alloc_fn
+                            .call(&mut caller, res_bytes_len)
+                            .map_err(|e| Trap::new(e.to_string()))?;
+
+                        let res_mem_range =
+                            res_offset as usize..res_offset as usize + res_bytes.len();
+                        memory.data_mut(&mut caller)[res_mem_range].copy_from_slice(&res_bytes[..]);
+
+                        res_offset
+                    };
+
+                    Ok((res_offset, res_bytes_len))
+                },
+            )
+            .map_err(Error::Initialization)?;
+
+        Ok(linker)
+    }
+
+    fn get_alloc_fn(caller: &mut Caller<State<W>>) -> Result<TypedFunc<u32, u32>, Trap> {
+        caller
+            .get_export(WASM_ALLOC_FN)
+            .ok_or_else(|| Trap::new(format!("{}: export not found", WASM_ALLOC_FN)))?
+            .into_func()
+            .ok_or_else(|| Trap::new(format!("{}: not a function", WASM_ALLOC_FN)))?
+            .typed::<u32, u32, _>(caller)
+            .map_err(|_error| Trap::new(format!("{}: unexpected declaration", WASM_ALLOC_FN)))
+    }
+
+    fn get_memory(caller: &mut Caller<State<W>>) -> Result<wasmtime::Memory, Trap> {
+        caller
+            .get_export(WASM_MEMORY_NAME)
+            .ok_or_else(|| Trap::new(format!("{}: export not found", WASM_MEMORY_NAME)))?
+            .into_memory()
+            .ok_or_else(|| Trap::new(format!("{}: not a memory", WASM_MEMORY_NAME)))
+    }
+
+    /// `Runtime` constructor
+    ///
+    /// # Errors
+    ///
+    /// If unable to construct runtime
+    pub fn new() -> Result<Self, Error> {
+        let config = Self::create_config();
+        let engine = Self::create_engine(&config)?;
+        let linker = Self::create_linker(&engine)?;
+
+        Ok(Self { engine, linker })
+    }
+
+    /// Executes the given wasm smartcontract
+    ///
+    /// # Errors
+    ///
+    /// If unable to construct wasm module or instance of wasm module, if unable to add fuel limit,
+    /// if unable to find expected exports(main, memory, allocator) or if the execution of the
+    /// smartcontract fails
+    pub fn execute(
+        &mut self,
+        wsv: &WorldStateView<W>,
+        account_id: AccountId,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<(), Error> {
+        let account_bytes = account_id.encode();
+
+        let module = Module::new(&self.engine, bytes).map_err(Error::Instantiation)?;
+        let mut store = Store::new(&self.engine, State::new(wsv, account_id));
+        store
+            .add_fuel(Self::FUEL_LIMIT)
+            .map_err(Error::Instantiation)?;
+
+        let instance = self
+            .linker
+            .instantiate(&mut store, &module)
+            .map_err(Error::Instantiation)?;
+        let alloc_fn = instance
+            .get_typed_func::<u32, u32, _>(&mut store, WASM_ALLOC_FN)
+            .map_err(Error::ExportNotFound)?;
+
+        let memory = instance
+            .get_memory(&mut store, WASM_MEMORY_NAME)
+            .ok_or_else(|| {
+                Error::ExportNotFound(anyhow::Error::msg(format!(
+                    "{}: export not found or not a memory",
+                    WASM_MEMORY_NAME
+                )))
+            })?;
+
+        let account_bytes_len = account_bytes
+            .len()
+            .try_into()
+            .wrap_err("Scale encoded account ID has size larger than u32::MAX")
+            .map_err(Error::Other)?;
+
+        let account_offset = {
+            let acc_offset = alloc_fn
+                .call(&mut store, account_bytes_len)
+                .map_err(Error::FnCall)?;
+
+            let acc_mem_range = acc_offset as usize..acc_offset as usize + account_bytes.len();
+            memory.data_mut(&mut store)[acc_mem_range].copy_from_slice(&account_bytes[..]);
+
+            acc_offset
+        };
+
+        let main = instance
+            .get_typed_func::<(u32, u32), (), _>(&mut store, WASM_MAIN_FN_NAME)
+            .map_err(Error::ExportNotFound)?;
+
+        main.call(&mut store, (account_offset, account_bytes_len))
+            .map_err(Error::FnCall)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::restriction)]
+
+    use iroha_crypto::KeyPair;
+    use iroha_data_model::{domain::DomainsMap, peer::PeersIds};
+
+    use super::*;
+    use crate::World;
+
+    fn world_with_test_account(account_id: AccountId) -> World {
+        let domain_id = account_id.domain_id.clone();
+        let public_key = KeyPair::generate().unwrap().public_key;
+        let account = Account::with_signatory(account_id, public_key);
+        let domain = Domain::with_accounts(domain_id.name.as_ref(), std::iter::once(account));
+
+        let domains = DomainsMap::new();
+        domains.insert(domain_id, domain);
+        World::with(domains, PeersIds::new())
+    }
+
+    fn memory_and_alloc(isi_hex: &str) -> String {
+        format!(
+            r#"
+            ;; Embed ISI into WASM binary memory
+            (memory (export "{memory_name}") 1)
+            (data (i32.const 0) "{isi_hex}")
+
+            ;; Variable which tracks total allocated size
+            (global $mem_size (mut i32) i32.const {isi_len})
+
+            ;; Export mock allocator to host. This allocator never frees!
+            (func (export "{alloc_fn_name}") (param $size i32) (result i32)
+                global.get $mem_size
+
+                (global.set $mem_size
+                    (i32.add (global.get $mem_size) (local.get $size))
+                )
+            )
+            "#,
+            memory_name = WASM_MEMORY_NAME,
+            alloc_fn_name = WASM_ALLOC_FN,
+            isi_len = isi_hex.len() / 3,
+            isi_hex = isi_hex,
+        )
+    }
+
+    fn encode_hex<T: Encode>(isi: T) -> String {
+        let isi_bytes = isi.encode();
+
+        let mut isi_hex = String::with_capacity(3 * isi_bytes.len());
+        for (i, c) in hex::encode(isi_bytes).chars().enumerate() {
+            if i % 2 == 0 {
+                isi_hex.push('\\');
+            }
+
+            isi_hex.push(c);
+        }
+
+        isi_hex
+    }
+
+    #[test]
+    fn execute_instruction_exported() -> Result<(), Error> {
+        let account_id = AccountId::test("alice", "wonderland");
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()));
+
+        let isi_hex = {
+            let new_account_id = AccountId::test("mad_hatter", "wonderland");
+            let register_isi = RegisterBox::new(NewAccount::new(new_account_id));
+            encode_hex(Instruction::Register(register_isi))
+        };
+
+        let wat = format!(
+            r#"
+            (module
+                ;; Import host function to execute
+                (import "iroha" "{execute_fn_name}"
+                    (func $exec_fn (param i32 i32))
+                )
+
+                {memory_and_alloc}
+
+                ;; Function which starts the smartcontract execution
+                (func (export "{main_fn_name}") (param i32 i32)
+                    (call $exec_fn (i32.const 0) (i32.const {isi_len}))
+                )
+            )
+            "#,
+            main_fn_name = WASM_MAIN_FN_NAME,
+            execute_fn_name = EXECUTE_ISI_FN_NAME,
+            memory_and_alloc = memory_and_alloc(&isi_hex),
+            isi_len = isi_hex.len() / 3,
+        );
+        let mut runtime = Runtime::new()?;
+        runtime.execute(&wsv, account_id, wat)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn execute_query_exported() -> Result<(), Error> {
+        let account_id = AccountId::test("alice", "wonderland");
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()));
+
+        let query_hex = {
+            let find_acc_query = FindAccountById::new(account_id.clone());
+            encode_hex(QueryBox::FindAccountById(find_acc_query))
+        };
+
+        let wat = format!(
+            r#"
+            (module
+                ;; Import host function to execute
+                (import "iroha" "{execute_fn_name}"
+                    (func $exec_fn (param i32 i32) (result i32 i32))
+                )
+
+                {memory_and_alloc}
+
+                ;; Function which starts the smartcontract execution
+                (func (export "{main_fn_name}") (param i32 i32)
+                    (call $exec_fn (i32.const 0) (i32.const {isi_len}))
+
+                    ;; No use of return values
+                    drop drop
+                )
+            )
+            "#,
+            main_fn_name = WASM_MAIN_FN_NAME,
+            execute_fn_name = EXECUTE_QUERY_FN_NAME,
+            memory_and_alloc = memory_and_alloc(&query_hex),
+            isi_len = query_hex.len() / 3,
+        );
+
+        let mut runtime = Runtime::new()?;
+        runtime.execute(&wsv, account_id, wat)?;
+
+        Ok(())
+    }
+}

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -192,7 +192,7 @@ impl<W: WorldTrait> WorldStateView<W> {
                     })?;
                 }
                 Executable::Wasm(bytes) => {
-                    let mut wasm_runtime = crate::wasm::Runtime::new()?;
+                    let mut wasm_runtime = crate::smartcontracts::wasm::Runtime::new()?;
                     wasm_runtime.execute(self, account_id.clone(), bytes)?;
                 }
             }
@@ -410,7 +410,7 @@ impl<W: WorldTrait> WorldStateView<W> {
     /// Fails if there is no domain or account
     pub fn map_account<T>(
         &self,
-        id: &<Account as Identifiable>::Id,
+        id: &AccountId,
         f: impl FnOnce(&Account) -> T,
     ) -> Result<T, FindError> {
         let domain = self.domain(&id.domain_id)?;
@@ -427,7 +427,7 @@ impl<W: WorldTrait> WorldStateView<W> {
     /// Fails if there is no domain or account
     pub fn modify_account(
         &self,
-        id: &<Account as Identifiable>::Id,
+        id: &AccountId,
         f: impl FnOnce(&mut Account) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let mut domain = self.domain_mut(&id.domain_id)?;
@@ -442,10 +442,7 @@ impl<W: WorldTrait> WorldStateView<W> {
     ///
     /// # Errors
     /// Fails if account finding fails
-    pub fn account_assets(
-        &self,
-        id: &<Account as Identifiable>::Id,
-    ) -> Result<Vec<Asset>, FindError> {
+    pub fn account_assets(&self, id: &AccountId) -> Result<Vec<Asset>, FindError> {
         self.map_account(id, |account| account.assets.values().cloned().collect())
     }
 

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -12,7 +12,7 @@ use dashmap::{
     mapref::one::{Ref as DashMapRef, RefMut as DashMapRefMut},
     DashSet,
 };
-use eyre::{Report, Result};
+use eyre::Result;
 use iroha_crypto::HashOf;
 use iroha_data_model::{domain::DomainsMap, peer::PeersIds, prelude::*};
 use iroha_logger::prelude::*;
@@ -181,16 +181,21 @@ impl<W: WorldTrait> WorldStateView<W> {
     pub async fn apply(&self, block: VersionedCommittedBlock) -> Result<()> {
         for tx in &block.as_v1().transactions {
             let account_id = &tx.payload().account_id;
-            tx.as_v1()
-                .payload
-                .instructions
-                .iter()
-                .cloned()
-                .try_for_each(|instruction| {
-                    let events = instruction.execute(account_id.clone(), self)?;
-                    self.produce_events(events);
-                    Ok::<_, Report>(())
-                })?;
+
+            match &tx.as_v1().payload.instructions {
+                Executable::Instructions(instructions) => {
+                    instructions.iter().cloned().try_for_each(|instruction| {
+                        let events = instruction.execute(account_id.clone(), self)?;
+
+                        self.produce_events(events);
+                        Ok::<_, eyre::Report>(())
+                    })?;
+                }
+                Executable::Wasm(bytes) => {
+                    let mut wasm_runtime = crate::wasm::Runtime::new()?;
+                    wasm_runtime.execute(self, account_id.clone(), bytes)?;
+                }
+            }
 
             self.transactions.insert(tx.hash());
             // Yield control cooperatively to the task scheduler.

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -265,7 +265,8 @@ pub mod utils {
         }
 
         pub fn sign_tx(isi: impl IntoIterator<Item = Instruction>) -> VersionedAcceptedTransaction {
-            let tx = Transaction::new(isi.into_iter().collect(), ALICE_ID.clone(), 100_000)
+            let instructions: Vec<_> = isi.into_iter().collect();
+            let tx = Transaction::new(ALICE_ID.clone(), instructions.into(), 100_000)
                 .sign(&ALICE_KEYS)
                 .unwrap();
             VersionedAcceptedTransaction::from_transaction(tx, 4096).unwrap()


### PR DESCRIPTION
Signed-off-by: Marin Veršić <marin.versic101@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR adds support for executing wasm smartcontracts to Iroha. 

Function parameters and return values are exchanged through **linear memory** via offset and length of the allocation. Since dealing with linear memory is very low-level(it's just a contiguous array of bytes) Rust types/values must be serialized to binary format before writing them to wasm memory. 

Wasm binary to be able to execute must export:
* `WASM_MAIN_FN` - function which the host calls to execute smartcontract
* `WASM_MEMORY` - linear memory (used to exchange more complex data than integers/floats)
* `WASM_ALLOC_FN` - function which hosts uses to allocate memory from wasm's linear memory


Notes:
* Note that since wasm is sandboxed there is no way for the module to get access to hosts memory.
* Writing wat directly or dealing with raw memory and manual allocation in Rust code that compiles to wasm is not a reasonable user experience. Helper functions and macros are kept for the followup PR. 
* Limits like wasm binary size and wasm fuel are added in a separate PR.

Should feature flag be introduced to include wasm support optionally?

### Issue

#1425

### Benefits

### Possible Drawbacks

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

Once [WebAssembly specification](https://github.com/webassembly/interface-types) adds support for `Interface Types` it would be much better to use those because no serialization would be required and types would just flow through wasm VM without VM actually understanding their representation.