### PR TITLE
[refactor] #2204: Make Asset-related operations generic

### DIFF
--- a/data_model/primitives/src/lib.rs
+++ b/data_model/primitives/src/lib.rs
@@ -15,3 +15,82 @@ extern crate alloc;
 pub mod atomic;
 pub mod fixed;
 pub mod small;
+
+use fixed::prelude::*;
+
+/// Trait for values that can be converted into `f64` and observed by prometheus.
+pub trait IntoMetric {
+    /// Convert `value` into `f64`.
+    fn into_metric(self) -> f64;
+}
+
+impl IntoMetric for u128 {
+    #[inline]
+    #[allow(clippy::cast_precision_loss)]
+    fn into_metric(self) -> f64 {
+        self as f64
+    }
+}
+
+impl IntoMetric for u32 {
+    #[inline]
+    fn into_metric(self) -> f64 {
+        self.into()
+    }
+}
+
+impl IntoMetric for Fixed {
+    #[inline]
+    fn into_metric(self) -> f64 {
+        self.into()
+    }
+}
+
+/// Trait for checked operations on iroha's primitive types.
+pub trait CheckedOp {
+    /// Checked addition. Computes `self + rhs`, returning None if overflow occurred.
+    fn checked_add(self, rhs: Self) -> Option<Self>
+    where
+        Self: Sized;
+
+    /// Checked subtraction. Computes `self - rhs`, returning None if overflow occurred.
+    fn checked_sub(self, rhs: Self) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl CheckedOp for u32 {
+    #[inline]
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs)
+    }
+
+    #[inline]
+    fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_sub(rhs)
+    }
+}
+
+impl CheckedOp for u128 {
+    #[inline]
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs)
+    }
+
+    #[inline]
+    fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_sub(rhs)
+    }
+}
+
+impl CheckedOp for Fixed {
+    #[inline]
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs).ok()
+    }
+
+    #[inline]
+    fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_sub(rhs).ok()
+    }
+}

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -22,7 +22,7 @@ use derive_more::{DebugCustom, Display};
 use events::FilterBox;
 use iroha_crypto::{Hash, PublicKey};
 use iroha_data_primitives::small::SmallVec;
-pub use iroha_data_primitives::{fixed, small};
+pub use iroha_data_primitives::{self as primitives, fixed, small};
 use iroha_macro::{error::ErrorTryFromEnum, FromVariant};
 use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode, Input};


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

As mentioned by @appetrosyan in #2204 we have very similar implementations for asset-related operations (`Mint`, `Burn`, `Transfer`), purpose of this PR make them generic.

The approach i took was to extract parts where implementation diverge (arithmetic operations, conversation to `f64`, default values, expected value type is assertion) for different asset value types and encapsulate them in traits. 

- Add traits `InnerMint`, `InnerBurn`, `InnerTransfer` that contains generic blanket implementations;
- Add traits `CheckedAdd`/`CheckedSub` to encapsulate differences between asset value `checked_add`/`checked_sub`;
- Add trait `FloatMetricFrom` to encapsulate differences between asset value conversation to `f64`.
- Add trait `AssetInstructionInfo` to collect fields (asset value type, default asset value) related to asset instructions.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

- Closes #2204.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

- Asset-related operations cannot be out of sync with each other.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

- One more call inside `excute` functions to inner `execute` blanket implementation increases overhead (most calls are inlined so overhead is small).

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs

Further improvements would be to change `metric` macro so that it can be parametrized in blanket implementations, with this change one could remove `InnerMint`, `InnerBurn`, `InnerTransfer` and create blanket implementations directly for `Mint<Asset, V>`, `Burn<Asset, V>`, `Transfer<Asset, V, Asset>`.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
