### PR TITLE
[fix] #1649: remove `spawn` from `do_send`

### DIFF
--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -161,16 +161,9 @@ impl<A: Actor> Addr<A> {
         A: ContextHandler<M>,
     {
         let envelope = SyncEnvelopeProxy::pack(message, None);
-        let sender = self.sender.clone();
-        // TODO: BUG: remove deadlock from iroha (probably issue inside of `iroha_p2p` crate) and remove this task::spawn
-        tokio::spawn(
-            async move {
-                if let Err(error) = sender.send(envelope).await {
-                    iroha_logger::error!(%error, "Error sending actor message");
-                }
-            }
-            .in_current_span(),
-        );
+        if let Err(error) = self.sender.send(envelope).await {
+            iroha_logger::error!(%error, "Error sending actor message");
+        }
     }
 
     /// Constructs recipient for sending only specific messages (without answers)


### PR DESCRIPTION
### Description of the Change
Deadlock described in #1649 is no longer reproducible. Tested under load for about an hour, periodically restarting and re-regestering peers.

### Issue

Closes #1649 

### Benefits

Performance

### Possible Drawbacks

None (if deadlock really is gone)