### PR TITLE
[feature] #1815: Make query responses more type-structured

### DIFF
--- a/config/src/runtime_upgrades.rs
+++ b/config/src/runtime_upgrades.rs
@@ -22,10 +22,10 @@ pub enum ReloadError {
     #[error("Resource dropped.")]
     Dropped,
 
-    /// If the reload handle wasn't properly initialised (using
+    /// If the reload handle wasn't properly initialized (using
     /// [`handle::Singleton::set`]), there's nothing to reload with.
-    #[error("Cannot reload an uninitialised handle.")]
-    NotInitialised,
+    #[error("Cannot reload an uninitialized handle.")]
+    NotInitialized,
 
     /// Error not specified by the implementer of the [`Reload`]
     /// traits. Use as last resort.
@@ -188,9 +188,9 @@ pub mod handle {
     }
 
     impl<T: Send + Sync> Singleton<T> {
-        /// Set and/or initialise the [`Self`] to a non-empty value.
+        /// Set and/or initialize the [`Self`] to a non-empty value.
         /// Reloading before calling this `fn` should cause
-        /// [`ReloadError::NotInitialised`].
+        /// [`ReloadError::NotInitialized`].
         ///
         /// # Errors
         /// [`ReloadError::Poisoned`] When the [`Mutex`] storing the reload handle is poisoned.
@@ -213,7 +213,7 @@ pub mod handle {
                     handle.reload(item)?;
                     Ok(())
                 }
-                None => Err(ReloadError::NotInitialised),
+                None => Err(ReloadError::NotInitialized),
             }
         }
     }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -98,11 +98,11 @@ impl Configuration {
         let mut configuration: Configuration = serde_json::from_reader(reader).wrap_err(
             format!("Failed to parse {:?} as Iroha peer configuration.", path),
         )?;
-        configuration.finalise();
+        configuration.finalize();
         Ok(configuration)
     }
 
-    fn finalise(&mut self) {
+    fn finalize(&mut self) {
         self.sumeragi.key_pair = self.key_pair().into();
         self.sumeragi.peer_id = PeerId::new(&self.torii.p2p_addr, &self.public_key.clone());
     }
@@ -114,7 +114,7 @@ impl Configuration {
     /// - Configuration `TrustedPeers` contains entries with duplicate public keys
     pub fn load_environment(&mut self) -> Result<()> {
         iroha_config::Configurable::load_environment(self)?;
-        self.finalise();
+        self.finalize();
         Ok(())
     }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -40,7 +40,7 @@ pub trait GenesisNetworkTrait:
     /// Construct [`GenesisNetwork`] from configuration.
     ///
     /// # Errors
-    /// Fails if genesis block is not found or cannot be deserialised.
+    /// Fails if genesis block is not found or cannot be deserialized.
     fn from_configuration(
         submit_genesis: bool,
         raw_block: RawGenesisBlock,

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -269,7 +269,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::new())
                 .wrap_err("Failed to evaluate account id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let roles = wsv.map_account(&account_id, |account| {
                 account.roles.iter().cloned().collect::<Vec<_>>()
             })?;
@@ -285,7 +285,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::new())
                 .wrap_err("Failed to evaluate account id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let tokens = wsv.map_account(&account_id, |account| {
                 wsv.account_permission_tokens(account)
                     .iter()
@@ -318,7 +318,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.map_account(&id, Clone::clone).map_err(Into::into)
         }
     }
