### PR TITLE
[refactor] #2307: Make `events_sender` in `WorldStateView` non-optional

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -177,10 +177,11 @@ where
             domains(&config),
             config.sumeragi.trusted_peers.peers.clone(),
         );
-        let wsv = Arc::new(
-            WorldStateView::from_configuration(config.wsv, world)
-                .with_events(events_sender.clone()),
-        );
+        let wsv = Arc::new(WorldStateView::from_configuration(
+            config.wsv,
+            world,
+            events_sender.clone(),
+        ));
 
         let query_validator = Arc::new(query_validator);
 


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Change `events_sender` in `WorldStateView` from `Option<EventsSender>` to `EventsSender`: this change is possible because previously `WorldStateView::with_events` was called single time during `Iroha` initialization just after `WorldStateView::from_configuration`. 
- Add `events_sender` parameter to `WorldStateView::from_configuration` constructor. 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2307.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Avoid overhead of checking if `events_sender` is `Some` with every call to `produce_event`.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

In `WorldStateView::new` fake `events_sender` is created, but since `new` called only in tests it should be fine.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
