### PR TITLE
[ci]: Remove the version specification of `archlinux:base-devel`

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM archlinux:base-devel-20220612.0.61195
+FROM archlinux:base-devel
 
 RUN set -eux && \
     pacman -Syu rustup mold rust-musl --noconfirm && \


### PR DESCRIPTION
### Description of the Change

Remove the version specification from the base image of `iroha2:base`

### Issue

None

### Benefits

`iroha2:base` can be built

### Possible Drawbacks

Different images can be built at the same commit