### PR TITLE
[feature] #1195: Close a websocket connection cleanly

### DIFF
--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -14,18 +14,23 @@ pub type EventsSender = broadcast::Sender<Event>;
 /// Type of `Receiver<Event>` which should be used for channels of `Event` messages.
 pub type EventsReceiver = broadcast::Receiver<Event>;
 
+/// Type of error for `Consumer`
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// Error from provided stream/websocket
     #[error("Stream error: {0}")]
     Stream(#[from] stream::Error<<WebSocket as Stream<VersionedEventSubscriberMessage>>::Err>),
 
+    /// Error from converting received message to filter
     #[error("Can't retrieve subscription filter: {0}")]
     CantRetrieveSubscriptionFilter(#[from] ErrorTryFromEnum<EventSubscriberMessage, EventFilter>),
 
+    /// Error, that occurs when client answered not with `EventReceived` message
     #[error("Got unexpected response. Expected `EventReceived`")]
     ExpectedEventReceived,
 }
 
+/// Result type for `Consumer`
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Consumer for Iroha `Event`(s).

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -78,4 +78,11 @@ impl Consumer {
             Err(Error::ExpectedEventReceived)
         }
     }
+
+    /// Returns mut reference to stored `stream`
+    ///
+    /// Useful for performing other read/write stuff with `stream`
+    pub fn stream_mut(&mut self) -> &mut WebSocket {
+        &mut self.stream
+    }
 }

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,6 +1,6 @@
 //! Iroha is a quite dynamic system so many events can happen.
 //! This module contains descriptions of such an events and
-//! utilitarian Iroha Special Instructions to work with them.
+//! utility Iroha Special Instructions to work with them.
 
 use iroha_data_model::events::prelude::*;
 use iroha_macro::error::ErrorTryFromEnum;
@@ -20,11 +20,9 @@ pub enum Error {
     /// Error from provided stream/websocket
     #[error("Stream error: {0}")]
     Stream(#[from] stream::Error<<WebSocket as Stream<VersionedEventSubscriberMessage>>::Err>),
-
     /// Error from converting received message to filter
     #[error("Can't retrieve subscription filter: {0}")]
     CantRetrieveSubscriptionFilter(#[from] ErrorTryFromEnum<EventSubscriberMessage, EventFilter>),
-
     /// Error, that occurs when client answered not with `EventReceived` message
     #[error("Got unexpected response. Expected `EventReceived`")]
     ExpectedEventReceived,

--- a/core/src/torii/routing.rs
+++ b/core/src/torii/routing.rs
@@ -168,8 +168,8 @@ async fn handle_subscription(events: EventsSender, stream: WebSocket) -> eyre::R
 
     loop {
         tokio::select! {
-            message = consumer.stream_mut().next() => {
-                if let Some(message) = message {
+            message_opt = consumer.stream_mut().next() => {
+                if let Some(message) = message_opt {
                     if message?.is_close() {
                         return Ok(());
                     }
@@ -180,6 +180,7 @@ async fn handle_subscription(events: EventsSender, stream: WebSocket) -> eyre::R
                 iroha_logger::trace!(?event);
                 consumer.consume(event).await?;
             }
+            else => ()
         }
     }
 }
@@ -330,7 +331,6 @@ impl<W: WorldTrait> Torii<W> {
             .map(|events, ws: Ws| {
                 ws.on_upgrade(|this_ws| async move {
                     if let Err(error) = handle_subscription(events, this_ws).await {
-                        println!("Failed to subscribe someone: {}", error);
                         iroha_logger::error!(%error, "Failed to subscribe someone");
                     }
                 })

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -547,7 +547,7 @@ async fn test_subscription_websocket_clean_closing() {
     let (torii, _) = create_torii().await;
     let router = torii.create_api_router();
 
-    let mut client = warp::test::ws()
+    let mut endpoint = warp::test::ws()
         .path("/events")
         .handshake(router)
         .await
@@ -560,10 +560,10 @@ async fn test_subscription_websocket_clean_closing() {
     let subscribe_message = VersionedEventSubscriberMessage::from(
         EventSubscriberMessage::SubscriptionRequest(event_filter),
     );
-    Sink::send(&mut client, subscribe_message).await.unwrap();
+    Sink::send(&mut endpoint, subscribe_message).await.unwrap();
 
     let confirmation_response: VersionedEventPublisherMessage =
-        Stream::recv(&mut client).await.unwrap();
+        Stream::recv(&mut endpoint).await.unwrap();
     let confirmation_response = confirmation_response.into_v1();
     assert!(matches!(
         confirmation_response,
@@ -572,6 +572,6 @@ async fn test_subscription_websocket_clean_closing() {
 
     // Closing connection
     let close_message = ws::Message::close();
-    client.send(close_message).await;
-    assert!(client.recv_closed().await.is_ok());
+    endpoint.send(close_message).await;
+    assert!(endpoint.recv_closed().await.is_ok());
 }

--- a/core/src/torii/tests.rs
+++ b/core/src/torii/tests.rs
@@ -573,7 +573,5 @@ async fn test_subscription_websocket_clean_closing() {
     // Closing connection
     let close_message = ws::Message::close();
     client.send(close_message).await;
-    let close_response = client.recv().await.unwrap();
-    assert!(close_response.is_close());
     assert!(client.recv_closed().await.is_ok());
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

* Now `torii` checks for WebSocket `Close` messages on `/events` path and gracefully handles them.
* Also added test for it.
* As a bonus I refactored some error types from `eyre::Report` to custom Error enums. I thought, that it will help me, but it doesn't. I can reset it, if everybody else think it wasn't necessary

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Resolves #1195 

I was working only with that `handle_subscription()` method, cause it's mentioned in the issue. I don't know if issue appears somewhere else

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Closing WebSocket requires waiting for response. `torii` wasn't doing it, so clients had to interrupt connection.
Now this works as it shoud be.


<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Any suggestions about additional tests will be helpful. May be it should be tested with js-client, as it was mentioned in #1195

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

See `torii/tests.rs`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
