### PR TITLE
[feature] #1754: Add Kura inspector CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,10 +456,40 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -656,7 +686,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1418,6 +1448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,7 +1791,7 @@ dependencies = [
 name = "iroha_crypto_cli"
 version = "2.0.0-pre.1"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "color-eyre",
  "hex",
  "iroha_crypto",
@@ -2062,6 +2098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "kura_inspector"
+version = "2.0.0-pre.1"
+dependencies = [
+ "clap 3.0.7",
+ "iroha_core",
+ "iroha_version",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2411,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3245,12 +3299,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -3261,7 +3321,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3383,6 +3443,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,8 +2102,11 @@ name = "kura_inspector"
 version = "2.0.0-pre.1"
 dependencies = [
  "clap 3.0.7",
+ "futures-util",
+ "iroha_config",
  "iroha_core",
- "iroha_version",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "schema/derive",
   "substrate",
   "telemetry",
+  "tools/kura_inspector",
   "version",
   "version/derive",
 ]

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -577,7 +577,6 @@ impl ValidBlock {
     ///
     /// # Panics
     /// If generating keys or block signing fails.
-    #[cfg(test)]
     #[allow(clippy::restriction)]
     pub fn new_dummy() -> Self {
         Self {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -578,6 +578,7 @@ impl ValidBlock {
     /// # Panics
     /// If generating keys or block signing fails.
     #[allow(clippy::restriction)]
+    #[cfg(test)]
     pub fn new_dummy() -> Self {
         Self {
             header: BlockHeader {

--- a/tools/kura_inspector/Cargo.toml
+++ b/tools/kura_inspector/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kura_inspector"
+version = "2.0.0-pre.1"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+iroha_core = { path = "../../core" }
+iroha_version = { path = "../../version" }
+
+clap = { version = "3.0", features = ["derive"] }

--- a/tools/kura_inspector/Cargo.toml
+++ b/tools/kura_inspector/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 
 [dependencies]
 iroha_core = { path = "../../core" }
-iroha_version = { path = "../../version" }
+iroha_config = { path = "../../config" }
 
 clap = { version = "3.0", features = ["derive"] }
+futures-util = "0.3"
+tokio = { version = "1.6.0", features = ["rt"]}
+
+[dev-dependencies]
+tempfile = "3"

--- a/tools/kura_inspector/src/lib.rs
+++ b/tools/kura_inspector/src/lib.rs
@@ -1,1 +1,80 @@
-use iroha_core::kura::BlockStore;
+//! General objects independent from executables.
+
+use std::path::Path;
+
+use iroha_config::Configurable;
+use iroha_core::kura;
+
+pub mod print;
+
+#[allow(missing_docs)]
+#[derive(Clone, Copy)]
+pub enum Config {
+    Print(print::Config),
+}
+
+/// Where to write the results of the inspection.
+pub struct Output<T, E>
+where
+    T: std::io::Write + Send,
+    E: std::io::Write + Send,
+{
+    /// Writer for valid data
+    pub ok: T,
+    /// Writer for invalid data
+    pub err: E,
+}
+
+impl Config {
+    /// Configure [`kura::BlockStore`] and route to the subcommand.
+    ///
+    /// # Errors
+    /// Fails if
+    /// 1. Fails to configure [`kura::BlockStore`].
+    /// 2. Fails to run the subcommand.
+    pub async fn run<T, E>(&self, output: &mut Output<T, E>) -> Result<(), Error>
+    where
+        T: std::io::Write + Send,
+        E: std::io::Write + Send,
+    {
+        let block_store = block_store().await?;
+        match self {
+            Self::Print(cfg) => cfg.run(&block_store, output).await.map_err(Error::Print)?,
+        }
+        Ok(())
+    }
+}
+
+async fn block_store() -> Result<kura::BlockStore<kura::DefaultIO>, Error> {
+    let mut kura_config = kura::config::KuraConfiguration::default();
+    kura_config.load_environment().map_err(Error::KuraConfig)?;
+    kura::BlockStore::new(
+        Path::new(&kura_config.block_store_path),
+        kura_config.blocks_per_storage_file,
+        kura::DefaultIO,
+    )
+    .await
+    .map_err(Error::SetBlockStore)
+}
+
+/// [`Output`] for CLI use.
+pub type DefaultOutput = Output<std::io::Stdout, std::io::Stderr>;
+
+impl DefaultOutput {
+    /// Construct [`DefaultOutput`].
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            ok: std::io::stdout(),
+            err: std::io::stderr(),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum Error {
+    KuraConfig(iroha_config::derive::Error),
+    SetBlockStore(kura::Error),
+    Print(print::Error),
+}

--- a/tools/kura_inspector/src/lib.rs
+++ b/tools/kura_inspector/src/lib.rs
@@ -1,0 +1,1 @@
+use iroha_core::kura::BlockStore;

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -1,18 +1,14 @@
-use std::path::PathBuf;
-
 use clap::{Parser, Subcommand};
+use kura_inspector::{print, Config, DefaultOutput};
 
 /// Kura inspector
 #[derive(Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 struct Opts {
     /// Height of the block up to which exclude from the inspection.
-    /// Defaults to the previous one from the current top
+    /// Defaults to exclude the all except the latest block
     #[clap(short, long, name = "BLOCK_HEIGHT")]
-    skip_to: Option<u64>,
-    /// Find blocks whose data collapsed
-    #[clap(long)]
-    scan: bool,
+    skip_to: Option<usize>,
     #[clap(subcommand)]
     command: Command,
 }
@@ -24,13 +20,27 @@ enum Command {
         /// Number of the blocks to print.
         /// The excess will be truncated
         #[clap(short = 'n', long, default_value_t = 1)]
-        length: u64,
+        length: usize,
     },
-    /// Listen for additions to the storage and report it
-    Follow,
 }
 
-fn main() {
+#[tokio::main]
+#[allow(clippy::use_debug, clippy::print_stderr)]
+async fn main() {
     let opts = Opts::parse();
-    // kura_inspector::run()
+    let mut output = DefaultOutput::new();
+    Config::from(opts)
+        .run(&mut output)
+        .await
+        .unwrap_or_else(|e| eprintln!("{:?}", e))
+}
+
+impl From<Opts> for Config {
+    fn from(src: Opts) -> Self {
+        let Opts { skip_to, command } = src;
+
+        match command {
+            Command::Print { length } => Config::Print(print::Config { skip_to, length }),
+        }
+    }
 }

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -5,10 +5,10 @@ use kura_inspector::{print, Config, DefaultOutput};
 #[derive(Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 struct Opts {
-    /// Height of the block up to which exclude from the inspection.
-    /// Defaults to exclude the all except the latest block
+    /// Height of the block from which start the inspection.
+    /// Defaults to the latest block height
     #[clap(short, long, name = "BLOCK_HEIGHT")]
-    skip_to: Option<usize>,
+    from: Option<usize>,
     #[clap(subcommand)]
     command: Command,
 }
@@ -37,10 +37,10 @@ async fn main() {
 
 impl From<Opts> for Config {
     fn from(src: Opts) -> Self {
-        let Opts { skip_to, command } = src;
+        let Opts { from, command } = src;
 
         match command {
-            Command::Print { length } => Config::Print(print::Config { skip_to, length }),
+            Command::Print { length } => Config::Print(print::Config { from, length }),
         }
     }
 }

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// Kura inspector
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
+struct Opts {
+    /// Height of the block up to which exclude from the inspection.
+    /// Defaults to the previous one from the current top
+    #[clap(short, long, name = "BLOCK_HEIGHT")]
+    skip_to: Option<u64>,
+    /// Find blocks whose data collapsed
+    #[clap(long)]
+    scan: bool,
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Print contents of a certain length of the blocks
+    Print {
+        /// Number of the blocks to print.
+        /// The excess will be truncated
+        #[clap(short = 'n', long, default_value_t = 1)]
+        length: u64,
+    },
+    /// Listen for additions to the storage and report it
+    Follow,
+}
+
+fn main() {
+    let opts = Opts::parse();
+    // kura_inspector::run()
+}

--- a/tools/kura_inspector/src/print.rs
+++ b/tools/kura_inspector/src/print.rs
@@ -1,0 +1,174 @@
+//! Objects for the `print` subcommand.
+
+use futures_util::StreamExt;
+use iroha_core::{kura, prelude::VersionedCommittedBlock};
+
+use crate::Output;
+
+/// Configuration for the `print` subcommand.
+#[derive(Clone, Copy)]
+pub struct Config {
+    /// Height of the block up to which exclude from the printing.
+    /// `None` means excluding the all except the latest block.
+    pub skip_to: Option<usize>,
+    /// Number of the blocks to print.
+    /// The excess will be truncated.
+    pub length: usize,
+}
+
+impl Config {
+    /// Read `block_store` and print the results to `output`.
+    ///
+    /// # Errors
+    /// Fails if
+    /// 1. Fails to read `block_store`.
+    /// 2. Fails to print to `output`.
+    /// 3. Tries to print the latest block and there is none.
+    pub async fn run<T, E>(
+        &self,
+        block_store: &kura::BlockStore<kura::DefaultIO>,
+        output: &mut Output<T, E>,
+    ) -> Result<(), Error>
+    where
+        T: std::io::Write + Send,
+        E: std::io::Write + Send,
+    {
+        let block_stream = block_store
+            .read_all()
+            .await
+            .map_err(Box::new)
+            .map_err(Error::ReadBlockStore)?;
+        tokio::pin!(block_stream);
+
+        if let Some(height) = self.skip_to {
+            let mut block_stream = block_stream.skip(height).take(self.length);
+            while let Some(block_result) = block_stream.next().await {
+                output.print(block_result).map_err(Error::Output)?
+            }
+        } else {
+            let last = match block_stream.next().await {
+                Some(block_result) => {
+                    block_stream
+                        .fold(block_result, |_acc, x| async move { x })
+                        .await
+                }
+                None => return Err(Error::NoBlock),
+            };
+            output.print(last).map_err(Error::Output)?
+        }
+        Ok(())
+    }
+}
+
+impl<T, E> Output<T, E>
+where
+    T: std::io::Write + Send,
+    E: std::io::Write + Send,
+{
+    #[allow(clippy::use_debug)]
+    fn print(
+        &mut self,
+        block_result: Result<VersionedCommittedBlock, kura::Error>,
+    ) -> Result<(), std::io::Error> {
+        match block_result {
+            Ok(block) => writeln!(self.ok, "{:#?}", block),
+            Err(error) => writeln!(self.err, "{:#?}", error),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum Error {
+    ReadBlockStore(Box<kura::Error>),
+    Output(std::io::Error),
+    NoBlock,
+}
+
+#[cfg(test)]
+#[allow(clippy::restriction)]
+mod tests {
+    use std::io::Write;
+
+    use iroha_core::prelude::ValidBlock;
+
+    use super::*;
+
+    type TestOutput = Output<Vec<u8>, Vec<u8>>;
+    const BLOCKS_PER_FILE: u64 = 3;
+
+    impl TestOutput {
+        fn new() -> Self {
+            Self {
+                ok: Vec::new(),
+                err: Vec::new(),
+            }
+        }
+    }
+
+    async fn block_store(dir: &tempfile::TempDir) -> kura::BlockStore<kura::DefaultIO> {
+        kura::BlockStore::new(
+            dir.path(),
+            std::num::NonZeroU64::new(BLOCKS_PER_FILE).unwrap(),
+            kura::DefaultIO,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    /// Confirm that `print` command defaults to print the latest block.
+    async fn test_print_default() {
+        const BLOCK_COUNT: usize = 10;
+
+        let dir = tempfile::tempdir().unwrap();
+        let brock_store = block_store(&dir).await;
+        let mut output = TestOutput::new();
+
+        let mut tester = Vec::new();
+        for height in 1..=BLOCK_COUNT {
+            let mut block: VersionedCommittedBlock = ValidBlock::new_dummy().commit().into();
+            block.as_mut_v1().header.height = height as u64;
+            if BLOCK_COUNT == height {
+                writeln!(tester, "{:#?}", block).unwrap()
+            }
+            brock_store.write(&block).await.unwrap();
+        }
+        let cfg = Config {
+            skip_to: None,
+            length: 1,
+        };
+        cfg.run(&brock_store, &mut output).await.unwrap();
+
+        assert_eq!(tester, output.ok)
+    }
+
+    #[tokio::test]
+    /// Confirm that `skip_to` and `length` options work properly.
+    async fn test_print_range() {
+        const BLOCK_COUNT: usize = 10;
+        const SKIP_TO: usize = 2;
+        const LENGTH: usize = 5;
+
+        let dir = tempfile::tempdir().unwrap();
+        let brock_store = block_store(&dir).await;
+        let mut output = TestOutput::new();
+
+        let mut tester = Vec::new();
+        for height in 1..=BLOCK_COUNT {
+            let mut block: VersionedCommittedBlock = ValidBlock::new_dummy().commit().into();
+            block.as_mut_v1().header.height = height as u64;
+            if (SKIP_TO + 1..=SKIP_TO + LENGTH).contains(&height) {
+                writeln!(tester, "{:#?}", block).unwrap()
+            }
+            brock_store.write(&block).await.unwrap();
+        }
+        let cfg = Config {
+            skip_to: Some(SKIP_TO),
+            length: LENGTH,
+        };
+        cfg.run(&brock_store, &mut output).await.unwrap();
+
+        assert_eq!(tester, output.ok)
+    }
+}


### PR DESCRIPTION
### Description of the Change
Add a CLI tool to inspect the disk storage

![2022-01-31T221621+090000](https://user-images.githubusercontent.com/49983831/151800236-110c75df-774c-4474-87da-d0011a06d927.png)

### Issue
Closes #1754

### Benefits
Now we can inspect the disk storage regardless of the operating status of Iroha

### Possible Drawbacks
None

### Usage Examples or Tests
- `kura_inspector print` prints the latest block
  - Tested by `kura_inspector::print::tests::test_print_default`
- `kura_inspector -f 100 print -n 5` prints every block, if exists, whose height is between 100 and 104
  - Tested by `kura_inspector::print::tests::test_print_range`
- `kura_inspector -f 100 print -n 5 >/dev/null` same as above, but prints only block read errors