### PR TITLE
[fix] #1716: Fix consensus failure with f=0 cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,16 +476,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -502,6 +502,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -2174,7 +2183,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 name = "kura_inspector"
 version = "2.0.0-pre-rc.3"
 dependencies = [
- "clap 3.1.8",
+ "clap 3.1.10",
  "futures-util",
  "iroha_config",
  "iroha_core",
@@ -2515,9 +2524,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owo-colors"
@@ -2555,7 +2561,7 @@ dependencies = [
 name = "parity_scale_decoder"
 version = "2.0.0-pre-rc.3"
 dependencies = [
- "clap 3.1.8",
+ "clap 3.1.10",
  "colored",
  "eyre",
  "iroha_core",

--- a/client/tests/integration/connected_peers.rs
+++ b/client/tests/integration/connected_peers.rs
@@ -14,13 +14,6 @@ fn connected_peers_with_f_2_1_2() {
 }
 
 #[test]
-// TODO This case does not have to be supported, but at least have to
-// be error-handled AP: Re-opening
-// [#1716](https://github.com/hyperledger/iroha/issues/1716). The
-// solution might be to add a field to status that indicates whether
-// or not there have been many view changes.
-#[ignore]
-#[should_panic] // Stop gap solution until we fix 1716.
 fn connected_peers_with_f_1_0_1() {
     connected_peers_with_f(1)
 }

--- a/client/tests/integration/unstable_network.rs
+++ b/client/tests/integration/unstable_network.rs
@@ -64,7 +64,6 @@ fn unstable_network(
     let (network, mut iroha_client) = rt.block_on(async {
         let mut configuration = Configuration::test();
         configuration.queue.maximum_transactions_in_block = MAXIMUM_TRANSACTIONS_IN_BLOCK;
-        configuration.sumeragi.n_topology_shifts_before_reshuffle = u64::from(n_peers);
         configuration.logger.max_log_level = Level(logger::Level::ERROR).into();
         let network =
             <Network>::new_with_offline_peers(Some(configuration), n_peers, n_offline_peers)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -157,7 +157,7 @@ pub mod logger {
     }
 }
 
-/// Trait for dynamic and asynchronous configuration via maintanence endpoint for rust structures
+/// Trait for dynamic and asynchronous configuration via maintenance endpoint for rust structures
 pub trait Configurable: Serialize + DeserializeOwned {
     /// Error type returned by methods of trait
     type Error;

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -719,7 +719,7 @@ impl VersionedCommittedBlock {
 }
 
 /// When Kura receives `ValidBlock`, the block is stored and
-/// then sent to later stage of the pipeline as `CommitedBlock`.
+/// then sent to later stage of the pipeline as `CommittedBlock`.
 #[version_with_scale(n = 1, versioned = "VersionedCommittedBlock")]
 #[derive(Debug, Clone, Decode, Encode, IntoSchema)]
 pub struct CommittedBlock {

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -134,7 +134,6 @@ async fn try_get_online_topology(
             .with_leader(this_peer_id.clone())
             .with_set_a(set_a)
             .with_set_b(set_b)
-            .reshuffle_after(network_topology.reshuffle_after())
             .build()
             .expect("Preconditions should be already checked.")
     };

--- a/core/src/sumeragi/config.rs
+++ b/core/src/sumeragi/config.rs
@@ -14,7 +14,6 @@ pub const DEFAULT_BLOCK_TIME_MS: u64 = 1000;
 pub const DEFAULT_COMMIT_TIME_MS: u64 = 2000;
 /// Default amount of time Peer waits for `TxReceipt` from the leader.
 pub const DEFAULT_TX_RECEIPT_TIME_MS: u64 = 500;
-const DEFAULT_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE: u64 = 1;
 const DEFAULT_MAILBOX_SIZE: u32 = 100;
 const DEFAULT_GOSSIP_PERIOD_MS: u64 = 1000;
 const DEFAULT_GOSSIP_BATCH_SIZE: u32 = 500;
@@ -39,8 +38,6 @@ pub struct SumeragiConfiguration {
     pub commit_time_ms: u64,
     /// Amount of time Peer waits for TxReceipt from the leader.
     pub tx_receipt_time_ms: u64,
-    /// After N view changes topology will change tactic from shifting by one, to reshuffle.
-    pub n_topology_shifts_before_reshuffle: u64,
     /// Limits to which transactions must adhere
     pub transaction_limits: TransactionLimits,
     /// Mailbox size
@@ -60,7 +57,6 @@ impl Default for SumeragiConfiguration {
             block_time_ms: DEFAULT_BLOCK_TIME_MS,
             commit_time_ms: DEFAULT_COMMIT_TIME_MS,
             tx_receipt_time_ms: DEFAULT_TX_RECEIPT_TIME_MS,
-            n_topology_shifts_before_reshuffle: DEFAULT_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE,
             transaction_limits: TransactionLimits {
                 max_instruction_number: transaction::DEFAULT_MAX_INSTRUCTION_NUMBER,
                 max_wasm_size_bytes: transaction::DEFAULT_MAX_WASM_SIZE_BYTES,

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -677,6 +677,15 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
         }
         let signed_block = block.sign(self.key_pair.clone())?;
         if !network_topology.is_consensus_required() {
+            self.broadcast_msg_to(
+                BlockCommitted::from(signed_block.clone()),
+                network_topology
+                    .validating_peers()
+                    .iter()
+                    .chain(std::iter::once(network_topology.leader()))
+                    .chain(network_topology.peers_set_b()),
+            )
+            .await;
             self.commit_block(signed_block).await;
             return Ok(());
         }

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -783,6 +783,10 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
             self.invalidated_blocks_hashes.push(hash)
         }
         self.topology.apply_view_change(proof.clone());
+        self.wsv
+            .metrics
+            .view_changes
+            .set(self.number_of_view_changes());
         self.voting_block = None;
         error!(
             peer_addr = %self.peer_id.address,

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -121,7 +121,6 @@ impl<G: GenesisNetworkTrait, K: KuraTrait<World = W>, W: WorldTrait, F: FaultInj
     ) -> Result<Self> {
         let network_topology = Topology::builder()
             .at_block(EmptyChainHash::default().into())
-            .reshuffle_after(configuration.n_topology_shifts_before_reshuffle)
             .with_peers(configuration.trusted_peers.peers.clone())
             .build()?;
 

--- a/core/src/sumeragi/network_topology.rs
+++ b/core/src/sumeragi/network_topology.rs
@@ -251,7 +251,7 @@ impl Topology {
 
     /// Answers if the consensus stage is required with the current number of peers.
     pub fn is_consensus_required(&self) -> bool {
-        self.sorted_peers.len() > 1
+        self.min_votes_for_commit() > 1
     }
 
     /// The minimum number of signatures needed to commit a block

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -232,11 +232,9 @@ where
         n_peers: u32,
         max_txs_in_block: u32,
         offline_peers: u32,
-        n_shifts: u64,
     ) -> (Self, Client) {
         let mut configuration = Configuration::test();
         configuration.queue.maximum_transactions_in_block = max_txs_in_block;
-        configuration.sumeragi.n_topology_shifts_before_reshuffle = n_shifts;
         let network = Network::new_with_offline_peers(Some(configuration), n_peers, offline_peers)
             .await
             .expect("Failed to init peers");
@@ -259,7 +257,6 @@ where
             n_peers,
             maximum_transactions_in_block,
             offline_peers,
-            SumeragiConfiguration::default().n_topology_shifts_before_reshuffle,
         )
         .await
     }

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -227,6 +227,7 @@ Also returns current status of peer in json string:
   + Number of committed blocks (block height)
   + Total number of transactions
   + `uptime` since creation of the genesis block in milliseconds.
+  + Number of view_changes in the current round
 
 ```json
 {
@@ -234,7 +235,11 @@ Also returns current status of peer in json string:
     "blocks": 1,
     "txs_accepted": 3,
     "txs_rejected": 0,
-    "uptime": 3200,
+    "uptime": {
+        "secs": 5,
+        "nanos": 937000000
+    },
+    "view_changes": 0
 }
 ```
 
@@ -251,26 +256,7 @@ Also returns current status of peer in json string:
 **Expects**: -
 
 **Responses**:
-- 200 OK - currently mirrors status:
-  + Number of connected peers, except for the reporting peer itself
-  + Number of committed blocks (block height)
-  + Total number of transactions
-  + `uptime` since creation of the genesis block in milliseconds.
-
-```bash
-# HELP block_height Current block height
-# TYPE block_height counter
-block_height 0
-# HELP connected_peers Total number of currently connected peers
-# TYPE connected_peers gauge
-connected_peers 0
-# HELP txs Transactions committed
-# TYPE txs counter
-txs 0
-# HELP uptime_since_genesis_ms Uptime of the network, starting from creation of the genesis block
-# TYPE uptime_since_genesis_ms gauge
-uptime_since_genesis_ms 0
-```
+In a typical use case, Prometheus handles the response
 
 ## Parity Scale Codec
 

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -256,7 +256,50 @@ Also returns current status of peer in json string:
 **Expects**: -
 
 **Responses**:
-In a typical use case, Prometheus handles the response
+- 200 OK - reports 8 of 10 metrics:
+
+```bash
+# HELP accounts User accounts registered at this time
+# TYPE accounts gauge
+accounts{domain="genesis"} 1
+accounts{domain="wonderland"} 1
+# HELP block_height Current block height
+# TYPE block_height counter
+block_height 1
+# HELP connected_peers Total number of currently connected peers
+# TYPE connected_peers gauge
+connected_peers 0
+# HELP domains Total number of domains
+# TYPE domains gauge
+domains 2
+# HELP tx_amount average amount involved in a transaction on this peer
+# TYPE tx_amount histogram
+tx_amount_bucket{le="0.005"} 0
+tx_amount_bucket{le="0.01"} 0
+tx_amount_bucket{le="0.025"} 0
+tx_amount_bucket{le="0.05"} 0
+tx_amount_bucket{le="0.1"} 0
+tx_amount_bucket{le="0.25"} 0
+tx_amount_bucket{le="0.5"} 0
+tx_amount_bucket{le="1"} 0
+tx_amount_bucket{le="2.5"} 0
+tx_amount_bucket{le="5"} 0
+tx_amount_bucket{le="10"} 0
+tx_amount_bucket{le="+Inf"} 2
+tx_amount_sum 26
+tx_amount_count 2
+# HELP txs Transactions committed
+# TYPE txs counter
+txs{type="accepted"} 1
+txs{type="rejected"} 0
+txs{type="total"} 1
+# HELP uptime_since_genesis_ms Network up-time, from creation of the genesis block
+# TYPE uptime_since_genesis_ms gauge
+uptime_since_genesis_ms 54572974
+# HELP view_changes Number of view_changes in the current round
+# TYPE view_changes gauge
+view_changes 0
+```
 
 ## Parity Scale Codec
 

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -34,7 +34,6 @@ The following is the default configuration used by Iroha.
     ],
     "COMMIT_TIME_MS": 2000,
     "TX_RECEIPT_TIME_MS": 500,
-    "N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE": 1,
     "TRANSACTION_LIMITS": {
       "max_instruction_number": 4096,
       "max_wasm_size_bytes": 4194304
@@ -473,7 +472,6 @@ Has type `SumeragiConfiguration`. Can be configured via environment variable `IR
   "GOSSIP_BATCH_SIZE": 500,
   "GOSSIP_PERIOD_MS": 1000,
   "MAILBOX": 100,
-  "N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE": 1,
   "PEER_ID": {
     "address": "127.0.0.1:1337",
     "public_key": "ed01201c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"
@@ -556,16 +554,6 @@ Has type `u32`. Can be configured via environment variable `SUMERAGI_MAILBOX`
 
 ```json
 100
-```
-
-### `sumeragi.n_topology_shifts_before_reshuffle`
-
-After N view changes topology will change tactic from shifting by one, to reshuffle.
-
-Has type `u64`. Can be configured via environment variable `SUMERAGI_N_TOPOLOGY_SHIFTS_BEFORE_RESHUFFLE`
-
-```json
-1
 ```
 
 ### `sumeragi.peer_id`

--- a/telemetry/src/metrics.rs
+++ b/telemetry/src/metrics.rs
@@ -33,6 +33,8 @@ pub struct Status {
     pub txs_rejected: u64,
     /// Uptime since genesis block creation
     pub uptime: Uptime,
+    /// Number of view changes in the current round
+    pub view_changes: u64,
 }
 
 impl<T: Deref<Target = Metrics>> From<&T> for Status {
@@ -44,6 +46,7 @@ impl<T: Deref<Target = Metrics>> From<&T> for Status {
             txs_accepted: val.txs.with_label_values(&["accepted"]).get(),
             txs_rejected: val.txs.with_label_values(&["rejected"]).get(),
             uptime: Uptime(Duration::from_millis(val.uptime_since_genesis_ms.get())),
+            view_changes: val.view_changes.get(),
         }
     }
 }
@@ -69,6 +72,8 @@ pub struct Metrics {
     pub isi: IntCounterVec,
     /// Query handle time Histogram
     pub isi_times: HistogramVec,
+    /// Number of view changes in the current round
+    pub view_changes: GenericGauge<AtomicU64>,
     // Internal use only.
     registry: Registry,
 }
@@ -112,6 +117,11 @@ impl Default for Metrics {
             &["domain"],
         )
         .expect("Infallible");
+        let view_changes = GenericGauge::new(
+            "view_changes",
+            "Number of view changes in the current round",
+        )
+        .expect("Infallible");
         let registry = Registry::new();
 
         macro_rules! register {
@@ -133,7 +143,8 @@ impl Default for Metrics {
             domains,
             accounts,
             isi,
-            isi_times
+            isi_times,
+            view_changes
         );
 
         Self {
@@ -147,6 +158,7 @@ impl Default for Metrics {
             tx_amounts,
             isi,
             isi_times,
+            view_changes,
         }
     }
 }

--- a/tools/kura_inspector/Cargo.toml
+++ b/tools/kura_inspector/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 iroha_core = { path = "../../core" }
 iroha_config = { path = "../../config" }
 
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.8", features = ["derive", "cargo"] }
 futures-util = "0.3"
 tokio = { version = "1.6.0", features = ["rt"]}
 

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -4,8 +4,8 @@ use kura_inspector::{print, Config, DefaultOutput};
 
 /// Kura inspector
 #[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
-struct Opts {
+#[clap(author, version, about)]
+struct Args {
     /// Height of the block from which start the inspection.
     /// Defaults to the latest block height
     #[clap(short, long, name = "BLOCK_HEIGHT")]
@@ -28,17 +28,17 @@ enum Command {
 #[tokio::main]
 #[allow(clippy::use_debug, clippy::print_stderr)]
 async fn main() {
-    let opts = Opts::parse();
+    let args = Args::parse();
     let mut output = DefaultOutput::new();
-    Config::from(opts)
+    Config::from(args)
         .run(&mut output)
         .await
         .unwrap_or_else(|e| eprintln!("{:?}", e))
 }
 
-impl From<Opts> for Config {
-    fn from(src: Opts) -> Self {
-        let Opts { from, command } = src;
+impl From<Args> for Config {
+    fn from(src: Args) -> Self {
+        let Args { from, command } = src;
 
         match command {
             Command::Print { length } => Config::Print(print::Config { from, length }),


### PR DESCRIPTION
### Description of the Change
- [x] The topology reshuffles when the shift goes full circle
- [x] Either of the followings:
  - Give an true solution to the failure
  - ~~Give an mitigation by exposing the number of the last view changes as the network sanity indicator~~

#### Minor changes
- As a bonus, expose the number of the view changes in the current round as the network sanity indicator
- Refactor `kura_inspector` with `clap` version bump

### Issue
- Closes #1716

### Benefits

### Possible Drawbacks
