### PR TITLE
[ci] #2153: Fix #2154

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -59,6 +59,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
+
+      # TODO Remove this step #2165
+      - name: Add component
+        run: rustup component add llvm-tools-preview
+
       - name: Run tests
         run: |
           mold --run cargo test \

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -57,13 +57,12 @@ jobs:
     container:
       image: 7272721/i2-ci:latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
-
       # TODO Remove this step #2165
       - name: Add component
         run: rustup component add llvm-tools-preview
 
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           mold --run cargo test \

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -185,6 +185,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
+
+      # TODO Remove this step #2165
+      - name: Add component
+        run: rustup component add llvm-tools-preview
+
       - name: Run tests
         run: |
           mold --run cargo test \

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -183,13 +183,12 @@ jobs:
     container:
       image: 7272721/i2-ci:latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
-
       # TODO Remove this step #2165
       - name: Add component
         run: rustup component add llvm-tools-preview
 
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           mold --run cargo test \

--- a/.github/workflows/iroha2.yml
+++ b/.github/workflows/iroha2.yml
@@ -13,13 +13,12 @@ jobs:
     container:
       image: 7272721/i2-ci:latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
-
       # TODO Remove this step #2165
       - name: Add component
         run: rustup component add llvm-tools-preview
 
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           mold --run cargo test \

--- a/.github/workflows/iroha2.yml
+++ b/.github/workflows/iroha2.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
+
+      # TODO Remove this step #2165
+      - name: Add component
+        run: rustup component add llvm-tools-preview
+
       - name: Run tests
         run: |
           mold --run cargo test \


### PR DESCRIPTION
### Description of the Change
- Add a step to add `llvm-tools-preview` component

### Issue
- Closes #2153
- Opens #2165

### Benefits
- Enables the coverage by fixing [the error](https://github.com/hyperledger/iroha/runs/6213237858?check_suite_focus=true#step:6:8) that #2154 did not resolve

### Possible Drawbacks
- CI cost by the duplicated step which [should have been done in the container](https://github.com/hyperledger/iroha/blob/7e338a5c762f7e0e25b79937e6215c10ae53b290/Dockerfile.ci#L51), which could be cut off