### PR TITLE
[refactor] #1896: Simplify `produce_event` implementation

### DIFF
--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -307,13 +307,14 @@ impl<W: WorldTrait> WorldStateView<W> {
 
     /// Send [`Event`]s to known subscribers.
     fn produce_event(&self, event: impl Into<Event>) {
-        let events_sender = if let Some(sender) = &self.events_sender {
-            sender
-        } else {
-            return warn!("wsv does not equip an events sender");
-        };
-
-        drop(events_sender.send(event.into()))
+        self.events_sender.as_ref().map_or_else(
+            || {
+                warn!("wsv does not equip an events sender");
+            },
+            |events_sender| {
+                drop(events_sender.send(event.into()));
+            },
+        )
     }
 
     /// Tries to get asset or inserts new with `default_asset_value`.


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Issue #1896 occured because `produce_event` function has misleading statement: 

```rust
return warn!("wsv does not equip an events sender");
```
So to avoid confusion it was decided to refactor `produce_event`.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Resolves #1896.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

No confusion.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs

Firstly alternative `produce_event` implementation was considered, but clippy rejects it.

Clippy error: ```error: use Option::map_or_else instead of an if let/else```

Alternative implementation: 

```rust
/// Send [`Event`]s to known subscribers.
fn produce_event(&self, event: impl Into<Event>) {
    if let Some(events_sender) = &self.events_sender {
        drop(events_sender.send(event.into()));
    } else {
        warn!("wsv does not equip an events sender");
    }
}
```

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
