### PR TITLE
[feature] #2276: Include current Block hash into BlockHeaderValue

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -725,6 +725,8 @@ impl VersionedCommittedBlock {
 
     /// Converts block to [`iroha_data_model`] representation for use in e.g. queries.
     pub fn into_value(self) -> BlockValue {
+        let current_block_hash = self.hash();
+
         let CommittedBlock {
             header,
             rejected_transactions,
@@ -732,7 +734,6 @@ impl VersionedCommittedBlock {
             event_recommendations,
             ..
         } = self.into_v1();
-
         let BlockHeader {
             timestamp,
             height,
@@ -750,6 +751,7 @@ impl VersionedCommittedBlock {
             transactions_hash,
             rejected_transactions_hash,
             invalidated_blocks_hashes: invalidated_blocks_hashes.into_iter().map(|h| *h).collect(),
+            current_block_hash: Hash::from(current_block_hash),
         };
 
         BlockValue {

--- a/data_model/src/block_value.rs
+++ b/data_model/src/block_value.rs
@@ -30,6 +30,8 @@ pub struct BlockHeaderValue {
     pub rejected_transactions_hash: HashOf<MerkleTree<VersionedTransaction>>,
     /// Hashes of the blocks that were rejected by consensus.
     pub invalidated_blocks_hashes: Vec<Hash>,
+    /// Hash of the most recent block
+    pub current_block_hash: Hash,
 }
 
 impl PartialOrd for BlockHeaderValue {


### PR DESCRIPTION

### Description of the Change
This PR introduces `current_block_hash` field to `BlockHeaderValue`. This field contains the hash of the latest `VersionComittedBlock`. 
### Issue
When we query for block headers we cannot reliably compute the hash of the block, since it's computed from the byte representation of the block and can be architecture dependent.
### Benefits
The Hash of a block will no longer be architecture dependent. 
### Possible Drawbacks
Not that I know of.
<!--### Usage Examples or Tests *[optional]*-->
<!--### Alternate Designs *[optional]*-->
