### PR TITLE
[refactor] #1985: Reduce size of `Name` struct

### DIFF
--- a/data_model/primitives/src/conststr.rs
+++ b/data_model/primitives/src/conststr.rs
@@ -1,0 +1,545 @@
+//! Const-string related implementation and structs.
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, str::from_boxed_utf8_unchecked, string::String, vec::Vec};
+use core::{
+    cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
+    convert::{AsRef, From, TryFrom},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+    mem::{size_of, ManuallyDrop},
+    ops::Deref,
+};
+#[cfg(feature = "std")]
+use std::str::from_boxed_utf8_unchecked;
+
+use iroha_schema::{IntoSchema, MetaMap};
+use parity_scale_codec::{Encode, Output};
+use serde::{Serialize, Serializer};
+
+const MAX_INLINED_STRING_LEN: usize = 2 * size_of::<usize>() - 1;
+
+/// Immutable inlinable string.
+/// Strings shorter than 15/7/3 bytes (depending on architecture 64/32/16 bit pointer width) are inlined.
+#[derive(Clone)]
+pub struct ConstString(ConstStringData);
+
+impl ConstString {
+    /// Returns the length of this [`ConstString`], in bytes.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if [`ConstString`] is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == 0
+    }
+
+    /// Returns `true` if [`ConstString`] data is inlined.
+    #[inline]
+    pub const fn is_inlined(&self) -> bool {
+        self.0.is_inlined()
+    }
+
+    /// Construct empty [`ConstString`].
+    #[inline]
+    pub const fn new() -> Self {
+        Self(ConstStringData::new())
+    }
+}
+
+impl Deref for ConstString {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for ConstString
+where
+    ConstStringData: AsRef<T>,
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.0.as_ref()
+    }
+}
+
+impl<T: Into<ConstStringData>> From<T> for ConstString {
+    #[inline]
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+impl Display for ConstString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", &self[..])
+    }
+}
+
+impl Debug for ConstString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", &self[..])
+    }
+}
+
+impl Hash for ConstString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state)
+    }
+}
+
+impl PartialOrd for ConstString {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&self[..], &other[..])
+    }
+}
+
+impl Ord for ConstString {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self[..], &other[..])
+    }
+}
+
+impl PartialEq for ConstString {
+    #[inline]
+    fn eq(&self, other: &ConstString) -> bool {
+        PartialEq::eq(&self[..], &other[..])
+    }
+}
+
+macro_rules! impl_eq {
+    ($($ty:ty,)*) => {
+        impl_eq!($($ty),*);
+    };
+    ($($ty:ty),*) => {$(
+        impl PartialEq<$ty> for ConstString {
+            #[allow(clippy::string_slice)]
+            #[inline]
+            fn eq(&self, other: &$ty) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
+        }
+
+        impl PartialEq<ConstString> for $ty {
+            #[allow(clippy::string_slice)]
+            #[inline]
+            fn eq(&self, other: &ConstString) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
+        }
+    )*};
+}
+
+impl_eq!(String, str, &str);
+
+impl Eq for ConstString {}
+
+impl Serialize for ConstString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self)
+    }
+}
+
+impl Encode for ConstString {
+    fn size_hint(&self) -> usize {
+        self.as_bytes().size_hint()
+    }
+
+    fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
+        self.as_bytes().encode_to(dest)
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        self.as_bytes().encode()
+    }
+
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.as_bytes().using_encoded(f)
+    }
+}
+
+impl IntoSchema for ConstString {
+    fn type_name() -> String {
+        String::type_name()
+    }
+    fn schema(map: &mut MetaMap) {
+        String::schema(map);
+    }
+}
+
+/// Union representing const-string variants: inlined or boxed.
+/// Distinction between variants are achieved by setting least significant bit for inlined variant.
+/// Boxed variant should have have 4/3/2 (depending on architecture 64/32/16 bit pointer width) trailing zeros due to pointer alignment.
+#[repr(C)]
+union ConstStringData {
+    inlined: InlinedString,
+    boxed: ManuallyDrop<BoxedString>,
+}
+
+impl ConstStringData {
+    #[inline]
+    const fn is_inlined(&self) -> bool {
+        self.inlined().is_inlined()
+    }
+
+    #[allow(unsafe_code)]
+    #[inline]
+    const fn inlined(&self) -> &InlinedString {
+        // SAFETY: safe to access if `is_inlined` == `true`.
+        unsafe { &self.inlined }
+    }
+
+    #[allow(unsafe_code)]
+    #[inline]
+    const fn boxed(&self) -> &ManuallyDrop<BoxedString> {
+        // SAFETY: safe to access if `is_inlined` == `false`.
+        unsafe { &self.boxed }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        if self.is_inlined() {
+            self.inlined().len()
+        } else {
+            self.boxed().len()
+        }
+    }
+
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            inlined: InlinedString::new(),
+        }
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for ConstStringData
+where
+    InlinedString: AsRef<T>,
+    BoxedString: AsRef<T>,
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        if self.is_inlined() {
+            self.inlined().as_ref()
+        } else {
+            self.boxed().as_ref()
+        }
+    }
+}
+
+impl<T> From<T> for ConstStringData
+where
+    T: TryInto<InlinedString>,
+    <T as TryInto<InlinedString>>::Error: Into<BoxedString>,
+{
+    #[inline]
+    fn from(value: T) -> Self {
+        match value.try_into() {
+            Ok(inlined) => Self { inlined },
+            Err(value) => Self {
+                boxed: core::mem::ManuallyDrop::new(value.into()),
+            },
+        }
+    }
+}
+
+impl Clone for ConstStringData {
+    fn clone(&self) -> Self {
+        if self.is_inlined() {
+            Self {
+                inlined: *self.inlined(),
+            }
+        } else {
+            Self {
+                boxed: self.boxed().clone(),
+            }
+        }
+    }
+}
+
+impl Drop for ConstStringData {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        if !self.is_inlined() {
+            // SAFETY: safe because`is_inlined` == `false`.
+            unsafe {
+                ManuallyDrop::drop(&mut self.boxed);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+struct BoxedString(Box<str>);
+
+impl BoxedString {
+    #[inline]
+    const fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl AsRef<str> for BoxedString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl From<&str> for BoxedString {
+    #[allow(unsafe_code)]
+    #[inline]
+    fn from(value: &str) -> Self {
+        let payload = value.as_bytes().to_vec().into_boxed_slice();
+        // SAFETY: correct string.
+        Self(unsafe { from_boxed_utf8_unchecked(payload) })
+    }
+}
+
+impl From<String> for BoxedString {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self(value.into_boxed_str())
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct InlinedString {
+    #[cfg(target_endian = "big")]
+    payload: [u8; MAX_INLINED_STRING_LEN],
+    /// Least-significant bit is always 1 to distinguish inlined variant.  
+    len: u8,
+    #[cfg(target_endian = "little")]
+    payload: [u8; MAX_INLINED_STRING_LEN],
+}
+
+impl InlinedString {
+    #[inline]
+    const fn len(self) -> usize {
+        (self.len >> 1_u8) as usize
+    }
+
+    #[inline]
+    const fn is_inlined(self) -> bool {
+        self.len % 2 > 0
+    }
+
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            payload: [0; MAX_INLINED_STRING_LEN],
+            // Set least-significant bit to mark inlined variant.
+            len: 1,
+        }
+    }
+}
+
+impl AsRef<str> for InlinedString {
+    #[allow(unsafe_code)]
+    #[inline]
+    fn as_ref(&self) -> &str {
+        // SAFETY: created from valid utf-8.
+        unsafe { core::str::from_utf8_unchecked(&self.payload[..self.len()]) }
+    }
+}
+
+impl<'value> TryFrom<&'value str> for InlinedString {
+    type Error = &'value str;
+
+    #[allow(clippy::cast_possible_truncation)]
+    #[inline]
+    fn try_from(value: &'value str) -> Result<Self, Self::Error> {
+        let len = value.len();
+        if len > MAX_INLINED_STRING_LEN {
+            return Err(value);
+        }
+        let mut inlined = Self::new();
+        inlined.payload.as_mut()[..len].copy_from_slice(value.as_bytes());
+        // Truncation won't happen because we checked that the length shorter than `MAX_INLINED_STRING_LEN`.
+        // Set least-significant bit to mark inlined variant.
+        inlined.len += (len << 1_usize) as u8;
+        Ok(inlined)
+    }
+}
+
+impl TryFrom<String> for InlinedString {
+    type Error = String;
+
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match Self::try_from(value.as_str()) {
+            Ok(inlined) => Ok(inlined),
+            Err(_) => Err(value),
+        }
+    }
+}
+
+impl Debug for InlinedString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("InlinedString")
+            .field("len", &self.len())
+            .field("payload", &self.as_ref())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::{align_of, size_of};
+    use std::collections::hash_map::DefaultHasher;
+
+    use super::*;
+
+    fn run_with_strings(f: impl Fn(String)) {
+        [0, 1, 7, 8, 15, 16, 30]
+            .into_iter()
+            // utf-8 encodes ascii characters in single byte
+            .map(|len| "x".repeat(len))
+            .for_each(f)
+    }
+
+    #[test]
+    fn const_string_layout() {
+        assert_eq!(size_of::<ConstString>(), size_of::<Box<str>>());
+        assert_eq!(align_of::<ConstString>(), align_of::<Box<str>>());
+    }
+
+    #[test]
+    fn const_string_new() {
+        let const_string = ConstString::new();
+        assert_eq!(const_string, "");
+        assert_eq!(const_string.len(), 0);
+    }
+
+    #[test]
+    fn const_string_is_inlined() {
+        run_with_strings(|string| {
+            let len = string.len();
+            let const_string = ConstString::from(string);
+            let is_inlined = len <= MAX_INLINED_STRING_LEN;
+            assert_eq!(const_string.is_inlined(), is_inlined, "with len {}", len);
+        });
+    }
+
+    #[test]
+    fn const_string_len() {
+        run_with_strings(|string| {
+            let len = string.len();
+            let const_string = ConstString::from(string);
+            assert_eq!(const_string.len(), len);
+        });
+    }
+
+    #[test]
+    fn const_string_deref() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.as_str());
+            assert_eq!(&*const_string, &*string);
+        });
+    }
+
+    #[test]
+    fn const_string_from_string() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.clone());
+            assert_eq!(const_string, string);
+        });
+    }
+
+    #[test]
+    fn const_string_from_str() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.as_str());
+            assert_eq!(const_string, string);
+        });
+    }
+
+    #[test]
+    fn const_string_clone() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string);
+            let const_string_clone = const_string.clone();
+            assert_eq!(const_string, const_string_clone);
+        });
+    }
+
+    #[test]
+    fn const_string_display() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.clone());
+            assert_eq!(format!("{const_string}"), string);
+        });
+    }
+
+    #[test]
+    fn const_string_hash() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.clone());
+            let mut string_hasher = DefaultHasher::new();
+            let mut const_string_hasher = DefaultHasher::new();
+            string.hash(&mut string_hasher);
+            const_string.hash(&mut const_string_hasher);
+            assert_eq!(const_string_hasher.finish(), string_hasher.finish());
+        });
+    }
+
+    #[test]
+    fn const_string_eq_string() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.as_str());
+            assert_eq!(const_string, string);
+            assert_eq!(string, const_string);
+        });
+    }
+
+    #[test]
+    fn const_string_eq_str() {
+        run_with_strings(|string| {
+            let const_string = ConstString::from(string.as_str());
+            assert_eq!(const_string, string.as_str());
+            assert_eq!(string.as_str(), const_string);
+        });
+    }
+
+    #[test]
+    fn const_string_eq_const_str() {
+        run_with_strings(|string| {
+            let const_string_1 = ConstString::from(string.as_str());
+            let const_string_2 = ConstString::from(string.as_str());
+            assert_eq!(const_string_1, const_string_2);
+            assert_eq!(const_string_2, const_string_1);
+        });
+    }
+
+    #[test]
+    fn const_string_cmp() {
+        run_with_strings(|string_1| {
+            run_with_strings(|string_2| {
+                let const_string_1 = ConstString::from(string_1.as_str());
+                let const_string_2 = ConstString::from(string_2.as_str());
+                assert!(
+                    ((const_string_1 <= const_string_2) && (string_1 <= string_2))
+                        || ((const_string_1 >= const_string_2) && (string_1 >= string_2))
+                );
+                assert!(
+                    ((const_string_2 >= const_string_1) && (string_2 >= string_1))
+                        || ((const_string_2 <= const_string_1) && (string_2 <= string_1))
+                );
+            });
+        });
+    }
+}

