### PR TITLE
[refactor]: Remove unnecessary `&mut` from the API.

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -193,7 +193,7 @@ impl Client {
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
     pub fn submit_transaction(
-        &mut self,
+        &self,
         transaction: Transaction,
     ) -> Result<HashOf<VersionedTransaction>> {
         transaction.check_limits(&self.transaction_limits)?;
@@ -319,7 +319,7 @@ impl Client {
     /// Fails if sending request fails
     #[log]
     pub fn request_with_pagination<R>(
-        &mut self,
+        &self,
         request: R,
         pagination: Pagination,
     ) -> Result<R::Output>
@@ -355,7 +355,7 @@ impl Client {
     /// # Errors
     /// Fails if sending request fails
     #[log]
-    pub fn request<R>(&mut self, request: R) -> Result<R::Output>
+    pub fn request<R>(&self, request: R) -> Result<R::Output>
     where
         R: Query + Into<QueryBox> + Debug,
         <R::Output as TryFrom<Value>>::Error: Into<eyre::Error>,
@@ -385,7 +385,7 @@ impl Client {
     /// # Errors
     /// Fails if subscribing to websocket fails
     pub fn get_original_transaction_with_pagination(
-        &mut self,
+        &self,
         transaction: &Transaction,
         retry_count: u32,
         retry_in: Duration,
@@ -431,7 +431,7 @@ impl Client {
     /// # Errors
     /// Fails if sending request fails
     pub fn get_original_transaction(
-        &mut self,
+        &self,
         transaction: &Transaction,
         retry_count: u32,
         retry_in: Duration,

--- a/client/tests/integration/events/data.rs
+++ b/client/tests/integration/events/data.rs
@@ -81,8 +81,7 @@ fn wasm_execution_should_produce_events() -> Result<()> {
 
             ;; Function which starts the smartcontract execution
             (func (export "{main_fn_name}") (param i32 i32)
-                {isi_calls})
-        )
+                {isi_calls}))
         "#,
         main_fn_name = wasm::WASM_MAIN_FN_NAME,
         wasm_template = wasm_template(&isi_hex.concat()),
@@ -95,8 +94,9 @@ fn wasm_execution_should_produce_events() -> Result<()> {
 }
 
 fn transaction_execution_should_produce_events(executable: Executable) -> Result<()> {
-    let (_rt, _peer, mut client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
+
     let pipeline_time = Configuration::pipeline_time();
 
     // spawn event reporter

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -37,7 +37,7 @@ fn test_with_instruction_and_status(
         let validating_event_received = Arc::new(RwLock::new([false; PEER_COUNT]));
         let rejected_event_received = Arc::new(RwLock::new([false; PEER_COUNT]));
         let peers: Vec<_> = network.peers().collect();
-        let mut submitter_client = Client::test(
+        let submitter_client = Client::test(
             &peers[submitting_peer].api_address,
             &peers[submitting_peer].telemetry_address,
         );

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -64,7 +64,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     client_configuration.account_id = account_id.clone();
     client_configuration.public_key = key_pair_1.public_key;
     client_configuration.private_key = key_pair_1.private_key;
-    let mut iroha_client = Client::new(&client_configuration);
+    let iroha_client = Client::new(&client_configuration);
     let instructions: Vec<Instruction> = vec![mint_asset.clone().into()];
     let transaction = iroha_client
         .build_transaction(instructions.into(), UnlimitedMetadata::new())
@@ -82,7 +82,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     client_configuration.torii_api_url = small::SmallStr::from_string(
         "http://".to_owned() + &network.peers.values().last().unwrap().api_address,
     );
-    let mut iroha_client_1 = Client::new(&client_configuration);
+    let iroha_client_1 = Client::new(&client_configuration);
     let request = client::asset::by_account_id(account_id);
     assert!(iroha_client_1
         .request(request.clone())
@@ -90,7 +90,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
         .is_empty());
     client_configuration.public_key = key_pair_2.public_key;
     client_configuration.private_key = key_pair_2.private_key;
-    let mut iroha_client_2 = Client::new(&client_configuration);
+    let iroha_client_2 = Client::new(&client_configuration);
     let instructions: Vec<Instruction> = vec![mint_asset.into()];
     let transaction = iroha_client_2
         .build_transaction(instructions.into(), UnlimitedMetadata::new())

--- a/client/tests/integration/offline_peers.rs
+++ b/client/tests/integration/offline_peers.rs
@@ -9,7 +9,8 @@ use tokio::runtime::Runtime;
 fn genesis_block_is_commited_with_some_offline_peers() {
     // Given
     let rt = Runtime::test();
-    let (network, mut iroha_client) = rt.block_on(<Network>::start_test_with_offline(4, 1, 1));
+
+    let (network, iroha_client) = rt.block_on(<Network>::start_test_with_offline(4, 1, 1));
     wait_for_genesis_committed(&network.clients(), 1);
 
     //When

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -149,7 +149,7 @@ pub fn submit(
     metadata: UnlimitedMetadata,
 ) -> Result<()> {
     let instruction = instruction.into();
-    let mut iroha_client = Client::new(cfg);
+    let iroha_client = Client::new(cfg);
     #[cfg(debug_assertions)]
     let err_msg = format!(
         "Failed to build transaction from instruction {:?}",
@@ -274,7 +274,7 @@ mod domain {
 
     impl RunArgs for List {
         fn run(self, cfg: &ClientConfiguration) -> Result<()> {
-            let mut client = Client::new(cfg);
+            let client = Client::new(cfg);
 
             let vec = match self {
                 Self::All => client
@@ -398,7 +398,7 @@ mod account {
 
     impl RunArgs for List {
         fn run(self, cfg: &ClientConfiguration) -> Result<()> {
-            let mut client = Client::new(cfg);
+            let client = Client::new(cfg);
 
             let vec = match self {
                 Self::All => client
@@ -559,7 +559,7 @@ mod asset {
     impl RunArgs for Get {
         fn run(self, cfg: &ClientConfiguration) -> Result<()> {
             let Self { account, asset } = self;
-            let mut iroha_client = Client::new(cfg);
+            let iroha_client = Client::new(cfg);
             let asset_id = AssetId::new(asset, account);
             let value = iroha_client
                 .request(asset::by_id(asset_id))
@@ -578,7 +578,7 @@ mod asset {
 
     impl RunArgs for List {
         fn run(self, cfg: &ClientConfiguration) -> Result<()> {
-            let mut client = Client::new(cfg);
+            let client = Client::new(cfg);
 
             let vec = match self {
                 Self::All => client


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

### Description of the Change

Remove unnecessary `&mut` references from the client. 

### Issue

HotFix

### Benefits

Fewer Mutexes needed

### Possible Drawbacks

None