### PR TITLE
Feature/proposal request optimization

### DIFF
--- a/irohad/ordering/impl/batches_cache.hpp
+++ b/irohad/ordering/impl/batches_cache.hpp
@@ -12,7 +12,6 @@
 #include <numeric>
 #include <set>
 #include <shared_mutex>
-#include <unordered_set>
 
 #include "consensus/round.hpp"
 

--- a/irohad/ordering/impl/batches_cache.hpp
+++ b/irohad/ordering/impl/batches_cache.hpp
@@ -29,7 +29,7 @@ namespace iroha::ordering {
    public:
     using BatchesSetType =
         std::set<std::shared_ptr<shared_model::interface::TransactionBatch>,
-                 shared_model::interface::BatchHashEquality>;
+                 shared_model::interface::BatchHashLess>;
 
     BatchesContext(BatchesContext const &) = delete;
     BatchesContext &operator=(BatchesContext const &) = delete;

--- a/irohad/ordering/impl/batches_cache.hpp
+++ b/irohad/ordering/impl/batches_cache.hpp
@@ -9,8 +9,8 @@
 #include "ordering/on_demand_ordering_service.hpp"
 
 #include <memory>
-#include <set>
 #include <numeric>
+#include <set>
 #include <shared_mutex>
 #include <unordered_set>
 
@@ -27,9 +27,9 @@ namespace iroha::ordering {
    */
   class BatchesContext {
    public:
-    using BatchesSetType = std::set<
-        std::shared_ptr<shared_model::interface::TransactionBatch>,
-        shared_model::interface::BatchHashEquality>;
+    using BatchesSetType =
+        std::set<std::shared_ptr<shared_model::interface::TransactionBatch>,
+                 shared_model::interface::BatchHashEquality>;
 
     BatchesContext(BatchesContext const &) = delete;
     BatchesContext &operator=(BatchesContext const &) = delete;

--- a/irohad/ordering/impl/batches_cache.hpp
+++ b/irohad/ordering/impl/batches_cache.hpp
@@ -9,6 +9,7 @@
 #include "ordering/on_demand_ordering_service.hpp"
 
 #include <memory>
+#include <set>
 #include <numeric>
 #include <shared_mutex>
 #include <unordered_set>
@@ -26,9 +27,8 @@ namespace iroha::ordering {
    */
   class BatchesContext {
    public:
-    using BatchesSetType = std::unordered_set<
+    using BatchesSetType = std::set<
         std::shared_ptr<shared_model::interface::TransactionBatch>,
-        OnDemandOrderingService::BatchPointerHasher,
         shared_model::interface::BatchHashEquality>;
 
     BatchesContext(BatchesContext const &) = delete;

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -61,7 +61,10 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
   propagate(kCommitConsumer);
 }
 
-void OnDemandConnectionManager::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) {
+void OnDemandConnectionManager::onRequestProposal(
+    consensus::Round round,
+    std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+        ref_proposal) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   if (stop_requested_.load(std::memory_order_relaxed)) {
     return;

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -61,7 +61,7 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
   propagate(kCommitConsumer);
 }
 
-void OnDemandConnectionManager::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) {
+void OnDemandConnectionManager::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   if (stop_requested_.load(std::memory_order_relaxed)) {
     return;

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -57,7 +57,7 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
   propagate(kCommitConsumer);
 }
 
-void OnDemandConnectionManager::onRequestProposal(consensus::Round round) {
+void OnDemandConnectionManager::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   if (stop_requested_.load(std::memory_order_relaxed)) {
     return;
@@ -66,7 +66,7 @@ void OnDemandConnectionManager::onRequestProposal(consensus::Round round) {
   log_->debug("onRequestProposal, {}", round);
 
   if (auto &connection = connections_.peers[kIssuer]) {
-    (*connection)->onRequestProposal(round);
+    (*connection)->onRequestProposal(round, std::move(ref_proposal));
   }
 }
 

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -31,6 +31,10 @@ OnDemandConnectionManager::~OnDemandConnectionManager() {
   std::lock_guard<std::shared_timed_mutex> lock(mutex_);
 }
 
+std::chrono::milliseconds OnDemandConnectionManager::getRequestDelay() const {
+  return factory_->getRequestDelay();
+}
+
 void OnDemandConnectionManager::onBatches(CollectionType batches) {
   /*
    * Transactions are sent to the current and next rounds (+1)

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -56,7 +56,7 @@ namespace iroha {
 
       void onBatches(CollectionType batches) override;
 
-      void onRequestProposal(consensus::Round round) override;
+      void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
 
       /**
        * Initialize corresponding peers in connections_ using factory_

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -56,7 +56,7 @@ namespace iroha {
 
       void onBatches(CollectionType batches) override;
       std::chrono::milliseconds getRequestDelay() const override;
-      void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
+      void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) override;
 
       /**
        * Initialize corresponding peers in connections_ using factory_

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -56,7 +56,11 @@ namespace iroha {
 
       void onBatches(CollectionType batches) override;
       std::chrono::milliseconds getRequestDelay() const override;
-      void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) override;
+      void onRequestProposal(
+          consensus::Round round,
+          std::optional<
+              std::shared_ptr<const shared_model::interface::Proposal>>
+              ref_proposal) override;
 
       /**
        * Initialize corresponding peers in connections_ using factory_

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -55,7 +55,7 @@ namespace iroha {
       ~OnDemandConnectionManager() override;
 
       void onBatches(CollectionType batches) override;
-
+      std::chrono::milliseconds getRequestDelay() const override;
       void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
 
       /**

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -77,9 +77,10 @@ void OnDemandOrderingGate::processRoundSwitch(RoundSwitch const &event) {
 
   this->sendCachedTransactions();
 
-  // request proposal for the current round
-  if (!syncing_mode_)
-    network_client_->onRequestProposal(event.next_round);
+  if (!syncing_mode_) {
+    assert(ordering_service_);
+    network_client_->onRequestProposal(event.next_round, ordering_service_->onRequestProposal(event.next_round));
+  }
 }
 
 void OnDemandOrderingGate::stop() {

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -22,8 +22,6 @@
 #include "logger/logger.hpp"
 #include "ordering/impl/on_demand_common.hpp"
 #include "validators/field_validator.hpp"
-#include "main/subscription.hpp"
-#include "subscription/scheduler_impl.hpp"
 
 using iroha::ordering::OnDemandOrderingGate;
 
@@ -62,45 +60,6 @@ void OnDemandOrderingGate::propagateBatch(
       transport::OdOsNotification::CollectionType{batch});
 }
 
-void OnDemandOrderingGate::waitForLocalProposal(consensus::Round const &round) {
-  assert(ordering_service_);
-  assert(network_client_);
-
-  if (!ordering_service_->hasProposal(round)
-      && !ordering_service_->hasEnoughBatchesInCache()) {
-    auto scheduler = std::make_shared<subscription::SchedulerBase>();
-    auto tid = getSubscription()->dispatcher()->bind(scheduler);
-
-    auto batches_subscription = SubscriberCreator<
-        bool,
-        std::shared_ptr<shared_model::interface::TransactionBatch>>::
-    template create<EventTypes::kOnTxsEnoughForProposal>(
-        static_cast<iroha::SubscriptionEngineHandlers>(*tid),
-        [scheduler(utils::make_weak(scheduler))](auto, auto) {
-          if (auto maybe_scheduler = scheduler.lock())
-            maybe_scheduler->dispose();
-        });
-    auto proposals_subscription =
-        SubscriberCreator<bool, consensus::Round>::template create<
-            EventTypes::kOnPackProposal>(
-            static_cast<iroha::SubscriptionEngineHandlers>(*tid),
-            [round, scheduler(utils::make_weak(scheduler))](auto,
-                                                            auto packed_round) {
-              if (auto maybe_scheduler = scheduler.lock();
-                  maybe_scheduler and round == packed_round)
-                maybe_scheduler->dispose();
-            });
-    scheduler->addDelayed(network_client_->getRequestDelay(), [scheduler(utils::make_weak(scheduler))] {
-      if (auto maybe_scheduler = scheduler.lock()) {
-        maybe_scheduler->dispose();
-      }
-    });
-
-    scheduler->process();
-    getSubscription()->dispatcher()->unbind(*tid);
-  }
-}
-
 void OnDemandOrderingGate::processRoundSwitch(RoundSwitch const &event) {
   log_->debug("Current: {}", event.next_round);
   current_round_ = event.next_round;
@@ -120,7 +79,9 @@ void OnDemandOrderingGate::processRoundSwitch(RoundSwitch const &event) {
 
   if (!syncing_mode_) {
     assert(ordering_service_);
-    waitForLocalProposal(event.next_round);
+    assert(network_client_);
+
+    ordering_service_->waitForLocalProposal(event.next_round, network_client_->getRequestDelay());
     network_client_->onRequestProposal(event.next_round, ordering_service_->onRequestProposal(event.next_round));
   }
 }

--- a/irohad/ordering/impl/on_demand_ordering_gate.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.cpp
@@ -81,8 +81,10 @@ void OnDemandOrderingGate::processRoundSwitch(RoundSwitch const &event) {
     assert(ordering_service_);
     assert(network_client_);
 
-    ordering_service_->waitForLocalProposal(event.next_round, network_client_->getRequestDelay());
-    network_client_->onRequestProposal(event.next_round, ordering_service_->onRequestProposal(event.next_round));
+    network_client_->onRequestProposal(
+        event.next_round,
+        ordering_service_->waitForLocalProposal(
+            event.next_round, network_client_->getRequestDelay()));
   }
 }
 

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -85,8 +85,6 @@ namespace iroha {
           std::shared_ptr<const shared_model::interface::Proposal> proposal)
           const;
 
-      void waitForLocalProposal(consensus::Round const &round);
-
       logger::LoggerPtr log_;
 
       /// max number of transactions passed to one ordering service

--- a/irohad/ordering/impl/on_demand_ordering_gate.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_gate.hpp
@@ -85,6 +85,8 @@ namespace iroha {
           std::shared_ptr<const shared_model::interface::Proposal> proposal)
           const;
 
+      void waitForLocalProposal(consensus::Round const &round);
+
       logger::LoggerPtr log_;
 
       /// max number of transactions passed to one ordering service

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -85,7 +85,7 @@ void OnDemandOrderingServiceImpl::forCachedBatches(
   batches_cache_.forCachedBatches(f);
 }
 
-void OnDemandOrderingServiceImpl::waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const {
+std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>> OnDemandOrderingServiceImpl::waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) {
   if (!hasProposal(round) && !hasEnoughBatchesInCache()) {
     auto scheduler = std::make_shared<subscription::SchedulerBase>();
     auto tid = getSubscription()->dispatcher()->bind(scheduler);
@@ -118,6 +118,8 @@ void OnDemandOrderingServiceImpl::waitForLocalProposal(consensus::Round const &r
     scheduler->process();
     getSubscription()->dispatcher()->unbind(*tid);
   }
+
+  return onRequestProposal(round);
 }
 
 std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -85,7 +85,9 @@ void OnDemandOrderingServiceImpl::forCachedBatches(
   batches_cache_.forCachedBatches(f);
 }
 
-std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>> OnDemandOrderingServiceImpl::waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) {
+std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>
+OnDemandOrderingServiceImpl::waitForLocalProposal(
+    consensus::Round const &round, std::chrono::milliseconds const &delay) {
   if (!hasProposal(round) && !hasEnoughBatchesInCache()) {
     auto scheduler = std::make_shared<subscription::SchedulerBase>();
     auto tid = getSubscription()->dispatcher()->bind(scheduler);
@@ -93,12 +95,12 @@ std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>> 
     auto batches_subscription = SubscriberCreator<
         bool,
         std::shared_ptr<shared_model::interface::TransactionBatch>>::
-    template create<EventTypes::kOnTxsEnoughForProposal>(
-        static_cast<iroha::SubscriptionEngineHandlers>(*tid),
-        [scheduler(utils::make_weak(scheduler))](auto, auto) {
-          if (auto maybe_scheduler = scheduler.lock())
-            maybe_scheduler->dispose();
-        });
+        template create<EventTypes::kOnTxsEnoughForProposal>(
+            static_cast<iroha::SubscriptionEngineHandlers>(*tid),
+            [scheduler(utils::make_weak(scheduler))](auto, auto) {
+              if (auto maybe_scheduler = scheduler.lock())
+                maybe_scheduler->dispose();
+            });
     auto proposals_subscription =
         SubscriberCreator<bool, consensus::Round>::template create<
             EventTypes::kOnPackProposal>(

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -18,6 +18,7 @@
 #include "interfaces/transaction.hpp"
 #include "logger/logger.hpp"
 #include "main/subscription.hpp"
+#include "subscription/scheduler_impl.hpp"
 
 using iroha::ordering::OnDemandOrderingServiceImpl;
 
@@ -82,6 +83,41 @@ bool OnDemandOrderingServiceImpl::hasEnoughBatchesInCache() const {
 void OnDemandOrderingServiceImpl::forCachedBatches(
     std::function<void(BatchesSetType &)> const &f) {
   batches_cache_.forCachedBatches(f);
+}
+
+void OnDemandOrderingServiceImpl::waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const {
+  if (!hasProposal(round) && !hasEnoughBatchesInCache()) {
+    auto scheduler = std::make_shared<subscription::SchedulerBase>();
+    auto tid = getSubscription()->dispatcher()->bind(scheduler);
+
+    auto batches_subscription = SubscriberCreator<
+        bool,
+        std::shared_ptr<shared_model::interface::TransactionBatch>>::
+    template create<EventTypes::kOnTxsEnoughForProposal>(
+        static_cast<iroha::SubscriptionEngineHandlers>(*tid),
+        [scheduler(utils::make_weak(scheduler))](auto, auto) {
+          if (auto maybe_scheduler = scheduler.lock())
+            maybe_scheduler->dispose();
+        });
+    auto proposals_subscription =
+        SubscriberCreator<bool, consensus::Round>::template create<
+            EventTypes::kOnPackProposal>(
+            static_cast<iroha::SubscriptionEngineHandlers>(*tid),
+            [round, scheduler(utils::make_weak(scheduler))](auto,
+                                                            auto packed_round) {
+              if (auto maybe_scheduler = scheduler.lock();
+                  maybe_scheduler and round == packed_round)
+                maybe_scheduler->dispose();
+            });
+    scheduler->addDelayed(delay, [scheduler(utils::make_weak(scheduler))] {
+      if (auto maybe_scheduler = scheduler.lock()) {
+        maybe_scheduler->dispose();
+      }
+    });
+
+    scheduler->process();
+    getSubscription()->dispatcher()->unbind(*tid);
+  }
 }
 
 std::optional<std::shared_ptr<const OnDemandOrderingServiceImpl::ProposalType>>

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -71,7 +71,7 @@ namespace iroha {
 
       void processReceivedProposal(CollectionType batches) override;
 
-      void waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const override;
+      std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) override;
 
      private:
       /**

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -71,7 +71,9 @@ namespace iroha {
 
       void processReceivedProposal(CollectionType batches) override;
 
-      std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) override;
+      std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(
+          consensus::Round const &round,
+          std::chrono::milliseconds const &delay) override;
 
      private:
       /**

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -71,6 +71,8 @@ namespace iroha {
 
       void processReceivedProposal(CollectionType batches) override;
 
+      void waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const override;
+
      private:
       /**
        * Packs new proposals and creates new rounds

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -159,7 +159,9 @@ void OnDemandOsClientGrpc::onRequestProposal(
   request.mutable_round()->set_block_round(round.block_round);
   request.mutable_round()->set_reject_round(round.reject_round);
   if (ref_proposal.has_value())
-    request.set_ref_proposal_hash(ref_proposal.value()->hash().hex());
+    request.set_ref_proposal_hash(
+        std::string((char *)ref_proposal.value()->hash().blob().data(),
+                    ref_proposal.value()->hash().blob().size()));
 
   getSubscription()->dispatcher()->add(
       getSubscription()->dispatcher()->kExecuteInPool,

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -151,6 +151,9 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::option
   proto::ProposalRequest request;
   request.mutable_round()->set_block_round(round.block_round);
   request.mutable_round()->set_reject_round(round.reject_round);
+  if (ref_proposal.has_value())
+    request.set_ref_proposal_hash(ref_proposal.value()->hash().hex());
+
   getSubscription()->dispatcher()->add(
       getSubscription()->dispatcher()->kExecuteInPool,
       [round,
@@ -230,4 +233,8 @@ OnDemandOsClientGrpcFactory::create(const shared_model::interface::Peer &to) {
                                                   os_execution_keepers_,
                                                   to.pubkey());
   };
+}
+
+std::chrono::milliseconds OnDemandOsClientGrpcFactory::getRequestDelay() const {
+  return proposal_request_timeout_;
 }

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -140,7 +140,7 @@ void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
   }
 }
 
-void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
+void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) {
   // Cancel an unfinished request
   if (auto maybe_context = context_.lock()) {
     maybe_context->TryCancel();
@@ -154,6 +154,7 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round) {
   getSubscription()->dispatcher()->add(
       getSubscription()->dispatcher()->kExecuteInPool,
       [round,
+        ref_proposal{std::move(ref_proposal)},
        time_provider(time_provider_),
        proposal_request_timeout(proposal_request_timeout_),
        context(std::move(context)),

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -144,7 +144,10 @@ std::chrono::milliseconds OnDemandOsClientGrpc::getRequestDelay() const {
   return proposal_request_timeout_;
 }
 
-void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) {
+void OnDemandOsClientGrpc::onRequestProposal(
+    consensus::Round round,
+    std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+        ref_proposal) {
   // Cancel an unfinished request
   if (auto maybe_context = context_.lock()) {
     maybe_context->TryCancel();
@@ -161,7 +164,7 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::option
   getSubscription()->dispatcher()->add(
       getSubscription()->dispatcher()->kExecuteInPool,
       [round,
-        ref_proposal{std::move(ref_proposal)},
+       ref_proposal{std::move(ref_proposal)},
        time_provider(time_provider_),
        proposal_request_timeout(proposal_request_timeout_),
        context(std::move(context)),
@@ -193,32 +196,31 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::option
         switch (response.optional_proposal_case()) {
           case proto::ProposalResponse::kSameProposalHash: {
             callback({std::move(ref_proposal), round});
-          }break;
+          } break;
           case proto::ProposalResponse::kProposal: {
-            auto proposal_result = maybe_proposal_factory->build(response.proposal());
+            auto proposal_result =
+                maybe_proposal_factory->build(response.proposal());
             if (expected::hasError(proposal_result)) {
               maybe_log->info("{}", proposal_result.assumeError().error);
               callback({std::nullopt, round});
             } else
               callback({std::move(proposal_result).assumeValue(), round});
-          }break;
-          default: {
-            callback({std::nullopt, round}); }
-            break;
+          } break;
+          default: { callback({std::nullopt, round}); } break;
         }
-/*
-        if (not response.has_proposal()) {
-          callback({std::nullopt, round});
-          return;
-        }
-        auto maybe_proposal =
-            maybe_proposal_factory->build(response.proposal());
-        if (expected::hasError(maybe_proposal)) {
-          maybe_log->info("{}", maybe_proposal.assumeError().error);
-          callback({std::nullopt, round});
-          return;
-        }
-        callback({std::move(maybe_proposal).assumeValue(), round});*/
+        /*
+                if (not response.has_proposal()) {
+                  callback({std::nullopt, round});
+                  return;
+                }
+                auto maybe_proposal =
+                    maybe_proposal_factory->build(response.proposal());
+                if (expected::hasError(maybe_proposal)) {
+                  maybe_log->info("{}", maybe_proposal.assumeError().error);
+                  callback({std::nullopt, round});
+                  return;
+                }
+                callback({std::move(maybe_proposal).assumeValue(), round});*/
       });
 }
 

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -140,6 +140,10 @@ void OnDemandOsClientGrpc::onBatches(CollectionType batches) {
   }
 }
 
+std::chrono::milliseconds OnDemandOsClientGrpc::getRequestDelay() const {
+  return proposal_request_timeout_;
+}
+
 void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) {
   // Cancel an unfinished request
   if (auto maybe_context = context_.lock()) {

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -144,7 +144,7 @@ std::chrono::milliseconds OnDemandOsClientGrpc::getRequestDelay() const {
   return proposal_request_timeout_;
 }
 
-void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) {
+void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) {
   // Cancel an unfinished request
   if (auto maybe_context = context_.lock()) {
     maybe_context->TryCancel();

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -189,6 +189,24 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::option
         } else {
           maybe_log->info("RPC succeeded: {}", context->peer());
         }
+
+        switch (response.optional_proposal_case()) {
+          case proto::ProposalResponse::kSameProposalHash: {
+            callback({std::move(ref_proposal), round});
+          }break;
+          case proto::ProposalResponse::kProposal: {
+            auto proposal_result = maybe_proposal_factory->build(response.proposal());
+            if (expected::hasError(proposal_result)) {
+              maybe_log->info("{}", proposal_result.assumeError().error);
+              callback({std::nullopt, round});
+            } else
+              callback({std::move(proposal_result).assumeValue(), round});
+          }break;
+          default: {
+            callback({std::nullopt, round}); }
+            break;
+        }
+/*
         if (not response.has_proposal()) {
           callback({std::nullopt, round});
           return;
@@ -200,7 +218,7 @@ void OnDemandOsClientGrpc::onRequestProposal(consensus::Round round, std::option
           callback({std::nullopt, round});
           return;
         }
-        callback({std::move(maybe_proposal).assumeValue(), round});
+        callback({std::move(maybe_proposal).assumeValue(), round});*/
       });
 }
 

--- a/irohad/ordering/impl/on_demand_os_client_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.cpp
@@ -208,19 +208,6 @@ void OnDemandOsClientGrpc::onRequestProposal(
           } break;
           default: { callback({std::nullopt, round}); } break;
         }