--- a/data_model/primitives/src/lib.rs
+++ b/data_model/primitives/src/lib.rs
@@ -13,6 +13,7 @@
 extern crate alloc;
 
 pub mod atomic;
+pub mod conststr;
 pub mod fixed;
 pub mod small;
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -15,21 +15,22 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{fmt, fmt::Debug, ops::RangeInclusive, str::FromStr};
+use core::{fmt, fmt::Debug, ops::RangeInclusive};
 
 use block_value::BlockValue;
-use derive_more::{DebugCustom, Display};
+use derive_more::Display;
 use events::FilterBox;
 use iroha_crypto::{Hash, PublicKey};
 use iroha_data_primitives::small::SmallVec;
 pub use iroha_data_primitives::{self as primitives, fixed, small};
 use iroha_macro::{error::ErrorTryFromEnum, FromVariant};
 use iroha_schema::IntoSchema;
-use parity_scale_codec::{Decode, Encode, Input};
+use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    account::SignatureCheckCondition, permissions::PermissionToken, transaction::TransactionValue,
+    account::SignatureCheckCondition, name::Name, permissions::PermissionToken,
+    transaction::TransactionValue,
 };
 
 pub mod account;
@@ -40,6 +41,7 @@ pub mod events;
 pub mod expression;
 pub mod isi;
 pub mod metadata;
