### PR TITLE
[feature] #1883: Remove embedded configuration files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ COPY . .
 RUN cargo build $PROFILE --workspace
 
 FROM $BASE_IMAGE
-COPY configs/peer/config.json .
-COPY configs/peer/genesis.json .
+ARG CONFIG_DIR=config
+RUN mkdir -p $CONFIG_DIR
 ARG BIN=iroha
 ARG TARGET_DIR=debug
 COPY --from=builder /iroha/target/$TARGET_DIR/$BIN .
@@ -56,4 +56,6 @@ RUN apt-get update -yq; \
     apt-get install -y --no-install-recommends libssl-dev; \
     rm -rf /var/lib/apt/lists/*
 ENV IROHA_TARGET_BIN=$BIN
+ENV IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
+ENV IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
 CMD ./$IROHA_TARGET_BIN

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -18,6 +18,9 @@ services:
       - "8180:8180"
     init: true
     command: ./iroha --submit-genesis
+    volumes:
+      - ./configs/peer:/config
+
 
   iroha1:
     depends_on:
@@ -37,6 +40,9 @@ services:
       - "8081:8081"
       - "8181:8181"
     init: true
+    volumes:
+      - ./configs/peer:/config
+
 
   iroha2:
     depends_on:
@@ -56,6 +62,9 @@ services:
       - "8082:8082"
       - "8182:8182"
     init: true
+    volumes:
+      - ./configs/peer:/config
+
 
   iroha3:
     depends_on:
@@ -75,3 +84,5 @@ services:
       - "8083:8083"
       - "8183:8183"
     init: true
+    volumes:
+      - ./configs/peer:/config

--- a/docker-compose-single.yml
+++ b/docker-compose-single.yml
@@ -18,3 +18,5 @@ services:
       - "8180:8180"
     init: true
     command: ./iroha --submit-genesis
+    volumes:
+      - ./configs/peer:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - "1337:1337"
       - "8080:8080"
       - "8180:8180"
+    volumes:
+      - ./configs/peer:/config
     command: ./iroha --submit-genesis
 
   iroha1:
@@ -28,6 +30,8 @@ services:
       - "1338:1338"
       - "8081:8081"
       - "8181:8181"
+    volumes:
+      - ./configs/peer:/config
 
   iroha2:
     image: hyperledger/iroha2:dev
@@ -42,6 +46,8 @@ services:
       - "1339:1339"
       - "8082:8082"
       - "8182:8182"
+    volumes:
+      - ./configs/peer:/config
 
   iroha3:
     image: hyperledger/iroha2:dev
@@ -56,3 +62,5 @@ services:
       - "1340:1340"
       - "8083:8083"
       - "8183:8183"
+    volumes:
+      - ./configs/peer:/config


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

### Description of the Change

Removed sample configurations from the docker file. Adjusted docker compose to work from the root of the repository clone. 

### Issue

Closes #1883 

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

No problems with unspecified or incorrectly specified configuraion/genesis. 

### Possible Drawbacks

More involved process of running an iroha peer. 

### Usage Examples or Tests *[optional]*

```
docker compose up
```

Inside existing docker compose fields, please add a line with the following: 

```
volumes: 
 - <path-to-config-and-genesis>:config
```

