### PR TITLE
[documentation] hyperledger#2446 adds a spoiler to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/lts-bug.yml
+++ b/.github/ISSUE_TEMPLATE/lts-bug.yml
@@ -29,9 +29,11 @@ body:
       description: |
         Please share a minimal working code that allows us to reproduce the issue.
         Make sure you enable [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting).
-      placeholder: |
+      value: |
         ```rust
         fn main() {
+             // Steps to reproduce …
+             // Steps to reproduce …
         }
         ```
     validations:
@@ -89,12 +91,19 @@ body:
     attributes:
       label: Logs in JSON format
       description: |
-        Please provide an output log in JSON format.
+        Provide an output log in JSON format, so we could determine what caused the issue faster.
         To configure a file path and level for logs, check the [reference documentation](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md#logger) or [peer configuration](https://hyperledger.github.io/iroha-2-docs/guide/configure/peer-configuration.html#logger).
-        Note: it is helpful to have JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) enabled.
-      placeholder: |
-        ```json
-        ```
+        **Please** leave JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) and [collapsed sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) (`<details>` tag) enabled.
+        If the log indentation is broken, use the [js-beautify](https://beautifier.io/) service to format it.
+      value: |
+        <details>
+          <summary>Log contents</summary>
+          
+          ```json
+          Replace this text with a JSON log,
+          so it doesn't grow too large and has highlighting.
+          ```
+        </details>
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/stable-bug.yml
+++ b/.github/ISSUE_TEMPLATE/stable-bug.yml
@@ -29,7 +29,7 @@ body:
       description: |
         Please share a minimal working code that allows us to reproduce the issue.
         Make sure you enable [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting).
-      placeholder: |
+      value: |
         ```rust
         fn main() {
         }
@@ -89,12 +89,19 @@ body:
     attributes:
       label: Logs in JSON format
       description: |
-        Please provide an output log in JSON format.
+        Provide an output log in JSON format, so we could determine what caused the issue faster.
         To configure a file path and level for logs, check the [reference documentation](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md#logger) or [peer configuration](https://hyperledger.github.io/iroha-2-docs/guide/configure/peer-configuration.html#logger).
-        Note: it is helpful to have JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) enabled.
-      placeholder: |
-        ```json
-        ```
+        **Please** leave JSON [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) and [collapsed sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) (`<details>` tag) enabled.
+        If the log indentation is broken, use the [js-beautify](https://beautifier.io/) service to format it.
+      value: |
+        <details>
+          <summary>Log contents</summary>
+          
+          ```json
+          Replace this text with a JSON log,
+          so it doesn't grow too large and has highlighting.
+          ```
+        </details>
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Signed-off-by: 6r1d <vic.6r1d@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Adds a spoiler to issue templates, like in #2456.

### Issue

Fixes #2446

### Benefits

* Adds a spoiler with highlight as a default value, potentially improving readability
* Asks user to format logs if formatting is broken for some reason
* Hints a code highlight is needed for Rust MWE

### Possible Drawbacks

None

### Usage Examples or Tests

Creating an example issue in [this fork](https://github.com/6r1d/iroha/issues/new/choose) can show the current form.