### PR TITLE
[feature] #2257: Revoke<Role> emits RoleRevoked event

### DIFF
--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -230,7 +230,7 @@ pub mod isi {
                     return Err(Error::Find(Box::new(FindError::Account(account_id))));
                 }
 
-                Ok(AccountEvent::PermissionRemoved(account_id))
+                Ok(AccountEvent::RoleRevoked(account_id))
             })
         }
     }

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -139,6 +139,7 @@ mod account {
         AuthenticationRemoved(AccountId),
         PermissionAdded(AccountId),
         PermissionRemoved(AccountId),
+        RoleRevoked(AccountId),
         MetadataInserted(AccountId),
         MetadataRemoved(AccountId),
     }
@@ -155,6 +156,7 @@ mod account {
                 | Self::AuthenticationRemoved(id)
                 | Self::PermissionAdded(id)
                 | Self::PermissionRemoved(id)
+                | Self::RoleRevoked(id)
                 | Self::MetadataInserted(id)
                 | Self::MetadataRemoved(id) => id,
             }

--- a/data_model/src/events/data/filters.rs
+++ b/data_model/src/events/data/filters.rs
@@ -458,6 +458,8 @@ mod account {
         ByPermissionAdded,
         /// Filter by PermissionRemoved event
         ByPermissionRemoved,
+        /// Filter by RoleRevoked event
+        ByRoleRevoked,
         /// Filter by MetadataInserted event
         ByMetadataInserted,
         /// Filter by MetadataRemoved event
@@ -478,6 +480,7 @@ mod account {
                 | (Self::ByAuthenticationRemoved, AccountEvent::AuthenticationRemoved(_))
                 | (Self::ByPermissionAdded, AccountEvent::PermissionAdded(_))
                 | (Self::ByPermissionRemoved, AccountEvent::PermissionRemoved(_))
+                | (Self::ByRoleRevoked, AccountEvent::RoleRevoked(_))
                 | (Self::ByMetadataInserted, AccountEvent::MetadataInserted(_))
                 | (Self::ByMetadataRemoved, AccountEvent::MetadataRemoved(_)) => true,
                 _ => false,


### PR DESCRIPTION
### Description of the Change
This PR makes `Revoke` role emit `RoleRevoked` instead of `Permission` event. 
### Issue
`Revoke` role emits `Permission` events which is a misleading since roles are a collection of permission events.
### Benefits
More accurate information about the user.
### Possible Drawbacks
Not sure about drawbacks because I am new to the codebase.