### PR TITLE
[refactor]: Refactor around `QueryError`

### DIFF
--- a/cli/src/torii/mod.rs
+++ b/cli/src/torii/mod.rs
@@ -86,7 +86,7 @@ pub enum Error {
 pub(crate) const fn query_status_code(query_error: &query::Error) -> StatusCode {
     use query::Error::*;
     match query_error {
-        Decode(_) | Version(_) | Evaluate(_) | Conversion(_) => StatusCode::BAD_REQUEST,
+        Decode(_) | Evaluate(_) | Conversion(_) => StatusCode::BAD_REQUEST,
         Signature(_) => StatusCode::UNAUTHORIZED,
         Permission(_) => StatusCode::FORBIDDEN,
         Find(_) => StatusCode::NOT_FOUND,

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -201,8 +201,8 @@ impl QuerySet {
 impl From<warp::http::Response<warp::hyper::body::Bytes>> for QueryResponseBody {
     fn from(src: warp::http::Response<warp::hyper::body::Bytes>) -> Self {
         if StatusCode::OK == src.status() {
-            let body = VersionedQueryResult::decode_versioned(src.body())
-                .expect("The response body failed to be decoded to VersionedQueryResult even though the status is Ok 200");
+            let body = VersionedPaginatedQueryResult::decode_versioned(src.body())
+                .expect("The response body failed to be decoded to VersionedPaginatedQueryResult even though the status is Ok 200");
             Self::Ok(Box::new(body))
         } else {
             let body = query::Error::decode(&mut src.body().as_ref())
@@ -221,7 +221,7 @@ struct QueryResponseTest {
 
 #[allow(variant_size_differences)]
 enum QueryResponseBody {
-    Ok(Box<VersionedQueryResult>),
+    Ok(Box<VersionedPaginatedQueryResult>),
     Err(query::Error),
 }
 
@@ -230,7 +230,10 @@ impl QueryResponseTest {
         self.status = Some(status);
         self
     }
-    fn body_matches_ok(mut self, predicate: impl Fn(&VersionedQueryResult) -> bool) -> Self {
+    fn body_matches_ok(
+        mut self,
+        predicate: impl Fn(&VersionedPaginatedQueryResult) -> bool,
+    ) -> Self {
         self.body_matches = if let QueryResponseBody::Ok(body) = &self.response_body {
             Some(predicate(body))
         } else {
@@ -299,7 +302,7 @@ fn asset_definition_new(name: &str) -> NewAssetDefinition {
     ))
 }
 
-// TODO: All the following tests must be parameterised and collapsed
+// TODO: All the following tests must be parameterized and collapsed
 
 #[tokio::test]
 async fn find_asset() {
@@ -314,9 +317,10 @@ async fn find_asset() {
         .await
         .status(StatusCode::OK)
         .body_matches_ok(|body| {
-            if let VersionedQueryResult::V1(QueryResult(Value::Identifiable(
-                IdentifiableBox::Asset(asset),
-            ))) = body
+            if let VersionedPaginatedQueryResult::V1(PaginatedQueryResult {
+                result: QueryResult(Value::Identifiable(IdentifiableBox::Asset(asset))),
+                ..
+            }) = body
             {
                 *asset.value() == AssetValue::Quantity(99)
             } else {
@@ -430,9 +434,12 @@ async fn find_asset_definition() {
         .await
         .status(StatusCode::OK)
         .body_matches_ok(|body| {
-            if let VersionedQueryResult::V1(QueryResult(Value::Identifiable(
-                IdentifiableBox::AssetDefinition(received),
-            ))) = body
+            if let VersionedPaginatedQueryResult::V1(PaginatedQueryResult {
+                result: QueryResult(Value::Identifiable(
+                    IdentifiableBox::AssetDefinition(received),
+                )),
+                ..
+            }) = body
             {
                 Box::new(asset_definition.clone().build()) == *received
             } else {

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -18,7 +18,7 @@ use iroha_core::{
     tx::TransactionValidator,
     wsv::World,
 };
-use iroha_data_model::{account::GENESIS_ACCOUNT_NAME, asset::NewAssetDefinition, prelude::*};
+use iroha_data_model::{account::GENESIS_ACCOUNT_NAME, prelude::*};
 use iroha_version::prelude::*;
 use tokio::time;
 use warp::test::WsClient;
@@ -275,31 +275,25 @@ fn register_account(name: &str) -> Instruction {
 }
 
 fn register_asset_definition(name: &str) -> Instruction {
-    RegisterBox::new(asset_definition_new(name)).into()
+    RegisterBox::new(AssetDefinition::quantity(asset_definition_id(name))).into()
 }
 
 fn mint_asset(quantity: u32, asset: &str, account: &str) -> Instruction {
-    MintBox::new(Value::U32(quantity), asset_id_new(asset, DOMAIN, account)).into()
+    MintBox::new(Value::U32(quantity), asset_id(asset, account)).into()
 }
 
-fn asset_id_new(asset: &str, domain: &str, account: &str) -> AssetId {
+fn asset_definition_id(name: &str) -> AssetDefinitionId {
+    AssetDefinitionId::new(name.parse().expect("Valid"), DOMAIN.parse().expect("Valid"))
+}
+
+fn asset_id(name: &str, account: &str) -> AssetId {
     AssetId::new(
-        AssetDefinitionId::new(
-            asset.parse().expect("Valid"),
-            domain.parse().expect("Valid"),
-        ),
+        asset_definition_id(name),
         AccountId::new(
             account.parse().expect("Valid"),
             DOMAIN.parse().expect("Valid"),
         ),
     )
-}
-
-fn asset_definition_new(name: &str) -> NewAssetDefinition {
-    AssetDefinition::quantity(AssetDefinitionId::new(
-        name.parse().expect("Valid"),
-        DOMAIN.parse().expect("Valid"),
-    ))
 }
 
 // TODO: All the following tests must be parameterized and collapsed
@@ -311,8 +305,8 @@ async fn find_asset() {
         .given(register_account("alice"))
         .given(register_asset_definition("rose"))
         .given(mint_asset(99, "rose", "alice"))
-        .query(QueryBox::FindAssetById(FindAssetById::new(asset_id_new(
-            "rose", DOMAIN, "alice",
+        .query(QueryBox::FindAssetById(FindAssetById::new(asset_id(
+            "rose", "alice",
         ))))
         .await
         .status(StatusCode::OK)
@@ -338,7 +332,7 @@ async fn find_asset_with_no_mint() {
         .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            asset_id_new("rose", DOMAIN, "alice"),
+            asset_id("rose", "alice"),
         )))
         .await
         .status(StatusCode::NOT_FOUND)
@@ -360,7 +354,7 @@ async fn find_asset_with_no_asset_definition() {
     // .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            asset_id_new("rose", DOMAIN, "alice"),
+            asset_id("rose", "alice"),
         )))
         .await
         .status(StatusCode::NOT_FOUND)
@@ -382,7 +376,7 @@ async fn find_asset_with_no_account() {
         .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            asset_id_new("rose", DOMAIN, "alice"),
+            asset_id("rose", "alice"),
         )))
         .await
         .status(StatusCode::NOT_FOUND)
@@ -404,7 +398,7 @@ async fn find_asset_with_no_domain() {
     // .given(register_asset_definition("rose"))
     // .given(mint_asset(99, "rose", "alice"))
         .query(QueryBox::FindAssetById(FindAssetById::new(
-            asset_id_new("rose", DOMAIN, "alice"),
+            asset_id("rose", "alice"),
         )))
         .await
         .status(StatusCode::NOT_FOUND)
@@ -420,28 +414,50 @@ async fn find_asset_with_no_domain() {
 
 #[tokio::test]
 async fn find_asset_definition() {
-    let asset_definition = asset_definition_new("rose");
-
     QuerySet::new()
         .given(register_domain())
-        .given(RegisterBox::new(asset_definition.clone()).into())
+        .given(register_asset_definition("rose"))
         .query(QueryBox::FindAssetDefinitionById(
-            FindAssetDefinitionById::new(AssetDefinitionId::new(
-                "rose".parse().expect("Valid"),
-                DOMAIN.parse().expect("Valid"),
-            )),
+            FindAssetDefinitionById::new(asset_definition_id("rose")),
         ))
         .await
         .status(StatusCode::OK)
-        .body_matches_ok(|body| {
-            if let VersionedPaginatedQueryResult::V1(PaginatedQueryResult {
-                result: QueryResult(Value::Identifiable(
-                    IdentifiableBox::AssetDefinition(received),
-                )),
-                ..
-            }) = body
-            {
-                Box::new(asset_definition.clone().build()) == *received
+        .assert()
+}
+
+#[tokio::test]
+async fn find_asset_definition_with_no_asset_definition() {
+    QuerySet::new()
+        .given(register_domain())
+    // .given(register_asset_definition("rose"))
+        .query(QueryBox::FindAssetDefinitionById(
+            FindAssetDefinitionById::new(asset_definition_id("rose")),
+        ))
+        .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::AssetDefinition(_))
+            } else {
+                false
+            }
+        })
+        .assert()
+}
+
+#[tokio::test]
+async fn find_asset_definition_with_no_domain() {
+    QuerySet::new()
+    // .given(register_domain())
+    // .given(register_asset_definition("rose"))
+        .query(QueryBox::FindAssetDefinitionById(
+            FindAssetDefinitionById::new(asset_definition_id("rose")),
+        ))
+        .await
+        .status(StatusCode::NOT_FOUND)
+        .body_matches_err(|body| {
+            if let query::Error::Find(err) = body {
+                matches!(**err, FindError::Domain(_))
             } else {
                 false
             }

--- a/cli/src/torii/utils.rs
+++ b/cli/src/torii/utils.rs
@@ -57,7 +57,7 @@ pub mod body {
 
         fn try_from(body: &Bytes) -> Result<Self, Self::Error> {
             let query = VersionedSignedQueryRequest::decode_versioned(body.as_ref())
-                .map_err(|e| WarpQueryError(QueryError::Decode(Box::new(e))))?;
+                .map_err(|e| WarpQueryError(Box::new(e).into()))?;
             let VersionedSignedQueryRequest::V1(query) = query;
             Ok(Self::try_from(query)?)
         }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1213,9 +1213,7 @@ mod tests {
             ];
 
             for (status_code, err) in responses {
-                let resp = Response::builder()
-                    .status(status_code)
-                    .body(err.clone().encode())?;
+                let resp = Response::builder().status(status_code).body(err.encode())?;
 
                 match sut.handle(resp) {
                     Err(ClientQueryError::QueryError(actual)) => {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1185,7 +1185,6 @@ mod tests {
     #[cfg(test)]
     mod query_errors_handling {
         use http::Response;
-        use iroha_core::smartcontracts::isi::query::UnsupportedVersionError;
 
         use super::*;
 
@@ -1193,10 +1192,6 @@ mod tests {
         fn certain_errors() -> Result<()> {
             let sut = QueryResponseHandler::<FindAllAssets>::default();
             let responses = vec![
-                (
-                    StatusCode::BAD_REQUEST,
-                    QueryError::Version(UnsupportedVersionError { version: 19 }),
-                ),
                 (
                     StatusCode::UNAUTHORIZED,
                     QueryError::Signature("whatever".to_owned()),

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -227,7 +227,7 @@ pub mod isi {
 
             wsv.modify_account(&account_id.clone(), |account| {
                 if !account.remove_role(&role_id) {
-                    return Err(Error::Find(Box::new(FindError::Account(account_id))));
+                    return Err(FindError::Account(account_id).into());
                 }
 
                 Ok(AccountEvent::PermissionRemoved(account_id))
@@ -353,7 +353,7 @@ pub mod query {
             wsv.map_account(&id, |account| {
                 account.metadata().get(&key).map(Clone::clone)
             })?
-            .ok_or_else(|| query::Error::Find(Box::new(FindError::MetadataKey(key))))
+            .ok_or_else(|| FindError::MetadataKey(key).into())
         }
     }
 

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -74,7 +74,7 @@ pub mod isi {
                     .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_add(self.object)
-                    .ok_or(Error::Math(MathError::Overflow))?;
+                    .ok_or(MathError::Overflow)?;
                 wsv.metrics.tx_amounts.observe(f64::from(*quantity));
 
                 Ok(AssetEvent::Added(asset_id.clone()))
@@ -102,7 +102,7 @@ pub mod isi {
                     .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_add(self.object)
-                    .ok_or(Error::Math(MathError::Overflow))?;
+                    .ok_or(MathError::Overflow)?;
                 #[allow(clippy::cast_precision_loss)]
                 wsv.metrics.tx_amounts.observe(*quantity as f64);
 
@@ -320,7 +320,7 @@ pub mod isi {
                     .map_err(|e| Error::Conversion(e.to_string()))?;
                 *quantity = quantity
                     .checked_sub(self.object)
-                    .ok_or(Error::Math(MathError::NotEnoughQuantity))?;
+                    .ok_or(MathError::NotEnoughQuantity)?;
 
                 Ok(AssetEvent::Removed(self.source_id.clone()))
             })?;

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -60,7 +60,7 @@ pub mod isi {
 
             wsv.modify_domain(&account_id.domain_id.clone(), |domain| {
                 if domain.remove_account(&account_id).is_none() {
-                    return Err(Error::Find(Box::new(FindError::Account(account_id))));
+                    return Err(FindError::Account(account_id).into());
                 }
 
                 Ok(DomainEvent::Account(AccountEvent::Deleted(account_id)))
@@ -143,9 +143,9 @@ pub mod isi {
                     .remove_asset_definition(&asset_definition_id)
                     .is_none()
                 {
-                    return Err(Error::Find(Box::new(FindError::AssetDefinition(
+                    return Err(FindError::AssetDefinition(
                         asset_definition_id,
-                    ))));
+                    ).into());
                 }
 
                 Ok(DomainEvent::AssetDefinition(AssetDefinitionEvent::Deleted(

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -143,9 +143,7 @@ pub mod isi {
                     .remove_asset_definition(&asset_definition_id)
                     .is_none()
                 {
-                    return Err(FindError::AssetDefinition(
-                        asset_definition_id,
-                    ).into());
+                    return Err(FindError::AssetDefinition(asset_definition_id).into());
                 }
 
                 Ok(DomainEvent::AssetDefinition(AssetDefinitionEvent::Deleted(

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -79,7 +79,7 @@ impl<W: WorldTrait> Evaluate<W> for ContextValue {
     ) -> Result<Self::Value, Self::Error> {
         context
             .get(&self.value_name)
-            .ok_or_else(|| Error::Find(Box::new(FindError::Context(self.value_name.clone()))))
+            .ok_or_else(|| FindError::Context(self.value_name.clone()).into())
             .map(ToOwned::to_owned)
     }
 }
@@ -345,7 +345,7 @@ impl<W: WorldTrait> Evaluate<W> for Divide {
         let right: u32 = self.right.evaluate(wsv, context)?;
         left.checked_div(right)
             .map(Value::U32)
-            .ok_or(Error::Math(MathError::DivideByZero))
+            .ok_or(MathError::DivideByZero.into())
     }
 }
 

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -345,7 +345,7 @@ impl<W: WorldTrait> Evaluate<W> for Divide {
         let right: u32 = self.right.evaluate(wsv, context)?;
         left.checked_div(right)
             .map(Value::U32)
-            .ok_or(MathError::DivideByZero.into())
+            .ok_or_else(|| MathError::DivideByZero.into())
     }
 }
 

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -91,9 +91,7 @@ pub mod error {
                 trigger::set::ModRepeatsError::NotFound(not_found_id) => {
                     FindError::Trigger(not_found_id).into()
                 }
-                trigger::set::ModRepeatsError::RepeatsOverflow(_) => {
-                    MathError::Overflow.into()
-                }
+                trigger::set::ModRepeatsError::RepeatsOverflow(_) => MathError::Overflow.into(),
             }
         }
     }
@@ -128,7 +126,7 @@ pub mod error {
     }
 
     /// Type assertion error
-    #[derive(Debug, Clone, Error, Decode, Encode, IntoSchema)]
+    #[derive(Debug, Error, Decode, Encode, IntoSchema)]
     pub enum FindError {
         /// Failed to find asset
         #[error("Failed to find asset: `{0}`")]

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -46,7 +46,7 @@ pub mod error {
     pub enum Error {
         /// Failed to find some entity
         #[error("Failed to find")]
-        Find(#[source] Box<FindError>),
+        Find(#[from] Box<FindError>),
         /// Failed to assert type
         #[error("Type assertion failed. {0}")]
         Type(#[from] TypeError),
@@ -89,10 +89,10 @@ pub mod error {
         fn from(err: trigger::set::ModRepeatsError) -> Self {
             match err {
                 trigger::set::ModRepeatsError::NotFound(not_found_id) => {
-                    Error::Find(Box::new(FindError::Trigger(not_found_id)))
+                    FindError::Trigger(not_found_id).into()
                 }
                 trigger::set::ModRepeatsError::RepeatsOverflow(_) => {
-                    Error::Math(MathError::Overflow)
+                    MathError::Overflow.into()
                 }
             }
         }
@@ -213,14 +213,14 @@ pub mod error {
     impl From<FixedPointOperationError> for Error {
         fn from(err: FixedPointOperationError) -> Self {
             match err {
-                FixedPointOperationError::NegativeValue(_) => Self::Math(MathError::NegativeValue),
+                FixedPointOperationError::NegativeValue(_) => MathError::NegativeValue.into(),
                 FixedPointOperationError::Conversion(e) => {
                     Self::Conversion(format!("Mathematical conversion failed. {}", e))
                 }
-                FixedPointOperationError::Overflow => Self::Math(MathError::Overflow),
-                FixedPointOperationError::DivideByZero => Self::Math(MathError::DivideByZero),
-                FixedPointOperationError::DomainViolation => Self::Math(MathError::DomainViolation),
-                FixedPointOperationError::Arithmetic => Self::Math(MathError::Unknown),
+                FixedPointOperationError::Overflow => MathError::Overflow.into(),
+                FixedPointOperationError::DivideByZero => MathError::DivideByZero.into(),
+                FixedPointOperationError::DomainViolation => MathError::DomainViolation.into(),
+                FixedPointOperationError::Arithmetic => MathError::Unknown.into(),
             }
         }
     }

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -79,7 +79,7 @@ pub enum Error {
 
 impl From<FindError> for Error {
     fn from(err: FindError) -> Self {
-        Error::Find(Box::new(err))
+        Box::new(err).into()
     }
 }
 

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -52,7 +52,7 @@ impl UnsupportedVersionError {
 }
 
 /// Query errors.
-#[derive(Error, Debug, Clone, Decode, Encode, IntoSchema)]
+#[derive(Error, Debug, Decode, Encode, IntoSchema)]
 pub enum Error {
     /// Query can not be decoded.
     #[error("Query can not be decoded")]

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -33,33 +33,12 @@ impl ValidQueryRequest {
     }
 }
 
-/// Unsupported version error
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Decode, Encode, IntoSchema, Error)]
-#[error(
-    "Unsupported version. Expected: {}, got: {version}",
-    Self::expected_version()
-)]
-pub struct UnsupportedVersionError {
-    /// Version that we got
-    pub version: u8,
-}
-
-impl UnsupportedVersionError {
-    /// Expected version
-    pub const fn expected_version() -> u8 {
-        1
-    }
-}
-
 /// Query errors.
 #[derive(Error, Debug, Decode, Encode, IntoSchema)]
 pub enum Error {
     /// Query can not be decoded.
     #[error("Query can not be decoded")]
     Decode(#[from] Box<iroha_version::error::Error>),
-    /// Query has unsupported version.
-    #[error("Query has unsupported version")]
-    Version(#[from] UnsupportedVersionError),
     /// Query has wrong signature.
     #[error("Query has the wrong signature: {0}")]
     Signature(String),

--- a/core/src/smartcontracts/isi/triggers.rs
+++ b/core/src/smartcontracts/isi/triggers.rs
@@ -30,7 +30,7 @@ pub mod isi {
                 match &new_trigger.action.repeats {
                     Repeats::Exactly(action) if action.get() == 1 => (),
                     _ => {
-                        return Err(Error::Math(MathError::Overflow));
+                        return Err(MathError::Overflow.into());
                     }
                 }
             }

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -186,7 +186,7 @@ pub mod isi {
                     return Ok(RoleEvent::Deleted(role_id).into());
                 }
 
-                Err(Error::Find(Box::new(FindError::Role(role_id))))
+                Err(FindError::Role(role_id).into())
             })
         }
     }

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -225,9 +225,9 @@ Also returns current status of peer in json string:
 - 200 OK - reports status:
   + Number of connected peers, except for the reporting peer itself
   + Number of committed blocks (block height)
-  + Total number of transactions
-  + `uptime` since creation of the genesis block in milliseconds.
-  + Number of view_changes in the current round
+  + Total number of accepted and rejected transactions
+  + Uptime since creation of the genesis block.
+  + Number of view changes in the current round
 
 ```json
 {
@@ -242,6 +242,7 @@ Also returns current status of peer in json string:
     "view_changes": 0
 }
 ```
+- __CAUTION__: Almost all fields are 64-bit integers and should be handled with care in JavaScript
 
 ### Metrics
 

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -338,7 +338,7 @@ For more information on codec check [Substrate Dev Hub](https://substrate.dev/do
 - `VersionedTransaction` - `iroha_data_model::transaction::VersionedTransaction`
 - `VersionedSignedQueryRequest` - `iroha_data_model::query::VersionedSignedQueryRequest`
 
-- `VersionedQueryResult` - `iroha_data_model::query::VersionedQueryResult`
+- `VersionedPaginatedQueryResult` - `iroha_data_model::query::VersionedPaginatedQueryResult`
 - `QueryError` - `iroha_core::smartcontracts::isi::query::Error`
 - `UnsupportedVersionError` - `iroha_core::smartcontracts::isi::query::UnsupportedVersionError`
 - `FindError` - `iroha_core::smartcontracts::isi::error::FindError`

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -347,7 +347,6 @@ pub fn generate_map() -> DumpDecodedMap {
         query::Payload,
         smartcontracts::isi::error::FindError,
         smartcontracts::isi::query::Error,
-        smartcontracts::isi::query::UnsupportedVersionError,
         sumeragi::network_topology::Topology,
         sumeragi::view_change::BlockCreationTimeout,
         sumeragi::view_change::CommitTimeout,

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -35,7 +35,7 @@ pub mod error {
     use super::UnsupportedVersion;
 
     /// Versioning errors
-    #[derive(Debug, Clone, FromVariant, IntoSchema)]
+    #[derive(Debug, FromVariant, IntoSchema)]
     #[cfg_attr(feature = "std", derive(thiserror::Error))]
     #[cfg_attr(feature = "scale", derive(Encode, Decode))]
     pub enum Error {
@@ -141,7 +141,7 @@ pub trait Version {
 }
 
 /// Structure describing a container content which version is not supported.
-#[derive(Debug, Clone, IntoSchema)]
+#[derive(Debug, IntoSchema)]
 #[cfg_attr(feature = "scale", derive(Encode, Decode))]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct UnsupportedVersion {
@@ -170,7 +170,7 @@ impl UnsupportedVersion {
 }
 
 /// Raw versioned content, serialized.
-#[derive(Debug, Clone, IntoSchema)]
+#[derive(Debug, IntoSchema)]
 #[cfg_attr(feature = "scale", derive(Encode, Decode))]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub enum RawVersioned {


### PR DESCRIPTION
### Description of the Change
- [refactor]
    - d9e4712f3ce44bf6f3b62861e8a30e607e21c306 Remove unused `query::Error` variants
    - 3554726991d421c6800e93a7a7428aac4c9f9308 Remove recovery from useless `Rejection`
    - 1f1028045b91b27bcd07aafb295e241624a47742 Un-implement unused `Clone`
    - 770168c69a4f6215f73f258d06ade747830f12ae Replace `#[source]` in a single field with `#[from]`
- minor [test]
    - 30f262e2aa669a6b127d5e203ab437a0f55896ee Add to `torii::tests`
- minor [fix]
    - ab382ddbbf1e112ec5484ba0721133e7fbbec7f0 Resolve apparent mismatch between `VersionedPaginatedQueryResult` and `VersionedQueryResult`
- minor [documentation]
    - ab492d748334d7caeb2d15bdb8f505856524f2fb Fix description for `Status` response
### Issue
None

### Benefits
Trimmed code

### Possible Drawbacks
None