-        /*
-                if (not response.has_proposal()) {
-                  callback({std::nullopt, round});
-                  return;
-                }
-                auto maybe_proposal =
-                    maybe_proposal_factory->build(response.proposal());
-                if (expected::hasError(maybe_proposal)) {
-                  maybe_log->info("{}", maybe_proposal.assumeError().error);
-                  callback({std::nullopt, round});
-                  return;
-                }
-                callback({std::move(maybe_proposal).assumeValue(), round});*/
       });
 }
 

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -59,6 +59,8 @@ namespace iroha {
 
         void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
 
+        std::chrono::milliseconds getRequestDelay() const override;
+
        private:
         logger::LoggerPtr log_;
         std::shared_ptr<proto::OnDemandOrdering::StubInterface> stub_;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -89,6 +89,8 @@ namespace iroha {
         iroha::expected::Result<std::unique_ptr<OdOsNotification>, std::string>
         create(const shared_model::interface::Peer &to) override;
 
+        std::chrono::milliseconds getRequestDelay() const override;
+
        private:
         std::shared_ptr<TransportFactoryType> proposal_factory_;
         std::function<OnDemandOsClientGrpc::TimepointType()> time_provider_;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -57,7 +57,11 @@ namespace iroha {
 
         void onBatches(CollectionType batches) override;
 
-        void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) override;
+        void onRequestProposal(
+            consensus::Round round,
+            std::optional<
+                std::shared_ptr<const shared_model::interface::Proposal>>
+                ref_proposal) override;
 
         std::chrono::milliseconds getRequestDelay() const override;
 

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -57,7 +57,7 @@ namespace iroha {
 
         void onBatches(CollectionType batches) override;
 
-        void onRequestProposal(consensus::Round round) override;
+        void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
 
        private:
         logger::LoggerPtr log_;

--- a/irohad/ordering/impl/on_demand_os_client_grpc.hpp
+++ b/irohad/ordering/impl/on_demand_os_client_grpc.hpp
@@ -57,7 +57,7 @@ namespace iroha {
 
         void onBatches(CollectionType batches) override;
 
-        void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) override;
+        void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) override;
 
         std::chrono::milliseconds getRequestDelay() const override;
 

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -70,24 +70,28 @@ grpc::Status OnDemandOsServerGrpc::RequestProposal(
   log_->info("Received RequestProposal for {} from {}", round, context->peer());
   auto maybe_proposal = ordering_service_->waitForLocalProposal(round, delay_);
   if (maybe_proposal.has_value()) {
-    if (request->has_ref_proposal_hash() && maybe_proposal.value()->hash() == shared_model::crypto::Hash(request->ref_proposal_hash()))
+    if (request->has_ref_proposal_hash()
+        && maybe_proposal.value()->hash()
+            == shared_model::crypto::Hash(request->ref_proposal_hash()))
       response->set_same_proposal_hash(request->ref_proposal_hash());
     else
-    *response->mutable_proposal() =
-        static_cast<const shared_model::proto::Proposal *>(
-            maybe_proposal->get())
-            ->getTransport();
+      *response->mutable_proposal() =
+          static_cast<const shared_model::proto::Proposal *>(
+              maybe_proposal->get())
+              ->getTransport();
   }
 
   log_->debug(
       "Responding for {} with {}: our proposal {}",
       round,
-      request->has_ref_proposal_hash() ? request->ref_proposal_hash() : "NO REFERENCE PROPOSAL HASH",
+      request->has_ref_proposal_hash() ? request->ref_proposal_hash()
+                                       : "NO REFERENCE PROPOSAL HASH",
       response->optional_proposal_case() == response->kProposal
-          ? fmt::format("has DIFFERENT hash {}, sending full proposal", maybe_proposal.value()->hash().hex())
+          ? fmt::format("has DIFFERENT hash {}, sending full proposal",
+                        maybe_proposal.value()->hash().hex())
           : response->optional_proposal_case() == response->kSameProposalHash
-          ? "has SAME hash, sending only hash"
-          : "is EMPTY");
+              ? "has SAME hash, sending only hash"
+              : "is EMPTY");
 
   return ::grpc::Status::OK;
 }

--- a/irohad/ordering/impl/on_demand_os_server_grpc.cpp
+++ b/irohad/ordering/impl/on_demand_os_server_grpc.cpp
@@ -68,13 +68,26 @@ grpc::Status OnDemandOsServerGrpc::RequestProposal(
   consensus::Round round{request->round().block_round(),
                          request->round().reject_round()};
   log_->info("Received RequestProposal for {} from {}", round, context->peer());
-  ordering_service_->waitForLocalProposal(round, delay_);
-
-  if (auto maybe_proposal = ordering_service_->onRequestProposal(round)) {
+  auto maybe_proposal = ordering_service_->waitForLocalProposal(round, delay_);
+  if (maybe_proposal.has_value()) {
+    if (request->has_ref_proposal_hash() && maybe_proposal.value()->hash() == shared_model::crypto::Hash(request->ref_proposal_hash()))
+      response->set_same_proposal_hash(request->ref_proposal_hash());
+    else
     *response->mutable_proposal() =
         static_cast<const shared_model::proto::Proposal *>(
             maybe_proposal->get())
             ->getTransport();
   }
+
+  log_->debug(
+      "Responding for {} with {}: our proposal {}",
+      round,
+      request->has_ref_proposal_hash() ? request->ref_proposal_hash() : "NO REFERENCE PROPOSAL HASH",
+      response->optional_proposal_case() == response->kProposal
+          ? fmt::format("has DIFFERENT hash {}, sending full proposal", maybe_proposal.value()->hash().hex())
+          : response->optional_proposal_case() == response->kSameProposalHash
+          ? "has SAME hash, sending only hash"
+          : "is EMPTY");
+
   return ::grpc::Status::OK;
 }

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -46,7 +46,7 @@ namespace iroha {
 
       using BatchesSetType =
           std::set<std::shared_ptr<shared_model::interface::TransactionBatch>,
-                   shared_model::interface::BatchHashEquality>;
+                   shared_model::interface::BatchHashLess>;
 
       /**
        * Type of stored transaction batches

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -7,6 +7,7 @@
 #define IROHA_ON_DEMAND_ORDERING_SERVICE_HPP
 
 #include <unordered_set>
+#include <chrono>
 
 #include "consensus/round.hpp"
 #include "cryptography/hash.hpp"
@@ -89,6 +90,13 @@ namespace iroha {
        * @param hashes - txs list
        */
       virtual void onDuplicates(const HashesSetType &hashes) = 0;
+
+      /**
+       * Method to wait until proposal become available.
+       * @param round which proposal to wait
+       * @param delay time to wait
+       */
+      virtual void waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const = 0;
 
       /**
        * Method to get betches under lock

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -6,8 +6,8 @@
 #ifndef IROHA_ON_DEMAND_ORDERING_SERVICE_HPP
 #define IROHA_ON_DEMAND_ORDERING_SERVICE_HPP
 
-#include <unordered_set>
 #include <chrono>
+#include <unordered_set>
 
 #include "consensus/round.hpp"
 #include "cryptography/hash.hpp"
@@ -44,9 +44,9 @@ namespace iroha {
         }
       };
 
-      using BatchesSetType = std::set<
-          std::shared_ptr<shared_model::interface::TransactionBatch>,
-          shared_model::interface::BatchHashEquality>;
+      using BatchesSetType =
+          std::set<std::shared_ptr<shared_model::interface::TransactionBatch>,
+                   shared_model::interface::BatchHashEquality>;
 
       /**
        * Type of stored transaction batches
@@ -95,7 +95,9 @@ namespace iroha {
        * @param round which proposal to wait
        * @param delay time to wait
        */
-      virtual std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) = 0;
+      virtual std::optional<std::shared_ptr<const ProposalType>>
+      waitForLocalProposal(consensus::Round const &round,
+                           std::chrono::milliseconds const &delay) = 0;
 
       /**
        * Method to get betches under lock

--- a/irohad/ordering/on_demand_ordering_service.hpp
+++ b/irohad/ordering/on_demand_ordering_service.hpp
@@ -44,9 +44,8 @@ namespace iroha {
         }
       };
 
-      using BatchesSetType = std::unordered_set<
+      using BatchesSetType = std::set<
           std::shared_ptr<shared_model::interface::TransactionBatch>,
-          BatchPointerHasher,
           shared_model::interface::BatchHashEquality>;
 
       /**
@@ -96,7 +95,7 @@ namespace iroha {
        * @param round which proposal to wait
        * @param delay time to wait
        */
-      virtual void waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) const = 0;
+      virtual std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(consensus::Round const &round, std::chrono::milliseconds const &delay) = 0;
 
       /**
        * Method to get betches under lock

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -55,7 +55,7 @@ namespace iroha {
          * @param round - number of collaboration round.
          * Calculated as block_height + 1
          */
-        virtual void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) = 0;
+        virtual void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) = 0;
 
         /**
          * @return delay proposal to wait for.

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -6,15 +6,15 @@
 #ifndef IROHA_ON_DEMAND_OS_TRANSPORT_HPP
 #define IROHA_ON_DEMAND_OS_TRANSPORT_HPP
 
+#include <chrono>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <chrono>
 
 #include "common/result_fwd.hpp"
 #include "consensus/round.hpp"
-#include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "interfaces/iroha_internal/proposal.hpp"
+#include "interfaces/iroha_internal/transaction_batch.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -55,7 +55,11 @@ namespace iroha {
          * @param round - number of collaboration round.
          * Calculated as block_height + 1
          */
