### PR TITLE
[feature] #2302: Add 'FindTriggersByDomainId' stub-query

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1137,6 +1137,16 @@ pub mod transaction {
     }
 }
 
+pub mod trigger {
+    //! Module with queries for triggers
+    use super::*;
+
+    /// Get query to get triggers by domain id
+    pub fn by_domain_id(domain_id: impl Into<EvaluatesTo<DomainId>>) -> FindTriggersByDomainId {
+        FindTriggersByDomainId::new(domain_id)
+    }
+}
+
 pub mod role {
     //! Module with queries for roles
     use super::*;

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -97,6 +97,7 @@ impl<W: WorldTrait> ValidQuery<W> for QueryBox {
             FindAllActiveTriggerIds(query) => query.execute_into_value(wsv),
             FindTriggerById(query) => query.execute_into_value(wsv),
             FindTriggerKeyValueByIdAndKey(query) => query.execute_into_value(wsv),
+            FindTriggersByDomainId(query) => query.execute_into_value(wsv),
             FindAllRoles(query) => query.execute_into_value(wsv),
             FindAllRoleIds(query) => query.execute_into_value(wsv),
             FindRolesByAccountId(query) => query.execute_into_value(wsv),

--- a/core/src/smartcontracts/isi/triggers.rs
+++ b/core/src/smartcontracts/isi/triggers.rs
@@ -223,4 +223,12 @@ pub mod query {
                 .ok_or_else(|| Error::Find(Box::new(FindError::Trigger(id))))?
         }
     }
+
+    impl<W: WorldTrait> ValidQuery<W> for FindTriggersByDomainId {
+        #[metrics(+"find_triggers_by_domain_id")]
+        fn execute(&self, _wsv: &WorldStateView<W>) -> eyre::Result<Self::Output, Error> {
+            iroha_logger::warn!("'find triggers by domain id' is implemented as a stub.");
+            Ok(vec![])
+        }
+    }
 }

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -86,6 +86,8 @@ pub enum QueryBox {
     FindTriggerById(FindTriggerById),
     /// [`FindTriggerKeyValueByIdAndKey`] variant.
     FindTriggerKeyValueByIdAndKey(FindTriggerKeyValueByIdAndKey),
+    /// [`FindTriggersByDomainId`] variant.
+    FindTriggersByDomainId(FindTriggersByDomainId),
     /// [`FindAllRoles`] variant.
     FindAllRoles(FindAllRoles),
     /// [`FindAllRoleIds`] variant.
@@ -964,7 +966,8 @@ pub mod trigger {
 
     use super::Query;
     use crate::{
-        events::FilterBox, expression::EvaluatesTo, trigger::Trigger, Identifiable, Name, Value,
+        domain::prelude::*, events::FilterBox, expression::EvaluatesTo, trigger::Trigger,
+        Identifiable, Name, Value,
     };
 
     /// Find all currently active (as in not disabled and/or expired)
@@ -1012,9 +1015,32 @@ pub mod trigger {
         type Output = Value;
     }
 
+    /// Find Triggers given domain ID.
+    #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, Deserialize, Serialize, IntoSchema)]
+    pub struct FindTriggersByDomainId {
+        /// `DomainId` under which triggers should be found.
+        pub domain_id: EvaluatesTo<DomainId>,
+    }
+
+    impl FindTriggersByDomainId {
+        /// Construct [`FindTriggersByDomainId`].
+        pub fn new(domain_id: impl Into<EvaluatesTo<DomainId>>) -> Self {
+            Self {
+                domain_id: domain_id.into(),
+            }
+        }
+    }
+
+    impl Query for FindTriggersByDomainId {
+        type Output = Vec<Trigger<FilterBox>>;
+    }
+
     pub mod prelude {
         //! Prelude Re-exports most commonly used traits, structs and macros from this crate.
-        pub use super::{FindAllActiveTriggerIds, FindTriggerById, FindTriggerKeyValueByIdAndKey};
+        pub use super::{
+            FindAllActiveTriggerIds, FindTriggerById, FindTriggerKeyValueByIdAndKey,
+            FindTriggersByDomainId,
+        };
     }
 }
 

--- a/permissions_validators/src/private_blockchain/query.rs
+++ b/permissions_validators/src/private_blockchain/query.rs
@@ -86,6 +86,21 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsDomain {
                         )
                     })?
             }
+            FindTriggersByDomainId(query) => {
+                let domain_id = query
+                    .domain_id
+                    .evaluate(wsv, &context)
+                    .map_err(|e| e.to_string())?;
+
+                if domain_id == authority.domain_id {
+                    return Ok(());
+                }
+
+                Err(format!(
+                    "Cannot access triggers with given domain {}, {} is permitted..",
+                    domain_id, authority.domain_id
+                ))
+            }
             FindAccountById(query) => {
                 let account_id = query
                     .id
@@ -345,7 +360,7 @@ impl<W: WorldTrait> IsAllowed<W, QueryBox> for OnlyAccountsData {
             FindAllRoles(_) | FindAllRoleIds(_) | FindRoleByRoleId(_) => {
                 Err("Only access to roles of the same account is permitted.".to_owned())
             },
-            | FindAllActiveTriggerIds(_) => {
+            FindAllActiveTriggerIds(_) | FindTriggersByDomainId(_) => {
                 Err("Only access to the triggers of the same account is permitted.".to_owned())
             }
             FindAllPeers(_) => {

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -172,6 +172,7 @@ pub fn generate_map() -> DumpDecodedMap {
         FindTransactionByHash,
         FindTransactionsByAccountId,
         FindTriggerKeyValueByIdAndKey,
+        FindTriggersByDomainId,
         FindTriggerById,
         GenesisDomain,
         GrantBox,


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Just add `FindTriggersByDomainId` as a stub.

### Issue

Partially resolves #2302 

### Benefits

Can be quickly introduced into the explorer.

### Possible Drawbacks

None.

### Alternate Designs *[optional]*

Research and try to find a short way for adding domain-scoped triggers, [related to.](https://github.com/hyperledger/iroha/issues/1889)

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
