### PR TITLE
[fix] #2294: Add flamegraph generation to oneshot.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,8 @@ dependencies = [
  "test_network",
  "thiserror",
  "tokio",
+ "tracing-flame",
+ "tracing-subscriber 0.3.11",
  "tungstenite 0.16.0",
 ]
 
@@ -3846,6 +3848,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber 0.3.11",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,6 +3898,7 @@ checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -50,6 +50,9 @@ color-eyre = "0.5.11"
 tempfile = "3"
 hex = "0.4.0"
 
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["fmt", "ansi"] }
+tracing-flame = { version = "0.2.0" }
+
 [[bench]]
 name = "torii"
 harness = false

--- a/client/benches/tps/oneshot.rs
+++ b/client/benches/tps/oneshot.rs
@@ -2,10 +2,41 @@
 
 mod lib;
 
-#[allow(clippy::expect_used)]
+use std::{fs::File, io::BufWriter};
+
+use tracing_flame::{FlameLayer, FlushGuard};
+use tracing_subscriber::prelude::*;
+
+#[allow(clippy::expect_used, clippy::print_stdout, clippy::use_debug)]
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut flush_guard: Option<FlushGuard<BufWriter<File>>> = None;
+
+    if args.len() >= 2 {
+        let file = File::create(&args[1]).expect("valid path");
+
+        let flame_layer = FlameLayer::new(BufWriter::new(file))
+            .with_threads_collapsed(true)
+            .with_empty_samples(true);
+        flush_guard = Some(flame_layer.flush_on_drop());
+
+        tracing_subscriber::registry().with(flame_layer).init();
+        iroha_logger::disable_logger();
+    }
+
     let config = lib::Config::from_path("benches/tps/config.json").expect("Failed to configure");
     let tps = config.measure().expect("Failed to measure");
-    iroha_logger::info!(?config);
-    iroha_logger::info!(%tps);
+
+    match flush_guard {
+        Some(guard) => {
+            guard.flush().expect("Flushed data without errors");
+            println!("Tracing data outputted to file: {}", &args[1]);
+            println!("TPS was {}", tps);
+            println!("Config was {:?}", config);
+        }
+        None => {
+            iroha_logger::info!(?config);
+            iroha_logger::info!(%tps);
+        }
+    }
 }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -56,6 +56,17 @@ pub fn init(configuration: &Configuration) -> Result<Option<Telemetries>> {
     Ok(Some(setup_logger(configuration)?))
 }
 
+/// Disables the logger by setting `LOGGER_SET` to true. Will fail
+/// if the logger has already been initialized. This function is
+/// required in order to generate flamegraphs and flamecharts.
+///
+/// Returns true on success.
+pub fn disable_logger() -> bool {
+    LOGGER_SET
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_ok()
+}
+
 fn setup_logger(configuration: &Configuration) -> Result<Telemetries> {
     if configuration.compact_mode {
         let layer = tracing_subscriber::fmt::layer()


### PR DESCRIPTION

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Adds the ability to generate folded stack information from the oneshot tps benchmark. That data can then be used in performance analysis.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue
#2294 

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
We can now generate flamecharts.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
There are no drawbacks per say. But we don't currently instrument that much so the charts generated are not that informative. That does not mean we should instrument everything since that would slow the application to a grinding halt. It simply means there is more work to do when optimizing, but this is a good start.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
