### PR TITLE
[fix] #2457: Fix tests flakiness related to shut down on panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1275,6 +1276,17 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1700,6 +1712,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "serial_test",
  "test_network",
  "thiserror",
  "tokio",
@@ -3309,6 +3322,32 @@ dependencies = [
  "itoa 1.0.2",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -63,4 +63,5 @@ tokio = { version = "1.6.0", features = ["sync", "time", "rt", "io-util", "rt-mu
 warp = "0.3"
 
 [dev-dependencies]
+serial_test = "0.8.0"
 test_network = { version = "=2.0.0-pre-rc.5", path = "../core/test_network" }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -29,6 +29,8 @@ pub struct Configuration {
     pub private_key: PrivateKey,
     /// Disable coloring of the backtrace and error report on panic.
     pub disable_panic_terminal_colors: bool,
+    /// Iroha will shutdown on any panic, if this option is set to `true`.
+    pub enable_shutdown_on_panic: bool,
     /// `Kura` related configuration.
     #[config(inner)]
     pub kura: KuraConfiguration,
@@ -71,6 +73,7 @@ impl Default for Configuration {
             public_key,
             private_key,
             disable_panic_terminal_colors: bool::default(),
+            enable_shutdown_on_panic: Default::default(),
             kura: KuraConfiguration::default(),
             sumeragi: sumeragi_configuration,
             torii: ToriiConfiguration::default(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -30,7 +30,7 @@ pub struct Configuration {
     /// Disable coloring of the backtrace and error report on panic.
     pub disable_panic_terminal_colors: bool,
     /// Iroha will shutdown on any panic if this option is set to `true`.
-    pub enable_shutdown_on_panic: bool,
+    pub shutdown_on_panic: bool,
     /// `Kura` related configuration.
     #[config(inner)]
     pub kura: KuraConfiguration,
@@ -73,7 +73,7 @@ impl Default for Configuration {
             public_key,
             private_key,
             disable_panic_terminal_colors: bool::default(),
-            enable_shutdown_on_panic: Default::default(),
+            shutdown_on_panic: false,
             kura: KuraConfiguration::default(),
             sumeragi: sumeragi_configuration,
             torii: ToriiConfiguration::default(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -29,7 +29,7 @@ pub struct Configuration {
     pub private_key: PrivateKey,
     /// Disable coloring of the backtrace and error report on panic.
     pub disable_panic_terminal_colors: bool,
-    /// Iroha will shutdown on any panic, if this option is set to `true`.
+    /// Iroha will shutdown on any panic if this option is set to `true`.
     pub enable_shutdown_on_panic: bool,
     /// `Kura` related configuration.
     #[config(inner)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -252,7 +252,9 @@ where
 
         Self::start_listening_signal(Arc::clone(&notify_shutdown))?;
 
-        Self::prepare_panic_hook(notify_shutdown);
+        if config.enable_shutdown_on_panic {
+            Self::prepare_panic_hook(notify_shutdown);
+        }
 
         let torii = Some(torii);
         Ok(Self {
@@ -368,9 +370,11 @@ mod tests {
     use std::{panic, thread};
 
     use super::*;
+    use serial_test::serial;
 
-    #[tokio::test]
     #[allow(clippy::panic)]
+    #[tokio::test]
+    #[serial]
     async fn iroha_should_notify_on_panic() {
         let notify = Arc::new(Notify::new());
         let hook = panic::take_hook();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -369,8 +369,9 @@ fn domains(configuration: &config::Configuration) -> [Domain; 1] {
 mod tests {
     use std::{panic, thread};
 
-    use super::*;
     use serial_test::serial;
+
+    use super::*;
 
     #[allow(clippy::panic)]
     #[tokio::test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -252,7 +252,7 @@ where
 
         Self::start_listening_signal(Arc::clone(&notify_shutdown))?;
 
-        if config.enable_shutdown_on_panic {
+        if config.shutdown_on_panic {
             Self::prepare_panic_hook(notify_shutdown);
         }
 

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -14,6 +14,7 @@ The following is the default configuration used by Iroha.
     "payload": "282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"
   },
   "DISABLE_PANIC_TERMINAL_COLORS": false,
+  "ENABLE_SHUTDOWN_ON_PANIC": false,
   "KURA": {
     "INIT_MODE": "strict",
     "BLOCK_STORE_PATH": "./blocks",
@@ -165,6 +166,16 @@ Has type `u64`. Can be configured via environment variable `BLOCK_SYNC_GOSSIP_PE
 Disable coloring of the backtrace and error report on panic.
 
 Has type `bool`. Can be configured via environment variable `IROHA_DISABLE_PANIC_TERMINAL_COLORS`
+
+```json
+false
+```
+
+## `enable_shutdown_on_panic`
+
+Iroha will shutdown on any panic, if this option is set to `true`.
+
+Has type `bool`. Can be configured via environment variable `IROHA_ENABLE_SHUTDOWN_ON_PANIC`
 
 ```json
 false

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -14,7 +14,7 @@ The following is the default configuration used by Iroha.
     "payload": "282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"
   },
   "DISABLE_PANIC_TERMINAL_COLORS": false,
-  "ENABLE_SHUTDOWN_ON_PANIC": false,
+  "SHUTDOWN_ON_PANIC": false,
   "KURA": {
     "INIT_MODE": "strict",
     "BLOCK_STORE_PATH": "./blocks",
@@ -166,16 +166,6 @@ Has type `u64`. Can be configured via environment variable `BLOCK_SYNC_GOSSIP_PE
 Disable coloring of the backtrace and error report on panic.
 
 Has type `bool`. Can be configured via environment variable `IROHA_DISABLE_PANIC_TERMINAL_COLORS`
-
-```json
-false
-```
-
-## `enable_shutdown_on_panic`
-
-Iroha will shutdown on any panic if this option is set to `true`.
-
-Has type `bool`. Can be configured via environment variable `IROHA_ENABLE_SHUTDOWN_ON_PANIC`
 
 ```json
 false
@@ -472,6 +462,16 @@ Has type `u64`. Can be configured via environment variable `QUEUE_TRANSACTION_TI
 
 ```json
 86400000
+```
+
+## `shutdown_on_panic`
+
+Iroha will shutdown on any panic if this option is set to `true`.
+
+Has type `bool`. Can be configured via environment variable `IROHA_SHUTDOWN_ON_PANIC`
+
+```json
+false
 ```
 
 ## `sumeragi`

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -173,7 +173,7 @@ false
 
 ## `enable_shutdown_on_panic`
 
-Iroha will shutdown on any panic, if this option is set to `true`.
+Iroha will shutdown on any panic if this option is set to `true`.
 
 Has type `bool`. Can be configured via environment variable `IROHA_ENABLE_SHUTDOWN_ON_PANIC`
 


### PR DESCRIPTION
Signed-off-by: Ales Tsurko <ales.tsurko@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
Added configuration to enable Iroha shutting down on panic. This prevents the tests expecting panic to fail. Also, the test for the responsible panic hook is now sequential, to prevent side effects on parallel run, while the hook is enabled.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->
We [introduced](https://github.com/hyperledger/iroha/pull/2445) a panic hook, which shuts down Iroha on panic (which just shutting down the thread by default). But the hook affects other tests and make them flaky.

### Benefits

<!-- What benefits will be realized by the code change? -->
Prevents tests flakiness. Allows users to choose the behavior on panic.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
The biggest one is the difference between the test and the production environment. Also, as the test case for the hook is running sequentially, the overall tests performance has a very little degradation.

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
It may seem that `#[cfg(not(test))]` can be used here, but it looks like integration tests ignore it.

Updating tests to work with the hook would be the best solution, but it's very hard to find out which tests should be updated, because random tests are failed and it's not clear which tests caused that.

Switching to [`cargo-nextest`](https://nexte.st/) can also fix the issue.

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