-        virtual void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> ref_proposal) = 0;
+        virtual void onRequestProposal(
+            consensus::Round round,
+            std::optional<
+                std::shared_ptr<const shared_model::interface::Proposal>>
+                ref_proposal) = 0;
 
         /**
          * @return delay proposal to wait for.

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -13,6 +13,7 @@
 #include "common/result_fwd.hpp"
 #include "consensus/round.hpp"
 #include "interfaces/iroha_internal/transaction_batch.hpp"
+#include "interfaces/iroha_internal/proposal.hpp"
 
 namespace shared_model {
   namespace interface {
@@ -53,7 +54,7 @@ namespace iroha {
          * @param round - number of collaboration round.
          * Calculated as block_height + 1
          */
-        virtual void onRequestProposal(consensus::Round round) = 0;
+        virtual void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) = 0;
 
         virtual ~OdOsNotification() = default;
       };

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -56,6 +56,11 @@ namespace iroha {
          */
         virtual void onRequestProposal(consensus::Round round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>> &&ref_proposal) = 0;
 
+        /**
+         * @return delay proposal to wait for.
+         */
+        virtual std::chrono::milliseconds getRequestDelay() const = 0;
+
         virtual ~OdOsNotification() = default;
       };
 
@@ -73,6 +78,11 @@ namespace iroha {
         virtual iroha::expected::Result<std::unique_ptr<OdOsNotification>,
                                         std::string>
         create(const shared_model::interface::Peer &to) = 0;
+
+        /**
+         * @return delay proposal to wait for.
+         */
+        virtual std::chrono::milliseconds getRequestDelay() const = 0;
 
         virtual ~OdOsNotificationFactory() = default;
       };

