### PR TITLE
[refactor]: bump rust version to 1.58.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.57.0
+    RUST_VERSION=1.58.0
 
 RUN set -eux; \
     apt-get update; \
@@ -49,7 +49,7 @@ RUN git clone https://github.com/rui314/mold.git; \
     rm -rf "./mold"
 
 RUN rustup component add llvm-tools-preview clippy; \
-    rustup install --profile default nightly-2021-12-02; \
+    rustup install --profile default nightly-2022-01-15; \
     cargo install cargo-lints cargo-nono grcov
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh; \

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -622,6 +622,7 @@ mod tests {
         #[async_trait::async_trait]
         impl Actor for Actor1 {
             async fn on_start(&mut self, _ctx: &mut Context<Self>) {
+                // Safety: This is just a test.
                 unsafe {
                     INIT_ORDER.push(1);
                 }
@@ -631,6 +632,7 @@ mod tests {
         #[async_trait::async_trait]
         impl Actor for Actor2 {
             async fn on_start(&mut self, _ctx: &mut Context<Self>) {
+                // Safety: This is just a test.
                 unsafe {
                     INIT_ORDER.push(2);
                 }
@@ -640,6 +642,7 @@ mod tests {
         Actor1.start().await;
         Actor2.start().await;
 
+        // Safety: This is just a test.
         unsafe {
             assert_eq!(INIT_ORDER, vec![1, 2]);
         }

--- a/client/tests/integration_tests/connected_peers.rs
+++ b/client/tests/integration_tests/connected_peers.rs
@@ -22,14 +22,13 @@ fn connected_peers_with_f_1_0_1() {
 /// Test the number of connected peers, changing the number of faults tolerated down and up
 fn connected_peers_with_f(faults: u64) {
     let n_peers = 3 * faults + 1;
-    let mut status;
 
     let (_rt, network, mut genesis_client) = <Network>::start_test_with_runtime(n_peers as u32, 1);
     wait_for_genesis_committed(network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 
     // Confirm all peers connected
-    status = genesis_client.get_status().unwrap();
+    let mut status = genesis_client.get_status().unwrap();
     assert_eq!(status.peers, n_peers - 1);
     assert_eq!(status.blocks, 1);
 

--- a/config/derive/src/lib.rs
+++ b/config/derive/src/lib.rs
@@ -22,7 +22,10 @@ mod attrs {
     pub const INNER: &str = "inner";
 }
 
-fn get_type_argument<'a, 'b>(s: &'a str, ty: &'b Type) -> Option<&'b GenericArgument> {
+fn get_type_argument<'first, 'second>(
+    s: &'first str,
+    ty: &'second Type,
+) -> Option<&'second GenericArgument> {
     let path = if let Type::Path(r#type) = ty {
         r#type
     } else {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -172,9 +172,9 @@ pub trait Configurable: Serialize + DeserializeOwned {
     /// Gets inner field of arbitrary inner depth and returns as json-value
     /// # Errors
     /// Fails if field was unknown
-    fn get_recursive<'a, T>(&self, inner_field: T) -> Result<Value, Self::Error>
+    fn get_recursive<'str_life, T>(&self, inner_field: T) -> Result<Value, Self::Error>
     where
-        T: AsRef<[&'a str]> + Send + 'a;
+        T: AsRef<[&'str_life str]> + Send + 'str_life;
 
     /// Fails if fails to deserialize from environment
     /// # Errors
@@ -184,8 +184,8 @@ pub trait Configurable: Serialize + DeserializeOwned {
     /// Gets docs of inner field of arbitrary depth
     /// # Errors
     /// Fails if field was unknown
-    fn get_doc_recursive<'a>(
-        field: impl AsRef<[&'a str]>,
+    fn get_doc_recursive<'str_life>(
+        field: impl AsRef<[&'str_life str]>,
     ) -> Result<Option<&'static str>, Self::Error>;
 
     /// Gets docs of field

--- a/config/src/runtime_upgrades.rs
+++ b/config/src/runtime_upgrades.rs
@@ -33,7 +33,8 @@ pub enum ReloadError {
     Other,
 }
 
-type PoisonErr<'a, T> = PoisonError<MutexGuard<'a, Option<Box<(dyn ReloadMut<T> + Send + Sync)>>>>;
+type PoisonErr<'guarded_life, T> =
+    PoisonError<MutexGuard<'guarded_life, Option<Box<(dyn ReloadMut<T> + Send + Sync)>>>>;
 
 impl<T> From<PoisonErr<'_, T>> for ReloadError {
     fn from(_: PoisonErr<'_, T>) -> Self {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -44,6 +44,7 @@ impl<T> From<EmptyChainHash<T>> for HashOf<T> {
 
 /// Blockchain.
 #[derive(Debug, Default)]
+#[must_use]
 pub struct Chain {
     blocks: DashMap<u64, VersionedCommittedBlock>,
 }
@@ -64,6 +65,7 @@ impl Chain {
     }
 
     /// Iterator over height and block.
+    #[allow(clippy::iter_not_returning_iterator)] // False-positive
     pub fn iter(&self) -> ChainIterator {
         ChainIterator::new(self)
     }
@@ -87,14 +89,14 @@ impl Chain {
 }
 
 /// Chain iterator
-pub struct ChainIterator<'a> {
-    chain: &'a Chain,
+pub struct ChainIterator<'life> {
+    chain: &'life Chain,
     pos_front: u64,
     pos_back: u64,
 }
 
-impl<'a> ChainIterator<'a> {
-    fn new(chain: &'a Chain) -> Self {
+impl<'chain_life> ChainIterator<'chain_life> {
+    fn new(chain: &'chain_life Chain) -> Self {
         ChainIterator {
             chain,
             pos_front: 1,
@@ -107,8 +109,8 @@ impl<'a> ChainIterator<'a> {
     }
 }
 
-impl<'a> Iterator for ChainIterator<'a> {
-    type Item = MapRef<'a, u64, VersionedCommittedBlock>;
+impl<'life> Iterator for ChainIterator<'life> {
+    type Item = MapRef<'life, u64, VersionedCommittedBlock>;
     fn next(&mut self) -> Option<Self::Item> {
         if !self.is_exhausted() {
             let val = self.chain.blocks.get(&self.pos_front);
@@ -141,7 +143,7 @@ impl<'a> Iterator for ChainIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for ChainIterator<'a> {
+impl<'life> DoubleEndedIterator for ChainIterator<'life> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if !self.is_exhausted() {
             let val = self.chain.blocks.get(&self.pos_back);
@@ -164,6 +166,7 @@ declare_versioned_with_scale!(VersionedPendingBlock 1..2, Debug, Clone, iroha_ma
 /// Blocks lifecycle starts from "Pending" state which is represented by `PendingBlock` struct.
 #[version_with_scale(n = 1, versioned = "VersionedPendingBlock")]
 #[derive(Debug, Clone, Decode, Encode)]
+#[must_use]
 pub struct PendingBlock {
     /// Unix time (in milliseconds) of block forming by a peer.
     pub timestamp: u128,
@@ -243,6 +246,7 @@ impl PendingBlock {
 
 /// When `PendingBlock` chained with a blockchain it becomes `ChainedBlock`
 #[derive(Debug, Clone, Decode, Encode)]
+#[must_use]
 pub struct ChainedBlock {
     /// Header
     pub header: BlockHeader,
@@ -373,6 +377,7 @@ impl VersionedValidBlock {
     }
 
     /// Validate block transactions against current state of the world.
+    #[must_use]
     pub fn revalidate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,
@@ -511,6 +516,7 @@ impl ValidBlock {
     }
 
     /// Validate block transactions against current state of the world.
+    #[must_use]
     pub fn revalidate<W: WorldTrait>(
         self,
         wsv: &WorldStateView<W>,

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -38,16 +38,16 @@ pub enum Error {
     Other(eyre::Error),
 }
 
-struct State<'a, W: WorldTrait> {
-    wsv: &'a WorldStateView<W>,
+struct State<'wsv_life, W: WorldTrait> {
+    wsv: &'wsv_life WorldStateView<W>,
     account_id: AccountId,
 
     /// Number of instructions in the smartcontract
     instruction_count: u64,
 }
 
-impl<'a, W: WorldTrait> State<'a, W> {
-    fn new(wsv: &'a WorldStateView<W>, account_id: AccountId) -> Self {
+impl<'wsv_life, W: WorldTrait> State<'wsv_life, W> {
+    fn new(wsv: &'wsv_life WorldStateView<W>, account_id: AccountId) -> Self {
         Self {
             wsv,
             account_id,
@@ -57,12 +57,12 @@ impl<'a, W: WorldTrait> State<'a, W> {
 }
 
 /// `WebAssembly` virtual machine
-pub struct Runtime<'a, W: WorldTrait> {
+pub struct Runtime<'wsv_life, W: WorldTrait> {
     engine: Engine,
-    linker: Linker<State<'a, W>>,
+    linker: Linker<State<'wsv_life, W>>,
 }
 
-impl<'a, W: WorldTrait> Runtime<'a, W> {
+impl<'wsv_life, W: WorldTrait> Runtime<'wsv_life, W> {
     /// Every WASM instruction costs approximately 1 unit of fuel. See
     /// [`wasmtime` reference](https://docs.rs/wasmtime/0.29.0/wasmtime/struct.Store.html#method.add_fuel)
     const FUEL_LIMIT: u64 = 10_000;
@@ -146,7 +146,7 @@ impl<'a, W: WorldTrait> Runtime<'a, W> {
         Ok(())
     }
 
-    fn create_linker(engine: &Engine) -> Result<Linker<State<'a, W>>, Error> {
+    fn create_linker(engine: &Engine) -> Result<Linker<State<'wsv_life, W>>, Error> {
         let mut linker = Linker::new(engine);
 
         linker

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -1161,9 +1161,9 @@ pub mod message {
         /// Send this message over the network to multiple `peers`.
         /// # Errors
         /// Fails if network sending fails
-        pub async fn send_to_multiple<'a, I>(self, broker: &Broker, peers: I)
+        pub async fn send_to_multiple<'item_life, I>(self, broker: &Broker, peers: I)
         where
-            I: IntoIterator<Item = &'a PeerId> + Send,
+            I: IntoIterator<Item = &'item_life PeerId> + Send,
         {
             let futures = peers
                 .into_iter()

--- a/core/src/sumeragi/network_topology.rs
+++ b/core/src/sumeragi/network_topology.rs
@@ -366,10 +366,10 @@ impl Topology {
     }
 
     /// Returns signatures of the peers with the specified `roles` from all `signatures`.
-    pub fn filter_signatures_by_roles<'a>(
-        &'a self,
-        roles: &'a [Role],
-        signatures: impl IntoIterator<Item = &'a SignatureOf<VersionedValidBlock>> + 'a,
+    pub fn filter_signatures_by_roles<'life>(
+        &'life self,
+        roles: &'life [Role],
+        signatures: impl IntoIterator<Item = &'life SignatureOf<VersionedValidBlock>> + 'life,
     ) -> Vec<SignatureOf<VersionedValidBlock>> {
         let roles: HashSet<Role> = roles.iter().copied().collect();
         let public_keys: HashSet<_> = roles

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -133,6 +133,7 @@ impl<W: WorldTrait> WorldStateView<W> {
     }
 
     /// Add the ability of emitting events to [`WorldStateView`].
+    #[must_use]
     pub fn with_events(mut self, events_sender: EventsSender) -> Self {
         self.events_sender = Some(events_sender);
         self

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -133,18 +133,21 @@ pub struct KeyGenConfiguration {
 
 impl KeyGenConfiguration {
     /// Use seed
+    #[must_use]
     pub fn use_seed(mut self, seed: Vec<u8>) -> Self {
         self.key_gen_option = Some(KeyGenOption::UseSeed(seed));
         self
     }
 
     /// Use private key
+    #[must_use]
     pub fn use_private_key(mut self, private_key: PrivateKey) -> Self {
         self.key_gen_option = Some(KeyGenOption::FromPrivateKey(private_key));
         self
     }
 
     /// With algorithm
+    #[must_use]
     pub fn with_algorithm(mut self, algorithm: Algorithm) -> Self {
         self.algorithm = algorithm;
         self

--- a/crypto/src/multihash.rs
+++ b/crypto/src/multihash.rs
@@ -24,6 +24,7 @@ pub const BLS12_381_G2_PUB: &str = "bls12_381-g2-pub";
 /// The corresponding byte codes are taken from [official multihash table](https://github.com/multiformats/multicodec/blob/master/table.csv)
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[allow(clippy::enum_variant_names)]
 pub enum DigestFunction {
     /// Ed25519
     #[display(fmt = "{}", "ED_25519_PUB_STR")]

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -197,6 +197,7 @@ impl ContextValue {
     }
 
     /// Constructs `ContextValue`.
+    #[must_use]
     pub fn new(value_name: &str) -> Self {
         Self {
             value_name: String::from(value_name),
@@ -229,6 +230,7 @@ impl Multiply {
     }
 
     /// Constructs `Multiply` expression.
+    #[must_use]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -262,6 +264,7 @@ impl Divide {
     }
 
     /// Constructs `Multiply` expression.
+    #[must_use]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -295,6 +298,7 @@ impl Mod {
     }
 
     /// Constructs `Mod` expression.
+    #[must_use]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -328,6 +332,7 @@ impl RaiseTo {
     }
 
     /// Constructs `RaiseTo` expression.
+    #[must_use]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -361,6 +366,7 @@ impl Add {
     }
 
     /// Constructs `Add` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -394,6 +400,7 @@ impl Subtract {
     }
 
     /// Constructs `Subtract` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -427,6 +434,7 @@ impl Greater {
     }
 
     /// Constructs `Greater` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -460,6 +468,7 @@ impl Less {
     }
 
     /// Constructs `Less` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -491,6 +500,7 @@ impl Not {
     }
 
     /// Constructs `Not` expression.
+    #[must_use]
     pub fn new<E: Into<EvaluatesTo<bool>>>(expression: E) -> Self {
         Self {
             expression: expression.into(),
@@ -522,6 +532,7 @@ impl And {
     }
 
     /// Constructs `And` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<bool>>, R: Into<EvaluatesTo<bool>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -554,6 +565,7 @@ impl Or {
     }
 
     /// Constructs `Or` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<bool>>, R: Into<EvaluatesTo<bool>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -584,7 +596,7 @@ pub struct IfBuilder {
 impl IfBuilder {
     ///Sets the `condition`.
     pub fn condition<C: Into<EvaluatesTo<bool>>>(condition: C) -> Self {
-        IfBuilder {
+        Self {
             condition: condition.into(),
             then_expression: None,
             else_expression: None,
@@ -593,7 +605,7 @@ impl IfBuilder {
 
     /// Sets `then_expression`.
     pub fn then_expression<E: Into<EvaluatesTo<Value>>>(self, expression: E) -> Self {
-        IfBuilder {
+        Self {
             then_expression: Some(expression.into()),
             ..self
         }
@@ -601,7 +613,7 @@ impl IfBuilder {
 
     /// Sets `else_expression`.
     pub fn else_expression<E: Into<EvaluatesTo<Value>>>(self, expression: E) -> Self {
-        IfBuilder {
+        Self {
             else_expression: Some(expression.into()),
             ..self
         }
@@ -644,6 +656,7 @@ impl If {
     }
 
     /// Constructs `If` expression.
+    #[must_use]
     pub fn new<
         C: Into<EvaluatesTo<bool>>,
         T: Into<EvaluatesTo<Value>>,
@@ -686,6 +699,7 @@ impl Contains {
     }
 
     /// Constructs `Contains` expression.
+    #[must_use]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Value>>>(
         collection: C,
         element: E,
@@ -722,6 +736,7 @@ impl ContainsAll {
     }
 
     /// Constructs `Contains` expression.
+    #[must_use]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Vec<Value>>>>(
         collection: C,
         elements: E,
@@ -758,6 +773,7 @@ impl ContainsAny {
     }
 
     /// Constructs `Contains` expression.
+    #[must_use]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Vec<Value>>>>(
         collection: C,
         elements: E,
@@ -793,6 +809,7 @@ impl Equal {
     }
 
     /// Constructs `Or` expression.
+    #[must_use]
     pub fn new<L: Into<EvaluatesTo<Value>>, R: Into<EvaluatesTo<Value>>>(
         left: L,
         right: R,
@@ -821,14 +838,16 @@ pub struct WhereBuilder {
 
 impl WhereBuilder {
     /// Sets the `expression` to be evaluated.
-    pub fn evaluate<E: Into<EvaluatesTo<Value>>>(expression: E) -> WhereBuilder {
-        WhereBuilder {
+    #[must_use]
+    pub fn evaluate<E: Into<EvaluatesTo<Value>>>(expression: E) -> Self {
+        Self {
             expression: expression.into(),
             values: btree_map::BTreeMap::new(),
         }
     }
 
     /// Binds `expression` result to a `value_name`, by which it will be reachable from the main expression.
+    #[must_use]
     pub fn with_value<E: Into<EvaluatesTo<Value>>>(
         mut self,
         value_name: ValueName,
@@ -839,6 +858,7 @@ impl WhereBuilder {
     }
 
     /// Returns a [`Where`] expression.
+    #[must_use]
     pub fn build(self) -> Where {
         Where::new(self.expression, self.values)
     }
@@ -863,6 +883,7 @@ impl Where {
     }
 
     /// Constructs `Or` expression.
+    #[must_use]
     pub fn new<E: Into<EvaluatesTo<Value>>>(
         expression: E,
         values: btree_map::BTreeMap<ValueName, EvaluatesTo<Value>>,

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, string::String, vec::Vec};
-use core::fmt::Debug;
+use core::{fmt::Debug, iter::IntoIterator};
 
 use iroha_macro::FromVariant;
 use iroha_schema::IntoSchema;
@@ -622,6 +622,7 @@ impl Pair {
     }
 
     /// Construct [`Pair`].
+    #[must_use]
     pub fn new<LI: Into<Instruction>, RI: Into<Instruction>>(
         left_instruction: LI,
         right_instruction: RI,
@@ -644,7 +645,17 @@ impl SequenceBox {
     }
 
     /// Construct [`SequenceBox`].
-    pub fn new(instructions: Vec<Instruction>) -> Self {
+    #[inline]
+    #[must_use]
+    pub fn new(instructions: impl IntoIterator<Item = Instruction>) -> Self {
+        Self {
+            instructions: instructions.into_iter().collect(),
+        }
+    }
+}
+
+impl From<Vec<Instruction>> for SequenceBox {
+    fn from(instructions: Vec<Instruction>) -> Self {
         Self { instructions }
     }
 }

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -218,12 +218,14 @@ impl Transaction {
     }
 
     /// Adds metadata to the `Transaction`
+    #[must_use]
     pub fn with_metadata(mut self, metadata: UnlimitedMetadata) -> Self {
         self.payload.metadata = metadata;
         self
     }
 
     /// Adds nonce to the `Transaction`
+    #[must_use]
     pub fn with_nonce(mut self, nonce: u32) -> Self {
         self.payload.nonce = Some(nonce);
         self

--- a/lints.toml
+++ b/lints.toml
@@ -49,6 +49,8 @@ allow = [
     'clippy::wildcard_enum_match_arm',
     'clippy::wildcard_imports',
     'elided_lifetimes_in_paths',
+    'clippy::manual_assert',    # We can't rely on Debug assertions.
+    'clippy::separated_literal_suffix',
     # Our preferred style.
     'clippy::mod-module-files',
     # Most trybuild code triggers a false-positive.

--- a/logger/src/telemetry.rs
+++ b/logger/src/telemetry.rs
@@ -152,6 +152,7 @@ impl<S: Subscriber> EventInspectorTrait for TelemetryLayer<S> {
         &self.subscriber
     }
 
+    #[allow(clippy::option_if_let_else)]
     fn event(&self, event: &Event<'_>) {
         let target = event.metadata().target();
         if let Some(telemetry_target) = target.strip_prefix(TELEMETRY_TARGET_PREFIX) {

--- a/schema/derive/src/lib.rs
+++ b/schema/derive/src/lib.rs
@@ -299,10 +299,10 @@ fn variant_index(v: &Variant, i: usize) -> TokenStream2 {
 }
 
 /// Finds specific attribute with codec ident satisfying predicate
-fn find_meta_item<'a, F, R, I, M>(mut itr: I, mut pred: F) -> Option<R>
+fn find_meta_item<'it_life, Func, Res, It, M>(mut itr: It, mut pred: Func) -> Option<Res>
 where
-    F: FnMut(M) -> Option<R> + Clone,
-    I: Iterator<Item = &'a Attribute>,
+    Func: FnMut(M) -> Option<Res> + Clone,
+    It: Iterator<Item = &'it_life Attribute>,
     M: Parse,
 {
     itr.find_map(|attr| {

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -16,7 +16,7 @@ iroha_futures = { version = "=2.0.0-pre.1", path = "../futures", features = ["te
 iroha_telemetry_derive = { version = "=2.0.0-pre.1", path = "derive" }
 
 
-async-trait = "0.1"
+async-trait = "0.1.52"
 chrono = "0.4"
 eyre = "0.6.5"
 futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -188,7 +188,7 @@ pub mod json {
     use super::{error::Result, Version};
 
     /// [`Serialize`] versioned analog, specifically for JSON.
-    pub trait DeserializeVersioned<'a>: Deserialize<'a> + Version {
+    pub trait DeserializeVersioned<'life>: Deserialize<'life> + Version {
         /// Use this function for versioned objects instead of [`serde_json::from_str`].
         ///
         /// # Errors


### PR DESCRIPTION
Signed-off-by: Aleksandr <a-p-petrosyan@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Bumped the version of `rust` and satisfied the lints added in 1.58. 

### Issue

None

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Update

### Possible Drawbacks

None

### Usage Examples or Tests *[optional]*

`rustup toolchain update stable && cargo lints clippy --workspace --benches --tests --examples`
