### PR TITLE
[fix] #2225: Fix benchmarks

### DIFF
--- a/client/benches/tps/lib.rs
+++ b/client/benches/tps/lib.rs
@@ -77,7 +77,7 @@ impl Config {
         }
         // END
         let elapsed_secs = timer.elapsed().as_secs_f64();
-        thread::sleep(core::time::Duration::from_secs(2));
+        thread::sleep(core::time::Duration::from_secs(4));
         let blocks_out_of_measure = 1 + 2 * self.peers;
         let mut blocks = network
             .genesis


### PR DESCRIPTION
Signed-off-by: Ales Tsurko <ales.tsurko@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

I've changed the waiting time (`thread::sleep`) for blocks to appear in WSV. The value is twice bigger, so I expect it will work on machines twice slower.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

As described in the ticket, `cargo bench` panicked. It turned out the panic caused by too little time of waiting for blocks to appear in WSV.
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

It should fix the bug.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

The needed time may vary from machine to machine. As for now I don't know how everything works exactly, I can only guess that it's because of the time of blocks validation. So it may fail on slower machines, and then we need to increase the value again. Also, it slows down the benchmarks.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

None.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

We may provide an optional config for benchmarks through an environment variable, for example, with the sleep time.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