--- a/irohad/ordering/on_demand_os_transport.hpp
+++ b/irohad/ordering/on_demand_os_transport.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <chrono>
 
 #include "common/result_fwd.hpp"
 #include "consensus/round.hpp"

--- a/schema/ordering.proto
+++ b/schema/ordering.proto
@@ -33,6 +33,7 @@ message ProposalRequest {
 message ProposalResponse {
   oneof optional_proposal {
     protocol.Proposal proposal = 1;
+    bytes same_proposal_hash = 2;
  }
 }
 

--- a/schema/ordering.proto
+++ b/schema/ordering.proto
@@ -25,6 +25,9 @@ message BatchesRequest {
 
 message ProposalRequest {
   ProposalRound round = 1;
+  oneof optional_ref_proposal {
+    bytes ref_proposal_hash = 2;
+  }
 }
 
 message ProposalResponse {

--- a/shared_model/interfaces/iroha_internal/transaction_batch.cpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch.cpp
@@ -5,6 +5,8 @@
 
 #include "interfaces/iroha_internal/transaction_batch.hpp"
 
+#include <string_view>
+
 #include "interfaces/transaction.hpp"
 #include "utils/string_builder.hpp"
 
@@ -22,6 +24,13 @@ namespace shared_model {
         const std::shared_ptr<TransactionBatch> &left_tx,
         const std::shared_ptr<TransactionBatch> &right_tx) const {
       return left_tx->reducedHash() == right_tx->reducedHash();
+    }
+
+    bool BatchHashLess::operator()(
+        const std::shared_ptr<TransactionBatch> &left_tx,
+        const std::shared_ptr<TransactionBatch> &right_tx) const {
+      return std::less<shared_model::crypto::Blob::Bytes>{}(
+          left_tx->reducedHash().blob(), right_tx->reducedHash().blob());
     }
   }  // namespace interface
 }  // namespace shared_model

--- a/shared_model/interfaces/iroha_internal/transaction_batch.hpp
+++ b/shared_model/interfaces/iroha_internal/transaction_batch.hpp
@@ -69,6 +69,19 @@ namespace shared_model {
       bool operator()(const std::shared_ptr<TransactionBatch> &left_tx,
                       const std::shared_ptr<TransactionBatch> &right_tx) const;
     };
+
+    /**
+     * This is a helper structure which serves as a predicate
+     * for hash comparison.
+     */
+    struct BatchHashLess {
+      /**
+       * The function used to compare batches for equality:
+       * check only hashes of batches, without signatures
+       */
+      bool operator()(const std::shared_ptr<TransactionBatch> &left_tx,
+                      const std::shared_ptr<TransactionBatch> &right_tx) const;
+    };
   }  // namespace interface
 }  // namespace shared_model
 

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -24,7 +24,10 @@ namespace integration_framework::fake_peer {
         std::make_shared<BatchesCollection>(std::move(batches)));
   }
 
