### PR TITLE
[fix] #1917: Use already existing FromStr macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "test_network",
  "thiserror",
  "tokio",
@@ -3350,6 +3352,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -36,6 +36,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
 warp = { version = "0.3", default-features = false, optional = true }
 thiserror = { version = "1.0.28", optional = true }
+strum = "0.24.0"
+strum_macros = "0.24.0"
 
 [dev-dependencies]
 iroha_core = { path = "../core", version = "=2.0.0-pre-rc.3", features = ["roles"] }

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -15,6 +15,7 @@ use iroha_macro::FromVariant;
 use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumString;
 
 use crate::{
     account::prelude::*,
@@ -104,6 +105,7 @@ pub struct Asset {
     Deserialize,
     Serialize,
     IntoSchema,
+    EnumString,
 )]
 pub enum AssetValueType {
     /// Asset's Quantity.
@@ -114,21 +116,6 @@ pub enum AssetValueType {
     Fixed,
     /// Asset's key-value structured data.
     Store,
-}
-
-impl FromStr for AssetValueType {
-    type Err = &'static str;
-
-    fn from_str(value_type: &str) -> Result<Self, Self::Err> {
-        // TODO: Could be implemented with some macro
-        match value_type {
-            "Quantity" => Ok(AssetValueType::Quantity),
-            "BigQuantity" => Ok(AssetValueType::BigQuantity),
-            "Fixed" => Ok(AssetValueType::Fixed),
-            "Store" => Ok(AssetValueType::Store),
-            _ => Err("Unknown variant"),
-        }
-    }
 }
 
 /// Asset's inner value.


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Replaced the FromStr implementation done by hand for the type AssetValueType with a derive macro from the rust crate strum.

### Issue

#1917 

### Benefits

Same functionality, less code.

### Possible Drawbacks

We depend on a foreign rust crate.
