### PR TITLE
[fix] #1845: Non-mintable assets can be minted once only.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"
@@ -134,9 +134,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -192,21 +192,24 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -284,6 +287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "block-modes"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +350,9 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
+checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
 name = "byte-tools"
@@ -350,9 +362,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.13"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f"
+checksum = "95ebf10dda65f19ff0f42ea15572a359ed60d7fc74fdc984d90310937be0014b"
 dependencies = [
  "utf8-width",
 ]
@@ -389,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -464,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -476,14 +488,14 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -542,9 +554,9 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -567,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -582,18 +594,18 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16922317bd7dd104d509a373887822caa0242fc1def00de66abb538db221db4"
+checksum = "5b9956ad3efeb062596e0b25a1091730080cb6483b500bd106b92c7a55e9e0b1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b80bf40380256307b68a3dcbe1b91cac92a533e212b5b635abc3e4525781a0a"
+checksum = "efc67870c31cae7d03808dfa430ee9ccda9bd82c61b49b939d925d9155cfc42d"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -608,33 +620,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d0ed7d3bc6c7a814ca12858175bf4e93167a3584127858c686e4b5dd6e432"
+checksum = "b0f0172d25539fcc64f581d3dce0df00e2065b00e1c750e18832d2cf1e0d27e0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f52311e1c90de12dcf8c4b9999c6ebfd1ed360373e88c357160936844511f6"
+checksum = "8f6cc5717ae2ea849e5c819eb70c95792c2843294d9503700ac55d8d159e2160"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bc82ef522c1f643baf7d4d40b7c52643ee4549d8960b0e6a047daacb83f897"
+checksum = "e822e0169d7a078cbc7ed19bca6636752c093e25d994a4febd9914d1118f3945"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc35e4251864b17515845ba47447bca88fec9ca1a4186b19fe42526e36140e8"
+checksum = "bf3bc8bd3bb8932e70b71c0de6cba277ae112d4e51dadde2e318f60f2fbe97bc"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -644,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b882b2251c9845d509d92aebfdb6c8bb3b3b48e207ac951f21fbd20cfe7f90b3"
+checksum = "a8090cade0761622fcb1c805c8ce2c2f085a2467bdee7e21cd9ba399026cf7ac"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -655,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.82.1"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0354e819732c02acdd98ab969dd81c7670304fff4c8fc4c86bc999b55fa1f0c"
+checksum = "be110a4560fa997ba8bc8376a459ec4d8707074f88058a17b29f43c27e983ad0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -671,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -730,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -751,10 +763,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -764,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -774,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -792,6 +805,16 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -847,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -917,6 +940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
  "signature",
 ]
@@ -1022,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -1056,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc225d8f637923fe585089fcf03e705c222131232d2c1fb622e84ecf725d0eb8"
+checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1113,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "file-per-thread-logger"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
  "env_logger",
  "log",
@@ -1191,9 +1224,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1205,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1215,21 +1248,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1238,21 +1271,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1287,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4addc164932852d066774c405dbbdb7914742d2b39e39e1a7ca949c856d054d1"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
@@ -1310,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1354,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1384,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1397,7 +1430,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -1415,9 +1448,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
 dependencies = [
  "base64",
  "bitflags",
@@ -1426,7 +1459,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha-1",
+ "sha-1 0.10.0",
 ]
 
 [[package]]
@@ -1521,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1533,18 +1566,15 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1555,7 +1585,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1577,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1594,11 +1624,11 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown",
  "serde",
 ]
@@ -1703,7 +1733,7 @@ dependencies = [
  "iroha_telemetry",
  "iroha_version",
  "parity-scale-codec",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "smallstr",
@@ -1778,7 +1808,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "pin-project",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "smallstr",
@@ -1887,7 +1917,7 @@ version = "2.0.0-pre-rc.3"
 dependencies = [
  "iroha_futures_derive",
  "iroha_logger",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
@@ -1918,7 +1948,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-core",
  "tracing-futures",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.10",
 ]
 
 [[package]]
@@ -1943,7 +1973,7 @@ dependencies = [
  "iroha_logger",
  "iroha_macro",
  "parity-scale-codec",
- "rand 0.8.4",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "unique_port",
@@ -2130,7 +2160,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 name = "kura_inspector"
 version = "2.0.0-pre-rc.3"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.8",
  "futures-util",
  "iroha_config",
  "iroha_core",
@@ -2158,9 +2188,9 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -2170,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -2188,18 +2218,19 @@ checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -2240,7 +2271,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2251,9 +2282,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
@@ -2266,19 +2297,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2315,7 +2347,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error",
- "rand 0.8.4",
+ "rand 0.8.5",
  "safemem",
  "tempfile",
  "twoway",
@@ -2323,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2341,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -2354,7 +2386,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -2364,7 +2396,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2379,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -2399,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "oorandom"
@@ -2447,7 +2479,7 @@ version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -2522,9 +2554,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "percent-encoding"
@@ -2586,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -2647,9 +2679,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
@@ -2704,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
+checksum = "871372391786ccec00d3c5d3d6608905b3d4db263639cfe075d3b60a736d115a"
 dependencies = [
  "cc",
 ]
@@ -2719,9 +2751,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -2738,7 +2770,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
@@ -2765,14 +2797,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2781,7 +2812,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.3.1",
 ]
 
@@ -2835,7 +2866,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -2854,15 +2885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2891,7 +2913,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.4.2",
 ]
 