-  std::optional<std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>> OnDemandOsNetworkNotifier::waitForLocalProposal(iroha::consensus::Round const &round, std::chrono::milliseconds const &/*delay*/) {
+  std::optional<std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>>
+  OnDemandOsNetworkNotifier::waitForLocalProposal(
+      iroha::consensus::Round const &round,
+      std::chrono::milliseconds const & /*delay*/) {
     return onRequestProposal(round);
   }
 

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.cpp
@@ -5,6 +5,8 @@
 
 #include "framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp"
 
+#include <chrono>
+
 #include "backend/protobuf/proposal.hpp"
 #include "framework/integration_framework/fake_peer/behaviour/behaviour.hpp"
 #include "framework/integration_framework/fake_peer/fake_peer.hpp"
@@ -20,6 +22,10 @@ namespace integration_framework::fake_peer {
     std::lock_guard<std::mutex> guard(batches_subject_mutex_);
     batches_subject_.get_subscriber().on_next(
         std::make_shared<BatchesCollection>(std::move(batches)));
+  }
+
+  std::optional<std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>> OnDemandOsNetworkNotifier::waitForLocalProposal(iroha::consensus::Round const &round, std::chrono::milliseconds const &/*delay*/) {
+    return onRequestProposal(round);
   }
 
   std::optional<std::shared_ptr<const OnDemandOsNetworkNotifier::ProposalType>>

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -37,7 +37,9 @@ namespace integration_framework::fake_peer {
             iroha::ordering::OnDemandOrderingService::BatchesSetType &)> const
             &f) override;
 
