### PR TITLE
[skip ci] Retire inactive maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,22 +9,25 @@ This is the list of maintainers, including their email address for direct commun
 |          Name          |     GitHub Id            |               email            |         Area of expertise       |
 |------------------------|--------------------------|--------------------------------|---------------------------------|
 | Makoto Takemiya        | @takemiyamakoto          | takemiya@soramitsu.co.jp       | Product vision                  |
-| Ryu Okada              | @ryuo88                  | okada@soramitsu.co.jp          | Product vision                  |
-| Nikolai Iushkevich     | @neewy                   | n.yushkevich@hotmail.com       | Development                     |
-| Fyodor Muratov         | @muratovv                | fyodor@soramitsu.co.jp         | Architecture, Java library, QA  |
-| Andrei Lebedev         | @lebdron                 | andrei@soramitsu.co.jp         | Research                        |
-| Sergei Solonets        | @Solonets                | ssolonets@gmail.com            | Development                     |
-| Yanno Ban              | @yannoban                | ban.yanno@nbc.org.kh           | Development                     |
-| Dumitru Savva          | @x3medima17              | savva@soramitsu.co.jp          | Development                     |
-| Nikita Alekseev        | @nickaleks               | alekseev@soramitsu.co.jp       | Development                     |
-| Victor Drobny          | @victordrobny            | drobny@soramitsu.co.jp         | Development                     |
-| Bulat Nasrulin         | @grimadas                | bulat@soramitsu.co.jp          | Development                     |
 | Kamil Salakhiev        | @kamilsa                 | kamil@soramitsu.co.jp          | Development                     |
+| Alexey Chernyshov      | @Alexey-N-Chernyshov     | chernyshov@soramitsu.co.jp     | Development                     |
+
+Emeritus:
+|          Name          |     GitHub Id            |               email            |         Area of expertise       |
+|------------------------|--------------------------|--------------------------------|---------------------------------|
+| Anatoly Tyukushin      | @tyvision                | tyukushin@soramitsu.co.jp      | Ansible                         |
+| Andrei Lebedev         | @lebdron                 | andrei@soramitsu.co.jp         | Research                        |
+| Arseniy Fokin          | @stinger112              | stinger112@gmail.com           | NodeJS library                  |
+| Artyom Bakhtin         | @bakhtin                 | a@bakhtin.net                  | Ansible, artifacts              |
+| Bulat Nasrulin         | @grimadas                | bulat@soramitsu.co.jp          | Development                     |
+| Dumitru Savva          | @x3medima17              | savva@soramitsu.co.jp          | Development                     |
+| Evgenii Mininbaev      | @l4l                     | evgenii@soramitsu.co.jp        | Security, Python library        |
 | Igor Egorov            | @igor-egorov             | igor@soramitsu.co.jp           | Development, Android library    |
 | Konstantin Munichev    | @luckychess              | konstantin@soramitsu.co.jp     | Security                        |
-| Evgenii Mininbaev      | @l4l                     | evgenii@soramitsu.co.jp        | Security, Python library        |
+| Nikita Alekseev        | @nickaleks               | alekseev@soramitsu.co.jp       | Development                     |
+| Nikolai Iushkevich     | @neewy                   | n.yushkevich@hotmail.com       | Development                     |
+| Ryu Okada              | @ryuo88                  | okada@soramitsu.co.jp          | Product vision                  |
+| Sergei Solonets        | @Solonets                | ssolonets@gmail.com            | Development                     |
+| Victor Drobny          | @victordrobny            | drobny@soramitsu.co.jp         | Development                     |
 | Vyacheslav Bikbaev     | @laSinteZ                | viacheslav@soramitsu.co.jp     | Documentation, NodeJS library   |
-| Arseniy Fokin          | @stinger112              | stinger112@gmail.com           | NodeJS library                  |
-| Alexey Chernyshov      | @Alexey-N-Chernyshov     | chernyshov@soramitsu.co.jp     | Development                     |
-| Artyom Bakhtin         | @bakhtin                 | a@bakhtin.net                  | Ansible, artifacts              |
-| Anatoly Tyukushin      | @tyvision                | tyukushin@soramitsu.co.jp      | Ansible                         |
+| Yanno Ban              | @yannoban                | ban.yanno@nbc.org.kh           | Development                     |


### PR DESCRIPTION
Last activity:
2019/07/24 06:25:12 issue_comment.update bakhtin
2018/12/11 14:07:33 issue_comment.update grimadas
2019/12/25 14:09:13 repository_vulnerability_alert.resolve igor-egorov
2019/01/16 12:36:58 issue_comment.update l4l
2018/09/25 11:34:38 issue_comment.update laSinteZ
2018/02/16 15:38:38 issue_comment.update luckychess
2018/07/19 16:06:05 issue_comment.destroy muratovv
2019/02/20 10:16:17 issue_comment.update neewy
2018/12/21 14:47:14 issue_comment.destroy nickaleks
2018/05/03 04:59:54 issue_comment.update Solonets
2018/07/10 13:27:31 issue_comment.update stinger112
2018/06/29 18:16:18 issue_comment.update tyvision
2018/03/20 14:42:37 issue_comment.update victordrobny
2018/03/27 10:07:33 issue_comment.update x3medima17
2017/06/28 05:35:19 org.oauth_app_access_requested yannoban

Signed-off-by: Ry Jones <ry@linux.com>

### Description of the Change

Retire inactive maintainers.