### PR TITLE
[refactor] #2238: Add peer builder for tests

### DIFF
--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -5,7 +5,7 @@ use iroha_core::genesis::{
     GenesisNetwork, GenesisNetworkTrait, RawGenesisBlock, RawGenesisBlockBuilder,
 };
 use iroha_data_model::prelude::*;
-use test_network::{get_key_pair, Peer as TestPeer, TestRuntime};
+use test_network::{get_key_pair, Peer as TestPeer, PeerBuilder, TestRuntime};
 use tokio::runtime::Runtime;
 
 fn main() {
@@ -43,10 +43,14 @@ fn main() {
     )
     .expect("genesis creation failed");
 
+    let builder = PeerBuilder::new()
+        .with_into_genesis(genesis)
+        .with_configuration(configuration);
+
     // This only submits the genesis. It doesn't check if the accounts
     // are created, because that check is 1) not needed for what the
     // test is actually for, 2) incredibly slow, making this sort of
     // test impractical, 3) very likely to overflow memory on systems
     // with less than 16GiB of free memory.
-    rt.block_on(peer.start_with_config(genesis, configuration));
+    rt.block_on(builder.start_with_peer(&mut peer));
 }

--- a/client/examples/million_accounts_tx.rs
+++ b/client/examples/million_accounts_tx.rs
@@ -2,10 +2,10 @@
 use std::{thread, time::Duration};
 
 use iroha_data_model::prelude::*;
