### PR TITLE
[feature] #0000: Add pagination to schema. 

### DIFF
--- a/data_model/src/pagination.rs
+++ b/data_model/src/pagination.rs
@@ -12,6 +12,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::collections::btree_map;
 
+use iroha_schema::IntoSchema;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "warp")]
 use warp::{
@@ -70,7 +71,7 @@ impl<I: Iterator> Iterator for Paginated<I> {
 }
 
 /// Structure for pagination requests
-#[derive(Clone, Eq, PartialEq, Debug, Default, Copy, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Debug, Default, Copy, Deserialize, Serialize, IntoSchema)]
 pub struct Pagination {
     /// start of indexing
     pub start: Option<u32>,


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

### Description of the Change



### Issue

Relevant to #1998 

### Benefits

Queries can now be paginated. 

### Possible Drawbacks

None

### Usage Examples or Tests 

```rust 
#![allow(clippy::restriction)]

use std::thread;

use iroha_client::client::asset;
use iroha_data_model::prelude::*;
use test_network::{Peer as TestPeer, *};

use super::Configuration;

#[test]
fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() {
    let (_rt, _peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
    wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
    let pipeline_time = Configuration::pipeline_time();

    let register: Vec<Instruction> = ('a'..'z')
        .map(|c| c.to_string())
        .map(|name| AssetDefinitionId::new(&name, "wonderland").expect("Valid"))
        .map(AssetDefinition::new_quantity)
        .map(IdentifiableBox::from)
        .map(RegisterBox::new)
        .map(Instruction::Register)
        .collect();
    iroha_client
        .submit_all(register)
        .expect("Failed to prepare state.");

    thread::sleep(pipeline_time);
    //When

    let vec = iroha_client
        .request_with_pagination(
            asset::all_definitions(),
            Pagination {
                start: Some(5),
                limit: Some(5),
            },
        )
        .expect("Failed to get assets");
    assert_eq!(vec.len(), 5);
}
```


