### PR TITLE
[fix] #1943: Add query errors to the schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ name = "iroha_version"
 version = "2.0.0-pre-rc.2"
 dependencies = [
  "iroha_macro",
+ "iroha_schema",
  "iroha_version_derive",
  "parity-scale-codec",
  "serde",

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -33,6 +33,7 @@ pub mod error {
 
     use iroha_crypto::HashOf;
     use iroha_data_model::{fixed::FixedPointOperationError, metadata, prelude::*};
+    use iroha_schema::IntoSchema;
     use parity_scale_codec::{Decode, Encode};
     use thiserror::Error;
 
@@ -129,7 +130,7 @@ pub mod error {
     }
 
     /// Type assertion error
-    #[derive(Debug, Clone, Error, Decode, Encode)]
+    #[derive(Debug, Clone, Error, Decode, Encode, IntoSchema)]
     pub enum FindError {
         /// Failed to find asset
         #[error("Failed to find asset: `{0}`")]
@@ -260,7 +261,7 @@ pub mod error {
     }
 
     /// Block with parent hash not found struct
-    #[derive(Debug, Clone, Copy, Decode, Encode)]
+    #[derive(Debug, Clone, Copy, Decode, Encode, IntoSchema)]
     pub struct ParentHashNotFound(pub HashOf<VersionedCommittedBlock>);
 
     impl Display for ParentHashNotFound {

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -5,6 +5,7 @@ use std::{error::Error as StdError, fmt};
 use eyre::Result;
 use iroha_crypto::SignatureOf;
 use iroha_data_model::{prelude::*, query};
+use iroha_schema::IntoSchema;
 use iroha_version::scale::DecodeVersioned;
 use parity_scale_codec::{Decode, Encode};
 use thiserror::Error;
@@ -90,7 +91,7 @@ impl ValidQueryRequest {
 }
 
 /// Unsupported version error
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Decode, Encode)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Decode, Encode, IntoSchema)]
 pub struct UnsupportedVersionError {
     /// Version that we got
     pub version: u8,
@@ -117,7 +118,7 @@ impl fmt::Display for UnsupportedVersionError {
 }
 
 /// Query errors.
-#[derive(Error, Debug, Clone, Decode, Encode)]
+#[derive(Error, Debug, Clone, Decode, Encode, IntoSchema)]
 pub enum Error {
     /// Query can not be decoded.
     #[error("Query can not be decoded")]

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -39,13 +39,13 @@
 
 | Response        | Status | Body [*](#iroha-structures) |
 | --------------- | ------ | ---- |
-| Decode err.     |    400 | `QueryError::Decode(_)` |
-| Version err.    |    400 | `QueryError::Version(_)` |
-| Signature err.  |    401 | `QueryError::Signature(_)` |
-| Permission err. |    403 | `QueryError::Permission(_)` |
-| Evaluate err.   |    400 | `QueryError::Evaluate(_)` |
+| Decode err.     |    400 | `QueryError::Decode(Box<iroha_version::error::Error>)` |
+| Version err.    |    400 | `QueryError::Version(UnsupportedVersionError)` |
+| Signature err.  |    401 | `QueryError::Signature(String)` |
+| Permission err. |    403 | `QueryError::Permission(String)` |
+| Evaluate err.   |    400 | `QueryError::Evaluate(String)` |
 | Find err.       |    404 | `QueryError::Find(Box<FindError>)` |
-| Conversion err. |    400 | `QueryError::Conversion(_)` |
+| Conversion err. |    400 | `QueryError::Conversion(String)` |
 | Success         |    200 | `VersionedQueryResult` |
 
 #### Asset Not Found 404
@@ -286,6 +286,7 @@ For more information on codec check [Substrate Dev Hub](https://substrate.dev/do
 
 - `VersionedQueryResult` - `iroha_data_model::query::VersionedQueryResult`
 - `QueryError` - `iroha_core::smartcontracts::isi::query::Error`
+- `UnsupportedVersionError` - `iroha_core::smartcontracts::isi::query::UnsupportedVersionError`
 - `FindError` - `iroha_core::smartcontracts::isi::error::FindError`
 
 - `EventStreamSubscriptionRequest` - `iroha_data_model::events::EventSubscriberMessage::SubscriptionRequest`

--- a/schema/bin/src/main.rs
+++ b/schema/bin/src/main.rs
@@ -8,6 +8,7 @@ fn build_schemas() -> MetaMap {
     use iroha_core::{
         block::{stream::prelude::*, VersionedValidBlock},
         genesis::RawGenesisBlock,
+        smartcontracts::isi::query::Error as QueryError,
     };
     use iroha_data_model::{merkle::MerkleTree, prelude::*};
 
@@ -30,6 +31,7 @@ fn build_schemas() -> MetaMap {
         VersionedQueryResult,
         VersionedSignedQueryRequest,
         VersionedTransaction,
+        QueryError,
 
         // Even though these schemas are not exchanged between server and client,
         // they can be useful to the client to generate and validate their hashes

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -16,6 +16,7 @@ json = ["serde", "serde_json"]
 [dependencies]
 iroha_version_derive = { version = "=2.0.0-pre-rc.2", path = "derive", default-features = false, optional = true }
 iroha_macro = { version = "=2.0.0-pre-rc.2", path = "../macro", default-features = false }
+iroha_schema = { version = "=2.0.0-pre-rc.2", path = "../schema", default-features = false }
 
 parity-scale-codec = { version = "2.3.1", default-features = false, optional = true, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -10,9 +10,10 @@ extern crate alloc;
 
 // TODO: #1854, CI doesn't catch errors with unused imports in this block.
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 use core::{fmt, ops::Range};
 
+use iroha_schema::IntoSchema;
 #[cfg(feature = "derive")]
 pub use iroha_version_derive::*;
 #[cfg(feature = "scale")]
@@ -22,16 +23,19 @@ use serde::{Deserialize, Serialize};
 
 /// Module which contains error and result for versioning
 pub mod error {
+    #[cfg(not(feature = "std"))]
+    use alloc::{format, string::String, vec::Vec};
     use core::fmt;
 
     use iroha_macro::FromVariant;
+    use iroha_schema::IntoSchema;
     #[cfg(feature = "scale")]
     use parity_scale_codec::{Decode, Encode};
 
     use super::UnsupportedVersion;
 
     /// Versioning errors
-    #[derive(Debug, Clone, FromVariant)]
+    #[derive(Debug, Clone, FromVariant, IntoSchema)]
     #[cfg_attr(feature = "std", derive(thiserror::Error))]
     #[cfg_attr(feature = "scale", derive(Encode, Decode))]
     pub enum Error {
@@ -137,7 +141,7 @@ pub trait Version {
 }
 
 /// Structure describing a container content which version is not supported.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, IntoSchema)]
 #[cfg_attr(feature = "scale", derive(Encode, Decode))]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct UnsupportedVersion {
@@ -166,7 +170,7 @@ impl UnsupportedVersion {
 }
 
 /// Raw versioned content, serialized.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, IntoSchema)]
 #[cfg_attr(feature = "scale", derive(Encode, Decode))]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub enum RawVersioned {


### PR DESCRIPTION
### Description of the Change
`iroha_core::smartcontracts::isi::query::Error` implements `IntoSchema` and is added to `iroha_schema_bin::build_schemas`

### Issue
Closes #1943

### Benefits

### Possible Drawbacks
None