@@ -2910,7 +2932,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2931,21 +2953,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.6",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -2961,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3026,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.4"
+version = "0.33.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7ec6a44fba95d21fa522760c03c16ca5ee95cebb6e4ef579cab3e6d7ba6c06"
+checksum = "03627528abcc4a365554d32a9f3bbf67f7694c102cfeda792dc86a2d6057cc85"
 dependencies = [
  "bitflags",
  "errno",
@@ -3109,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3122,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3132,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -3177,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -3209,6 +3232,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3270,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallstr"
@@ -3295,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -3386,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3415,9 +3449,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
@@ -3435,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -3470,7 +3504,7 @@ dependencies = [
  "iroha_logger",
  "iroha_p2p",
  "once_cell",
- "rand 0.8.4",
+ "rand 0.8.5",
  "smallstr",
  "tempfile",
  "tokio",
@@ -3488,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3533,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "itoa 1.0.1",
  "libc",
@@ -3569,9 +3603,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -3579,6 +3613,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -3645,6 +3680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,9 +3710,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "log",
@@ -3674,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3693,20 +3742,21 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.7",
+ "time 0.3.9",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.10",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -3753,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term",
  "sharded-slab",
@@ -3771,13 +3821,14 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.54"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04343ff86b62ca40bd5dca986aadf4f10c152a9ebe9a869e456b60fa85afd3f"
+checksum = "606ab3fe0065741fdbb51f64bcb6ba76f13fad49f1723030041826c631782764"
 dependencies = [
  "glob",
  "once_cell",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",
@@ -3795,8 +3846,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.4",
- "sha-1",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
@@ -3814,8 +3865,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.4",
- "sha-1",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
@@ -3862,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -3957,9 +4008,15 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -4041,7 +4098,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.15.0",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower-service",
  "tracing",
 ]
@@ -4057,6 +4114,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4120,9 +4183,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wasmtime"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f4245f65310fb41e4bdb75b0f794798aab23e3911c34a38a11c6e15f4906dd"
+checksum = "637f73fff13248d13882246b67a8208d466c36d7b836b783a62903cb96f11b61"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4154,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a365679fb088f9660caad68f4c98e33aee7dd013bdf2a0fc3f93abd9886ce4"
+checksum = "6d1fe25e704090ec08e1ddee309d95d1b19acd5aca66eb51ad20a966447e15df"
 dependencies = [
  "anyhow",
  "base64",
@@ -4174,9 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da49deb7024bbf9ee72019a30c05fa752dab8cba8b32f709b2ddf66329d46c74"
+checksum = "a2d233418e5f560e8010fe13e60943df8be0685c68cbdf9f588dd846a727f2e4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4196,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbf66220878adc123fe744df623eb141d4e73f03daed3f2aba3dbc7786d921e"
+checksum = "0f38f25934156bb5496b3fd30be10c8ef41936330d9c936654ebf4eac02e352e"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4216,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd237d717b719577f8944010d1a9221c736b2288913a87f70d8f844d4f928c"
+checksum = "45f38d11e4e69c49e3ebb8558ef040936cf011f982dabadacc122b7576a0370d"
 dependencies = [
  "cc",
  "rustix",
@@ -4227,9 +4290,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62157c76f1204c4845c2c33f6aa4472369c7d9d7deb2e6218c4fabebbae8ac1b"
+checksum = "bf7d3293e643c3b397012a579b025116e5818118a7982373551df8f8b0a4c524"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4254,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d314887fca993322b7ee4e08e5e2c0e79e812fbd1d6272c1781db884e3daabb"
+checksum = "f8b4b40b84a96da6fcd7f2460747564091b9b8dedcc7bd66c0cb741adf451de8"
 dependencies = [
  "lazy_static",
  "object",
@@ -4265,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c0a7901d0645bf99b1efaebf7f7e144170641c575e96eb1fb6a9218290726c"
+checksum = "b60eb01e3413a54e791a397d556962876902d7481be496b4b9eb1dc68de14fce"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4280,7 +4343,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "more-asserts",
- "rand 0.8.4",
+ "rand 0.8.5",
  "region",
  "rustix",
  "thiserror",
@@ -4292,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9841ad7624110410291d03645876474a79fcedaed729016e384308145c29eb"
+checksum = "86cd8d51aa648f2ba5a25bd11a74c08ce2b66796a5bbd5c099ab5db672a2e68f"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -4397,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -258,10 +258,13 @@ fn register_account(name: &str) -> Instruction {
 }
 
 fn register_asset_definition(name: &str) -> Instruction {
-    RegisterBox::new(AssetDefinition::new_quantity(AssetDefinitionId::new(
-        name.parse().expect("Valid"),
-        DOMAIN.parse().expect("Valid"),
-    )))
+    RegisterBox::new(
+        AssetDefinition::quantity(AssetDefinitionId::new(
+            name.parse().expect("Valid"),
+            DOMAIN.parse().expect("Valid"),
+        ))
+        .build(),
+    )
     .into()
 }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -40,7 +40,7 @@ base64 = "0.13.0"
 iroha_core = { version = "=2.0.0-pre-rc.3", path = "../core", features = ["dev-telemetry", "telemetry"] }
 iroha_permissions_validators = { version = "=2.0.0-pre-rc.3", path = "../permissions_validators" }
 iroha = { path = "../cli", features = ["dev-telemetry", "telemetry"] }
-iroha_data_model = { version = "=2.0.0-pre-rc.3", path = "../data_model", features = ["warp", "cross_crate_testing"] }
+iroha_data_model = { version = "=2.0.0-pre-rc.3", path = "../data_model", features = ["warp", "cross_crate_testing", "roles"] }
 
 test_network = { version = "=2.0.0-pre-rc.3", path = "../core/test_network" }
 

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -59,7 +59,8 @@ fn query_requests(criterion: &mut Criterion) {
             .public_key],
     ));
     let asset_definition_id = AssetDefinitionId::new("xor".parse().expect("Valid"), domain_id);
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let quantity: u32 = 200;
     let mint_asset = MintBox::new(
         Value::U32(quantity),

--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -20,9 +20,12 @@ fn main() {
                     PublicKey::default(),
                 )
                 .with_asset(
-                    format!("xor-{}", i).parse().expect("Valid"),
-                    AssetValueType::Quantity,
-                    false,
+                    AssetDefinition::quantity(
+                        format!("xor-{}", i)
+                            .parse::<<AssetDefinition as Identifiable>::Id>()
+                            .expect("Valid"),
+                    )
+                    .build(),
                 )
                 .finish_domain();
         }

--- a/client/tests/integration/add_asset.rs
+++ b/client/tests/integration/add_asset.rs
@@ -17,7 +17,8 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let metadata = iroha_data_model::metadata::UnlimitedMetadata::default();
     //When
     let quantity: u32 = 200;
@@ -48,9 +49,8 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_big_quantity(
-        asset_definition_id.clone(),
-    ));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::big_quantity(asset_definition_id.clone()).build());
     let metadata = iroha_data_model::metadata::UnlimitedMetadata::default();
     //When
     let quantity: u128 = 2_u128.pow(65);
@@ -80,7 +80,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let identifiable_box = AssetDefinition::new_fixed_precision(asset_definition_id.clone());
+    let identifiable_box = AssetDefinition::fixed(asset_definition_id.clone()).build();
     let create_asset = RegisterBox::new(identifiable_box);
     let metadata = iroha_data_model::metadata::UnlimitedMetadata::default();
 
@@ -132,18 +132,16 @@ fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transacti
 
     // Given
     let normal_asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(
-        normal_asset_definition_id.clone(),
-    ));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(normal_asset_definition_id.clone()).build());
     test_client.submit(create_asset)?;
     iroha_logger::info!("Creating asset");
 
     let too_long_asset_name = "0".repeat(2_usize.pow(14));
     let incorrect_asset_definition_id =
         AssetDefinitionId::from_str(&(too_long_asset_name + "#wonderland")).expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(
-        incorrect_asset_definition_id.clone(),
-    ));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(incorrect_asset_definition_id.clone()).build());
 
     test_client.submit(create_asset)?;
     iroha_logger::info!("Creating another asset");

