### PR TITLE
[feature] #2100: Add query to find all accounts with asset

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
-          mold --run cargo test \
+          mold --run cargo +nightly-2022-04-20 test \
           --quiet --workspace --no-fail-fast -- \
           --skip unstable_network --skip ui --test-threads 3
         env:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -66,11 +66,11 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
-          mold --run cargo test \
+          mold --run cargo +nightly-2022-04-20 test \
           --quiet --workspace --no-fail-fast -- \
           --skip unstable_network --skip ui --test-threads 3
         env:
-          RUSTFLAGS: "-C instrument-coverage"
+          RUSTFLAGS: "-Z instrument-coverage"
           LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate a grcov coverage report
         run: |

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_BOOTSTRAP: 1
 
 jobs:
   test:
@@ -65,7 +66,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
-          mold --run cargo +nightly-2022-04-20 test \
+          mold --run cargo test \
           --quiet --workspace --no-fail-fast -- \
           --skip unstable_network --skip ui --test-threads 3
         env:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_BOOTSTRAP: 1
 
 jobs:
   test:
@@ -70,7 +69,7 @@ jobs:
           --quiet --workspace --no-fail-fast -- \
           --skip unstable_network --skip ui --test-threads 3
         env:
-          RUSTFLAGS: "-Z instrument-coverage"
+          RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate a grcov coverage report
         run: |

--- a/client/build.rs
+++ b/client/build.rs
@@ -28,23 +28,23 @@ fn main() {
     assert!(fmt.success(), "Can't format smartcontract");
 
     let build = Command::new("cargo")
-            // Removing environment variable to avoid
-            // `error: infinite recursion detected` when running `cargo lints`
-            .env_remove("RUST_RECURSION_COUNT")
-            .env("CARGO_TARGET_DIR", out_dir)
-            .current_dir(smartcontract_path)
-            .args(&[
-                "+nightly-2022-04-20",
-                "build",
-                "--release",
-                "-Z",
-                "build-std",
-                "-Z",
-                "build-std-features=panic_immediate_abort",
-                "--target",
-                "wasm32-unknown-unknown",
-            ])
-            .status()
-            .expect("Failed to run `cargo build` on smartcontract");
+        // Removing environment variable to avoid
+        // `error: infinite recursion detected` when running `cargo lints`
+        .env_remove("RUST_RECURSION_COUNT")
+        .env("CARGO_TARGET_DIR", out_dir)
+        .current_dir(smartcontract_path)
+        .args(&[
+            "+nightly-2022-04-20",
+            "build",
+            "--release",
+            "-Z",
+            "build-std",
+            "-Z",
+            "build-std-features=panic_immediate_abort",
+            "--target",
+            "wasm32-unknown-unknown",
+        ])
+        .status()
+        .expect("Failed to run `cargo build` on smartcontract");
     assert!(build.success(), "Can't build smartcontract")
 }

--- a/client/build.rs
+++ b/client/build.rs
@@ -27,14 +27,7 @@ fn main() {
         .expect("Failed to run `rustfmt` on smartcontract");
     assert!(fmt.success(), "Can't format smartcontract");
 
-    let instrumenting_coverage = if let Ok(flags) = env::var("RUSTFLAGS") {
-        flags.contains("instrument-coverage")
-    } else {
-        false
-    };
-
-    if instrumenting_coverage {
-        let build = Command::new("cargo")
+    let build = Command::new("cargo")
             // Removing environment variable to avoid
             // `error: infinite recursion detected` when running `cargo lints`
             .env_remove("RUST_RECURSION_COUNT")
@@ -53,6 +46,5 @@ fn main() {
             ])
             .status()
             .expect("Failed to run `cargo build` on smartcontract");
-        assert!(build.success(), "Can't build smartcontract")
-    }
+    assert!(build.success(), "Can't build smartcontract")
 }

