### PR TITLE
[feature] #2132: Add `endpointN` proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "futures",
  "hex",
  "iroha_actor",
+ "iroha_cli_derive",
  "iroha_config",
  "iroha_core",
  "iroha_crypto",
@@ -1720,6 +1721,19 @@ name = "iroha_actor_derive"
 version = "2.0.0-pre-rc.4"
 dependencies = [
  "iroha_actor",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
+]
+
+[[package]]
+name = "iroha_cli_derive"
+version = "2.0.0-pre-rc.4"
+dependencies = [
+ "iroha",
+ "iroha_macro",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "actor",
   "actor/derive",
   "cli",
+  "cli/derive",
   "client",
   "client_cli",
   "config",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,7 @@ iroha_config = { version = "=2.0.0-pre-rc.4", path = "../config" }
 iroha_crypto = { version = "=2.0.0-pre-rc.4", path = "../crypto" }
 iroha_p2p = { version = "=2.0.0-pre-rc.4", path = "../p2p" }
 iroha_schema_gen = { version = "=2.0.0-pre-rc.4", path = "../schema/gen", optional = true }
+iroha_cli_derive = { version = "=2.0.0-pre-rc.4", path = "derive" }
 
 eyre = "0.6.5"
 futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }

--- a/cli/derive/Cargo.toml
+++ b/cli/derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "iroha_cli_derive"
+version = "2.0.0-pre-rc.4"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = {version = "1", default-features = false, features = ["parsing", "printing", "extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+proc-macro-error = "1.0"
+
+[dev-dependencies]
+iroha = { version = "=2.0.0-pre-rc.4", path = ".." }
+iroha_macro = { version = "=2.0.0-pre-rc.4", path = "../../macro" }
+trybuild = "1.0.53"

--- a/cli/derive/src/lib.rs
+++ b/cli/derive/src/lib.rs
@@ -1,0 +1,168 @@
+//! Crate with a proc macro for torii endpoint generation
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    Ident, LitInt, Result as SynResult, Token,
+};
+
+/// Generate warp filters for endpoints, accepting functions
+/// with any positive number of arguments within the range of `u8`.
+///
+/// Only the endpoint functions stated explicitly in the macro invocation
+/// are created.
+///
+/// There are two kinds of accepted arguments. One is supplying
+/// an integer literal denoting the number of arguments in a function
+/// that the endpoint accepts. The endpoint name is generated automatically
+/// in this case and will be in the shape of `endpoint{arg_count}`.
+///
+/// Another kind is a colon-separated string literal
+/// followed by an integer literal, denoting custom name of the endpoint being
+/// created and the number of arguments in a function that it accepts.
+///
+/// Also relies on `WarpResult` custom wrapper,
+/// and thus any module using this macro should also reexport
+/// the former, as well as some types from `warp` (see example).
+///
+/// # Panics:
+/// 1) When provided with neither a string nor integer literal.
+/// 2) When any of the argument count literals are not unique.
+/// 3) When the colon-separated form has spaces in the provided name.
+///
+/// # Examples:
+/// ```rust
+/// use warp::{Rejection, Filter};
+/// use std::convert::Infallible;
+/// use iroha_cli::torii::utils::WarpResult;
+///
+/// // An example with arguments of both acceptable kinds.
+/// // This would generate endpoints accepting functions with
+/// // 2, 3, 4 and 5 arguments. The first and the last of them
+/// // will have the custom names provided, whereas the other two will have
+/// // default ones such as `endpoint3`.
+/// generate_endpoints!(3, my_endpoint: 2, 4, anotherOne: 5, );
+/// ```
+#[proc_macro]
+pub fn generate_endpoints(input: TokenStream) -> TokenStream {
+    let EndpointList(list) = parse_macro_input!(input as EndpointList);
+    let arg_names = (1_u8..).map(|count| {
+        Ident::new(
+            format!("__endpoint_arg_{count}").as_str(),
+            Span::call_site(),
+        )
+    });
+    let arg_types = (1_u8..).map(|count| {
+        Ident::new(
+            format!("__Endpoint_Arg_{count}").as_str(),
+            Span::call_site(),
+        )
+    });
+    let mut endpoints = Vec::new();
+
+    for item in list {
+        let (fun_name, arg_names, arg_types) = match item {
+            EndpointItem::ArgCount(arg_count) => {
+                let fun_name = Ident::new(&format!("endpoint{arg_count}"), Span::call_site());
+                #[allow(clippy::expect_used)]
+                let count = arg_count
+                    .base10_parse::<usize>()
+                    .expect("Already checked at parse stage");
+                let arg_names = arg_names.clone().take(count).collect::<Vec<_>>();
+                let arg_types = arg_types.clone().take(count).collect::<Vec<_>>();
+                (fun_name, arg_names, arg_types)
+            }
+            EndpointItem::NameAndArgCount {
+                name: fun_name,
+                arg_count,
+            } => {
+                #[allow(clippy::expect_used)]
+                let count = arg_count
+                    .base10_parse::<usize>()
+                    .expect("Already checked at parse stage");
+                let arg_names = arg_names.clone().take(count).collect::<Vec<_>>();
+                let arg_types = arg_types.clone().take(count).collect::<Vec<_>>();
+                (*fun_name, arg_names, arg_types)
+            }
+        };
+
+        let expanded = quote! {
+            #[inline]
+            #[allow(clippy::redundant_pub_crate)]
+            pub(crate) fn #fun_name < O, E, F, Fut, Fil, #( #arg_types ),* > (
+                f: F,
+                router: Fil,
+            ) -> impl Filter<Extract = (WarpResult<O, E>,), Error = Rejection> + Clone
+            where
+                Fil: Filter<Extract = ( #( #arg_types ),* ), Error = Rejection> + Clone,
+                F: Fn( #( #arg_types ),* ) -> Fut + Copy + Send + Sync + 'static,
+                Fut: std::future::Future<Output = Result<O, E>> + Send,
+                #( #arg_types: Send ),*
+                {
+                    router.and_then(move | #( #arg_names ),* | async move {
+                        Ok::<_, Infallible>(WarpResult(f( #( #arg_names ),* ).await))
+                    })
+                }
+        };
+
+        endpoints.push(expanded);
+    }
+
+    quote! {
+        #( #endpoints )*
+    }
+    .into()
+}
+
+#[derive(Debug)]
+struct EndpointList(Vec<EndpointItem>);
+
+#[derive(Debug)]
+enum EndpointItem {
+    NameAndArgCount { arg_count: LitInt, name: Box<Ident> },
+    ArgCount(LitInt),
+}
+
+impl Parse for EndpointList {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let items = Punctuated::<EndpointItem, Token![,]>::parse_terminated(input)?;
+        let mut seen_arg_counts = Vec::new();
+        for item in items.iter() {
+            match item {
+                EndpointItem::NameAndArgCount { arg_count, .. }
+                | EndpointItem::ArgCount(arg_count) => {
+                    let curr_count = arg_count.base10_parse::<u8>()?;
+                    if seen_arg_counts.contains(&curr_count) {
+                        return Err(syn::Error::new_spanned(
+                            arg_count.token(),
+                            "argument counts for all endpoints should be distinct",
+                        ));
+                    }
+                    seen_arg_counts.push(curr_count);
+                }
+            }
+        }
+
+        Ok(Self(items.into_iter().collect()))
+    }
+}
+
+impl Parse for EndpointItem {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(LitInt) {
+            input.parse().map(EndpointItem::ArgCount)
+        } else if lookahead.peek(Ident) {
+            let name = input.parse()?;
+            let _semicolon: Token![:] = input.parse()?;
+            let arg_count = input.parse()?;
+            Ok(Self::NameAndArgCount { name, arg_count })
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Replaced the declarative macro generating `endpointN` functions with a procedural one in a separate crate.

### Issue
Resolves #2132.
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Improved readability and extensibility.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
As the macro expansion uses `WarpResult` wrapper defined in `cli/src/torii/utils.rs`, all the users of macro should reexport that struct as well. Alternatively, the macro implementation could be amended to ditch the use of that altogether.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
