### PR TITLE
[fix] #2232: Make Iroha print meaningful message when genesis has too many isi

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -155,8 +155,10 @@ where
         telemetry: Option<iroha_logger::Telemetries>,
     ) -> Result<Self> {
         if !config.disable_panic_terminal_colors {
-            // Ignoring error if `iroha_logger` has already installed colors
-            let _color_res = color_eyre::install();
+            if let Err(e) = color_eyre::install() {
+                let error_message = format!("{e:#}");
+                iroha_logger::error!(error = %error_message, "Tried to install eyre_hook twice",);
+            }
         }
         let listen_addr = config.torii.p2p_addr.clone();
         iroha_logger::info!(%listen_addr, "Starting peer");

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -96,11 +96,15 @@ where
     /// To make `Iroha` peer work all actors should be started first.
     /// After that moment it you can start it with listening to torii events.
     ///
+    /// # Side effect
+    /// - Prints welcome message in the log
+    ///
     /// # Errors
     /// - Reading genesis from disk
     /// - Reading telemetry configs
     /// - telemetry setup
-    /// - Initialisation of [`Sumeragi`]
+    /// - Initialization of [`Sumeragi`]
+    #[allow(clippy::non_ascii_literal)]
     pub async fn new(
         args: &Arguments,
         instruction_validator: IsInstructionAllowedBoxed<K::World>,
@@ -112,6 +116,10 @@ where
             Err(_) => Configuration::default(),
         };
         config.load_environment()?;
+
+        let telemetry = iroha_logger::init(&config.logger)?;
+        iroha_logger::info!("Hyperledgerいろは2にようこそ！");
+        iroha_logger::info!("(translation) Welcome to Hyperledger Iroha 2!");
 
         let genesis = G::from_configuration(
             args.submit_genesis,
@@ -127,6 +135,7 @@ where
             instruction_validator,
             query_validator,
             broker,
+            telemetry,
         )
         .await
     }
@@ -137,22 +146,18 @@ where
     /// - Reading telemetry configs
     /// - telemetry setup
     /// - Initialization of [`Sumeragi`]