-use test_network::{wait_for_genesis_committed, Peer as TestPeer};
+use test_network::{wait_for_genesis_committed, PeerBuilder};
 
 fn create_million_accounts_directly() {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     for i in 0_u32..1_000_000_u32 {
         let domain_id: DomainId = format!("wonderland-{}", i).parse().expect("Valid");

--- a/client/examples/ten_million_accounts.rs
+++ b/client/examples/ten_million_accounts.rs
@@ -2,10 +2,10 @@
 use std::{thread, time::Duration};
 
 use iroha_data_model::prelude::*;
-use test_network::{wait_for_genesis_committed, Peer as TestPeer};
+use test_network::{wait_for_genesis_committed, PeerBuilder};
 
 fn create_million_accounts_directly() {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     for i in 0_u32..10_000_000_u32 {
         let domain_id: DomainId = format!("wonderland-{}", i).parse().expect("Valid");

--- a/client/tests/integration/add_account.rs
+++ b/client/tests/integration/add_account.rs
@@ -5,12 +5,12 @@ use std::thread;
 use eyre::Result;
 use iroha_client::client;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 #[test]
 fn client_add_account_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let pipeline_time = super::Configuration::pipeline_time();

--- a/client/tests/integration/add_asset.rs
+++ b/client/tests/integration/add_asset.rs
@@ -5,13 +5,13 @@ use std::{str::FromStr as _, thread};
 use eyre::Result;
 use iroha_client::client;
 use iroha_data_model::{fixed::Fixed, prelude::*};
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -42,7 +42,7 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
 
 #[test]
 fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -73,7 +73,7 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
 
 #[test]
 fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
 
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
@@ -125,7 +125,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
 
 #[test]
 fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     let pipeline_time = Configuration::pipeline_time();
 
     // Given

--- a/client/tests/integration/add_domain.rs
+++ b/client/tests/integration/add_domain.rs
@@ -5,14 +5,14 @@ use std::thread;
 use eyre::Result;
 use iroha_client::client;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn client_add_domain_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/burn_public_keys.rs
+++ b/client/tests/integration/burn_public_keys.rs
@@ -5,7 +5,7 @@ use std::thread;
 use iroha_client::client::{account, transaction, Client};
 use iroha_core::prelude::*;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
@@ -31,7 +31,7 @@ fn public_keys_cannot_be_burned_to_nothing() {
     let bob_id: AccountId = "bob@wonderland".parse().expect("Valid");
     let bob_keys_count = |client: &mut Client| account_keys_count(client, bob_id.clone());
 
-    let (_rt, _peer, mut client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     let register_bob = RegisterBox::new(Account::new(bob_id.clone(), [])).into();

--- a/client/tests/integration/config.rs
+++ b/client/tests/integration/config.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::restriction)]
 
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn get_config() {
     // The underscored variables must not be dropped until end of closure.
-    let (_dont_drop, _dont_drop_either, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_dont_drop, _dont_drop_either, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let field = test_client.get_config_docs(&["torii"]).unwrap().unwrap();

--- a/client/tests/integration/events/data.rs
+++ b/client/tests/integration/events/data.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use iroha_core::smartcontracts::wasm;
 use iroha_data_model::{prelude::*, transaction::WasmSmartContract};
 use parity_scale_codec::Encode;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 use crate::wasm::utils::wasm_template;
@@ -94,7 +94,7 @@ fn wasm_execution_should_produce_events() -> Result<()> {
 }
 
 fn transaction_execution_should_produce_events(executable: Executable) -> Result<()> {
-    let (_rt, _peer, client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/integration/multisignature_account.rs
+++ b/client/tests/integration/multisignature_account.rs
@@ -6,13 +6,13 @@ use eyre::Result;
 use iroha_client::client::{self, Client};
 use iroha_core::prelude::*;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
-    let (_rt, peer, iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, peer, iroha_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -5,11 +5,11 @@ use std::str::FromStr as _;
 use eyre::Result;
 use iroha_client::client;
 use iroha_data_model::{metadata::UnlimitedMetadata, prelude::*};
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 #[test]
 fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -4,13 +4,13 @@ use std::thread;
 
 use iroha_client::client::asset;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() {
-    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/queries/account.rs
+++ b/client/tests/integration/queries/account.rs
@@ -5,11 +5,11 @@ use std::{collections::HashSet, str::FromStr as _};
 use eyre::Result;
 use iroha_client::client;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 #[test]
 fn find_accounts_with_asset() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Registering new asset definition

--- a/client/tests/integration/queries/role.rs
+++ b/client/tests/integration/queries/role.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use iroha_client::client;
 use iroha_core::smartcontracts::isi::query::Error as QueryError;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 fn create_role_ids() -> [<Role as Identifiable>::Id; 5] {
     [
@@ -20,7 +20,7 @@ fn create_role_ids() -> [<Role as Identifiable>::Id; 5] {
 
 #[test]
 fn find_roles() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();
@@ -49,7 +49,7 @@ fn find_roles() -> Result<()> {
 
 #[test]
 fn find_role_ids() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();
@@ -75,7 +75,7 @@ fn find_role_ids() -> Result<()> {
 
 #[test]
 fn find_role_by_id() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id: <Role as Identifiable>::Id = "root".parse().expect("Valid");
@@ -94,7 +94,7 @@ fn find_role_by_id() -> Result<()> {
 
 #[test]
 fn find_unregistered_role_by_id() {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id: <Role as Identifiable>::Id = "root".parse().expect("Valid");
@@ -111,7 +111,7 @@ fn find_unregistered_role_by_id() {
 
 #[test]
 fn find_roles_by_account_id() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();

--- a/client/tests/integration/query_errors.rs
+++ b/client/tests/integration/query_errors.rs
@@ -8,7 +8,7 @@ use iroha_data_model::prelude::*;
 
 #[test]
 fn non_existent_account_is_specific_error() {
-    let (_rt, _peer, client) = <test_network::Peer>::start_test_with_runtime();
+    let (_rt, _peer, client) = <test_network::PeerBuilder>::new().start_with_runtime();
     // we can not wait for genesis committment
 
     let err = client

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -3,8 +3,8 @@
 use std::{str::FromStr, sync::Arc, thread, time::Duration};
 
 use eyre::Result;
-use iroha_client::client::{self, Client};
-use iroha_core::{genesis::GenesisNetwork, prelude::*};
+use iroha_client::client;
+use iroha_core::prelude::*;
 use iroha_data_model::prelude::*;
 use tempfile::TempDir;
 use test_network::{Peer as TestPeer, *};
@@ -24,14 +24,16 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
 
     // Given
     let rt = Runtime::test();
-    rt.block_on(peer.start_with_config_permissions_dir(
-        configuration.clone(),
-        GenesisNetwork::test(true),
-        AllowAll,
-        AllowAll,
-        Arc::clone(&temp_dir),
-    ));
-    let mut iroha_client = Client::test(&peer.api_address, &peer.telemetry_address);
+    rt.block_on(
+        PeerBuilder::new()
+            .with_configuration(configuration.clone())
+            .with_instruction_validator(AllowAll)
+            .with_query_validator(AllowAll)
+            .with_dir(Arc::clone(&temp_dir))
+            .start_with_peer(&mut peer),
+    );
+    let mut iroha_client = client::Client::test(&peer.api_address, &peer.telemetry_address);
+
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
     let account_id = AccountId::from_str("alice@wonderland").unwrap();
@@ -65,13 +67,14 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
     thread::sleep(Duration::from_millis(2000));
 
     let rt = Runtime::test();
-    rt.block_on(peer.start_with_config_permissions_dir(
-        configuration,
-        GenesisNetwork::test(true),
-        AllowAll,
-        AllowAll,
-        temp_dir,
-    ));
+
+    let builder = PeerBuilder::new()
+        .with_configuration(configuration)
+        .with_instruction_validator(AllowAll)
+        .with_query_validator(AllowAll)
+        .with_dir(temp_dir);
+
+    rt.block_on(builder.start_with_peer(&mut peer));
 
     let account_asset = iroha_client
         .poll_request(client::asset::by_account_id(account_id), |assets| {

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -5,7 +5,7 @@ use std::thread;
 use iroha_client::client;
 use iroha_core::prelude::*;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
@@ -51,7 +51,7 @@ fn simulate_transfer<
 ) where
     Value: From<T>,
 {
-    let (_rt, _peer, mut iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut iroha_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -5,13 +5,13 @@ use std::{str::FromStr as _, sync::mpsc, thread, time::Duration};
 use eyre::{eyre, Result, WrapErr};
 use iroha_client::client::{self, Client};
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 const TRIGGER_NAME: &str = "mint_rose";
 
 #[test]
 fn call_execute_trigger() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -35,7 +35,7 @@ fn call_execute_trigger() -> Result<()> {
 
 #[test]
 fn execute_trigger_should_produce_event() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -70,7 +70,7 @@ fn execute_trigger_should_produce_event() -> Result<()> {
 
 #[test]
 fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -97,7 +97,7 @@ fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
 
 #[test]
 fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -151,7 +151,7 @@ fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
 
 #[test]
 fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -193,7 +193,7 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
 
 #[test]
 fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -238,7 +238,7 @@ fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
 
 #[test]
 fn unregister_trigger() -> Result<()> {
-    let (_rt, _peer, test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let account_id = AccountId::from_str("alice@wonderland")?;

--- a/client/tests/integration/triggers/event_trigger.rs
+++ b/client/tests/integration/triggers/event_trigger.rs
@@ -5,11 +5,11 @@ use std::str::FromStr;
 use eyre::Result;
 use iroha_client::client::{self, Client};
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 #[test]
 fn test_mint_asset_when_new_asset_definition_created() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;

--- a/client/tests/integration/triggers/time_trigger.rs
+++ b/client/tests/integration/triggers/time_trigger.rs
@@ -6,7 +6,7 @@ use eyre::{Context, Result};
 use iroha_client::client::{self, Client};
 use iroha_core::block::DEFAULT_CONSENSUS_ESTIMATION_MS;
 use iroha_data_model::{prelude::*, transaction::WasmSmartContract};
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 /// Macro to abort compilation, if `e` isn't `true`
 macro_rules! const_assert {
@@ -28,7 +28,7 @@ fn time_trigger_execution_count_error_should_be_less_than_10_percent() -> Result
     const_assert!(PERIOD_MS < DEFAULT_CONSENSUS_ESTIMATION_MS);
     const_assert!(ACCEPTABLE_ERROR_PERCENT <= 100);
 
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let start_time = current_time();
 
@@ -82,7 +82,7 @@ fn time_trigger_execution_count_error_should_be_less_than_10_percent() -> Result
 fn change_asset_metadata_after_1_sec() -> Result<()> {
     const PERIOD_MS: u64 = 1000;
 
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let start_time = current_time();
 
@@ -123,7 +123,7 @@ fn change_asset_metadata_after_1_sec() -> Result<()> {
 fn pre_commit_trigger_should_be_executed() -> Result<()> {
     const CHECKS_COUNT: usize = 5;
 
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse().expect("Valid");
@@ -175,7 +175,7 @@ fn mint_nft_for_every_user_every_1_sec() -> Result<()> {
     const TRIGGER_PERIOD_MS: u64 = 1000;
     const EXPECTED_COUNT: u64 = 4;
 
-    let (_rt, _peer, mut test_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let alice_id = "alice@wonderland"

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -4,13 +4,13 @@ use std::{str::FromStr as _, thread};
 
 use iroha_client::client::transaction;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn client_has_rejected_and_acepted_txs_should_return_tx_history() {
-    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -4,13 +4,13 @@ use std::{str::FromStr as _, thread};
 
 use iroha_client::client;
 use iroha_data_model::prelude::*;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 
 use super::Configuration;
 
 #[test]
 fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes() {
-    let (_rt, _peer, iroha_client) = <TestPeer>::start_test_with_runtime();
+    let (_rt, _peer, iroha_client) = <PeerBuilder>::new().start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/reload.rs
+++ b/client/tests/reload.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::restriction)]
 use iroha_config::{logger::Level::*, PostConfiguration};
-use test_network::Peer as TestPeer;
+use test_network::PeerBuilder;
 
 #[test]
 fn reload_log_level() {
-    let (_dont_drop, _dont_drop_either, cl) = <TestPeer>::start_test_with_runtime();
+    let (_dont_drop, _dont_drop_either, cl) = <PeerBuilder>::new().start_with_runtime();
 
     let verify = |level| {
         let field: bool = cl.set_config(PostConfiguration::LogLevel(level)).unwrap();

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -52,52 +52,6 @@ pub struct Network<
     pub peers: HashMap<PeerId, Peer<W, G, K, S, B>>,
 }
 
-impl From<Peer> for Box<iroha_core::tx::Peer> {
-    fn from(val: Peer) -> Self {
-        Box::new(iroha_core::tx::Peer { id: val.id.clone() })
-    }
-}
-
-/// Peer structure
-pub struct Peer<
-    W = World,
-    G = GenesisNetwork,
-    K = Kura<W>,
-    S = Sumeragi<G, K, W>,
-    B = BlockSynchronizer<S, W>,
-> where
-    W: WorldTrait,
-    G: GenesisNetworkTrait,
-    K: KuraTrait<World = W>,
-    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
-    B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
-{
-    /// id of peer
-    pub id: PeerId,
-    /// api address
-    pub api_address: String,
-    /// p2p address
-    pub p2p_address: String,
-    /// telemetry address
-    pub telemetry_address: String,
-    /// Key pair of peer
-    pub key_pair: KeyPair,
-    /// Broker
-    pub broker: Broker,
-    /// Shutdown handle
-    shutdown: Option<JoinHandle<()>>,
-    /// Iroha itself
-    pub iroha: Option<Iroha<W, G, K, S, B>>,
-}
-
-impl std::cmp::PartialEq for Peer {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl std::cmp::Eq for Peer {}
-
 /// Get a standardised key-pair from the hard-coded literals.
 ///
 /// # Panics
@@ -258,16 +212,27 @@ where
     /// Adds peer to network and waits for it to start block
     /// synchronization.
     pub async fn add_peer(&self) -> (Peer, Client) {
-        let client = Client::test(&self.genesis.api_address, &self.genesis.telemetry_address);
-        let mut peer = Peer::new().expect("Failed to create new peer");
+        let genesis_client =
+            Client::test(&self.genesis.api_address, &self.genesis.telemetry_address);
+
         let mut config = Configuration::test();
         config.sumeragi.trusted_peers.peers = self.peers().map(|peer| &peer.id).cloned().collect();
-        peer.start_with_config(GenesisNetwork::test(false), config)
+
+        let peer = PeerBuilder::new()
+            .with_configuration(config)
+            .with_into_genesis(GenesisNetwork::test(false))
+            .start()
             .await;
+
         time::sleep(Configuration::pipeline_time() + Configuration::block_sync_gossip_time()).await;
+
         let add_peer = RegisterBox::new(DataModelPeer::new(peer.id.clone()));
-        client.submit(add_peer).expect("Failed to add new peer.");
+        genesis_client
+            .submit(add_peer)
+            .expect("Failed to add new peer.");
+
         let client = Client::test(&peer.api_address, &peer.telemetry_address);
+
         (peer, client)
     }
 
@@ -285,7 +250,7 @@ where
         offline_peers: u32,
     ) -> Result<Self> {
         let n_peers = n_peers - 1;
-        let mut genesis = Peer::new()?;
+        let mut genesis = Peer::<W, G, K, S, B>::new()?;
         let mut peers = (0..n_peers)
             .map(|_| Peer::new())
             .map(|result| result.map(|peer| (peer.id.clone(), peer)))
@@ -302,12 +267,20 @@ where
         let online_peers = n_peers - offline_peers;
         let futures = FuturesUnordered::new();
 
-        futures.push(genesis.start_with_config(G::test(true), configuration.clone()));
+        let builder = PeerBuilder::<W, G>::new()
+            .with_into_genesis(G::test(true))
+            .with_configuration(configuration.clone());
+
+        futures.push(builder.start_with_peer(&mut genesis));
         for peer in peers
             .values_mut()
             .choose_multiple(rng, online_peers as usize)
         {
-            futures.push(peer.start_with_config(G::test(false), configuration.clone()));
+            let builder = PeerBuilder::<W, G>::new()
+                .with_into_genesis(G::test(false))
+                .with_configuration(configuration.clone());
+
+            futures.push(builder.start_with_peer(peer));
         }
         futures.collect::<()>().await;
 
@@ -369,6 +342,52 @@ pub fn wait_for_genesis_committed(clients: &[Client], offline_peers: u32) {
     );
 }
 
+/// Peer structure
+pub struct Peer<
+    W = World,
+    G = GenesisNetwork,
+    K = Kura<W>,
+    S = Sumeragi<G, K, W>,
+    B = BlockSynchronizer<S, W>,
+> where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+    K: KuraTrait<World = W>,
+    S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
+    B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
+{
+    /// The id of the peer
+    pub id: PeerId,
+    /// API address
+    pub api_address: String,
+    /// P2P address
+    pub p2p_address: String,
+    /// Telemetry address
+    pub telemetry_address: String,
+    /// The key-pair for the peer
+    pub key_pair: KeyPair,
+    /// Broker
+    pub broker: Broker,
+    /// Shutdown handle
+    shutdown: Option<JoinHandle<()>>,
+    /// Iroha itself
+    pub iroha: Option<Iroha<W, G, K, S, B>>,
+}
+
+impl From<Peer> for Box<iroha_core::tx::Peer> {
+    fn from(val: Peer) -> Self {
+        Box::new(iroha_core::tx::Peer { id: val.id.clone() })
+    }
+}
+
+impl std::cmp::PartialEq for Peer {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl std::cmp::Eq for Peer {}
+
 impl<W, G, K, S, B> Drop for Peer<W, G, K, S, B>
 where
     W: WorldTrait,
@@ -422,22 +441,13 @@ where
         }
     }
 
-    /// Starts peer with config, permissions and temporary directory
-    ///
-    /// # Panics
-    /// - Starting [`Iroha`] instance fails.
-    /// - Block store path not readable
-    /// - [`Iroha::start_as_task`] failed or produced empty job handle.
-    /// - `receiver` fails to produce a message.
-    ///
-    /// # TODO
-    /// Use *Builder* pattern (#2238)
-    pub async fn start_with_config_permissions_dir(
+    /// Starts a peer with arguments.
+    async fn start(
         &mut self,
         configuration: Configuration,
         genesis: Option<G>,
-        instruction_validator: impl Into<IsInstructionAllowedBoxed<W>> + Send + 'static,
-        query_validator: impl Into<IsQueryAllowedBoxed<W>> + Send + 'static,
+        instruction_validator: IsInstructionAllowedBoxed<W>,
+        query_validator: IsQueryAllowedBoxed<W>,
         temp_dir: Arc<TempDir>,
     ) {
         let mut configuration = self.get_config(configuration);
@@ -455,6 +465,7 @@ where
         let telemetry =
             iroha_logger::init(&configuration.logger).expect("Failed to initialize telemetry");
         let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+
         let handle = task::spawn(
             async move {
                 // Prevent temporary directory deleting
@@ -462,8 +473,8 @@ where
                 let mut iroha = <Iroha<W, G, K, S, B>>::with_genesis(
                     genesis,
                     configuration,
-                    instruction_validator.into(),
-                    query_validator.into(),
+                    instruction_validator,
+                    query_validator,
                     broker,
                     telemetry,
                 )
@@ -479,50 +490,6 @@ where
         self.iroha = Some(receiver.recv().unwrap());
         time::sleep(Duration::from_millis(300)).await;
         self.shutdown = Some(handle);
-    }
-
-    /// Starts peer with config and permissions
-    ///
-    /// # Panics
-    /// - [`TempDir::new`] failed.
-    /// - Initializing [telemetry](iroha_logger::init()) failed
-    /// - [`Iroha::with_genesis`] failed.
-    /// - Failed to send [`Iroha`] via sender.
-    /// - [`Iroha::start_as_task`] failed or produced empty job handle.
-    pub async fn start_with_config_permissions(
-        &mut self,
-        configuration: Configuration,
-        genesis: Option<G>,
-        instruction_validator: impl Into<IsInstructionAllowedBoxed<W>> + Send + 'static,
-        query_validator: impl Into<IsQueryAllowedBoxed<W>> + Send + 'static,
-    ) {
-        let temp_dir = Arc::new(TempDir::new().expect("Failed to create temp dir."));
-        self.start_with_config_permissions_dir(
-            configuration,
-            genesis,
-            instruction_validator,
-            query_validator,
-            temp_dir,
-        )
-        .await;
-    }
-
-    /// Start peer with config
-    #[inline]
-    pub async fn start_with_config(&mut self, genesis: Option<G>, configuration: Configuration) {
-        self.start_with_config_permissions(configuration, genesis, AllowAll, AllowAll)
-            .await;
-    }
-
-    /// Start peer with config
-    pub async fn start_with_genesis(&mut self, genesis: Option<G>) {
-        self.start_with_config_permissions(Configuration::test(), genesis, AllowAll, AllowAll)
-            .await;
-    }
-
-    /// Start peer
-    pub async fn start(&mut self, submit_genesis: bool) {
-        self.start_with_genesis(G::test(submit_genesis)).await;
     }
 
     /// Creates peer
@@ -553,42 +520,209 @@ where
             broker: Broker::new(),
         })
     }
+}
 
-    /// Starts peer with default configuration.  **IMPORTANT**: Retain
-    /// all three parameters for the scope of the test. Do not ignore
-    /// the first two elements of the tuple.
-    /// Returns its info and client for connecting to it.
-    pub fn start_test_with_runtime() -> (Runtime, Self, Client) {
-        let rt = Runtime::test();
-        let (peer, client) = rt.block_on(Self::start_test_with_permissions(
-            AllowAll.into(),
-            AllowAll.into(),
-        ));
-        (rt, peer, client)
+/// `WithGenesis` structure.
+///
+/// Options for setting up the genesis network for `PeerBuilder`.
+pub enum WithGenesis<G> {
+    /// Use the default genesis network.
+    Default,
+    /// Do not use any genesis networks.
+    None,
+    /// Use the given genesis network.
+    Has(G),
+}
+
+impl<G> Default for WithGenesis<G> {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl<G> From<Option<G>> for WithGenesis<G> {
+    fn from(x: Option<G>) -> Self {
+        match x {
+            None => Self::None,
+            Some(genesis) => Self::Has(genesis),
+        }
+    }
+}
+
+/// `PeerBuilder` structure that helps to create a peer.
+pub struct PeerBuilder<W = World, G = GenesisNetwork>
+where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+{
+    configuration: Option<Configuration>,
+    genesis: WithGenesis<G>,
+    instruction_validator: Option<IsInstructionAllowedBoxed<W>>,
+    query_validator: Option<IsQueryAllowedBoxed<W>>,
+    temp_dir: Option<Arc<TempDir>>,
+}
+
+impl<W, G> PeerBuilder<W, G>
+where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+{
+    /// Creates [`PeerBuilder`].
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Starts peer with default configuration and specified permissions.
-    /// Returns its info and client for connecting to it.
-    pub async fn start_test_with_permissions(
-        instruction_validator: IsInstructionAllowedBoxed<W>,
-        query_validator: IsQueryAllowedBoxed<W>,
-    ) -> (Self, Client) {
-        let mut configuration = Configuration::test();
-        let mut peer = Self::new().expect("Failed to create peer.");
-        configuration.sumeragi.trusted_peers.peers = std::iter::once(peer.id.clone()).collect();
-        peer.start_with_config_permissions(
-            configuration.clone(),
-            G::test(true),
+    /// Sets the optional genesis network.
+    #[must_use]
+    pub fn with_into_genesis(mut self, genesis: impl Into<WithGenesis<G>>) -> Self {
+        self.genesis = genesis.into();
+        self
+    }
+
+    /// Sets the genesis network.
+    #[must_use]
+    pub fn with_genesis(mut self, genesis: G) -> Self {
+        self.genesis = WithGenesis::<G>::Has(genesis);
+        self
+    }
+
+    /// Sets the test genesis network.
+    #[must_use]
+    pub fn with_test_genesis(self, submit_genesis: bool) -> Self {
+        self.with_into_genesis(G::test(submit_genesis))
+    }
+
+    /// Sets Iroha configuration
+    #[must_use]
+    pub fn with_configuration(mut self, configuration: Configuration) -> Self {
+        self.configuration.replace(configuration);
+        self
+    }
+
+    /// Sets permissions for instructions.
+    #[must_use]
+    pub fn with_instruction_validator(
+        mut self,
+        instruction_validator: impl Into<IsInstructionAllowedBoxed<W>> + Send + 'static,
+    ) -> Self {
+        self.instruction_validator
+            .replace(instruction_validator.into());
+        self
+    }
+
+    /// Sets permissions for queries.
+    #[must_use]
+    pub fn with_query_validator(
+        mut self,
+        query_validator: impl Into<IsQueryAllowedBoxed<W>> + Send + 'static,
+    ) -> Self {
+        self.query_validator.replace(query_validator.into());
+        self
+    }
+
+    /// Sets the directory to be used as a stub.
+    #[must_use]
+    pub fn with_dir(mut self, temp_dir: Arc<TempDir>) -> Self {
+        self.temp_dir.replace(temp_dir);
+        self
+    }
+
+    /// Accepts a peer and starts it.
+    pub async fn start_with_peer<K, S, B>(self, peer: &mut Peer<W, G, K, S, B>)
+    where
+        K: KuraTrait<World = W>,
+        S: SumeragiTrait<GenesisNetwork = G, Kura = K, World = W>,
+        B: BlockSynchronizerTrait<Sumeragi = S, World = W>,
+    {
+        let configuration = self.configuration.unwrap_or_else(|| {
+            let mut config = Configuration::test();
+            config.sumeragi.trusted_peers.peers = std::iter::once(peer.id.clone()).collect();
+            config
+        });
+        let genesis = match self.genesis {
+            WithGenesis::<G>::Default => G::test(true),
+            WithGenesis::<G>::None => None,
+            WithGenesis::<G>::Has(genesis) => Some(genesis),
+        };
+        let instruction_validator = self
+            .instruction_validator
+            .unwrap_or_else(|| AllowAll.into());
+        let query_validator = self.query_validator.unwrap_or_else(|| AllowAll.into());
+        let temp_dir = self
+            .temp_dir
+            .unwrap_or_else(|| Arc::new(TempDir::new().expect("Failed to create temp dir.")));
+
+        peer.start(
+            configuration,
+            genesis,
             instruction_validator,
             query_validator,
+            temp_dir,
         )
         .await;
+    }
+
+    /// Creates and starts a peer with preapplied arguments.
+    pub async fn start(
+        self,
+    ) -> Peer<W, G, Kura<W>, Sumeragi<G, Kura<W>, W>, BlockSynchronizer<Sumeragi<G, Kura<W>, W>, W>>
+    {
+        let mut peer = Peer::new().expect("Failed to create a peer.");
+        self.start_with_peer(&mut peer).await;
+        peer
+    }
+
+    /// Creates and starts a peer, creates a client and connects it to the peer and returns both.
+    pub async fn start_with_client(
+        self,
+    ) -> (
+        Peer<W, G, Kura<W>, Sumeragi<G, Kura<W>, W>, BlockSynchronizer<Sumeragi<G, Kura<W>, W>, W>>,
+        Client,
+    ) {
+        let configuration = self
+            .configuration
+            .clone()
+            .unwrap_or_else(Configuration::test);
+
+        let peer = self.start().await;
+
         let client = Client::test(&peer.api_address, &peer.telemetry_address);
+
         time::sleep(Duration::from_millis(
             configuration.sumeragi.pipeline_time_ms(),
         ))
         .await;
+
         (peer, client)
+    }
+
+    /// Creates a peer with a client, creates a runtime, and synchronously starts the peer on the runtime.
+    pub fn start_with_runtime(self) -> PeerWithRuntimeAndClient<W, G> {
+        let rt = Runtime::test();
+        let (peer, client) = rt.block_on(self.start_with_client());
+        (rt, peer, client)
+    }
+}
+
+type PeerWithRuntimeAndClient<W, G> = (
+    Runtime,
+    Peer<W, G, Kura<W>, Sumeragi<G, Kura<W>, W>, BlockSynchronizer<Sumeragi<G, Kura<W>, W>, W>>,
+    Client,
+);
+
+impl<W, G> Default for PeerBuilder<W, G>
+where
+    W: WorldTrait,
+    G: GenesisNetworkTrait,
+{
+    fn default() -> Self {
+        Self {
+            genesis: WithGenesis::<G>::default(),
+            configuration: None,
+            instruction_validator: None,
+            query_validator: None,
+            temp_dir: None,
+        }
     }
 }
 

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -10,7 +10,7 @@ use iroha_core::{
 };
 use iroha_data_model::{prelude::*, ParseError};
 use small::SmallStr;
-use test_network::{Peer as TestPeer, TestRuntime};
+use test_network::{Peer as TestPeer, PeerBuilder, TestRuntime};
 use tokio::runtime::Runtime;
 
 fn asset_id_new(
@@ -168,11 +168,16 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         &configuration.genesis,
         &configuration.sumeragi.transaction_limits,
     )
+    .unwrap()
     .unwrap();
     let rt = Runtime::test();
     let mut client_configuration = get_client_config(&configuration.sumeragi.key_pair);
 
-    rt.block_on(peer.start_with_config_permissions(configuration, genesis, AllowAll, AllowAll));
+    let builder = PeerBuilder::new()
+        .with_configuration(configuration)
+        .with_genesis(genesis);
+
+    rt.block_on(builder.start_with_peer(&mut peer));
     thread::sleep(pipeline_time);
 
     client_configuration.torii_api_url =


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This replaces nested methods which creates `Peer` with `PeerBuilder` structure (Builder pattern).

- [x] MVP
- [x] CI checks pass
- [x] Add the docs/comments

### Issue

Resolves #2238

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Makes creating a test environment more flexible and convenient.

### Possible Drawbacks

Idk may increase test run time.

### Alternate Designs *[optional]*

Make `Peer` structure a builder itself. But in that design, will need to keep parameters (`genesis`, `configuration`, `instruction_validator`, `query_validator`, `temp_dir`) inside the `Peer` structure to start the peer's task - it will makes `Peer` structure a huge.

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
