### PR TITLE
[feature] #2000: Disallow empty names

### DIFF
--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -167,7 +167,7 @@ fn account_can_query_only_its_own_domain() {
         .request(client::domain::by_id(domain_id))
         .is_ok());
 
-    // Alice can not query other domains.
+    // Alice cannot query other domains.
     assert!(iroha_client
         .request(client::domain::by_id(new_domain_id))
         .is_err());

--- a/client/tests/integration/query_errors.rs
+++ b/client/tests/integration/query_errors.rs
@@ -9,7 +9,7 @@ use iroha_data_model::prelude::*;
 #[test]
 fn non_existent_account_is_specific_error() {
     let (_rt, _peer, client) = <test_network::PeerBuilder>::new().start_with_runtime();
-    // we can not wait for genesis committment
+    // we cannot wait for genesis committment
 
     let err = client
         .request(client::account::by_id(

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -36,8 +36,8 @@ impl ValidQueryRequest {
 /// Query errors.
 #[derive(Error, Debug, Decode, Encode, IntoSchema)]
 pub enum Error {
-    /// Query can not be decoded.
-    #[error("Query can not be decoded")]
+    /// Query cannot be decoded.
+    #[error("Query cannot be decoded")]
     Decode(#[from] Box<iroha_version::error::Error>),
     /// Query has wrong signature.
     #[error("Query has the wrong signature: {0}")]

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -455,7 +455,7 @@ impl FromStr for Id {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
             return Err(ParseError {
-                reason: "`AccountId` can not be empty",
+                reason: "`AccountId` cannot be empty",
             });
         }
 

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -429,13 +429,6 @@ pub struct Id {
 }
 
 impl Id {
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-            domain_id: DomainId::empty(),
-        }
-    }
-
     /// Construct [`Id`] from an account `name` and a `domain_name` if
     /// these names are valid.
     #[inline]
@@ -461,7 +454,9 @@ impl FromStr for Id {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
-            return Ok(Self::empty());
+            return Err(ParseError {
+                reason: "`AccountId` can not be empty",
+            });
         }
 
         let vector: Vec<&str> = string.split('@').collect();

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -648,7 +648,7 @@ impl FromStr for DefinitionId {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
             return Err(ParseError {
-                reason: "`DefinitionId` can not be empty",
+                reason: "`DefinitionId` cannot be empty",
             });
         }
 

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -583,13 +583,6 @@ impl DefinitionId {
     pub const fn new(name: Name, domain_id: <Domain as Identifiable>::Id) -> Self {
         Self { name, domain_id }
     }
-
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-            domain_id: DomainId::empty(),
-        }
-    }
 }
 
 impl Id {
@@ -654,7 +647,9 @@ impl FromStr for DefinitionId {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         if string.is_empty() {
-            return Ok(Self::empty());
+            return Err(ParseError {
+                reason: "`DefinitionId` can not be empty",
+            });
         }
 
         let vector: Vec<&str> = string.split('#').collect();

--- a/data_model/src/domain.rs
+++ b/data_model/src/domain.rs
@@ -457,12 +457,6 @@ impl Id {
     pub const fn new(name: Name) -> Self {
         Self { name }
     }
-
-    pub(crate) const fn empty() -> Self {
-        Self {
-            name: Name::empty(),
-        }
-    }
 }
 
 /// The prelude re-exports most commonly used traits, structs and macros from this crate.

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -22,9 +22,9 @@ use crate::{ParseError, ValidationError};
 pub struct Name(ConstString);
 
 impl Name {
-    pub(crate) const fn empty() -> Self {
-        Self(ConstString::new())
-    }
+    // pub(crate) const fn empty() -> Self {
+    // Self(ConstString::new())
+    // }
 
     /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
     ///
@@ -52,9 +52,10 @@ impl Name {
     /// Fails if not valid [`Name`].
     fn validate_str(candidate: &str) -> Result<(), ParseError> {
         if candidate.is_empty() {
-            return Ok(());
+            return Err(ParseError {
+                reason: "`Name` can not be empty",
+            });
         }
-
         if candidate.chars().any(char::is_whitespace) {
             return Err(ParseError {
                 reason: "White space not allowed in `Name` constructs",
@@ -80,12 +81,7 @@ impl FromStr for Name {
     type Err = ParseError;
 
     fn from_str(candidate: &str) -> Result<Self, Self::Err> {
-        Self::validate_str(candidate).map(|_| {
-            if candidate.is_empty() {
-                return Self::empty();
-            }
-            Self(ConstString::from(candidate))
-        })
+        Self::validate_str(candidate).map(|_| Self(ConstString::from(candidate)))
     }
 }
 
@@ -126,12 +122,7 @@ impl<'de> Deserialize<'de> for Name {
 
         let name = ConstString::deserialize(deserializer)?;
         Self::validate_str(&name)
-            .map(|_| {
-                if name.is_empty() {
-                    return Self::empty();
-                }
-                Self(name)
-            })
+            .map(|_| Self(name))
             .map_err(D::Error::custom)
     }
 }
@@ -139,12 +130,7 @@ impl Decode for Name {
     fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
         let name = ConstString::decode(input)?;
         Self::validate_str(&name)
-            .map(|_| {
-                if name.is_empty() {
-                    return Self::empty();
-                }
-                Self(name)
-            })
+            .map(|_| Self(name))
             .map_err(|error| error.reason.into())
     }
 }

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -49,7 +49,7 @@ impl Name {
     fn validate_str(candidate: &str) -> Result<(), ParseError> {
         if candidate.is_empty() {
             return Err(ParseError {
-                reason: "`Name` can not be empty",
+                reason: "`Name` cannot be empty",
             });
         }
         if candidate.chars().any(char::is_whitespace) {

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -22,10 +22,6 @@ use crate::{ParseError, ValidationError};
 pub struct Name(ConstString);
 
 impl Name {
-    // pub(crate) const fn empty() -> Self {
-    // Self(ConstString::new())
-    // }
-
     /// Check if `range` contains the number of chars in the inner `String` of this [`Name`].
     ///
     /// # Errors

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -142,7 +142,7 @@ mod tests {
 
     use super::*;
 
-    const INVALID_NAMES: [&str; 3] = [" ", "@", "#"];
+    const INVALID_NAMES: [&str; 4] = ["", " ", "@", "#"];
 
     #[test]
     fn deserialize_name() {

--- a/permissions_validators/src/public_blockchain/mod.rs
+++ b/permissions_validators/src/public_blockchain/mod.rs
@@ -182,7 +182,7 @@ pub fn check_asset_creator_for_asset_definition(
         .unwrap_or(false);
     if !registered_by_signer_account {
         return Err(
-            "Can not grant access for assets, registered by another account."
+            "Cannot grant access for assets, registered by another account."
                 .to_owned()
                 .into(),
         );

--- a/tools/parity_scale_decoder/src/main.rs
+++ b/tools/parity_scale_decoder/src/main.rs
@@ -34,7 +34,7 @@ struct DecodeArgs {
 
 /// Function pointer to [`DumpDecoded::dump_decoded()`]
 ///
-/// Function pointer is used cause trait object can not be used
+/// Function pointer is used cause trait object cannot be used
 /// due to [`Sized`] bound in [`Decode`] trait
 pub type DumpDecodedPtr = fn(&[u8], &mut dyn io::Write) -> Result<(), eyre::Error>;
 


### PR DESCRIPTION
This PR disallows to use empty strings for `iroha_data_model::Name`. Thus, it forbids empty `AccountId`, `DomainId` etc. In case of `Name`'s initialization from an empty string, an error is raised. For discussion see the linked issue (#2000).