### PR TITLE
[schema] #2114: Sorted collections support in schemas

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -183,12 +183,15 @@ impl<T: Encode> HashOf<T> {
     }
 }
 
-impl<T> IntoSchema for HashOf<T> {
+impl<T: IntoSchema> IntoSchema for HashOf<T> {
+    fn type_name() -> String {
+        format!("{}::HashOf<{}>", module_path!(), T::type_name())
+    }
     fn schema(map: &mut MetaMap) {
         Hash::schema(map);
 
         map.entry(Self::type_name()).or_insert_with(|| {
-            Metadata::TupleStruct(UnnamedFieldsMeta {
+            Metadata::Tuple(UnnamedFieldsMeta {
                 types: vec![Hash::type_name()],
             })
         });

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -1,7 +1,7 @@
 //! Merkle tree implementation.
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
@@ -18,10 +18,16 @@ pub struct MerkleTree<T> {
 }
 
 impl<T: IntoSchema> IntoSchema for MerkleTree<T> {
+    fn type_name() -> String {
+        format!("{}::MerkleTree<{}>", module_path!(), T::type_name())
+    }
     fn schema(map: &mut MetaMap) {
         map.entry(Self::type_name()).or_insert_with(|| {
             // BFS ordered list of leaf nodes
-            Metadata::Vec(HashOf::<T>::type_name())
+            Metadata::Vec(VecMeta {
+                ty: HashOf::<T>::type_name(),
+                sorted: true,
+            })
         });
         if !map.contains_key(&HashOf::<T>::type_name()) {
             HashOf::<T>::schema(map);

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -27,14 +27,13 @@ roles = []
 
 # Internal use only
 mutable_api = []
-cross_crate_testing = []
 
 [dependencies]
+iroha_data_primitives = { path = "primitives", version = "=2.0.0-pre-rc.3", default-features = false }
 iroha_crypto = { path = "../crypto", version = "=2.0.0-pre-rc.3", default-features = false }
 iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.3", default-features = false }
-iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.3", default-features = false }
 iroha_version = { path = "../version", version = "=2.0.0-pre-rc.3", default-features = false, features = ["derive", "json", "scale"] }
-iroha_data_primitives = { path = "primitives", version = "=2.0.0-pre-rc.3", default-features = false }
+iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.3" }
 
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.16", default-features = false, features = ["display"] }

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -59,7 +59,10 @@ impl<V: TryFrom<Value>> EvaluatesTo<V> {
     }
 }
 
-impl<V: TryFrom<Value>> IntoSchema for EvaluatesTo<V> {
+impl<V: IntoSchema + TryFrom<Value>> IntoSchema for EvaluatesTo<V> {
+    fn type_name() -> String {
+        format!("{}::EvaluatesTo<{}>", module_path!(), V::type_name())
+    }
     fn schema(map: &mut MetaMap) {
         ExpressionBox::schema(map);
 

--- a/data_model/src/role.rs
+++ b/data_model/src/role.rs
@@ -1,11 +1,10 @@
 //! Structures, traits and impls related to `Role`s.
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, collections::btree_set, string::String};
-use core::fmt;
+use alloc::{collections::btree_set, format, string::String, vec::Vec};
+use core::{fmt, str::FromStr};
 #[cfg(feature = "std")]
 use std::collections::btree_set;
-use std::str::FromStr;
 
 use getset::Getters;
 use iroha_schema::IntoSchema;

--- a/schema/derive/src/lib.rs
+++ b/schema/derive/src/lib.rs
@@ -104,7 +104,7 @@ fn metadata(data: &Data) -> TokenStream2 {
             fields: Fields::Unit,
             ..
         }) => {
-            let expr = syn::parse2(quote! {iroha_schema::Metadata::TupleStruct(
+            let expr = syn::parse2(quote! {iroha_schema::Metadata::Tuple(
                 iroha_schema::UnnamedFieldsMeta {
                     types: Vec::new()
                 }
@@ -135,7 +135,7 @@ fn metadata_for_tuplestructs(fields: &FieldsUnnamed) -> (Vec<Type>, Expr) {
         .map(|field| field.ty)
         .map(|ty| quote! { <#ty as iroha_schema::IntoSchema>::type_name()});
     let expr = syn::parse2(quote! {
-        iroha_schema::Metadata::TupleStruct(
+        iroha_schema::Metadata::Tuple(
             iroha_schema::UnnamedFieldsMeta {
                 types: {
                     let mut types = Vec::new();

--- a/schema/tests/struct_with_named_fields.rs
+++ b/schema/tests/struct_with_named_fields.rs
@@ -36,7 +36,13 @@ fn named_fields() {
 
     let expected = vec![
         ("String".to_owned(), String),
-        ("Vec<String>".to_owned(), Vec("String".to_owned())),
+        (
+            "Vec<String>".to_owned(),
+            Vec(VecMeta {
+                ty: "String".to_owned(),
+                sorted: false,
+            }),
+        ),
         ("i32".to_owned(), Int(FixedWidth)),
         (
             "struct_with_named_fields::Command".to_owned(),

--- a/schema/tests/struct_with_unnamed_fields.rs
+++ b/schema/tests/struct_with_unnamed_fields.rs
@@ -12,10 +12,16 @@ fn unnamed() {
 
     let expected = vec![
         ("String".to_owned(), String),
-        ("Vec<String>".to_owned(), Vec("String".to_owned())),
+        (
+            "Vec<String>".to_owned(),
+            Vec(VecMeta {
+                ty: "String".to_owned(),
+                sorted: false,
+            }),
+        ),
         (
             "struct_with_unnamed_fields::Command".to_owned(),
-            TupleStruct(UnnamedFieldsMeta {
+            Tuple(UnnamedFieldsMeta {
                 types: vec!["String".to_owned(), "Vec<String>".to_owned()],
             }),
         ),

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -53,8 +53,7 @@ macro_rules! generate_map {
 }
 
 /// Generate map with types and `dump_decoded()` ptr
-#[allow(trivial_casts)]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, trivial_casts)]
 pub fn generate_map() -> DumpDecodedMap {
     let mut map = generate_map! {
         Account,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -130,7 +130,7 @@ unsafe fn decode_with_length_prefix_from_raw<T: Decode>(ptr: WasmUsize) -> T {
     let len_size_bytes = core::mem::size_of::<WasmUsize>();
 
     #[allow(clippy::expect_used)]
-    let len = WasmUsize::from_be_bytes(
+    let len = WasmUsize::from_le_bytes(
         core::slice::from_raw_parts(ptr as *mut _, len_size_bytes)
             .try_into()
             .expect("Prefix length size(bytes) incorrect. This is a bug."),


### PR DESCRIPTION
Signed-off-by: Marin Veršić <marin.versic101@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

* define stable schema type names
* introduce sorted collections to schemas

Considering that we make abundant use of digital signatures, serialized formats of our internal structures must have a defined ordering, e.g. `BTreeMap` must be represented as a sorted vector of tuples. While it may be possible that there will be `BTreeMap`s that won't be part of a structure that is signed(and require a defined ordering of tuples), I find it to be quite unlikely and don't think it worth to support such exception.

### Issue

Closes #2114 

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
