### PR TITLE
[refactor] #2145: refactor client's `WebSocket` side, extract pure data logic

### DIFF
--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -76,7 +76,7 @@ fn query_requests(criterion: &mut Criterion) {
         client_config.torii_telemetry_url =
             small::SmallStr::from_string(format!("http://{}", client_config.torii_telemetry_url));
     }
-    let mut iroha_client = Client::new(&client_config).expect("Invalid client configuration");
+    let iroha_client = Client::new(&client_config).expect("Invalid client configuration");
     thread::sleep(std::time::Duration::from_millis(5000));
 
     let _ = iroha_client
@@ -157,7 +157,7 @@ fn instruction_submits(criterion: &mut Criterion) {
         client_config.torii_telemetry_url =
             small::SmallStr::from_string(format!("http://{}", client_config.torii_telemetry_url));
     }
-    let mut iroha_client = Client::new(&client_config).expect("Invalid client configuration");
+    let iroha_client = Client::new(&client_config).expect("Invalid client configuration");
     thread::sleep(std::time::Duration::from_millis(5000));
     let _ = iroha_client
         .submit_all(vec![create_domain.into(), create_account.into()])

--- a/client/benches/tps/lib.rs
+++ b/client/benches/tps/lib.rs
@@ -116,7 +116,7 @@ type UnitName = u32;
 impl MeasurerUnit {
     /// Submit initial transactions for measurement
     #[allow(clippy::expect_used, clippy::unwrap_in_result)]
-    fn ready(mut self) -> Result<Self> {
+    fn ready(self) -> Result<Self> {
         let (public_key, _) = iroha_core::prelude::KeyPair::generate()
             .expect("Failed to generate KeyPair.")
             .into();
@@ -133,7 +133,7 @@ impl MeasurerUnit {
     /// Spawn who checks if all the expected blocks are committed
     #[allow(clippy::expect_used)]
     fn spawn_event_counter(&self) -> thread::JoinHandle<Result<()>> {
-        let mut listener = self.client.clone();
+        let listener = self.client.clone();
         let (init_sender, init_receiver) = mpsc::channel();
         let event_filter = PipelineEventFilter::new()
             .entity_kind(PipelineEntityKind::Block)
@@ -157,7 +157,7 @@ impl MeasurerUnit {
 
     /// Spawn who periodically submits transactions
     fn spawn_transaction_submitter(&self) {
-        let mut submitter = self.client.clone();
+        let submitter = self.client.clone();
         let interval_us_per_tx = self.config.interval_us_per_tx;
         let instructions = self.instructions();
         thread::spawn(move || -> Result<()> {

--- a/client/examples/million_accounts_tx.rs
+++ b/client/examples/million_accounts_tx.rs
@@ -5,7 +5,7 @@ use iroha_data_model::prelude::*;
 use test_network::{wait_for_genesis_committed, Peer as TestPeer};
 
 fn create_million_accounts_directly() {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     for i in 0_u32..1_000_000_u32 {
         let domain_id: DomainId = format!("wonderland-{}", i).parse().expect("Valid");

--- a/client/examples/ten_million_accounts.rs
+++ b/client/examples/ten_million_accounts.rs
@@ -5,7 +5,7 @@ use iroha_data_model::prelude::*;
 use test_network::{wait_for_genesis_committed, Peer as TestPeer};
 
 fn create_million_accounts_directly() {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     for i in 0_u32..10_000_000_u32 {
         let domain_id: DomainId = format!("wonderland-{}", i).parse().expect("Valid");

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -613,6 +613,10 @@ impl Client {
         EventIterator::new(self.events_handler(event_filter)?)
     }
 
+    /// Constructs an Events API handler. With it, you can use any WS client you want.
+    ///
+    /// # Errors
+    /// Fails if handler construction fails
     pub fn events_handler(&self, event_filter: EventFilter) -> Result<EventsApiFlowInit> {
         EventsApiFlowInit::new(
             event_filter,
@@ -844,6 +848,7 @@ impl WebSocketFlowInit for EventsApiFlowInit {
 }
 
 /// Events API flow handshake handler
+#[derive(Copy)]
 pub struct EventsApiFlowHandshake;
 
 impl WebSocketFlowHandshake for EventsApiFlowHandshake {
@@ -863,7 +868,7 @@ impl WebSocketFlowHandshake for EventsApiFlowHandshake {
 }
 
 /// Events API flow events handler
-#[derive(Debug)]
+#[derive(Debug, Copy)]
 pub struct EventsApiFlowEvents;
 
 impl WebSocketFlowEvents for EventsApiFlowEvents {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -647,7 +647,7 @@ impl Client {
     /// Fails if subscribing to websocket fails
     pub fn listen_for_events(
         &self,
-        event_filter: EventFilter,
+        event_filter: FilterBox,
     ) -> Result<impl Iterator<Item = Result<Event>>> {
         events_api::EventIterator::new(self.events_handler(event_filter)?)
     }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -617,6 +617,7 @@ impl Client {
     ///
     /// # Errors
     /// Fails if handler construction fails
+    #[inline]
     pub fn events_handler(&self, event_filter: EventFilter) -> Result<EventsApiFlowInit> {
         EventsApiFlowInit::new(
             event_filter,
@@ -807,6 +808,7 @@ impl EventsApiFlowInit {
     ///
     /// # Errors
     /// Fails if URL transformation fails
+    #[inline]
     fn new<U>(filter: EventFilter, headers: HttpHeaders, url: U) -> Result<Self>
     where
         U: AsRef<str>,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -607,7 +607,7 @@ impl Client {
     /// Query API entry point. Requests queries from `Iroha` peers with pagination.
     ///
     /// Uses default blocking http-client. If you need some custom integration, look at
-    /// [`Self::prepare_query_request()`].
+    /// [`Self::prepare_query_request`].
     ///
     /// # Errors
     /// Fails if sending request fails
@@ -807,7 +807,7 @@ impl Client {
         resp_handler.handle(resp)
     }
 
-    /// Prepares http-request to implement [`Self::get_status()`] on your own.
+    /// Prepares http-request to implement [`Self::get_status`] on your own.
     ///
     /// For general usage example see [`Client::prepare_query_request`].
     ///

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -23,13 +23,11 @@ use small::SmallStr;
 
 use crate::{
     config::Configuration,
-    http::{
-        transform_ws_url, Headers as HttpHeaders, Method as HttpMethod, RequestBuilder, Response,
-        StatusCode, WebSocketFlowEvents, WebSocketFlowHandshake, WebSocketFlowInit,
-        WebSocketHandleEventResponse, WebSocketInitData,
-    },
+    http::{Method as HttpMethod, RequestBuilder, Response, StatusCode},
     http_default::{self, DefaultRequestBuilder, WebSocketError, WebSocketMessage},
 };
+
+const APPLICATION_JSON: &str = "application/json";
 
 /// General trait for all response handlers
 pub trait ResponseHandler<T = Vec<u8>> {
@@ -198,7 +196,7 @@ pub struct Client {
     /// Current account
     account_id: AccountId,
     /// Http headers which will be appended to each request
-    headers: HttpHeaders,
+    headers: HashMap<String, String>,
     /// If `true` add nonce, which makes different hashes for
     /// transactions which occur repeatedly and/or simultaneously
     add_transaction_nonce: bool,
@@ -211,7 +209,7 @@ impl Client {
     /// # Errors
     /// If configuration isn't valid (e.g public/private keys don't match)
     pub fn new(configuration: &Configuration) -> Result<Self> {
-        Self::with_headers(configuration, HttpHeaders::default())
+        Self::with_headers(configuration, HashMap::new())
     }
 
     /// Constructor for client from configuration and headers
@@ -359,7 +357,8 @@ impl Client {
     ) -> Result<HashOf<VersionedTransaction>> {
         let (req, hash, resp_handler) =
             self.prepare_transaction_request::<DefaultRequestBuilder>(transaction)?;
-        let response = req?
+        let response = req
+            .build()?
             .send()
             .wrap_err_with(|| format!("Failed to send transaction with hash {:?}", hash))?;
         resp_handler.handle(response)?;
@@ -376,17 +375,10 @@ impl Client {
     ///
     /// # Errors
     /// Fails if transaction check fails
-    pub fn prepare_transaction_request<B>(
+    pub fn prepare_transaction_request<B: RequestBuilder>(
         &self,
         transaction: Transaction,
-    ) -> Result<(
-        B::Output,
-        HashOf<VersionedTransaction>,
-        TransactionResponseHandler,
-    )>
-    where
-        B: RequestBuilder,
-    {
+    ) -> Result<(B, HashOf<VersionedTransaction>, TransactionResponseHandler)> {
         transaction.check_limits(&self.transaction_limits)?;
         let transaction: VersionedTransaction = transaction.into();
         let hash = transaction.hash();
@@ -398,7 +390,7 @@ impl Client {
                 format!("{}/{}", &self.torii_url, uri::TRANSACTION),
             )
             .headers(self.headers.clone())
-            .body(Some(transaction_bytes)),
+            .body(transaction_bytes),
             hash,
             TransactionResponseHandler,
         ))
@@ -543,7 +535,7 @@ impl Client {
         &self,
         request: R,
         pagination: Pagination,
-    ) -> Result<(B::Output, QueryResponseHandler<R>)>
+    ) -> Result<(B, QueryResponseHandler<R>)>
     where
         R: Query + Into<QueryBox> + Debug,
         <R::Output as TryFrom<Value>>::Error: Into<eyre::Error>,
@@ -560,7 +552,7 @@ impl Client {
             )
             .params(pagination)
             .headers(self.headers.clone())
-            .body(Some(request.encode_versioned())),
+            .body(request.encode_versioned()),
             QueryResponseHandler::default(),
         ))
     }
@@ -584,7 +576,7 @@ impl Client {
     {
         let (req, resp_handler) =
             self.prepare_query_request::<R, DefaultRequestBuilder>(request, pagination)?;
-        let response = req?.send()?;
+        let response = req.build()?.send()?;
         resp_handler.handle(response)
     }
 
@@ -610,7 +602,7 @@ impl Client {
         &self,
         event_filter: EventFilter,
     ) -> Result<impl Iterator<Item = Result<Event>>> {
-        EventIterator::new(self.events_handler(event_filter)?)
+        events_api::EventIterator::new(self.events_handler(event_filter)?)
     }
 
     /// Constructs an Events API handler. With it, you can use any WS client you want.
@@ -618,8 +610,8 @@ impl Client {
     /// # Errors
     /// Fails if handler construction fails
     #[inline]
-    pub fn events_handler(&self, event_filter: EventFilter) -> Result<EventsApiFlowInit> {
-        EventsApiFlowInit::new(
+    pub fn events_handler(&self, event_filter: EventFilter) -> Result<events_api::flow::Init> {
+        events_api::flow::Init::new(
             event_filter,
             self.headers.clone(),
             &format!("{}/{}", &self.torii_url, uri::SUBSCRIPTION),
@@ -647,7 +639,7 @@ impl Client {
             )
             .params(pagination.clone())
             .headers(self.headers.clone())
-            .body(None)?
+            .build()?
             .send()?;
 
             if response.status() == StatusCode::OK {
@@ -696,17 +688,13 @@ impl Client {
     }
 
     fn get_config<T: DeserializeOwned>(&self, get_config: &GetConfiguration) -> Result<T> {
-        let headers = [("Content-Type".to_owned(), "application/json".to_owned())]
-            .into_iter()
-            .collect();
         let resp = DefaultRequestBuilder::new(
             HttpMethod::GET,
             format!("{}/{}", &self.torii_url, uri::CONFIGURATION),
         )
-        .headers(headers)
-        .body(Some(
-            serde_json::to_vec(get_config).wrap_err("Failed to serialize")?,
-        ))?
+        .header(http::header::CONTENT_TYPE, APPLICATION_JSON)
+        .body(serde_json::to_vec(get_config).wrap_err("Failed to serialize")?)
+        .build()?
         .send()?;
 
         if resp.status() != StatusCode::OK {
@@ -724,15 +712,13 @@ impl Client {
     /// # Errors
     /// If sending request or decoding fails
     pub fn set_config(&self, post_config: PostConfiguration) -> Result<bool> {
-        let headers = [("Content-type".to_owned(), "application/json".to_owned())]
-            .into_iter()
-            .collect();
         let body = serde_json::to_vec(&post_config)
             .wrap_err(format!("Failed to serialize {:?}", post_config))?;
         let url = &format!("{}/{}", self.torii_url, uri::CONFIGURATION);
         let resp = DefaultRequestBuilder::new(HttpMethod::POST, url)
-            .headers(headers)
-            .body(Some(body))?
+            .header(http::header::CONTENT_TYPE, APPLICATION_JSON)
+            .body(body)
+            .build()?
             .send()?;
 
         if resp.status() != StatusCode::OK {
@@ -770,7 +756,7 @@ impl Client {
     /// Fails if sending request or decoding fails
     pub fn get_status(&self) -> Result<Status> {
         let (req, resp_handler) = self.prepare_status_request::<DefaultRequestBuilder>();
-        let resp = req?.send()?;
+        let resp = req.build()?.send()?;
         resp_handler.handle(resp)
     }
 
@@ -780,7 +766,7 @@ impl Client {
     ///
     /// # Errors
     /// Fails if request build fails
-    pub fn prepare_status_request<B>(&self) -> (B::Output, StatusResponseHandler)
+    pub fn prepare_status_request<B>(&self) -> (B, StatusResponseHandler)
     where
         B: RequestBuilder,
     {
@@ -789,194 +775,9 @@ impl Client {
                 HttpMethod::GET,
                 format!("{}/{}", &self.telemetry_url, uri::STATUS),
             )
-            .headers(self.headers.clone())
-            .body(None),
+            .headers(self.headers.clone()),
             StatusResponseHandler,
         )
-    }
-}
-
-/// Events API flow initializer
-pub struct EventsApiFlowInit {
-    filter: EventFilter,
-    headers: HttpHeaders,
-    url: String,
-}
-
-impl EventsApiFlowInit {
-    /// Construct new item with provided filter, headers and url.
-    ///
-    /// # Errors
-    /// Fails if [`transform_ws_url`] fails.
-    #[inline]
-    fn new<U>(filter: EventFilter, headers: HttpHeaders, url: U) -> Result<Self>
-    where
-        U: AsRef<str>,
-    {
-        Ok(Self {
-            filter,
-            headers,
-            url: transform_ws_url(url)?,
-        })
-    }
-}
-
-impl WebSocketFlowInit for EventsApiFlowInit {
-    type Next = EventsApiFlowHandshake;
-
-    fn init<B>(self) -> Result<(WebSocketInitData<B>, Self::Next)>
-    where
-        B: RequestBuilder,
-        Self: Sized,
-        Self::Next: WebSocketFlowHandshake,
-    {
-        let Self {
-            filter,
-            headers,
-            url,
-        } = self;
-
-        let msg = VersionedEventSubscriberMessage::from(EventSubscriberMessage::from(filter))
-            .encode_versioned();
-
-        Ok((
-            WebSocketInitData::new(
-                B::new(HttpMethod::GET, url).headers(headers).body(None),
-                msg,
-            ),
-            EventsApiFlowHandshake,
-        ))
-    }
-}
-
-/// Events API flow handshake handler
-#[derive(Copy, Clone)]
-pub struct EventsApiFlowHandshake;
-
-impl WebSocketFlowHandshake for EventsApiFlowHandshake {
-    type Next = EventsApiFlowEvents;
-
-    fn message(self, message: Vec<u8>) -> Result<Self::Next>
-    where
-        Self::Next: WebSocketFlowEvents,
-    {
-        if let EventPublisherMessage::SubscriptionAccepted =
-            VersionedEventPublisherMessage::decode_versioned(&message)?.into_v1()
-        {
-            return Ok(EventsApiFlowEvents);
-        }
-        return Err(eyre!("Expected `SubscriptionAccepted`."));
-    }
-}
-
-/// Events API flow events handler
-#[derive(Debug, Copy, Clone)]
-pub struct EventsApiFlowEvents;
-
-impl WebSocketFlowEvents for EventsApiFlowEvents {
-    type Event = iroha_data_model::prelude::Event;
-
-    fn message(&self, message: Vec<u8>) -> Result<WebSocketHandleEventResponse<Self::Event>> {
-        let event_socket_message = match VersionedEventPublisherMessage::decode_versioned(&message)
-        {
-            Ok(event_socket_message) => event_socket_message.into_v1(),
-            Err(err) => return Err(err.into()),
-        };
-        let event = match event_socket_message {
-            EventPublisherMessage::Event(event) => event,
-            msg => return Err(eyre!("Expected Event but got {:?}", msg)),
-        };
-        let versioned_message =
-            VersionedEventSubscriberMessage::from(EventSubscriberMessage::EventReceived)
-                .encode_versioned();
-
-        Ok(WebSocketHandleEventResponse::new(event, versioned_message))
-    }
-}
-
-/// Iterator for getting events from the `WebSocket` stream.
-#[derive(Debug)]
-pub struct EventIterator {
-    stream: WebSocketStream,
-    handler: EventsApiFlowEvents,
-}
-
-impl EventIterator {
-    /// Constructs `EventIterator` and sends the subscription request.
-    ///
-    /// # Errors
-    /// Fails if connecting and sending subscription to web socket fails
-    pub fn new(handler: EventsApiFlowInit) -> Result<Self> {
-        let (
-            WebSocketInitData {
-                first_message,
-                request,
-            },
-            handler,
-        ) = handler.init::<http_default::DefaultWebSocketRequestBuilder>()?;
-
-        let mut stream = request?.connect()?;
-        stream.write_message(WebSocketMessage::Binary(first_message))?;
-
-        let handler = loop {
-            match stream.read_message() {
-                Ok(WebSocketMessage::Binary(message)) => break handler.message(message)?,
-                Ok(_) => continue,
-                Err(WebSocketError::ConnectionClosed | WebSocketError::AlreadyClosed) => {
-                    return Err(eyre!("WebSocket connection closed."))
-                }
-                Err(err) => return Err(err.into()),
-            }
-        };
-        Ok(Self { stream, handler })
-    }
-}
-
-impl Iterator for EventIterator {
-    type Item = Result<Event>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.stream.read_message() {
-                Ok(WebSocketMessage::Binary(message)) => {
-                    let result = self.handler.message(message);
-
-                    match result {
-                        Ok(WebSocketHandleEventResponse { reply, event }) => {
-                            match self.stream.write_message(WebSocketMessage::Binary(reply)) {
-                                Ok(_) => (),
-                                Err(err) => return Some(Err(eyre!("Failed to reply: {}", err))),
-                            }
-
-                            return Some(Ok(event));
-                        }
-                        Err(err) => return Some(Err(err)),
-                    }
-                }
-                Ok(_) => continue,
-                Err(WebSocketError::ConnectionClosed | WebSocketError::AlreadyClosed) => {
-                    return None
-                }
-                Err(err) => return Some(Err(err.into())),
-            }
-        }
-    }
-}
-
-impl Drop for EventIterator {
-    fn drop(&mut self) {
-        let mut close = || -> eyre::Result<()> {
-            self.stream.close(None)?;
-            let mes = self.stream.read_message()?;
-            if !mes.is_close() {
-                return Err(eyre!(
-                    "Server hasn't sent `Close` message for websocket handshake"
-                ));
-            }
-            Ok(())
-        };
-
-        let _ = close().map_err(|e| warn!(%e));
     }
 }
 
@@ -987,6 +788,196 @@ impl Debug for Client {
             .field("torii_url", &self.torii_url)
             .field("telemetry_url", &self.telemetry_url)
             .finish()
+    }
+}
+
+/// Logic related to Events API client implementation.
+pub mod events_api {
+    use super::*;
+    use crate::http::ws::{
+        conn_flow::{
+            EventData, Events as FlowEvents, Handshake as FlowHandshake, Init as FlowInit, InitData,
+        },
+        transform_ws_url,
+    };
+
+    /// Events API flow. For documentation and example usage please follow to [`crate::http::ws::conn_flow`].
+    pub mod flow {
+        use super::*;
+
+        /// Initialization struct for Events API flow.
+        pub struct Init {
+            /// Event filter
+            filter: EventFilter,
+            /// HTTP request headers
+            headers: HashMap<String, String>,
+            /// TORII URL
+            url: String,
+        }
+
+        impl Init {
+            /// Construct new item with provided filter, headers and url.
+            ///
+            /// # Errors
+            /// Fails if [`transform_ws_url`] fails.
+            #[inline]
+            pub(in super::super) fn new(
+                filter: EventFilter,
+                headers: HashMap<String, String>,
+                url: impl AsRef<str>,
+            ) -> Result<Self> {
+                Ok(Self {
+                    filter,
+                    headers,
+                    url: transform_ws_url(url.as_ref())?,
+                })
+            }
+        }
+
+        impl<R: RequestBuilder> FlowInit<R> for Init {
+            type Next = Handshake;
+
+            fn init(self) -> InitData<R, Self::Next> {
+                let Self {
+                    filter,
+                    headers,
+                    url,
+                } = self;
+
+                let msg =
+                    VersionedEventSubscriberMessage::from(EventSubscriberMessage::from(filter))
+                        .encode_versioned();
+
+                InitData::new(
+                    R::new(HttpMethod::GET, url).headers(headers),
+                    msg,
+                    Handshake,
+                )
+            }
+        }
+
+        /// Events API flow handshake handler
+        #[derive(Copy, Clone)]
+        pub struct Handshake;
+
+        impl FlowHandshake for Handshake {
+            type Next = Events;
+
+            fn message(self, message: Vec<u8>) -> Result<Self::Next>
+            where
+                Self::Next: FlowEvents,
+            {
+                if let EventPublisherMessage::SubscriptionAccepted =
+                    VersionedEventPublisherMessage::decode_versioned(&message)?.into_v1()
+                {
+                    return Ok(Events);
+                }
+                return Err(eyre!("Expected `SubscriptionAccepted`."));
+            }
+        }
+
+        /// Events API flow events handler
+        #[derive(Debug, Copy, Clone)]
+        pub struct Events;
+
+        impl FlowEvents for Events {
+            type Event = iroha_data_model::prelude::Event;
+
+            fn message(&self, message: Vec<u8>) -> Result<EventData<Self::Event>> {
+                let event_socket_message =
+                    VersionedEventPublisherMessage::decode_versioned(&message)
+                        .map(iroha_data_model::events::VersionedEventPublisherMessage::into_v1)
+                        .map_err(Into::<eyre::Error>::into)?;
+                let event = match event_socket_message {
+                    EventPublisherMessage::Event(event) => event,
+                    msg => return Err(eyre!("Expected Event but got {:?}", msg)),
+                };
+                let versioned_message =
+                    VersionedEventSubscriberMessage::from(EventSubscriberMessage::EventReceived)
+                        .encode_versioned();
+
+                Ok(EventData::new(event, versioned_message))
+            }
+        }
+    }
+
+    /// Iterator for getting events from the `WebSocket` stream.
+    #[derive(Debug)]
+    pub(super) struct EventIterator {
+        stream: WebSocketStream,
+        handler: flow::Events,
+    }
+
+    impl EventIterator {
+        /// Constructs `EventIterator` and sends the subscription request.
+        ///
+        /// # Errors
+        /// Fails if connecting and sending subscription to web socket fails
+        pub fn new(handler: flow::Init) -> Result<Self> {
+            let InitData {
+                first_message,
+                req,
+                next: handler,
+            } = FlowInit::<http_default::DefaultWebSocketRequestBuilder>::init(handler);
+
+            let mut stream = req.build()?.connect()?;
+            stream.write_message(WebSocketMessage::Binary(first_message))?;
+
+            let handler = loop {
+                match stream.read_message() {
+                    Ok(WebSocketMessage::Binary(message)) => break handler.message(message)?,
+                    Ok(_) => continue,
+                    Err(WebSocketError::ConnectionClosed | WebSocketError::AlreadyClosed) => {
+                        return Err(eyre!("WebSocket connection closed."))
+                    }
+                    Err(err) => return Err(err.into()),
+                }
+            };
+            Ok(Self { stream, handler })
+        }
+    }
+
+    impl Iterator for EventIterator {
+        type Item = Result<Event>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            loop {
+                match self.stream.read_message() {
+                    Ok(WebSocketMessage::Binary(message)) => {
+                        return Some(self.handler.message(message).and_then(
+                            |EventData { reply, event }| {
+                                self.stream
+                                    .write_message(WebSocketMessage::Binary(reply))
+                                    .map(|_| event)
+                                    .wrap_err("Failed to reply")
+                            },
+                        ));
+                    }
+                    Ok(_) => continue,
+                    Err(WebSocketError::ConnectionClosed | WebSocketError::AlreadyClosed) => {
+                        return None
+                    }
+                    Err(err) => return Some(Err(err.into())),
+                }
+            }
+        }
+    }
+
+    impl Drop for EventIterator {
+        fn drop(&mut self) {
+            let mut close = || -> eyre::Result<()> {
+                self.stream.close(None)?;
+                let mes = self.stream.read_message()?;
+                if !mes.is_close() {
+                    return Err(eyre!(
+                        "Server hasn't sent `Close` message for websocket handshake"
+                    ));
+                }
+                Ok(())
+            };
+
+            let _ = close().map_err(|e| warn!(%e));
+        }
     }
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -804,10 +804,10 @@ pub struct EventsApiFlowInit {
 }
 
 impl EventsApiFlowInit {
-    /// Constructs new item with provided filter, headers and url
+    /// Construct new item with provided filter, headers and url.
     ///
     /// # Errors
-    /// Fails if URL transformation fails
+    /// Fails if [`transform_ws_url`] fails.
     #[inline]
     fn new<U>(filter: EventFilter, headers: HttpHeaders, url: U) -> Result<Self>
     where

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -848,7 +848,7 @@ impl WebSocketFlowInit for EventsApiFlowInit {
 }
 
 /// Events API flow handshake handler
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct EventsApiFlowHandshake;
 
 impl WebSocketFlowHandshake for EventsApiFlowHandshake {
@@ -868,7 +868,7 @@ impl WebSocketFlowHandshake for EventsApiFlowHandshake {
 }
 
 /// Events API flow events handler
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct EventsApiFlowEvents;
 
 impl WebSocketFlowEvents for EventsApiFlowEvents {

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -88,34 +88,13 @@ pub trait WebSocketHandleEvent {
 }
 
 pub struct WebSocketHandleEventResponse<T> {
-    pub event: Option<T>,
-    pub reply: Option<Vec<u8>>,
+    pub event: T,
+    pub reply: Vec<u8>,
 }
 
 impl<T> WebSocketHandleEventResponse<T> {
-    pub fn empty() -> Self {
-        Self {
-            event: None,
-            reply: None,
-        }
-    }
-
-    pub fn new() -> Self {
-        Self::empty()
-    }
-
-    pub fn reply(self, payload: Vec<u8>) -> Self {
-        Self {
-            reply: Some(payload),
-            ..self
-        }
-    }
-
-    pub fn event(self, event: T) -> Self {
-        Self {
-            event: Some(event),
-            ..self
-        }
+    pub fn new(event: T, reply: Vec<u8>) -> Self {
+        Self { event, reply }
     }
 }
 
@@ -133,14 +112,3 @@ where
 
     Ok(ws_uri)
 }
-
-// trait WebSocketHandlerThen {
-//     fn test() -> Self;
-// }
-
-// enum IrohaWebSocketHandlerResponse<T>
-// where
-//     T: Sized,
-// {
-//     Reply { message: Vec<u8>, decoded: T },
-// }

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -9,13 +9,13 @@ pub use http::{Method, Response, StatusCode};
 /// to the client that will fill it with data.
 ///
 /// The order of builder methods invocation is not strict. There is no guarantee that builder user calls
-/// all methods. Only [`RequestBuilder::new()`] is the required one.
+/// all methods. Only [`RequestBuilder::new`] is the required one.
 pub trait RequestBuilder {
     /// Entrypoint - create a new builder with specified method and URL.
     #[must_use]
     fn new(method: Method, url: impl AsRef<str>) -> Self;
 
-    /// Add multiple query params at once. Uses [`RequestBuilder::param()`] for each param.
+    /// Add multiple query params at once. Uses [`RequestBuilder::param`] for each param.
     #[must_use]
     fn params<P, K, V>(mut self, params: P) -> Self
     where
@@ -39,7 +39,7 @@ pub trait RequestBuilder {
         K: AsRef<str>,
         V: ToString;
 
-    /// Add multiple headers at once. Uses [`RequestBuilder::header()`] for each param.
+    /// Add multiple headers at once. Uses [`RequestBuilder::header`] for each param.
     #[must_use]
     fn headers<H, N, V>(mut self, headers: H) -> Self
     where
@@ -157,7 +157,7 @@ pub mod ws {
     /// the client library should provide an API wrapped into the flow traits. Anyway, firstly you should implement
     /// [`super::RequestBuilder`] trait for your transport.
     ///
-    /// Let's take Events API as an example. [`crate::client::Client::events_handler()`] function creates a struct of
+    /// Let's take Events API as an example. [`crate::client::Client::events_handler`] creates a struct of
     /// initial WS flow stage - [`crate::client::events_api::flow::Init`].
     /// Here is an example (oversimplified) of how you can use it:
     ///

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -9,13 +9,13 @@ pub use http::{Method, Response, StatusCode};
 /// to the client that will fill it with data.
 ///
 /// The order of builder methods invocation is not strict. There is no guarantee that builder user calls
-/// all methods. Only [`RequestBuilder::new]` is required one.
+/// all methods. Only [`RequestBuilder::new()`] is required one.
 pub trait RequestBuilder {
     /// Entrypoint - create a new builder with specified method and URL.
     #[must_use]
     fn new(method: Method, url: impl AsRef<str>) -> Self;
 
-    /// Add multiple query params at once. Uses `[RequestBuilder::param]` for each param.
+    /// Add multiple query params at once. Uses [`RequestBuilder::param()`] for each param.
     #[must_use]
     fn params<P, K, V>(mut self, params: P) -> Self
     where
@@ -39,7 +39,7 @@ pub trait RequestBuilder {
         K: AsRef<str>,
         V: ToString;
 
-    /// Add multiple headers at once. Uses `[RequestBuilder::header]` for each param.
+    /// Add multiple headers at once. Uses [`RequestBuilder::header()`] for each param.
     #[must_use]
     fn headers<H, N, V>(mut self, headers: H) -> Self
     where

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -128,18 +128,18 @@ pub fn transform_ws_url<S>(uri: S) -> Result<String>
 where
     S: AsRef<str>,
 {
+    // Separate-compilation friendly private implementation.
+    fn _transform_ws_url(uri: &str) -> Result<String> {
+        let ws_uri = if let Some(https_uri) = uri.strip_prefix("https://") {
+            "wss://".to_owned() + https_uri
+        } else if let Some(http_uri) = uri.strip_prefix("http://") {
+            "ws://".to_owned() + http_uri
+        } else {
+            return Err(eyre!("No schema in web socket uri provided"));
+        };
+
+        Ok(ws_uri)
+    }
+
     _transform_ws_url(uri.as_ref())
-}
-
-// Separate-compilation friendly private implementation.
-fn _transform_ws_url(uri: &str) -> Result<String> {
-    let ws_uri = if let Some(https_uri) = uri.strip_prefix("https://") {
-        "wss://".to_owned() + https_uri
-    } else if let Some(http_uri) = uri.strip_prefix("http://") {
-        "ws://".to_owned() + http_uri
-    } else {
-        return Err(eyre!("No schema in web socket uri provided"));
-    };
-
-    Ok(ws_uri)
 }

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -1,135 +1,329 @@
-use std::{borrow::Borrow, collections::HashMap};
+use std::borrow::Borrow;
 
 use eyre::{eyre, Result};
 pub use http::{Method, Response, StatusCode};
 
-/// Type alias for HTTP headers hash map
-pub type Headers = HashMap<String, String>;
-
-/// General trait for building http-requests.
+/// General HTTP request builder.
 ///
 /// To use custom builder with client, you need to implement this trait for some type and pass it
-/// to the client that will fill it.
+/// to the client that will fill it with data.
+///
+/// The order of builder methods invocation is not strict. There is no guarantee that builder user calls
+/// all methods. Only [`RequestBuilder::new]` is required one.
 pub trait RequestBuilder {
-    /// Builder output, returned by [`RequestBuilder::body()`].
-    type Output;
-
-    /// Constructs a new builder with provided method and URL
+    /// Entrypoint - create a new builder with specified method and URL.
     #[must_use]
-    fn new<U>(method: Method, url: U) -> Self
-    where
-        U: AsRef<str>;
+    fn new(method: Method, url: impl AsRef<str>) -> Self;
 
-    /// Sets request's query params
+    /// Add multiple query params at once. Uses `[RequestBuilder::param]` for each param.
     #[must_use]
-    fn params<P, K, V>(self, params: P) -> Self
+    fn params<P, K, V>(mut self, params: P) -> Self
     where
         P: IntoIterator,
         P::Item: Borrow<(K, V)>,
         K: AsRef<str>,
+        V: ToString,
+        Self: Sized,
+    {
+        for pair in params {
+            let (k, v) = pair.borrow();
+            self = self.param(k, v.to_string());
+        }
+        self
+    }
+
+    /// Add a single query param
+    #[must_use]
+    fn param<K, V>(self, key: K, value: V) -> Self
+    where
+        K: AsRef<str>,
         V: ToString;
 
-    /// Sets request's headers
+    /// Add multiple headers at once. Uses `[RequestBuilder::header]` for each param.
     #[must_use]
-    fn headers(self, headers: Headers) -> Self;
+    fn headers<H, N, V>(mut self, headers: H) -> Self
+    where
+        H: IntoIterator,
+        H::Item: Borrow<(N, V)>,
+        N: AsRef<str>,
+        V: ToString,
+        Self: Sized,
+    {
+        for pair in headers {
+            let (k, v) = pair.borrow();
+            self = self.header(k, v.to_string());
+        }
+        self
+    }
 
-    /// Set request's body in bytes and `build()` the output
+    /// Add a single header
     #[must_use]
-    fn body(self, data: Option<Vec<u8>>) -> Self::Output;
+    fn header<N, V>(self, name: N, value: V) -> Self
+    where
+        N: AsRef<str>,
+        V: ToString;
+
+    /// Set request's binary body
+    #[must_use]
+    fn body(self, data: Vec<u8>) -> Self;
 }
 
-/// Represents data required to initialize any `WebSocket` connection with Iroha
-pub struct WebSocketInitData<B>
-where
-    B: RequestBuilder,
-{
-    /// Basic HTTP request that should be done and then upgraded to WS
-    pub request: B::Output,
-    /// Data that should be sent to Iroha immediately when WS connection is initialized
-    pub first_message: Vec<u8>,
-}
+/// Generalization of `WebSocket` client's functionality
+pub mod ws {
+    use super::{eyre, RequestBuilder, Result};
 
-impl<B> WebSocketInitData<B>
-where
-    B: RequestBuilder,
-{
-    /// Creates struct with provided request and first message
-    #[inline]
-    pub fn new(request: B::Output, first_message: Vec<u8>) -> Self {
-        Self {
-            request,
-            first_message,
+    /// `WebSocket` connection flow stages.
+    ///
+    /// Flow consists of the following:
+    ///
+    /// 1. **Init stage** - establish `WebSocket` connection with Iroha
+    /// 2. **Handshake stage** - send a "subscription" message to Iroha and ensure that the next message from Iroha
+    ///     is a "subscription accepted" message
+    /// 3. **Events stage** - wait for messages from Iroha. For each message, decode *some event* from it
+    ///     and send back *some "received"* mesage
+    ///
+    ///
+    ///
+    /// This module has a set of abstraction to extract pure data logic from transportation logic. Following sections
+    /// describe how to use this module from both **flow implemention** (data side) and
+    /// **transport implementation** sides.
+    ///
+    /// ## Flow implementation
+    ///
+    /// From data side, you should implement a state machine built on top of these traits:
+    ///
+    /// - [`Init`] - it is designed to consume it's impl struct and produce a tuple, that has 2 items:
+    ///   **initial data** to establish WS connection, and the **handler** of the next flow stage - **handshake**.
+    ///   Then, transportation side should open a connection, send first message into it, receive message from Iroha
+    ///   and pass it into the next handler.
+    /// - [`Handshake`] - handles incoming message and ensures that it is OK. Which message is OK -
+    ///   implementation dependent. If it is OK, returns the handler for the next, final flow stage - **events**.
+    /// - [`Events`] - handles incoming messages and returns a **binary reply** back Iroha and **some decoded event**.
+    ///
+    /// Here is an example of how to implement flow in a transport-agnostic manner:
+    ///
+    /// ```rust
+    /// use eyre::{eyre, Result};
+    /// use iroha_client::http::{
+    ///     ws::conn_flow::{
+    ///         EventData, Events as FlowEvents, Handshake as FlowHandshake, Init as FlowInit,
+    ///         InitData,
+    ///     },
+    ///     Method, RequestBuilder,
+    /// };
+    ///
+    /// struct Init;
+    ///
+    /// impl<R: RequestBuilder> FlowInit<R> for Init {
+    ///     type Next = Handshake;
+    ///
+    ///     fn init(self) -> InitData<R, Self::Next> {
+    ///         InitData::new(
+    ///             R::new(Method::GET, "http://localhost:3000"),
+    ///             vec![1, 2, 3],
+    ///             Handshake,
+    ///         )
+    ///     }
+    /// }
+    ///
+    /// struct Handshake;
+    ///
+    /// impl FlowHandshake for Handshake {
+    ///     type Next = Events;
+    ///
+    ///     fn message(self, message: Vec<u8>) -> Result<Self::Next> {
+    ///         if message[0] == 42 {
+    ///             Ok(Events)
+    ///         } else {
+    ///             Err(eyre!("Wrong"))
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// struct Events;
+    ///
+    /// impl FlowEvents for Events {
+    ///     type Event = u8;
+    ///
+    ///     fn message(&self, message: Vec<u8>) -> Result<EventData<Self::Event>> {
+    ///         Ok(EventData::new(message[0], vec![3, 2, 1]))
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ## Transport implementation
+    ///
+    /// You are a library user and want to use Iroha Client with your own HTTP/WS implementation. For such a purpose
+    /// the client library should provide an API wrapped into the flow traits. Anyway, firstly you should implement
+    /// [`super::RequestBuilder`] trait for your transport.
+    ///
+    /// Let's take Events API as an example. [`crate::client::Client::events_handler()`] function creates a struct of
+    /// initial WS flow stage - [`crate::client::events_api::flow::Init`].
+    /// Here is an example (oversimplified) of how you can use it:
+    ///
+    /// ```rust,ignore
+    /// use eyre::Result;
+    /// use iroha_data_model::prelude::Event;
+    /// use iroha_client::{
+    ///     client::events_api::flow as events_api_flow,
+    ///     http::{
+    ///         ws::conn_flow::{EventData, Events, Handshake, Init, InitData},
+    ///         RequestBuilder,
+    ///     },
+    /// };
+    ///
+    /// // Some request builder
+    /// struct MyBuilder;
+    ///
+    /// impl RequestBuilder for MyBuilder {
+    ///     /* ... */
+    /// }
+    ///
+    /// impl MyBuilder {
+    ///     fn connect(self) -> MyStream {
+    ///         /* ... */
+    ///     }
+    /// }
+    ///
+    /// // Some `WebSocket` stream
+    /// struct MyStream;
+    ///
+    /// impl MyStream {
+    ///     // Receive message
+    ///     fn get_next(&self) -> Vec<u8> {
+    ///         /* ... */
+    ///     }
+    ///     
+    ///     // Send message
+    ///     fn send(&self, msg: Vec<u8>) {
+    ///         /* ... */
+    ///     }
+    /// }
+    ///
+    /// fn collect_5_events(flow: events_api_flow::Init) -> Result<Vec<Event>> {
+    ///     // Constructing initial flow data
+    ///     let InitData {
+    ///         next: flow,
+    ///         first_message,
+    ///         req,
+    ///     }: InitData<MyBuilder, _> = flow.init();
+    ///
+    ///     // Firstly, sending the message
+    ///     let stream = req.connect();
+    ///     stream.send(first_message);
+    ///
+    ///     // Then handling Iroha response on it
+    ///     let response = stream.get_next();
+    ///     let flow = flow.message(response)?;
+    ///
+    ///     // And now we are able to collect events
+    ///     let mut events: Vec<Event> = Vec::with_capacity(5);
+    ///     while events.len() < 5 {
+    ///         let msg = stream.get_next();
+    ///         let EventData { reply, event } = flow.message(msg)?;
+    ///         // Do not forget to send reply back to Iroha!
+    ///         stream.send(reply);
+    ///         events.push(event);
+    ///     }
+    ///
+    ///     Ok(events)
+    /// }
+    /// ```
+    pub mod conn_flow {
+        use super::*;
+
+        /// Initial data to initialize connection and acquire handshake. Produced by implementor of [`Init`].
+        pub struct InitData<R, H>
+        where
+            R: RequestBuilder,
+            H: Handshake,
+        {
+            /// Built HTTP request to init WS connection
+            pub req: R,
+            /// Should be sent immediately after WS connection establishment
+            pub first_message: Vec<u8>,
+            /// Handler for the next flow stage - handshake
+            pub next: H,
+        }
+
+        impl<R, H> InitData<R, H>
+        where
+            R: RequestBuilder,
+            H: Handshake,
+        {
+            /// Construct new item.
+            pub fn new(req: R, first_message: Vec<u8>, next: H) -> Self {
+                Self {
+                    req,
+                    first_message,
+                    next,
+                }
+            }
+        }
+
+        /// Struct that is emitted from [`Events`] handler when message is handled.
+        pub struct EventData<T> {
+            /// Decoded event
+            pub event: T,
+            /// Reply that should be sent back to Iroha
+            pub reply: Vec<u8>,
+        }
+
+        impl<T> EventData<T> {
+            /// Construct new item.
+            pub fn new(event: T, reply: Vec<u8>) -> Self {
+                Self { event, reply }
+            }
+        }
+
+        /// Initial flow stage.
+        pub trait Init<R: RequestBuilder> {
+            /// The next handler
+            type Next: Handshake;
+
+            /// Consumes itself to produce initial data to:
+            ///
+            /// - Open WS connection;
+            /// - Send first message into it;
+            /// - Handle first message from Iroha with the next handler.
+            ///
+            /// It doesn't return a `Result` because it doesn't accept any parameters except of itself.
+            fn init(self) -> InitData<R, Self::Next>;
+        }
+
+        /// Handshake flow stage.
+        pub trait Handshake {
+            /// The next handler
+            type Next: Events;
+
+            /// Handles first messages. If it is OK, returns the next handler.
+            ///
+            /// # Errors
+            /// Implementation dependent.
+            fn message(self, message: Vec<u8>) -> Result<Self::Next>;
+        }
+
+        /// Events flow stage.
+        pub trait Events {
+            /// Something yielded by the handler
+            type Event;
+
+            /// Handles forthcoming Iroha message and returns:
+            ///
+            /// - Decoded event;
+            /// - Message to reply with.
+            ///
+            /// # Errors
+            /// Implementation dependent.
+            fn message(&self, message: Vec<u8>) -> Result<EventData<Self::Event>>;
         }
     }
-}
 
-/// Struct in the initial state of WS connection flow. 
-pub trait WebSocketFlowInit {
-    /// Some type that handles the next step of WS flow --- handshake.
-    /// This type is returned by the init function.
-    type Next: WebSocketFlowHandshake;
-
-    /// Builds data for connection initialization and returns handler for the next
-    /// step of WS flow.
+    /// Replaces `http(s)://` with `ws(s)://`
     ///
     /// # Errors
-    /// Implementation dependent.
-    fn init<B>(self) -> Result<(WebSocketInitData<B>, Self::Next)>
-    where
-        B: RequestBuilder,
-        Self: Sized;
-}
-
-/// Represents a struct in the handshake-acquiring-state of WS connection flow
-pub trait WebSocketFlowHandshake {
-    /// Some type that will handle incoming events when handshake acquiring is done.
-    type Next: WebSocketFlowEvents;
-
-    /// Handles binary WS message and returns events handler if handshake is acquired.
-    ///
-    /// # Errors
-    /// Implementation dependent.
-    fn message(self, message: Vec<u8>) -> Result<Self::Next>;
-}
-
-/// Represents a struct in the events-handling, final state of WS connection flow
-pub trait WebSocketFlowEvents {
-    /// Some event type that is yielded by the handler
-    type Event;
-
-    /// Handles binary WS message and returns reply with decoded event.
-    ///
-    /// # Errors
-    /// Implementation dependent.
-    fn message(&self, message: Vec<u8>) -> Result<WebSocketHandleEventResponse<Self::Event>>;
-}
-
-/// Represents WS event handler response.
-pub struct WebSocketHandleEventResponse<T> {
-    /// Decoded event
-    pub event: T,
-    /// Binary reply that should be sent back through the WS connection
-    pub reply: Vec<u8>,
-}
-
-impl<T> WebSocketHandleEventResponse<T> {
-    /// Constructs it with provided event and binary reply
-    #[inline]
-    pub fn new(event: T, reply: Vec<u8>) -> Self {
-        Self { event, reply }
-    }
-}
-
-/// Replaces `http(s)://` with `ws(s)://`
-///
-/// # Errors
-/// Fails if passed URI doesn't have a valid protocol
-pub fn transform_ws_url<S>(uri: S) -> Result<String>
-where
-    S: AsRef<str>,
-{
-    // Separate-compilation friendly private implementation.
-    fn _transform_ws_url(uri: &str) -> Result<String> {
+    /// Fails if passed URI doesn't have a valid protocol
+    pub fn transform_ws_url(uri: &str) -> Result<String> {
         let ws_uri = if let Some(https_uri) = uri.strip_prefix("https://") {
             "wss://".to_owned() + https_uri
         } else if let Some(http_uri) = uri.strip_prefix("http://") {
@@ -140,6 +334,4 @@ where
 
         Ok(ws_uri)
     }
-
-    _transform_ws_url(uri.as_ref())
 }

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Borrow, collections::HashMap};
 
+use eyre::{eyre, Result};
 pub use http::{Method, Response, StatusCode};
 
 /// Type alias for HTTP headers hash map
@@ -10,15 +11,13 @@ pub type Headers = HashMap<String, String>;
 /// To use custom builder with client, you need to implement this trait for some type and pass it
 /// to the client that will fill it.
 pub trait RequestBuilder {
+    type Output;
+
     /// Constructs a new builder with provided method and URL
     #[must_use]
     fn new<U>(method: Method, url: U) -> Self
     where
         U: AsRef<str>;
-
-    /// Sets request's body in bytes
-    #[must_use]
-    fn bytes(self, data: Vec<u8>) -> Self;
 
     /// Sets request's query params
     #[must_use]
@@ -32,4 +31,116 @@ pub trait RequestBuilder {
     /// Sets request's headers
     #[must_use]
     fn headers(self, headers: Headers) -> Self;
+
+    /// Sets request's body in bytes
+    fn body(self, data: Vec<u8>) -> Self::Output;
+
+    fn body_empty(self) -> Self::Output
+    where
+        Self: Sized,
+    {
+        self.body(Vec::new())
+    }
 }
+
+pub struct WebSocketInitData<B>
+where
+    B: RequestBuilder,
+{
+    pub request: B::Output,
+    pub first_message: Vec<u8>,
+}
+
+impl<B> WebSocketInitData<B>
+where
+    B: RequestBuilder,
+{
+    pub fn new(request: B::Output, first_message: Vec<u8>) -> Self {
+        Self {
+            request,
+            first_message,
+        }
+    }
+}
+
+pub trait WebSocketInit {
+    type Next;
+
+    fn init<B>(self) -> Result<(WebSocketInitData<B>, Self::Next)>
+    where
+        B: RequestBuilder,
+        Self: Sized,
+        Self::Next: WebSocketHandleHandshake;
+}
+
+pub trait WebSocketHandleHandshake {
+    type Next;
+
+    fn handle(self, message: Vec<u8>) -> Result<Self::Next>
+    where
+        Self::Next: WebSocketHandleEvent;
+}
+
+pub trait WebSocketHandleEvent {
+    type Event;
+
+    fn handle(&self, message: Vec<u8>) -> Result<WebSocketHandleEventResponse<Self::Event>>;
+}
+
+pub struct WebSocketHandleEventResponse<T> {
+    pub event: Option<T>,
+    pub reply: Option<Vec<u8>>,
+}
+
+impl<T> WebSocketHandleEventResponse<T> {
+    pub fn empty() -> Self {
+        Self {
+            event: None,
+            reply: None,
+        }
+    }
+
+    pub fn new() -> Self {
+        Self::empty()
+    }
+
+    pub fn reply(self, payload: Vec<u8>) -> Self {
+        Self {
+            reply: Some(payload),
+            ..self
+        }
+    }
+
+    pub fn event(self, event: T) -> Self {
+        Self {
+            event: Some(event),
+            ..self
+        }
+    }
+}
+
+pub fn transform_ws_url<S>(uri: S) -> Result<String>
+where
+    S: AsRef<str>,
+{
+    let ws_uri = if let Some(https_uri) = uri.as_ref().strip_prefix("https://") {
+        "wss://".to_owned() + https_uri
+    } else if let Some(http_uri) = uri.as_ref().strip_prefix("http://") {
+        "ws://".to_owned() + http_uri
+    } else {
+        return Err(eyre!("No schema in web socket uri provided"));
+    };
+
+    Ok(ws_uri)
+}
+
+// trait WebSocketHandlerThen {
+//     fn test() -> Self;
+// }
+
+// enum IrohaWebSocketHandlerResponse<T>
+// where
+//     T: Sized,
+// {
+//     Reply { message: Vec<u8>, decoded: T },
+// }

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -11,7 +11,7 @@ pub type Headers = HashMap<String, String>;
 /// To use custom builder with client, you need to implement this trait for some type and pass it
 /// to the client that will fill it.
 pub trait RequestBuilder {
-    /// Builder output. It is returned by [`RequestBuilder::body()`] function.
+    /// Builder output, returned by [`RequestBuilder::body()`].
     type Output;
 
     /// Constructs a new builder with provided method and URL
@@ -33,7 +33,7 @@ pub trait RequestBuilder {
     #[must_use]
     fn headers(self, headers: Headers) -> Self;
 
-    /// Sets request's body in bytes and transforms the builder to its output
+    /// Set request's body in bytes and `build()` the output
     #[must_use]
     fn body(self, data: Option<Vec<u8>>) -> Self::Output;
 }
@@ -63,9 +63,9 @@ where
     }
 }
 
-/// Represents a struct in the initial state of WS connection flow
+/// Struct in the initial state of WS connection flow. 
 pub trait WebSocketFlowInit {
-    /// Some type that handles the next step of WS flow - handshake acquiring.
+    /// Some type that handles the next step of WS flow --- handshake.
     /// This type is returned by the init function.
     type Next: WebSocketFlowHandshake;
 
@@ -135,7 +135,7 @@ where
         } else if let Some(http_uri) = uri.strip_prefix("http://") {
             "ws://".to_owned() + http_uri
         } else {
-            return Err(eyre!("No schema in web socket uri provided"));
+            return Err(eyre!("No schema in web socket uri provided. {}", uri));
         };
 
         Ok(ws_uri)

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -9,7 +9,7 @@ pub use http::{Method, Response, StatusCode};
 /// to the client that will fill it with data.
 ///
 /// The order of builder methods invocation is not strict. There is no guarantee that builder user calls
-/// all methods. Only [`RequestBuilder::new()`] is required one.
+/// all methods. Only [`RequestBuilder::new()`] is the required one.
 pub trait RequestBuilder {
     /// Entrypoint - create a new builder with specified method and URL.
     #[must_use]

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -34,6 +34,7 @@ pub trait RequestBuilder {
     fn headers(self, headers: Headers) -> Self;
 
     /// Sets request's body in bytes and transforms the builder to its output
+    #[must_use]
     fn body(self, data: Option<Vec<u8>>) -> Self::Output;
 }
 
@@ -53,6 +54,7 @@ where
     B: RequestBuilder,
 {
     /// Creates struct with provided request and first message
+    #[inline]
     pub fn new(request: B::Output, first_message: Vec<u8>) -> Self {
         Self {
             request,
@@ -112,6 +114,7 @@ pub struct WebSocketHandleEventResponse<T> {
 
 impl<T> WebSocketHandleEventResponse<T> {
     /// Constructs it with provided event and binary reply
+    #[inline]
     pub fn new(event: T, reply: Vec<u8>) -> Self {
         Self { event, reply }
     }
@@ -125,9 +128,14 @@ pub fn transform_ws_url<S>(uri: S) -> Result<String>
 where
     S: AsRef<str>,
 {
-    let ws_uri = if let Some(https_uri) = uri.as_ref().strip_prefix("https://") {
+    _transform_ws_url(uri.as_ref())
+}
+
+// Separate-compilation friendly private implementation.
+fn _transform_ws_url(uri: &str) -> Result<String> {
+    let ws_uri = if let Some(https_uri) = uri.strip_prefix("https://") {
         "wss://".to_owned() + https_uri
-    } else if let Some(http_uri) = uri.as_ref().strip_prefix("http://") {
+    } else if let Some(http_uri) = uri.strip_prefix("http://") {
         "ws://".to_owned() + http_uri
     } else {
         return Err(eyre!("No schema in web socket uri provided"));

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -11,6 +11,7 @@ pub type Headers = HashMap<String, String>;
 /// To use custom builder with client, you need to implement this trait for some type and pass it
 /// to the client that will fill it.
 pub trait RequestBuilder {
+    /// Builder output. It is returned by [`RequestBuilder::body()`] function.
     type Output;
 
     /// Constructs a new builder with provided method and URL
@@ -36,7 +37,7 @@ pub trait RequestBuilder {
     fn body(self, data: Option<Vec<u8>>) -> Self::Output;
 }
 
-/// Represents data required to initialize any WebSocket connection with Iroha
+/// Represents data required to initialize any `WebSocket` connection with Iroha
 pub struct WebSocketInitData<B>
 where
     B: RequestBuilder,

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, net::TcpStream};
+use std::{net::TcpStream, str::FromStr};
 
 use attohttpc::{
     body as atto_body, RequestBuilder as AttoHttpRequestBuilder, Response as AttoHttpResponse,
@@ -8,67 +8,50 @@ use http::header::HeaderName;
 use tungstenite::{stream::MaybeTlsStream, WebSocket};
 pub use tungstenite::{Error as WebSocketError, Message as WebSocketMessage};
 
-use crate::http::{Headers, Method, RequestBuilder, Response};
+use crate::http::{Method, RequestBuilder, Response};
 
 type Bytes = Vec<u8>;
 type AttoHttpRequestBuilderWithBytes = AttoHttpRequestBuilder<atto_body::Bytes<Bytes>>;
 
-trait SetSingleHeader {
-    fn header(self, key: HeaderName, value: String) -> Self;
+fn header_name_from_str(str: &str) -> Result<HeaderName> {
+    HeaderName::from_str(str).wrap_err_with(|| format!("Failed to parse header name {}", str))
 }
 
-impl SetSingleHeader for AttoHttpRequestBuilder {
-    #[allow(clippy::only_used_in_recursion)] // False-positive
-    fn header(self, key: HeaderName, value: String) -> Self {
-        self.header(key, value)
-    }
+/// Default request builder implemented on top of `attohttpc` crate.
+pub struct DefaultRequestBuilder {
+    inner: Result<AttoHttpRequestBuilder>,
+    body: Option<Vec<u8>>,
 }
-
-impl SetSingleHeader for http::request::Builder {
-    fn header(self, key: HeaderName, value: String) -> Self {
-        self.header(key, value)
-    }
-}
-
-trait SetHeadersExt: Sized + SetSingleHeader {
-    fn set_headers(mut self, headers: Headers) -> Result<Self> {
-        for (h, v) in headers {
-            let h = HeaderName::from_bytes(h.as_ref())
-                .wrap_err_with(|| format!("Failed to parse header name {}", h))?;
-            self = self.header(h, v);
-        }
-        Ok(self)
-    }
-}
-
-impl SetHeadersExt for AttoHttpRequestBuilder {}
-
-impl SetHeadersExt for http::request::Builder {}
-
-/// Default request builder & sender implemented on top of `attohttpc` crate.
-///
-/// Its main goal is not to be efficient, but simple. Its implementation contains
-/// some intermediate allocations that could be avoided with additional complexity.
-pub struct DefaultRequestBuilder(Result<AttoHttpRequestBuilder>);
 
 impl DefaultRequestBuilder {
+    /// Applies `.and_then()` semantics to the inner `Result` with underlying request builder.
     fn and_then<F>(self, fun: F) -> Self
     where
         F: FnOnce(AttoHttpRequestBuilder) -> Result<AttoHttpRequestBuilder>,
     {
-        Self(self.0.and_then(fun))
+        Self {
+            inner: self.inner.and_then(fun),
+            ..self
+        }
+    }
+
+    /// Consumes itself to build request.
+    pub fn build(self) -> Result<DefaultRequest> {
+        self.inner.map(|b| {
+            let body = match self.body {
+                Some(vec) => vec,
+                None => Vec::new(),
+            };
+            DefaultRequest(b.bytes(body))
+        })
     }
 }
 
+/// Request built by [`DefaultRequestBuilder`].
 pub struct DefaultRequest(AttoHttpRequestBuilderWithBytes);
 
 impl DefaultRequest {
-    /// Private
-    fn new(builder: AttoHttpRequestBuilderWithBytes) -> Self {
-        Self(builder)
-    }
-
-    /// Sends prepared request and returns bytes response
+    /// Sends itself and returns byte response
     ///
     /// # Errors
     /// Fails if request building and sending fails or response transformation fails
@@ -88,56 +71,64 @@ impl DefaultRequest {
 }
 
 impl RequestBuilder for DefaultRequestBuilder {
-    type Output = Result<DefaultRequest>;
-
-    fn new<U>(method: Method, url: U) -> Self
-    where
-        U: AsRef<str>,
-    {
-        Self(Ok(AttoHttpRequestBuilder::new(method, url)))
+    fn new(method: Method, url: impl AsRef<str>) -> Self {
+        Self {
+            inner: Ok(AttoHttpRequestBuilder::new(method, url)),
+            body: None,
+        }
     }
 
-    fn headers(self, headers: Headers) -> Self {
-        self.and_then(|b| b.set_headers(headers))
-    }
-
-    fn params<P, K, V>(self, params: P) -> Self
+    fn header<K, V>(self, key: K, value: V) -> Self
     where
-        P: IntoIterator,
-        P::Item: Borrow<(K, V)>,
         K: AsRef<str>,
         V: ToString,
     {
-        self.and_then(|b| Ok(b.params(params)))
+        self.and_then(|builder| {
+            Ok(builder.header(header_name_from_str(key.as_ref())?, value.to_string()))
+        })
     }
 
-    fn body(self, data: Option<Vec<u8>>) -> Self::Output {
-        self.0.map(|b| {
-            DefaultRequest::new(b.bytes(match data {
-                Some(bytes) => bytes,
-                None => Vec::new(),
-            }))
-        })
+    fn param<K, V>(self, key: K, value: V) -> Self
+    where
+        K: AsRef<str>,
+        V: ToString,
+    {
+        self.and_then(|b| Ok(b.param(key, value)))
+    }
+
+    fn body(self, data: Vec<u8>) -> Self {
+        Self {
+            body: Some(data),
+            ..self
+        }
     }
 }
 
-/// Special builder for WS connections
+/// Request builder built on top of [`http::request::Builder`]. Used for `WebSocket` connections.
 pub struct DefaultWebSocketRequestBuilder(Result<http::request::Builder>);
 
 impl DefaultWebSocketRequestBuilder {
+    /// Same as [`DefaultRequestBuilder::and_then()`].
     fn and_then<F>(self, func: F) -> Self
     where
         F: FnOnce(http::request::Builder) -> Result<http::request::Builder>,
     {
         Self(self.0.and_then(func))
     }
+
+    /// Consumes itself to build request.
+    pub fn build(self) -> Result<DefaultWebSocketStreamRequest> {
+        self.0
+            .and_then(|b| b.body(()).map_err(Into::into))
+            .map(DefaultWebSocketStreamRequest)
+    }
 }
 
-/// Successfully built WS request
+/// `WebSocket` request built by [`DefaultWebSocketRequestBuilder`]
 pub struct DefaultWebSocketStreamRequest(http::Request<()>);
 
 impl DefaultWebSocketStreamRequest {
-    /// Opens WS stream using `tungstenite`
+    /// Opens WS stream using [`tungstenite`] crate
     pub fn connect(self) -> Result<WebSocketStream> {
         let (stream, _) = tungstenite::connect(self.0)?;
         Ok(stream)
@@ -145,39 +136,32 @@ impl DefaultWebSocketStreamRequest {
 }
 
 impl RequestBuilder for DefaultWebSocketRequestBuilder {
-    type Output = Result<DefaultWebSocketStreamRequest>;
-
-    fn new<U>(method: Method, url: U) -> Self
-    where
-        U: AsRef<str>,
-    {
+    fn new(method: Method, url: impl AsRef<str>) -> Self {
         Self(Ok(http::Request::builder()
             .method(method)
             .uri(url.as_ref())))
     }
 
-    fn params<P, K, V>(self, _params: P) -> Self
-    where
-        P: IntoIterator,
-        P::Item: Borrow<(K, V)>,
-        K: AsRef<str>,
-        V: ToString,
-    {
+    fn param<K, V>(self, _key: K, _val: V) -> Self {
         Self(self.0.and(Err(eyre!("No params expected"))))
     }
 
-    fn headers(self, headers: Headers) -> Self {
-        self.and_then(|b| b.set_headers(headers))
+    fn header<N, V>(self, name: N, value: V) -> Self
+    where
+        N: AsRef<str>,
+        V: ToString,
+    {
+        self.and_then(|b| Ok(b.header(header_name_from_str(name.as_ref())?, value.to_string())))
     }
 
-    fn body(self, data: Option<Vec<u8>>) -> Self::Output {
-        match data {
-            Some(body) => Err(eyre!("Empty body expected, got: {:?}", body)),
-            None => self
-                .0
-                .and_then(|b| b.body(()).map_err(Into::into))
-                .map(DefaultWebSocketStreamRequest),
-        }
+    fn body(self, data: Vec<u8>) -> Self {
+        self.and_then(|b| {
+            if data.is_empty() {
+                Ok(b)
+            } else {
+                Err(eyre!("Empty body expected, got: {:?}", data))
+            }
+        })
     }
 }
 

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -52,11 +52,11 @@ impl SetHeadersExt for http::request::Builder {}
 pub struct DefaultRequestBuilder(Result<AttoHttpRequestBuilder>);
 
 impl DefaultRequestBuilder {
-    fn and_then<F>(self, func: F) -> Self
+    fn and_then<F>(self, fun: F) -> Self
     where
         F: FnOnce(AttoHttpRequestBuilder) -> Result<AttoHttpRequestBuilder>,
     {
-        Self(self.0.and_then(func))
+        Self(self.0.and_then(fun))
     }
 }
 

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -112,11 +112,17 @@ impl RequestBuilder for DefaultRequestBuilder {
         self.and_then(|b| Ok(b.params(params)))
     }
 
-    fn body(self, data: Vec<u8>) -> Self::Output {
-        self.0.map(|b| DefaultRequest::new(b.bytes(data)))
+    fn body(self, data: Option<Vec<u8>>) -> Self::Output {
+        self.0.map(|b| {
+            DefaultRequest::new(b.bytes(match data {
+                Some(bytes) => bytes,
+                None => Vec::new(),
+            }))
+        })
     }
 }
 
+/// Special builder for WS connections
 pub struct DefaultWebSocketRequestBuilder(Result<http::request::Builder>);
 
 impl DefaultWebSocketRequestBuilder {
@@ -128,9 +134,11 @@ impl DefaultWebSocketRequestBuilder {
     }
 }
 
+/// Successfully built WS request
 pub struct DefaultWebSocketStreamRequest(http::Request<()>);
 
 impl DefaultWebSocketStreamRequest {
+    /// Opens WS stream using `tungstenite`
     pub fn connect(self) -> Result<WebSocketStream> {
         let (stream, _) = tungstenite::connect(self.0)?;
         Ok(stream)
@@ -156,19 +164,24 @@ impl RequestBuilder for DefaultWebSocketRequestBuilder {
         K: AsRef<str>,
         V: ToString,
     {
-        // ignoring params
-        self
+        Self(self.0.and(Err(eyre!("No params expected"))))
     }
 
     fn headers(self, headers: Headers) -> Self {
         self.and_then(|b| b.set_headers(headers))
     }
 
-    fn body(self, _data: Vec<u8>) -> Self::Output {
-        // ignoring passed data
-        self.0
-            .and_then(|b| b.body(()).map_err(|e| e.into()))
-            .map(|req| DefaultWebSocketStreamRequest(req))
+    fn body(self, data: Option<Vec<u8>>) -> Self::Output {
+        match data {
+            Some(body) => Err(eyre!("Empty body expected, got: {:?}", body)),
+            None => self
+                .0
+                .and_then(|b| {
+                    let req = b.body(()).map_err(|e| e.into());
+                    req
+                })
+                .map(|req| DefaultWebSocketStreamRequest(req)),
+        }
     }
 }
 

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -108,7 +108,7 @@ impl RequestBuilder for DefaultRequestBuilder {
 pub struct DefaultWebSocketRequestBuilder(Result<http::request::Builder>);
 
 impl DefaultWebSocketRequestBuilder {
-    /// Same as [`DefaultRequestBuilder::and_then()`].
+    /// Same as [`DefaultRequestBuilder::and_then`].
     fn and_then<F>(self, func: F) -> Self
     where
         F: FnOnce(http::request::Builder) -> Result<http::request::Builder>,

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -63,12 +63,11 @@ impl DefaultRequestBuilder {
 pub struct DefaultRequest(AttoHttpRequestBuilderWithBytes);
 
 impl DefaultRequest {
+    /// Private
     fn new(builder: AttoHttpRequestBuilderWithBytes) -> Self {
         Self(builder)
     }
-}
 
-impl DefaultRequest {
     /// Sends prepared request and returns bytes response
     ///
     /// # Errors
@@ -176,11 +175,8 @@ impl RequestBuilder for DefaultWebSocketRequestBuilder {
             Some(body) => Err(eyre!("Empty body expected, got: {:?}", body)),
             None => self
                 .0
-                .and_then(|b| {
-                    let req = b.body(()).map_err(|e| e.into());
-                    req
-                })
-                .map(|req| DefaultWebSocketStreamRequest(req)),
+                .and_then(|b| b.body(()).map_err(Into::into))
+                .map(DefaultWebSocketStreamRequest),
         }
     }
 }

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -17,7 +17,7 @@ trait SetSingleHeader {
     fn header(self, key: HeaderName, value: String) -> Self;
 }
 
-impl SetSingleHeader for AttoHttpRequestBuilderWithBytes {
+impl SetSingleHeader for AttoHttpRequestBuilder {
     #[allow(clippy::only_used_in_recursion)] // False-positive
     fn header(self, key: HeaderName, value: String) -> Self {
         self.header(key, value)
@@ -41,7 +41,7 @@ trait SetHeadersExt: Sized + SetSingleHeader {
     }
 }
 
-impl SetHeadersExt for AttoHttpRequestBuilderWithBytes {}
+impl SetHeadersExt for AttoHttpRequestBuilder {}
 
 impl SetHeadersExt for http::request::Builder {}
 
@@ -49,82 +49,57 @@ impl SetHeadersExt for http::request::Builder {}
 ///
 /// Its main goal is not to be efficient, but simple. Its implementation contains
 /// some intermediate allocations that could be avoided with additional complexity.
-pub struct DefaultRequestBuilder {
-    method: Method,
-    url: String,
-    params: Option<Vec<(String, String)>>,
-    headers: Option<Headers>,
-    body: Option<Bytes>,
-}
+pub struct DefaultRequestBuilder(Result<AttoHttpRequestBuilder>);
 
 impl DefaultRequestBuilder {
+    fn and_then<F>(self, func: F) -> Self
+    where
+        F: FnOnce(AttoHttpRequestBuilder) -> Result<AttoHttpRequestBuilder>,
+    {
+        Self(self.0.and_then(func))
+    }
+}
+
+pub struct DefaultRequest(AttoHttpRequestBuilderWithBytes);
+
+impl DefaultRequest {
+    fn new(builder: AttoHttpRequestBuilderWithBytes) -> Self {
+        Self(builder)
+    }
+}
+
+impl DefaultRequest {
     /// Sends prepared request and returns bytes response
     ///
     /// # Errors
     /// Fails if request building and sending fails or response transformation fails
-    pub fn send(self) -> Result<Response<Bytes>> {
-        let Self {
-            method,
-            url,
-            body,
-            params,
-            headers,
-            ..
-        } = self;
-
-        let bytes_anyway = match body {
-            Some(bytes) => bytes,
-            None => Vec::new(),
+    pub fn send(mut self) -> Result<Response<Bytes>> {
+        let (method, url) = {
+            let inspect = self.0.inspect();
+            (inspect.method().clone(), inspect.url().clone())
         };
 
-        // for error formatting
-        let method_url_cloned = (method.clone(), url.clone());
-
-        let mut builder = AttoHttpRequestBuilder::new(method, url).bytes(bytes_anyway);
-        if let Some(params) = params {
-            builder = builder.params(params);
-        }
-        if let Some(headers) = headers {
-            builder = builder.set_headers(headers)?;
-        }
-
-        let response = builder.send().wrap_err_with(|| {
-            format!(
-                "Failed to send http {} request to {}",
-                &method_url_cloned.0, &method_url_cloned.1
-            )
-        })?;
+        let response = self
+            .0
+            .send()
+            .wrap_err_with(|| format!("Failed to send http {} request to {}", method, url))?;
 
         ClientResponse(response).try_into()
     }
 }
 
 impl RequestBuilder for DefaultRequestBuilder {
+    type Output = Result<DefaultRequest>;
+
     fn new<U>(method: Method, url: U) -> Self
     where
         U: AsRef<str>,
     {
-        Self {
-            method,
-            url: url.as_ref().to_owned(),
-            headers: None,
-            params: None,
-            body: None,
-        }
-    }
-
-    fn bytes(self, data: Vec<u8>) -> Self {
-        Self {
-            body: Some(data),
-            ..self
-        }
+        Self(Ok(AttoHttpRequestBuilder::new(method, url)))
     }
 
     fn headers(self, headers: Headers) -> Self {
-        Self {
-            headers: Some(headers),
-            ..self
-        }
+        self.and_then(|b| b.set_headers(headers))
     }
 
     fn params<P, K, V>(self, params: P) -> Self
@@ -134,45 +109,70 @@ impl RequestBuilder for DefaultRequestBuilder {
         K: AsRef<str>,
         V: ToString,
     {
-        Self {
-            params: Some(
-                params
-                    .into_iter()
-                    .map(|pair| {
-                        let (k, v) = pair.borrow();
-                        (k.as_ref().to_owned(), v.to_string())
-                    })
-                    .collect(),
-            ),
-            ..self
-        }
+        self.and_then(|b| Ok(b.params(params)))
+    }
+
+    fn body(self, data: Vec<u8>) -> Self::Output {
+        self.0.map(|b| DefaultRequest::new(b.bytes(data)))
+    }
+}
+
+pub struct DefaultWebSocketRequestBuilder(Result<http::request::Builder>);
+
+impl DefaultWebSocketRequestBuilder {
+    fn and_then<F>(self, func: F) -> Self
+    where
+        F: FnOnce(http::request::Builder) -> Result<http::request::Builder>,
+    {
+        Self(self.0.and_then(func))
+    }
+}
+
+pub struct DefaultWebSocketStreamRequest(http::Request<()>);
+
+impl DefaultWebSocketStreamRequest {
+    pub fn connect(self) -> Result<WebSocketStream> {
+        let (stream, _) = tungstenite::connect(self.0)?;
+        Ok(stream)
+    }
+}
+
+impl RequestBuilder for DefaultWebSocketRequestBuilder {
+    type Output = Result<DefaultWebSocketStreamRequest>;
+
+    fn new<U>(method: Method, url: U) -> Self
+    where
+        U: AsRef<str>,
+    {
+        Self(Ok(http::Request::builder()
+            .method(method)
+            .uri(url.as_ref())))
+    }
+
+    fn params<P, K, V>(self, _params: P) -> Self
+    where
+        P: IntoIterator,
+        P::Item: Borrow<(K, V)>,
+        K: AsRef<str>,
+        V: ToString,
+    {
+        // ignoring params
+        self
+    }
+
+    fn headers(self, headers: Headers) -> Self {
+        self.and_then(|b| b.set_headers(headers))
+    }
+
+    fn body(self, _data: Vec<u8>) -> Self::Output {
+        // ignoring passed data
+        self.0
+            .and_then(|b| b.body(()).map_err(|e| e.into()))
+            .map(|req| DefaultWebSocketStreamRequest(req))
     }
 }
 
 pub type WebSocketStream = WebSocket<MaybeTlsStream<TcpStream>>;
-
-pub fn web_socket_connect<U>(uri: U, headers: Headers) -> Result<WebSocketStream>
-where
-    U: AsRef<str>,
-{
-    let ws_uri = if let Some(https_uri) = uri.as_ref().strip_prefix("https://") {
-        "wss://".to_owned() + https_uri
-    } else if let Some(http_uri) = uri.as_ref().strip_prefix("http://") {
-        "ws://".to_owned() + http_uri
-    } else {
-        return Err(eyre!("No schema in web socket uri provided"));
-    };
-
-    let req = http::Request::builder()
-        .uri(ws_uri)
-        .set_headers(headers)
-        .wrap_err("Failed to build web socket request")?
-        .body(())
-        .wrap_err("Failed to build web socket request")?;
-
-    let (stream, _) = tungstenite::connect(req)?;
-    Ok(stream)
-}
 
 struct ClientResponse(AttoHttpResponse);
 

--- a/client/tests/integration/add_account.rs
+++ b/client/tests/integration/add_account.rs
@@ -10,7 +10,7 @@ use test_network::{Peer as TestPeer, *};
 #[test]
 fn client_add_account_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let pipeline_time = super::Configuration::pipeline_time();

--- a/client/tests/integration/add_asset.rs
+++ b/client/tests/integration/add_asset.rs
@@ -127,7 +127,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
 
 #[test]
 fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     let pipeline_time = Configuration::pipeline_time();
 
     // Given

--- a/client/tests/integration/add_domain.rs
+++ b/client/tests/integration/add_domain.rs
@@ -12,7 +12,7 @@ use super::Configuration;
 #[test]
 fn client_add_domain_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -14,7 +14,7 @@ use super::Configuration;
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_another_peer(
 ) -> Result<()> {
     // Given
-    let (_rt, network, mut iroha_client) = <Network>::start_test_with_runtime(4, 1);
+    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1);
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/connected_peers.rs
+++ b/client/tests/integration/connected_peers.rs
@@ -22,7 +22,7 @@ fn connected_peers_with_f_1_0_1() {
 fn connected_peers_with_f(faults: u64) {
     let n_peers = 3 * faults + 1;
 
-    let (_rt, network, mut genesis_client) = <Network>::start_test_with_runtime(n_peers as u32, 1);
+    let (_rt, network, genesis_client) = <Network>::start_test_with_runtime(n_peers as u32, 1);
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/events/data.rs
+++ b/client/tests/integration/events/data.rs
@@ -100,7 +100,7 @@ fn transaction_execution_should_produce_events(executable: Executable) -> Result
     let pipeline_time = Configuration::pipeline_time();
 
     // spawn event reporter
-    let mut listener = client.clone();
+    let listener = client.clone();
     let (init_sender, init_receiver) = mpsc::channel();
     let (event_sender, event_receiver) = mpsc::channel();
     let event_filter = DataEventFilter::AcceptAll.into();

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -60,7 +60,7 @@ struct Checker {
 }
 
 impl Checker {
-    fn spawn(mut self, status_kind: PipelineStatusKind) -> JoinHandle<()> {
+    fn spawn(self, status_kind: PipelineStatusKind) -> JoinHandle<()> {
         thread::spawn(move || {
             let mut event_iterator = self
                 .listener

--- a/client/tests/integration/multiple_blocks_created.rs
+++ b/client/tests/integration/multiple_blocks_created.rs
@@ -15,7 +15,7 @@ const N_BLOCKS: usize = 510;
 #[test]
 fn long_multiple_blocks_created() {
     // Given
-    let (_rt, network, mut iroha_client) = <Network>::start_test_with_runtime(4, 1);
+    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1);
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/multisignature_account.rs
+++ b/client/tests/integration/multisignature_account.rs
@@ -12,7 +12,7 @@ use super::Configuration;
 
 #[test]
 fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
-    let (_rt, peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, peer, iroha_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -48,8 +48,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
         &network.genesis.api_address,
         &network.genesis.telemetry_address,
     );
-    let mut iroha_client =
-        Client::new(&client_configuration).expect("Invalid client configuration");
+    let iroha_client = Client::new(&client_configuration).expect("Invalid client configuration");
     iroha_client
         .submit_all(vec![
             create_domain.into(),

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -10,7 +10,7 @@ use super::Configuration;
 
 #[test]
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() {
-    let (_rt, _peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -151,7 +151,7 @@ fn permissions_disallow_asset_burn() {
 #[test]
 fn account_can_query_only_its_own_domain() {
     let rt = Runtime::test();
-    let (_not_drop, mut iroha_client) = rt.block_on(<TestPeer>::start_test_with_permissions(
+    let (_not_drop, iroha_client) = rt.block_on(<TestPeer>::start_test_with_permissions(
         AllowAll.into(),
         private_blockchain::query::OnlyAccountsDomain.into(),
     ));
@@ -186,7 +186,7 @@ fn account_can_query_only_its_own_domain() {
 // a potential security liability that gives an attacker a backdoor for gaining root access
 fn permissions_checked_before_transaction_execution() {
     let rt = Runtime::test();
-    let (_not_drop, mut iroha_client) = rt.block_on(<TestPeer>::start_test_with_permissions(
+    let (_not_drop, iroha_client) = rt.block_on(<TestPeer>::start_test_with_permissions(
         // New domain registration is the only permitted instruction
         private_blockchain::register::GrantedAllowedRegisterDomains.into(),
         DenyAll.into(),

--- a/client/tests/integration/queries/account.rs
+++ b/client/tests/integration/queries/account.rs
@@ -9,7 +9,7 @@ use test_network::{Peer as TestPeer, *};
 
 #[test]
 fn find_accounts_with_asset() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Registering new asset definition

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -99,7 +99,7 @@ fn get_asset_value(client: &mut Client, asset_id: AssetId) -> Result<u32> {
 
 #[test]
 fn register_empty_role() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id = iroha_data_model::role::Id::new("root".parse::<Name>().expect("Valid"));
@@ -111,7 +111,7 @@ fn register_empty_role() -> Result<()> {
 
 #[test]
 fn register_role_with_empty_token_params() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id = iroha_data_model::role::Id::new("root".parse::<Name>().expect("Valid"));
@@ -133,7 +133,7 @@ fn register_role_with_empty_token_params() -> Result<()> {
 /// SDK, I'll update both tests to actually verify functionality.
 #[test]
 fn register_metadata_role() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let bob_id = <Account as Identifiable>::Id::from_str("bob@wonderland")?;

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -35,7 +35,7 @@ fn call_execute_trigger() -> Result<()> {
 
 #[test]
 fn execute_trigger_should_produce_event() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -49,7 +49,7 @@ fn execute_trigger_should_produce_event() -> Result<()> {
     let trigger_id = TriggerId::new(TRIGGER_NAME.parse()?);
     let call_trigger = ExecuteTriggerBox::new(trigger_id.clone());
 
-    let mut thread_client = test_client.clone();
+    let thread_client = test_client.clone();
     let (sender, receiver) = mpsc::channel();
     let _handle = thread::spawn(move || -> Result<()> {
         let mut event_it = thread_client

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -10,7 +10,7 @@ use super::Configuration;
 
 #[test]
 fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
-    let (_rt, _peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -10,7 +10,7 @@ use super::Configuration;
 
 #[test]
 fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes() {
-    let (_rt, _peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/integration/unregister_peer.rs
+++ b/client/tests/integration/unregister_peer.rs
@@ -97,7 +97,7 @@ fn init() -> Result<(
     AccountId,
     AssetDefinitionId,
 )> {
-    let (rt, network, mut client) = <Network>::start_test_with_runtime(4, 1);
+    let (rt, network, client) = <Network>::start_test_with_runtime(4, 1);
     let pipeline_time = Configuration::pipeline_time();
     thread::sleep(pipeline_time * 2);
     iroha_logger::info!("Started");

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -208,7 +208,7 @@ mod events {
     }
 
     pub fn listen(filter: EventFilter, cfg: &Configuration) -> Result<()> {
-        let mut iroha_client = Client::new(cfg)?;
+        let iroha_client = Client::new(cfg)?;
         println!("Listening to events with filter: {:?}", filter);
         for event in iroha_client
             .listen_for_events(filter)

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -264,7 +264,7 @@ where
     /// Adds peer to network and waits for it to start block
     /// synchronization.
     pub async fn add_peer(&self) -> (Peer, Client) {
-        let mut client = Client::test(&self.genesis.api_address, &self.genesis.telemetry_address);
+        let client = Client::test(&self.genesis.api_address, &self.genesis.telemetry_address);
         let mut peer = Peer::new().expect("Failed to create new peer");
         let mut config = Configuration::test();
         config.sumeragi.trusted_peers.peers = self.peers().map(|peer| &peer.id).cloned().collect();
@@ -830,7 +830,7 @@ impl TestClient for Client {
         Client::new(&configuration).expect("Invalid client configuration")
     }
 
-    fn for_each_event(mut self, event_filter: EventFilter, f: impl Fn(Result<Event>)) {
+    fn for_each_event(self, event_filter: EventFilter, f: impl Fn(Result<Event>)) {
         for event_result in self
             .listen_for_events(event_filter)
             .expect("Failed to create event iterator.")

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -180,8 +180,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
 
     client_configuration.torii_api_url =
         SmallStr::from_string("http://".to_owned() + &peer.api_address);
-    let mut iroha_client =
-        Client::new(&client_configuration).expect("Invalid client configuration");
+    let iroha_client = Client::new(&client_configuration).expect("Invalid client configuration");
     iroha_client
         .submit_all(vec![
             register::domain("exchange").into(),


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

The idea is the same as in #2147, but now it is about WebSocket side.

Iroha Events API and Blocks Stream API are built on top of the same WebSocket flow:

1. Open a WS connection
2. Client sends some "subscription" message
3. Server responses with some "accepted" message
4. Client waiting for some events and responses to them with some "accepted" message, not same as for p.3

In this PR I've normalized this flow with a few traits. They are binded to each. Their relationship aims to provide API that targets these goals:

- don't have `dyn`s, but clear abstraction
- prevent "invariant violation" by scoping flow stages in separate traits
- be functional and data-oriented

Also, I've refactored `trait RequestBuilder`. Now it forces to call `.body()` fn anyway to get the output of the builder. It is how `RequestBuilder` from `http` crate works. With this design, its impls became clearer.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

Resolves #2145 

### Benefits

<!-- What benefits will be realized by the code change? -->

With this change, it is possible to use Events API with any WebSocket client, async or not.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

I don't like naming of `WebSocketFlowXXX` traits.

### Usage Examples or Tests

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

See how now Events API is implemented. Note that all data-related logic is incapsulated within flow-structs, and all transportation logic is moved away from it.

<!-- ### Alternate Designs *[optional]* -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
