### PR TITLE
[fix] #2465: Reimplement sumeragi node as singlethreaded state machine

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -210,12 +210,6 @@ impl Iroha {
         let mut wsv_mutable =
             WorldStateView::from_configuration(config.wsv, world, events_sender.clone());
 
-        wsv_mutable.init(kura.init()?);
-
-        let wsv = wsv_mutable;
-        let latest_block_hash = wsv.latest_block_hash();
-        let latest_block_height = wsv.height();
-
         let query_validator = Arc::new(query_validator);
 
         let transaction_validator = TransactionValidator::new(
@@ -227,9 +221,15 @@ impl Iroha {
         // Validate every transaction in genesis block
         if let Some(ref genesis) = genesis {
             transaction_validator
-                .validate_every(&***genesis, &wsv)
+                .validate_every(&***genesis, &wsv_mutable)
                 .wrap_err("Transaction validation failed in genesis block")?;
         }
+
+        wsv_mutable.init(kura.init()?);
+
+        let wsv = wsv_mutable;
+        let latest_block_hash = wsv.latest_block_hash();
+        let latest_block_height = wsv.height();
 
         let notify_shutdown = Arc::new(Notify::new());
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -72,6 +72,48 @@ pub struct Iroha {
     pub block_sync: AlwaysAddr<BlockSynchronizer>,
     /// Torii web server
     pub torii: Option<Torii>,
+    sumeragi_relay: AlwaysAddr<FromNetworkBaseRelay>,
+}
+
+use iroha_p2p::network::NetworkBaseRelayOnlinePeers;
+struct FromNetworkBaseRelay {
+    sumeragi: Arc<Sumeragi>,
+    broker: Broker,
+}
+
+#[async_trait::async_trait]
+impl Actor for FromNetworkBaseRelay {
+    async fn on_start(&mut self, ctx: &mut iroha_actor::prelude::Context<Self>) {
+        // to start connections
+        self.broker.subscribe::<NetworkBaseRelayOnlinePeers, _>(ctx);
+        self.broker.subscribe::<iroha_core::NetworkMessage, _>(ctx);
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<NetworkBaseRelayOnlinePeers> for FromNetworkBaseRelay {
+    type Result = ();
+
+    async fn handle(&mut self, msg: NetworkBaseRelayOnlinePeers) {
+        self.sumeragi.update_online_peers(msg.online_peers);
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<iroha_core::NetworkMessage> for FromNetworkBaseRelay {
+    type Result = ();
+
+    async fn handle(&mut self, msg: iroha_core::NetworkMessage) -> Self::Result {
+        use iroha_core::NetworkMessage::*;
+
+        match msg {
+            SumeragiMessage(data) => {
+                self.sumeragi.incoming_message(data.into_v1());
+            }
+            BlockSync(data) => self.broker.issue_send(data.into_v1()).await,
+            Health => {}
+        }
+    }
 }
 
 impl Iroha {
@@ -205,10 +247,18 @@ impl Iroha {
                 Arc::clone(&queue),
                 broker.clone(),
                 Arc::clone(&kura),
-                // network_addr.clone(),
+                network_addr.clone(),
             )
             .wrap_err("Failed to initialize Sumeragi.")?,
         );
+
+        let sumeragi_relay = FromNetworkBaseRelay {
+            sumeragi: sumeragi.clone(),
+            broker: broker.clone(),
+        }
+        .start()
+        .await
+        .expect_running();
 
         Sumeragi::initialize_and_start_thread(
             sumeragi.clone(),
@@ -245,6 +295,7 @@ impl Iroha {
             kura,
             block_sync,
             torii,
+            sumeragi_relay,
         })
     }
 

--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -99,7 +99,7 @@ pub(crate) async fn handle_instructions(
     sumeragi: Arc<Sumeragi>,
     transaction: VersionedTransaction,
 ) -> Result<Empty> {
-    let wsv = sumeragi.get_clone_of_world_state_view(); // This probably means this function doesn't work
+    let wsv = sumeragi.wsv_clone();
     let transaction: Transaction = transaction.into_v1();
     let transaction = VersionedAcceptedTransaction::from_transaction(
         transaction,
@@ -124,7 +124,7 @@ pub(crate) async fn handle_queries(
     pagination: Pagination,
     request: VerifiedQueryRequest,
 ) -> Result<Scale<VersionedPaginatedQueryResult>> {
-    let wsv = sumeragi.get_clone_of_world_state_view();
+    let wsv = sumeragi.wsv_clone();
     let (valid_request, filter) = request.validate(&wsv, &query_validator)?;
     let original_result = valid_request.execute(&wsv)?;
     let result = filter.filter(original_result);
@@ -172,7 +172,7 @@ async fn handle_pending_transactions(
     sumeragi: Arc<Sumeragi>,
     pagination: Pagination,
 ) -> Result<Scale<VersionedPendingTransactions>> {
-    let wsv = sumeragi.get_clone_of_world_state_view();
+    let wsv = sumeragi.wsv_clone();
     Ok(Scale(
         queue
             .all_transactions(&wsv)
@@ -387,13 +387,10 @@ async fn handle_metrics(sumeragi: Arc<Sumeragi>, network: Addr<IrohaNetwork>) ->
 
 #[cfg(feature = "telemetry")]
 async fn handle_status(sumeragi: Arc<Sumeragi>, network: Addr<IrohaNetwork>) -> Result<Json> {
-    /*
-    update_metrics(&wsv, network).await?;
-    let status = Status::from(&wsv.metrics);
+    sumeragi.update_metrics(network);
+    let status = Status::from(&sumeragi.wsv_clone().metrics);
+    println!("{:?}", status);
     Ok(reply::json(&status))
-     */
-
-    Ok(warp::reply::json(b"Not implemented"))
 }
 
 /*

--- a/client/benches/tps/lib.rs
+++ b/client/benches/tps/lib.rs
@@ -85,7 +85,7 @@ impl Config {
             .as_ref()
             .expect("Must be some")
             .sumeragi
-            .get_clone_of_world_state_view();
+            .wsv_clone();
         let mut blocks = blocks_wsv.blocks().skip(blocks_out_of_measure as usize);
         let (txs_accepted, txs_rejected) = (0..self.blocks)
             .map(|_| {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -486,7 +486,7 @@ impl VersionedValidBlock {
         if block_height + 1 != self.header().height {
             return Err(eyre!(
                 "Block heights are in an inconsistent state. Expected: {}, actual: {}",
-                block_height,
+                block_height + 1,
                 self.header().height
             ));
         }

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -59,29 +59,6 @@ pub trait GenesisNetworkTrait:
         network: Addr<IrohaNetwork>,
     ) -> Result<Topology>;
 
-    // FIXME: Having `ctx` reference and `sumaregi` reference here is
-    // not ideal.  The way it is currently designed, this function is
-    // called from sumeragi and then calls sumeragi, while being in an
-    // unrelated module.  This needs to be restructured.
-
-    /// Submits genesis transactions.
-    ///
-    /// # Errors
-    /// Returns error if waiting for peers or genesis round itself fails
-    async fn submit_transactions<F: FaultInjection>(
-        &self,
-        sumeragi: &mut SumeragiWithFault<F>,
-        network: Addr<IrohaNetwork>,
-    ) -> Result<()> {
-        iroha_logger::debug!("Starting submit genesis");
-        let genesis_topology = self
-            .wait_for_peers(sumeragi.peer_id.clone(), sumeragi.topology.clone(), network)
-            .await?;
-        time::sleep(Duration::from_millis(self.genesis_submission_delay_ms())).await;
-        iroha_logger::info!("Initializing iroha using the genesis block.");
-        sumeragi.start_genesis_round(self.deref().clone(), genesis_topology)
-    }
-
     /// See [`GenesisConfiguration`] docs.
     fn genesis_submission_delay_ms(&self) -> u64;
 }

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -156,7 +156,6 @@ impl<F: FaultInjection> SumeragiWithFault<F> {
         self.broadcast_msg(TransactionGossip::new(txs), topology);
     }
 
-
     /// Connects or disconnects peers according to the current network topology.
     pub fn connect_peers(&self, topology: &Topology) {
         trace!("Connecting peers...");

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -2,6 +2,8 @@
 //! should be reserved for testing, and only [`NoFault`], should be
 //! used in code.
 
+use std::sync::{mpsc, Mutex};
+
 use super::{config::SumeragiConfiguration, *};
 use crate::genesis::GenesisNetwork;
 
@@ -32,6 +34,17 @@ impl FaultInjection for NoFault {
 }
 
 /// `Sumeragi` is the implementation of the consensus. This struct allows also to add fault injection for tests.
+///
+///
+/// sumeragi_state_machine_data is a Mutex instead of a RWLock because
+/// it communicates more clearly the correct use of the lock. The most
+/// frequent action on this lock is the main loop writing to it. This
+/// means that if anyone holds this lock they are blocking the sumeragi
+/// thread. A RWLock will tempt someone to hold a read lock because
+/// they think they are being smart, whilst a Mutex screams *DO NOT
+/// HOLD ME*. That is why the SumeragiStateMachineData is wrapped in
+/// a mutex, it's more self documenting.
+
 pub struct SumeragiWithFault<F>
 where
     F: FaultInjection,
@@ -39,12 +52,8 @@ where
     pub(crate) key_pair: KeyPair,
     /// Address of queue
     pub queue: Arc<Queue>,
-    /// The current topology of the peer to peer network.
-    pub topology: Topology,
     /// The peer id of myself.
     pub peer_id: PeerId,
-    /// The block in discussion this round, received from a leader.
-    pub(crate) voting_block: Option<VotingBlock>,
     /// This field is used to count votes when the peer is a proxy tail role.
     pub(crate) votes_for_blocks: BTreeMap<HashOf<VersionedValidBlock>, VersionedValidBlock>,
     pub(crate) events_sender: EventsSender,
@@ -68,194 +77,55 @@ where
     pub(crate) transaction_limits: TransactionLimits,
     pub(crate) transaction_validator: TransactionValidator,
     pub(crate) telemetry_started: bool,
-    /// Genesis network
-    pub genesis_network: Option<GenesisNetwork>,
     /// Broker
     pub broker: Broker,
     /// Kura instance used for IO
     pub kura: Arc<Kura>,
     /// [`iroha_p2p::Network`] actor address
-    // pub network: Addr<IrohaNetwork>,
+    pub network: Addr<IrohaNetwork>,
     /// Buffer capacity of actor's MPSC channel
     pub actor_channel_capacity: u32,
     pub(crate) fault_injection: PhantomData<F>,
     pub(crate) gossip_batch_size: u32,
     pub(crate) gossip_period: Duration,
+
+    pub sumeragi_state_machine_data: Mutex<SumeragiStateMachineData>,
+    pub current_online_peers_by_public_key: Mutex<Vec<PublicKey>>,
+
+    pub incoming_message_sender: Mutex<mpsc::Sender<Message>>,
+    pub incoming_message_receiver: Mutex<mpsc::Receiver<Message>>,
+}
+
+pub struct SumeragiStateMachineData {
+    pub genesis_network: Option<GenesisNetwork>,
+    pub latest_block_hash: HashOf<VersionedCommittedBlock>,
+    pub latest_block_height: u64,
+    pub current_topology: Topology,
 }
 
 impl<F: FaultInjection> SumeragiWithFault<F> {
-    fn from_configuration(
-        configuration: &SumeragiConfiguration,
-        events_sender: EventsSender,
-        wsv: WorldStateView,
-        transaction_validator: TransactionValidator,
-        telemetry_started: bool,
-        genesis_network: Option<GenesisNetwork>,
-        queue: Arc<Queue>,
-        broker: Broker,
-        kura: Arc<Kura>,
-        // network: Addr<IrohaNetwork>,
-    ) -> Result<Self> {
-        let network_topology = Topology::builder()
-            .at_block(EmptyChainHash::default().into())
-            .with_peers(configuration.trusted_peers.peers.clone())
-            .build()?;
-
-        Ok(Self {
-            key_pair: configuration.key_pair.clone(),
-            topology: network_topology,
-            peer_id: configuration.peer_id.clone(),
-            voting_block: None,
-            votes_for_blocks: BTreeMap::new(),
-            events_sender,
-            wsv: std::sync::Mutex::new(wsv),
-            txs_awaiting_receipts: HashMap::new(),
-            txs_awaiting_created_block: HashSet::new(),
-            votes_for_view_change: HashMap::new(),
-            commit_time: Duration::from_millis(configuration.commit_time_limit_ms),
-            tx_receipt_time: Duration::from_millis(configuration.tx_receipt_time_limit_ms),
-            block_time: Duration::from_millis(configuration.block_time_ms),
-            block_height: 0,
-            invalidated_blocks_hashes: Vec::new(),
-            telemetry_started,
-            transaction_limits: configuration.transaction_limits,
-            transaction_validator,
-            genesis_network,
-            queue,
-            broker,
-            kura,
-            // network,
-            actor_channel_capacity: configuration.actor_channel_capacity,
-            fault_injection: PhantomData,
-            gossip_batch_size: configuration.gossip_batch_size,
-            gossip_period: Duration::from_millis(configuration.gossip_period_ms),
-        })
-    }
-
-    /// Initializes sumeragi with the `latest_block_hash` and `block_height` after Kura loads the blocks.
-    pub fn init(&mut self, latest_block: HashOf<VersionedCommittedBlock>, block_height: u64) {
-        self.block_height = block_height;
-        self.topology.apply_block(latest_block);
+    pub fn get_online_peer_keys(&self) -> Vec<PublicKey> {
+        self.current_online_peers_by_public_key
+            .lock()
+            .expect("lock on online peer keys")
+            .clone()
     }
 
     /// Updates network topology by taking the actual list of peers from `WorldStateView`.
     /// Updates it only if there is a change in WSV peers, otherwise leaves the order unchanged.
     #[allow(clippy::expect_used)]
-    pub fn update_network_topology(&mut self) {
-        let wsv_peers: HashSet<_> = self
-            .wsv
-            .lock()
-            .unwrap()
-            .trusted_peers_ids()
-            .clone()
-            .into_iter()
-            .collect();
-        let topology_peers: HashSet<_> = self.topology.sorted_peers().iter().cloned().collect();
+    pub fn update_network_topology(topology: &mut Topology, wsv: &WorldStateView) {
+        let wsv_peers: HashSet<_> = wsv.trusted_peers_ids().clone().into_iter().collect();
+        let topology_peers: HashSet<_> = topology.sorted_peers().iter().cloned().collect();
         if topology_peers != wsv_peers {
-            self.topology = self.topology
-                .clone()
-                .into_builder()
-                .with_peers(wsv_peers)
-                .build()
-                // TODO: Check it during instruction execution.
-                .expect("The safety of changing the number of peers should have been checked at Instruction execution stage.");
+            *topology = topology
+                    .clone()
+                    .into_builder()
+                    .with_peers(wsv_peers)
+                    .build()
+                    // TODO: Check it during instruction execution.
+                    .expect("The safety of changing the number of peers should have been checked at Instruction execution stage.");
         }
-    }
-
-    /// Returns `true` if some block is in discussion, `false` otherwise.
-    pub fn voting_in_progress(&self) -> bool {
-        self.voting_block.is_some()
-    }
-
-    /// Latest block hash as seen by sumeragi.
-    pub fn latest_block_hash(&self) -> &HashOf<VersionedCommittedBlock> {
-        self.topology.at_block()
-    }
-
-    /// Number of view changes.
-    /// Where a view change is a change in topology made if there was some consensus misfunction during round (faulty peers).
-    pub fn number_of_view_changes(&self) -> u64 {
-        self.topology.view_change_proofs().len() as u64
-    }
-
-    /// The proofs of view changes that happened after the last block was committed.
-    pub fn view_change_proofs(&self) -> &ViewChangeProofs {
-        self.topology.view_change_proofs()
-    }
-
-    /// The hash of the latest view change.
-    pub fn latest_view_change_hash(&self) -> HashOf<Proof> {
-        self.view_change_proofs().latest_hash()
-    }
-
-    /// Get peers as a hash set of their ids.
-    pub fn peers(&self) -> HashSet<PeerId> {
-        self.topology.sorted_peers().iter().cloned().collect()
-    }
-
-    /// Assumes this peer is a leader and starts the round with the given `genesis_topology`.
-    ///
-    /// # Errors
-    /// Can fail if:
-    /// * transactions are empty
-    /// * peer is not leader
-    /// * there are already some blocks in blockchain
-
-    #[log(skip(self, transactions, genesis_topology))]
-    pub fn start_genesis_round(
-        &mut self,
-        transactions: Vec<VersionedAcceptedTransaction>,
-        genesis_topology: Topology,
-    ) -> Result<()> {
-        if transactions.is_empty() {
-            Err(eyre!(
-                "Genesis transactions set contains no valid transactions"
-            ))
-        } else if genesis_topology.leader() != &self.peer_id {
-            Err(eyre!(
-                "Incorrect network topology this peer should be {:?} but is {:?}",
-                Role::Leader,
-                genesis_topology.role(&self.peer_id)
-            ))
-        } else if self.block_height > 0 {
-            Err(eyre!(
-                "Block height should be 0 for genesis round. But it is: {}",
-                self.block_height
-            ))
-        } else {
-            self.validate_and_publish_created_block(
-                PendingBlock::new(transactions, Vec::new())
-                    .chain_first_with_genesis_topology(genesis_topology),
-            )
-        }
-    }
-
-    /// The leader of each round just uses the transactions they have at hand to create a block.
-    ///
-    /// # Errors
-    /// Can fail during signing of block
-
-    pub fn round(
-        &mut self,
-        transactions: Vec<VersionedAcceptedTransaction>,
-        event_recommendations: Vec<Event>,
-    ) -> Result<()> {
-        if transactions.is_empty() {
-            return Ok(());
-        }
-
-        if Role::Leader == self.topology.role(&self.peer_id) {
-            let block = PendingBlock::new(transactions, event_recommendations).chain(
-                self.block_height,
-                *self.latest_block_hash(),
-                self.view_change_proofs().clone(),
-                self.invalidated_blocks_hashes.clone(),
-            );
-            self.validate_and_publish_created_block(block)?;
-        } else {
-            self.forward_txs_to_leader(&transactions);
-        }
-        Ok(())
     }
 
     pub(crate) fn broadcast_msg_to<'a>(
@@ -266,323 +136,44 @@ impl<F: FaultInjection> SumeragiWithFault<F> {
         VersionedMessage::from(msg.into()).send_to_multiple(&self.broker, ids);
     }
 
-    /// Forwards transactions to the leader and waits for receipts.
-    /// In consensus it is used to check the liveness of a leader.
-
-    #[allow(clippy::expect_used)]
-    pub fn forward_txs_to_leader(&mut self, txs: &[VersionedAcceptedTransaction]) {
-        // If already sent tx and awaiting receipt or created block, then quit.
-        if !self.txs_awaiting_receipts.is_empty() || !self.txs_awaiting_created_block.is_empty() {
-            return;
-        }
-
-        // It is assumed that we only need to send 1 tx to check liveness.
-        let tx = txs
-            .choose(&mut rand::thread_rng())
-            .expect("It was checked earlier that transactions are not empty.")
-            .clone();
-        let tx_hash = tx.hash();
-        info!(
-            peer_addr = %self.peer_id.address,
-            peer_role = ?self.topology.role(&self.peer_id),
-            leader_addr = %self.topology.leader().address,
-            %tx_hash,
-            "Forwarding tx to leader"
-        );
-        // Don't require leader to submit receipts and therefore create blocks if the tx is still waiting for more signatures.
-        if let Ok(true) = tx.check_signature_condition(&self.wsv.lock().unwrap()) {
-            self.txs_awaiting_receipts.insert(tx.hash(), Instant::now());
-        }
-        let no_tx_receipt = view_change::Proof::no_transaction_receipt_received(
-            self.latest_view_change_hash(),
-            *self.latest_block_hash(),
-            self.key_pair.clone(),
-        )
-        .expect("Failed to put first signature.");
-
-        /*
-            TODO: REPLACE
-            ctx.notify(
-                CheckReceiptTimeout {
-                    tx_hash,
-                    proof: no_tx_receipt,
-                },
-                self.tx_receipt_time,
-        );
-            */
-
-        VersionedMessage::from(Message::from(TransactionForwarded::new(
-            tx,
-            self.peer_id.clone(),
-        )))
-        .send_to(&self.broker, self.topology.leader());
-    }
-
-    /// Returns:
-    /// `true` - if new votes were added
-    /// `false` - otherwise
-    ///
-    /// And the actual Proof as it is contained in `votes_for_view_change` with merged votes.
-    pub(crate) fn merge_view_change_votes(&mut self, proof: Proof) -> (bool, Proof) {
-        match self.votes_for_view_change.entry(proof.hash()) {
-            Entry::Occupied(mut occupied) => {
-                let proof_votes = occupied.get_mut();
-                let count = proof_votes.signatures().len();
-                proof_votes.merge_signatures(proof.signatures().clone());
-
-                if proof_votes.signatures().len() > count {
-                    (true, proof_votes.clone())
-                } else {
-                    (false, proof_votes.clone())
-                }
-            }
-            Entry::Vacant(vacant) => {
-                vacant.insert(proof.clone());
-                (true, proof)
-            }
-        }
-    }
-
-    fn vote_for_view_change(&mut self, proof: Proof) {
-        if !proof.has_same_state(self.latest_block_hash(), &self.latest_view_change_hash()) {
-            return;
-        }
-        let (count_increased, merged_proof) = self.merge_view_change_votes(proof.clone());
-        if count_increased {
-            self.broadcast_msg(ViewChangeSuggested::new(
-                proof,
-                self.view_change_proofs().clone(),
-            ));
-            if merged_proof.verify(&self.peers(), self.topology.max_faults()) {
-                let invalidated_block_hash = match merged_proof.reason() {
-                    view_change::Reason::CommitTimeout(reason) => Some(reason.hash),
-                    view_change::Reason::NoTransactionReceiptReceived(_)
-                    | view_change::Reason::BlockCreationTimeout(_) => None,
-                };
-                self.change_view(merged_proof.clone(), invalidated_block_hash);
-            }
-        }
-    }
-
-    fn broadcast_msg(&self, msg: impl Into<Message> + Send) {
-        let msg = VersionedMessage::from(msg.into());
-        msg.send_to_multiple(&self.broker, self.topology.sorted_peers());
+    fn broadcast_msg(&self, msg: impl Into<Message> + Send, topology: &Topology) {
+        self.broadcast_msg_to(msg, topology.sorted_peers().iter());
     }
 
     /// Gossip transactions to other peers.
 
-    pub fn gossip_transactions(&mut self, txs: Vec<VersionedAcceptedTransaction>) {
+    pub fn gossip_transactions(&self, txs: Vec<VersionedAcceptedTransaction>, topology: &Topology) {
         if txs.is_empty() {
             return;
         }
 
         debug!(
-            peer_role = ?self.topology.role(&self.peer_id),
+            peer_role = ?topology.role(&self.peer_id),
             tx_count = txs.len(),
             "Gossiping transactions"
         );
 
-        self.broadcast_msg(TransactionGossip::new(txs));
+        self.broadcast_msg(TransactionGossip::new(txs), topology);
     }
 
-    /// Should be called by a leader to start the consensus round with `BlockCreated` message.
-    ///
-    /// # Errors
-    /// Can fail signing block
-
-    pub fn validate_and_publish_created_block(&mut self, block: ChainedBlock) -> Result<()> {
-        info!(block_hash = %block.hash(), "Validating block");
-
-        let block = block.validate(&self.transaction_validator, &self.wsv.lock().unwrap());
-        let network_topology = self.network_topology_current_or_genesis(block.header());
-
-        info!(
-            peer_role = ?network_topology.role(&self.peer_id),
-            block_hash = %block.hash(),
-            "Created a block",
-        );
-        for event in Vec::<Event>::from(&block) {
-            trace!(?event);
-            drop(self.events_sender.send(event));
-        }
-        let signed_block = block.sign(self.key_pair.clone())?;
-        if !network_topology.is_consensus_required() {
-            self.broadcast_msg_to(
-                BlockCommitted::from(signed_block.clone()),
-                network_topology
-                    .validating_peers()
-                    .iter()
-                    .chain([network_topology.leader()])
-                    .chain(network_topology.peers_set_b()),
-            );
-            self.commit_block(signed_block);
-            return Ok(());
-        }
-
-        let voting_block = VotingBlock::new(signed_block.clone());
-        let voting_block_hash = voting_block.block.hash();
-
-        self.voting_block = Some(voting_block);
-        self.broadcast_msg(BlockCreated::from(signed_block.clone()));
-        self.start_commit_countdown(
-            voting_block_hash,
-            *self.latest_block_hash(),
-            self.latest_view_change_hash(),
-        );
-        Ok(())
-    }
-
-    /// Starts countdown for a period in which the `voting_block` should be committed.
-
-    #[log(skip(self, voting_block_hash))]
-    #[allow(clippy::expect_used)]
-    pub fn start_commit_countdown(
-        &self,
-        voting_block_hash: HashOf<VersionedValidBlock>,
-        latest_block: HashOf<VersionedCommittedBlock>,
-        latest_view_change: HashOf<Proof>,
-    ) {
-        let proof = view_change::Proof::commit_timeout(
-            voting_block_hash,
-            latest_view_change,
-            latest_block,
-            self.key_pair.clone(),
-        )
-        .expect("Failed to sign CommitTimeout");
-        /*
-            TODO: REPLACE
-            ctx.notify(
-                CheckCommitTimeout {
-                    block_hash: voting_block_hash,
-                    proof,
-                },
-                self.commit_time,
-        )
-            */
-    }
-
-    /// Commits `ValidBlock` and changes the state of the `Sumeragi` and its `NetworkTopology`.
-    #[log(skip(self, block))]
-
-    pub fn commit_block(&mut self, block: VersionedValidBlock) {
-        self.invalidated_blocks_hashes.clear();
-        self.txs_awaiting_created_block.clear();
-        self.txs_awaiting_receipts.clear();
-        self.votes_for_view_change.clear();
-        self.block_height = block.header().height;
-
-        let block = block.commit();
-        let block_hash = block.hash();
-
-        if let Err(error) = self.wsv.lock().unwrap().apply(block.clone()) {
-            warn!(?error, %block_hash, "Failed to apply block on WSV");
-        }
-
-        for event in Vec::<Event>::from(&block) {
-            trace!(?event);
-            drop(self.events_sender.send(event));
-        }
-
-        let previous_role = self.topology.role(&self.peer_id);
-        self.topology.apply_block(block_hash);
-        info!(
-            prev_peer_role = ?previous_role,
-            new_peer_role = ?self.topology.role(&self.peer_id),
-            new_block_height = %self.block_height,
-            %block_hash,
-            "Committing block"
-        );
-        self.voting_block = None;
-        self.votes_for_blocks.clear();
-        self.kura.store_block_async(block);
-        self.update_network_topology();
-    }
-
-    pub(crate) fn change_view(
-        &mut self,
-        proof: view_change::Proof,
-        invalidated_block_hash: Option<HashOf<VersionedValidBlock>>,
-    ) {
-        self.txs_awaiting_created_block.clear();
-        self.txs_awaiting_receipts.clear();
-        self.votes_for_view_change.clear();
-        let previous_role = self.topology.role(&self.peer_id);
-        if let Some(hash) = invalidated_block_hash {
-            self.invalidated_blocks_hashes.push(hash)
-        }
-        self.topology.apply_view_change(proof.clone());
-        self.wsv
-            .lock()
-            .unwrap()
-            .metrics
-            .view_changes
-            .set(self.number_of_view_changes());
-        self.voting_block = None;
-        error!(
-            peer_addr = %self.peer_id.address,
-            prev_peer_role = ?previous_role,
-            new_peer_role = ?self.topology.role(&self.peer_id),
-            block_hash = %self.latest_block_hash(),
-            view_changes_count = %self.number_of_view_changes(),
-            view_change_hash = %proof.hash(),
-            reason = %proof.reason(),
-            "Changing view at block",
-        );
-    }
-
-    /// If this peer is a leader in this round.
-    pub fn is_leader(&self) -> bool {
-        self.topology.role(&self.peer_id) == Role::Leader
-    }
-
-    /// Role
-    pub fn role(&self) -> Role {
-        self.topology.role(&self.peer_id)
-    }
-
-    /// Returns current network topology or genesis specific one, if the `block` is a genesis block.
-    pub fn network_topology_current_or_genesis(&self, header: &BlockHeader) -> Topology {
-        if header.is_genesis() && self.block_height == 0 {
-            if let Some(genesis_topology) = &header.genesis_topology {
-                info!("Using network topology from genesis block");
-                return genesis_topology.clone();
-            }
-        }
-
-        self.topology.clone()
-    }
 
     /// Connects or disconnects peers according to the current network topology.
-    pub fn connect_peers(&self) {
+    pub fn connect_peers(&self, topology: &Topology) {
         trace!("Connecting peers...");
         let peers_expected = {
-            let mut res = self.topology.sorted_peers().to_owned();
+            let mut res = topology.sorted_peers().to_owned();
             res.retain(|id| id.address != self.peer_id.address);
             res.shuffle(&mut rand::thread_rng());
             res
         };
 
-        /*
-        TODO: REPLACE
-        #[allow(clippy::expect_used)]
-        let peers_online = self
-            .network
-            .send(iroha_p2p::network::GetConnectedPeers)
-
-            .expect("Failed to get connected peers from the network")
-        .peers;
-         */
-        let peers_online = HashSet::new();
-
-        for peer_to_be_connected in peers_expected
-            .iter()
-            .filter(|id| !peers_online.contains(&id.public_key))
-        {
-            info!(%peer_to_be_connected.address, "Connecting peer");
+        for peer_to_be_connected in peers_expected.iter() {
             self.broker.issue_send_sync(&ConnectPeer {
-                address: peer_to_be_connected.address.clone(),
+                peer: peer_to_be_connected.clone(),
             })
         }
+
+        /* TODO FIX
         for peer_to_be_disconnected in
             peers_online.difference(&peers_expected.into_iter().map(|id| id.public_key).collect())
         {
@@ -590,36 +181,106 @@ impl<F: FaultInjection> SumeragiWithFault<F> {
             self.broker
                 .issue_send_sync(&DisconnectPeer(peer_to_be_disconnected.clone()))
         }
+        */
     }
 
     /// If `suggested_chain` of view change proofs is bigger than the the current one - replace the current one.
-    pub fn update_view_changes(&mut self, suggested_chain: view_change::ProofChain) {
+    pub fn update_view_changes(
+        &self,
+        suggested_chain: view_change::ProofChain,
+        topology: Topology,
+        latest_block_hash: &HashOf<VersionedCommittedBlock>,
+    ) -> Topology {
         #[allow(clippy::expect_used)]
-        if suggested_chain.len() > self.topology.view_change_proofs().len()
+        if suggested_chain.len() > topology.view_change_proofs().len()
             && suggested_chain.verify_with_state(
-                &self.peers(),
-                self.topology.max_faults(),
-                self.latest_block_hash(),
+                &topology.sorted_peers().iter().cloned().collect(),
+                topology.max_faults(),
+                latest_block_hash,
             )
         {
             info!(
-                prev_view_changes_count = self.topology.view_change_proofs().len(),
+                prev_view_changes_count = topology.view_change_proofs().len(),
                 new_view_changes_count = suggested_chain.len(),
-                latest_block = ?self.latest_block_hash(),
+                latest_block = ?latest_block_hash,
                 "Swapping view change proof chain."
             );
-            self.topology = self
-                .topology
+            topology
                 .clone()
                 .into_builder()
                 .with_view_changes(suggested_chain)
                 .build()
                 .expect("When only changing view changes it should not fail.")
+        } else {
+            topology
         }
     }
 
-    pub fn get_network_topology(&self, header: &BlockHeader) -> Topology {
-        self.network_topology_current_or_genesis(&header)
+    fn check_peers_status(
+        &self,
+        this_peer_id: &PeerId,
+        network_topology: &Topology,
+    ) -> (Vec<PeerId>, Vec<PeerId>) {
+        let online_peers = self.get_online_peer_keys();
+        iroha_logger::info!(peer_count = online_peers.len(), "Peers status");
+
+        let (online, offline): (Vec<PeerId>, Vec<PeerId>) = network_topology
+            .sorted_peers()
+            .iter()
+            .cloned()
+            .partition(|id| {
+                online_peers.contains(&id.public_key) || this_peer_id.public_key == id.public_key
+            });
+
+        (online, offline)
+    }
+
+    fn try_get_online_topology(&self, network_topology: &Topology) -> Result<Topology> {
+        use crate::sumeragi::network_topology::GenesisBuilder;
+        let (online_peers, offline_peers) =
+            self.check_peers_status(&self.peer_id, network_topology);
+        let set_a_len = network_topology.min_votes_for_commit();
+        if online_peers.len() < set_a_len {
+            return Err(eyre!("Not enough online peers for consensus."));
+        }
+        let genesis_topology = if network_topology.sorted_peers().len() == 1 {
+            network_topology.clone()
+        } else {
+            let set_a: HashSet<_> = online_peers[..set_a_len].iter().cloned().collect();
+            let set_b: HashSet<_> = online_peers[set_a_len..]
+                .iter()
+                .cloned()
+                .chain(offline_peers.into_iter())
+                .collect();
+            #[allow(clippy::expect_used)]
+            GenesisBuilder::new()
+                .with_leader(self.peer_id.clone())
+                .with_set_a(set_a)
+                .with_set_b(set_b)
+                .build()
+                .expect("Preconditions should be already checked.")
+        };
+        iroha_logger::info!("Waiting for active peers finished.");
+        Ok(genesis_topology)
+    }
+
+    pub fn wait_for_peers(&self, network_topology: &Topology) {
+        iroha_logger::info!("Waiting for active peers",);
+        for i in 0..80 {
+            self.connect_peers(&network_topology);
+
+            let online_peers = self.current_online_peers_by_public_key.lock().unwrap();
+
+            let peer_count_required = network_topology.min_votes_for_commit();
+
+            if online_peers.len() + 1 >= peer_count_required {
+                return;
+            }
+
+            let reconnect_in_ms = 100;
+            std::thread::sleep(Duration::from_millis(reconnect_in_ms));
+        }
+        panic!("Timed out waiting for peers to come online");
     }
 }
 
@@ -630,11 +291,1293 @@ pub fn run_sumeragi_main_loop<F>(
 ) where
     F: FaultInjection,
 {
-    // TODO INIT
+    use std::sync::mpsc::TryRecvError;
 
-    loop {
-        println!("Sumeragi is running");
-        std::thread::sleep(Duration::from_secs(1));
+    let mut incoming_message_receiver = sumeragi
+        .incoming_message_receiver
+        .lock()
+        .expect("lock on reciever");
+
+    let mut voting_block_option: Option<VotingBlock> = None;
+
+    {
+        let mut state_machine_guard = sumeragi
+            .sumeragi_state_machine_data
+            .lock()
+            .expect("take lock");
+        if initial_block_height != 0 && initial_latest_block != Hash::zeroed().typed() {
+            // Normal startup
+            state_machine_guard.latest_block_hash = initial_latest_block;
+            state_machine_guard.latest_block_height = initial_block_height;
+            state_machine_guard
+                .current_topology
+                .apply_block(initial_latest_block);
+        } else if !state_machine_guard.current_topology.is_consensus_required() {
+            let genesis_network = state_machine_guard.genesis_network.take().unwrap();
+            iroha_logger::debug!("Starting commit genesis. Since consensus is not required.");
+
+            iroha_logger::info!("Initializing iroha using the genesis block.");
+
+            state_machine_guard.current_topology = sumeragi
+                .try_get_online_topology(&state_machine_guard.current_topology)
+                .expect("enough peers to pass genesis");
+
+            assert!(!state_machine_guard.current_topology.is_consensus_required());
+
+            println!("Genesis being submitted by {}", sumeragi.peer_id.public_key);
+            println!("Online peers are {:?}", sumeragi.get_online_peer_keys());
+
+            state_machine_guard.latest_block_height = 0;
+
+            assert_eq!(
+                state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                Role::Leader
+            );
+            let transactions = genesis_network.transactions.clone();
+            {
+                // Don't start genesis round. Instead just commit the genesis block.
+                if transactions.is_empty() {
+                    panic!("Genesis transactions set contains no valid transactions");
+                } else {
+                    let mut wsv_guard = sumeragi.wsv.lock().unwrap();
+                    let block = PendingBlock::new(transactions, Vec::new())
+                        .chain_first_with_genesis_topology(
+                            state_machine_guard.current_topology.clone(),
+                        );
+
+                    {
+                        info!(block_hash = %block.hash(), "Publishing genesis block.");
+
+                        let block = block.validate(&sumeragi.transaction_validator, &wsv_guard);
+
+                        info!(
+                            peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                            block_hash = %block.hash(),
+                            "Created a block",
+                        );
+                        for event in Vec::<Event>::from(&block) {
+                            trace!(?event);
+                            drop(sumeragi.events_sender.send(event));
+                        }
+                        let signed_block = block
+                            .sign(sumeragi.key_pair.clone())
+                            .expect("Sign genesis block.");
+                        {
+                            {
+                                /*
+                                TODO: purge the unneeded of these
+                                self.invalidated_blocks_hashes.clear();
+                                self.txs_awaiting_created_block.clear();
+                                self.txs_awaiting_receipts.clear();
+                                self.votes_for_view_change.clear();
+                                */
+                                state_machine_guard.latest_block_height =
+                                    signed_block.header().height;
+
+                                sumeragi.broadcast_msg(
+                                    BlockCommitted::from(signed_block.clone()),
+                                    &state_machine_guard.current_topology,
+                                );
+
+                                let block = signed_block.commit();
+                                let block_hash = block.hash();
+
+                                if let Err(error) = wsv_guard.apply(block.clone()) {
+                                    panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                                }
+
+                                for event in Vec::<Event>::from(&block) {
+                                    trace!(?event);
+                                    drop(sumeragi.events_sender.send(event));
+                                }
+
+                                let previous_role =
+                                    state_machine_guard.current_topology.role(&sumeragi.peer_id);
+                                state_machine_guard.current_topology.apply_block(block_hash);
+                                info!(
+                                    prev_peer_role = ?previous_role,
+                                    new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                    new_block_height = %state_machine_guard.latest_block_height,
+                                    %block_hash,
+                                    "Committing block"
+                                );
+                                sumeragi.kura.blocking_store_block(block);
+                                SumeragiWithFault::<F>::update_network_topology(
+                                    &mut state_machine_guard.current_topology,
+                                    &wsv_guard,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            if let Some(genesis_network) = state_machine_guard.genesis_network.take() {
+                // Submit genesis
+                {
+                    iroha_logger::debug!("Starting submit genesis");
+
+                    sumeragi.wait_for_peers(&state_machine_guard.current_topology);
+
+                    iroha_logger::info!("Initializing iroha using the genesis block.");
+
+                    state_machine_guard.current_topology = sumeragi
+                        .try_get_online_topology(&state_machine_guard.current_topology)
+                        .expect("enough peers to pass genesis");
+
+                    println!("Genesis being submitted by {}", sumeragi.peer_id.public_key);
+                    println!("Online peers are {:?}", sumeragi.get_online_peer_keys());
+
+                    state_machine_guard.latest_block_height = 0;
+
+                    let genesis_topology = &state_machine_guard.current_topology;
+                    assert_eq!(genesis_topology.role(&sumeragi.peer_id), Role::Leader);
+                    let transactions = genesis_network.transactions.clone();
+                    {
+                        // Start genesis round
+                        if transactions.is_empty() {
+                            panic!("Genesis transactions set contains no valid transactions");
+                        } else {
+                            let mut wsv_guard = sumeragi.wsv.lock().unwrap();
+                            let block = PendingBlock::new(transactions, Vec::new())
+                                .chain_first_with_genesis_topology(genesis_topology.clone());
+
+                            {
+                                info!(block_hash = %block.hash(), "Publishing genesis block.");
+
+                                let block =
+                                    block.validate(&sumeragi.transaction_validator, &wsv_guard);
+
+                                info!(
+                                    peer_role = ?genesis_topology.role(&sumeragi.peer_id),
+                                    block_hash = %block.hash(),
+                                    "Created a block",
+                                );
+                                for event in Vec::<Event>::from(&block) {
+                                    trace!(?event);
+                                    drop(sumeragi.events_sender.send(event));
+                                }
+                                let signed_block = block
+                                    .sign(sumeragi.key_pair.clone())
+                                    .expect("Sign genesis block.");
+
+                                let voting_block = VotingBlock::new(signed_block.clone());
+                                let voting_block_hash = voting_block.block.hash();
+
+                                voting_block_option = Some(voting_block);
+                                sumeragi.broadcast_msg(
+                                    BlockCreated::from(signed_block.clone()),
+                                    genesis_topology,
+                                );
+
+                                {
+                                    // view change proof
+                                    let proof = view_change::Proof::commit_timeout(
+                                        voting_block_hash,
+                                        genesis_topology.view_change_proofs().latest_hash(),
+                                        *genesis_topology.at_block(),
+                                        sumeragi.key_pair.clone(),
+                                    )
+                                    .expect("Failed to sign CommitTimeout");
+                                    // TODO: Commit timeout causes viewchange
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                sumeragi.wait_for_peers(&state_machine_guard.current_topology);
+            }
+
+            {
+                // now do the genesis *round*.
+                {
+                    while voting_block_option.is_none() {
+                        println!("no voting block");
+
+                        match incoming_message_receiver.try_recv() {
+                            Ok(msg) => {
+                                match msg {
+                                    Message::BlockCreated(block_created) => {
+                                        let block = block_created.block;
+
+                                        let mut wsv_guard =
+                                            sumeragi.wsv.lock().expect("lock on wsv");
+
+                                        for event in Vec::<Event>::from(&block) {
+                                            trace!(?event);
+                                            drop(sumeragi.events_sender.send(event));
+                                        }
+                                        state_machine_guard.current_topology = sumeragi
+                                            .update_view_changes(
+                                                block.header().view_change_proofs.clone(),
+                                                state_machine_guard.current_topology.clone(),
+                                                &state_machine_guard.latest_block_hash,
+                                            );
+
+                                        // During the genesis round we blindly take on the network topology described in
+                                        // the provided genesis block.
+                                        let block_header = block.header();
+                                        if block_header.is_genesis()
+                                            && state_machine_guard.latest_block_height == 0
+                                            && block_header.genesis_topology.is_some()
+                                        {
+                                            info!("Using network topology from genesis block");
+                                            state_machine_guard.current_topology = block_header
+                                                .genesis_topology
+                                                .clone()
+                                                .take()
+                                                .expect("We just checked that it is some");
+                                        }
+
+                                        if state_machine_guard
+                                            .current_topology
+                                            .filter_signatures_by_roles(
+                                                &[Role::Leader],
+                                                block.verified_signatures(),
+                                            )
+                                            .is_empty()
+                                        {
+                                            error!(
+                                                role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                                "Rejecting Block as it is not signed by leader.",
+                                            );
+                                            continue;
+                                        }
+                                        let network_topology =
+                                            &state_machine_guard.current_topology;
+
+                                        // sumeragi.txs_awaiting_created_block.clear(); TODO: Figure out what this is for
+                                        if network_topology.role(&sumeragi.peer_id)
+                                            == Role::ValidatingPeer
+                                        {
+                                            if let Err(e) = block.validation_check(
+                                                &mut wsv_guard,
+                                                &state_machine_guard.latest_block_hash,
+                                                &state_machine_guard
+                                                    .current_topology
+                                                    .view_change_proofs()
+                                                    .latest_hash(),
+                                                state_machine_guard.latest_block_height,
+                                                &sumeragi.transaction_limits,
+                                            ) {
+                                                warn!(%e)
+                                            } else {
+                                                let block_clone = block.clone();
+                                                let key_pair_clone = sumeragi.key_pair.clone();
+                                                let transaction_validator =
+                                                    sumeragi.transaction_validator.clone();
+                                                let signed_block = block_clone
+                                                    .revalidate(&transaction_validator, &wsv_guard)
+                                                    .sign(key_pair_clone)
+                                                    .expect("maybe we should handle this error");
+                                                {
+                                                    let post = iroha_p2p::Post {
+                                                        data: NetworkMessage::SumeragiMessage(
+                                                            Box::new(VersionedMessage::from(
+                                                                Message::BlockSigned(
+                                                                    signed_block.into(),
+                                                                ),
+                                                            )),
+                                                        ),
+                                                        peer: network_topology.proxy_tail().clone(),
+                                                    };
+                                                    sumeragi.broker.issue_send_sync(&post);
+                                                }
+                                                info!(
+                                                    peer_role = ?network_topology.role(&sumeragi.peer_id),
+                                                    block_hash = %block.hash(),
+                                                    "Signed block candidate",
+                                                );
+                                                println!("Signed block and sent to proxy tail.");
+                                            }
+                                            //TODO: send to set b so they can observe
+                                        }
+                                        let voting_block = VotingBlock::new(block.clone());
+                                        let voting_block_hash = voting_block.block.hash();
+                                        voting_block_option = Some(voting_block);
+
+                                        // TODO: Do commit countdown.
+                                    }
+                                    _ => {
+                                        println!("Not handling message {:?}", msg);
+                                    }
+                                }
+                            }
+                            Err(recv_error) => {
+                                match recv_error {
+                                    TryRecvError::Empty => {
+                                        std::thread::sleep(Duration::from_millis(100));
+                                    }
+                                    TryRecvError::Disconnected => {
+                                        panic!("Sumeragi message pump disconnected.")
+                                    }
+                                };
+                            }
+                        }
+                    }
+                }
+
+                // We have a voting block
+                if state_machine_guard.current_topology.role(&sumeragi.peer_id) == Role::ProxyTail {
+                    let validating_peers = state_machine_guard.current_topology.peers_set_a();
+                    let mut peer_signatures = vec![None; validating_peers.len()];
+                    let voting_block = voting_block_option.take().expect("take voting block");
+                    let voting_block_hash = voting_block.block.hash();
+                    loop {
+                        match incoming_message_receiver.try_recv() {
+                            Ok(msg) => match msg {
+                                Message::BlockSigned(block_signed) => {
+                                    let block = block_signed.block;
+
+                                    // I don't think we update the topology here. That ship has sailed.
+
+                                    let network_topology = &state_machine_guard.current_topology;
+
+                                    let block_hash = block.hash();
+
+                                    if block_hash != voting_block_hash {
+                                        error!("Block hash does not match voting block hash.");
+                                    }
+
+                                    let valid_signatures = network_topology
+                                        .filter_signatures_by_roles(
+                                            &[Role::ValidatingPeer, Role::Leader],
+                                            block.verified_signatures(),
+                                        );
+
+                                    let mut number_of_votes = 0;
+                                    for i in 0..validating_peers.len() {
+                                        for sig in &valid_signatures {
+                                            if *sig.public_key() == validating_peers[i].public_key {
+                                                peer_signatures[i] = Some(sig.clone());
+                                            }
+                                        }
+
+                                        if peer_signatures[i].is_some() {
+                                            number_of_votes += 1;
+                                        }
+                                    }
+
+                                    info!(
+                                        %block_hash,
+                                        number_of_votes = number_of_votes,
+                                        required_number_of_votes = network_topology.min_votes_for_commit() - 1,
+                                        "Received a vote for block",
+                                    );
+
+                                    if number_of_votes < network_topology.min_votes_for_commit() - 1
+                                    {
+                                        continue;
+                                    }
+
+                                    let mut signatures: Vec<SignatureOf<VersionedValidBlock>> =
+                                        peer_signatures.into_iter().filter_map(|x| x).collect();
+                                    let mut block = voting_block.block;
+                                    block.as_mut_v1().signatures = signatures
+                                        .into_iter()
+                                        .map(SignatureOf::transmute)
+                                        .collect();
+                                    let block = block
+                                        .sign(sumeragi.key_pair.clone())
+                                        .expect("Why should signing fail?");
+
+                                    assert!(
+                                        block.as_v1().signatures.len()
+                                            >= network_topology.min_votes_for_commit()
+                                    );
+
+                                    info!(
+                                        %voting_block_hash,
+                                        "Block reached required number of votes",
+                                    );
+
+                                    sumeragi.broadcast_msg_to(
+                                        BlockCommitted::from(block.clone()),
+                                        network_topology
+                                            .validating_peers()
+                                            .iter()
+                                            .chain([network_topology.leader()])
+                                            .chain(network_topology.peers_set_b()),
+                                    );
+                                    {
+                                        /*
+                                        TODO: purge the unneeded of these
+                                        self.invalidated_blocks_hashes.clear();
+                                        self.txs_awaiting_created_block.clear();
+                                        self.txs_awaiting_receipts.clear();
+                                        self.votes_for_view_change.clear();
+                                        */
+                                        state_machine_guard.latest_block_height =
+                                            block.header().height;
+
+                                        let block = block.commit();
+                                        let block_hash = block.hash();
+
+                                        let mut wsv_guard = sumeragi.wsv.lock().unwrap();
+                                        if let Err(error) = wsv_guard.apply(block.clone()) {
+                                            panic!("Failed to apply block on WSV. This is not a recoverable state.");
+                                        }
+
+                                        for event in Vec::<Event>::from(&block) {
+                                            trace!(?event);
+                                            drop(sumeragi.events_sender.send(event));
+                                        }
+
+                                        let previous_role = state_machine_guard
+                                            .current_topology
+                                            .role(&sumeragi.peer_id);
+                                        state_machine_guard
+                                            .current_topology
+                                            .apply_block(block_hash);
+                                        info!(
+                                            prev_peer_role = ?previous_role,
+                                            new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                            new_block_height = %state_machine_guard.latest_block_height,
+                                            %block_hash,
+                                            "Committing block"
+                                        );
+                                        sumeragi.kura.blocking_store_block(block);
+                                        SumeragiWithFault::<F>::update_network_topology(
+                                            &mut state_machine_guard.current_topology,
+                                            &wsv_guard,
+                                        );
+                                    }
+                                    break;
+                                }
+                                _ => {
+                                    println!("Not handling message {:?}", msg);
+                                }
+                            },
+                            Err(recv_error) => {
+                                match recv_error {
+                                    TryRecvError::Empty => {
+                                        std::thread::sleep(Duration::from_millis(100));
+                                    }
+                                    TryRecvError::Disconnected => {
+                                        panic!("Sumeragi message pump disconnected.")
+                                    }
+                                };
+                            }
+                        }
+                    }
+                } else {
+                    loop {
+                        match incoming_message_receiver.try_recv() {
+                            Ok(msg) => match msg {
+                                Message::BlockCommitted(block_committed) => {
+                                    let block = block_committed.block;
+                                    let network_topology =
+                                        state_machine_guard.current_topology.clone();
+
+                                    let verified_signatures =
+                                        block.verified_signatures().cloned().collect::<Vec<_>>();
+                                    let valid_signatures = network_topology
+                                        .filter_signatures_by_roles(
+                                            &[Role::ValidatingPeer, Role::Leader, Role::ProxyTail],
+                                            &verified_signatures,
+                                        );
+                                    let proxy_tail_signatures = network_topology
+                                        .filter_signatures_by_roles(
+                                            &[Role::ProxyTail],
+                                            &verified_signatures,
+                                        );
+                                    if valid_signatures.len()
+                                        >= network_topology.min_votes_for_commit()
+                                        && proxy_tail_signatures.len() == 1
+                                        && state_machine_guard.latest_block_hash
+                                            == block.header().previous_block_hash
+                                    {
+                                        {
+                                            /*
+                                            TODO: purge the unneeded of these
+                                            self.invalidated_blocks_hashes.clear();
+                                            self.txs_awaiting_created_block.clear();
+                                            self.txs_awaiting_receipts.clear();
+                                            self.votes_for_view_change.clear();
+                                            */
+                                            state_machine_guard.latest_block_height =
+                                                block.header().height;
+
+                                            let block = block.commit();
+                                            let block_hash = block.hash();
+
+                                            let mut wsv_guard = sumeragi.wsv.lock().unwrap();
+                                            if let Err(error) = wsv_guard.apply(block.clone()) {
+                                                panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                                            }
+
+                                            for event in Vec::<Event>::from(&block) {
+                                                trace!(?event);
+                                                drop(sumeragi.events_sender.send(event));
+                                            }
+
+                                            let previous_role = state_machine_guard
+                                                .current_topology
+                                                .role(&sumeragi.peer_id);
+                                            state_machine_guard
+                                                .current_topology
+                                                .apply_block(block_hash);
+                                            info!(
+                                                prev_peer_role = ?previous_role,
+                                                new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                                new_block_height = %state_machine_guard.latest_block_height,
+                                                %block_hash,
+                                                "Committing block"
+                                            );
+                                            sumeragi.kura.blocking_store_block(block);
+                                            SumeragiWithFault::<F>::update_network_topology(
+                                                &mut state_machine_guard.current_topology,
+                                                &wsv_guard,
+                                            );
+                                        }
+                                        break;
+                                    }
+                                }
+                                _ => {
+                                    println!("Not handling message {:?}", msg);
+                                }
+                            },
+                            Err(recv_error) => {
+                                match recv_error {
+                                    TryRecvError::Empty => {
+                                        std::thread::sleep(Duration::from_millis(100));
+                                    }
+                                    TryRecvError::Disconnected => {
+                                        panic!("Sumeragi message pump disconnected.")
+                                    }
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    {
+        let mut state_machine_guard = sumeragi.sumeragi_state_machine_data.lock().unwrap();
+        assert!(state_machine_guard.latest_block_height >= 1);
+        println!(
+            "I, {}, got to the end. My role in the first round is {:?}",
+            sumeragi.peer_id.public_key,
+            state_machine_guard.current_topology.role(&sumeragi.peer_id),
+        );
+        voting_block_option = None;
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    {
+        // do normal rounds
+
+        let mut voting_block_option = None;
+
+        let mut block_signature_acc = Vec::new();
+
+        let mut should_sleep = false;
+
+        let mut has_sent_transactions = false; // temporary, should be replaced with reciepts
+
+        let mut maybe_incoming_message = None;
+        loop {
+            if should_sleep {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                should_sleep = false;
+            }
+            let mut state_machine_guard = sumeragi.sumeragi_state_machine_data.lock().unwrap();
+            let mut wsv_guard = sumeragi.wsv.lock().unwrap();
+
+            if maybe_incoming_message.is_some() {
+                panic!("If there is a message available it must be consumed within one loop cycle. A in house rule in place to stop one from implementing bugs that render a node not responding.");
+            }
+            maybe_incoming_message = match incoming_message_receiver.try_recv() {
+                Ok(msg) => Some(msg),
+                Err(recv_error) => match recv_error {
+                    TryRecvError::Empty => None,
+                    TryRecvError::Disconnected => {
+                        panic!("Sumeragi message pump disconnected.")
+                    }
+                },
+            };
+
+            if state_machine_guard.current_topology.role(&sumeragi.peer_id) != Role::Leader {
+                let transactions = sumeragi.queue.get_transactions_for_block(&wsv_guard);
+                if transactions.len() > 0 && !has_sent_transactions {
+                    // If already sent tx and awaiting receipt or created block, then quit.
+                    // if !self.txs_awaiting_receipts.is_empty() || !self.txs_awaiting_created_block.is_empty() {
+                    //     return;
+                    // }
+                    // It is assumed that we only need to send 1 tx to check liveness.
+                    let tx = transactions
+                        .choose(&mut rand::thread_rng())
+                        .expect("It was checked earlier that transactions are not empty.")
+                        .clone();
+                    let tx_hash = tx.hash();
+                    info!(
+                        peer_addr = %sumeragi.peer_id.address,
+                        peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                        leader_addr = %state_machine_guard.current_topology.leader().address,
+                        %tx_hash,
+                        "Forwarding tx to leader"
+                    );
+
+                    // Don't require leader to submit receipts and therefore create blocks if the tx is still waiting for more signatures.
+                    if let Ok(true) = tx.check_signature_condition(&wsv_guard) {
+                        // self.txs_awaiting_receipts.insert(tx.hash(), Instant::now());
+                    }
+                    /*
+                                            let no_tx_receipt = view_change::Proof::no_transaction_receipt_received(
+                                                self.latest_view_change_hash(),
+                                                *self.latest_block_hash(),
+                                                self.key_pair.clone(),
+                                            )
+                                            .expect("Failed to put first signature.");
+
+                                            ctx.notify(
+                                                CheckReceiptTimeout {
+                                                    tx_hash,
+                                                    proof: no_tx_receipt,
+                                                },
+                                                self.tx_receipt_time,
+                                            );
+                    */
+
+                    let post = iroha_p2p::Post {
+                        data: NetworkMessage::SumeragiMessage(Box::new(VersionedMessage::from(
+                            Message::from(TransactionForwarded::new(tx, sumeragi.peer_id.clone())),
+                        ))),
+                        peer: state_machine_guard.current_topology.leader().clone(),
+                    };
+                    sumeragi.broker.issue_send_sync(&post);
+
+                    has_sent_transactions = true; // temporary
+                                                  /*
+                                                  println!(
+                                                      "I, {}, a non leader, have sent a transaction to the leader.",
+                                                      sumeragi.peer_id.public_key
+                                                  );*/
+                }
+            }
+
+            if state_machine_guard.current_topology.role(&sumeragi.peer_id) == Role::ObservingPeer {
+                if maybe_incoming_message.is_some() {
+                    let incoming_message = maybe_incoming_message.take().unwrap();
+                    match incoming_message {
+                        Message::BlockCreated(_) => {}
+                        _ => {
+                            println!("Observing peer not handling message {:?}", incoming_message);
+                        }
+                    }
+                } else {
+                    should_sleep = true;
+                }
+                continue;
+            }
+
+            if state_machine_guard.current_topology.role(&sumeragi.peer_id) == Role::Leader {
+                if maybe_incoming_message.is_some() {
+                    use crate::sumeragi::Message::TransactionForwarded;
+
+                    let msg = maybe_incoming_message.take().unwrap();
+                    match msg {
+                        TransactionForwarded(transaction_forwarded) => {
+                            let transaction_maybe = VersionedAcceptedTransaction::from_transaction(
+                                transaction_forwarded.transaction.clone().into_v1(),
+                                &sumeragi.transaction_limits,
+                            );
+                            if transaction_maybe.is_ok() {
+                                let transaction = transaction_maybe.unwrap();
+                                match sumeragi.queue.push(transaction, &wsv_guard) {
+                                    Ok(()) => (),
+                                    Err((_, crate::queue::Error::InBlockchain)) | Ok(()) => (),
+                                    Err((_, err)) => {
+                                        error!(%err, "Error while pushing transaction into queue?");
+                                    }
+                                }
+                            } else {
+                                error!(
+                                    "Recieved transaction that did not pass transaction limits."
+                                );
+                            }
+                        }
+                        Message::BlockCommitted(block_committed) => {
+                            let block = block_committed.block;
+                            let network_topology = state_machine_guard.current_topology.clone();
+
+                            let verified_signatures =
+                                block.verified_signatures().cloned().collect::<Vec<_>>();
+                            let valid_signatures = network_topology.filter_signatures_by_roles(
+                                &[Role::ValidatingPeer, Role::Leader, Role::ProxyTail],
+                                &verified_signatures,
+                            );
+                            let proxy_tail_signatures = network_topology
+                                .filter_signatures_by_roles(
+                                    &[Role::ProxyTail],
+                                    &verified_signatures,
+                                );
+                            if valid_signatures.len() >= network_topology.min_votes_for_commit()
+                                && proxy_tail_signatures.len() == 1
+                                && state_machine_guard.latest_block_hash
+                                    == block.header().previous_block_hash
+                            {
+                                {
+                                    /*
+                                    TODO: purge the unneeded of these
+                                    self.invalidated_blocks_hashes.clear();
+                                    self.txs_awaiting_created_block.clear();
+                                    self.txs_awaiting_receipts.clear();
+                                    self.votes_for_view_change.clear();
+                                    */
+                                    state_machine_guard.latest_block_height = block.header().height;
+
+                                    let block = block.commit();
+                                    let block_hash = block.hash();
+
+                                    if let Err(error) = wsv_guard.apply(block.clone()) {
+                                        panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                                    }
+
+                                    for event in Vec::<Event>::from(&block) {
+                                        trace!(?event);
+                                        drop(sumeragi.events_sender.send(event));
+                                    }
+
+                                    let previous_role = state_machine_guard
+                                        .current_topology
+                                        .role(&sumeragi.peer_id);
+                                    state_machine_guard.current_topology.apply_block(block_hash);
+                                    info!(
+                                        prev_peer_role = ?previous_role,
+                                        new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                        new_block_height = %state_machine_guard.latest_block_height,
+                                        %block_hash,
+                                        "Committing block"
+                                    );
+                                    sumeragi.kura.blocking_store_block(block);
+                                    SumeragiWithFault::<F>::update_network_topology(
+                                        &mut state_machine_guard.current_topology,
+                                        &wsv_guard,
+                                    );
+                                    has_sent_transactions = false;
+                                    voting_block_option = None;
+                                    println!("Leader has committed the block.");
+                                }
+                            }
+                        }
+                        _ => println!("Leader not handling message, {:?}", msg),
+                    }
+                } else {
+                    should_sleep = true;
+                }
+
+                if voting_block_option.is_none() {
+                    let transactions = sumeragi.queue.get_transactions_for_block(&wsv_guard);
+                    if transactions.len() == 0 {
+                        continue;
+                    }
+                    println!(
+                        "I, {}, have transactions to make a block with.",
+                        sumeragi.peer_id.public_key
+                    );
+                    // TODO: This should properly process triggers
+                    let event_recommendations = Vec::new();
+
+                    let block = PendingBlock::new(transactions, event_recommendations).chain(
+                        state_machine_guard.latest_block_height,
+                        state_machine_guard.latest_block_hash,
+                        ViewChangeProofs::empty(), // self.view_change_proofs().clone(),
+                        Vec::new(),                //self.invalidated_blocks_hashes.clone(),
+                    );
+                    {
+                        let block = block.validate(&sumeragi.transaction_validator, &wsv_guard);
+
+                        for event in Vec::<Event>::from(&block) {
+                            trace!(?event);
+                            drop(sumeragi.events_sender.send(event));
+                        }
+                        let signed_block = block
+                            .sign(sumeragi.key_pair.clone())
+                            .expect("Sign genesis block.");
+
+                        if !state_machine_guard.current_topology.is_consensus_required() {
+                            /*
+                            TODO: purge the unneeded of these
+                            self.invalidated_blocks_hashes.clear();
+                            self.txs_awaiting_created_block.clear();
+                            self.txs_awaiting_receipts.clear();
+                            self.votes_for_view_change.clear();
+                            */
+                            state_machine_guard.latest_block_height = signed_block.header().height;
+
+                            sumeragi.broadcast_msg(
+                                BlockCommitted::from(signed_block.clone()),
+                                &state_machine_guard.current_topology,
+                            );
+
+                            let block = signed_block.commit();
+                            let block_hash = block.hash();
+
+                            if let Err(error) = wsv_guard.apply(block.clone()) {
+                                panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                            }
+
+                            for event in Vec::<Event>::from(&block) {
+                                trace!(?event);
+                                drop(sumeragi.events_sender.send(event));
+                            }
+
+                            let previous_role =
+                                state_machine_guard.current_topology.role(&sumeragi.peer_id);
+                            state_machine_guard.current_topology.apply_block(block_hash);
+                            info!(
+                                prev_peer_role = ?previous_role,
+                                new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                new_block_height = %state_machine_guard.latest_block_height,
+                                %block_hash,
+                                "Committing block"
+                            );
+                            sumeragi.kura.blocking_store_block(block);
+                            SumeragiWithFault::<F>::update_network_topology(
+                                &mut state_machine_guard.current_topology,
+                                &wsv_guard,
+                            );
+                            has_sent_transactions = false;
+                            voting_block_option = None;
+                            continue;
+                        }
+
+                        let voting_block = VotingBlock::new(signed_block.clone());
+                        let voting_block_hash = voting_block.block.hash();
+
+                        voting_block_option = Some(voting_block);
+                        sumeragi.broadcast_msg(
+                            BlockCreated::from(signed_block.clone()),
+                            &state_machine_guard.current_topology,
+                        );
+
+                        {
+                            // view change proof
+                            let proof = view_change::Proof::commit_timeout(
+                                voting_block_hash,
+                                state_machine_guard
+                                    .current_topology
+                                    .view_change_proofs()
+                                    .latest_hash(),
+                                *state_machine_guard.current_topology.at_block(),
+                                sumeragi.key_pair.clone(),
+                            )
+                            .expect("Failed to sign CommitTimeout");
+                            // TODO: Commit timeout causes viewchange
+                        }
+                        println!(
+                            "I, {}, the leader, have created a block.",
+                            sumeragi.peer_id.public_key
+                        );
+                    }
+                }
+
+                continue;
+            }
+            if state_machine_guard.current_topology.role(&sumeragi.peer_id) == Role::ValidatingPeer
+            {
+                if maybe_incoming_message.is_some() {
+                    let incoming_message = maybe_incoming_message.take().unwrap();
+
+                    println!(
+                        "I, {}, a validating peer, have recieved a message.",
+                        sumeragi.peer_id.public_key
+                    );
+
+                    match incoming_message {
+                        Message::BlockCreated(block_created) => {
+                            let block = block_created.block;
+
+                            if voting_block_option.is_some() {
+                                eprintln!("Already have block, ignoring.");
+                                continue;
+                            }
+
+                            for event in Vec::<Event>::from(&block) {
+                                trace!(?event);
+                                drop(sumeragi.events_sender.send(event));
+                            }
+                            state_machine_guard.current_topology = sumeragi.update_view_changes(
+                                block.header().view_change_proofs.clone(),
+                                state_machine_guard.current_topology.clone(),
+                                &state_machine_guard.latest_block_hash,
+                            );
+
+                            // During the genesis round we blindly take on the network topology described in
+                            // the provided genesis block.
+                            let block_header = block.header();
+                            if block_header.is_genesis()
+                                && state_machine_guard.latest_block_height == 0
+                                && block_header.genesis_topology.is_some()
+                            {
+                                info!("Using network topology from genesis block");
+                                state_machine_guard.current_topology = block_header
+                                    .genesis_topology
+                                    .clone()
+                                    .take()
+                                    .expect("We just checked that it is some");
+                            }
+
+                            if state_machine_guard
+                                .current_topology
+                                .filter_signatures_by_roles(
+                                    &[Role::Leader],
+                                    block.verified_signatures(),
+                                )
+                                .is_empty()
+                            {
+                                error!(
+                                    role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                    "Rejecting Block as it is not signed by leader.",
+                                );
+                                eprintln!("Rejecting Block as it is not signed by leader.");
+                                continue;
+                            }
+                            let network_topology = &state_machine_guard.current_topology;
+
+                            // sumeragi.txs_awaiting_created_block.clear(); TODO: Figure out what this is for
+                            if let Err(e) = block.validation_check(
+                                &mut wsv_guard,
+                                &state_machine_guard.latest_block_hash,
+                                &state_machine_guard
+                                    .current_topology
+                                    .view_change_proofs()
+                                    .latest_hash(),
+                                state_machine_guard.latest_block_height,
+                                &sumeragi.transaction_limits,
+                            ) {
+                                warn!(%e);
+                                println!("Block validation failed, {:?}", e);
+                            } else {
+                                let block_clone = block.clone();
+                                let key_pair_clone = sumeragi.key_pair.clone();
+                                let transaction_validator = sumeragi.transaction_validator.clone();
+                                let signed_block = block_clone
+                                    .revalidate(&transaction_validator, &wsv_guard)
+                                    .sign(key_pair_clone)
+                                    .expect("maybe we should handle this error");
+                                {
+                                    let post = iroha_p2p::Post {
+                                        data: NetworkMessage::SumeragiMessage(Box::new(
+                                            VersionedMessage::from(Message::BlockSigned(
+                                                signed_block.into(),
+                                            )),
+                                        )),
+                                        peer: network_topology.proxy_tail().clone(),
+                                    };
+                                    sumeragi.broker.issue_send_sync(&post);
+                                }
+                                info!(
+                                    peer_role = ?network_topology.role(&sumeragi.peer_id),
+                                    block_hash = %block.hash(),
+                                    "Signed block candidate",
+                                );
+                                println!("Signed block and sent to proxy tail.");
+                            }
+                            //TODO: send to set b so they can observe
+
+                            let voting_block = VotingBlock::new(block.clone());
+                            let voting_block_hash = voting_block.block.hash();
+                            voting_block_option = Some(voting_block);
+
+                            // TODO: Do commit countdown.
+                        }
+                        Message::BlockCommitted(block_committed) => {
+                            let block = block_committed.block;
+                            let network_topology = state_machine_guard.current_topology.clone();
+
+                            let verified_signatures =
+                                block.verified_signatures().cloned().collect::<Vec<_>>();
+                            let valid_signatures = network_topology.filter_signatures_by_roles(
+                                &[Role::ValidatingPeer, Role::Leader, Role::ProxyTail],
+                                &verified_signatures,
+                            );
+                            let proxy_tail_signatures = network_topology
+                                .filter_signatures_by_roles(
+                                    &[Role::ProxyTail],
+                                    &verified_signatures,
+                                );
+                            if valid_signatures.len() >= network_topology.min_votes_for_commit()
+                                && proxy_tail_signatures.len() == 1
+                                && state_machine_guard.latest_block_hash
+                                    == block.header().previous_block_hash
+                            {
+                                {
+                                    /*
+                                    TODO: purge the unneeded of these
+                                    self.invalidated_blocks_hashes.clear();
+                                    self.txs_awaiting_created_block.clear();
+                                    self.txs_awaiting_receipts.clear();
+                                    self.votes_for_view_change.clear();
+                                    */
+                                    state_machine_guard.latest_block_height = block.header().height;
+
+                                    let block = block.commit();
+                                    let block_hash = block.hash();
+
+                                    if let Err(error) = wsv_guard.apply(block.clone()) {
+                                        panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                                    }
+
+                                    for event in Vec::<Event>::from(&block) {
+                                        trace!(?event);
+                                        drop(sumeragi.events_sender.send(event));
+                                    }
+
+                                    let previous_role = state_machine_guard
+                                        .current_topology
+                                        .role(&sumeragi.peer_id);
+                                    state_machine_guard.current_topology.apply_block(block_hash);
+                                    info!(
+                                        prev_peer_role = ?previous_role,
+                                        new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                        new_block_height = %state_machine_guard.latest_block_height,
+                                        %block_hash,
+                                        "Committing block"
+                                    );
+                                    sumeragi.kura.blocking_store_block(block);
+                                    SumeragiWithFault::<F>::update_network_topology(
+                                        &mut state_machine_guard.current_topology,
+                                        &wsv_guard,
+                                    );
+                                    has_sent_transactions = false;
+                                    voting_block_option = None;
+                                    println!("ValidatingPeer has committed the block.");
+                                }
+                            }
+                        }
+                        _ => {
+                            println!("Not handling message {:?}", incoming_message);
+                        }
+                    }
+                } else {
+                    // if there is no message sleep
+                    should_sleep = true;
+                }
+                continue;
+            }
+            if state_machine_guard.current_topology.role(&sumeragi.peer_id) == Role::ProxyTail {
+                if maybe_incoming_message.is_some() {
+                    let incoming_message = maybe_incoming_message.take().unwrap();
+
+                    println!(
+                        "I, {}, the proxy tail, have recieved a message.",
+                        sumeragi.peer_id.public_key
+                    );
+
+                    match incoming_message {
+                        Message::BlockCreated(block_created) => {
+                            let block = block_created.block;
+
+                            if voting_block_option.is_some() {
+                                eprintln!("Already have block, ignoring.");
+                                continue;
+                            }
+
+                            for event in Vec::<Event>::from(&block) {
+                                trace!(?event);
+                                drop(sumeragi.events_sender.send(event));
+                            }
+                            state_machine_guard.current_topology = sumeragi.update_view_changes(
+                                block.header().view_change_proofs.clone(),
+                                state_machine_guard.current_topology.clone(),
+                                &state_machine_guard.latest_block_hash,
+                            );
+
+                            // During the genesis round we blindly take on the network topology described in
+                            // the provided genesis block.
+                            let block_header = block.header();
+                            if block_header.is_genesis()
+                                && state_machine_guard.latest_block_height == 0
+                                && block_header.genesis_topology.is_some()
+                            {
+                                info!("Using network topology from genesis block");
+                                state_machine_guard.current_topology = block_header
+                                    .genesis_topology
+                                    .clone()
+                                    .take()
+                                    .expect("We just checked that it is some");
+                            }
+
+                            if state_machine_guard
+                                .current_topology
+                                .filter_signatures_by_roles(
+                                    &[Role::Leader],
+                                    block.verified_signatures(),
+                                )
+                                .is_empty()
+                            {
+                                error!(
+                                    role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                    "Rejecting Block as it is not signed by leader.",
+                                );
+                                continue;
+                            }
+                            let network_topology = &state_machine_guard.current_topology;
+
+                            let valid_signatures = network_topology.filter_signatures_by_roles(
+                                &[Role::ValidatingPeer, Role::Leader],
+                                block.verified_signatures(),
+                            );
+
+                            for sig in &valid_signatures {
+                                block_signature_acc.push((block.hash(), sig.clone()));
+                            }
+                            // sumeragi.txs_awaiting_created_block.clear(); TODO: Figure out what this is for
+
+                            let voting_block = VotingBlock::new(block.clone());
+                            let voting_block_hash = voting_block.block.hash();
+                            voting_block_option = Some(voting_block);
+
+                            // TODO: Do commit countdown.
+                        }
+                        Message::BlockSigned(block_signed) => {
+                            println!("block signed message");
+                            let block = block_signed.block;
+                            let block_hash = block.hash();
+
+                            if voting_block_option.is_some()
+                                && block_hash != voting_block_option.as_ref().unwrap().block.hash()
+                            {
+                                println!("block signed is not relevant block");
+                                continue;
+                            }
+
+                            // I don't think we update the topology here. That ship has sailed.
+
+                            let network_topology = &state_machine_guard.current_topology;
+
+                            let valid_signatures = network_topology.filter_signatures_by_roles(
+                                &[Role::ValidatingPeer, Role::Leader],
+                                block.verified_signatures(),
+                            );
+
+                            for sig in &valid_signatures {
+                                block_signature_acc.push((block_hash, sig.clone()));
+                            }
+                        }
+                        _ => {
+                            println!("Not handling message {:?}", incoming_message);
+                        }
+                    }
+                } else {
+                    // if there is no message sleep
+                    should_sleep = true;
+                }
+
+                if voting_block_option.is_some() {
+                    // count votes
+
+                    let validating_peers = state_machine_guard.current_topology.peers_set_a();
+
+                    let mut signatures_on_this_block = Vec::new();
+
+                    let voting_block_hash = voting_block_option.as_ref().unwrap().block.hash();
+                    for (block_hash, signature) in &block_signature_acc {
+                        if *block_hash == voting_block_hash {
+                            signatures_on_this_block.push(signature);
+                        }
+                    }
+
+                    let mut vote_count = 0;
+                    let mut peer_has_voted = vec![false; validating_peers.len()];
+                    let mut peer_signatures = Vec::new();
+                    for signature in signatures_on_this_block {
+                        for i in 0..validating_peers.len() {
+                            if *signature.public_key() == validating_peers[i].public_key {
+                                if !peer_has_voted[i] {
+                                    peer_has_voted[i] = true;
+                                    vote_count += 1;
+                                    peer_signatures.push(signature.clone());
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    vote_count += 1; // We are also voting for this block.
+                    if vote_count >= state_machine_guard.current_topology.min_votes_for_commit() {
+                        println!("Block passes!");
+                        let mut block = voting_block_option.unwrap().block;
+                        voting_block_option = None;
+                        block.as_mut_v1().signatures = peer_signatures
+                            .into_iter()
+                            .map(SignatureOf::transmute)
+                            .collect();
+                        let block = block
+                            .sign(sumeragi.key_pair.clone())
+                            .expect("Why should signing fail?");
+
+                        assert!(
+                            block.as_v1().signatures.len()
+                                >= state_machine_guard.current_topology.min_votes_for_commit()
+                        );
+
+                        info!(
+                            %voting_block_hash,
+                            "Block reached required number of votes",
+                        );
+
+                        sumeragi.broadcast_msg_to(
+                            BlockCommitted::from(block.clone()),
+                            state_machine_guard
+                                .current_topology
+                                .validating_peers()
+                                .iter()
+                                .chain([state_machine_guard.current_topology.leader()])
+                                .chain(state_machine_guard.current_topology.peers_set_b()),
+                        );
+                        {
+                            /*
+                            TODO: purge the unneeded of these
+                            self.invalidated_blocks_hashes.clear();
+                            self.txs_awaiting_created_block.clear();
+                            self.txs_awaiting_receipts.clear();
+                            self.votes_for_view_change.clear();
+                            */
+                            state_machine_guard.latest_block_height = block.header().height;
+
+                            let block = block.commit();
+                            let block_hash = block.hash();
+
+                            if let Err(error) = wsv_guard.apply(block.clone()) {
+                                panic!("Failed to apply block on WSV. This is absolutely not acceptable.");
+                            }
+
+                            for event in Vec::<Event>::from(&block) {
+                                trace!(?event);
+                                drop(sumeragi.events_sender.send(event));
+                            }
+
+                            let previous_role =
+                                state_machine_guard.current_topology.role(&sumeragi.peer_id);
+                            state_machine_guard.current_topology.apply_block(block_hash);
+                            info!(
+                                prev_peer_role = ?previous_role,
+                                new_peer_role = ?state_machine_guard.current_topology.role(&sumeragi.peer_id),
+                                new_block_height = %state_machine_guard.latest_block_height,
+                                %block_hash,
+                                "Committing block"
+                            );
+                            sumeragi.kura.blocking_store_block(block);
+                            SumeragiWithFault::<F>::update_network_topology(
+                                &mut state_machine_guard.current_topology,
+                                &wsv_guard,
+                            );
+                            has_sent_transactions = false;
+                            voting_block_option = None;
+                            block_signature_acc.clear();
+                        }
+                    }
+                }
+
+                continue;
+            }
+        }
     }
 }
 
@@ -642,9 +1585,9 @@ impl<F: FaultInjection> Debug for SumeragiWithFault<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sumeragi")
             .field("public_key", &self.key_pair.public_key())
-            .field("network_topology", &self.topology)
+            // .field("network_topology", &self.topology) TODO FIX
             .field("peer_id", &self.peer_id)
-            .field("voting_block", &self.voting_block)
+            //.field("voting_block", &self.voting_block)
             .finish()
     }
 }

--- a/core/src/sumeragi/message.rs
+++ b/core/src/sumeragi/message.rs
@@ -73,14 +73,6 @@ impl VersionedMessage {
             self.clone().send_to(broker, peer_id);
         }
     }
-
-    /// Handles this message as part of `Sumeragi` consensus.
-    /// # Errors
-    /// Fails if message handling fails
-
-    pub fn handle<F: FaultInjection>(self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        self.into_v1().handle(sumeragi)
-    }
 }
 
 /// Message's variants that are used by peers to communicate in the process of consensus.
@@ -103,36 +95,6 @@ pub enum Message {
     TransactionGossip(TransactionGossip),
 }
 
-impl Message {
-    /// Handles this message as part of `Sumeragi` consensus.
-    /// # Errors
-    /// Fails if message handling fails
-    #[log(skip(self, sumeragi))]
-
-    pub fn handle<F: FaultInjection>(self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        let message = if let Some(message) = F::faulty_message(sumeragi, self) {
-            message
-        } else {
-            return Ok(());
-        };
-        match message {
-            Message::BlockCreated(block_created) => block_created.handle(sumeragi),
-            Message::BlockSigned(block_signed) => block_signed.handle(sumeragi),
-            Message::BlockCommitted(block_committed) => block_committed.handle(sumeragi),
-            Message::TransactionReceived(transaction_receipt) => {
-                transaction_receipt.handle(sumeragi)
-            }
-            Message::TransactionForwarded(transaction_forwarded) => {
-                transaction_forwarded.handle(sumeragi)
-            }
-            Message::ViewChangeSuggested(view_change_suggested) => {
-                view_change_suggested.handle(sumeragi)
-            }
-            Message::TransactionGossip(transaction_gossip) => transaction_gossip.handle(sumeragi),
-        }
-    }
-}
-
 /// `ViewChangeSuggested` message structure.
 #[derive(Debug, Clone, Decode, Encode)]
 pub struct ViewChangeSuggested {
@@ -150,31 +112,6 @@ impl ViewChangeSuggested {
     ) -> ViewChangeSuggested {
         Self { proof, chain }
     }
-
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with transaction signing.
-
-    pub fn handle<F: FaultInjection>(&self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        use view_change::Reason::*;
-        sumeragi.update_view_changes(self.chain.clone());
-        if !self.proof.has_same_state(
-            sumeragi.latest_block_hash(),
-            &sumeragi.latest_view_change_hash(),
-        ) {
-            return Ok(());
-        }
-        let (_, merged_proof) = sumeragi.merge_view_change_votes(self.proof.clone());
-        if merged_proof.verify(&sumeragi.peers(), sumeragi.topology.max_faults()) {
-            let invalidated_block_hash = match merged_proof.reason() {
-                CommitTimeout(reason) => Some(reason.hash),
-                NoTransactionReceiptReceived(_) | BlockCreationTimeout(_) => None,
-            };
-            sumeragi.change_view(merged_proof.clone(), invalidated_block_hash);
-        }
-        Ok(())
-    }
 }
 
 /// `BlockCreated` message structure.
@@ -183,77 +120,6 @@ impl ViewChangeSuggested {
 pub struct BlockCreated {
     /// The corresponding block.
     pub block: VersionedValidBlock,
-}
-
-impl BlockCreated {
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with block signing.
-
-    pub fn handle<F: FaultInjection>(&self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        // There should be only one block in discussion during a round.
-        if sumeragi.voting_block.is_some() {
-            return Ok(());
-        }
-
-        for event in Vec::<Event>::from(&self.block) {
-            trace!(?event);
-            drop(sumeragi.events_sender.send(event));
-        }
-        sumeragi.update_view_changes(self.block.header().view_change_proofs.clone());
-        let network_topology = sumeragi.network_topology_current_or_genesis(self.block.header());
-        if network_topology
-            .filter_signatures_by_roles(&[Role::Leader], self.block.verified_signatures())
-            .is_empty()
-        {
-            error!(
-                role = ?sumeragi.topology.role(&sumeragi.peer_id),
-                "Rejecting Block as it is not signed by leader.",
-            );
-            return Ok(());
-        }
-        sumeragi.txs_awaiting_created_block.clear();
-        if network_topology.role(&sumeragi.peer_id) == Role::ValidatingPeer {
-            if let Err(e) = self.block.validation_check(
-                &sumeragi.wsv.lock().unwrap(),
-                sumeragi.latest_block_hash(),
-                &sumeragi.latest_view_change_hash(),
-                sumeragi.block_height,
-                &sumeragi.transaction_limits,
-            ) {
-                warn!(%e)
-            } else {
-                let block_clone = self.block.clone();
-                let key_pair_clone = sumeragi.key_pair.clone();
-                let transaction_validator = sumeragi.transaction_validator.clone();
-                let signed_block = {
-                    block_clone
-                        .revalidate(&transaction_validator, &sumeragi.wsv.lock().unwrap())
-                        .sign(key_pair_clone)
-                        .map(Into::into)
-                }?;
-                VersionedMessage::from(Message::BlockSigned(signed_block))
-                    .send_to(&sumeragi.broker, network_topology.proxy_tail());
-                info!(
-                    peer_role = ?network_topology.role(&sumeragi.peer_id),
-                    block_hash = %self.block.hash(),
-                    "Signed block candidate",
-                );
-            }
-            //TODO: send to set b so they can observe
-        }
-        let voting_block = VotingBlock::new(self.block.clone());
-        let voting_block_hash = voting_block.block.hash();
-        sumeragi.voting_block = Some(voting_block);
-
-        sumeragi.start_commit_countdown(
-            voting_block_hash,
-            *sumeragi.latest_block_hash(),
-            sumeragi.latest_view_change_hash(),
-        );
-        Ok(())
-    }
 }
 
 impl From<VersionedValidBlock> for BlockCreated {
@@ -270,75 +136,6 @@ pub struct BlockSigned {
     pub block: VersionedValidBlock,
 }
 
-impl BlockSigned {
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with block signing.
-
-    pub fn handle<F: FaultInjection>(&self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        sumeragi.update_view_changes(self.block.header().view_change_proofs.clone());
-        let network_topology = sumeragi.network_topology_current_or_genesis(self.block.header());
-        if Role::ProxyTail != network_topology.role(&sumeragi.peer_id) {
-            return Ok(());
-        }
-        let block_hash = self.block.hash();
-        let entry = sumeragi
-            .votes_for_blocks
-            .entry(block_hash)
-            .or_insert_with(|| self.block.clone());
-        entry.as_mut_v1().signatures.extend(
-            self.block
-                .verified_signatures()
-                .cloned()
-                .map(SignatureOf::transmute),
-        );
-        let valid_signatures = network_topology.filter_signatures_by_roles(
-            &[Role::ValidatingPeer, Role::Leader],
-            entry.verified_signatures(),
-        );
-
-        info!(
-            peer_role = ?network_topology.role(&sumeragi.peer_id),
-            %block_hash,
-            valid_signatures_count = valid_signatures.len(),
-            required_signatures_count = network_topology.min_votes_for_commit() - 1,
-            "Received a vote for block",
-        );
-
-        if valid_signatures.len() < network_topology.min_votes_for_commit() - 1 {
-            return Ok(());
-        }
-
-        let signatures = valid_signatures
-            .into_iter()
-            .map(SignatureOf::transmute)
-            .collect();
-        let mut block = entry.clone();
-        block.as_mut_v1().signatures = signatures;
-        let block = block.sign(sumeragi.key_pair.clone())?;
-
-        info!(
-            peer_role = ?network_topology.role(&sumeragi.peer_id),
-            %block_hash,
-            "Block reached required number of votes",
-        );
-
-        sumeragi.broadcast_msg_to(
-            BlockCommitted::from(block.clone()),
-            network_topology
-                .validating_peers()
-                .iter()
-                .chain([network_topology.leader()])
-                .chain(network_topology.peers_set_b()),
-        );
-        sumeragi.votes_for_blocks.clear();
-        sumeragi.commit_block(block);
-
-        Ok(())
-    }
-}
-
 impl From<VersionedValidBlock> for BlockSigned {
     fn from(block: VersionedValidBlock) -> Self {
         Self { block }
@@ -351,44 +148,6 @@ impl From<VersionedValidBlock> for BlockSigned {
 pub struct BlockCommitted {
     /// The corresponding block.
     pub block: VersionedValidBlock,
-}
-
-impl BlockCommitted {
-    /// Handles this message as part of `Sumeragi` consensus.
-
-    pub fn handle<F: FaultInjection>(&self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        let network_topology = sumeragi.network_topology_current_or_genesis(self.block.header());
-        #[allow(clippy::expect_used)]
-        let network_topology = network_topology
-            .into_builder()
-            .with_view_changes(self.block.header().view_change_proofs.clone())
-            .build()
-            .expect("When only changing view changes it should not fail.");
-        let verified_signatures = self
-            .block
-            .verified_signatures()
-            .cloned()
-            .collect::<Vec<_>>();
-        let valid_signatures = network_topology.filter_signatures_by_roles(
-            &[Role::ValidatingPeer, Role::Leader, Role::ProxyTail],
-            &verified_signatures,
-        );
-        let proxy_tail_signatures =
-            network_topology.filter_signatures_by_roles(&[Role::ProxyTail], &verified_signatures);
-        if valid_signatures.len() >= network_topology.min_votes_for_commit()
-            && proxy_tail_signatures.len() == 1
-            && sumeragi.latest_block_hash() == &self.block.header().previous_block_hash
-        {
-            let mut block = self.block.clone();
-            block.as_mut_v1().signatures.clear();
-            block
-                .as_mut_v1()
-                .signatures
-                .extend(valid_signatures.into_iter().map(SignatureOf::transmute));
-            sumeragi.commit_block(block);
-        }
-        Ok(())
-    }
 }
 
 impl From<VersionedValidBlock> for BlockCommitted {
@@ -417,33 +176,6 @@ impl TransactionForwarded {
             peer,
         }
     }
-
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with transaction signing.
-
-    pub fn handle<F: FaultInjection>(self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        let transaction = VersionedAcceptedTransaction::from_transaction(
-            self.transaction.clone().into_v1(),
-            &sumeragi.transaction_limits,
-        )?;
-        match sumeragi
-            .queue
-            .push(transaction, &sumeragi.wsv.lock().unwrap())
-        {
-            Ok(()) if sumeragi.is_leader() => {
-                VersionedMessage::from(Message::TransactionReceived(TransactionReceipt::new(
-                    &self.transaction,
-                    &sumeragi.key_pair,
-                )?))
-                .send_to(&sumeragi.broker, &self.peer);
-                Ok(())
-            }
-            Err((_, queue::Error::InBlockchain)) | Ok(()) => Ok(()),
-            Err((_, err)) => Err(err.into()),
-        }
-    }
 }
 
 /// Message for gossiping batches of transactions.
@@ -460,26 +192,6 @@ impl TransactionGossip {
             // to guarantee that the sending peer checked transaction limits
             txs: txs.into_iter().map(Into::into).collect(),
         }
-    }
-
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with transaction signing.
-    pub fn handle<F: FaultInjection>(self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        for transaction in self.txs {
-            let tx = VersionedAcceptedTransaction::from_transaction(
-                transaction.into_v1(),
-                &sumeragi.transaction_limits,
-            )?;
-            match sumeragi.queue.push(tx, &sumeragi.wsv.lock().unwrap()) {
-                Err((_, queue::Error::InBlockchain)) | Ok(()) => {}
-                Err((_, err)) => {
-                    warn!(?err, "Failed to push into queue gossiped transaction.")
-                }
-            }
-        }
-        Ok(())
     }
 }
 
@@ -524,47 +236,5 @@ impl TransactionReceipt {
     /// Checks if the block should have been already created by the `Leader`.
     pub fn is_block_should_be_created(&self, block_time: Duration) -> bool {
         (current_time() - self.received_at) >= block_time
-    }
-
-    /// Handles this message as part of `Sumeragi` consensus.
-    ///
-    /// # Errors
-    /// Fails if there is an issue with block signing.
-
-    pub fn handle<F: FaultInjection>(&self, sumeragi: &mut SumeragiWithFault<F>) -> Result<()> {
-        let now = current_time();
-
-        // Implausible time in the future, means that the leader lies
-        if sumeragi.topology.role(&sumeragi.peer_id) == Role::Leader
-            || self.received_at > now
-            || !self.is_valid(&sumeragi.topology)
-            || !sumeragi.txs_awaiting_receipts.contains_key(&self.hash)
-        {
-            return Ok(());
-        }
-
-        sumeragi.txs_awaiting_receipts.remove(&self.hash);
-        let tx_hash = self.hash;
-        let block_creation_timeout = view_change::Proof::block_creation_timeout(
-            sumeragi.latest_view_change_hash(),
-            *sumeragi.latest_block_hash(),
-            sumeragi.key_pair.clone(),
-        )
-        .wrap_err("Failed to put first signature.")?;
-        sumeragi.txs_awaiting_created_block.insert(tx_hash);
-
-        // Suspect leader if the block was not yet created
-        /*
-        TODO: REPLACE
-        ctx.notify(
-            CheckCreationTimeout {
-                tx_hash,
-                proof: block_creation_timeout,
-            },
-            sumeragi.block_time,
-        );
-        Ok(())
-         */
-        Ok(())
     }
 }

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use eyre::{eyre, Result};
-use iroha_actor::broker::Broker;
-use iroha_crypto::{HashOf, KeyPair};
+use iroha_actor::{broker::Broker, Addr};
+use iroha_crypto::{HashOf, KeyPair, SignatureOf};
 use iroha_data_model::prelude::*;
 use iroha_logger::prelude::*;
 use iroha_p2p::{ConnectPeer, DisconnectPeer};
@@ -24,6 +24,10 @@ pub mod fault;
 pub mod message;
 pub mod network_topology;
 pub mod view_change;
+
+use std::sync::Mutex;
+
+use fault::SumeragiStateMachineData;
 
 use self::{
     fault::{NoFault, SumeragiWithFault},
@@ -66,19 +70,26 @@ impl Sumeragi {
         queue: Arc<Queue>,
         broker: Broker,
         kura: Arc<Kura>,
-        // network: Addr<IrohaNetwork>,
+        network: Addr<IrohaNetwork>,
     ) -> Result<Self> {
         let network_topology = Topology::builder()
             .at_block(EmptyChainHash::default().into())
             .with_peers(configuration.trusted_peers.peers.clone())
             .build()?;
 
+        let sumeragi_state_machine_data = SumeragiStateMachineData {
+            genesis_network,
+            latest_block_hash: Hash::zeroed().typed(),
+            latest_block_height: 0,
+            current_topology: network_topology,
+        };
+
+        let (incoming_message_sender, incoming_message_receiver) = std::sync::mpsc::channel();
+
         Ok(Self {
             internal: SumeragiWithFault::<NoFault> {
                 key_pair: configuration.key_pair.clone(),
-                topology: network_topology,
                 peer_id: configuration.peer_id.clone(),
-                voting_block: None,
                 votes_for_blocks: BTreeMap::new(),
                 events_sender,
                 wsv: std::sync::Mutex::new(wsv),
@@ -93,17 +104,57 @@ impl Sumeragi {
                 telemetry_started,
                 transaction_limits: configuration.transaction_limits,
                 transaction_validator,
-                genesis_network,
                 queue,
                 broker,
                 kura,
-                // network,
+                network,
                 actor_channel_capacity: configuration.actor_channel_capacity,
                 fault_injection: PhantomData,
                 gossip_batch_size: configuration.gossip_batch_size,
                 gossip_period: Duration::from_millis(configuration.gossip_period_ms),
+
+                sumeragi_state_machine_data: Mutex::new(sumeragi_state_machine_data),
+                current_online_peers_by_public_key: Mutex::new(Vec::new()),
+                incoming_message_sender: Mutex::new(incoming_message_sender),
+                incoming_message_receiver: Mutex::new(incoming_message_receiver),
             },
         })
+    }
+
+    pub fn update_metrics(&self, network: Addr<IrohaNetwork>) -> Result<()> {
+        use eyre::WrapErr;
+        use thiserror::Error;
+        let online_peers_count: u64 = self
+            .internal
+            .current_online_peers_by_public_key
+            .lock()
+            .unwrap()
+            .len()
+            .try_into()
+            .expect("casting usize to u64");
+
+        let mut wsv_guard = self.internal.wsv.lock().unwrap();
+
+        #[allow(clippy::cast_possible_truncation)]
+        if let Some(timestamp) = wsv_guard.genesis_timestamp() {
+            // this will overflow in 584942417years.
+            wsv_guard
+                .metrics
+                .uptime_since_genesis_ms
+                .set((current_time().as_millis() - timestamp) as u64)
+        };
+        let domains = wsv_guard.domains();
+        wsv_guard.metrics.domains.set(domains.len() as u64);
+        wsv_guard.metrics.connected_peers.set(online_peers_count);
+        for domain in domains {
+            wsv_guard
+                .metrics
+                .accounts
+                .get_metric_with_label_values(&[domain.id().name.as_ref()])
+                .wrap_err("Failed to compose domains")?
+                .set(domain.accounts().len() as u64);
+        }
+        Ok(())
     }
 
     pub fn latest_block_hash(&self) -> HashOf<VersionedCommittedBlock> {
@@ -111,7 +162,13 @@ impl Sumeragi {
     }
 
     pub fn get_network_topology(&self, header: &BlockHeader) -> Topology {
-        self.internal.get_network_topology(header)
+        // TODO: make use of block header
+        self.internal
+            .sumeragi_state_machine_data
+            .lock()
+            .expect("Get network topology lock.")
+            .current_topology
+            .clone()
     }
 
     pub fn blocks_after_hash(
@@ -139,7 +196,7 @@ impl Sumeragi {
             .cloned()
     }
 
-    pub fn get_clone_of_world_state_view(&self) -> WorldStateView {
+    pub fn wsv_clone(&self) -> WorldStateView {
         self.internal.wsv.lock().unwrap().clone()
     }
 
@@ -155,6 +212,22 @@ impl Sumeragi {
                 latest_block_height,
             )
         });
+    }
+
+    pub fn update_online_peers(&self, online_peers: Vec<PublicKey>) {
+        *self
+            .internal
+            .current_online_peers_by_public_key
+            .lock()
+            .expect("Lock on update online peers.") = online_peers;
+    }
+
+    pub fn incoming_message(&self, msg: Message) {
+        self.internal
+            .incoming_message_sender
+            .lock()
+            .expect("Lock on sender")
+            .send(msg);
     }
 }
 

--- a/core/src/sumeragi/network_topology.rs
+++ b/core/src/sumeragi/network_topology.rs
@@ -228,13 +228,16 @@ impl Topology {
     /// Apply new committed block hash.
     #[allow(clippy::expect_used)]
     pub fn apply_block(&mut self, block: HashOf<VersionedCommittedBlock>) {
+        /*
+        /// TODO: reimplement view changes before merging into dev (https://github.com/hyperledger/iroha/issues/2561)
         *self = self
             .clone()
             .into_builder()
             .at_block(block)
             .with_view_changes(ViewChangeProofs::empty())
             .build()
-            .expect("Given a valid Topology, it is impossible to have error here.")
+        .expect("Given a valid Topology, it is impossible to have error here.")
+        */
     }
 
     /// Apply a view change - change topology in case there were faults in the consensus round.

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -198,13 +198,17 @@ where
     type Result = ();
 
     async fn handle(&mut self, msg: ConnectPeer) {
+        if self.peers.contains_key(&msg.peer.public_key) {
+            return;
+        }
+
         debug!(
-            listen_addr = %self.listen_addr, peer.id.address = %msg.address,
+            listen_addr = %self.listen_addr, peer.id.address = %msg.peer.address,
             "Creating new peer actor",
         );
-        self.untrusted_peers.remove(&ip(&msg.address));
+        self.untrusted_peers.remove(&ip(&msg.peer.address));
         let peer_to_key_exchange = match Peer::new_to(
-            PeerId::new(&msg.address, &self.public_key),
+            PeerId::new(&msg.peer.address, &self.public_key),
             self.broker.clone(),
         )
         .await
@@ -269,6 +273,11 @@ where
     }
 }
 
+#[derive(Clone, iroha_actor::Message)]
+pub struct NetworkBaseRelayOnlinePeers {
+    pub online_peers: Vec<PublicKey>,
+}
+
 #[async_trait::async_trait]
 impl<T, K, E> Handler<PeerMessage<T>> for NetworkBase<T, K, E>
 where
@@ -317,6 +326,13 @@ where
                 self.broker.issue_send(*msg).await;
             }
         };
+        let mut online_peer_keys = self.peers.keys().cloned().collect();
+
+        self.broker
+            .issue_send(NetworkBaseRelayOnlinePeers {
+                online_peers: online_peer_keys,
+            })
+            .await;
     }
 }
 
@@ -405,7 +421,7 @@ where
 #[derive(Clone, Debug, iroha_actor::Message)]
 pub struct ConnectPeer {
     /// Socket address of the outgoing peer
-    pub address: String,
+    pub peer: PeerId,
 }
 
 /// The message that is sent to [`NetworkBase`] to stop connection to some other peer.

--- a/p2p/tests/integration/p2p.rs
+++ b/p2p/tests/integration/p2p.rs
@@ -73,7 +73,7 @@ async fn network_create() {
     };
     broker
         .issue_send(ConnectPeer {
-            address: peer1.address.clone(),
+            peer: peer1.clone(),
         })
         .await;
     tokio::time::sleep(delay).await;
@@ -164,7 +164,7 @@ async fn two_networks() {
     // Connecting to second peer from network1
     broker1
         .issue_send(ConnectPeer {
-            address: peer2.address.clone(),
+            peer: peer2.clone(),
         })
         .await;
     tokio::time::sleep(delay).await;
@@ -189,7 +189,7 @@ async fn two_networks() {
     // Connecting to the same peer from network1
     broker1
         .issue_send(ConnectPeer {
-            address: peer2.address.clone(),
+            peer: peer2.clone(),
         })
         .await;
     tokio::time::sleep(delay).await;
@@ -293,11 +293,7 @@ async fn start_network(
                 public_key: keypair.public_key().clone(),
             };
 
-            broker
-                .issue_send(ConnectPeer {
-                    address: peer.address,
-                })
-                .await;
+            broker.issue_send(ConnectPeer { peer }).await;
             conn_count += 1_usize;
             tokio::time::sleep(Duration::from_millis(100)).await;
         }


### PR DESCRIPTION
Signed-off-by: Sam H. Smith <sam.henning.smith@protonmail.com>

### Description of the Change

Sumeragi now runs on it's own thread and is a relatively simple statemachine. To the eye it might seem more complicated because it is laid out flat. But that is to make explicit everything that is done. The final form of the code is not this. But it is a very malleable intermediate stage. Which is why it's going on the staging branch.

#### What you want to pay attention to is `run_sumeragi_main_loop` in `fault.rs`

### Issue

#2465
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

It's actually very possible to debug this implementation as opposed to the previous version.

### Possible Drawbacks
None
### Usage Examples or Tests *[optional]*
The best way to get an understanding for the code is to run
`cargo test integration::unstable_network::unstable_network_4_peers_1_fault -- --nocapture`.
I have left in prints to stdout that should help you follow the execution.
### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
