### PR TITLE
[ci]: DOPS-1789 Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,28 @@
-ARG BASE_IMAGE=ubuntu:20.04
-FROM $BASE_IMAGE AS rust-base
+FROM iroha2:build AS builder
 
-ENV CARGO_HOME=/cargo_home \
-    RUSTUP_HOME=/rustup_home \
-    DEBIAN_FRONTEND=noninteractive
-ENV PATH="$CARGO_HOME/bin:$PATH"
+FROM alpine:3.16
 
-RUN set -ex; \
-    apt-get update  -yq; \
-    apt-get install -y --no-install-recommends curl apt-utils; \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        libssl-dev \
-        clang \
-        pkg-config \
-        llvm-dev; \
-    rm -rf /var/lib/apt/lists/*
+ENV  GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
+ENV  GLIBC_VERSION=2.30-r0
+ENV  BIN_PATH=/usr/local/bin/
+ENV  CONFIG_DIR=config
+ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
+ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
+ARG  TARGET_DIR=/iroha/target/release
 
-ARG TOOLCHAIN=stable
-RUN set -ex; \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >/tmp/rustup.sh; \
-    sh /tmp/rustup.sh -y --no-modify-path --default-toolchain "$TOOLCHAIN"; \
-    rm /tmp/*.sh
-
-RUN set -ex; \
-    rustup toolchain install --profile default nightly-2022-04-20; \
-    rustup target add wasm32-unknown-unknown; \
-    rustup component add rust-src
-
-FROM rust-base as cargo-chef
-RUN cargo install cargo-chef
-
-FROM cargo-chef as planner
-WORKDIR /iroha
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM cargo-chef as builder
-ARG PROFILE
-WORKDIR /iroha
-COPY --from=planner /iroha/recipe.json recipe.json
-RUN cargo chef cook $PROFILE --recipe-path recipe.json
-COPY . .
-RUN cargo build $PROFILE --workspace
-
-FROM $BASE_IMAGE
-ARG CONFIG_DIR=config
-RUN mkdir -p $CONFIG_DIR
-ARG BIN=iroha
-ARG TARGET_DIR=debug
-COPY --from=builder /iroha/target/$TARGET_DIR/$BIN .
-RUN apt-get update -yq; \
-    apt-get install -y --no-install-recommends libssl-dev; \
-    rm -rf /var/lib/apt/lists/*
-ENV IROHA_TARGET_BIN=$BIN
-ENV IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
-ENV IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
-CMD ./$IROHA_TARGET_BIN
+RUN  set -ex && \
+     apk --update add libstdc++ curl ca-certificates && \
+     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
+         do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
+     apk add --allow-untrusted /tmp/*.apk && \
+     rm -v /tmp/*.apk && \
+     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
+     adduser --disabled-password iroha --shell /bin/bash --home /app && \
+     mkdir -p $CONFIG_DIR && \
+     mkdir /chain && \
+     chown iroha:iroha /chain
+COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
+COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH
+COPY --from=builder $TARGET_DIR/kagami $BIN_PATH
+USER iroha
+CMD  iroha

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,4 @@
+FROM    iroha2:env
+WORKDIR /iroha
+COPY    . .
+RUN     mold --run cargo build --release

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,13 +1,12 @@
-ARG VERSION=latest
-FROM ubuntu:$VERSION
+FROM debian:bullseye-slim
 ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.60.0
 
-RUN set -eux; \
-    apt-get update; \
+RUN set -eux && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         gcc \
@@ -23,45 +22,42 @@ RUN set -eux; \
         zlib1g-dev \
         libxxhash-dev \
         build-essential \
-        pkg-config \
-    ; \
-    dpkgArch="$(dpkg --print-architecture)"; \
+        pkg-config && \
+    dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338' ;; \
         armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
         arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
         i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \
-    wget "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    esac && \
+    url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init" && \
+    wget "$url" && \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c - && \
+    chmod +x rustup-init && \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} && \
+    rm rustup-init && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/rui314/mold.git; \
-    git -C "./mold" checkout v1.2.0; \
-    make --directory="./mold" CXX=clang++; \
-    make --directory="./mold" install; \
+RUN git clone https://github.com/rui314/mold.git && \
+    git -C "./mold" checkout v1.2.0 && \
+    make --directory="./mold" CXX=clang++ && \
+    make --directory="./mold" install && \
     rm -rf "./mold"
 
-RUN rustup component add llvm-tools-preview clippy; \
-    rustup install --profile default nightly-2022-04-20; \
-    rustup component add rust-src; \
-    rustup component add rust-src --toolchain nightly-2022-04-20-x86_64-unknown-linux-gnu; \
-    rustup target add wasm32-unknown-unknown; \
-    rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-20; \
+RUN rustup component add llvm-tools-preview clippy && \
+    rustup install --profile default nightly-2022-04-20 && \
+    rustup component add rust-src && \
+    rustup component add rust-src --toolchain nightly-2022-04-20-x86_64-unknown-linux-gnu && \
+    rustup target add wasm32-unknown-unknown && \
+    rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-20 && \
     cargo install cargo-lints cargo-nono webassembly-test-runner
 
-RUN curl -fsSL https://get.docker.com -o get-docker.sh; \
-    chmod +x get-docker.sh; \
-    ./get-docker.sh; \
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
+    chmod +x get-docker.sh && \
+    ./get-docker.sh && \
     rm get-docker.sh
 
-
-RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose; \
+RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
-

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -3,10 +3,8 @@ services:
   iroha0:
     build: .
     image: iroha0:debug
-    volumes:
-      - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha0:1337
       TORII_API_URL: iroha0:8080
       TORII_TELEMETRY_URL: iroha0:8180
@@ -18,17 +16,17 @@ services:
       - "8080:8080"
       - "8180:8180"
     init: true
-    command: ./iroha --submit-genesis
+    command: iroha --submit-genesis
+    volumes:
+      - ./configs/peer:/config
 
 
   iroha1:
     depends_on:
       - iroha0
     image: iroha0:debug
-    volumes:
-      - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha1:1338
       TORII_API_URL: iroha1:8081
       TORII_TELEMETRY_URL: iroha1:8181
@@ -40,16 +38,16 @@ services:
       - "8081:8081"
       - "8181:8181"
     init: true
+    volumes:
+      - ./configs/peer:/config
 
 
   iroha2:
     depends_on:
       - iroha0
     image: iroha0:debug
-    volumes:
-      - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha2:1339
       TORII_API_URL: iroha2:8082
       TORII_TELEMETRY_URL: iroha2:8182
@@ -61,16 +59,16 @@ services:
       - "8082:8082"
       - "8182:8182"
     init: true
+    volumes:
+      - ./configs/peer:/config
 
 
   iroha3:
     depends_on:
       - iroha0
     image: iroha0:debug
-    volumes:
-      - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha3:1340
       TORII_API_URL: iroha3:8083
       TORII_TELEMETRY_URL: iroha3:8183
@@ -82,3 +80,5 @@ services:
       - "8083:8083"
       - "8183:8183"
     init: true
+    volumes:
+      - ./configs/peer:/config

--- a/docker-compose-single.yml
+++ b/docker-compose-single.yml
@@ -5,7 +5,6 @@ services:
     image: iroha0:debug
     volumes:
       - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
       TORII_P2P_ADDR: iroha0:1337
       TORII_API_URL: iroha0:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   iroha0:
     image: hyperledger/iroha2:dev
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha0:1337
       TORII_API_URL: iroha0:8080
       TORII_TELEMETRY_URL: iroha0:8180
@@ -20,6 +21,7 @@ services:
   iroha1:
     image: hyperledger/iroha2:dev
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha1:1338
       TORII_API_URL: iroha1:8081
       TORII_TELEMETRY_URL: iroha1:8181
@@ -36,6 +38,7 @@ services:
   iroha2:
     image: hyperledger/iroha2:dev
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha2:1339
       TORII_API_URL: iroha2:8082
       TORII_TELEMETRY_URL: iroha2:8182
@@ -52,6 +55,7 @@ services:
   iroha3:
     image: hyperledger/iroha2:dev
     environment:
+      KURA_BLOCK_STORE_PATH: /chain
       TORII_P2P_ADDR: iroha3:1340
       TORII_API_URL: iroha3:8083
       TORII_TELEMETRY_URL: iroha3:8183


### PR DESCRIPTION
# Description of Change

Move single-stage implementation of docker containers in Iroha v2 CI pipeline to a multistage assembly and testing with multiple layers. 

- [x] Introduce alpine final docker image
- [ ] Create env container for CI.
- [ ] Set up automatic action for building and pushing the env container from unprotected branches. 
- [ ] Build iroha binaries in GHA CI. 
- [ ] Test the built binaries using the `check.sh` and `test/*.sh`
- [ ] Build Iroha binaries with the `musl` target. 
- [ ] Copy and deploy the binaries in a single container versioned according to the branch it gets pushed from. 