### PR TITLE
[feature] #2467: Add account grant subcommand into iroha_client_cli

### DIFF
--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -256,7 +256,7 @@ mod domain {
         /// Domain's name as double-quoted string
         #[structopt(short, long)]
         pub id: DomainId,
-        /// The filename with key-value metadata pairs in JSON
+        /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -313,7 +313,7 @@ mod account {
         /// List accounts
         #[clap(subcommand)]
         List(List),
-        /// Grant permission to account
+        /// Grant permission to the account
         Grant(Grant),
     }
 
@@ -332,7 +332,7 @@ mod account {
         /// Its public key
         #[structopt(short, long)]
         pub key: PublicKey,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -383,7 +383,7 @@ mod account {
     pub struct SignatureCondition {
         /// Signature condition file
         pub condition: Signature,
-        /// The filename with key-value metadata pairs in JSON
+        /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -426,10 +426,10 @@ mod account {
         /// Account id
         #[structopt(short, long)]
         pub id: <Account as Identifiable>::Id,
-        /// The filename with permission token in JSON
+        /// The JSON file with a permission token
         #[structopt(short, long)]
         pub permission: Permission,
-        /// The filename with key-value metadata pairs in JSON
+        /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -506,7 +506,7 @@ mod asset {
         /// Value type stored in asset
         #[structopt(short, long)]
         pub value_type: AssetValueType,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -545,7 +545,7 @@ mod asset {
         /// Quantity to mint
         #[structopt(short, long)]
         pub quantity: u32,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -581,7 +581,7 @@ mod asset {
         /// Quantity of asset as number
         #[structopt(short, long)]
         pub quantity: u32,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -680,7 +680,7 @@ mod peer {
         /// Public key of the peer
         #[structopt(short, long)]
         pub key: PublicKey,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }
@@ -710,7 +710,7 @@ mod peer {
         /// Public key of the peer
         #[structopt(short, long)]
         pub key: PublicKey,
-        /// The filename with key-value metadata pairs in JSON
+        /// /// The JSON file with key-value metadata pairs
         #[structopt(short, long, default_value = "")]
         pub metadata: super::Metadata,
     }

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -253,7 +253,7 @@ mod domain {
     /// Add subcommand for domain
     #[derive(Debug, StructOpt)]
     pub struct Register {
-        /// Domain's name as double-quoted string
+        /// Domain name as double-quoted string
         #[structopt(short, long)]
         pub id: DomainId,
         /// The JSON file with key-value metadata pairs
@@ -313,7 +313,7 @@ mod account {
         /// List accounts
         #[clap(subcommand)]
         List(List),
-        /// Grant permission to the account
+        /// Grant a permission to the account
         Grant(Grant),
     }
 
@@ -444,9 +444,11 @@ mod account {
         fn from_str(s: &str) -> Result<Self> {
             let file = File::open(s)
                 .wrap_err(format!("Failed to open the permission token file {}", &s))?;
-            let permission_token: PermissionToken = serde_json::from_reader(file).wrap_err(
-                format!("Failed to deserialize permission token from file {}", &s),
-            )?;
+            let permission_token: PermissionToken =
+                serde_json::from_reader(file).wrap_err(format!(
+                    "Failed to deserialize the permission token from file {}",
+                    &s
+                ))?;
             Ok(Self(permission_token))
         }
     }
@@ -459,7 +461,7 @@ mod account {
                 metadata: Metadata(metadata),
             } = self;
             let grant = GrantBox::new(permission.0, id);
-            submit(grant, cfg, metadata).wrap_err("Failed to grant permission to account")
+            submit(grant, cfg, metadata).wrap_err("Failed to grant the permission to the account")
         }
     }
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

* Added `grant` subcommand for `account` command
* Added `list-permissions` subcommand for `account` command as @s8sato suggested

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

* Closes #2467


### Benefits

Now users can grant permissions using `iroha_client_cli`

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

* Not a drawback of this PR, but still no support for roles
* We might need to introduce server response cheking in `Client::submit_transaction()` so that user can see if something has failed on the server-side
* I've mentioned that the documentation for `iroha_client_cli` tells about possibility to pass empty line for key when registering new account. This does not work now

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

1. Run docker compose:

``` bash
docker compose up
```

2. Open new terminal window and go to `configs/client_cli`

3. Run this commands:

```bash
cargo run --bin iroha_client_cli -- domain register --id looking_glass
cargo run --bin iroha_client_cli -- account register --id="mad_hatter@looking_glass" --key="ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
cargo run --bin iroha_client_cli -- asset register --id tea#looking_glass --value-type Quantity
```

4. Then create file `premission_token.json` and paste the following:

```json
{
    "name": "can_transfer_user_assets",
    "params": {
        "asset_id": {
            "Id": {
                "AssetId": {
                    "definition_id": {
                        "name": "tea",
                        "domain_id": {
                            "name": "looking_glass"
                        }
                    },
                    "account_id": {
                        "name": "mad_hatter",
                        "domain_id": {
                            "name": "looking_glass"
                        }
                    }
                }
            }
        }
    }
}
```

5. Open `config.json` in `configs/client_cli` directory and replace `alice` with `mad_hatter` and `wonderland` with `looking_glass`. This is needed because `alice` can't grant permissions to assets of another domain (I think so; I didn't checked if it's the real reason why it's not working without it)

6. Run the final commands:

```bash
cargo run --bin iroha_client_cli -- account grant --id "mad_hatter@looking_glass" --permission permission_token.json
cargo run --bin iroha_client_cli -- account list-permissions --id "mad_hatter@looking_glass"
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
