### PR TITLE
[ci]: add proper tag to push workflow on main.

### DIFF
--- a/.github/workflows/iroha2.yml
+++ b/.github/workflows/iroha2.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: hyperledger/iroha2:dev
+          tags: hyperledger/iroha2:2.0.0-pre-rc.2
           build-args: |
             TARGET_DIR=release
             PROFILE=--release


### PR DESCRIPTION
Signed-off-by: Aleksandr <a-p-petrosyan@yandex.ru>

Final PR to be merged into RC2. 


### Description of the Change

Changes the tag for the push of the main docker container to the appropriate version number. 

### Issue

None

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Finality

### Possible Drawbacks

None

