### PR TITLE
[feature] #2395: Add panic if genesis cannot be applied

### DIFF
--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -34,6 +34,8 @@ jobs:
         if: always()
       - name: Cleanup test environment
         run: bash -c './scripts/test_env.sh cleanup'
+      - name: Panic on invalid genesis test
+        run: bash -c './scripts/tests/panic_on_invalid_genesis.sh'
 
   docker-test:
     # This workflow is too unreliable to enable. Even for

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -191,6 +191,13 @@ where
             Arc::clone(&wsv),
         );
 
+        // Validate every transaction in genesis block
+        if let Some(ref genesis) = genesis {
+            transaction_validator
+                .validate_every(&***genesis)
+                .wrap_err("Transaction validation failed in genesis block")?;
+        }
+
         let notify_shutdown = Arc::new(Notify::new());
 
         let queue = Arc::new(Queue::from_configuration(&config.queue, Arc::clone(&wsv)));

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -85,6 +85,20 @@ impl TransactionValidator {
         .into())
     }
 
+    /// Validate every transaction in `txs`
+    ///
+    /// # Errors
+    /// Fails if validation of any transaction fails
+    pub fn validate_every(
+        &self,
+        txs: &[VersionedAcceptedTransaction],
+    ) -> Result<(), TransactionRejectionReason> {
+        for tx in txs {
+            self.validate_internal(tx.as_v1(), true)?;
+        }
+        Ok(())
+    }
+
     fn validate_internal(
         &self,
         tx: &AcceptedTransaction,

--- a/scripts/tests/panic_on_invalid_genesis.sh
+++ b/scripts/tests/panic_on_invalid_genesis.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -ex
+# Setup env
+export TORII_P2P_ADDR='127.0.0.1:1341'
+export TORII_API_URL='127.0.0.1:8084'
+export TORII_TELEMETRY_URL='127.0.0.1:8184'
+export IROHA_PUBLIC_KEY='ed01201c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b'
+export IROHA_PRIVATE_KEY='{"digest_function": "ed25519", "payload": "282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"}'
+export IROHA2_CONFIG_PATH="configs/peer/config.json"
+export SUMERAGI_TRUSTED_PEERS='[{"address":"127.0.0.1:1341", "public_key": "ed01201c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"}]'
+# Create tmp file for genesis
+export IROHA2_GENESIS_PATH="$(mktemp)" 
+# Remove on exit
+trap 'rm -- "$IROHA2_GENESIS_PATH"' EXIT
+
+# Create invalid genesis
+# NewAssetDefinition replaced with AssetDefinition
+cat > $IROHA2_GENESIS_PATH <<- EOF
+{
+  "transactions": [
+    {
+      "isi": [
+        {
+          "Register": {
+            "object": {
+              "Raw": {
+                "Identifiable": {
+                  "NewDomain": {
+                    "id": {
+                      "name": "wonderland"
+                    },
+                    "logo": null,
+                    "metadata": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "Register": {
+            "object": {
+              "Raw": {
+                "Identifiable": {
+                  "NewAccount": {
+                    "id": {
+                      "name": "alice",
+                      "domain_id": {
+                        "name": "wonderland"
+                      }
+                    },
+                    "signatories": [
+                      "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
+                    ],
+                    "metadata": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "Register": {
+            "object": {
+              "Raw": {
+                "Identifiable": {
+                  "AssetDefinition": {
+                    "id": {
+                      "name": "rose",
+                      "domain_id": {
+                        "name": "wonderland"
+                      }
+                    },
+                    "value_type": "Quantity",
+                    "mintable": "Infinitely",
+                    "metadata": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "Mint": {
+            "object": {
+              "Raw": {
+                "U32": 13
+              }
+            },
+            "destination_id": {
+              "Raw": {
+                "Id": {
+                  "AssetId": {
+                    "definition_id": {
+                      "name": "rose",
+                      "domain_id": {
+                        "name": "wonderland"
+                      }
+                    },
+                    "account_id": {
+                      "name": "alice",
+                      "domain_id": {
+                        "name": "wonderland"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+timeout 1m target/debug/iroha --submit-genesis 2>&1 | tee /dev/stderr | grep -q 'Transaction validation failed in genesis block'


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Raise panic if genesis contains invalid transactions.

Changes:

- Add function `validate_every` to `TransactionValidator` to validate slice of transactions;
- Add genesis transactions validity check to the `Iroha` constructor;
- Add test `scripts/tests/panic_on_invalid_jenesis.sh` to check that panic indeed invoked;
- Add test to `iroha2-pr` pipeline.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2395.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Early detection of problems associated with genesis.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

All instructions in genesis must be valid, impossible to have `FailBox` instruction for example.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

```
bash -c './scripts/tests/panic_on_invalid_genesis.sh' 
```
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs

Correct type checking would make possible to detects invalid transactions during deserialization.

<!-- Explain what other alternates were considered and why the proposed version was selected -->
<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
