### PR TITLE
[feature] #2004: Forbid `isize` and `usize` from becoming `IntoSchema`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc2ceeb474920e0d451e95df08409ac01a207851b564ba9dafcdb07a34fa6de"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,7 +1992,9 @@ name = "iroha_schema"
 version = "2.0.0-pre-rc.4"
 dependencies = [
  "fixnum",
+ "impls",
  "iroha_schema_derive",
+ "iroha_schema_gen",
  "parity-scale-codec",
  "serde",
 ]

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -12,3 +12,6 @@ fixnum = { version = "0.6.1", default-features = false, features = ["i64"] }
 
 [dev-dependencies]
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive", "full"] }
+impls = { version = "=1.0.0" }
+
+iroha_schema_gen = { version = "=2.0.0-pre-rc.4", path = "gen" }

--- a/schema/tests/architecture-dependent.rs
+++ b/schema/tests/architecture-dependent.rs
@@ -1,0 +1,24 @@
+use impls::impls;
+use iroha_schema::IntoSchema;
+use parity_scale_codec::{Decode, Encode};
+
+#[test]
+fn usize_isize_not_into_schema() {
+    // The architecture-dependent
+    assert!(!impls!(usize: IntoSchema));
+    assert!(!impls!(isize: IntoSchema));
+
+    // use serde::Serialize;
+    //
+    // assert!(!impls!(usize: Serialize));
+    // `usize` should be `Serialize`.
+
+    // But not `Encode`/`Decode`.
+    assert!(!impls!(usize: Encode | Decode));
+    assert!(!impls!(isize: Encode | Decode));
+
+    // There are no other primitive architecture-dependent types, so
+    // as long as `IntoSchema` requires all variants and all fields to
+    // also be `IntoSchema`, we are guaranteed that all schema types
+    // are safe to exchange.
+}


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

### Description of the Change

Add a unit test that fails when `usize`/`isize` are `Encode`/`Decode`/`IntoSchema`

### Issue

Closes #2004 

### Benefits

Impossible to add structures which utilise `usize`, `isize` inside the schema, and thus cause UB in decoding if the pointer size on the host machine is smaller than the encoded integer.

### Possible Drawbacks
None

### Usage Examples or Tests *[optional]*


```
cargo test -p iroha_schema --test architecture-dependent
```