### PR TITLE
[fix] #1714: Compare PeerId only by key

### DIFF
--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -1806,7 +1806,7 @@ pub mod domain {
 pub mod peer {
     //! This module contains [`Peer`] structure and related implementations and traits implementations.
 
-    use std::hash::Hash;
+    use std::hash::{Hash, Hasher};
 
     use dashmap::DashSet;
     use iroha_macro::Io;
@@ -1841,25 +1841,28 @@ pub mod peer {
 
     /// Peer's identification.
     #[derive(
-        Clone,
-        Debug,
-        Eq,
-        PartialEq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Io,
-        Encode,
-        Decode,
-        IntoSchema,
-        Hash,
+        Clone, Debug, PartialOrd, Ord, Serialize, Deserialize, Io, Encode, Decode, IntoSchema,
     )]
     pub struct Id {
         /// Address of the `Peer`'s entrypoint.
         pub address: String,
         /// Public Key of the `Peer`.
         pub public_key: PublicKey,
+    }
+
+    impl PartialEq for Id {
+        fn eq(&self, other: &Self) -> bool {
+            // Comparison is done by public key only, so that full domain names can be present in trusted peers and local address in this peer config without a conflict.
+            self.public_key == other.public_key
+        }
+    }
+
+    impl Eq for Id {}
+
+    impl Hash for Id {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.public_key.hash(state);
+        }
     }
 
     impl Peer {


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Compare PeerId only by key.
Comparison is done by public key only, so that full domain names can be present in trusted peers and local address in this peer config without a conflict.

The problem was found during longevity stand setup. When:
1. `TORII_P2P_ADDR` was `0.0.0.0:1337`
2. `SUMERAGI_TRUSTED_PEERS` had `[{"address": "some.test.domain:1337", ...}, ... ]`

The peers therefore did not discover themselves in trusted peers and were not considering themselves to be validators, leading to genesis block not being committed.