--- a/client/tests/integration/add_asset.rs
+++ b/client/tests/integration/add_asset.rs
@@ -36,7 +36,7 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Quantity(quantity)
         })
-    });
+    })?;
     Ok(())
 }
 
@@ -69,7 +69,7 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::BigQuantity(quantity)
         })
-    });
+    })?;
     Ok(())
 }
 
@@ -101,7 +101,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Fixed(quantity)
         })
-    });
+    })?;
 
     // Add some fractional part
     let quantity2: Fixed = Fixed::try_from(0.55_f64).unwrap();
@@ -121,7 +121,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Fixed(sum)
         })
-    });
+    })?;
     Ok(())
 }
 

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -25,7 +25,8 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
         [KeyPair::generate()?.public_key],
     ));
     let asset_definition_id = AssetDefinitionId::from_str("xor#domain")?;
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     iroha_client.submit_all(vec![
         create_domain.into(),
         create_account.into(),

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -53,6 +53,6 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
                     && *asset.value() == AssetValue::Quantity(quantity)
             })
         },
-    );
+    )?;
     Ok(())
 }

--- a/client/tests/integration/mod.rs
+++ b/client/tests/integration/mod.rs
@@ -11,6 +11,7 @@ mod events;
 mod multiple_blocks_created;
 mod multisignature_account;
 mod multisignature_transaction;
+mod non_mintable;
 mod offline_peers;
 mod pagination;
 mod permissions;