@@ -331,7 +331,7 @@ pub mod query {
                 .name
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get account name")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
                 for (id, account) in &domain.accounts {
@@ -352,7 +352,7 @@ pub mod query {
                 .domain_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get domain id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             Ok(wsv
                 .domain(&id)?
                 .accounts
@@ -370,12 +370,12 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get account id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let key = self
                 .key
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get key")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.map_account(&id, |account| account.metadata.get(&key).map(Clone::clone))?
                 .ok_or_else(|| query::Error::Find(Box::new(FindError::MetadataKey(key))))
         }

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -66,7 +66,7 @@ pub mod isi {
                 let quantity: &mut u32 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(Error::Math(MathError::Overflow))?;
@@ -101,7 +101,7 @@ pub mod isi {
                 let quantity: &mut u128 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(Error::Math(MathError::Overflow))?;
@@ -136,7 +136,7 @@ pub mod isi {
                 let quantity: &mut Fixed = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity.checked_add(self.object)?;
                 wsv.metrics.tx_amounts.observe((*quantity).into());
                 Ok(())
@@ -167,7 +167,7 @@ pub mod isi {
                 let store: &mut Metadata = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 store.insert_with_limits(self.key, self.value, asset_metadata_limits)?;
                 Ok(())
             })?;
@@ -194,7 +194,7 @@ pub mod isi {
                 let quantity: &mut u32 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
@@ -227,7 +227,7 @@ pub mod isi {
                 let quantity: &mut u128 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(MathError::NotEnoughQuantity)?;
@@ -261,7 +261,7 @@ pub mod isi {
                 let quantity: &mut Fixed = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity.checked_sub(self.object)?;
                 // Careful if `Fixed` stops being `Copy`.
                 wsv.metrics.tx_amounts.observe((*quantity).into());
@@ -291,7 +291,7 @@ pub mod isi {
                 let store: &mut Metadata = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 store
                     .remove(&self.key)
                     .ok_or(FindError::MetadataKey(self.key))?;
@@ -336,7 +336,7 @@ pub mod isi {
                 let quantity: &mut u32 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_sub(self.object)
                     .ok_or(Error::Math(MathError::NotEnoughQuantity))?;
@@ -347,7 +347,7 @@ pub mod isi {
                 let quantity: &mut u32 = asset
                     .try_as_mut()
                     .map_err(eyre::Error::from)
-                    .map_err(Error::Conversion)?;
+                    .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_add(self.object)
                     .ok_or(MathError::Overflow)?;
@@ -409,7 +409,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.asset(&id)
                 .map_err(
                     |asset_err| match wsv.asset_definition_entry(&id.definition_id) {
@@ -429,7 +429,7 @@ pub mod query {
                 .name
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset name")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
                 for account in domain.accounts.values() {
@@ -452,7 +452,7 @@ pub mod query {
                 .account_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get account id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.account_assets(&id).map_err(Into::into)
         }
     }
@@ -465,7 +465,7 @@ pub mod query {
                 .asset_definition_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset definition id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
                 for account in domain.accounts.values() {
@@ -488,7 +488,7 @@ pub mod query {
                 .domain_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get domain id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let mut vec = Vec::new();
             for account in wsv.domain(&id)?.accounts.values() {
                 for asset in account.assets.values() {
@@ -507,12 +507,12 @@ pub mod query {
                 .domain_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get domain id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let asset_definition_id = self
                 .asset_definition_id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset definition id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let domain = wsv.domain(&domain_id)?;
             let _definition = domain
                 .asset_definitions
@@ -540,7 +540,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.asset(&id)
                 .map_err(
                     |asset_err| match wsv.asset_definition_entry(&id.definition_id) {
@@ -551,7 +551,7 @@ pub mod query {
                 .value
                 .try_as_ref()
                 .map_err(eyre::Error::from)
-                .map_err(Error::Conversion)
+                .map_err(|e| Error::Conversion(e.to_string()))
                 .map(Clone::clone)
         }
     }
@@ -564,12 +564,12 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let key = self
                 .key
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get key")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let asset = wsv.asset(&id).map_err(|asset_err| {
                 match wsv.asset_definition_entry(&id.definition_id) {
                     Ok(_) => asset_err,
@@ -580,7 +580,7 @@ pub mod query {
                 .value
                 .try_as_ref()
                 .map_err(eyre::Error::from)
-                .map_err(Error::Conversion)?;
+                .map_err(|e| Error::Conversion(e.to_string()))?;
             Ok(store
                 .get(&key)
                 .ok_or_else(|| Error::Find(Box::new(FindError::MetadataKey(key))))?

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -273,7 +273,7 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get domain id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             Ok(wsv.domain(&id)?.clone())
         }
     }
@@ -286,12 +286,12 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get domain id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let key = self
                 .key
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get key")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             wsv.map_domain(&id, |domain| domain.metadata.get(&key).map(Clone::clone))?
                 .ok_or_else(|| FindError::MetadataKey(key).into())
         }
@@ -304,12 +304,12 @@ pub mod query {
                 .id
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset definition id")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             let key = self
                 .key
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get key")
-                .map_err(Error::Evaluate)?;
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
             Ok(wsv
                 .asset_definition_entry(&id)?
                 .definition

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -25,7 +25,7 @@ where
 
         V::try_from(expr)
             .map_err(Into::into)
-            .map_err(Error::Conversion)
+            .map_err(|e| Error::Conversion(e.to_string()))
     }
 }
 
@@ -618,7 +618,7 @@ mod tests {
         let serialized_expression =
             serde_json::to_string(&expression).expect("Failed to serialize.");
         let deserialized_expression: ExpressionBox =
-            serde_json::from_str(&serialized_expression).expect("Failed to de-serialise.");
+            serde_json::from_str(&serialized_expression).expect("Failed to de-serialize.");
         let wsv = WorldStateView::<World>::new(World::new());
         assert_eq!(
             expression

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -33,6 +33,7 @@ pub mod error {
 
     use iroha_crypto::HashOf;
     use iroha_data_model::{fixed::FixedPointOperationError, metadata, prelude::*};
+    use parity_scale_codec::{Decode, Encode};
     use thiserror::Error;
 
     use super::{query, VersionedCommittedBlock};
@@ -66,7 +67,7 @@ pub mod error {
         FailBox(std::string::String),
         /// Conversion Error
         #[error("Conversion Error: {0}")]
-        Conversion(#[source] eyre::Error),
+        Conversion(std::string::String),
         /// Repeated instruction
         #[error("Repetition")]
         Repetition(InstructionType, IdBox),
@@ -128,7 +129,7 @@ pub mod error {
     }
 
     /// Type assertion error
-    #[derive(Debug, Clone, Error)]
+    #[derive(Debug, Clone, Error, Decode, Encode)]
     pub enum FindError {
         /// Failed to find asset
         #[error("Failed to find asset: `{0}`")]
@@ -242,7 +243,7 @@ pub mod error {
             match err {
                 FixedPointOperationError::NegativeValue(_) => Self::Math(MathError::NegativeValue),
                 FixedPointOperationError::Conversion(e) => {
-                    Self::Conversion(eyre::eyre!("Mathematical conversion failed. {}", e))
+                    Self::Conversion(format!("Mathematical conversion failed. {}", e))
                 }
                 FixedPointOperationError::Overflow => Self::Math(MathError::Overflow),
                 FixedPointOperationError::DivideByZero => Self::Math(MathError::DivideByZero),
@@ -259,7 +260,7 @@ pub mod error {
     }
 
     /// Block with parent hash not found struct
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Decode, Encode)]
     pub struct ParentHashNotFound(pub HashOf<VersionedCommittedBlock>);
 
     impl Display for ParentHashNotFound {

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error as StdError, fmt};
 
-use eyre::{eyre, Result};
+use eyre::Result;
 use iroha_crypto::SignatureOf;
 use iroha_data_model::{prelude::*, query};
 use iroha_version::scale::DecodeVersioned;
@@ -44,8 +44,8 @@ impl VerifiedQueryRequest {
             account.signatories.contains(&self.signature.public_key)
         })?;
         if !account_has_public_key {
-            return Err(Error::Signature(eyre!(
-                "Signature public key doesn't correspond to the account."
+            return Err(Error::Signature(String::from(
+                "Signature public key doesn't correspond to the account.",
             )));
         }
         query_validator
@@ -68,7 +68,7 @@ impl TryFrom<SignedQueryRequest> for VerifiedQueryRequest {
                 payload: query.payload,
                 signature: query.signature,
             })
-            .map_err(|e| Error::Signature(eyre!(e)))
+            .map_err(|e| Error::Signature(e.to_string()))
     }
 }
 
@@ -89,84 +89,101 @@ impl ValidQueryRequest {
     }
 }
 
-/// Unsupported version error
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub struct UnsupportedVersionError {
-    /// Version that we got
-    pub version: u8,
-}
+/// SATO
+pub mod error {
+    use super::*;
 
-impl UnsupportedVersionError {
-    /// Expected version
-    pub const fn expected_version() -> u8 {
-        1
+    /// Unsupported version error
+    #[derive(Clone, Copy, Eq, PartialEq, Debug, Decode, Encode)]
+    pub struct UnsupportedVersion {
+        /// Version that we got
+        pub version: u8,
     }
-}
 
-impl StdError for UnsupportedVersionError {}
-
-impl fmt::Display for UnsupportedVersionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Unsupported version. Expected version {}, got: {}",
-            Self::expected_version(),
-            self.version
-        )
-    }
-}
-
-/// Query errors.
-#[derive(Error, Debug)]
-pub enum Error {
-    /// Query can not be decoded.
-    #[error("Query can not be decoded")]
-    Decode(#[source] Box<iroha_version::error::Error>),
-    /// Query has unsupported version.
-    #[error("Query has unsupported version")]
-    Version(#[source] UnsupportedVersionError),
-    /// Query has wrong signature.
-    #[error("Query has wrong signature: {0}")]
-    Signature(eyre::Error),
-    /// Query is not allowed.
-    #[error("Query is not allowed: {0}")]
-    Permission(String),
-    /// Query found nothing.
-    #[error("Query found nothing: {0}")]
-    Find(#[source] Box<FindError>),
-    /// Evaluate
-    #[error("Evaluation failed. {0}")]
-    Evaluate(#[source] eyre::Report),
-    /// Conversion failures
-    #[error("Conversion failed")]
-    Conversion(#[source] eyre::Report),
-}
-
-impl From<FindError> for Error {
-    fn from(err: FindError) -> Self {
-        Error::Find(Box::new(err))
-    }
-}
-
-impl Error {
-    /// Status code for query error response.
-    pub const fn status_code(&self) -> StatusCode {
-        use Error::*;
-        match *self {
-            Conversion(_) | Decode(_) | Version(_) => StatusCode::BAD_REQUEST,
-            Signature(_) => StatusCode::UNAUTHORIZED,
-            Evaluate(_) | Permission(_) | Find(_) => StatusCode::NOT_FOUND,
+    impl UnsupportedVersion {
+        /// Expected version
+        pub const fn expected_version() -> u8 {
+            1
         }
     }
+
+    impl StdError for UnsupportedVersion {}
+
+    impl fmt::Display for UnsupportedVersion {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "Unsupported version. Expected version {}, got: {}",
+                Self::expected_version(),
+                self.version
+            )
+        }
+    }
+
+    /// Query errors.
+    #[derive(Error, Debug, Clone, Decode, Encode)]
+    pub enum Error {
+        /// Query can not be decoded.
+        #[error("Query can not be decoded")]
+        Decode(#[source] Box<iroha_version::error::Error>),
+        /// Query has unsupported version.
+        #[error("Query has unsupported version")]
+        Version(#[source] UnsupportedVersion),
+        /// Query has wrong signature.
+        #[error("Query has wrong signature: {0}")]
+        Signature(String),
+        /// Query is not allowed.
+        #[error("Query is not allowed: {0}")]
+        Permission(String),
+        /// Query found nothing.
+        #[error("Query found nothing: {0}")]
+        Find(#[source] Box<FindError>),
+        /// Evaluate
+        #[error("Evaluation failed: {0}")]
+        Evaluate(String),
+        /// Conversion failures
+        #[error("Conversion failed: {0}")]
+        Conversion(String),
+    }
+
+    // #[derive(Debug)]
+    // enum Signature {}
+    // #[derive(Debug)]
+    // enum Evaluate {}
+    // #[derive(Debug)]
+    // enum Conversion {}
+
+    impl From<FindError> for Error {
+        fn from(err: FindError) -> Self {
+            Error::Find(Box::new(err))
+        }
+    }
+
+    impl Error {
+        /// Status code for query error response.
+        pub const fn status_code(&self) -> StatusCode {
+            use Error::*;
+            match *self {
+                Decode(_) | Version(_) | Evaluate(_) | Conversion(_) => StatusCode::BAD_REQUEST,
+                Signature(_) => StatusCode::UNAUTHORIZED,
+                Permission(_) => StatusCode::FORBIDDEN,
+                Find(_) => StatusCode::NOT_FOUND,
+            }
+        }
+    }
+
+    impl Reply for Error {
+        #[inline]
+        fn into_response(self) -> Response {
+            let status_code = self.status_code();
+            reply::with_status(crate::torii::utils::Scale(self), status_code).into_response()
+        }
+    }
+
+    impl warp::reject::Reject for Error {}
 }
 
-impl Reply for Error {
-    #[inline]
-    fn into_response(self) -> Response {
-        reply::with_status(self.to_string(), self.status_code()).into_response()
-    }
-}
-impl warp::reject::Reject for Error {}
+pub use error::{Error, UnsupportedVersion as UnsupportedVersionError};
 
 impl TryFrom<&Bytes> for VerifiedQueryRequest {
     type Error = Error;

--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -15,7 +15,7 @@ impl<W: WorldTrait> ValidQuery<W> for FindTransactionsByAccountId {
             .account_id
             .evaluate(wsv, &Context::default())
             .wrap_err("Failed to get account id")
-            .map_err(query::Error::Evaluate)?;
+            .map_err(|e| query::Error::Evaluate(e.to_string()))?;
         Ok(wsv.transactions_values_by_account_id(&id))
     }
 }
@@ -28,7 +28,7 @@ impl<W: WorldTrait> ValidQuery<W> for FindTransactionByHash {
             .hash
             .evaluate(wsv, &Context::default())
             .wrap_err("Failed to get hash")
-            .map_err(query::Error::Evaluate)?;
+            .map_err(|e| query::Error::Evaluate(e.to_string()))?;
         let hash = HashOf::from_hash(hash);
         if !wsv.has_transaction(&hash) {
             return Err(FindError::Transaction(hash).into());

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 #[macro_use]
-pub mod utils;
+pub(crate) mod utils;
 pub mod config;
 pub mod routing;
 

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 #[macro_use]
-mod utils;
+pub mod utils;
 pub mod config;
 pub mod routing;
 

--- a/core/src/torii/routing.rs
+++ b/core/src/torii/routing.rs
@@ -298,7 +298,7 @@ pub(crate) async fn handle_rejection(rejection: Rejection) -> Result<Response, R
     let err = if let Some(err) = rejection.find::<Error>() {
         err
     } else {
-        iroha_logger::error!(?rejection, "unhandled rejection");
+        iroha_logger::warn!(?rejection, "unhandled rejection");
         return Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response());
     };
 
@@ -329,7 +329,7 @@ pub(crate) async fn handle_rejection(rejection: Rejection) -> Result<Response, R
 
 // TODO: Remove this. Handle all the `Error` cases in `handle_rejection`
 fn unhandled(rejection: Rejection) -> Result<Response, Rejection> {
-    iroha_logger::error!(?rejection, "unhandled rejection");
+    iroha_logger::warn!(?rejection, "unhandled rejection");
     Err(rejection)
 }
 

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -197,7 +197,7 @@ impl AssertReady {
         let router = warp::post()
             .and(post_router)
             .with(warp::trace::request())
-            .recover(Torii::<World>::recover_arg_parse);
+            .recover(handle_rejection);
 
         let request: VersionedSignedQueryRequest =
             QueryRequest::new(self.query, self.account.unwrap_or(authority))

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -12,7 +12,7 @@ use super::{routing::*, *};
 use crate::{
     queue::Queue,
     samples::{get_config, get_trusted_peers},
-    smartcontracts::permissions::DenyAll,
+    smartcontracts::{isi::error::FindError, permissions::DenyAll},
     stream::{Sink, Stream},
     wsv::World,
 };
@@ -107,14 +107,14 @@ async fn torii_pagination() {
 }
 
 #[derive(Default)]
-struct AssertSet {
+struct QuerySet {
     instructions: Vec<Instruction>,
     account: Option<AccountId>,
     keys: Option<KeyPair>,
     deny_all: bool,
 }
 
-impl AssertSet {
+impl QuerySet {
     fn new() -> Self {
         Self::default()
     }
@@ -134,45 +134,7 @@ impl AssertSet {
         self.deny_all = true;
         self
     }
-    fn query(self, query: QueryBox) -> AssertReady {
-        let Self {
-            instructions,
-            account,
-            keys,
-            deny_all,
-        } = self;
-        AssertReady {
-            instructions,
-            account,
-            keys,
-            deny_all,
-            query,
-            status: None,
-            hints: Vec::new(),
-        }
-    }
-}
-
-struct AssertReady {
-    instructions: Vec<Instruction>,
-    account: Option<AccountId>,
-    keys: Option<KeyPair>,
-    deny_all: bool,
-    query: QueryBox,
-    status: Option<StatusCode>,
-    hints: Vec<&'static str>,
-}
-
-impl AssertReady {
-    fn status(mut self, status: StatusCode) -> Self {
-        self.status = Some(status);
-        self
-    }
-    fn hint(mut self, hint: &'static str) -> Self {
-        self.hints.push(hint);
-        self
-    }
-    async fn assert(self) {
+    async fn query(self, query: QueryBox) -> QueryResponseTest {
         use crate::smartcontracts::Execute;
 
         let (mut torii, keys) = create_torii().await;
@@ -187,20 +149,10 @@ impl AssertReady {
                 .expect("Given instructions disorder");
         }
 
-        let post_router = endpoint4(
-            handle_queries,
-            warp::path(uri::QUERY)
-                .and(add_state!(torii.wsv, torii.query_validator))
-                .and(paginate())
-                .and(body::query()),
-        );
-        let router = warp::post()
-            .and(post_router)
-            .with(warp::trace::request())
-            .recover(handle_rejection);
+        let router = torii.create_api_router();
 
         let request: VersionedSignedQueryRequest =
-            QueryRequest::new(self.query, self.account.unwrap_or(authority))
+            QueryRequest::new(query, self.account.unwrap_or(authority))
                 .sign(self.keys.unwrap_or(keys))
                 .expect("Failed to sign query with keys")
                 .into();
@@ -212,22 +164,69 @@ impl AssertReady {
             .reply(&router)
             .await;
 
-        let response_body = match response.status() {
-            StatusCode::OK => {
-                let response = VersionedQueryResult::decode_versioned(response.body()).unwrap();
-                let VersionedQueryResult::V1(QueryResult(value)) = response;
-                format!("{:?}", value)
-            }
-            _ => String::from_utf8(response.body().to_vec()).unwrap_or_default(),
-        };
-        dbg!(&response_body);
-
-        if let Some(status) = self.status {
-            assert_eq!(response.status(), status)
+        QueryResponseTest {
+            response_status: response.status(),
+            response_body: response.into(),
+            status: None,
+            body_matches: None,
         }
-        for hint in self.hints {
-            dbg!(hint);
-            assert!(response_body.contains(hint))
+    }
+}
+
+impl From<warp::http::Response<warp::hyper::body::Bytes>> for QueryResponseBody {
+    fn from(src: warp::http::Response<warp::hyper::body::Bytes>) -> Self {
+        if StatusCode::OK == src.status() {
+            let body = VersionedQueryResult::decode_versioned(src.body())
+                .expect("The response body failed to be decoded to VersionedQueryResult even though the status is Ok 200");
+            Self::Ok(body)
+        } else {
+            let body = query::Error::decode(&mut src.body().as_ref())
+                .expect("The response body failed to be decoded to query::Error even though the status is not Ok 200");
+            Self::Err(body)
+        }
+    }
+}
+
+struct QueryResponseTest {
+    response_status: StatusCode,
+    response_body: QueryResponseBody,
+    status: Option<StatusCode>,
+    body_matches: Option<bool>,
+}
+
+#[allow(variant_size_differences)]
+enum QueryResponseBody {
+    Ok(VersionedQueryResult),
+    Err(query::Error),
+}
+
+impl QueryResponseTest {
+    fn status(mut self, status: StatusCode) -> Self {
+        self.status = Some(status);
+        self
+    }
+    fn body_matches_ok(mut self, predicate: impl Fn(&VersionedQueryResult) -> bool) -> Self {
+        self.body_matches = if let QueryResponseBody::Ok(body) = &self.response_body {
+            Some(predicate(body))
+        } else {
+            Some(false)
+        };
+        self
+    }
+    fn body_matches_err(mut self, predicate: impl Fn(&query::Error) -> bool) -> Self {
+        self.body_matches = if let QueryResponseBody::Err(body) = &self.response_body {
+            Some(predicate(body))
+        } else {
+            Some(false)
+        };
+        self
+    }
+    fn assert(self) {
+        if let Some(status) = self.status {
+            assert_eq!(self.response_status, status)
+        }
+        if let Some(body_matches) = self.body_matches {
+            assert!(body_matches)
         }
     }
 }
@@ -256,7 +255,7 @@ fn mint_asset(quantity: u32, asset: &str, account: &str) -> Instruction {
 }
 #[tokio::test]
 async fn find_asset() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .given(register_asset_definition("rose"))
@@ -264,15 +263,23 @@ async fn find_asset() {
         .query(QueryBox::FindAssetById(FindAssetById::new(AssetId::test(
             "rose", DOMAIN, "alice", DOMAIN,
         ))))
-        .status(StatusCode::OK)
-        .hint("Quantity")
-        .hint("99")
-        .assert()
         .await
+        .status(StatusCode::OK)
+        .body_matches_ok(|body| {
+            if let VersionedQueryResult::V1(QueryResult(Value::Identifiable(
+                IdentifiableBox::Asset(asset),
+            ))) = body
+            {
+                asset.value == AssetValue::Quantity(99)
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_asset_with_no_mint() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .given(register_asset_definition("rose"))
@@ -280,13 +287,20 @@ async fn find_asset_with_no_mint() {
         .query(QueryBox::FindAssetById(FindAssetById::new(
             AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Asset(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_asset_with_no_asset_definition() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
     // .given(register_asset_definition("rose"))
@@ -294,14 +308,20 @@ async fn find_asset_with_no_asset_definition() {
         .query(QueryBox::FindAssetById(FindAssetById::new(
             AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .hint("definition")
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::AssetDefinition(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_asset_with_no_account() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
     // .given(register_account("alice"))
         .given(register_asset_definition("rose"))
@@ -309,14 +329,20 @@ async fn find_asset_with_no_account() {
         .query(QueryBox::FindAssetById(FindAssetById::new(
             AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .hint("account")
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Account(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_asset_with_no_domain() {
-    AssertSet::new()
+    QuerySet::new()
     // .given(register_domain())
     // .given(register_account("alice"))
     // .given(register_asset_definition("rose"))
@@ -324,157 +350,203 @@ async fn find_asset_with_no_domain() {
         .query(QueryBox::FindAssetById(FindAssetById::new(
             AssetId::test("rose", DOMAIN, "alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .hint("domain")
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Domain(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_asset_definition() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_asset_definition("rose"))
         .query(QueryBox::FindAllAssetsDefinitions(Default::default()))
-        .status(StatusCode::OK)
-        .hint("rose")
-        .hint(DOMAIN)
-        .assert()
         .await
+        .status(StatusCode::OK)
+        .body_matches_ok(|body| {
+            if let VersionedQueryResult::V1(QueryResult(Value::Vec(vec))) = body {
+                vec.iter().any(|value| {
+                    if let Value::Identifiable(IdentifiableBox::AssetDefinition(asset_definition)) =
+                        value
+                    {
+                        asset_definition.id.name.as_ref() == "rose"
+                    } else {
+                        false
+                    }
+                })
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_account() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
             AccountId::test("alice", DOMAIN),
         )))
+        .await
         .status(StatusCode::OK)
         .assert()
-        .await
 }
 #[tokio::test]
 async fn find_account_with_no_account() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
     // .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
             AccountId::test("alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Account(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_account_with_no_domain() {
-    AssertSet::new()
+    QuerySet::new()
     // .given(register_domain())
     // .given(register_account("alice"))
         .query(QueryBox::FindAccountById(FindAccountById::new(
             AccountId::test("alice", DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .hint("domain")
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Domain(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 #[tokio::test]
 async fn find_domain() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .query(QueryBox::FindDomainById(FindDomainById::new(
             DomainId::test(DOMAIN),
         )))
+        .await
         .status(StatusCode::OK)
         .assert()
-        .await
 }
 #[tokio::test]
 async fn find_domain_with_no_domain() {
-    AssertSet::new()
+    QuerySet::new()
     // .given(register_domain())
         .query(QueryBox::FindDomainById(FindDomainById::new(
-            DOMAIN.to_string(),
+            DomainId::test(DOMAIN),
         )))
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Domain(_))
+            } else {
+                false
+            }
+        })
+        .assert()
 }
 fn query() -> QueryBox {
     QueryBox::FindAccountById(FindAccountById::new(AccountId::test("alice", DOMAIN)))
 }
 #[tokio::test]
 async fn query_with_wrong_signatory() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .account(AccountId::test("alice", DOMAIN))
     // .deny_all()
         .query(query())
-        .status(StatusCode::UNAUTHORIZED)
-        .assert()
         .await
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(*body, query::Error::Signature(_)))
+        .assert()
 }
 #[tokio::test]
 async fn query_with_wrong_signature() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .keys(KeyPair::generate().unwrap())
     // .deny_all()
         .query(query())
-        .status(StatusCode::UNAUTHORIZED)
-        .assert()
         .await
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(*body, query::Error::Signature(_)))
+        .assert()
 }
 #[tokio::test]
 async fn query_with_wrong_signature_and_no_permission() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
         .keys(KeyPair::generate().unwrap())
         .deny_all()
         .query(query())
-        .status(StatusCode::UNAUTHORIZED)
-        .assert()
         .await
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(*body, query::Error::Signature(_)))
+        .assert()
 }
 #[tokio::test]
 async fn query_with_no_permission() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
         .given(register_account("alice"))
     // .keys(KeyPair::generate().unwrap())
         .deny_all()
         .query(query())
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::FORBIDDEN)
+        .body_matches_err(|body| matches!(*body, query::Error::Permission(_)))
+        .assert()
 }
 #[tokio::test]
 async fn query_with_no_permission_and_no_find() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
     // .given(register_account("alice"))
     // .keys(KeyPair::generate().unwrap())
         .deny_all()
         .query(query())
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::FORBIDDEN)
+        .body_matches_err(|body| matches!(*body, query::Error::Permission(_)))
+        .assert()
 }
 #[tokio::test]
 async fn query_with_no_find() {
-    AssertSet::new()
+    QuerySet::new()
         .given(register_domain())
     // .given(register_account("alice"))
     // .keys(KeyPair::generate().unwrap())
     // .deny_all()
         .query(query())
-        .status(StatusCode::NOT_FOUND)
-        .assert()
         .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| matches!(*body, query::Error::Find(_)))
+        .assert()
 }
+
 #[tokio::test]
 async fn blocks_stream() {
     const BLOCK_COUNT: usize = 4;

--- a/core/src/torii/utils.rs
+++ b/core/src/torii/utils.rs
@@ -1,5 +1,3 @@
-//! // SATO
-
 use std::convert::Infallible;
 
 use iroha_version::scale::DecodeVersioned;
@@ -37,7 +35,6 @@ macro_rules! add_state {
     }
 }
 
-/// SATO
 pub mod body {
     use super::*;
 

--- a/core/src/torii/utils.rs
+++ b/core/src/torii/utils.rs
@@ -1,3 +1,5 @@
+//! // SATO
+
 use std::convert::Infallible;
 
 use iroha_version::scale::DecodeVersioned;
@@ -7,6 +9,7 @@ use warp::{hyper::body::Bytes, reply::Response, Filter, Rejection, Reply};
 use super::VerifiedQueryRequest;
 
 /// Structure for empty response body
+#[derive(Clone, Copy)]
 pub struct Empty;
 
 impl Reply for Empty {
@@ -34,6 +37,7 @@ macro_rules! add_state {
     }
 }
 
+/// SATO
 pub mod body {
     use super::*;
 
@@ -84,7 +88,7 @@ macro_rules! impl_custom_and_then {
     }
 }
 
-//impl_custom_and_then!(endpoint1(a: A));
+// impl_custom_and_then!(endpoint1(a: A));
 impl_custom_and_then!(endpoint2(a: A, b: B));
 impl_custom_and_then!(endpoint3(a: A, b: B, c: C));
 impl_custom_and_then!(endpoint4(a: A, b: B, c: C, d: D));

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -162,7 +162,7 @@ impl QueryRequest {
         }
     }
 
-    /// Consumes self and returns a signed `QueryReuest`.
+    /// Consumes self and returns a signed `QueryRequest`.
     ///
     /// # Errors
     /// Fails if signature creation fails.

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -123,7 +123,7 @@ impl<T: IntoIterator<Item = Instruction>> From<T> for Executable {
 }
 
 /// Wrapper for byte representation of [`Executable::Wasm`].  Inline
-/// into [`Executable::Wasm`] as soon as GATs are stabilised and
+/// into [`Executable::Wasm`] as soon as GATs are stabilized and
 /// implementations for from byte vector can be split off from
 /// [`IntoIterator<Item = Instruction>`].
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, Deserialize, Serialize, IntoSchema)]

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -36,34 +36,15 @@
   + `limit` - Optional parameter in queries where results can be indexed. Use to return specific number of results.
 
 **Responses**:
-- 200 OK - Query Executed Successfully and Found Value
-  + Body: `VersionedQueryResult` [*](#iroha-structures)
-- 4xx - Query Rejected or Found Nothing
 
-Status and whether each step succeeded:
-| Status | Decode & Versioning | Signature | Permission | Find |
-| -- | -- | -- | -- | -- |
-| 400 | N | - | - | - |
-| 401 | Y | N | - | - |
-| 404 | Y | Y | N | - |
-| 404 | Y | Y | Y | N |
-| 200 | Y | Y | Y | Y |
-
-#### Asset Not Found 404
-Hint and whether each object exists:
-| Hint | Domain | Account | Asset Definition | Asset |
-| -- | -- | -- | -- | -- |
-| "domain" | N | - | - | - |
-| "account" | Y | N | - | - |
-| "definition" | Y | - | N | - |
-| - | Y | Y | Y | N |
-
-#### Account Not Found 404
-Hint and whether each object exists:
-| Hint | Domain | Account |
-| -- | -- | -- |
-| "domain" | N | - |
-| - | Y | N |
+| Response        | Status | Body [*](#iroha-structures) |
+| --------------- | ------ | ---- |
+| Decode err.     |    400 | `QueryError::Decode` |
+| Version err.    |    400 | `QueryError::Version` |
+| Signature err.  |    401 | `QueryError::Signature` |
+| Permission err. |    403 | `QueryError::Permission` |
+| Find err.       |    404 | `QueryError::Find` |
+| Success         |    200 | `VersionedQueryResult` |
 
 ### Events
 
@@ -245,6 +226,8 @@ For more information on codec check [Substrate Dev Hub](https://substrate.dev/do
 - `VersionedTransaction` - `iroha_data_model::transaction::VersionedTransaction`
 - `VersionedSignedQueryRequest` - `iroha_data_model::query::VersionedSignedQueryRequest`
 - `VersionedQueryResult` - `iroha_data_model::query::VersionedQueryResult`
+<!-- SATO -->
+- `QueryError` - 
 
 - `EventStreamSubscriptionRequest` - `iroha_data_model::events::EventSubscriberMessage::SubscriptionRequest`
 - `EventStreamSubscriptionAccepted` - `iroha_data_model::events::EventPublisherMessage::SubscriptionAccepted`

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -39,12 +39,30 @@
 
 | Response        | Status | Body [*](#iroha-structures) |
 | --------------- | ------ | ---- |
-| Decode err.     |    400 | `QueryError::Decode` |
-| Version err.    |    400 | `QueryError::Version` |
-| Signature err.  |    401 | `QueryError::Signature` |
-| Permission err. |    403 | `QueryError::Permission` |
-| Find err.       |    404 | `QueryError::Find` |
+| Decode err.     |    400 | `QueryError::Decode(_)` |
+| Version err.    |    400 | `QueryError::Version(_)` |
+| Signature err.  |    401 | `QueryError::Signature(_)` |
+| Permission err. |    403 | `QueryError::Permission(_)` |
+| Evaluate err.   |    400 | `QueryError::Evaluate(_)` |
+| Find err.       |    404 | `QueryError::Find(Box<FindError>)` |
+| Conversion err. |    400 | `QueryError::Conversion(_)` |
 | Success         |    200 | `VersionedQueryResult` |
+
+#### Asset Not Found 404
+Whether each prerequisite object was found and `FindError`:
+| Domain | Account | Asset Definition | Asset | `FindError` |
+| -- | -- | -- | -- | -- |
+| N | - | - | - | `FindError::Domain(DomainId)` |
+| Y | N | - | - | `FindError::Account(AccountId)` |
+| Y | - | N | - | `FindError::AssetDefinition(AssetDefinitionId)` |
+| Y | Y | Y | N | `FindError::Asset(AssetId)` |
+
+#### Account Not Found 404
+Whether each prerequisite object was found and `FindError`:
+| Domain | Account | `FindError` |
+| -- | -- | -- |
+| N | - | `FindError::Domain(DomainId)` |
+| Y | N | `FindError::Account(AccountId)` |
 
 ### Events
 
@@ -225,9 +243,10 @@ For more information on codec check [Substrate Dev Hub](https://substrate.dev/do
 
 - `VersionedTransaction` - `iroha_data_model::transaction::VersionedTransaction`
 - `VersionedSignedQueryRequest` - `iroha_data_model::query::VersionedSignedQueryRequest`
+
 - `VersionedQueryResult` - `iroha_data_model::query::VersionedQueryResult`
-<!-- SATO -->
-- `QueryError` - 
+- `QueryError` - `iroha_core::smartcontracts::isi::query::Error`
+- `FindError` - `iroha_core::smartcontracts::isi::error::FindError`
 
 - `EventStreamSubscriptionRequest` - `iroha_data_model::events::EventSubscriberMessage::SubscriptionRequest`
 - `EventStreamSubscriptionAccepted` - `iroha_data_model::events::EventPublisherMessage::SubscriptionAccepted`


### PR DESCRIPTION
### Description of the Change
Please see [`api_spec.md`](https://github.com/s8sato/iroha/blob/feat/1815/docs/source/references/api_spec.md#query).

### Issue
Closes #1815
Opens #1934

### Benefits
Now clients can handle query errors based on types.

### Possible Drawbacks
- Query responses depends on `iroha_core::smartcontracts::isi`
- `iroha_version::error::Error` loses some details for SCALE compatibility