-    #[allow(clippy::non_ascii_literal)]
     pub async fn with_genesis(
         genesis: Option<G>,
         config: Configuration,
         instruction_validator: IsInstructionAllowedBoxed<K::World>,
         query_validator: IsQueryAllowedBoxed<K::World>,
         broker: Broker,
+        telemetry: Option<iroha_logger::Telemetries>,
     ) -> Result<Self> {
         if !config.disable_panic_terminal_colors {
-            if let Err(e) = color_eyre::install() {
-                iroha_logger::error!("Tried to install eyre_hook twice: {:?}", e);
-            }
+            // Ignoring error if `iroha_logger` has already installed colors
+            let _color_res = color_eyre::install();
         }
-        let telemetry = iroha_logger::init(&config.logger)?;
-        iroha_logger::info!("Hyperledgerいろは2にようこそ！");
-        iroha_logger::info!("(translation) Welcome to Hyperledger Iroha 2!");
         let listen_addr = config.torii.p2p_addr.clone();
         iroha_logger::info!(%listen_addr, "Starting peer");
         let network = IrohaNetwork::new(

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -195,7 +195,7 @@ impl From<warp::http::Response<warp::hyper::body::Bytes>> for QueryResponseBody 
         if StatusCode::OK == src.status() {
             let body = VersionedQueryResult::decode_versioned(src.body())
                 .expect("The response body failed to be decoded to VersionedQueryResult even though the status is Ok 200");
-            Self::Ok(body)
+            Self::Ok(Box::new(body))
         } else {
             let body = query::Error::decode(&mut src.body().as_ref())
                 .expect("The response body failed to be decoded to query::Error even though the status is not Ok 200");
@@ -213,7 +213,7 @@ struct QueryResponseTest {
 
 #[allow(variant_size_differences)]
 enum QueryResponseBody {
-    Ok(VersionedQueryResult),
+    Ok(Box<VersionedQueryResult>),
     Err(query::Error),
 }
 

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -4,7 +4,7 @@ use std::{str::FromStr, thread, time::Duration};
 
 use eyre::Result;
 use iroha_client::client::{self, Client};
-use iroha_core::prelude::*;
+use iroha_core::{genesis::GenesisNetwork, prelude::*};
 use iroha_data_model::prelude::*;
 use tempfile::TempDir;
 use test_network::{Peer as TestPeer, *};
@@ -24,7 +24,13 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
 
     // Given
     let rt = Runtime::test();
-    rt.block_on(peer.start_with_config_permissions_dir(configuration.clone(), AllowAll, &temp_dir));
+    rt.block_on(peer.start_with_config_permissions_dir(
+        configuration.clone(),
+        GenesisNetwork::test(true),
+        AllowAll,
+        AllowAll,
+        &temp_dir,
+    ));
     let mut iroha_client = Client::test(&peer.api_address, &peer.telemetry_address);
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
@@ -60,7 +66,13 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
     thread::sleep(Duration::from_millis(2000));
 
     let rt = Runtime::test();
-    rt.block_on(peer.start_with_config_permissions_dir(configuration, AllowAll, &temp_dir));
+    rt.block_on(peer.start_with_config_permissions_dir(
+        configuration,
+        GenesisNetwork::test(true),
+        AllowAll,
+        AllowAll,
+        &temp_dir,
+    ));
 
     let account_asset = iroha_client
         .poll_request(client::asset::by_account_id(account_id), |assets| {

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -200,7 +200,7 @@ impl GenesisNetworkTrait for GenesisNetwork {
                 .filter_map(|(i, res)| {
                     res.map_err(|error| {
                         let error_msg = format!("{error:#}");
-                        iroha_logger::error!(error = %error_msg, "Genesis transaction #{i} didn't succeed")
+                        iroha_logger::error!(error = %error_msg, "Genesis transaction #{i} failed")
                     })
                     .ok()
                 })

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -467,7 +467,7 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
     ) -> Result<()> {
         if transactions.is_empty() {
             Err(eyre!(
-                "Genesis transactions set is empty or all of the transactions are incorrect"
+                "Genesis transactions set contains no valid transactions"
             ))
         } else if genesis_topology.leader() != &self.peer_id {
             Err(eyre!(

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -466,7 +466,9 @@ impl<G: GenesisNetworkTrait, K: KuraTrait, W: WorldTrait, F: FaultInjection>
         ctx: &mut Context<Self>,
     ) -> Result<()> {
         if transactions.is_empty() {
-            Err(eyre!("Genesis transactions set is empty."))
+            Err(eyre!(
+                "Genesis transactions set is empty or all of the transactions are incorrect"
+            ))
         } else if genesis_topology.leader() != &self.peer_id {
             Err(eyre!(
                 "Incorrect network topology this peer should be {:?} but is {:?}",

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -439,7 +439,10 @@ mod tests {
         );
         assert_eq!(
             chain.next().unwrap().to_string(),
-            "Too many instructions in payload"
+            format!(
+                "Too many instructions in payload, max number is {}",
+                tx_limits.max_instruction_number
+            )
         );
     }
 }

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -440,8 +440,9 @@ mod tests {
         assert_eq!(
             chain.next().unwrap().to_string(),
             format!(
-                "Too many instructions in payload, max number is {}",
-                tx_limits.max_instruction_number
+                "Too many instructions in payload, max number is {}, but got {}",
+                tx_limits.max_instruction_number,
+                DEFAULT_MAX_INSTRUCTION_NUMBER + 1
             )
         );
     }

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -67,14 +67,18 @@ pub trait Txn {
                 let instruction_count: usize = instructions.iter().map(Instruction::len).sum();
 
                 if instruction_count as u64 > limits.max_instruction_number {
-                    return Err(TransactionLimitError(String::from(
-                        "Too many instructions in payload",
+                    return Err(TransactionLimitError(format!(
+                        "Too many instructions in payload, max number is {}",
+                        limits.max_instruction_number
                     )));
                 }
             }
             Executable::Wasm(WasmSmartContract { raw_data }) => {
                 if raw_data.len() as u64 > limits.max_wasm_size_bytes {
-                    return Err(TransactionLimitError(String::from("wasm binary too large")));
+                    return Err(TransactionLimitError(format!(
+                        "Wasm binary too large, max size is {}",
+                        limits.max_wasm_size_bytes
+                    )));
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Daniil Polyakov <arjentix@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

* Added error message when can't process genesis transaction
* Logger initialization now starts eralier to be able to capture genesis creating logs

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

* Closes #2232 
* Opens #2238 

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Now users will get more meaningful message when they have too many instructions inside transactions

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

You can take a big genesis from issue description and run Iroha with it to check this out.

I don't think I can write a test for it. This is UI-specific problem

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
