### PR TITLE
[refactor]: Move `TriggerSet` to `data_model`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ name = "iroha_data_model"
 version = "2.0.0-pre-rc.4"
 dependencies = [
  "criterion",
+ "dashmap",
  "derive_more",
  "getset",
  "iroha",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,6 @@ pub mod modules;
 pub mod queue;
 pub mod smartcontracts;
 pub mod sumeragi;
-pub mod triggers;
 pub mod tx;
 pub mod wsv;
 

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -33,7 +33,7 @@ pub mod error {
 
     use iroha_crypto::HashOf;
     use iroha_data_model::{
-        fixed::FixedPointOperationError, metadata, prelude::*, MintabilityError,
+        fixed::FixedPointOperationError, metadata, prelude::*, trigger, MintabilityError,
     };
     use iroha_schema::IntoSchema;
     use parity_scale_codec::{Decode, Encode};
@@ -82,6 +82,19 @@ pub mod error {
     impl From<FindError> for Error {
         fn from(err: FindError) -> Self {
             Self::Find(Box::new(err))
+        }
+    }
+
+    impl From<trigger::set::ModRepeatsError> for Error {
+        fn from(err: trigger::set::ModRepeatsError) -> Self {
+            match err {
+                trigger::set::ModRepeatsError::NotFound(not_found_id) => {
+                    Error::Find(Box::new(FindError::Trigger(not_found_id)))
+                }
+                trigger::set::ModRepeatsError::RepeatsOverflow(_) => {
+                    Error::Math(MathError::Overflow)
+                }
+            }
         }
     }
 

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -25,7 +25,6 @@ use crate::{
     block::Chain,
     prelude::*,
     smartcontracts::{isi::Error, wasm, Execute, FindError},
-    triggers::TriggerSet,
     DomainsMap, EventsSender, PeersIds,
 };
 

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 # Enable static linkage of the rust standard library.
 # Disabled for WASM interoperability, to reduce the binary size.
 # Please refer to https://docs.rust-embedded.org/book/intro/no-std.html
-std = ["iroha_macro/std", "iroha_version/std", "iroha_version/warp", "iroha_crypto/std", "iroha_data_primitives/std", "thiserror", "strum/std"]
+std = ["iroha_macro/std", "iroha_version/std", "iroha_version/warp", "iroha_crypto/std", "iroha_data_primitives/std", "thiserror", "strum/std", "dashmap", "tokio"]
 
 # Internal use only
 mutable_api = []
@@ -33,8 +33,8 @@ iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.4", default-features
 iroha_version = { path = "../version", version = "=2.0.0-pre-rc.4", default-features = false, features = ["derive", "json", "scale"] }
 iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.4" }
 
-dashmap = { version = "4.0" }
-tokio = { version = "1.6.0", features = ["sync", "rt-multi-thread"] }
+dashmap = { version = "4.0", optional = true}
+tokio = { version = "1.6.0", features = ["sync", "rt-multi-thread"], optional = true}
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.16", default-features = false, features = ["display"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -33,6 +33,8 @@ iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.4", default-features
 iroha_version = { path = "../version", version = "=2.0.0-pre-rc.4", default-features = false, features = ["derive", "json", "scale"] }
 iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.4" }
 
+dashmap = { version = "4.0" }
+tokio = { version = "1.6.0", features = ["sync", "rt-multi-thread"] }
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.16", default-features = false, features = ["display"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/data_model/src/trigger/mod.rs
+++ b/data_model/src/trigger/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     events::prelude::*, metadata::Metadata, transaction::Executable, Identifiable, Name, ParseError,
 };
 
+#[cfg(feature = "std")]
 pub mod set;
 
 /// Type which is used for registering a `Trigger`.
@@ -372,7 +373,10 @@ pub mod action {
 
 pub mod prelude {
     //! Re-exports of commonly used types.
-    pub use super::{action::prelude::*, set::Set as TriggerSet, Id as TriggerId, Trigger};
+
+    #[cfg(feature = "std")]
+    pub use super::set::Set as TriggerSet;
+    pub use super::{action::prelude::*, Id as TriggerId, Trigger};
 }
 
 #[cfg(test)]

--- a/data_model/src/trigger/mod.rs
+++ b/data_model/src/trigger/mod.rs
@@ -12,7 +12,6 @@ use crate::{
     events::prelude::*, metadata::Metadata, transaction::Executable, Identifiable, Name, ParseError,
 };
 
-#[cfg(feature = "std")]
 pub mod set;
 
 /// Type which is used for registering a `Trigger`.

--- a/data_model/src/trigger/mod.rs
+++ b/data_model/src/trigger/mod.rs
@@ -12,6 +12,8 @@ use crate::{
     events::prelude::*, metadata::Metadata, transaction::Executable, Identifiable, Name, ParseError,
 };
 
+pub mod set;
+
 /// Type which is used for registering a `Trigger`.
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Decode, Encode, Deserialize, Serialize, IntoSchema,
@@ -370,7 +372,7 @@ pub mod action {
 
 pub mod prelude {
     //! Re-exports of commonly used types.
-    pub use super::{action::prelude::*, Id as TriggerId, Trigger};
+    pub use super::{action::prelude::*, set::Set as TriggerSet, Id as TriggerId, Trigger};
 }
 
 #[cfg(test)]

--- a/data_model/src/trigger/set.rs
+++ b/data_model/src/trigger/set.rs
@@ -219,7 +219,7 @@ impl Set {
     /// Handle [`DataEvent`].
     ///
     /// Finds all actions, that are triggered by `event` and stores them.
-    /// This actions will be inspected in the next `Set::inspect_matched()` call
+    /// This actions will be inspected in the next [`Set::handle_data_event()`] call
     pub fn handle_data_event(&self, event: &DataEvent) {
         self.handle_event(&self.data_triggers, event, EventType::Data)
     }
@@ -227,7 +227,7 @@ impl Set {
     /// Handle [`PipelineEvent`].
     ///
     /// Finds all actions, that are triggered by `event` and stores them.
-    /// This actions will be inspected in the next `Set::inspect_matched()` call
+    /// This actions will be inspected in the next [`Set::inspect_matched()`] call
     pub fn handle_pipeline_event(&self, event: &PipelineEvent) {
         self.handle_event(&self.pipeline_triggers, event, EventType::Pipeline)
     }
@@ -235,7 +235,7 @@ impl Set {
     /// Handle [`TimeEvent`].
     ///
     /// Finds all actions, that are triggered by `event` and stores them.
-    /// This actions will be inspected in the next `Set::inspect_matched()` call
+    /// This actions will be inspected in the next [`Set::inspect_matched()`] call
     pub fn handle_time_event(&self, event: &TimeEvent) {
         for entry in &self.time_triggers {
             let action = entry.value();
@@ -261,7 +261,7 @@ impl Set {
     /// Handle [`ExecuteTriggerEvent`].
     ///
     /// Finds all actions, that are triggered by `event` and stores them.
-    /// This actions will be inspected ln the next `Set::inspect_matched()` call
+    /// This actions will be inspected ln the next [`Set::inspect_matched()`] call
     pub fn handle_execute_trigger_event(&self, event: &ExecuteTriggerEvent) {
         self.handle_event(&self.by_call_triggers, event, EventType::ExecuteTrigger)
     }

--- a/data_model/src/trigger/set.rs
+++ b/data_model/src/trigger/set.rs
@@ -8,6 +8,7 @@
 //! search trees (common lisp) or hash tables (racket) to quickly
 //! trigger hooks.
 
+#![cfg(feature = "std")]
 #![allow(clippy::expect_used)]
 
 use std::{cmp::min, result::Result, sync::Arc};

--- a/permissions_validators/src/private_blockchain/query.rs
+++ b/permissions_validators/src/private_blockchain/query.rs
@@ -55,7 +55,12 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsDomain {
                                 .to_owned())
                         }
                     })
-                    .map_err(|err| err.to_string())?
+                    .ok_or_else(|| {
+                        format!(
+                            "A trigger with the specified Id: {} is not accessible to you",
+                            id.clone()
+                        )
+                    })?
             }
             FindTriggerKeyValueByIdAndKey(query) => {
                 let id = query
@@ -74,7 +79,12 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsDomain {
                     )
                         }
                     })
-                    .map_err(|err| err.to_string())?
+                    .ok_or_else(|| {
+                        format!(
+                            "A trigger with the specified Id: {} is not accessible to you",
+                            id.clone()
+                        )
+                    })?
             }
             FindAccountById(query) => {
                 let account_id = query
@@ -330,9 +340,9 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsData {
                     .id
                     .evaluate(wsv, &context)
                     .map_err(|e| e.to_string())?;
-                if let Ok(true) = wsv.world.triggers.inspect(&id, |action|
+                if wsv.world.triggers.inspect(&id, |action|
                     action.technical_account() == authority
-                ) {
+                ) == Some(true) {
                     return Ok(())
                 }
                 Err(format!(
@@ -346,9 +356,9 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsData {
                     .id
                     .evaluate(wsv, &context)
                     .map_err(|e| e.to_string())?;
-                if let Ok(true) = wsv.world.triggers.inspect(&id, |action|
+                if wsv.world.triggers.inspect(&id, |action|
                     action.technical_account() == authority
-                ) {
+                ) == Some(true) {
                     return Ok(())
                 }
                 Err(format!(


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Initially it suppose to close #1889 but in the middle of work it was decided to wait until we get dynamic wasm linking. Dynamic linking is important, cause it will remove `no_std` limitations from `data_model` and `TriggerSet` is not compatible with `no_std`.
So this PR contains only `TriggerSet` moving to `data_model`. It should be useful for the future.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

None

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

* `TriggerSet` now is stored there it should be
* Errors produced by `TriggerSet` make more sense

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None

