### PR TITLE
[documentation] #2446: improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Telegram
+    url: https://t.me/hyperledgeriroha
+    about: Hyperledger Iroha Community channel is a good place to ask questions about Iroha.
+  - name: Discord
+    url: https://discord.com/channels/905194001349627914/905205848547155968
+    about: There's also an Iroha channel on the Hyperledger Discord server.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,42 @@
+name: "\U0001F4D6 Documentation"
+description: Submit a doc request or report outdated, incorrect, or insufficient documentation
+title: "[documentation] "
+labels: [ "Documentation", "iroha2" ]
+body:
+  - type: textarea
+    id: doc-urls
+    attributes:
+      label: Documentation URL(s)
+      description: |
+        Tell us which page(s) should be updated or fixed
+      placeholder: https://github.com/hyperledger/iroha/blob/main/README.md
+  - type: textarea
+    id: improvement-section
+    attributes:
+      label: Description
+      description: Tell us what exactly needs to be improved, updated, or fixed in Iroha documentation
+      placeholder: |
+        The documentation for feature X is outdated.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion-text
+    attributes:
+      label: Your suggestions
+      description: Share your ideas on how to address the issue
+      placeholder: |
+        Feature X currently works in a different way: …
+    validations:
+      required: false
+  - type: input
+    id: who-can-help
+    attributes:
+      label: Who can help?
+      description: |
+        If you figure out the right person to tag, your issue might be resolved faster.
+        You can use `git blame` or tag the documentation owners:
+        
+        * Ekaterina Mekhnetsova (`@outoftardis`)
+        * Victor Gridnevsky (`@6r1d`)
+
+      placeholder: "@Username ..."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,39 @@
+name: "\U0001F680 Feature / enhancement request"
+description: Suggest a feature or an enhancement you'd like to see in Iroha
+title: "[suggestion] "
+labels: [ "Enhancement", "iroha2" ]
+body:
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: Feature request
+      description: |
+        Please describe a feature or an enhancement you'd like to see in Iroha. To better explain your idea, provide examples and as many relevant details as you can.
+      placeholder: |
+        I'd like Iroha 2 to …
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Outline the motivation for adding a new feature.
+        If your request is related to other issues, adding a link to those issues would be helpful.
+      placeholder: |
+        Iroha will be even more useful if …
+    validations:
+      required: true
+  - type: input
+    id: who-can-help
+    attributes:
+      label: Who can help?
+      description: |
+        If you figure out the right person to tag, your request might be addressed faster.
+        You can **tag** people from the following list based on the issue topic:
+        
+         - WASM: Marin Veršić (`@mversic`)
+         - Triggers: Daniil Polyakov (`@Arjentix`)
+         - Theoretical questions: Shunkichi Sato (`@s8sato`)
+         - Other topics: Aleksandr Petrosyan (`@appetrosyan`)
+      placeholder: "@Username ..."

