### PR TITLE
[fix] #2215: Make nightly-2022-04-20 optional for `cargo build`

### DIFF
--- a/.github/workflows/iroha2-dev-pr-unstable.yml
+++ b/.github/workflows/iroha2-dev-pr-unstable.yml
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
-        run: mold --run cargo test -p iroha_client --tests unstable_network --quiet
+        run: mold --run cargo +nightly-2022-04-20 test -p iroha_client --tests unstable_network --quiet

--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -43,4 +43,4 @@ jobs:
 
       # Tests
       - name: Run tests
-        run: mold --run cargo test --tests --quiet --no-fail-fast
+        run: mold --run cargo +nightly-2022-04-20 test --tests --quiet --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "strum",
  "test_network",
  "thiserror",
  "tokio",
@@ -3415,6 +3416,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/client/build.rs
+++ b/client/build.rs
@@ -8,49 +8,58 @@ use std::{env, path::Path, process::Command};
 
 #[allow(clippy::expect_used)]
 fn main() {
-    let manifest_dir =
-        env::var("CARGO_MANIFEST_DIR").expect("Expected `CARGO_MANIFEST_DIR` environment variable");
-    let smartcontract_path =
-        Path::new(&manifest_dir).join("tests/integration/create_nft_for_every_user_smartcontract");
-    let out_dir = env::var_os("OUT_DIR").expect("Expected `OUT_DIR` environment variable");
+    // Build and format the smartcontract if and only if the tests are
+    // invoked with the nightly toolchain. We should not force our
+    // users to have the `nightly` if we don't use any `nightly`
+    // features in the actual binary.
+    if env::var("RUSTUP_TOOLCHAIN")
+        .expect("Should be defined")
+        .contains("nightly")
+    {
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+            .expect("Expected `CARGO_MANIFEST_DIR` environment variable");
+        let smartcontract_path = Path::new(&manifest_dir)
+            .join("tests/integration/create_nft_for_every_user_smartcontract");
+        let out_dir = env::var_os("OUT_DIR").expect("Expected `OUT_DIR` environment variable");
 
-    // TODO: check if this was causing the recursive loop.
-    // println!("cargo:rerun-if-changed=..");
+        // TODO: check if this was causing the recursive loop.
+        // println!("cargo:rerun-if-changed=..");
 
-    let fmt = Command::new("rustfmt")
-        .current_dir(smartcontract_path.clone())
-        .args(&[smartcontract_path
-            .join("src/lib.rs")
-            .to_str()
-            .expect("Can't convert smartcontract path to str")])
-        .status()
-        .expect("Failed to run `rustfmt` on smartcontract");
-    assert!(fmt.success(), "Can't format smartcontract");
+        let fmt = Command::new("rustfmt")
+            .current_dir(smartcontract_path.clone())
+            .args(&[smartcontract_path
+                .join("src/lib.rs")
+                .to_str()
+                .expect("Can't convert smartcontract path to str")])
+            .status()
+            .expect("Failed to run `rustfmt` on smartcontract");
+        assert!(fmt.success(), "Can't format smartcontract");
 
-    // TODO: Remove cargo invocation (#2152)
-    let build = Command::new("cargo")
+        // TODO: Remove cargo invocation (#2152)
+        let build = Command::new("cargo")
         // Removing environment variable to avoid
         // `error: infinite recursion detected` when running `cargo lints`
-        .env_remove("RUST_RECURSION_COUNT")
+            .env_remove("RUST_RECURSION_COUNT")
         // Removing environment variable to avoid
         // `error: `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]``
         // when running with `-C instrument-coverage`
         // TODO: Check if there are no problems with that
-        .env_remove("CARGO_ENCODED_RUSTFLAGS")
-        .env("CARGO_TARGET_DIR", out_dir)
-        .current_dir(smartcontract_path)
-        .args(&[
-            "+nightly-2022-04-20",
-            "build",
-            "--release",
-            "-Z",
-            "build-std",
-            "-Z",
-            "build-std-features=panic_immediate_abort",
-            "--target",
-            "wasm32-unknown-unknown",
-        ])
-        .status()
-        .expect("Failed to run `cargo build` on smartcontract");
-    assert!(build.success(), "Can't build smartcontract")
+            .env_remove("CARGO_ENCODED_RUSTFLAGS")
+            .env("CARGO_TARGET_DIR", out_dir)
+            .current_dir(smartcontract_path)
+            .args(&[
+                "+nightly-2022-04-20",
+                "build",
+                "--release",
+                "-Z",
+                "build-std",
+                "-Z",
+                "build-std-features=panic_immediate_abort",
+                "--target",
+                "wasm32-unknown-unknown",
+            ])
+            .status()
+            .expect("Failed to run `cargo build` on smartcontract");
+        assert!(build.success(), "Can't build smartcontract")
+    }
 }

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 # Enable static linkage of the rust standard library.
 # Disabled for WASM interoperability, to reduce the binary size.
 # Please refer to https://docs.rust-embedded.org/book/intro/no-std.html
-std = ["iroha_macro/std", "iroha_version/std", "iroha_version/warp", "iroha_crypto/std", "iroha_data_primitives/std", "thiserror"]
+std = ["iroha_macro/std", "iroha_version/std", "iroha_version/warp", "iroha_crypto/std", "iroha_data_primitives/std", "thiserror", "strum/std"]
 
 # Internal use only
 mutable_api = []
@@ -40,6 +40,7 @@ serde_json = { version = "1.0.59", default-features = false }
 warp = { version = "0.3", default-features = false, optional = true }
 thiserror = { version = "1.0.28", optional = true }
 getset = "0.1.2"
+strum = { version = "0.24.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 iroha_core = { path = "../core", version = "=2.0.0-pre-rc.4" }

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -16,6 +16,7 @@ use iroha_macro::FromVariant;
 use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use strum::EnumString;
 
 use self::definition_builder::NewAssetDefinition;
 use crate::{
@@ -175,6 +176,7 @@ pub struct Asset {
     Deserialize,
     Serialize,
     IntoSchema,
+    EnumString,
 )]
 pub enum AssetValueType {
     /// Asset's Quantity.
@@ -186,31 +188,6 @@ pub enum AssetValueType {
     /// Asset's key-value structured data.
     Store,
 }
-
-/// A declarative macro that implements `FromStr` for a given
-/// C like enumeration. The macro is invoked like follows:
-/// `easy_from_str_impl! { NameOfEnum, EnumVariation1, EnumVariation2, ... }`
-macro_rules! easy_from_str_impl {
-    (eval_to $cmp:expr, $enum_type:ty, $enum_value:tt) => {
-        if $cmp == stringify!($enum_value) {
-            return Ok(<$enum_type>::$enum_value);
-        }
-    };
-    ($enum_type:ty, $( $enum_value:tt ),+ ) => {
-        impl FromStr for $enum_type {
-            type Err = &'static str;
-
-            fn from_str(value_type: &str) -> Result<Self, Self::Err> {
-                $(
-                    easy_from_str_impl!{eval_to value_type, $enum_type, $enum_value}
-                )+
-                return Err(concat!("Unknown variant for type ", stringify!($enum_type)));
-            }
-        }
-    };
-}
-
-easy_from_str_impl! {AssetValueType, Quantity, BigQuantity, Fixed, Store}
 
 /// Asset's inner value.
 #[derive(


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Removed the requirement for having the `nightly-2022-04-20` installed with the right components for building Iroha. The client test with the WASM smartcontract is now only ran if the `+nightly` toolchain was used to run cargo. 

### Issue

Closes #2215
Opens #2225 

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Easier to compile for users. 

### Possible Drawbacks

None
