### PR TITLE
[fix] #1848: Prevent public keys from being burned to nothing

### DIFF
--- a/client/tests/integration_tests/burn_public_keys.rs
+++ b/client/tests/integration_tests/burn_public_keys.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::pedantic, clippy::restriction)]
+
+use std::thread;
+
+use iroha_client::client::{account, transaction, Client};
+use iroha_core::{config::Configuration, prelude::*};
+use iroha_data_model::prelude::*;
+use test_network::{Peer as TestPeer, *};
+
+fn submit_and_get(
+    client: &mut Client,
+    instructions: impl IntoIterator<Item = Instruction>,
+) -> TransactionValue {
+    let hash = client.submit_all(instructions).unwrap();
+    thread::sleep(Configuration::pipeline_time() * 2);
+
+    client.request(transaction::by_hash(*hash)).unwrap()
+}
+
+fn account_keys_count(client: &mut Client, account_id: AccountId) -> usize {
+    let account = client.request(account::by_id(account_id)).unwrap();
+    account.signatories.len()
+}
+
+#[test]
+fn public_keys_cannot_be_burned_to_nothing() {
+    const KEYS_COUNT: usize = 3;
+    let mut keys_count;
+    let mut committed_txn;
+    let bob_id = AccountId::test("bob", "wonderland");
+    let bob_keys_count = |client: &mut Client| account_keys_count(client, bob_id.clone());
+
+    let (_rt, _peer, mut client) = <TestPeer>::start_test_with_runtime();
+    wait_for_genesis_committed(vec![client.clone()], 0);
+
+    let register_bob = RegisterBox::new(NewAccount::new(bob_id.clone())).into();
+
+    let _ = submit_and_get(&mut client, [register_bob]);
+    keys_count = bob_keys_count(&mut client);
+    assert_eq!(keys_count, 0);
+
+    let mint_keys = (0..KEYS_COUNT)
+        .map(|_| MintBox::new(KeyPair::generate().unwrap().public_key, bob_id.clone()).into());
+
+    let _ = submit_and_get(&mut client, mint_keys);
+    keys_count = bob_keys_count(&mut client);
+    assert_eq!(keys_count, KEYS_COUNT);
+
+    let bob = client.request(account::by_id(bob_id.clone())).unwrap();
+    let mut keys = bob.signatories.into_iter();
+    let burn = |key: PublicKey| Instruction::from(BurnBox::new(key, bob_id.clone()));
+    let burn_keys_leaving_one = keys.by_ref().take(KEYS_COUNT - 1).map(burn);
+
+    committed_txn = submit_and_get(&mut client, burn_keys_leaving_one);
+    keys_count = bob_keys_count(&mut client);
+    assert_eq!(keys_count, 1);
+    assert!(matches!(committed_txn, TransactionValue::Transaction(_)));
+
+    let burn_the_last_key = keys.map(burn);
+
+    committed_txn = submit_and_get(&mut client, burn_the_last_key);
+    keys_count = bob_keys_count(&mut client);
+    assert_eq!(keys_count, 1);
+    assert!(matches!(
+        committed_txn,
+        TransactionValue::RejectedTransaction(_)
+    ));
+}

--- a/client/tests/integration_tests/mod.rs
+++ b/client/tests/integration_tests/mod.rs
@@ -2,6 +2,7 @@ mod add_account;
 mod add_asset;
 mod add_domain;
 mod asset_propagation;
+mod burn_public_keys;
 mod config;
 mod connected_peers;
 mod events;

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -65,6 +65,11 @@ pub mod isi {
         ) -> Result<Self::Diff, Self::Error> {
             let public_key = self.object.clone();
             wsv.modify_account(&self.destination_id, |account| {
+                if account.signatories.len() < 2 {
+                    return Err(Self::Error::Validate(ValidationError::new(
+                        "Public keys cannot be burned to nothing.",
+                    )));
+                }
                 if let Some(index) = account
                     .signatories
                     .iter()

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -67,7 +67,7 @@ pub mod isi {
             wsv.modify_account(&self.destination_id, |account| {
                 if account.signatories.len() < 2 {
                     return Err(Self::Error::Validate(ValidationError::new(
-                        "Public keys cannot be burned to nothing.",
+                        "Public keys cannot be burned to nothing. If you want to delete the account, please use an unregister instruction.",
                     )));
                 }
                 if let Some(index) = account

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -70,7 +70,7 @@ pub mod error {
         #[error("Repetition")]
         Repetition(InstructionType, IdBox),
         /// Failed to validate.
-        #[error("Failed to validate.")]
+        #[error("Failed to validate: {0}")]
         Validate(#[source] ValidationError),
     }
 

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -175,7 +175,7 @@ impl<T: Into<Value>> From<T> for ExpressionBox {
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Decode, Encode, Deserialize, Serialize, IntoSchema,
 )]
 pub struct ContextValue {
-    /// Name binded to the value.
+    /// Name bound to the value.
     pub value_name: String,
 }
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -109,7 +109,7 @@ impl Name {
             Ok(())
         } else {
             Err(ValidationError::new(&format!(
-                "Number of chars in the name not in range [{}..{}>",
+                "Name must be between {} and {} characters in length.",
                 &range.start(),
                 &range.end()
             )))

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -50,6 +50,15 @@ pub struct ValidationError {
 #[cfg(feature = "std")]
 impl std::error::Error for ValidationError {}
 
+impl ValidationError {
+    /// Construct [`ValidationError`].
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_owned(),
+        }
+    }
+}
+
 /// `Name` struct represents type for Iroha Entities names, like
 /// [`Domain`](`domain::Domain`)'s name or
 /// [`Account`](`account::Account`)'s name.
@@ -99,13 +108,11 @@ impl Name {
         if range.contains(&self.as_ref().chars().count()) {
             Ok(())
         } else {
-            Err(ValidationError {
-                reason: format!(
-                    "Number of chars in the name not in range [{}..{}>",
-                    &range.start(),
-                    &range.end()
-                ),
-            })
+            Err(ValidationError::new(&format!(
+                "Number of chars in the name not in range [{}..{}>",
+                &range.start(),
+                &range.end()
+            )))
         }
     }
 }


### PR DESCRIPTION
### Description of the Change
Add a validation to the `Burn<Account, PublicKey>` execution

### Issue
Closes #1848

### Benefits
First-aid for the issue:
- Prevent accidentally burning the last key for the account
- Prevent users from assuming that they can delete the account by burning its last key
  - Direct them to `Unregister<Account>`
### Possible Drawbacks
None

### Alternate Designs
The true solution will be the new account structure #1594 where an account is identified by its public key