--- a/client/tests/integration/multiple_blocks_created.rs
+++ b/client/tests/integration/multiple_blocks_created.rs
@@ -28,7 +28,8 @@ fn long_multiple_blocks_created() {
             .public_key],
     ));
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse().expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
 
     iroha_client
         .submit_all(vec![

--- a/client/tests/integration/multiple_blocks_created.rs
+++ b/client/tests/integration/multiple_blocks_created.rs
@@ -62,13 +62,12 @@ fn long_multiple_blocks_created() {
 
     //Then
     let peer = network.peers().last().unwrap();
-    Client::test(&peer.api_address, &peer.telemetry_address).poll_request(
-        client::asset::by_account_id(account_id),
-        |result| {
+    Client::test(&peer.api_address, &peer.telemetry_address)
+        .poll_request(client::asset::by_account_id(account_id), |result| {
             result.iter().any(|asset| {
                 asset.id().definition_id == asset_definition_id
                     && *asset.value() == AssetValue::Quantity(account_has_quantity)
             })
-        },
-    );
+        })
+        .expect("Panic on case assertion failure.");
 }

--- a/client/tests/integration/multisignature_account.rs
+++ b/client/tests/integration/multisignature_account.rs
@@ -19,7 +19,8 @@ fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
     // Given
     let account_id: AccountId = "alice@wonderland".parse().expect("Valid");
     let asset_definition_id: AssetDefinitionId = "xor#wonderland".parse().expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let key_pair = KeyPair::generate()?;
     let add_signatory = MintBox::new(
         key_pair.public_key.clone(),

--- a/client/tests/integration/multisignature_account.rs
+++ b/client/tests/integration/multisignature_account.rs
@@ -46,6 +46,6 @@ fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
                     && *asset.value() == AssetValue::Quantity(quantity)
             })
         },
-    );
+    )?;
     Ok(())
 }

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -28,7 +28,8 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
         [key_pair_1.public_key.clone()],
     ));
     let asset_definition_id = AssetDefinitionId::from_str("xor#domain").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let set_signature_condition = MintBox::new(
         SignatureCheckCondition(
             ContainsAll::new(

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -1,0 +1,55 @@
+#![allow(clippy::restriction)]
+
+use eyre::Result;
+use iroha_client::client;
+use iroha_data_model::{metadata::UnlimitedMetadata, prelude::*};
+use test_network::{Peer as TestPeer, *};
+
+#[test]
+fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
+    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+
+    // Given
+    let account_id = AccountId::new("alice", "wonderland").expect("Valid");
+    let asset_definition_id = AssetDefinitionId::new("xor", "wonderland").expect("Valid");
+    let create_asset = RegisterBox::new(IdentifiableBox::from(
+        AssetDefinition::new_quantity_token(asset_definition_id.clone()),
+    ));
+
+    let metadata = UnlimitedMetadata::default();
+
+    let mint = MintBox::new(
+        Value::U32(200_u32),
+        IdBox::AssetId(AssetId::new(
+            asset_definition_id.clone(),
+            account_id.clone(),
+        )),
+    );
+
+    let instructions: Vec<Instruction> = vec![create_asset.into(), mint.clone().into()];
+    let tx = test_client.build_transaction(instructions.into(), metadata)?;
+
+    // We can register and mint the non-mintable token
+    test_client.submit_transaction(tx)?;
+    test_client.poll_request(client::asset::by_account_id(account_id.clone()), |result| {
+        result.iter().any(|asset| {
+            asset.id.definition_id == asset_definition_id
+                && asset.value == AssetValue::Quantity(200_u32)
+        })
+    })?;
+
+    // We can submit the request to mint again.
+    test_client.submit_all(vec![mint.into()])?;
+
+    // However, this will fail
+    assert!(test_client
+        .poll_request(client::asset::by_account_id(account_id), |result| {
+            result.iter().any(|asset| {
+                asset.id.definition_id == asset_definition_id
+                    && asset.value == AssetValue::Quantity(400_u32)
+            })
+        })
+        .is_err());
+    Ok(())
+}

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -15,9 +15,11 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(IdentifiableBox::from(
-        AssetDefinition::new_quantity_token(asset_definition_id.clone()),
-    ));
+    let create_asset = RegisterBox::new(
+        AssetDefinition::quantity(asset_definition_id.clone())
+            .mintable_once()
+            .build(),
+    );
 
     let metadata = UnlimitedMetadata::default();
 
@@ -29,7 +31,7 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
         )),
     );
 
-    let instructions: Vec<Instruction> = vec![create_asset.into(), mint.clone().into()];
+    let instructions: [Instruction; 2] = [create_asset.into(), mint.clone().into()];
     let tx = test_client.build_transaction(instructions.into(), metadata)?;
 
     // We can register and mint the non-mintable token
@@ -42,7 +44,7 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
     })?;
 
     // We can submit the request to mint again.
