### PR TITLE
[feature] #1769: Optimize pub/sub messaging

### DIFF
--- a/actor/examples/broker.rs
+++ b/actor/examples/broker.rs
@@ -1,0 +1,91 @@
+use iroha_actor::{broker::*, prelude::*};
+
+struct Alice(Broker);
+
+struct Bob(Broker);
+
+struct Carol(Broker);
+
+#[derive(Clone, Debug, Message)]
+#[message(result = "()")]
+struct MsgXA;
+
+#[derive(Clone, Debug, Message)]
+#[message(result = "()")]
+struct MsgAB;
+
+#[derive(Clone, Debug, Message)]
+#[message(result = "()")]
+struct MsgAC;
+
+#[derive(Clone, Debug, Message)]
+#[message(result = "()")]
+struct MsgBC;
+
+#[async_trait::async_trait]
+impl Actor for Alice {
+    async fn on_start(&mut self, ctx: &mut Context<Self>) {
+        self.0.subscribe::<MsgXA, _>(ctx);
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for Bob {
+    async fn on_start(&mut self, ctx: &mut Context<Self>) {
+        self.0.subscribe::<MsgAB, _>(ctx);
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for Carol {
+    async fn on_start(&mut self, ctx: &mut Context<Self>) {
+        self.0.subscribe::<MsgAC, _>(ctx);
+        self.0.subscribe::<MsgBC, _>(ctx);
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<MsgXA> for Alice {
+    type Result = ();
+    async fn handle(&mut self, msg: MsgXA) {
+        println!("{:?}", msg);
+        self.0.issue_send(MsgAB).await;
+        self.0.issue_send(MsgAC).await;
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<MsgAB> for Bob {
+    type Result = ();
+    async fn handle(&mut self, msg: MsgAB) {
+        println!("{:?}", msg);
+        self.0.issue_send(MsgBC).await;
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<MsgAC> for Carol {
+    type Result = ();
+    async fn handle(&mut self, msg: MsgAC) {
+        println!("{:?}", msg);
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<MsgBC> for Carol {
+    type Result = ();
+    async fn handle(&mut self, msg: MsgBC) {
+        println!("{:?}", msg);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let broker = Broker::new();
+    Alice(broker.clone()).start().await;
+    Bob(broker.clone()).start().await;
+    Carol(broker.clone()).start().await;
+    broker.issue_send(MsgXA).await;
+    // Expected:
+    // MsgXA, MsgAB, MsgAC, and MsgBC appear once each （may be in no particular order)
+}


### PR DESCRIPTION
### Description of the Change

WIP.

- Establish all the possible channels at the components initialization
- Remove the broker

### Issue

- Closes #1769

### Benefits

- No broker access

### Possible Drawbacks

- Readability, if the boilerplate were pushed into macros

### Usage Examples or Tests

- 4082d4d1 implies the current implementation is not properly working
- f8e4dc0d is a blueprint -- not working due to lack of implementations

### Alternate Designs

The broker stores a receiver of 1:n channel on the publish declaration and clones on the subscription request:

```rust
use tokio::sync::watch::Receiver;

pub struct Broker {
    receivers: Arc<DashSet<Receiver<Box<dyn Msg>>>>,
}
```