### PR TITLE
[feature] #2228: Add Unauthorized variant to smartcontracts query error

### DIFF
--- a/cli/src/torii/mod.rs
+++ b/cli/src/torii/mod.rs
@@ -86,7 +86,7 @@ pub(crate) const fn query_status_code(query_error: &query::Error) -> StatusCode 
     use query::Error::*;
     match query_error {
         Decode(_) | Evaluate(_) | Conversion(_) => StatusCode::BAD_REQUEST,
-        Signature(_) => StatusCode::UNAUTHORIZED,
+        Signature(_) | Unauthorized => StatusCode::UNAUTHORIZED,
         Permission(_) => StatusCode::FORBIDDEN,
         Find(_) => StatusCode::NOT_FOUND,
     }

--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -62,13 +62,6 @@ impl VerifiedQueryRequest {
         let account_has_public_key = wsv.map_account(&self.payload.account_id, |account| {
             account.contains_signatory(self.signature.public_key())
         })?;
-        // .map_err(|err| {
-        // let query_error = QueryError::from(err);
-        // match query_error {
-        // QueryError::Find(_) => QueryError::Unauthorized,
-        // _ => query_error,
-        // }
-        // })?;
         if !account_has_public_key {
             return Err(QueryError::Signature(String::from(
                 "Signature public key doesn't correspond to the account.",

--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -62,6 +62,13 @@ impl VerifiedQueryRequest {
         let account_has_public_key = wsv.map_account(&self.payload.account_id, |account| {
             account.contains_signatory(self.signature.public_key())
         })?;
+        // .map_err(|err| {
+        // let query_error = QueryError::from(err);
+        // match query_error {
+        // QueryError::Find(_) => QueryError::Unauthorized,
+        // _ => query_error,
+        // }
+        // })?;
         if !account_has_public_key {
             return Err(QueryError::Signature(String::from(
                 "Signature public key doesn't correspond to the account.",

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -398,14 +398,8 @@ async fn find_asset_with_no_account() {
             asset_id("rose", "alice"),
         )))
         .await
-        .status(StatusCode::NOT_FOUND)
-        .body_matches_err(|body| {
-            if let query::Error::Find(err) = body {
-                matches!(**err, FindError::Account(_))
-            } else {
-                false
-            }
-        })
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(body, query::Error::Unauthorized))
         .assert()
 }
 

--- a/cli/src/torii/tests.rs
+++ b/cli/src/torii/tests.rs
@@ -509,14 +509,8 @@ async fn find_account_with_no_account() {
             AccountId::new("alice".parse().expect("Valid"), DOMAIN.parse().expect("Valid")),
         )))
         .await
-        .status(StatusCode::NOT_FOUND)
-        .body_matches_err(|body| {
-            if let query::Error::Find(err) = body {
-                matches!(**err, FindError::Account(_))
-            } else {
-                false
-            }
-        })
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(body, query::Error::Unauthorized))
         .assert()
 }
 
@@ -665,8 +659,8 @@ async fn query_with_no_find() {
     // .deny_all()
         .query(query())
         .await
-        .status(StatusCode::NOT_FOUND)
-        .body_matches_err(|body| matches!(*body, query::Error::Find(_)))
+        .status(StatusCode::UNAUTHORIZED)
+        .body_matches_err(|body| matches!(body, query::Error::Unauthorized))
         .assert()
 }
 

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -32,15 +32,11 @@ pub mod isi {
 
             match wsv.asset(asset_id) {
                 Err(err) => match err {
-                    QueryError::Find(ref find_err) => {
-                        if let FindError::Asset(_) = **find_err {
-                            assert_can_register(&asset_id.definition_id, wsv, self.object.value())?;
-                            wsv.asset_or_insert(asset_id, self.object.value().clone())
-                                .expect("Account exists");
-                            Ok(())
-                        } else {
-                            Err(err.into())
-                        }
+                    QueryError::Find(find_err) if matches!(*find_err, FindError::Asset(_)) => {
+                        assert_can_register(&asset_id.definition_id, wsv, self.object.value())?;
+                        wsv.asset_or_insert(asset_id, self.object.value().clone())
+                            .expect("Account exists");
+                        Ok(())
                     }
                     _ => Err(err.into()),
                 },

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -13,7 +13,10 @@ use crate::{ValidQuery, WorldStateView};
 /// - grant permissions and roles
 /// - Revoke permissions or roles
 pub mod isi {
-    use super::{super::prelude::*, super::query::Error as QueryError, *};
+    use super::{
+        super::{prelude::*, query::Error as QueryError},
+        *,
+    };
 
     #[allow(clippy::expect_used, clippy::unwrap_in_result)]
     impl Execute for Register<Asset> {

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -13,7 +13,7 @@ use crate::{ValidQuery, WorldStateView};
 /// - grant permissions and roles
 /// - Revoke permissions or roles
 pub mod isi {
-    use super::{super::prelude::*, *};
+    use super::{super::prelude::*, super::query::Error as QueryError, *};
 
     #[allow(clippy::expect_used, clippy::unwrap_in_result)]
     impl Execute for Register<Asset> {
@@ -28,13 +28,19 @@ pub mod isi {
             let asset_id = self.object.id();
 
             match wsv.asset(asset_id) {
-                Err(FindError::Asset(_)) => {
-                    assert_can_register(&asset_id.definition_id, wsv, self.object.value())?;
-                    wsv.asset_or_insert(asset_id, self.object.value().clone())
-                        .expect("Account exists");
-                    Ok(())
-                }
-                Err(e) => Err(Error::Find(Box::new(e))),
+                Err(err) => match err {
+                    QueryError::Find(ref find_err) => {
+                        if let FindError::Asset(_) = **find_err {
+                            assert_can_register(&asset_id.definition_id, wsv, self.object.value())?;
+                            wsv.asset_or_insert(asset_id, self.object.value().clone())
+                                .expect("Account exists");
+                            Ok(())
+                        } else {
+                            Err(err.into())
+                        }
+                    }
+                    _ => Err(err.into()),
+                },
                 Ok(_) => Err(Error::Repetition(
                     InstructionType::Register,
                     IdBox::AssetId(asset_id.clone()),

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -397,14 +397,13 @@ pub mod query {
                 .wrap_err("Failed to get asset id")
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
             iroha_logger::trace!(%id);
-            wsv.asset(&id)
-                .map_err(
-                    |asset_err| match wsv.asset_definition_entry(&id.definition_id) {
-                        Ok(_) => asset_err,
-                        Err(definition_err) => definition_err,
-                    },
-                )
-                .map_err(Into::into)
+            wsv.asset(&id).map_err(|asset_err| {
+                match wsv.asset_definition_entry(&id.definition_id) {
+                    Ok(_) => asset_err,
+                    Err(definition_err) => definition_err.into(),
+                }
+            })
+            // .map_err(Into::into)
         }
     }
 
@@ -545,7 +544,7 @@ pub mod query {
             wsv.asset(&id)
                 .map_err(
                     |asset_err| match wsv.asset_definition_entry(&id.definition_id) {
-                        Ok(_) => Error::Find(Box::new(asset_err)),
+                        Ok(_) => asset_err,
                         Err(definition_err) => Error::Find(Box::new(definition_err)),
                     },
                 )?
@@ -573,7 +572,7 @@ pub mod query {
             let asset = wsv.asset(&id).map_err(|asset_err| {
                 match wsv.asset_definition_entry(&id.definition_id) {
                     Ok(_) => asset_err,
-                    Err(definition_err) => definition_err,
+                    Err(definition_err) => Error::Find(Box::new(definition_err)),
                 }
             })?;
             iroha_logger::trace!(%id, %key);

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -403,7 +403,6 @@ pub mod query {
                     Err(definition_err) => definition_err.into(),
                 }
             })
-            // .map_err(Into::into)
         }
     }
 

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -398,9 +398,10 @@ pub mod query {
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
             iroha_logger::trace!(%id);
             wsv.asset(&id).map_err(|asset_err| {
-                match wsv.asset_definition_entry(&id.definition_id) {
-                    Ok(_) => asset_err,
-                    Err(definition_err) => definition_err.into(),
+                if let Err(definition_err) = wsv.asset_definition_entry(&id.definition_id) {
+                    definition_err.into()
+                } else {
+                    asset_err
                 }
             })
         }
@@ -541,12 +542,13 @@ pub mod query {
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
             iroha_logger::trace!(%id);
             wsv.asset(&id)
-                .map_err(
-                    |asset_err| match wsv.asset_definition_entry(&id.definition_id) {
-                        Ok(_) => asset_err,
-                        Err(definition_err) => Error::Find(Box::new(definition_err)),
-                    },
-                )?
+                .map_err(|asset_err| {
+                    if let Err(definition_err) = wsv.asset_definition_entry(&id.definition_id) {
+                        Error::Find(Box::new(definition_err))
+                    } else {
+                        asset_err
+                    }
+                })?
                 .value()
                 .try_as_ref()
                 .map_err(eyre::Error::from)
@@ -569,9 +571,10 @@ pub mod query {
                 .wrap_err("Failed to get key")
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
             let asset = wsv.asset(&id).map_err(|asset_err| {
-                match wsv.asset_definition_entry(&id.definition_id) {
-                    Ok(_) => asset_err,
-                    Err(definition_err) => Error::Find(Box::new(definition_err)),
+                if let Err(definition_err) = wsv.asset_definition_entry(&id.definition_id) {
+                    Error::Find(Box::new(definition_err))
+                } else {
+                    asset_err
                 }
             })?;
             iroha_logger::trace!(%id, %key);

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -54,6 +54,9 @@ pub enum Error {
     /// Query found wrong type of asset.
     #[error("Query found wrong type of asset: {0}")]
     Conversion(String),
+    /// Query without account.
+    #[error("Unauthorized query: account not provided")]
+    Unauthorized,
 }
 
 impl From<FindError> for Error {

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -555,7 +555,7 @@ impl WorldStateView {
         f: impl FnOnce(&Account) -> T,
     ) -> Result<T, QueryError> {
         let domain = self.domain(&id.domain_id)?;
-        let account = domain.account(id).ok_or_else(|| QueryError::Unauthorized)?;
+        let account = domain.account(id).ok_or(QueryError::Unauthorized)?;
         Ok(f(account))
     }
 

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -131,7 +131,6 @@ impl WorldStateView {
     /// Fails if there is no domain or account
     pub fn account_assets(&self, id: &AccountId) -> Result<Vec<Asset>, QueryError> {
         self.map_account(id, |account| account.assets().cloned().collect())
-        // .map_err(Into::into)
     }
 
     /// Returns a set of permission tokens granted to this account as part of roles and separately.

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -19,7 +19,7 @@ use tokio::{sync::broadcast, task};
 use crate::{
     block::Chain,
     prelude::*,
-    smartcontracts::{isi::Error, wasm, Execute, FindError},
+    smartcontracts::{isi::query::Error as QueryError, isi::Error, wasm, Execute, FindError},
     DomainsMap, EventsSender, PeersIds,
 };
 
@@ -126,8 +126,9 @@ impl WorldStateView {
     ///
     /// # Errors
     /// Fails if there is no domain or account
-    pub fn account_assets(&self, id: &AccountId) -> Result<Vec<Asset>, FindError> {
+    pub fn account_assets(&self, id: &AccountId) -> Result<Vec<Asset>, QueryError> {
         self.map_account(id, |account| account.assets().cloned().collect())
+        // .map_err(Into::into)
     }
 
     /// Returns a set of permission tokens granted to this account as part of roles and separately.
@@ -261,11 +262,11 @@ impl WorldStateView {
     /// - No such [`Asset`]
     /// - The [`Account`] with which the [`Asset`] is associated doesn't exist.
     /// - The [`Domain`] with which the [`Account`] is associated doesn't exist.
-    pub fn asset(&self, id: &<Asset as Identifiable>::Id) -> Result<Asset, FindError> {
-        self.map_account(&id.account_id, |account| -> Result<Asset, FindError> {
+    pub fn asset(&self, id: &<Asset as Identifiable>::Id) -> Result<Asset, QueryError> {
+        self.map_account(&id.account_id, |account| -> Result<Asset, QueryError> {
             account
                 .asset(id)
-                .ok_or_else(|| FindError::Asset(id.clone()))
+                .ok_or_else(|| QueryError::Find(Box::new(FindError::Asset(id.clone()))))
                 .map(Clone::clone)
         })?
     }
@@ -552,11 +553,9 @@ impl WorldStateView {
         &self,
         id: &AccountId,
         f: impl FnOnce(&Account) -> T,
-    ) -> Result<T, FindError> {
+    ) -> Result<T, QueryError> {
         let domain = self.domain(&id.domain_id)?;
-        let account = domain
-            .account(id)
-            .ok_or_else(|| FindError::Account(id.clone()))?;
+        let account = domain.account(id).ok_or_else(|| QueryError::Unauthorized)?;
         Ok(f(account))
     }
 

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -19,7 +19,10 @@ use tokio::{sync::broadcast, task};
 use crate::{
     block::Chain,
     prelude::*,
-    smartcontracts::{isi::query::Error as QueryError, isi::Error, wasm, Execute, FindError},
+    smartcontracts::{
+        isi::{query::Error as QueryError, Error},
+        wasm, Execute, FindError,
+    },
     DomainsMap, EventsSender, PeersIds,
 };
 


### PR DESCRIPTION
Closes #2228

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Added `iroha_core::smartcontracts::query::Error::Unauthorized` to better mirror semantics of unauthorized request (i.e. without an account in this case). Also, in case of querying without an account, **HTTP 401 UNAUTHORIZED** status is returned.

### Issue

Previously, in case of query without an account `FindError::Account` returned. And the corresponding **HTTP 404 NOT_FOUND** status code returned. That appeared to be semantically incorrect.

### Benefits

Now `POST /query` in case of request without an account returns `Error::Unauthorized` and **HTTP 401 UNAUTHORIZED** status code.

### Alternate Designs *[optional]*

At first glance, this can be moved to `Error::Permission` and the `Unauthorized` variant could be added to `DenialReason`, but it doesn't share semantics with **HTTP 401 UNAUTHORIZED** (it's **HTTP 403 FORBIDDEN** instead, [which is different](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403)).
<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