-    test_client.submit_all(vec![mint.into()])?;
+    test_client.submit_all([mint.into()])?;
 
     // However, this will fail
     assert!(test_client

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -17,9 +17,11 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() {
     let register: Vec<Instruction> = ('a'..'z')
         .map(|c| c.to_string())
         .map(|name| (name + "#wonderland").parse().expect("Valid"))
-        .map(AssetDefinition::new_quantity)
-        .map(RegisterBox::new)
-        .map(Instruction::Register)
+        .map(|asset_definition_id| {
+            Instruction::Register(RegisterBox::new(
+                AssetDefinition::quantity(asset_definition_id).build(),
+            ))
+        })
         .collect();
     iroha_client
         .submit_all(register)

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -41,7 +41,8 @@ fn permissions_disallow_asset_transfer() {
     let alice_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let bob_id = AccountId::from_str("bob@wonderland").expect("Valid");
     let asset_definition_id: AssetDefinitionId = "xor#wonderland".parse().expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let register_bob = RegisterBox::new(Account::new(bob_id.clone(), []));
 
     let alice_start_assets = get_assets(&mut iroha_client, &alice_id);
@@ -100,7 +101,8 @@ fn permissions_disallow_asset_burn() {
     let alice_id = "alice@wonderland".parse().expect("Valid");
     let bob_id: AccountId = "bob@wonderland".parse().expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let register_bob = RegisterBox::new(Account::new(bob_id.clone(), []));
 
     let alice_start_assets = get_assets(&mut iroha_client, &alice_id);

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -30,7 +30,8 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
 
     let account_id = AccountId::from_str("alice@wonderland").unwrap();
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").unwrap();
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     iroha_client.submit(create_asset)?;
     thread::sleep(pipeline_time * 2);
     //When

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -68,6 +68,7 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
                 .iter()
                 .any(|asset| asset.id().definition_id == asset_definition_id)
         })
+        .expect("Valid")
         .into_iter()
         .find(|asset| asset.id().definition_id == asset_definition_id)
         .unwrap();

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::restriction)]
 
-use std::{str::FromStr as _, time::Duration};
+use std::{collections::BTreeMap, str::FromStr as _, time::Duration};
 
 use eyre::{eyre, Result};
 use iroha_client::client::{self, Client};
@@ -9,8 +9,6 @@ use iroha_data_model::{permissions::Permissions, prelude::*};
 use iroha_permissions_validators::public_blockchain::transfer;
 use test_network::{Peer as TestPeer, *};
 use tokio::runtime::Runtime;
-use std::collections::BTreeMap;
-
 
 #[test]
 fn add_role_to_limit_transfer_count() -> Result<()> {
@@ -97,24 +95,20 @@ fn get_asset_value(client: &mut Client, asset_id: AssetId) -> Result<u32> {
     Ok(*TryAsRef::<u32>::try_as_ref(asset.value())?)
 }
 
-
 #[test]
 fn register_empty_role() -> Result<()> {
     let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id = iroha_data_model::role::Id::new("root".parse::<Name>().expect("Valid"));
-    let register_role = RegisterBox::new(IdentifiableBox::from(Role::new(
-        role_id,
-        Permissions::new(),
-    )));
+    let register_role = RegisterBox::new(Role::new(role_id, Permissions::new()));
 
     test_client.submit(register_role)?;
     Ok(())
 }
 
 #[test]
-fn register_role_with_empty_token() -> Result<()> {
+fn register_role_with_empty_token_params() -> Result<()> {
     let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
@@ -124,7 +118,7 @@ fn register_role_with_empty_token() -> Result<()> {
         name: "token".parse().expect("Valid"),
         params: BTreeMap::new(),
     });
-    let register_role = RegisterBox::new(IdentifiableBox::from(Role::new(role_id, permissions)));
+    let register_role = RegisterBox::new(Role::new(role_id, permissions));
 
     test_client.submit(register_role)?;
     Ok(())

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -73,5 +73,5 @@ fn client_can_transfer_asset_to_another_account() {
                     && asset.id().account_id == account2_id
             })
         },
-    );
+    ).expect("Test case failure.");
 }

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -32,7 +32,8 @@ fn client_can_transfer_asset_to_another_account() {
     ));
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse().expect("Valid");
     let quantity: u32 = 200;
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     let mint_asset = MintBox::new(
         Value::U32(quantity),
         IdBox::AssetId(AssetId::new(

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -63,15 +63,17 @@ fn client_can_transfer_asset_to_another_account() {
             account2_id.clone(),
         )),
     );
-    iroha_client.submit_till(
-        transfer_asset,
-        client::asset::by_account_id(account2_id.clone()),
-        |result| {
-            result.iter().any(|asset| {
-                asset.id().definition_id == asset_definition_id
-                    && *asset.value() == AssetValue::Quantity(quantity)
-                    && asset.id().account_id == account2_id
-            })
-        },
-    ).expect("Test case failure.");
+    iroha_client
+        .submit_till(
+            transfer_asset,
+            client::asset::by_account_id(account2_id.clone()),
+            |result| {
+                result.iter().any(|asset| {
+                    asset.id().definition_id == asset_definition_id
+                        && *asset.value() == AssetValue::Quantity(quantity)
+                        && asset.id().account_id == account2_id
+                })
+            },
+        )
+        .expect("Test case failure.");
 }

--- a/client/tests/integration/triggers/event_trigger.rs
+++ b/client/tests/integration/triggers/event_trigger.rs
@@ -36,7 +36,7 @@ fn test_mint_asset_when_new_asset_definition_created() -> Result<()> {
 
     let tea_definition_id = "tea#wonderland".parse()?;
     let register_tea_definition =
-        RegisterBox::new(AssetDefinition::new_quantity(tea_definition_id));
+        RegisterBox::new(AssetDefinition::quantity(tea_definition_id).build());
     test_client.submit_blocking(register_tea_definition)?;
 
     let new_value = get_asset_value(&mut test_client, asset_id)?;

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -18,7 +18,8 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     iroha_client
         .submit(create_asset)
         .expect("Failed to prepare state.");

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -19,7 +19,7 @@ fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes(
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
     let wrong_asset_definition_id = AssetDefinitionId::from_str("ksor#wonderland").expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id));