--- a/.github/ISSUE_TEMPLATE/lts-bug.yml
+++ b/.github/ISSUE_TEMPLATE/lts-bug.yml
@@ -1,0 +1,113 @@
+name: "\U0001F41C Bug report: LTS version (iroha2-lts)"
+description: Submit a bug you found in the LTS version of Iroha
+title: "[BUG] "
+labels: [ "Bug", "iroha2", "LTS" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this form! You may refer to the [contributing guide](https://github.com/hyperledger/iroha/blob/iroha2-dev/CONTRIBUTING.md#reporting-bugs) for further details on filling the bug reports.
+
+        Please be aware that SDK issues belong to other repositories:
+         - JavaScript library for Iroha, [`iroha-javascript`](https://github.com/hyperledger/iroha-javascript)
+         - Java 8 client library for Iroha, [`iroha-java`](https://github.com/hyperledger/iroha-java)
+  - type: input
+    id: commit-hash
+    attributes:
+      label: GIT commit hash
+      description: |
+        What is the commit hash of your Iroha version?
+        You can use the `git rev-parse --short HEAD` command to retrieve it.
+        Note that older versions may have more bugs.
+      placeholder: abc123
+    validations:
+      required: true
+  - type: textarea
+    id: mwe
+    attributes:
+      label: Minimum working example
+      description: |
+        Please share a minimal working code that allows us to reproduce the issue.
+        Make sure you enable [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting).
+      placeholder: |
+        ```rust
+        fn main() {
+        }
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: What is the result or behaviour you expected to get?
+      placeholder: I expected Iroha to run normally on bare-metal after building the LTS version.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behaviour
+    attributes:
+      label: Actual behaviour
+      description: What is the result or behaviour you got?
+      placeholder: |
+        I get an error message when running Iroha:
+
+        Example error #123 
+    validations:
+      required: true
+  - type: input
+    id: os-type
+    attributes:
+      label: Operating system
+      description: |
+        Which operating system did you use when you encountered the issue?
+      placeholder: Arch Linux
+    validations:
+      required: true
+  - type: input
+    id: libc-type-and-version
+    attributes:
+      label: LibC type and version
+      description: |
+        Please specify the type of LibC you're using (`GNU libc` or `musl libc`) and its version.
+        Use the `ldd --version ldd` command to determine it.
+      placeholder: musl libc v1.2.3
+  - type: dropdown
+    id: env
+    attributes:
+      label: Current environment
+      description: |
+        Did you build Iroha from the source code or pulled it from [Docker Hub](https://hub.docker.com/) or [Nix](https://search.nixos.org/packages) packages?
+      options:
+        - Source code build
+        - Docker Hub
+        - Nix
+    validations:
+      required: true
+  - type: textarea
+    id: json-logs
+    attributes:
+      label: Logs in JSON format
+      description: |
+        Please provide an output log in JSON format.
+        To configure a file path and level for logs, check the [reference documentation](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md#logger) or [peer configuration](https://hyperledger.github.io/iroha-2-docs/guide/configure/peer-configuration.html#logger).
+        Note: it is helpful to have JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) enabled.
+      placeholder: |
+        ```json
+        ```
+    validations:
+      required: true
+  - type: input
+    id: who-can-help
+    attributes:
+      label: Who can help?
+      description: |
+        If you figure out the right person to tag, your issue might be resolved faster.
+        You can use `git blame` or check the following list of people **you can tag** based on what the issue is connected to:
+
+         - Documentation issues: Ekaterina Mekhnetsova (`@outoftardis`), Victor Gridnevsky (`@6r1d`)
+         - WASM: Marin Veršić (`@mversic`)
+         - Triggers: Daniil Polyakov (`@Arjentix`)
+         - Theoretical questions: Shunkichi Sato (`@s8sato`)
+         - Other topics: Aleksandr Petrosyan (`@appetrosyan`)
+      placeholder: "@Username ..."

--- a/.github/ISSUE_TEMPLATE/stable-bug.yml
+++ b/.github/ISSUE_TEMPLATE/stable-bug.yml
@@ -1,0 +1,113 @@
+name: "\U0001F41E Bug report: Stable version (iroha2)"
+description: Submit a bug you found in the stable version of Iroha
+title: "[BUG] "
+labels: [ "Bug", "iroha2" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this form! You may refer to the [contributing guide](https://github.com/hyperledger/iroha/blob/iroha2-dev/CONTRIBUTING.md#reporting-bugs) for further details on filling the bug reports.
+
+        Please be aware that SDK issues belong to other repositories:
+         - JavaScript library for Iroha, [`iroha-javascript`](https://github.com/hyperledger/iroha-javascript)
+         - Java 8 client library for Iroha, [`iroha-java`](https://github.com/hyperledger/iroha-java)
+  - type: input
+    id: commit-hash
+    attributes:
+      label: GIT commit hash
+      description: |
+        What is the commit hash of your Iroha version?
+        You can use the `git rev-parse --short HEAD` command to retrieve it.
+        Note that older versions may have more bugs.
+      placeholder: abc123
+    validations:
+      required: true
+  - type: textarea
+    id: mwe
+    attributes:
+      label: Minimum working example
+      description: |
+        Please share a minimal working code that allows us to reproduce the issue.
+        Make sure you enable [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting).
+      placeholder: |
+        ```rust
+        fn main() {
+        }
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: What is the result or behaviour you expected to get?
+      placeholder: I expected Iroha to run normally on bare-metal after building a stable version.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behaviour
+    attributes:
+      label: Actual behaviour
+      description: What is the result or behaviour you got?
+      placeholder: |
+        I get an error message when running Iroha:
+
+        Example error #123 
+    validations:
+      required: true
+  - type: input
+    id: os-type
+    attributes:
+      label: Operating system
+      description: |
+        Which operating system did you use when you encountered the issue?
+      placeholder: Arch Linux
+    validations:
+      required: true
+  - type: input
+    id: libc-type-and-version
+    attributes:
+      label: LibC type and version
+      description: |
+        Please specify the type of LibC you're using (`GNU libc` or `musl libc`) and its version.
+        Use the `ldd --version ldd` command to determine it.
+      placeholder: musl libc v1.2.3
+  - type: dropdown
+    id: env
+    attributes:
+      label: Current environment
+      description: |
+        Did you build Iroha from the source code or pulled it from [Docker Hub](https://hub.docker.com/) or [Nix](https://search.nixos.org/packages) packages?
+      options:
+        - Source code build
+        - Docker Hub
+        - Nix
+    validations:
+      required: true
+  - type: textarea
+    id: json-logs
+    attributes:
+      label: Logs in JSON format
+      description: |
+        Please provide an output log in JSON format.
+        To configure a file path and level for logs, check the [reference documentation](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md#logger) or [peer configuration](https://hyperledger.github.io/iroha-2-docs/guide/configure/peer-configuration.html#logger).
+        Note: it is helpful to have JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) enabled.
+      placeholder: |
+        ```json
+        ```
+    validations:
+      required: true
+  - type: input
+    id: who-can-help
+    attributes:
+      label: Who can help?
+      description: |
+        If you figure out the right person to tag, your issue might be resolved faster.
+        You can use `git blame` or check the following list of people **you can tag** based on what the issue is connected to:
+
+         - Documentation issues: Ekaterina Mekhnetsova (`@outoftardis`), Victor Gridnevsky (`@6r1d`)
+         - WASM: Marin Veršić (`@mversic`)
+         - Triggers: Daniil Polyakov (`@Arjentix`)
+         - Theoretical questions: Shunkichi Sato (`@s8sato`)
+         - Other topics: Aleksandr Petrosyan (`@appetrosyan`)
+      placeholder: "@Username ..."

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,0 @@
-## Hello! 
-
-It is great that you've decided to contribute to Hyperledger Iroha by telling us more about the issue you've encountered!
-
-To report the issue here, please, try to **explain** it as thoroughly as possible and **include Iroha version and logs**, if you have any, as well as your **environment information**: OS, specifications etc.


### PR DESCRIPTION
### Description of the Change

This PR adds detailed forms to fill into the issues. To see the issue form, open [this page](https://github.com/6r1d/iroha/issues/new/choose).

### Issue

This PR closes #2446 and covers all the items in it.

### Benefits

* Contributors sending the bug requests will fill the form with all the details that are needed for quicker debugging.
* The supported branches of Iroha are immediately visible.
* Contributors also see who to tag, so the issue gets resolved faster.
* People who have questions will immediately see Discord and Telegram community links.

### Possible Drawbacks

~~I have several questions I'll be marking as resolved here~~.
**UPD**: these questions were resolved.

- [x] I am not sure where to redirect people who have an SDK problem. In addition to that, it is possible to add a link to SDK in `/issues/new/choose`. This detail needs to be considered before the merge.
- [x] The [Discord server link](https://discord.gg/hyperledger) with `#iroha` channel shows a Telegram bridge and little activity. Is it the current actual Discord for Iroha?
- [x] The tags are auto-filled and need a change; I have not seen a `stable` tag, so both types of issues are tagged the same way, making it confusing.
- [x] This PR still has `blank_issues_enabled` as `true` for now. I think this will need a bit of a discussion: should we have blank issues in addition to the "bug" issues for questions, not related to bugs or future planning?
- [x] I am not sure if [this](https://hyperledger.github.io/iroha-2-docs/guide/configure/peer-configuration.html#logger) is the correct documentation link for JSON logs. While all the details match, is it the correct doc to refer to?

### Alternate Designs

At a later date, there may be an internal command to collect most of the current Iroha environment data: LibC version, OS info, etc. I am not sure if this can be done reliably all the time, so I am thinking of implementing this at a later date.