--- a/client/build.rs
+++ b/client/build.rs
@@ -27,6 +27,7 @@ fn main() {
         .expect("Failed to run `rustfmt` on smartcontract");
     assert!(fmt.success(), "Can't format smartcontract");
 
+    // TODO: Remove cargo invocation (#2152)
     let build = Command::new("cargo")
         // Removing environment variable to avoid
         // `error: infinite recursion detected` when running `cargo lints`
@@ -34,6 +35,7 @@ fn main() {
         // Removing environment variable to avoid
         // `error: `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]``
         // when running with `-C instrument-coverage`
+        // TODO: Check if there are no problems with that
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env("CARGO_TARGET_DIR", out_dir)
         .current_dir(smartcontract_path)

--- a/client/build.rs
+++ b/client/build.rs
@@ -31,6 +31,10 @@ fn main() {
         // Removing environment variable to avoid
         // `error: infinite recursion detected` when running `cargo lints`
         .env_remove("RUST_RECURSION_COUNT")
+        // Removing environment variable to avoid
+        // `error: `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]``
+        // when running with `-C instrument-coverage`
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env("CARGO_TARGET_DIR", out_dir)
         .current_dir(smartcontract_path)
         .args(&[

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -938,6 +938,13 @@ pub mod account {
     pub fn by_id(account_id: impl Into<EvaluatesTo<AccountId>>) -> FindAccountById {
         FindAccountById::new(account_id)
     }
+
+    /// Get query to get all accounts containing specified asset
+    pub fn all_with_asset(
+        asset_definition_id: impl Into<EvaluatesTo<AssetDefinitionId>>,
+    ) -> FindAccountsWithAsset {
+        FindAccountsWithAsset::new(asset_definition_id)
+    }
 }
 
 pub mod asset {

--- a/client/tests/integration/mod.rs
+++ b/client/tests/integration/mod.rs
@@ -15,6 +15,7 @@ mod non_mintable;
 mod offline_peers;
 mod pagination;
 mod permissions;
+mod queries;
 mod query_errors;
 mod restart_peer;
 mod roles;

--- a/client/tests/integration/queries/account.rs
+++ b/client/tests/integration/queries/account.rs
@@ -1,0 +1,58 @@
+#![allow(clippy::restriction)]
+
+use std::{collections::HashSet, str::FromStr as _};
+
+use eyre::Result;
+use iroha_client::client;
+use iroha_data_model::prelude::*;
+use test_network::{Peer as TestPeer, *};
+
+#[test]
+fn find_accounts_with_asset() -> Result<()> {
+    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+
+    // Registering new asset definition
+    let definition_id =
+        <AssetDefinition as Identifiable>::Id::from_str("test_coin#wonderland").expect("Valid");
+    let asset_definition = AssetDefinition::quantity(definition_id.clone()).build();
+    test_client.submit_blocking(RegisterBox::new(asset_definition))?;
+
+    let accounts: [AccountId; 5] = [
+        "alice@wonderland".parse().expect("Valid"),
+        "mad_hatter@wonderland".parse().expect("Valid"),
+        "cheshire_cat@wonderland".parse().expect("Valid"),
+        "caterpillar@wonderland".parse().expect("Valid"),
+        "white_rabbit@wonderland".parse().expect("Valid"),
+    ];
+
+    // Registering accounts
+    let register_accounts = accounts
+        .iter()
+        .skip(1) // Alice has already been registered in genesis
+        .cloned()
+        .map(|account_id| RegisterBox::new(Account::new(account_id, [])).into())
+        .collect::<Vec<_>>();
+    test_client.submit_all_blocking(register_accounts)?;
+
+    let mint_asset = accounts
+        .iter()
+        .cloned()
+        .map(|account_id| <Asset as Identifiable>::Id::new(definition_id.clone(), account_id))
+        .map(|asset_id| MintBox::new(1_u32, asset_id).into())
+        .collect::<Vec<_>>();
+    test_client.submit_all_blocking(mint_asset)?;
+
+    let accounts = HashSet::from(accounts);
+
+    // Checking results
+    let found_accounts = test_client.request(client::account::all_with_asset(definition_id))?;
+    let found_ids = found_accounts
+        .into_iter()
+        .map(|account| account.id().clone())
+        .collect::<HashSet<_>>();
+
+    assert_eq!(found_ids, accounts);
+
+    Ok(())
+}

--- a/client/tests/integration/queries/mod.rs
+++ b/client/tests/integration/queries/mod.rs
@@ -1,0 +1,1 @@
+mod account;

--- a/client/tests/integration/triggers/time_trigger.rs
+++ b/client/tests/integration/triggers/time_trigger.rs
@@ -170,7 +170,6 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
 }
 
 #[test]
-#[ignore = "flaky and unreliable. Re-enable once performance improvements are made"]
 fn mint_nft_for_every_user_every_1_sec() -> Result<()> {
     const TRIGGER_PERIOD_MS: u64 = 1000;
     const EXPECTED_COUNT: u64 = 4;

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -360,7 +360,6 @@ pub mod query {
     }
 
     impl<W: WorldTrait> ValidQuery<W> for FindAccountsWithAsset {
-        #[log]
         #[metrics(+"find_accounts_with_asset")]
         fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output, Error> {
             let asset_definition_id = self
@@ -368,6 +367,8 @@ pub mod query {
                 .evaluate(wsv, &Context::default())
                 .wrap_err("Failed to get asset id")
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
+            iroha_logger::trace!(%asset_definition_id);
+
             let domain_id = &asset_definition_id.domain_id;
 
             wsv.map_domain(domain_id, |domain| {

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -358,4 +358,28 @@ pub mod query {
             .ok_or_else(|| query::Error::Find(Box::new(FindError::MetadataKey(key))))
         }
     }
+
+    impl<W: WorldTrait> ValidQuery<W> for FindAccountsWithAsset {
+        #[log]
+        #[metrics(+"find_accounts_with_asset")]
+        fn execute(&self, wsv: &WorldStateView<W>) -> Result<Self::Output, Error> {
+            let asset_id = self
+                .asset_id
+                .evaluate(wsv, &Context::default())
+                .wrap_err("Failed to get asset id")
+                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let domain_id = &asset_id.definition_id.domain_id;
+
+            let mut found_accounts = Vec::new();
+            wsv.map_domain(domain_id, |domain| {
+                domain
+                    .accounts()
+                    .filter(|account| account.asset(&asset_id).is_some())
+                    .for_each(|account| found_accounts.push(account.clone()));
+                Ok(())
+            })?;
+
+            Ok(found_accounts)
+        }
+    }
 }

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -103,6 +103,7 @@ impl<W: WorldTrait> ValidQuery<W> for QueryBox {
             FindAccountById(query) => query.execute_into_value(wsv),
             FindAccountsByName(query) => query.execute_into_value(wsv),
             FindAccountsByDomainId(query) => query.execute_into_value(wsv),
+            FindAccountsWithAsset(query) => query.execute_into_value(wsv),
             FindAllAssets(query) => query.execute_into_value(wsv),
             FindAllAssetsDefinitions(query) => query.execute_into_value(wsv),
             FindAssetById(query) => query.execute_into_value(wsv),

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -478,6 +478,30 @@ pub mod account {
         type Output = Vec<Account>;
     }
 
+    /// `FindAccountsWithAsset` Iroha Query will get `Asset`s id as input and
+    /// find all `Account`s storing that `Asset`.
+    #[derive(
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Decode,
+        Encode,
+        Deserialize,
+        Serialize,
+        IntoSchema,
+    )]
+    pub struct FindAccountsWithAsset {
+        /// `Id` of the asset which should be stored in founded accounts.
+        pub asset_id: EvaluatesTo<AssetId>,
+    }
+
+    impl Query for FindAccountsWithAsset {
+        type Output = Vec<Account>;
+    }
+
     impl FindAllAccounts {
         /// Construct [`FindAllAccounts`].
         pub const fn new() -> Self {
@@ -521,11 +545,19 @@ pub mod account {
         }
     }
 
+    impl FindAccountsWithAsset {
+        /// Construct [`FindAccountsWithAsset`].
+        pub fn new(asset_id: impl Into<EvaluatesTo<AssetId>>) -> Self {
+            let asset_id = asset_id.into();
+            FindAccountsWithAsset { asset_id }
+        }
+    }
+
     /// The prelude re-exports most commonly used traits, structs and macros from this crate.
     pub mod prelude {
         pub use super::{
             FindAccountById, FindAccountKeyValueByIdAndKey, FindAccountsByDomainId,
-            FindAccountsByName, FindAllAccounts,
+            FindAccountsByName, FindAccountsWithAsset, FindAllAccounts,
         };
     }
 }

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -478,8 +478,8 @@ pub mod account {
         type Output = Vec<Account>;
     }
 
-    /// `FindAccountsWithAsset` Iroha Query will get `Asset`s id as input and
-    /// find all `Account`s storing that `Asset`.
+    /// `FindAccountsWithAsset` Iroha Query will get `AssetDefinition`s id as input and
+    /// find all `Account`s storing `Asset` with such definition.
     #[derive(
         Debug,
         Clone,
@@ -494,8 +494,8 @@ pub mod account {
         IntoSchema,
     )]
     pub struct FindAccountsWithAsset {
-        /// `Id` of the asset which should be stored in founded accounts.
-        pub asset_id: EvaluatesTo<AssetId>,
+        /// `Id` of the definition of the asset which should be stored in founded accounts.
+        pub asset_definition_id: EvaluatesTo<AssetDefinitionId>,
     }
 
     impl Query for FindAccountsWithAsset {
@@ -547,9 +547,11 @@ pub mod account {
 
     impl FindAccountsWithAsset {
         /// Construct [`FindAccountsWithAsset`].
-        pub fn new(asset_id: impl Into<EvaluatesTo<AssetId>>) -> Self {
-            let asset_id = asset_id.into();
-            FindAccountsWithAsset { asset_id }
+        pub fn new(asset_definition_id: impl Into<EvaluatesTo<AssetDefinitionId>>) -> Self {
+            let asset_definition_id = asset_definition_id.into();
+            FindAccountsWithAsset {
+                asset_definition_id,
+            }
         }
     }
 

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -46,6 +46,8 @@ pub enum QueryBox {
     FindAccountsByName(FindAccountsByName),
     /// [`FindAccountsByDomainId`] variant.
     FindAccountsByDomainId(FindAccountsByDomainId),
+    /// [`FindAccountsWithAsset`] variant.
+    FindAccountsWithAsset(FindAccountsWithAsset),
     /// [`FindAllAssets`] variant.
     FindAllAssets(FindAllAssets),
     /// [`FindAllAssetsDefinitions`] variant.

--- a/permissions_validators/src/private_blockchain/query.rs
+++ b/permissions_validators/src/private_blockchain/query.rs
@@ -20,7 +20,7 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsDomain {
             FindAssetsByAssetDefinitionId(_) | FindAssetsByName(_) | FindAllAssets(_) => {
                 Err("Only access to the assets of the same domain is permitted.".to_owned())
             }
-            FindAllAccounts(_) | FindAccountsByName(_) => {
+            FindAllAccounts(_) | FindAccountsByName(_) | FindAccountsWithAsset(_) => {
                 Err("Only access to the accounts of the same domain is permitted.".to_owned())
             }
             FindAllAssetsDefinitions(_) => Err(
@@ -293,6 +293,7 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsData {
         match query {
             FindAccountsByName(_)
                 | FindAccountsByDomainId(_)
+                | FindAccountsWithAsset(_)
                 | FindAllAccounts(_) => {
                     Err("Other accounts are private.".to_owned())
                 }

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -140,6 +140,7 @@ pub fn generate_map() -> DumpDecodedMap {
         FindAccountKeyValueByIdAndKey,
         FindAccountsByDomainId,
         FindAccountsByName,
+        FindAccountsWithAsset,
         FindAllAccounts,
         FindAllAssets,
         FindAllAssetsDefinitions,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

* Added `FindAccountsWithAsset` query
* Added test for it
* Fixed bug when block events (including `Committed` event) were sent before actual block applying to *WSV*
* Cause of this bugfix some of previously flaky tests are no longer such. Tested with `cargo flaky` running every test for **100** times for about 4 hours
* Smartcontract test is enabled back as it seems not being flaky anymore. But still takes about 50 secs to complete on my machine

Results of running ```cargo flaky``` (edited for readability):
```
====== FOUND 4 FAILING TESTS ======
- test: two_networks stdout
failures: 1/100 (1%)

- test: integration::unregister_peer::unstable_network_stable_after_add_and_after_remove_peer stdout
failures: 2/100 (2%)

- test: config::tests::parse_example_json stdout
failures: 100/100 (100%)

- test: ui stdout
failures: 600/100 (600%)
```

The **3'rd** case isn't a real problem. This test just depends on a folder it runs from, we should be able to fix it probably.
The **4'th** case is a compilation tests (as @mversic suggested). Not sure what does it means here.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

* Closes #2100 

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

* New query
* Less number of flaky tests

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

I've enabled `mint_nft_for_every_user_every_1_sec` test back. I haven't run `cargo flaky` with it but I've run it mannually (bash script) for about 30 times and it seems to work fine. The only problem is a long execution time (~50 sec on my M1 Mac), so probably I need to ignore this test again.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

```bash
cargo test --package iroha_client --test mod -- integration::queries::account::find_accounts_with_asset --exact --nocapture
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
