### PR TITLE
[fix] #1897: Removed usize/isize from serialization

### DIFF
--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -1,5 +1,6 @@
 //! Iroha simple actor framework.
 #![allow(clippy::same_name_method)]
+#![allow(clippy::expect_used)]
 
 #[cfg(feature = "deadlock_detection")]
 use std::any::type_name;
@@ -288,7 +289,7 @@ where
 #[async_trait::async_trait]
 pub trait Actor: Send + Sized + 'static {
     /// Capacity of actor queue
-    fn mailbox_capacity(&self) -> usize {
+    fn mailbox_capacity(&self) -> u32 {
         100
     }
 
@@ -305,7 +306,12 @@ pub trait Actor: Send + Sized + 'static {
     /// Initialize actor with its address.
     fn preinit(self) -> InitializedActor<Self> {
         let mailbox_capacity = self.mailbox_capacity();
-        InitializedActor::new(self, mailbox_capacity)
+        InitializedActor::new(
+            self,
+            mailbox_capacity
+                .try_into()
+                .expect("u32 should always fit in usize"),
+        )
     }
 
     /// Initialize actor with default values

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -69,10 +69,10 @@ pub struct Configuration {
 #[config(env_prefix = "IROHA_NETWORK_")]
 pub struct NetworkConfiguration {
     /// Actor mailbox size
-    pub mailbox: usize,
+    pub mailbox: u32,
 }
 
-const DEFAULT_MAILBOX_SIZE: usize = 100;
+const DEFAULT_MAILBOX_SIZE: u32 = 100;
 
 impl Default for NetworkConfiguration {
     fn default() -> Self {

--- a/cli/src/torii/config.rs
+++ b/cli/src/torii/config.rs
@@ -8,9 +8,9 @@ pub const DEFAULT_TORII_P2P_ADDR: &str = "127.0.0.1:1337";
 /// Default socket for reporting internal status and metrics
 pub const DEFAULT_TORII_TELEMETRY_URL: &str = "127.0.0.1:8180";
 /// Default maximum size of single transaction
-pub const DEFAULT_TORII_MAX_TRANSACTION_SIZE: usize = 2_usize.pow(15);
+pub const DEFAULT_TORII_MAX_TRANSACTION_SIZE: u32 = 2_u32.pow(15);
 /// Default upper bound on `content-length` specified in the HTTP request header
-pub const DEFAULT_TORII_MAX_CONTENT_LENGTH: usize = 2_usize.pow(12) * 4000;
+pub const DEFAULT_TORII_MAX_CONTENT_LENGTH: u32 = 2_u32.pow(12) * 4000;
 
 /// Structure that defines the configuration parameters of `Torii` which is the routing module.
 /// For example the `p2p_addr`, which is used for consensus and block-synchronisation purposes,
@@ -27,9 +27,9 @@ pub struct ToriiConfiguration {
     /// Torii URL for reporting internal status and metrics for administration.
     pub telemetry_url: String,
     /// Maximum number of bytes in raw transaction. Used to prevent from DOS attacks.
-    pub max_transaction_size: usize,
+    pub max_transaction_size: u32,
     /// Maximum number of bytes in raw message. Used to prevent from DOS attacks.
-    pub max_content_len: usize,
+    pub max_content_len: u32,
 }
 
 impl Default for ToriiConfiguration {

--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -431,7 +431,7 @@ impl<W: WorldTrait> Torii<W> {
             warp::path(uri::TRANSACTION)
                 .and(add_state!(self.iroha_cfg, self.queue))
                 .and(warp::body::content_length_limit(
-                    self.iroha_cfg.torii.max_content_len as u64,
+                    self.iroha_cfg.torii.max_content_len.into(),
                 ))
                 .and(body::versioned()),
         )

--- a/core/src/block_sync.rs
+++ b/core/src/block_sync.rs
@@ -43,7 +43,7 @@ pub struct BlockSynchronizer<S: SumeragiTrait, W: WorldTrait> {
     gossip_period: Duration,
     batch_size: u32,
     broker: Broker,
-    mailbox: usize,
+    mailbox: u32,
 }
 
 /// Block synchronizer
@@ -99,7 +99,7 @@ pub struct ReceiveUpdates;
 
 #[async_trait::async_trait]
 impl<S: SumeragiTrait, W: WorldTrait> Actor for BlockSynchronizer<S, W> {
-    fn mailbox_capacity(&self) -> usize {
+    fn mailbox_capacity(&self) -> u32 {
         self.mailbox
     }
 
@@ -350,7 +350,7 @@ pub mod config {
 
     const DEFAULT_BATCH_SIZE: u32 = 4;
     const DEFAULT_GOSSIP_PERIOD_MS: u64 = 10000;
-    const DEFAULT_MAILBOX_SIZE: usize = 100;
+    const DEFAULT_MAILBOX_SIZE: u32 = 100;
 
     /// Configuration for `BlockSynchronizer`.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Configurable)]
@@ -364,7 +364,7 @@ pub mod config {
         /// Underlying network (`iroha_network`) should support transferring messages this large.
         pub batch_size: u32,
         /// Mailbox size
-        pub mailbox: usize,
+        pub mailbox: u32,
     }
 
     impl Default for BlockSyncConfiguration {

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -53,7 +53,7 @@ pub struct KuraWithIO<W: WorldTrait, IO> {
     merkle_tree: MerkleTree<VersionedCommittedBlock>,
     wsv: Arc<WorldStateView<W>>,
     broker: Broker,
-    mailbox: usize,
+    mailbox: u32,
 }
 
 /// Production qualification of `KuraWithIO`
@@ -70,7 +70,7 @@ impl<W: WorldTrait, IO: DiskIO> KuraWithIO<W, IO> {
         blocks_per_file: NonZeroU64,
         wsv: Arc<WorldStateView<W>>,
         broker: Broker,
-        mailbox: usize,
+        mailbox: u32,
         io: IO,
     ) -> Result<Self> {
         Ok(Self {
@@ -105,7 +105,7 @@ pub trait KuraTrait:
         blocks_per_file: NonZeroU64,
         wsv: Arc<WorldStateView<Self::World>>,
         broker: Broker,
-        mailbox: usize,
+        mailbox: u32,
     ) -> Result<Self>;
 
     /// Loads kura from configuration
@@ -138,7 +138,7 @@ impl<W: WorldTrait> KuraTrait for Kura<W> {
         blocks_per_file: NonZeroU64,
         wsv: Arc<WorldStateView<W>>,
         broker: Broker,
-        mailbox: usize,
+        mailbox: u32,
     ) -> Result<Self> {
         Self::new_meta(
             mode,
@@ -155,7 +155,7 @@ impl<W: WorldTrait> KuraTrait for Kura<W> {
 
 #[async_trait::async_trait]
 impl<W: WorldTrait, IO: DiskIO> Actor for KuraWithIO<W, IO> {
-    fn mailbox_capacity(&self) -> usize {
+    fn mailbox_capacity(&self) -> u32 {
         self.mailbox
     }
 
@@ -486,7 +486,7 @@ pub mod config {
 
     const DEFAULT_BLOCKS_PER_STORAGE_FILE: u64 = 1000_u64;
     const DEFAULT_BLOCK_STORE_PATH: &str = "./blocks";
-    const DEFAULT_MAILBOX_SIZE: usize = 100;
+    const DEFAULT_MAILBOX_SIZE: u32 = 100;
 
     /// Configuration of kura
     #[derive(Clone, Deserialize, Serialize, Debug, Configurable, PartialEq, Eq)]
@@ -504,7 +504,7 @@ pub mod config {
         pub blocks_per_storage_file: NonZeroU64,
         /// Default mailbox size
         #[serde(default = "default_mailbox_size")]
-        pub mailbox: usize,
+        pub mailbox: u32,
     }
 
     impl Default for KuraConfiguration {
@@ -543,7 +543,7 @@ pub mod config {
         )
     }
 
-    const fn default_mailbox_size() -> usize {
+    const fn default_mailbox_size() -> u32 {
         DEFAULT_MAILBOX_SIZE
     }
 }

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -1,4 +1,5 @@
 //! Module with queue actor
+#![allow(clippy::expect_used)]
 
 use std::{sync::Arc, time::Duration};
 
@@ -80,12 +81,15 @@ impl<W: WorldTrait> Queue<W> {
     }
 
     /// Returns `n` randomly selected transaction from the queue.
-    pub fn n_random_transactions(&self, n: usize) -> Vec<VersionedAcceptedTransaction> {
+    pub fn n_random_transactions(&self, n: u32) -> Vec<VersionedAcceptedTransaction> {
         self.txs
             .iter()
             .filter(|e| self.is_pending(e.value()))
             .map(|e| e.value().clone())
-            .choose_multiple(&mut rand::thread_rng(), n)
+            .choose_multiple(
+                &mut rand::thread_rng(),
+                n.try_into().expect("u32 should always fit in usize"),
+            )
     }
 
     fn check_tx(&self, tx: &VersionedAcceptedTransaction) -> Result<(), Error> {

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -1,6 +1,7 @@
 //! This module contains logic related to executing smartcontracts via
 //! `WebAssembly` VM Smartcontracts can be written in Rust, compiled
 //! to wasm format and submitted in a transaction
+#![allow(clippy::expect_used)]
 
 use std::sync::Arc;
 
@@ -140,7 +141,9 @@ impl<'a, W: WorldTrait> State<'a, W> {
             validator: None,
 
             store_limits: StoreLimitsBuilder::new()
-                .memory_size(config.max_memory)
+                .memory_size(config.max_memory.try_into().expect(
+                    "config.max_memory is a u32 so this can't fail on any supported platform",
+                ))
                 .instances(1)
                 .memories(1)
                 .tables(1)
@@ -491,7 +494,7 @@ pub mod config {
     use serde::{Deserialize, Serialize};
 
     const DEFAULT_FUEL_LIMIT: u64 = 1_000_000;
-    const DEFAULT_MAX_MEMORY: usize = 500 * 2_usize.pow(20); // 500 MiB
+    const DEFAULT_MAX_MEMORY: u32 = 500 * 2_u32.pow(20); // 500 MiB
 
     /// [`WebAssembly Runtime`](super::Runtime) configuration.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Configurable)]
@@ -503,7 +506,7 @@ pub mod config {
         pub fuel_limit: u64,
 
         /// Maximum amount of linear memory a given smartcontract can allocate
-        pub max_memory: usize,
+        pub max_memory: u32,
     }
 
     impl Default for Configuration {

--- a/core/src/sumeragi/config.rs
+++ b/core/src/sumeragi/config.rs
@@ -15,9 +15,9 @@ pub const DEFAULT_COMMIT_TIME_MS: u64 = 2000;
 /// Default amount of time Peer waits for `TxReceipt` from the leader.
 pub const DEFAULT_TX_RECEIPT_TIME_MS: u64 = 500;
 const DEFAULT_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE: u64 = 1;
-const DEFAULT_MAILBOX_SIZE: usize = 100;
+const DEFAULT_MAILBOX_SIZE: u32 = 100;
 const DEFAULT_GOSSIP_PERIOD_MS: u64 = 1000;
-const DEFAULT_GOSSIP_BATCH_SIZE: usize = 500;
+const DEFAULT_GOSSIP_BATCH_SIZE: u32 = 500;
 
 /// `SumeragiConfiguration` provides an ability to define parameters such as `BLOCK_TIME_MS`
 /// and list of `TRUSTED_PEERS`.
@@ -44,9 +44,9 @@ pub struct SumeragiConfiguration {
     /// Limits to which transactions must adhere
     pub transaction_limits: TransactionLimits,
     /// Mailbox size
-    pub mailbox: usize,
+    pub mailbox: u32,
     /// Maximum number of transactions in tx gossip batch message. While configuring this, attention should be payed to `p2p` max message size.
-    pub gossip_batch_size: usize,
+    pub gossip_batch_size: u32,
     /// Period in milliseconds for pending transaction gossiping between peers.
     pub gossip_period_ms: u64,
 }

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -94,9 +94,9 @@ where
     /// [`iroha_p2p::Network`] actor address
     pub network: Addr<IrohaNetwork>,
     /// Mailbox size
-    pub mailbox: usize,
+    pub mailbox: u32,
     pub(crate) fault_injection: PhantomData<F>,
-    pub(crate) gossip_batch_size: usize,
+    pub(crate) gossip_batch_size: u32,
     pub(crate) gossip_period: Duration,
 }
 
@@ -161,7 +161,7 @@ impl<G: GenesisNetworkTrait, K: KuraTrait<World = W>, W: WorldTrait, F: FaultInj
 impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection> Actor
     for SumeragiWithFault<G, K, W, F>
 {
-    fn mailbox_capacity(&self) -> usize {
+    fn mailbox_capacity(&self) -> u32 {
         self.mailbox
     }
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -1,7 +1,7 @@
 //! Iroha Data Model contains structures for Domains, Peers, Accounts and Assets with simple,
 //! non-specific functions like serialization.
 
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::unwrap_in_result)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -143,7 +143,7 @@ Has type `u64`. Can be configured via environment variable `BLOCK_SYNC_GOSSIP_PE
 
 Mailbox size
 
-Has type `usize`. Can be configured via environment variable `BLOCK_SYNC_MAILBOX`
+Has type `u32`. Can be configured via environment variable `BLOCK_SYNC_MAILBOX`
 
 ```json
 100
@@ -274,7 +274,7 @@ Has type `Mode`. Can be configured via environment variable `KURA_INIT_MODE`
 
 Default mailbox size
 
-Has type `usize`. Can be configured via environment variable `KURA_MAILBOX`
+Has type `u32`. Can be configured via environment variable `KURA_MAILBOX`
 
 ```json
 100
@@ -330,7 +330,7 @@ Has type `handle::SyncValue<Level,handle::Singleton<Level>>`. Can be configured 
 
 Capacity (or batch size) for telemetry channel
 
-Has type `usize`. Can be configured via environment variable `TELEMETRY_CAPACITY`
+Has type `u32`. Can be configured via environment variable `TELEMETRY_CAPACITY`
 
 ```json
 1000
@@ -362,7 +362,7 @@ Has type `NetworkConfiguration`. Can be configured via environment variable `IRO
 
 Actor mailbox size
 
-Has type `usize`. Can be configured via environment variable `IROHA_NETWORK_MAILBOX`
+Has type `u32`. Can be configured via environment variable `IROHA_NETWORK_MAILBOX`
 
 ```json
 100
@@ -497,7 +497,7 @@ Has type `u64`. Can be configured via environment variable `SUMERAGI_COMMIT_TIME
 
 Maximum number of transactions in tx gossip batch message. While configuring this, attention should be payed to `p2p` max message size.
 
-Has type `usize`. Can be configured via environment variable `SUMERAGI_GOSSIP_BATCH_SIZE`
+Has type `u32`. Can be configured via environment variable `SUMERAGI_GOSSIP_BATCH_SIZE`
 
 ```json
 500
@@ -533,7 +533,7 @@ Has type `KeyPair`. Can be configured via environment variable `SUMERAGI_KEY_PAI
 
 Mailbox size
 
-Has type `usize`. Can be configured via environment variable `SUMERAGI_MAILBOX`
+Has type `u32`. Can be configured via environment variable `SUMERAGI_MAILBOX`
 
 ```json
 100
@@ -691,7 +691,7 @@ Has type `String`. Can be configured via environment variable `TORII_API_URL`
 
 Maximum number of bytes in raw message. Used to prevent from DOS attacks.
 
-Has type `usize`. Can be configured via environment variable `TORII_MAX_CONTENT_LEN`
+Has type `u32`. Can be configured via environment variable `TORII_MAX_CONTENT_LEN`
 
 ```json
 16384000
@@ -701,7 +701,7 @@ Has type `usize`. Can be configured via environment variable `TORII_MAX_CONTENT_
 
 Maximum number of bytes in raw transaction. Used to prevent from DOS attacks.
 
-Has type `usize`. Can be configured via environment variable `TORII_MAX_TRANSACTION_SIZE`
+Has type `u32`. Can be configured via environment variable `TORII_MAX_TRANSACTION_SIZE`
 
 ```json
 32768

--- a/logger/src/config.rs
+++ b/logger/src/config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Subscriber;
 use tracing_subscriber::{filter::LevelFilter, reload::Handle};
 
-const TELEMETRY_CAPACITY: usize = 1000;
+const TELEMETRY_CAPACITY: u32 = 1000;
 const DEFAULT_COMPACT_MODE: bool = false;
 const DEFAULT_TERMINAL_COLORS: bool = true;
 
@@ -60,7 +60,7 @@ pub struct Configuration {
     #[config(serde_as_str)]
     pub max_log_level: handle::SyncValue<Level, handle::Singleton<Level>>,
     /// Capacity (or batch size) for telemetry channel
-    pub telemetry_capacity: usize,
+    pub telemetry_capacity: u32,
     /// Compact mode (no spans from telemetry)
     pub compact_mode: bool,
     /// If provided, logs will be copied to said file in the

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,4 +1,5 @@
 //! Iroha's logging utilities.
+#![allow(clippy::expect_used)]
 
 pub mod config;
 pub mod layer;
@@ -110,8 +111,13 @@ fn add_telemetry_and_set_default<S: Subscriber + Send + Sync + 'static>(
     subscriber: S,
 ) -> Result<Telemetries> {
     // static global_subscriber: dyn Subscriber = once_cell::new;
-    let (subscriber, receiver, receiver_future) =
-        TelemetryLayer::from_capacity(subscriber, configuration.telemetry_capacity);
+    let (subscriber, receiver, receiver_future) = TelemetryLayer::from_capacity(
+        subscriber,
+        configuration
+            .telemetry_capacity
+            .try_into()
+            .expect("u32 should always fit in usize"),
+    );
     set_global_default(subscriber)?;
     Ok((receiver, receiver_future))
 }

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -70,7 +70,7 @@ where
     /// Flag that stops listening stream
     finish_sender: Option<Sender<()>>,
     /// Mailbox capacity
-    mailbox: usize,
+    mailbox: u32,
 }
 
 impl<T, K, E> NetworkBase<T, K, E>
@@ -88,7 +88,7 @@ where
         broker: Broker,
         listen_addr: String,
         public_key: PublicKey,
-        mailbox: usize,
+        mailbox: u32,
     ) -> Result<Self, Error> {
         info!(%listen_addr, "Binding listener");
         let listener = TcpListener::bind(&listen_addr).await?;
@@ -159,7 +159,7 @@ where
     K: KeyExchangeScheme + Send + 'static,
     E: Encryptor + Send + 'static,
 {
-    fn mailbox_capacity(&self) -> usize {
+    fn mailbox_capacity(&self) -> u32 {
         self.mailbox
     }
 

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1,5 +1,6 @@
 //! Module for schematizing rust types in other languages for translation.
 
+#![allow(clippy::expect_used)]
 #![no_std]
 
 extern crate alloc;
@@ -47,7 +48,7 @@ pub trait IntoSchema {
 /// Applicable for types that represents decimal place of fixed point
 pub trait DecimalPlacesAware {
     /// decimal places of fixed point
-    fn decimal_places() -> usize;
+    fn decimal_places() -> u32;
 }
 
 /// Metadata
@@ -85,7 +86,7 @@ pub struct ArrayMeta {
     /// Type
     pub ty: String,
     /// Length
-    pub len: usize,
+    pub len: u64,
 }
 
 /// Named fields
@@ -167,7 +168,7 @@ pub struct Compact<T>(T);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct FixedMeta {
     base: String,
-    decimal_places: usize,
+    decimal_places: u32,
 }
 
 macro_rules! impl_schema_int {
@@ -215,7 +216,7 @@ impl<I: IntoSchema, P: DecimalPlacesAware> IntoSchema for fixnum::FixedPoint<I, 
 }
 
 impl DecimalPlacesAware for fixnum::typenum::U9 {
-    fn decimal_places() -> usize {
+    fn decimal_places() -> u32 {
         9
     }
 }
@@ -359,7 +360,7 @@ impl<T: IntoSchema, const L: usize> IntoSchema for [T; L] {
         let _ = map.entry(Self::type_name()).or_insert_with(|| {
             Metadata::Array(ArrayMeta {
                 ty: T::type_name(),
-                len: L,
+                len: L.try_into().expect("usize should always fit in u64"),
             })
         });
         if !map.contains_key(&T::type_name()) {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

In all the locations where a struct derives Serialize or Deserialize usize has been replaced
with either u64 or u32. No instances of isize existed. In the cases where code using the
data required a usize u32 was chosen as the replacement. There is no point in avoiding usize
in the on disk formats if 32-bit platforms can't read and use the values written.

### Issue

Resolves #1897 
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

No chance of crashing due to serializing on 64-bit then deserializing on 32-bit or vice versa.

### Possible Drawbacks

This change limits the size of certain configuration values to 4 billion. Probably a non issue.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->