### PR TITLE
[feature] #1638: `configuration` return doc subtree

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -186,19 +186,21 @@ pub trait Configurable: Serialize + DeserializeOwned {
     ///
     /// # Errors
     /// Fails if field was unknown
-    fn get_doc_recursive<'tl>(
-        field: impl AsRef<[&'tl str]>,
-    ) -> Result<Option<&'static str>, Self::Error>;
+    fn get_doc_recursive<'tl>(field: impl AsRef<[&'tl str]>)
+        -> Result<Option<String>, Self::Error>;
 
     /// Gets docs of field
     /// # Errors
     /// Fails if field was unknown
-    fn get_doc(field: &str) -> Result<Option<&'static str>, Self::Error> {
+    fn get_doc(field: &str) -> Result<Option<String>, Self::Error> {
         Self::get_doc_recursive([field])
     }
 
     /// Returns documentation for all fields in form of json object
     fn get_docs() -> Value;
+
+    /// Gets inner docs for non-leaf fields
+    fn get_inner_docs() -> String;
 }
 
 /// Json config for getting configuration

--- a/config/tests/simple.rs
+++ b/config/tests/simple.rs
@@ -24,14 +24,17 @@ struct InnerConfiguration {
 fn test_docs() {
     assert_eq!(
         Configuration::get_doc_recursive(["inner", "b"]).unwrap(),
-        Some(" Docs from b\n\nHas type `i32`. Can be configured via environment variable `CONF_INNER_B`")
+        Some(" Docs from b\n\nHas type `i32`. Can be configured via environment variable `CONF_INNER_B`".to_owned())
     );
     assert_eq!(
         Configuration::get_doc_recursive(["inner", "a"]).unwrap(),
-        Some("Has type `String`. Can be configured via environment variable `CONF_INNER_A`")
+        Some(
+            "Has type `String`. Can be configured via environment variable `CONF_INNER_A`"
+                .to_owned()
+        )
     );
     assert_eq!(
         Configuration::get_doc_recursive(["inner"]).unwrap(),
-        Some(" Inner structure\n\nHas type `InnerConfiguration`. Can be configured via environment variable `CONF_INNER`")
+        Some(" Inner structure\n\nHas type `InnerConfiguration`. Can be configured via environment variable `CONF_INNER`\n\nHas following fields:\n\na: Has type `String`. Can be configured via environment variable `CONF_INNER_A`\n\nb:  Docs from b\n\nHas type `i32`. Can be configured via environment variable `CONF_INNER_B`\n\n\n".to_owned())
     );
 }

--- a/docs/source/references/api_spec.md
+++ b/docs/source/references/api_spec.md
@@ -145,9 +145,12 @@ continues to stream blocks as they are added to the blockchain.
 **Method**: `GET`
 
 **Expects**:
-There are 2 variants:
-- It either expects json body `"Value"` and returns configuration value as json
-- Or it expects json body like below and returns documentation for specific field (as json string) or null (here for field `a.b.c`):
+There are 2 options:
+- Expects: a JSON body `"Value"`. Returns: configuration value as JSON.
+- Expects: a JSON body that specifies the field (see example below). Returns: documentation for a specific field (as JSON string) or `null`.
+
+Note that if the requested field has more fields inside of it, then all the documentation for its inner members is returned as well.
+Here is an example for getting a field `a.b.c`:
 ```json
 {
     "Docs": ["a", "b", "c"]
@@ -155,7 +158,7 @@ There are 2 variants:
 ```
 
 **Examples**:
-To get the top-level configuration docs for [`Torii`]
+To get the top-level configuration docs for [`Torii`] and all the fields within it:
 ```bash
 curl -X GET -H 'content-type: application/json' http://127.0.0.1:8080/configuration -d '{"Docs" : ["torii"]} ' -i
 ```

--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -267,11 +267,13 @@ mod docs {
                     Value::Object(_) => {
                         let doc = Self::get_doc_recursive(&get_field)
                             .expect("Should be there, as already in docs");
-                        (doc.unwrap_or_default().to_owned(), true)
+                        (doc.unwrap_or_default(), true)
                     }
                     Value::String(s) => (s.clone(), false),
                     _ => unreachable!("Only strings and objects in docs"),
                 };
+                // Hacky workaround to avoid duplicating inner fields docs in the reference
+                let doc = doc.lines().take(3).collect::<Vec<&str>>().join("\n");
                 let doc = doc.strip_prefix(' ').unwrap_or(&doc);
                 let defaults = Self::default()
                     .get_recursive(get_field)


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
The `configuration` endpoint now returns all the inner fields as well when queried for docs.

### Issue
Resolves #1638.
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->
More helpful doc API calls.

### Possible Drawbacks
The only way to return a `&'static str` while also making it custom formatted that I found was by boxing a `String` and then leaking it explicitly. Hopefully it doesn't introduce security issues. 
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