-    std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(iroha::consensus::Round const &round, std::chrono::milliseconds const &delay) override;
+    std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(
+        iroha::consensus::Round const &round,
+        std::chrono::milliseconds const &delay) override;
 
     bool isEmptyBatchesCache() override;
 

--- a/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
+++ b/test/framework/integration_framework/fake_peer/network/on_demand_os_network_notifier.hpp
@@ -37,6 +37,8 @@ namespace integration_framework::fake_peer {
             iroha::ordering::OnDemandOrderingService::BatchesSetType &)> const
             &f) override;
 
+    std::optional<std::shared_ptr<const ProposalType>> waitForLocalProposal(iroha::consensus::Round const &round, std::chrono::milliseconds const &delay) override;
+
     bool isEmptyBatchesCache() override;
 
     bool hasEnoughBatchesInCache() const override;

--- a/test/integration/acceptance/fake_peer_example_test.cpp
+++ b/test/integration/acceptance/fake_peer_example_test.cpp
@@ -93,14 +93,16 @@ TEST_P(FakePeerExampleTest, SynchronizeTheRightVersionOfForkedLedger) {
       bad_fake_peers.front();  // the malicious actor
 
   // Add two blocks to the ledger.
-  itf.sendTx(complete(baseTx(kAdminId).transferAsset(
-                          kAdminId, kUserId, kAssetId, "common_tx1", "1.0"),
-                      kAdminKeypair))
-      .skipBlock();
-  itf.sendTx(complete(baseTx(kAdminId).transferAsset(
-                          kAdminId, kUserId, kAssetId, "common_tx2", "2.0"),
-                      kAdminKeypair))
-      .skipBlock();
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).transferAsset(
+                   kAdminId, kUserId, kAssetId, "common_tx1", "1.0"),
+               kAdminKeypair),
+      [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
+  itf.sendTxAwait(
+      complete(baseTx(kAdminId).transferAsset(
+                   kAdminId, kUserId, kAssetId, "common_tx2", "2.0"),
+               kAdminKeypair),
+      [](auto &block) { ASSERT_EQ(block->transactions().size(), 1); });
 
   // Create the valid branch, supported by the good fake peers:
   auto valid_block_storage =

--- a/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
+++ b/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
@@ -16,8 +16,8 @@ namespace iroha {
 
       struct MockOdOsNotification : public OdOsNotification {
         MOCK_METHOD1(onBatches, void(CollectionType));
-
-        MOCK_METHOD1(onRequestProposal, void(consensus::Round));
+        MOCK_METHOD2(onRequestProposal, void(consensus::Round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>>));
+        MOCK_CONST_METHOD0(getRequestDelay, std::chrono::milliseconds());
       };
 
     }  // namespace transport

--- a/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
+++ b/test/module/irohad/ordering/mock_on_demand_os_notification.hpp
@@ -16,7 +16,10 @@ namespace iroha {
 
       struct MockOdOsNotification : public OdOsNotification {
         MOCK_METHOD1(onBatches, void(CollectionType));
-        MOCK_METHOD2(onRequestProposal, void(consensus::Round, std::optional<std::shared_ptr<const shared_model::interface::Proposal>>));
+        MOCK_METHOD2(onRequestProposal,
+                     void(consensus::Round,
+                          std::optional<std::shared_ptr<
+                              const shared_model::interface::Proposal>>));
         MOCK_CONST_METHOD0(getRequestDelay, std::chrono::milliseconds());
       };
 

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -96,7 +96,8 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
  */
 TEST_F(OnDemandConnectionManagerTest, onRequestProposal) {
   consensus::Round round{};
-  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> prop{};
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
+      prop{};
   EXPECT_CALL(*connections[OnDemandConnectionManager::kIssuer],
               onRequestProposal(round, prop))
       .Times(1);

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -96,9 +96,10 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
  */
 TEST_F(OnDemandConnectionManagerTest, onRequestProposal) {
   consensus::Round round{};
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> prop{};
   EXPECT_CALL(*connections[OnDemandConnectionManager::kIssuer],
-              onRequestProposal(round))
+              onRequestProposal(round, prop))
       .Times(1);
 
-  manager->onRequestProposal(round);
+  manager->onRequestProposal(round, prop);
 }

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -135,7 +135,8 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
   EXPECT_CALL(*ordering_service, forCachedBatches(_))
       .WillOnce(InvokeArgument<0>(transactions));
 
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
 
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
@@ -170,7 +171,8 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
   EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
 
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
 
   auto event = RoundSwitch(round, ledger_state);
@@ -193,11 +195,12 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
 
-std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
   EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
 
   ordering_gate->processRoundSwitch(RoundSwitch(round, ledger_state));
@@ -218,7 +221,8 @@ TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
@@ -254,7 +258,8 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
@@ -311,7 +316,8 @@ TEST_F(OnDemandOrderingGateTest, RepeatedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
@@ -359,7 +365,8 @@ TEST_F(OnDemandOrderingGateTest, PopNonEmptyBatchesFromTheCache) {
 
   OnDemandOrderingService::BatchesSetType collection{batch1, batch2};
   OnDemandOrderingService::BatchesSetType collection2{batch1, batch2};
-  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+  EXPECT_CALL(*ordering_service,
+              waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, forCachedBatches(_))
       .WillOnce(InvokeArgument<0>(collection2));

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -135,7 +135,11 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
   EXPECT_CALL(*ordering_service, forCachedBatches(_))
       .WillOnce(InvokeArgument<0>(transactions));
 
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
+
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
 
   auto event = RoundSwitch(round, ledger_state);
 
@@ -163,7 +167,11 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
           .build());
 
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
+
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
 
   auto event = RoundSwitch(round, ledger_state);
 
@@ -185,8 +193,12 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+
+std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
 
   ordering_gate->processRoundSwitch(RoundSwitch(round, ledger_state));
 
@@ -206,8 +218,11 @@ TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
 
   ordering_gate->processRoundSwitch(RoundSwitch(round, ledger_state));
 
@@ -239,8 +254,11 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
   EXPECT_CALL(*tx_cache,
               check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
       .WillOnce(Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
@@ -293,8 +311,11 @@ TEST_F(OnDemandOrderingGateTest, RepeatedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
-  EXPECT_CALL(*notification, onRequestProposal(round)).Times(1);
+  std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
+  EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
   EXPECT_CALL(*tx_cache,
               check(testing::Matcher<const shared_model::crypto::Hash &>(_)))
       .WillRepeatedly(Return(boost::make_optional<ametsuchi::TxCacheStatusType>(
@@ -338,6 +359,8 @@ TEST_F(OnDemandOrderingGateTest, PopNonEmptyBatchesFromTheCache) {
 
   OnDemandOrderingService::BatchesSetType collection{batch1, batch2};
   OnDemandOrderingService::BatchesSetType collection2{batch1, batch2};
+  EXPECT_CALL(*ordering_service, waitForLocalProposal(round, std::chrono::milliseconds(1)))
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*ordering_service, forCachedBatches(_))
       .WillOnce(InvokeArgument<0>(collection2));
 

--- a/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
+++ b/test/module/irohad/ordering/on_demand_ordering_gate_test.cpp
@@ -135,6 +135,9 @@ TEST_F(OnDemandOrderingGateTest, BlockEvent) {
   EXPECT_CALL(*ordering_service, forCachedBatches(_))
       .WillOnce(InvokeArgument<0>(transactions));
 
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
+
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
@@ -167,6 +170,8 @@ TEST_F(OnDemandOrderingGateTest, EmptyEvent) {
               std::vector<shared_model::proto::Transaction>{generateTx()})
           .build());
 
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service, onCollaborationOutcome(round)).Times(1);
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>> p{};
   EXPECT_CALL(*notification, onRequestProposal(round, p)).Times(1);
@@ -195,6 +200,8 @@ TEST_F(OnDemandOrderingGateTest, BlockEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
@@ -221,6 +228,8 @@ TEST_F(OnDemandOrderingGateTest, EmptyEventNoProposal) {
   std::optional<std::shared_ptr<const shared_model::interface::Proposal>>
       proposal;
 
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
@@ -258,6 +267,8 @@ TEST_F(OnDemandOrderingGateTest, ReplayedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
@@ -316,6 +327,8 @@ TEST_F(OnDemandOrderingGateTest, RepeatedTransactionInProposal) {
           std::move(proposal)));
 
   // set expectations for ordering service
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));
@@ -365,6 +378,8 @@ TEST_F(OnDemandOrderingGateTest, PopNonEmptyBatchesFromTheCache) {
 
   OnDemandOrderingService::BatchesSetType collection{batch1, batch2};
   OnDemandOrderingService::BatchesSetType collection2{batch1, batch2};
+  EXPECT_CALL(*notification, getRequestDelay())
+      .WillOnce(Return(std::chrono::milliseconds(1)));
   EXPECT_CALL(*ordering_service,
               waitForLocalProposal(round, std::chrono::milliseconds(1)))
       .WillOnce(Return(std::nullopt));

--- a/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_client_grpc_test.cpp
@@ -171,7 +171,7 @@ TEST_F(OnDemandOsClientGrpcTest, onRequestProposal) {
                       SetArgPointee<2>(response),
                       Return(grpc::Status::OK)));
 
-  client->onRequestProposal(round);
+  client->onRequestProposal(round, std::nullopt);
 
   ASSERT_EQ(timepoint + timeout, deadline);
   ASSERT_EQ(request.round().block_round(), round.block_round);
@@ -199,7 +199,7 @@ TEST_F(OnDemandOsClientGrpcTest, onRequestProposalNone) {
                       SetArgPointee<2>(response),
                       Return(grpc::Status::OK)));
 
-  client->onRequestProposal(round);
+  client->onRequestProposal(round, std::nullopt);
 
   ASSERT_EQ(timepoint + timeout, deadline);
   ASSERT_EQ(request.round().block_round(), round.block_round);

--- a/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
@@ -132,9 +132,9 @@ TEST_F(OnDemandOsServerGrpcTest, RequestProposal) {
 
   std::shared_ptr<const shared_model::interface::Proposal> iproposal(
       std::make_shared<const shared_model::proto::Proposal>(proposal));
-  EXPECT_CALL(*notification, onRequestProposal(round))
+  std::chrono::milliseconds delay(0);
+  EXPECT_CALL(*notification, waitForLocalProposal(round, delay))
       .WillOnce(Return(ByMove(std::move(iproposal))));
-  EXPECT_CALL(*notification, hasEnoughBatchesInCache()).WillOnce(Return(true));
 
   grpc::ServerContext context;
   server->RequestProposal(&context, &request, &response);
@@ -160,9 +160,9 @@ TEST_F(OnDemandOsServerGrpcTest, RequestProposalNone) {
   request.mutable_round()->set_block_round(round.block_round);
   request.mutable_round()->set_reject_round(round.reject_round);
   proto::ProposalResponse response;
-  EXPECT_CALL(*notification, onRequestProposal(round))
+  std::chrono::milliseconds delay(0);
+  EXPECT_CALL(*notification, waitForLocalProposal(round, delay))
       .WillOnce(Return(ByMove(std::move(std::nullopt))));
-  EXPECT_CALL(*notification, hasEnoughBatchesInCache()).WillOnce(Return(false));
 
   grpc::ServerContext context;
   server->RequestProposal(&context, &request, &response);

--- a/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
+++ b/test/module/irohad/ordering/on_demand_os_server_grpc_test.cpp
@@ -114,6 +114,40 @@ TEST_F(OnDemandOsServerGrpcTest, SendBatches) {
 
 /**
  * @given server
+ * @when proposal is requested with reference hash same as proposal hash
+ * @then only hash returns
+ */
+TEST_F(OnDemandOsServerGrpcTest, RequestSameProposal) {
+  auto creator = "test";
+  protocol::Proposal proposal;
+  proposal.add_transactions()
+      ->mutable_payload()
+      ->mutable_reduced_payload()
+      ->set_creator_account_id(creator);
+
+  std::shared_ptr<const shared_model::interface::Proposal> iproposal(
+      std::make_shared<const shared_model::proto::Proposal>(proposal));
+
+  proto::ProposalRequest request;
+  request.mutable_round()->set_block_round(round.block_round);
+  request.mutable_round()->set_reject_round(round.reject_round);
+  request.set_ref_proposal_hash(
+      std::string((char *)iproposal->hash().blob().data(),
+                  iproposal->hash().blob().size()));
+
+  std::chrono::milliseconds delay(0);
+  EXPECT_CALL(*notification, waitForLocalProposal(round, delay))
+      .WillOnce(Return(ByMove(std::move(iproposal))));
+
+  grpc::ServerContext context;
+  proto::ProposalResponse response;
+  server->RequestProposal(&context, &request, &response);
+
+  ASSERT_TRUE(response.has_same_proposal_hash());
+}
+
+/**
+ * @given server
  * @when proposal is requested
  * AND proposal returned
  * @then it is correctly serialized

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -20,6 +20,8 @@ namespace iroha::ordering::transport {
                 create,
                 (const shared_model::interface::Peer &),
                 (override));
+    MOCK_CONST_METHOD0(getRequestDelay,
+                 std::chrono::milliseconds());
   };
 }  // namespace iroha::ordering::transport
 
@@ -42,6 +44,8 @@ namespace iroha::ordering {
     MOCK_METHOD(bool, hasEnoughBatchesInCache, (), (const, override));
     MOCK_METHOD(bool, hasProposal, (consensus::Round), (const, override));
     MOCK_METHOD(void, processReceivedProposal, (CollectionType), (override));
+
+    MOCK_METHOD2(waitForLocalProposal, std::optional<std::shared_ptr<const ProposalType>>(consensus::Round const &, std::chrono::milliseconds const &));
   };
 }  // namespace iroha::ordering
 

--- a/test/module/irohad/ordering/ordering_mocks.hpp
+++ b/test/module/irohad/ordering/ordering_mocks.hpp
@@ -20,8 +20,7 @@ namespace iroha::ordering::transport {
                 create,
                 (const shared_model::interface::Peer &),
                 (override));
-    MOCK_CONST_METHOD0(getRequestDelay,
-                 std::chrono::milliseconds());
+    MOCK_CONST_METHOD0(getRequestDelay, std::chrono::milliseconds());
   };
 }  // namespace iroha::ordering::transport
 
@@ -45,7 +44,10 @@ namespace iroha::ordering {
     MOCK_METHOD(bool, hasProposal, (consensus::Round), (const, override));
     MOCK_METHOD(void, processReceivedProposal, (CollectionType), (override));
 
-    MOCK_METHOD2(waitForLocalProposal, std::optional<std::shared_ptr<const ProposalType>>(consensus::Round const &, std::chrono::milliseconds const &));
+    MOCK_METHOD2(waitForLocalProposal,
+                 std::optional<std::shared_ptr<const ProposalType>>(
+                     consensus::Round const &,
+                     std::chrono::milliseconds const &));
   };
 }  // namespace iroha::ordering
 


### PR DESCRIPTION
### Description of the Change
Node calculates ```proposal``` on local ```OS``` before remote ```request```. Then it sends ```request``` with local ```proposal``` hash. In the case the ```proposal``` on remote ```OS``` is equal to local, there is no proposal data transfer in ```response```.