### PR TITLE
#2008: Interning of common objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.6",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,7 +1670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1668,6 +1688,16 @@ name = "int_traits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33c9a5c599d67d051c4dc25eb1b6b4ef715d1763c20c85c688717a1734f204e"
+
+[[package]]
+name = "internment"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a798d7677f07d6f1e77be484ea8626ddb1566194de399f1206306820c406371"
+dependencies = [
+ "hashbrown 0.12.1",
+ "parking_lot",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -1880,6 +1910,7 @@ dependencies = [
  "derive_more",
  "getset",
  "hex",
+ "internment",
  "iroha",
  "iroha_client",
  "iroha_core",

--- a/client/examples/million_accounts_two_domains_tx.rs
+++ b/client/examples/million_accounts_two_domains_tx.rs
@@ -1,0 +1,64 @@
+#![allow(missing_docs, clippy::restriction)]
+use std::{thread, time::Duration};
+
+use iroha_data_model::prelude::*;
+use test_network::{wait_for_genesis_committed, PeerBuilder};
+
+fn create_accounts_two_domains_directly() {
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+
+    let domain1_id: DomainId = format!("wonderland-1").parse().expect("Valid");
+    let create_domain1 = RegisterBox::new(Domain::new(domain1_id.clone()));
+    if test_client
+        .submit(create_domain1)
+        .is_err()
+    {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let domain2_id: DomainId = format!("wonderland-2").parse().expect("Valid");
+    let create_domain2 = RegisterBox::new(Domain::new(domain2_id.clone()));
+    if test_client
+        .submit(create_domain2)
+        .is_err()
+    {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    // first domain accounts
+    for i in 0_u32..500_000_u32 {
+        let normal_account_id = AccountId::new(
+            format!("bob-{}", i).parse().expect("Valid"),
+            domain1_id.clone(),
+        );
+        let create_account = RegisterBox::new(Account::new(normal_account_id.clone(), []));
+        if test_client
+            .submit(create_account)
+            .is_err()
+        {
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    // second domain account creation
+    for i in 0_u32..500_000_u32 {
+        let normal_account_id = AccountId::new(
+            format!("bob-{}", i).parse().expect("Valid"),
+            domain2_id.clone(),
+        );
+        let create_account = RegisterBox::new(Account::new(normal_account_id.clone(), []));
+        if test_client
+            .submit(create_account)
+            .is_err()
+        {
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    thread::sleep(Duration::from_secs(1000));
+}
+
+fn main() {
+    create_accounts_two_domains_directly();
+}

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -46,6 +46,7 @@ warp = { version = "0.3", default-features = false, optional = true }
 thiserror = { version = "1.0.28", optional = true }
 getset = "0.1.2"
 strum = { version = "0.24.0", default-features = false, features = ["derive"] }
+internment = "0.7.0"
 
 [dev-dependencies]
 iroha_core = { path = "../core", version = "=2.0.0-pre-rc.5" }

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -10,6 +10,7 @@ use alloc::{
 use core::str::FromStr;
 #[cfg(feature = "std")]
 use std::collections::{btree_map, btree_set};
+use internment::Intern;
 
 use derive_more::Display;
 use getset::{Getters, MutGetters, Setters};
@@ -439,8 +440,10 @@ impl Id {
     /// Construct [`Id`] from an account `name` and a `domain_name` if
     /// these names are valid.
     #[inline]
-    pub const fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
-        Self { name, domain_id }
+    pub fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
+        let intern_domain = Intern::new(domain_id);
+        Self { name, domain_id: (*intern_domain).clone() }
+        // Self { name, domain_id }
     }
 
     /// Construct [`Id`] of the genesis account.

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -14,6 +14,7 @@ use iroha_schema::IntoSchema;
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
+use internment::Intern;
 
 use crate::{
     account::prelude::*, domain::prelude::*, fixed, fixed::Fixed, metadata::Metadata, HasMetadata,
@@ -580,8 +581,14 @@ impl DefinitionId {
     /// # Errors
     /// Fails if any sub-construction fails
     #[inline]
-    pub const fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
-        Self { name, domain_id }
+    pub fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
+        let name_intern = Intern::new(name);
+        let domain_intern = Intern::new(domain_id);
+        Self {
+            name: (*name_intern).clone(),
+            domain_id: (*domain_intern).clone(),
+        }
+        // Self { name, domain_id }
     }
 
     pub(crate) const fn empty() -> Self {
@@ -595,7 +602,7 @@ impl DefinitionId {
 impl Id {
     /// Construct [`Id`] from [`DefinitionId`] and [`AccountId`].
     #[inline]
-    pub const fn new(
+    pub fn new(
         definition_id: <AssetDefinition as Identifiable>::Id,
         account_id: <Account as Identifiable>::Id,
     ) -> Self {


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Tried adding internment inside `new()` methods of `data_model/src/account.rs` and `data_model/src/asset.rs`. Also added a new example to the `client` crate that would supposedly showcase interning better, with two domains having 500_000 accounts each. For note, the traces given in the last section were produced on a slightly smaller example of 300_000 accounts each.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Work in progress towards #2008.
<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
The only positive thing that I was able to track is a very slightly reduced number of calls to allocation functions, down from 1.22 billion to about 1.18 billion. The distribution of allocation sizes also changed slightly, with the internment case seeing an increase in mid-sized allocations (9 to 64 bytes), and a decrease in allocations <= 8B or within 65-256B range.

A smaller feature worthy of attention is that the memory consumed graph in the internment case has a small dip around 6 minute mark (probably connected to the fact that the two domains are created first, and only then they are populated with accounts), whereas no internment case just grows linearly from the start until both of them peak off around 1h40m and plunge (I suppose this marks hash verification stage).
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
The actual performance seems to have degraded a bit, with a heap memory overhead max increased by about 4 Mb, from ~85 to 89 Mb.

It could also easily be the case that I'm just doing it wrong. The `internment` crate returns a `&'static T`, and as `Id` methods require ownership (otherwise I believe the refactoring would take up too many of the codebase, introducing lifetimes and drastically increasing complexity), there is inadvertent cloning involved even when the object is present in the intern, which definitely takes its toll. I couldn't come up with any strategy to circumvent that, so feedback would be appreciated.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests
The below traces were produced for use with [heaptrack](https://github.com/KDE/heaptrack), which gives flamegraphs to diagnose allocations or memory usage and provides a few other helpful visualizations compared to valgrind's massif. However, I've struggled with making actionable conclusions out of the differences produced between the cases. The links will die in 24 hours, so I'll update them after that should need arise.

Trace of `two_domains_million_accounts_tx.rs` with internment: [link](https://wormhole.app/lPAl1#B7wit4sFt_o7q06CT6zj1Q)
Same example, but without: [link](https://wormhole.app/ApZoO#X6iqIXJBk6sjO-b5Jp61LQ)
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs
Another crate allowing internment of any structures is [hashconsing](https://docs.rs/hashconsing/latest/hashconsing/index.html). It makes use of a lazy static `RWLock`-wrapped `HashSet` or `HashMap`, with the consigned terms each put into `Arc`. The `internment` crate also has other options for the strategy, such as arena or arc internment. Neither of those were tested properly yet.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