+pub mod name;
 pub mod pagination;
 pub mod peer;
 pub mod permissions;
@@ -74,121 +76,6 @@ impl ValidationError {
         Self {
             reason: String::from(reason),
         }
-    }
-}
-
-/// `Name` struct represents type for Iroha Entities names, like
-/// [`Domain`](`domain::Domain`)'s name or
-/// [`Account`](`account::Account`)'s name.
-#[derive(
-    DebugCustom, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Serialize, IntoSchema,
-)]
-#[repr(transparent)]
-pub struct Name(String);
-
-impl Name {
-    pub(crate) const fn empty() -> Self {
-        Self(String::new())
-    }
-
-    /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
-    ///
-    /// # Errors
-    /// Fails if `range` does not
-    pub fn validate_len(
-        &self,
-        range: impl Into<RangeInclusive<usize>>,
-    ) -> Result<(), ValidationError> {
-        let range = range.into();
-        if range.contains(&self.as_ref().chars().count()) {
-            Ok(())
-        } else {
-            Err(ValidationError::new(&format!(
-                "Name must be between {} and {} characters in length.",
-                &range.start(),
-                &range.end()
-            )))
-        }
-    }
-}
-
-impl AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl FromStr for Name {
-    type Err = ParseError;
-
-    fn from_str(candidate: &str) -> Result<Self, Self::Err> {
-        if candidate.is_empty() {
-            return Ok(Self::empty());
-        }
-
-        if candidate.chars().any(char::is_whitespace) {
-            return Err(ParseError {
-                reason: "White space not allowed in `Name` constructs",
-            });
-        }
-        if candidate.chars().any(|ch| ch == '@' || ch == '#') {
-            #[allow(clippy::non_ascii_literal)]
-            return Err(ParseError {
-                reason: "The `@` character is reserved for `account@domain` constructs, `#` — for `asset#domain`",
-            });
-        }
-        Ok(Self(String::from(candidate)))
-    }
-}
-
-/// FFI function equivalent of [`Name::from_str`]
-///
-/// # Safety
-///
-/// All of the given pointers must be valid
-#[cfg(feature = "ffi_api")]
-#[allow(non_snake_case, unsafe_code)]
-pub unsafe extern "C" fn Name__from_str(
-    candidate: *const u8,
-    candidate_len: usize,
-    output: *mut *mut Name,
-) -> iroha_ffi::FfiResult {
-    let candidate = core::slice::from_raw_parts(candidate, candidate_len);
-
-    let method_res = match core::str::from_utf8(candidate) {
-        Err(_error) => return iroha_ffi::FfiResult::Utf8Error,
-        Ok(candidate) => Name::from_str(candidate),
-    };
-    let method_res = match method_res {
-        Err(_error) => return iroha_ffi::FfiResult::ExecutionFail,
-        Ok(method_res) => method_res,
-    };
-    let method_res = Box::into_raw(Box::new(method_res));
-
-    output.write(method_res);
-    iroha_ffi::FfiResult::Ok
-}
-
-impl<'de> Deserialize<'de> for Name {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[cfg(not(feature = "std"))]
-        use alloc::borrow::Cow;
-        #[cfg(feature = "std")]
-        use std::borrow::Cow;
-
-        use serde::de::Error as _;
-
-        let name = <Cow<str>>::deserialize(deserializer)?;
-        Self::from_str(&name).map_err(D::Error::custom)
-    }
-}
-impl Decode for Name {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
-        let name = String::decode(input)?;
-        Self::from_str(&name).map_err(|error| error.reason.into())
     }
 }
 
