### PR TITLE
[fix] #2473: parse rustc --version instead of RUSTUP_TOOLCHAIN

### DIFF
--- a/client/build.rs
+++ b/client/build.rs
@@ -12,8 +12,13 @@ fn main() {
     // invoked with the nightly toolchain. We should not force our
     // users to have the `nightly` if we don't use any `nightly`
     // features in the actual binary.
-    if env::var("RUSTUP_TOOLCHAIN")
-        .expect("Should be defined")
+    let rustc_version_output = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .expect("Failed to run `rustc --version`");
+
+    if std::str::from_utf8(&rustc_version_output.stdout)
+        .expect("Garbage in `rustc --version` output")
         .contains("nightly")
     {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR")


### PR DESCRIPTION
Signed-off-by: Artemii Gerasimovich <gerasimovich@soramitsu.co.jp>

### Description of the Change

Buildscript for `client` relies on parsing `RUSTUP_TOOLCHAIN` to check whether we are using nightly, which fails for non-rustup rust installations. This changes it to parse output of `rustc --version`.

### Issue

#2473 

### Benefits

More build environments supported.

### Possible Drawbacks

None
