### PR TITLE
[fix] #1802: Logging readability improvements

### DIFF
--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -646,7 +646,7 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
     /// * peer is not leader
     /// * there are already some blocks in blockchain
     #[iroha_futures::telemetry_future]
-    #[log(skip(self, transactions, genesis_topology))]
+    #[log(skip(self, transactions, genesis_topology, ctx))]
     pub async fn start_genesis_round(
         &mut self,
         transactions: Vec<VersionedAcceptedTransaction>,
@@ -854,7 +854,7 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
             "Created a block",
         );
         for event in Vec::<Event>::from(&block) {
-            info!(?event);
+            trace!(?event);
             drop(self.events_sender.send(event));
         }
         if !network_topology.is_consensus_required() {
@@ -918,7 +918,7 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
         let block_hash = block.hash();
 
         for event in Vec::<Event>::from(&block) {
-            info!(?event);
+            trace!(?event);
             drop(self.events_sender.send(event));
         }
 
@@ -1213,7 +1213,7 @@ pub mod message {
         /// Handles this message as part of `Sumeragi` consensus.
         /// # Errors
         /// Fails if message handling fails
-        #[iroha_logger::log(skip(self, sumeragi))]
+        #[iroha_logger::log(skip(self, sumeragi, ctx))]
         #[iroha_futures::telemetry_future]
         pub async fn handle<
             G: GenesisNetworkTrait,
@@ -1334,7 +1334,7 @@ pub mod message {
             }
 
             for event in Vec::<Event>::from(&self.block) {
-                iroha_logger::info!(?event);
+                iroha_logger::trace!(?event);
                 drop(sumeragi.events_sender.send(event));
             }
             sumeragi.update_view_changes(self.block.header().view_change_proofs.clone());

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -57,7 +57,8 @@ The following is the default configuration used by Iroha.
     "MAX_LOG_LEVEL": "INFO",
     "TELEMETRY_CAPACITY": 1000,
     "COMPACT_MODE": false,
-    "LOG_FILE_PATH": null
+    "LOG_FILE_PATH": null,
+    "TERMINAL_COLORS": true
   },
   "GENESIS": {
     "ACCOUNT_PUBLIC_KEY": null,
@@ -277,7 +278,8 @@ Has type `LoggerConfiguration`. Can be configured via environment variable `IROH
   "COMPACT_MODE": false,
   "LOG_FILE_PATH": null,
   "MAX_LOG_LEVEL": "INFO",
-  "TELEMETRY_CAPACITY": 1000
+  "TELEMETRY_CAPACITY": 1000,
+  "TERMINAL_COLORS": true
 }
 ```
 
@@ -319,6 +321,16 @@ Has type `usize`. Can be configured via environment variable `TELEMETRY_CAPACITY
 
 ```json
 1000
+```
+
+### `logger.terminal_colors`
+
+Enable ANSI terminal colors for formatted output.
+
+Has type `bool`. Can be configured via environment variable `TERMINAL_COLORS`
+
+```json
+true
 ```
 
 ## `network`

--- a/logger/src/config.rs
+++ b/logger/src/config.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::{filter::LevelFilter, reload::Handle};
 
 const TELEMETRY_CAPACITY: usize = 1000;
 const DEFAULT_COMPACT_MODE: bool = false;
+const DEFAULT_TERMINAL_COLORS: bool = true;
 
 /// Log level for reading from environment and (de)serializing
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -65,6 +66,8 @@ pub struct Configuration {
     /// If provided, logs will be copied to said file in the
     /// format readable by [bunyan](https://lib.rs/crates/bunyan)
     pub log_file_path: Option<std::path::PathBuf>,
+    /// Enable ANSI terminal colors for formatted output.
+    pub terminal_colors: bool,
 }
 
 impl Default for Configuration {
@@ -74,6 +77,7 @@ impl Default for Configuration {
             telemetry_capacity: TELEMETRY_CAPACITY,
             compact_mode: DEFAULT_COMPACT_MODE,
             log_file_path: None,
+            terminal_colors: DEFAULT_TERMINAL_COLORS,
         }
     }
 }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -58,11 +58,14 @@ pub fn init(configuration: &Configuration) -> Result<Option<Telemetries>> {
 fn setup_logger(configuration: &Configuration) -> Result<Telemetries> {
     if configuration.compact_mode {
         let layer = tracing_subscriber::fmt::layer()
+            .with_ansi(configuration.terminal_colors)
             .with_test_writer()
             .compact();
         Ok(add_bunyan(configuration, layer)?)
     } else {
-        let layer = tracing_subscriber::fmt::layer().with_test_writer();
+        let layer = tracing_subscriber::fmt::layer()
+            .with_ansi(configuration.terminal_colors)
+            .with_test_writer();
         Ok(add_bunyan(configuration, layer)?)
     }
 }

--- a/logger/tests/configuration.rs
+++ b/logger/tests/configuration.rs
@@ -13,6 +13,7 @@ async fn telemetry_separation_custom() {
         telemetry_capacity: 100,
         compact_mode: true,
         log_file_path: Some("/dev/stdout".into()),
+        terminal_colors: true,
     };
     let (mut receiver, _) = init(&config).unwrap().unwrap();
     info!(target: "telemetry::test", a = 2, c = true, d = "this won't be logged");


### PR DESCRIPTION
See #1803 

- events log moved to trace level
- ctx removed from log capture
- terminal colors are made optional (for better log output to files)

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>
