### PR TITLE
[ci] #2393: Bump the version of the Docker base image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,8 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 [[package]]
 name = "unique_port"
 version = "0.2.1"
-source = "git+https://github.com/ales-tsurko/iroha2-unique_port?rev=09e95bb3608626c995b8e7e51c64ba7486c88948#09e95bb3608626c995b8e7e51c64ba7486c88948"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f903132efabcb4242e0bbf16aedb2c3867526e42126b6ed3cb1b0bc4577708"
 dependencies = [
  "once_cell",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE AS rust-base
 
 ENV CARGO_HOME=/cargo_home \


### PR DESCRIPTION
### Description of the Change
Version bump, which fixes the build failure. This is a stopgap until #2278 is merged

### Issue
- Closes #2393

### Benefits
- Docker can build

### Possible Drawbacks
- None