@@ -871,11 +758,12 @@ pub mod prelude {
         block_value::prelude::*,
         domain::prelude::*,
         fixed::prelude::*,
+        name::prelude::*,
         pagination::{prelude::*, Pagination},
         peer::prelude::*,
         role::prelude::*,
         trigger::prelude::*,
-        uri, EnumTryAsError, HasMetadata, IdBox, Identifiable, IdentifiableBox, Name, Parameter,
+        uri, EnumTryAsError, HasMetadata, IdBox, Identifiable, IdentifiableBox, Parameter,
         PredicateTrait, RegistrableBox, TryAsMut, TryAsRef, ValidationError, Value,
     };
     pub use crate::{
@@ -883,67 +771,4 @@ pub mod prelude {
         permissions::prelude::*, query::prelude::*, small, transaction::prelude::*,
         trigger::prelude::*,
     };
-}
-
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::restriction)]
-
-    use super::*;
-
-    const INVALID_NAMES: [&str; 3] = [" ", "@", "#"];
-
-    #[test]
-    fn deserialize_name() {
-        for invalid_name in INVALID_NAMES {
-            let invalid_name = Name(invalid_name.to_owned());
-            let serialized = serde_json::to_string(&invalid_name).expect("Valid");
-            let name = serde_json::from_str::<Name>(serialized.as_str());
-
-            assert!(name.is_err());
-        }
-    }
-
-    #[test]
-    fn decode_name() {
-        for invalid_name in INVALID_NAMES {
-            let invalid_name = Name(invalid_name.to_owned());
-            let bytes = invalid_name.encode();
-            let name = Name::decode(&mut &bytes[..]);
-
-            assert!(name.is_err());
-        }
-    }
-
-    #[test]
-    #[allow(unsafe_code)]
-    #[cfg(feature = "ffi_api")]
-    fn ffi_name_from_str() -> Result<(), ParseError> {
-        use ffi::{Handle, __drop};
-
-        let candidate = "Name";
-        let candidate_bytes = candidate.as_bytes();
-        let candidate_bytes_len = candidate_bytes.len();
-
-        unsafe {
-            let mut name = core::mem::MaybeUninit::new(core::ptr::null_mut());
-
-            assert_eq!(
-                iroha_ffi::FfiResult::Ok,
-                Name__from_str(
-                    candidate_bytes.as_ptr(),
-                    candidate_bytes_len,
-                    name.as_mut_ptr()
-                )
-            );
-
-            let name = name.assume_init();
-            assert_ne!(core::ptr::null_mut(), name);
-            assert_eq!(Name::from_str(candidate)?, *name);
-
-            assert_eq!(iroha_ffi::FfiResult::Ok, __drop(Name::ID, name.cast()));
-        }
-
-        Ok(())
-    }
 }

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -1,0 +1,218 @@
+//! This module contains [`Name`](`crate::name::Name`) structure
+//! and related implementations and trait implementations.
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, format, string::String, vec::Vec};
+use core::{ops::RangeInclusive, str::FromStr};
+
+use derive_more::{DebugCustom, Display};
+use iroha_data_primitives::conststr::ConstString;
+use iroha_schema::IntoSchema;
+use parity_scale_codec::{Decode, Encode, Input};
+use serde::{Deserialize, Serialize};
+
+use crate::{ParseError, ValidationError};
+
+/// `Name` struct represents type for Iroha Entities names, like
+/// [`Domain`](`crate::domain::Domain`)'s name or
+/// [`Account`](`crate::account::Account`)'s name.
+#[derive(
+    DebugCustom, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Serialize, IntoSchema,
+)]
+#[repr(transparent)]
+pub struct Name(ConstString);
+
+impl Name {
+    pub(crate) const fn empty() -> Self {
+        Self(ConstString::new())
+    }
+
+    /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
+    ///
+    /// # Errors
+    /// Fails if `range` does not
+    pub fn validate_len(
+        &self,
+        range: impl Into<RangeInclusive<usize>>,
+    ) -> Result<(), ValidationError> {
+        let range = range.into();
+        if range.contains(&self.as_ref().chars().count()) {
+            Ok(())
+        } else {
+            Err(ValidationError::new(&format!(
+                "Name must be between {} and {} characters in length.",
+                &range.start(),
+                &range.end()
+            )))
+        }
+    }
+
+    /// Check if `candidate` string would be valid [`Name`].
+    ///
+    /// # Errors
+    /// Fails if not valid [`Name`].
+    fn validate_str(candidate: &str) -> Result<(), ParseError> {
+        if candidate.is_empty() {
+            return Ok(());
+        }
+
+        if candidate.chars().any(char::is_whitespace) {
+            return Err(ParseError {
+                reason: "White space not allowed in `Name` constructs",
+            });
+        }
+        if candidate.chars().any(|ch| ch == '@' || ch == '#') {
+            #[allow(clippy::non_ascii_literal)]
+            return Err(ParseError {
+                reason: "The `@` character is reserved for `account@domain` constructs, `#` — for `asset#domain`",
+            });
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl FromStr for Name {
+    type Err = ParseError;
+
+    fn from_str(candidate: &str) -> Result<Self, Self::Err> {
+        Self::validate_str(candidate).map(|_| {
+            if candidate.is_empty() {
+                return Self::empty();
+            }
+            Self(ConstString::from(candidate))
+        })
+    }
+}
+
+/// FFI function equivalent of [`Name::from_str`]
+///
+/// # Safety
+///
+/// All of the given pointers must be valid
+#[cfg(feature = "ffi_api")]
+#[allow(non_snake_case, unsafe_code)]
+pub unsafe extern "C" fn Name__from_str(
+    candidate: *const u8,
+    candidate_len: usize,
+    output: *mut *mut Name,
+) -> iroha_ffi::FfiResult {
+    let candidate = core::slice::from_raw_parts(candidate, candidate_len);
+
+    let method_res = match core::str::from_utf8(candidate) {
+        Err(_error) => return iroha_ffi::FfiResult::Utf8Error,
+        Ok(candidate) => Name::from_str(candidate),
+    };
+    let method_res = match method_res {
+        Err(_error) => return iroha_ffi::FfiResult::ExecutionFail,
+        Ok(method_res) => method_res,
+    };
+    let method_res = Box::into_raw(Box::new(method_res));
+
+    output.write(method_res);
+    iroha_ffi::FfiResult::Ok
+}
+
+impl<'de> Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        let name = ConstString::deserialize(deserializer)?;
+        Self::validate_str(&name)
+            .map(|_| {
+                if name.is_empty() {
+                    return Self::empty();
+                }
+                Self(name)
+            })
+            .map_err(D::Error::custom)
+    }
+}
+impl Decode for Name {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+        let name = ConstString::decode(input)?;
+        Self::validate_str(&name)
+            .map(|_| {
+                if name.is_empty() {
+                    return Self::empty();
+                }
+                Self(name)
+            })
+            .map_err(|error| error.reason.into())
+    }
+}
+
+/// The prelude re-exports most commonly used traits, structs and macros from this crate.
+pub mod prelude {
+    pub use super::Name;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::restriction)]
+
+    use super::*;
+
+    const INVALID_NAMES: [&str; 3] = [" ", "@", "#"];
+
+    #[test]
+    fn deserialize_name() {
+        for invalid_name in INVALID_NAMES {
+            let invalid_name = Name(invalid_name.to_owned().into());
+            let serialized = serde_json::to_string(&invalid_name).expect("Valid");
+            let name = serde_json::from_str::<Name>(serialized.as_str());
+
+            assert!(name.is_err());
+        }
+    }
+
+    #[test]
+    fn decode_name() {
+        for invalid_name in INVALID_NAMES {
+            let invalid_name = Name(invalid_name.to_owned().into());
+            let bytes = invalid_name.encode();
+            let name = Name::decode(&mut &bytes[..]);
+
+            assert!(name.is_err());
+        }
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    #[cfg(feature = "ffi_api")]
+    fn ffi_name_from_str() -> Result<(), ParseError> {
+        use crate::ffi::{Handle, __drop};
+
+        let candidate = "Name";
+        let candidate_bytes = candidate.as_bytes();
+        let candidate_bytes_len = candidate_bytes.len();
+
+        unsafe {
+            let mut name = core::mem::MaybeUninit::new(core::ptr::null_mut());
+
+            assert_eq!(
+                iroha_ffi::FfiResult::Ok,
+                Name__from_str(
+                    candidate_bytes.as_ptr(),
+                    candidate_bytes_len,
+                    name.as_mut_ptr()
+                )
+            );
+
+            let name = name.assume_init();
+            assert_ne!(core::ptr::null_mut(), name);
+            assert_eq!(Name::from_str(candidate)?, *name);
+
+            assert_eq!(iroha_ffi::FfiResult::Ok, __drop(Name::ID, name.cast()));
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Add `ConstString`: immutable, inlinable string, which uses `union` internally to store boxed and inlined variants in the same space;
- Replace `String` with `ConstString` in `Name` struct.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #1985.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

All structs that uses `Name` take up less space.
We win at least one machine word for every instance of `Name` and up to 23 byte for strings 15 bytes long on 64-bit architecture, also strings shorter than 15 bytes are stored on the stack, which avoids allocation.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

`ConstString` uses `unsafe` code, which increases the risk of bugs and vulnerabilities.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

Run unit tests:
```
cargo test --package iroha_data_primitives --lib -- conststr::tests --nocapture
```

Run unit tests with miri to find leaks and UB:
```
cargo +nightly-2022-04-20 miri test --package iroha_data_primitives --lib -- conststr::tests --nocapture
```

### Alternate Designs

It possible to use enum instead of union to avoid `unsafe`, but it take 24 bytes instead of 16, [see](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a28c4bfc22d99f5808638dcc82c46553).

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
