### PR TITLE
[feature] #2360: Make `genesis.json` optional again

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,11 @@ async fn main() -> Result<(), color_eyre::Report> {
 
     if std::env::args().any(|a| is_submit(&a)) {
         args.submit_genesis = true;
+        if let Ok(genesis_path) = std::env::var("IROHA2_GENESIS_PATH") {
+            args.genesis_path = Some(std::path::PathBuf::from_str(&genesis_path)?);
+        }
+    } else {
+        args.genesis_path = None;
     }
 
     for arg in std::env::args().skip(1) {
@@ -46,10 +51,6 @@ async fn main() -> Result<(), color_eyre::Report> {
                 "Failed to retrieve required environment variable: {var_name}"
             ))?;
         }
-    }
-
-    if let Ok(genesis_path) = std::env::var("IROHA2_GENESIS_PATH") {
-        args.genesis_path = std::path::PathBuf::from_str(&genesis_path)?;
     }
 
     <iroha::Iroha>::new(&args, default_permissions(), AllowAll.into())

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -32,7 +32,7 @@ fn query_requests(criterion: &mut Criterion) {
             "wonderland".parse().expect("Valid"),
             get_key_pair().public_key().clone(),
         ),
-        &configuration.genesis,
+        &Some(configuration.genesis.clone()),
         &configuration.sumeragi.transaction_limits,
     )
     .expect("genesis creation failed");
@@ -131,7 +131,7 @@ fn instruction_submits(criterion: &mut Criterion) {
             "wonderland".parse().expect("Valid"),
             configuration.public_key.clone(),
         ),
-        &configuration.genesis,
+        &Some(configuration.genesis.clone()),
         &configuration.sumeragi.transaction_limits,
     )
     .expect("failed to create genesis");

--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -38,7 +38,7 @@ fn main() {
     let genesis = GenesisNetwork::from_configuration(
         true,
         generate_genesis(1_000_000_u32),
-        &configuration.genesis,
+        &Some(configuration.genesis.clone()),
         &configuration.sumeragi.transaction_limits,
     )
     .expect("genesis creation failed");

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -118,7 +118,7 @@ impl<G: GenesisNetworkTrait> TestGenesis for G {
         G::from_configuration(
             submit_genesis,
             genesis,
-            &cfg.genesis,
+            &Some(cfg.genesis),
             &cfg.sumeragi.transaction_limits,
         )
         .expect("Failed to init genesis")

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -166,7 +166,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
             "wonderland".parse().expect("Valid"),
             kp.public_key().clone(),
         ),
-        &configuration.genesis,
+        &Some(configuration.genesis.clone()),
         &configuration.sumeragi.transaction_limits,
     )
     .unwrap()


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Pretty much wrapping `GenesisConfiguration` from `cli` crate into an `Option` to allow peer startup without a `genesis.json` if they're not submitting genesis.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue
Resolves #2360 .
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
More flexibility with deployment.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Slightly wordier initialization of all the related structs, as we have to wrap in `Some`.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