+    let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id).build());
     let quantity: u32 = 200;
     let mint_asset = MintBox::new(
         Value::U32(quantity),

--- a/client/tests/integration/unregister_peer.rs
+++ b/client/tests/integration/unregister_peer.rs
@@ -45,6 +45,7 @@ fn network_stable_after_add_and_after_remove_peer() -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::expect_used)]
 fn check_assets(
     iroha_client: &mut client::Client,
     account_id: &AccountId,
@@ -61,7 +62,7 @@ fn check_assets(
                     && *asset.value() == AssetValue::Quantity(quantity)
             })
         },
-    );
+    ).expect("Test case failure");
 }
 
 fn mint(

--- a/client/tests/integration/unregister_peer.rs
+++ b/client/tests/integration/unregister_peer.rs
@@ -107,7 +107,8 @@ fn init() -> Result<(
         [KeyPair::generate()?.public_key],
     ));
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse().expect("Valid");
-    let create_asset = RegisterBox::new(AssetDefinition::new_quantity(asset_definition_id.clone()));
+    let create_asset =
+        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
     client.submit_all(vec![
         create_domain.into(),
         create_account.into(),

--- a/client/tests/integration/unregister_peer.rs
+++ b/client/tests/integration/unregister_peer.rs
@@ -52,17 +52,19 @@ fn check_assets(
     asset_definition_id: &AssetDefinitionId,
     quantity: u32,
 ) {
-    iroha_client.poll_request_with_period(
-        client::asset::by_account_id(account_id.clone()),
-        Configuration::block_sync_gossip_time(),
-        15,
-        |result| {
-            result.iter().any(|asset| {
-                asset.id().definition_id == *asset_definition_id
-                    && *asset.value() == AssetValue::Quantity(quantity)
-            })
-        },
-    ).expect("Test case failure");
+    iroha_client
+        .poll_request_with_period(
+            client::asset::by_account_id(account_id.clone()),
+            Configuration::block_sync_gossip_time(),
+            15,
+            |result| {
+                result.iter().any(|asset| {
+                    asset.id().definition_id == *asset_definition_id
+                        && *asset.value() == AssetValue::Quantity(quantity)
+                })
+            },
+        )
+        .expect("Test case failure");
 }
 
 fn mint(

--- a/client/tests/integration/unstable_network.rs
+++ b/client/tests/integration/unstable_network.rs
@@ -105,15 +105,17 @@ fn unstable_network(
     thread::sleep(pipeline_time);
 
     //Then
-    iroha_client.poll_request_with_period(
-        client::asset::by_account_id(account_id),
-        polling_period,
-        polling_max_attempts,
-        |result| {
-            result.iter().any(|asset| {
-                asset.id().definition_id == asset_definition_id
-                    && *asset.value() == AssetValue::Quantity(account_has_quantity)
-            })
-        },
-    );
+    iroha_client
+        .poll_request_with_period(
+            client::asset::by_account_id(account_id),
+            polling_period,
+            polling_max_attempts,
+            |result| {
+                result.iter().any(|asset| {
+                    asset.id().definition_id == asset_definition_id
+                        && *asset.value() == AssetValue::Quantity(account_has_quantity)
+                })
+            },
+        )
+        .expect("Test case failure.");
 }

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -413,6 +413,7 @@ mod account {
 
 mod asset {
     use iroha_client::client::{self, asset, Client};
+    use iroha_data_model::asset::definition_builder::NewAssetDefinition;
 
     use super::*;
 
@@ -466,7 +467,7 @@ mod asset {
                 metadata: Metadata(metadata),
             } = self;
             submit(
-                RegisterBox::new(AssetDefinition::new(id, value_type, !unmintable)),
+                RegisterBox::new(NewAssetDefinition::new(id, value_type, !unmintable).build()),
                 cfg,
                 metadata,
             )

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -39,11 +39,7 @@ fn build_test_transaction(keys: KeyPair) -> Transaction {
         "xor".parse().expect("Valid"),
         domain_name.parse().expect("Valid"),
     );
-    let create_asset = RegisterBox::new(AssetDefinition::new(
-        asset_definition_id,
-        AssetValueType::Quantity,
-        true,
-    ));
+    let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id).build());
     let instructions: Vec<Instruction> = vec![
         create_domain.into(),
         create_account.into(),

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -649,7 +649,7 @@ impl From<&ValidBlock> for Vec<Event> {
         block
             .transactions
             .iter()
-            .map(|transaction| {
+            .map(|transaction| -> Event {
                 PipelineEvent::new(
                     PipelineEntityKind::Transaction,
                     PipelineStatus::Validating,

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -11,7 +11,7 @@ use super::prelude::*;
 /// - update metadata
 /// - transfer, etc.
 pub mod isi {
-    use iroha_data_model::asset::Mintable;
+    use iroha_data_model::{asset::Mintable, MintabilityError};
     use iroha_logger::prelude::*;
 
     use super::*;
@@ -44,10 +44,10 @@ pub mod isi {
         let definition = assert_asset_type(definition_id, wsv, expected_value_type)?;
         match definition.mintable() {
             Mintable::Infinitely => Ok(()),
-            Mintable::Not => Err(Error::Mintability(MintabilityError::MintUnmintableError)),
+            Mintable::Not => Err(Error::Mintability(MintabilityError::MintUnmintable)),
             Mintable::Once => {
                 wsv.modify_asset_definition_entry(definition_id, |entry| {
-                    entry.forbid_minting();
+                    entry.forbid_minting()?;
                     Ok(AssetDefinitionEvent::MintabilityChanged(
                         definition_id.clone(),
                     ))

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -22,7 +22,8 @@ pub mod isi {
         wsv: &WorldStateView<W>,
         expected_value_type: AssetValueType,
     ) -> Result<AssetDefinition, Error> {
-        let definition = wsv.asset_definition_entry(definition_id)?.definition();
+        let asset_definition = wsv.asset_definition_entry(definition_id)?;
+        let definition = asset_definition.definition();
 
         if *definition.value_type() == expected_value_type {
             Ok(definition.clone())
@@ -46,10 +47,7 @@ pub mod isi {
             Mintable::Not => Err(Error::Mintability(MintabilityError::MintUnmintableError)),
             Mintable::Once => {
                 wsv.modify_asset_definition_entry(definition_id, |entry| {
-                    entry.definition = AssetDefinition {
-                        mintable: Mintable::Not,
-                        ..definition
-                    };
+                    entry.forbid_minting();
                     Ok(AssetDefinitionEvent::MintabilityChanged(
                         definition_id.clone(),
                     ))

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -236,7 +236,7 @@ mod tests {
         let asset_definition_id = AssetDefinitionId::from_str("rose#wonderland").expect("Valid");
         assert!(domain
             .add_asset_definition(
-                AssetDefinition::new(asset_definition_id, AssetValueType::Quantity, true),
+                AssetDefinition::quantity(asset_definition_id).build(),
                 ALICE_ID.clone(),
             )
             .is_none());
@@ -249,7 +249,7 @@ mod tests {
         let mut account = Account::new(ALICE_ID.clone(), [ALICE_KEYS.public_key.clone()]).build();
         assert!(domain
             .add_asset_definition(
-                AssetDefinition::new(asset_definition_id.clone(), AssetValueType::Quantity, true),
+                AssetDefinition::quantity(asset_definition_id.clone()).build(),
                 ALICE_ID.clone(),
             )
             .is_none());
@@ -286,7 +286,7 @@ mod tests {
         let asset_definition_id = AssetDefinitionId::from_str("rose#wonderland").expect("Valid");
         assert!(domain
             .add_asset_definition(
-                AssetDefinition::new(asset_definition_id, AssetValueType::Quantity, true),
+                AssetDefinition::quantity(asset_definition_id).build(),
                 ALICE_ID.clone(),
             )
             .is_none());
@@ -382,7 +382,7 @@ mod tests {
             let asset_definition_id = AssetDefinitionId::from_str("rose#wonderland")?;
             assert!(domain
                 .add_asset_definition(
-                    AssetDefinition::new(asset_definition_id, AssetValueType::Quantity, true),
+                    AssetDefinition::quantity(asset_definition_id).build(),
                     ALICE_ID.clone(),
                 )
                 .is_none());

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -133,15 +133,21 @@ impl<G: GenesisNetworkTrait> TestGenesis for G {
             get_key_pair().public_key,
         );
         genesis.transactions[0].isi.push(
-            RegisterBox::new(AssetDefinition::new_quantity(
-                AssetDefinitionId::from_str("rose#wonderland").expect("valid names"),
-            ))
+            RegisterBox::new(
+                AssetDefinition::quantity(
+                    AssetDefinitionId::from_str("rose#wonderland").expect("valid names"),
+                )
+                .build(),
+            )
             .into(),
         );
         genesis.transactions[0].isi.push(
-            RegisterBox::new(AssetDefinition::new_quantity(
-                AssetDefinitionId::from_str("tulip#wonderland").expect("valid names"),
-            ))
+            RegisterBox::new(
+                AssetDefinition::quantity(
+                    AssetDefinitionId::from_str("tulip#wonderland").expect("valid names"),
+                )
+                .build(),
+            )
             .into(),
         );
         genesis.transactions[0].isi.push(
@@ -650,9 +656,6 @@ pub trait TestClient: Sized {
     fn test_with_key(api_url: &str, telemetry_url: &str, keys: KeyPair) -> Self;
 
     /// Creates test client from api url, keypair, and account id
-    ///
-    /// # Errors
-    /// If predicate is not satisfied, after maximum retries.
     fn test_with_account(
         api_url: &str,
         telemetry_url: &str,

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -358,6 +358,7 @@ impl AssetDefinition {
             } else {
                 Mintable::Once
             },
+            value_type,
         }
     }
 

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -51,6 +51,9 @@ mod asset {
         MetadataInserted(AssetDefinitionId),
         MetadataRemoved(AssetDefinitionId),
     }
+    // NOTE: Whenever you add a new event here, please also update the
+    // AssetDefinitionEventFilter enum and its `impl Filter for
+    // AssetDefinitionEventFilter`.
 
     impl IdTrait for AssetDefinitionEvent {
         type Id = AssetDefinitionId;

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -46,6 +46,7 @@ mod asset {
     #[allow(missing_docs)]
     pub enum AssetDefinitionEvent {
         Created(AssetDefinitionId),
+        MintabilityChanged(AssetDefinitionId),
         Deleted(AssetDefinitionId),
         MetadataInserted(AssetDefinitionId),
         MetadataRemoved(AssetDefinitionId),
@@ -58,6 +59,7 @@ mod asset {
             match self {
                 Self::Created(id)
                 | Self::Deleted(id)
+                | Self::MintabilityChanged(id)
                 | Self::MetadataInserted(id)
                 | Self::MetadataRemoved(id) => id,
             }

--- a/data_model/src/events/data/filters.rs
+++ b/data_model/src/events/data/filters.rs
@@ -276,6 +276,7 @@ mod asset {
     pub enum AssetDefinitionEventFilter {
         ByCreated,
         ByDeleted,
+        ByMintabilityChanged,
         ByMetadataInserted,
         ByMetadataRemoved,
     }
@@ -295,6 +296,10 @@ mod asset {
                     | (
                         Self::ByMetadataRemoved,
                         AssetDefinitionEvent::MetadataRemoved(_)
+                    )
+                    | (
+                        Self::ByMintabilityChanged,
+                        AssetDefinitionEvent::MintabilityChanged(_)
                     )
             )
         }

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -42,6 +42,32 @@ pub mod transaction;
 pub mod trigger;
 pub mod uri;
 
+/// Mintability logic error
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MintabilityError {
+    /// Tried to mint an Un-mintable asset.
+    MintUnmintable,
+    /// Tried to forbid minting on assets that should be mintable.
+    ForbidMintOnMintable,
+}
+
+impl fmt::Display for MintabilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            MintabilityError::MintUnmintable => {
+                "This asset cannot be minted more than once and it was already minted."
+            }
+            MintabilityError::ForbidMintOnMintable => {
+                "This asset was set as infinitely mintable. You cannot forbid its minting."
+            }
+        };
+        write!(f, "{}", message)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MintabilityError {}
+
 /// Error which occurs when parsing string into a data model entity
 #[derive(Debug, Display, Clone, Copy)]
 pub struct ParseError {

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -8,7 +8,7 @@ use iroha_core::{
     genesis::{GenesisNetwork, GenesisNetworkTrait, RawGenesisBlock},
     prelude::*,
 };
-use iroha_data_model::prelude::*;
+use iroha_data_model::{prelude::*, ParseError};
 use small::SmallStr;
 use test_network::{Peer as TestPeer, TestRuntime};
 use tokio::runtime::Runtime;
@@ -133,10 +133,13 @@ mod register {
     }
 
     pub fn asset_definition(asset_name: &str, domain_name: &str) -> RegisterBox {
-        RegisterBox::new(AssetDefinition::new_quantity(AssetDefinitionId::new(
-            asset_name.parse().expect("Valid"),
-            domain_name.parse().expect("Valid"),
-        )))
+        RegisterBox::new(
+            AssetDefinition::quantity(AssetDefinitionId::new(
+                asset_name.parse().expect("Valid"),
+                domain_name.parse().expect("Valid"),
+            ))
+            .build(),
+        )
     }
 }
 
@@ -270,11 +273,8 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
 }
 
 #[test]
-#[should_panic]
-fn cannot_forbid_minting_on_asset_mintable_infinitely() {
-    if let Ok(id) = "test".parse() {
-        let mut definition = AssetDefinition::new_quantity(id);
-        definition.forbid_minting();
-    }
-    // We should fail the test if it returns an error.
+fn cannot_forbid_minting_on_asset_mintable_infinitely() -> Result<(), ParseError> {
+    let mut definition = AssetDefinition::quantity("test#hello".parse()?).build();
+    assert!(definition.forbid_minting().is_err());
+    Ok(())
 }

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -268,3 +268,13 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         .expect("Failed to execute Iroha Query");
     assert_eq!(expected_buyer_btc, buyer_btc_quantity);
 }
+
+#[test]
+#[should_panic]
+fn cannot_forbid_minting_on_asset_mintable_infinitely() {
+    if let Ok(id) = "test".parse() {
+        let mut definition = AssetDefinition::new_quantity(id);
+        definition.forbid_minting();
+    }
+    // We should fail the test if it returns an error.
+}

--- a/permissions_validators/src/public_blockchain/mod.rs
+++ b/permissions_validators/src/public_blockchain/mod.rs
@@ -178,7 +178,7 @@ mod tests {
     use super::*;
 
     fn new_xor_definition(xor_id: &AssetDefinitionId) -> AssetDefinition {
-        AssetDefinition::new_quantity(xor_id.clone())
+        AssetDefinition::quantity(xor_id.clone()).build()
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "1.59"
-components = [ "rustc", "clippy" ]
+components = [ "rustc", "clippy", "fmt" ]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

### Description of the Change

Non-mintable assets are now registered as `Mintable::Once` and can be minted precisely once. 

### Issue
Closes #1845 

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Non-mintable assets are now functional. 

### Possible Drawbacks

None

### Usage examples/tests 

```client/integration/non_mintable.rs```