### PR TITLE
[ci] #2461: Reverse docker login ver

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
-      - name: set up buildx
+      - name: Set up buildx
         uses: docker/setup-buildx-action@v2
         id: buildx
         with:
@@ -47,7 +47,7 @@ jobs:
         run: |
           docker build -f Dockerfile -t hyperledger/iroha2:dev .
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -80,8 +80,6 @@ jobs:
           workflow: iroha2-dev-pr.yml
           name: lcov-${{ github.event.pull_request.head.sha }}.info
           search_artifacts: true
-      - name: Rename lcov report file
-        run: mv lcov-${{ github.event.pull_request.head.sha }}.info lcov.info
       - name: Upload to codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>


### Description of the Change

1. Revert to `docker/login-action@v1`
2. Remove `Rename lcov report file` step in `upload_coverage` job

### Issue
`deploy` and `upload_coverage` jobs doesn't work in `I2::Dev::Deploy` workflow.

- Resolves partially #2461

### Benefits
Hopefully to resolve the current `I2::Dev::Deploy` workflow failing.

### Possible Drawbacks
`I2::Dev::Deploy` might still to be failed.

### Usage Examples or Tests *[optional]*
1. [Upload coverage](https://codecov.io/gh/BAStos525/soramitsu-iroha/commit/630c2877f6abaf8e2642686b6b8539ce814307e4/build)
2. [Uploaded iroha2 image from fork's runner](https://hub.docker.com/layers/iroha2/bastos525/iroha2/dev/images/sha256-593958d9ed760bfe864b7ee62a4a2c5a99bdb1c11e27316195a0eaacb4d384b2?context=explore)