### PR TITLE
[feature] #2000: Disallow empty names

### DIFF
--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -429,13 +429,6 @@ pub struct Id {
 }
 
 impl Id {
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-            domain_id: DomainId::empty(),
-        }
-    }
-
     /// Construct [`Id`] from an account `name` and a `domain_name` if
     /// these names are valid.
     #[inline]
@@ -461,7 +454,9 @@ impl FromStr for Id {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
-            return Ok(Self::empty());
+            return Err(ParseError {
+                reason: "`AccountId` can not be empty",
+            });
         }
 
         let vector: Vec<&str> = string.split('@').collect();

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -583,13 +583,6 @@ impl DefinitionId {
     pub const fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
         Self { name, domain_id }
     }
-
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-            domain_id: DomainId::empty(),
-        }
-    }
 }
 
 impl Id {
@@ -654,7 +647,9 @@ impl FromStr for DefinitionId {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
-            return Ok(Self::empty());
+            return Err(ParseError {
+                reason: "`DefinitionId` can not be empty",
+            });
         }
 
         let vector: Vec<&str> = string.split('#').collect();

--- a/data_model/src/domain.rs
+++ b/data_model/src/domain.rs
@@ -457,12 +457,6 @@ impl Id {
     pub const fn new(name: Name) -> Self {
         Self { name }
     }
-
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-        }
-    }
 }
 
 /// The prelude re-exports most commonly used traits, structs and macros from this crate.

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -22,9 +22,9 @@ use crate::{ParseError, ValidationError};
 pub struct Name(ConstString);
 
 impl Name {
-    pub(crate) const fn empty() -> Self {
-        Self(ConstString::new())
-    }
+    // pub(crate) const fn empty() -> Self {
+    // Self(ConstString::new())
+    // }
 
     /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
     ///
@@ -52,9 +52,10 @@ impl Name {
     /// Fails if not valid [`Name`].
     fn validate_str(candidate: &str) -> Result<(), ParseError> {
         if candidate.is_empty() {
-            return Ok(());
+            return Err(ParseError {
+                reason: "`Name` can not be empty",
+            });
         }
-
         if candidate.chars().any(char::is_whitespace) {
             return Err(ParseError {
                 reason: "White space not allowed in `Name` constructs",
@@ -80,12 +81,7 @@ impl FromStr for Name {
     type Err = ParseError;
 
     fn from_str(candidate: &str) -> Result<Self, Self::Err> {
-        Self::validate_str(candidate).map(|_| {
-            if candidate.is_empty() {
-                return Self::empty();
-            }
-            Self(ConstString::from(candidate))
-        })
+        Self::validate_str(candidate).map(|_| Self(ConstString::from(candidate)))
     }
 }
 
@@ -126,12 +122,7 @@ impl<'de> Deserialize<'de> for Name {
 
         let name = ConstString::deserialize(deserializer)?;
         Self::validate_str(&name)
-            .map(|_| {
-                if name.is_empty() {
-                    return Self::empty();
-                }
-                Self(name)
-            })
+            .map(|_| Self(name))
             .map_err(D::Error::custom)
     }
 }
@@ -139,12 +130,7 @@ impl Decode for Name {
     fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
         let name = ConstString::decode(input)?;
         Self::validate_str(&name)
-            .map(|_| {
-                if name.is_empty() {
-                    return Self::empty();
-                }
-                Self(name)
-            })
+            .map(|_| Self(name))
             .map_err(|error| error.reason.into())
     }
 }


### PR DESCRIPTION
This PR disallows to use empty strings for `iroha_data_model::Name`. Thus, it forbids empty `AccountId`, `DomainId` etc. In case of `Name`'s initialization from an empty string, an error is raised. For discussion see the linked issue (#2000).