### PR TITLE
[refactor] #2001: `EvaluatesTo` static type checking

### DIFF
--- a/cli/src/torii/mod.rs
+++ b/cli/src/torii/mod.rs
@@ -124,7 +124,7 @@ impl Error {
             Config(_) => StatusCode::NOT_FOUND,
             PushIntoQueue(err) => match **err {
                 queue::Error::Full => StatusCode::INTERNAL_SERVER_ERROR,
-                queue::Error::SignatureCondition(_) => StatusCode::UNAUTHORIZED,
+                queue::Error::SignatureCondition { .. } => StatusCode::UNAUTHORIZED,
                 _ => StatusCode::BAD_REQUEST,
             },
             #[cfg(feature = "telemetry")]

--- a/client/benches/tps/lib.rs
+++ b/client/benches/tps/lib.rs
@@ -215,11 +215,12 @@ impl MeasurerUnit {
     }
 
     fn mint_or_burn(&self) -> Instruction {
-        let is_running_out: Expression = Less::new(
-            Expression::Query(FindAssetQuantityById::new(asset_id(self.name)).into()),
-            Value::U32(100),
-        )
-        .into();
+        let is_running_out = Less::new(
+            EvaluatesTo::new_unchecked(
+                Expression::Query(FindAssetQuantityById::new(asset_id(self.name)).into()).into(),
+            ),
+            100_u32,
+        );
         let supply_roses = MintBox::new(Value::U32(100), asset_id(self.name));
         let burn_a_rose = BurnBox::new(Value::U32(1), asset_id(self.name));
 

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -12,6 +12,7 @@ use test_network::*;
 use super::Configuration;
 
 #[allow(clippy::too_many_lines)]
+#[ignore = "Multisignature is not working for now. See #2595"]
 #[test]
 fn multisignature_transactions_should_wait_for_all_signatures() {
     let (_rt, network, _) = <Network>::start_test_with_runtime(4, 1);

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -5,7 +5,7 @@ use std::{str::FromStr as _, thread, time::Duration};
 use iroha_client::client::{self, Client};
 use iroha_config::client::Configuration as ClientConfiguration;
 use iroha_core::prelude::*;
-use iroha_data_model::{account::TRANSACTION_SIGNATORIES_VALUE, prelude::*};
+use iroha_data_model::{account::TRANSACTION_SIGNATORIES_VALUE, prelude::*, vec_of_values};
 use iroha_primitives::small::SmallStr;
 use test_network::*;
 
@@ -24,16 +24,16 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
     let asset_definition_id = AssetDefinitionId::from_str("camomile#wonderland").expect("Valid");
     let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()));
     let set_signature_condition = MintBox::new(
-        SignatureCheckCondition(
+        SignatureCheckCondition(EvaluatesTo::new_unchecked(
             ContainsAll::new(
-                ContextValue::new(TRANSACTION_SIGNATORIES_VALUE),
-                vec![
+                EvaluatesTo::new_unchecked(ContextValue::new(TRANSACTION_SIGNATORIES_VALUE).into()),
+                vec_of_values![
                     alice_key_pair.public_key().clone(),
                     key_pair_2.public_key().clone(),
                 ],
             )
             .into(),
-        ),
+        )),
         IdBox::AccountId(alice_id.clone()),
     );
 

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -5,7 +5,7 @@ use std::{str::FromStr as _, thread, time::Duration};
 use iroha_client::client::{self, Client};
 use iroha_config::client::Configuration as ClientConfiguration;
 use iroha_core::prelude::*;
-use iroha_data_model::{account::TRANSACTION_SIGNATORIES_VALUE, prelude::*, vec_of_values};
+use iroha_data_model::{account::TRANSACTION_SIGNATORIES_VALUE, prelude::*, val_vec};
 use iroha_primitives::small::SmallStr;
 use test_network::*;
 
@@ -27,7 +27,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() {
         SignatureCheckCondition(EvaluatesTo::new_unchecked(
             ContainsAll::new(
                 EvaluatesTo::new_unchecked(ContextValue::new(TRANSACTION_SIGNATORIES_VALUE).into()),
-                vec_of_values![
+                val_vec![
                     alice_key_pair.public_key().clone(),
                     key_pair_2.public_key().clone(),
                 ],

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -120,8 +120,7 @@ fn permissions_disallow_asset_burn() {
     let alice_id = "alice@wonderland".parse().expect("Valid");
     let bob_id: <Account as Identifiable>::Id = "bob@wonderland".parse().expect("Valid");
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset =
-        RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()).build());
+    let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id.clone()));
     let register_bob = RegisterBox::new(Account::new(bob_id.clone(), []));
 
     let alice_start_assets = get_assets(&mut iroha_client, &alice_id);

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -385,7 +385,9 @@ mod account {
             let file = File::open(s).wrap_err(err_msg)?;
             let condition: Box<Expression> =
                 serde_json::from_reader(file).wrap_err(deser_err_msg)?;
-            Ok(Self(SignatureCheckCondition(condition.into())))
+            Ok(Self(SignatureCheckCondition(EvaluatesTo::new_unchecked(
+                condition,
+            ))))
         }
     }
 
@@ -406,8 +408,12 @@ mod account {
                 condition: Signature(condition),
                 metadata: Metadata(metadata),
             } = self;
-            submit(MintBox::new(account, condition), cfg, metadata)
-                .wrap_err("Failed to set signature condition")
+            submit(
+                MintBox::new(account, EvaluatesTo::new_unchecked(condition.into())),
+                cfg,
+                metadata,
+            )
+            .wrap_err("Failed to set signature condition")
         }
     }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -381,9 +381,10 @@ impl RawGenesisDomainBuilder {
     /// Should only be used for testing.
     #[must_use]
     pub fn with_account_without_public_key(mut self, account_name: Name) -> Self {
+        let account_id = AccountId::new(account_name, self.domain_id.clone());
         self.transaction
             .isi
-            .push(RegisterBox::new(AccountId::new(account_name, self.domain_id.clone())).into());
+            .push(RegisterBox::new(Account::new(account_id, [])).into());
         self
     }
 
@@ -465,12 +466,19 @@ mod tests {
             );
             assert_eq!(
                 finished_genesis_block.transactions[0].isi[1],
-                RegisterBox::new(AccountId::new("alice".parse().unwrap(), domain_id.clone()))
-                    .into()
+                RegisterBox::new(Account::new(
+                    AccountId::new("alice".parse().unwrap(), domain_id.clone()),
+                    []
+                ))
+                .into()
             );
             assert_eq!(
                 finished_genesis_block.transactions[0].isi[2],
-                RegisterBox::new(AccountId::new("bob".parse().unwrap(), domain_id)).into()
+                RegisterBox::new(Account::new(
+                    AccountId::new("bob".parse().unwrap(), domain_id),
+                    []
+                ))
+                .into()
             );
         }
         {
@@ -481,7 +489,11 @@ mod tests {
             );
             assert_eq!(
                 finished_genesis_block.transactions[0].isi[4],
-                RegisterBox::new(AccountId::new("Cheshire_Cat".parse().unwrap(), domain_id)).into()
+                RegisterBox::new(Account::new(
+                    AccountId::new("Cheshire_Cat".parse().unwrap(), domain_id),
+                    []
+                ))
+                .into()
             );
         }
         {

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -330,7 +330,7 @@ mod tests {
             let mut domain = Domain::new(domain_id.clone()).build();
             let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
             let mut account = Account::new(account_id, [public_key]).build();
-            account.set_signature_check_condition(SignatureCheckCondition(0_u32.into()));
+            account.set_signature_check_condition(SignatureCheckCondition(false.into()));
             assert!(domain.add_account(account).is_none());
 
             Arc::new(WorldStateView::new(World::with([domain], PeersIds::new())))

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 
 use crossbeam_queue::ArrayQueue;
 use dashmap::{mapref::entry::Entry, DashMap};
-use eyre::{Report, Result};
+use eyre::{eyre, Report, Result};
 use iroha_config::queue::Configuration;
 use iroha_crypto::HashOf;
 use iroha_data_model::transaction::prelude::*;
@@ -100,8 +100,13 @@ impl Queue {
             return Err(Error::InBlockchain);
         }
 
-        tx.check_signature_condition(&self.wsv)?;
-        Ok(())
+        if tx.check_signature_condition(&self.wsv)? {
+            Ok(())
+        } else {
+            Err(Error::SignatureCondition(eyre!(
+                "Signature condition check failed"
+            )))
+        }
     }
 
     /// Pushes transaction into queue.

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -367,7 +367,6 @@ mod tests {
         ));
     }
 
-    // #[ignore = "Multisignature is not working for now. See #2595"]
     #[test]
     fn push_multisignature_tx() {
         let key_pairs = [KeyPair::generate().unwrap(), KeyPair::generate().unwrap()];

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -100,7 +100,7 @@ impl Queue {
             return Err(Error::InBlockchain);
         }
 
-        if tx.check_signature_condition(&self.wsv)? {
+        if *tx.check_signature_condition(&self.wsv)? {
             Ok(())
         } else {
             Err(Error::SignatureCondition(eyre!(
@@ -184,7 +184,7 @@ impl Queue {
             }
 
             seen.push(hash);
-            if entry
+            if *entry
                 .get()
                 .check_signature_condition(&self.wsv)
                 .expect("Checked in `check_tx` just above")

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -99,14 +99,13 @@ impl Queue {
         if tx.is_in_blockchain(&self.wsv) {
             return Err(Error::InBlockchain);
         }
-
-        if *tx.check_signature_condition(&self.wsv)? {
-            Ok(())
-        } else {
-            Err(Error::SignatureCondition(eyre!(
+        if !*tx.check_signature_condition(&self.wsv)? {
+            return Err(Error::SignatureCondition(eyre!(
                 "Signature condition check failed"
-            )))
+            )));
         }
+
+        Ok(())
     }
 
     /// Pushes transaction into queue.

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -369,6 +369,7 @@ mod tests {
 
     use eyre::Result;
     use iroha_crypto::KeyPair;
+    use iroha_data_model::vec_of_values;
     use iroha_macro::error::ErrorTryFromEnum;
     use parity_scale_codec::{Decode, Encode};
 
@@ -383,65 +384,83 @@ mod tests {
         let (public_key_teller_1, _) = KeyPair::generate()?.into();
         let (public_key_teller_2, _) = KeyPair::generate()?.into();
         let (manager_public_key, _) = KeyPair::generate()?.into();
-        let teller_signatory_set = Value::Vec(vec![
+        let teller_signatory_set = vec![
             Value::PublicKey(public_key_teller_1.clone()),
             Value::PublicKey(public_key_teller_2),
-        ]);
+        ];
         let one_teller_set = Value::Vec(vec![Value::PublicKey(public_key_teller_1)]);
         let manager_signatory = Value::PublicKey(manager_public_key);
         let manager_signatory_set = Value::Vec(vec![manager_signatory.clone()]);
-        let condition: ExpressionBox = IfBuilder::condition(And::new(
-            Greater::new(ContextValue::new("usd_quantity"), 500_u32),
-            Less::new(ContextValue::new("usd_quantity"), 1000_u32),
-        ))
-        .then_expression(Or::new(
-            ContainsAll::new(
-                ContextValue::new("signatories"),
-                teller_signatory_set.clone(),
+        let condition = IfBuilder::condition(And::new(
+            Greater::new(
+                EvaluatesTo::new_unchecked(ContextValue::new("usd_quantity").into()),
+                500_u32,
             ),
-            Contains::new(ContextValue::new("signatories"), manager_signatory),
+            Less::new(
+                EvaluatesTo::new_unchecked(ContextValue::new("usd_quantity").into()),
+                1000_u32,
+            ),
+        ))
+        .then_expression(EvaluatesTo::new_evaluates_to_value(
+            Or::new(
+                ContainsAll::new(
+                    EvaluatesTo::new_unchecked(ContextValue::new("signatories").into()),
+                    teller_signatory_set.clone(),
+                ),
+                Contains::new(
+                    EvaluatesTo::new_unchecked(ContextValue::new("signatories").into()),
+                    manager_signatory,
+                ),
+            )
+            .into(),
         ))
         .else_expression(true)
         .build()
-        .unwrap()
-        .into();
+        .unwrap();
         // Signed by all tellers
-        let expression = WhereBuilder::evaluate(condition.clone())
-            .with_value(
-                //TODO: use query to get the actual quantity of an asset from WSV
-                "usd_quantity".to_owned(),
-                asset_quantity_high.clone(),
-            )
-            .with_value("signatories".to_owned(), teller_signatory_set)
-            .build();
+        let expression = WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(
+            condition.clone().into(),
+        ))
+        .with_value(
+            //TODO: use query to get the actual quantity of an asset from WSV
+            "usd_quantity".to_owned(),
+            asset_quantity_high.clone(),
+        )
+        .with_value("signatories".to_owned(), teller_signatory_set)
+        .build();
         let wsv = WorldStateView::new(World::new());
         assert_eq!(
             expression.evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         // Signed by manager
-        let expression = WhereBuilder::evaluate(condition.clone())
-            .with_value("usd_quantity".to_owned(), asset_quantity_high.clone())
-            .with_value("signatories".to_owned(), manager_signatory_set)
-            .build();
+        let expression = WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(
+            condition.clone().into(),
+        ))
+        .with_value("usd_quantity".to_owned(), asset_quantity_high.clone())
+        .with_value("signatories".to_owned(), manager_signatory_set)
+        .build();
         assert_eq!(
             expression.evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         // Signed by one teller
-        let expression = WhereBuilder::evaluate(condition.clone())
-            .with_value("usd_quantity".to_owned(), asset_quantity_high)
-            .with_value("signatories".to_owned(), one_teller_set.clone())
-            .build();
+        let expression = WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(
+            condition.clone().into(),
+        ))
+        .with_value("usd_quantity".to_owned(), asset_quantity_high)
+        .with_value("signatories".to_owned(), one_teller_set.clone())
+        .build();
         assert_eq!(
             expression.evaluate(&wsv, &Context::new())?,
             Value::Bool(false)
         );
         // Signed by one teller with less value
-        let expression = WhereBuilder::evaluate(condition)
-            .with_value("usd_quantity".to_owned(), asset_quantity_low)
-            .with_value("signatories".to_owned(), one_teller_set)
-            .build();
+        let expression =
+            WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(condition.into()))
+                .with_value("usd_quantity".to_owned(), asset_quantity_low)
+                .with_value("signatories".to_owned(), one_teller_set)
+                .build();
         assert_eq!(
             expression.evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
@@ -452,10 +471,15 @@ mod tests {
     #[test]
     fn where_expression() -> Result<()> {
         assert_eq!(
-            WhereBuilder::evaluate(ContextValue::new("test_value"))
-                .with_value("test_value".to_owned(), Add::new(2_u32, 3_u32))
-                .build()
-                .evaluate(&WorldStateView::new(World::new()), &Context::new())?,
+            WhereBuilder::evaluate(EvaluatesTo::new_unchecked(
+                ContextValue::new("test_value").into()
+            ))
+            .with_value(
+                "test_value".to_owned(),
+                EvaluatesTo::new_evaluates_to_value(Add::new(2_u32, 3_u32).into())
+            )
+            .build()
+            .evaluate(&WorldStateView::new(World::new()), &Context::new())?,
             Value::U32(5)
         );
         Ok(())
@@ -463,14 +487,21 @@ mod tests {
 
     #[test]
     fn nested_where_expression() -> Result<()> {
-        let expression = WhereBuilder::evaluate(ContextValue::new("a"))
-            .with_value("a".to_owned(), 2_u32)
-            .build();
+        let expression =
+            WhereBuilder::evaluate(EvaluatesTo::new_unchecked(ContextValue::new("a").into()))
+                .with_value("a".to_owned(), 2_u32)
+                .build();
         let outer_expression: ExpressionBox =
-            WhereBuilder::evaluate(Add::new(expression, ContextValue::new("b")))
-                .with_value("b".to_owned(), 4_u32)
-                .build()
-                .into();
+            WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(
+                Add::new(
+                    EvaluatesTo::new_unchecked(expression.into()),
+                    EvaluatesTo::new_unchecked(ContextValue::new("b").into()),
+                )
+                .into(),
+            ))
+            .with_value("b".to_owned(), 4_u32)
+            .build()
+            .into();
         assert_eq!(
             outer_expression.evaluate(&WorldStateView::new(World::new()), &Context::new())?,
             Value::U32(6)
@@ -532,23 +563,35 @@ mod tests {
             "Should not be possible to subtract int and bool.",
         );
         assert_eval::<_, ErrorTryFromEnum<Value, bool>>(
-            &And::new(1_u32, Vec::<Value>::new()),
+            &And::new(
+                EvaluatesTo::new_unchecked(1_u32.into()),
+                EvaluatesTo::new_unchecked(Vec::<Value>::new().into()),
+            ),
             "Should not be possible to apply logical and to int and vec.",
         );
         assert_eval::<_, ErrorTryFromEnum<Value, bool>>(
-            &Or::new(1_u32, Vec::<Value>::new()),
+            &Or::new(
+                EvaluatesTo::new_unchecked(1_u32.into()),
+                EvaluatesTo::new_unchecked(Vec::<Value>::new().into()),
+            ),
             "Should not be possible to apply logical or to int and vec.",
         );
         assert_eval::<_, ErrorTryFromEnum<Value, u32>>(
-            &Greater::new(1_u32, Vec::<Value>::new()),
+            &Greater::new(
+                EvaluatesTo::new_unchecked(1_u32.into()),
+                EvaluatesTo::new_unchecked(Vec::<Value>::new().into()),
+            ),
             "Should not be possible to apply greater sign to int and vec.",
         );
         assert_eval::<_, ErrorTryFromEnum<Value, u32>>(
-            &Less::new(1_u32, Vec::<Value>::new()),
+            &Less::new(
+                EvaluatesTo::new_unchecked(1_u32.into()),
+                EvaluatesTo::new_unchecked(Vec::<Value>::new().into()),
+            ),
             "Should not be possible to apply greater sign to int and vec.",
         );
         assert_eval::<_, ErrorTryFromEnum<Value, bool>>(
-            &IfExpression::new(1_u32, 2_u32, 3_u32),
+            &IfExpression::new(EvaluatesTo::new_unchecked(1_u32.into()), 2_u32, 3_u32),
             "If condition should be bool",
         );
         Ok(())
@@ -591,21 +634,29 @@ mod tests {
             Value::Bool(true)
         );
         assert_eq!(
-            Contains::new(vec![1_u32, 3_u32, 5_u32], 3_u32).evaluate(&wsv, &Context::new())?,
+            Contains::new(vec_of_values![1_u32, 3_u32, 5_u32], 3_u32)
+                .evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         assert_eq!(
-            Contains::new(vec![1_u32, 3_u32, 5_u32], 7_u32).evaluate(&wsv, &Context::new())?,
+            Contains::new(vec_of_values![1_u32, 3_u32, 5_u32], 7_u32)
+                .evaluate(&wsv, &Context::new())?,
             Value::Bool(false)
         );
         assert_eq!(
-            ContainsAll::new(vec![1_u32, 3_u32, 5_u32], vec![1_u32, 5_u32])
-                .evaluate(&wsv, &Context::new())?,
+            ContainsAll::new(
+                vec_of_values![1_u32, 3_u32, 5_u32],
+                vec_of_values![1_u32, 5_u32]
+            )
+            .evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         assert_eq!(
-            ContainsAll::new(vec![1_u32, 3_u32, 5_u32], vec![1_u32, 5_u32, 7_u32])
-                .evaluate(&wsv, &Context::new())?,
+            ContainsAll::new(
+                vec_of_values![1_u32, 3_u32, 5_u32],
+                vec_of_values![1_u32, 5_u32, 7_u32]
+            )
+            .evaluate(&wsv, &Context::new())?,
             Value::Bool(false)
         );
         Ok(())

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -369,7 +369,7 @@ mod tests {
 
     use eyre::Result;
     use iroha_crypto::KeyPair;
-    use iroha_data_model::vec_of_values;
+    use iroha_data_model::val_vec;
     use iroha_macro::error::ErrorTryFromEnum;
     use parity_scale_codec::{Decode, Encode};
 
@@ -634,29 +634,21 @@ mod tests {
             Value::Bool(true)
         );
         assert_eq!(
-            Contains::new(vec_of_values![1_u32, 3_u32, 5_u32], 3_u32)
-                .evaluate(&wsv, &Context::new())?,
+            Contains::new(val_vec![1_u32, 3_u32, 5_u32], 3_u32).evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         assert_eq!(
-            Contains::new(vec_of_values![1_u32, 3_u32, 5_u32], 7_u32)
-                .evaluate(&wsv, &Context::new())?,
+            Contains::new(val_vec![1_u32, 3_u32, 5_u32], 7_u32).evaluate(&wsv, &Context::new())?,
             Value::Bool(false)
         );
         assert_eq!(
-            ContainsAll::new(
-                vec_of_values![1_u32, 3_u32, 5_u32],
-                vec_of_values![1_u32, 5_u32]
-            )
-            .evaluate(&wsv, &Context::new())?,
+            ContainsAll::new(val_vec![1_u32, 3_u32, 5_u32], val_vec![1_u32, 5_u32])
+                .evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
         );
         assert_eq!(
-            ContainsAll::new(
-                vec_of_values![1_u32, 3_u32, 5_u32],
-                vec_of_values![1_u32, 5_u32, 7_u32]
-            )
-            .evaluate(&wsv, &Context::new())?,
+            ContainsAll::new(val_vec![1_u32, 3_u32, 5_u32], val_vec![1_u32, 5_u32, 7_u32])
+                .evaluate(&wsv, &Context::new())?,
             Value::Bool(false)
         );
         Ok(())

--- a/core/src/smartcontracts/isi/permissions/mod.rs
+++ b/core/src/smartcontracts/isi/permissions/mod.rs
@@ -520,16 +520,23 @@ mod tests {
         let instruction: Instruction = Pair::new(
             TransferBox::new(
                 asset_id("btc", "crypto", "seller", "company"),
-                Expression::Add(Add::new(
-                    Expression::Query(
-                        FindAssetQuantityById::new(AssetId::new(
-                            AssetDefinitionId::from_str("btc2eth_rate#exchange").expect("Valid"),
-                            AccountId::from_str("dex@exchange").expect("Valid"),
-                        ))
-                        .into(),
-                    ),
-                    10_u32,
-                )),
+                EvaluatesTo::new_evaluates_to_value(
+                    Add::new(
+                        EvaluatesTo::new_unchecked(
+                            Expression::Query(
+                                FindAssetQuantityById::new(AssetId::new(
+                                    AssetDefinitionId::from_str("btc2eth_rate#exchange")
+                                        .expect("Valid"),
+                                    AccountId::from_str("dex@exchange").expect("Valid"),
+                                ))
+                                .into(),
+                            )
+                            .into(),
+                        ),
+                        10_u32,
+                    )
+                    .into(),
+                ),
                 asset_id("btc", "crypto", "buyer", "company"),
             ),
             TransferBox::new(

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -526,7 +526,10 @@ impl<G: GenesisNetworkTrait, F: FaultInjection> SumeragiWithFault<G, F> {
             "Forwarding tx to leader"
         );
         // Don't require leader to submit receipts and therefore create blocks if the tx is still waiting for more signatures.
-        if let Ok(true) = tx.check_signature_condition(&self.wsv) {
+        if matches!(
+            tx.check_signature_condition(&self.wsv),
+            Ok(must_use_bool) if *must_use_bool
+        ) {
             self.txs_awaiting_receipts.insert(tx.hash(), Instant::now());
         }
         let no_tx_receipt = view_change::Proof::no_transaction_receipt_received(

--- a/core/src/sumeragi/fault.rs
+++ b/core/src/sumeragi/fault.rs
@@ -3,6 +3,7 @@
 //! used in code.
 
 use iroha_config::sumeragi::Configuration;
+use iroha_primitives::must_use::MustUse;
 
 use super::*;
 
@@ -526,10 +527,7 @@ impl<G: GenesisNetworkTrait, F: FaultInjection> SumeragiWithFault<G, F> {
             "Forwarding tx to leader"
         );
         // Don't require leader to submit receipts and therefore create blocks if the tx is still waiting for more signatures.
-        if matches!(
-            tx.check_signature_condition(&self.wsv),
-            Ok(must_use_bool) if *must_use_bool
-        ) {
+        if let Ok(MustUse(true)) = tx.check_signature_condition(&self.wsv) {
             self.txs_awaiting_receipts.insert(tx.hash(), Instant::now());
         }
         let no_tx_receipt = view_change::Proof::no_transaction_receipt_received(

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -181,13 +181,8 @@ impl TransactionValidator {
         }
 
         let option_reason = match tx.check_signature_condition(&self.wsv) {
-            Ok(must_use_bool) => {
-                if *must_use_bool {
-                    None
-                } else {
-                    Some("Signature condition not satisfied.".to_owned())
-                }
-            }
+            Ok(MustUse(true)) => None,
+            Ok(MustUse(false)) => Some("Signature condition not satisfied.".to_owned()),
             Err(reason) => Some(reason.to_string()),
         }
         .map(|reason| UnsatisfiedSignatureConditionFail { reason })

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -310,17 +310,19 @@ fn check_signature_condition(
     account: &Account,
     signatories: impl IntoIterator<Item = PublicKey>,
 ) -> EvaluatesTo<bool> {
-    WhereBuilder::evaluate(account.signature_check_condition().as_expression().clone())
-        .with_value(
-            String::from(iroha_data_model::account::ACCOUNT_SIGNATORIES_VALUE),
-            account.signatories().cloned().collect::<Vec<_>>(),
-        )
-        .with_value(
-            String::from(iroha_data_model::account::TRANSACTION_SIGNATORIES_VALUE),
-            signatories.into_iter().collect::<Vec<_>>(),
-        )
-        .build()
-        .into()
+    let where_expr = WhereBuilder::evaluate(EvaluatesTo::new_evaluates_to_value(
+        account.signature_check_condition().as_expression().clone(),
+    ))
+    .with_value(
+        String::from(iroha_data_model::account::ACCOUNT_SIGNATORIES_VALUE),
+        account.signatories().cloned().collect::<Vec<_>>(),
+    )
+    .with_value(
+        String::from(iroha_data_model::account::TRANSACTION_SIGNATORIES_VALUE),
+        signatories.into_iter().collect::<Vec<_>>(),
+    )
+    .build();
+    EvaluatesTo::new_unchecked(where_expr.into())
 }
 
 impl Txn for AcceptedTransaction {

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -20,7 +20,7 @@ use crate::{
     prelude::*,
     smartcontracts::{
         permissions::{check_instruction_permissions, judge::InstructionJudgeArc, prelude::*},
-        wasm, Evaluate, Execute, FindError,
+        wasm, Evaluate, Execute,
     },
 };
 
@@ -298,9 +298,8 @@ impl AcceptedTransaction {
         wsv.map_account(account_id, |account| {
             check_signature_condition(account, signatories)
                 .evaluate(wsv, &Context::new())
-                .map_err(|_err| FindError::Account(account_id.clone()))
+                .map_err(Into::into)
         })?
-        .wrap_err("Failed to find the account")
     }
 }
 

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -61,7 +61,6 @@ test_network = { path = "../core/test_network", version = "=2.0.0-pre-rc.7" }
 tokio = { version = "1.6.0", features = ["rt", "rt-multi-thread"]}
 trybuild = "1.0.53"
 criterion = "0.3"
-trybuild = "1.0.53"
 
 [[bench]]
 name = "time_event_filter"

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -61,6 +61,7 @@ test_network = { path = "../core/test_network", version = "=2.0.0-pre-rc.7" }
 tokio = { version = "1.6.0", features = ["rt", "rt-multi-thread"]}
 trybuild = "1.0.53"
 criterion = "0.3"
+trybuild = "1.0.53"
 
 [[bench]]
 name = "time_event_filter"

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -117,14 +117,15 @@ impl From<EvaluatesTo<bool>> for SignatureCheckCondition {
     }
 }
 
-/// Default signature condition check for accounts. Returns true if any of the signatories have signed a transaction.
+/// Default signature condition check for accounts.
+/// Returns true if any of the signatories have signed a transaction.
 impl Default for SignatureCheckCondition {
     #[inline]
     fn default() -> Self {
         Self(
             ContainsAny::new(
-                ContextValue::new(TRANSACTION_SIGNATORIES_VALUE),
-                ContextValue::new(ACCOUNT_SIGNATORIES_VALUE),
+                EvaluatesTo::new_unchecked(ContextValue::new(TRANSACTION_SIGNATORIES_VALUE).into()),
+                EvaluatesTo::new_unchecked(ContextValue::new(ACCOUNT_SIGNATORIES_VALUE).into()),
             )
             .into(),
         )

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -118,7 +118,7 @@ impl From<EvaluatesTo<bool>> for SignatureCheckCondition {
 }
 
 /// Default signature condition check for accounts.
-/// Returns true if any of the signatories have signed a transaction.
+/// Returns true if any of the signatories have signed the transaction.
 impl Default for SignatureCheckCondition {
     #[inline]
     fn default() -> Self {

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -66,9 +66,7 @@ impl<V: TryFrom<Value>> EvaluatesTo<V> {
     ///
     /// # Warning
     /// Prefer using [`Into`] conversions rather than this method,
-    /// cause it does not check type at compile-time.
-    ///
-    /// Exists mainly to test unsupported expressions.
+    /// because it does not check the value type at compile-time.
     #[inline]
     pub fn new_unchecked(expression: ExpressionBox) -> Self {
         Self {
@@ -123,9 +121,11 @@ impl EvaluatesTo<Value> {
 }
 
 impl<V: IntoSchema + TryFrom<Value>> IntoSchema for EvaluatesTo<V> {
+    #[inline]
     fn type_name() -> String {
         format!("{}::EvaluatesTo<{}>", module_path!(), V::type_name())
     }
+
     fn schema(map: &mut MetaMap) {
         ExpressionBox::schema(map);
 
@@ -205,6 +205,7 @@ mod operation {
     }
 
     impl PartialOrd for Priority {
+        #[inline]
         fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             Some(self.cmp(other))
         }
@@ -317,6 +318,7 @@ impl Expression {
 }
 
 impl<T: Into<Value>> From<T> for ExpressionBox {
+    #[inline]
     fn from(value: T) -> Self {
         Expression::Raw(Box::new(value.into())).into()
     }
@@ -397,11 +399,13 @@ pub struct Multiply {
 
 impl Multiply {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Multiply` expression.
+    #[inline]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -411,12 +415,14 @@ impl Multiply {
 }
 
 impl From<Multiply> for ExpressionBox {
+    #[inline]
     fn from(expression: Multiply) -> Self {
         Expression::Multiply(expression).into()
     }
 }
 
 impl From<Multiply> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: Multiply) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -452,11 +458,13 @@ pub struct Divide {
 
 impl Divide {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Multiply` expression.
+    #[inline]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -466,12 +474,14 @@ impl Divide {
 }
 
 impl From<Divide> for ExpressionBox {
+    #[inline]
     fn from(expression: Divide) -> Self {
         Expression::Divide(expression).into()
     }
 }
 
 impl From<Divide> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: Divide) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -507,11 +517,13 @@ pub struct Mod {
 
 impl Mod {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Mod` expression.
+    #[inline]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -521,12 +533,14 @@ impl Mod {
 }
 
 impl From<Mod> for ExpressionBox {
+    #[inline]
     fn from(expression: Mod) -> Self {
         Expression::Mod(expression).into()
     }
 }
 
 impl From<Mod> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: Mod) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -562,11 +576,13 @@ pub struct RaiseTo {
 
 impl RaiseTo {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `RaiseTo` expression.
+    #[inline]
     pub fn new(left: impl Into<EvaluatesTo<u32>>, right: impl Into<EvaluatesTo<u32>>) -> Self {
         Self {
             left: left.into(),
@@ -576,12 +592,14 @@ impl RaiseTo {
 }
 
 impl From<RaiseTo> for ExpressionBox {
+    #[inline]
     fn from(expression: RaiseTo) -> Self {
         Expression::RaiseTo(expression).into()
     }
 }
 
 impl From<RaiseTo> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: RaiseTo) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -617,11 +635,13 @@ pub struct Add {
 
 impl Add {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Add` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -631,12 +651,14 @@ impl Add {
 }
 
 impl From<Add> for ExpressionBox {
+    #[inline]
     fn from(expression: Add) -> Self {
         Expression::Add(expression).into()
     }
 }
 
 impl From<Add> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: Add) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -673,11 +695,13 @@ pub struct Subtract {
 
 impl Subtract {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Subtract` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -687,12 +711,14 @@ impl Subtract {
 }
 
 impl From<Subtract> for ExpressionBox {
+    #[inline]
     fn from(expression: Subtract) -> Self {
         Expression::Subtract(expression).into()
     }
 }
 
 impl From<Subtract> for EvaluatesTo<u32> {
+    #[inline]
     fn from(expression: Subtract) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -728,11 +754,13 @@ pub struct Greater {
 
 impl Greater {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Greater` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -742,12 +770,14 @@ impl Greater {
 }
 
 impl From<Greater> for ExpressionBox {
+    #[inline]
     fn from(expression: Greater) -> Self {
         Expression::Greater(expression).into()
     }
 }
 
 impl From<Greater> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Greater) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -783,11 +813,13 @@ pub struct Less {
 
 impl Less {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Less` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<u32>>, R: Into<EvaluatesTo<u32>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -797,12 +829,14 @@ impl Less {
 }
 
 impl From<Less> for ExpressionBox {
+    #[inline]
     fn from(expression: Less) -> Self {
         Expression::Less(expression).into()
     }
 }
 
 impl From<Less> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Less) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -832,11 +866,13 @@ pub struct Not {
 
 impl Not {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.expression.len() + 1
     }
 
     /// Constructs `Not` expression.
+    #[inline]
     pub fn new<E: Into<EvaluatesTo<bool>>>(expression: E) -> Self {
         Self {
             expression: expression.into(),
@@ -845,12 +881,14 @@ impl Not {
 }
 
 impl From<Not> for ExpressionBox {
+    #[inline]
     fn from(expression: Not) -> Self {
         Expression::Not(expression).into()
     }
 }
 
 impl From<Not> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Not) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -885,11 +923,13 @@ pub struct And {
 
 impl And {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `And` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<bool>>, R: Into<EvaluatesTo<bool>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -899,12 +939,14 @@ impl And {
 }
 
 impl From<And> for ExpressionBox {
+    #[inline]
     fn from(expression: And) -> Self {
         Expression::And(expression).into()
     }
 }
 
 impl From<And> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: And) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -939,11 +981,13 @@ pub struct Or {
 
 impl Or {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Or` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<bool>>, R: Into<EvaluatesTo<bool>>>(left: L, right: R) -> Self {
         Self {
             left: left.into(),
@@ -953,12 +997,14 @@ impl Or {
 }
 
 impl From<Or> for ExpressionBox {
+    #[inline]
     fn from(expression: Or) -> Self {
         Expression::Or(expression).into()
     }
 }
 
 impl From<Or> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Or) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -979,6 +1025,7 @@ pub struct IfBuilder {
 
 impl IfBuilder {
     ///Sets the `condition`.
+    #[inline]
     pub fn condition<C: Into<EvaluatesTo<bool>>>(condition: C) -> Self {
         IfBuilder {
             condition: condition.into(),
@@ -988,6 +1035,7 @@ impl IfBuilder {
     }
 
     /// Sets `then_expression`.
+    #[inline]
     pub fn then_expression<E: Into<EvaluatesTo<Value>>>(self, expression: E) -> Self {
         IfBuilder {
             then_expression: Some(expression.into()),
@@ -996,6 +1044,7 @@ impl IfBuilder {
     }
 
     /// Sets `else_expression`.
+    #[inline]
     pub fn else_expression<E: Into<EvaluatesTo<Value>>>(self, expression: E) -> Self {
         IfBuilder {
             else_expression: Some(expression.into()),
@@ -1052,11 +1101,13 @@ pub struct If {
 
 impl If {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.condition.len() + self.then_expression.len() + self.else_expression.len() + 1
     }
 
     /// Constructs `If` expression.
+    #[inline]
     pub fn new<
         C: Into<EvaluatesTo<bool>>,
         T: Into<EvaluatesTo<Value>>,
@@ -1110,11 +1161,13 @@ pub struct Contains {
 
 impl Contains {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.collection.len() + self.element.len() + 1
     }
 
     /// Constructs `Contains` expression.
+    #[inline]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Value>>>(
         collection: C,
         element: E,
@@ -1127,12 +1180,14 @@ impl Contains {
 }
 
 impl From<Contains> for ExpressionBox {
+    #[inline]
     fn from(expression: Contains) -> Self {
         Expression::Contains(expression).into()
     }
 }
 
 impl From<Contains> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Contains) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -1169,11 +1224,13 @@ pub struct ContainsAll {
 
 impl ContainsAll {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.collection.len() + self.elements.len() + 1
     }
 
     /// Constructs `Contains` expression.
+    #[inline]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Vec<Value>>>>(
         collection: C,
         elements: E,
@@ -1186,12 +1243,14 @@ impl ContainsAll {
 }
 
 impl From<ContainsAll> for ExpressionBox {
+    #[inline]
     fn from(expression: ContainsAll) -> Self {
         Expression::ContainsAll(expression).into()
     }
 }
 
 impl From<ContainsAll> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: ContainsAll) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -1227,11 +1286,13 @@ pub struct ContainsAny {
 
 impl ContainsAny {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.collection.len() + self.elements.len() + 1
     }
 
     /// Constructs `Contains` expression.
+    #[inline]
     pub fn new<C: Into<EvaluatesTo<Vec<Value>>>, E: Into<EvaluatesTo<Vec<Value>>>>(
         collection: C,
         elements: E,
@@ -1244,12 +1305,14 @@ impl ContainsAny {
 }
 
 impl From<ContainsAny> for ExpressionBox {
+    #[inline]
     fn from(expression: ContainsAny) -> Self {
         Expression::ContainsAny(expression).into()
     }
 }
 
 impl From<ContainsAny> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: ContainsAny) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -1284,11 +1347,13 @@ pub struct Equal {
 
 impl Equal {
     /// Number of underneath expressions.
+    #[inline]
     pub fn len(&self) -> usize {
         self.left.len() + self.right.len() + 1
     }
 
     /// Constructs `Or` expression.
+    #[inline]
     pub fn new<L: Into<EvaluatesTo<Value>>, R: Into<EvaluatesTo<Value>>>(
         left: L,
         right: R,
@@ -1301,12 +1366,14 @@ impl Equal {
 }
 
 impl From<Equal> for ExpressionBox {
+    #[inline]
     fn from(equal: Equal) -> Self {
         Expression::Equal(equal).into()
     }
 }
 
 impl From<Equal> for EvaluatesTo<bool> {
+    #[inline]
     fn from(expression: Equal) -> Self {
         EvaluatesTo::new_unchecked(expression.into())
     }
@@ -1323,6 +1390,7 @@ pub struct WhereBuilder {
 
 impl WhereBuilder {
     /// Sets the `expression` to be evaluated.
+    #[inline]
     #[must_use]
     pub fn evaluate<E: Into<EvaluatesTo<Value>>>(expression: E) -> Self {
         Self {
@@ -1332,6 +1400,7 @@ impl WhereBuilder {
     }
 
     /// Binds `expression` result to a `value_name`, by which it will be reachable from the main expression.
+    #[inline]
     #[must_use]
     pub fn with_value<E: Into<EvaluatesTo<Value>>>(
         mut self,
@@ -1389,6 +1458,7 @@ impl Where {
 
     /// Constructs `Or` expression.
     #[must_use]
+    #[inline]
     pub fn new<E: Into<EvaluatesTo<Value>>>(
         expression: E,
         values: btree_map::BTreeMap<ValueName, EvaluatesTo<Value>>,
@@ -1401,6 +1471,7 @@ impl Where {
 }
 
 impl From<Where> for ExpressionBox {
+    #[inline]
     fn from(where_expression: Where) -> Self {
         Expression::Where(where_expression).into()
     }
@@ -1408,12 +1479,14 @@ impl From<Where> for ExpressionBox {
 
 impl QueryBox {
     /// Number of underneath expressions.
+    #[inline]
     pub const fn len(&self) -> usize {
         1
     }
 }
 
 impl From<QueryBox> for ExpressionBox {
+    #[inline]
     fn from(query: QueryBox) -> Self {
         Expression::Query(query).into()
     }

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -34,7 +34,7 @@ use super::{query::QueryBox, Value, ValueBox};
 /// gen_expr_and_impls! {
 ///     /// Comment
 ///     #[derive(Derives)]
-///     pub Expr(Type1, Type2, Type3, ...) -> OutputType
+///     pub Expr(param1: Type1, param2: Type2, param3: Type3, ...) -> OutputType
 /// }
 /// ```
 ///

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -310,7 +310,7 @@ mod operation {
     /// Priority of operation.
     ///
     /// [`First`](Operation::First) is the highest priority
-    /// and [`Eight`](Operation::Eight) is the lowest.
+    /// and [`Ninth`](Operation::Ninth) is the lowest.
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum Priority {
         First = 1,

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -100,30 +100,18 @@ use super::{query::QueryBox, Value, ValueBox};
 /// }
 /// ```
 macro_rules! gen_expr_and_impls {
-    // Case: one unnamed parameter with known result type
-    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty $(,)?) -> $result_type:ty) => {
-        gen_expr_and_impls!($(#[$me])* $v $i(expression: $first_type) -> $result_type);
+    // Case: one unnamed parameter
+    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty $(,)?) -> $($result:tt)*) => {
+        gen_expr_and_impls!($(#[$me])* $v $i(expression: $first_type) -> $($result)*);
     };
-    // Case: one unnamed parameter with unknown result type
-    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty $(,)?) -> ?) => {
-        gen_expr_and_impls!($(#[$me])* $v $i(expression: $first_type) -> ?);
+    // Case: two unnamed parameters
+    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty, $second_type:ty $(,)?) -> $($result:tt)*) => {
+        gen_expr_and_impls!($(#[$me])* $v $i(left: $first_type, right: $second_type) -> $($result)*);
     };
-    // Case: two unnamed parameters with known result type
-    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty, $second_type:ty $(,)?) -> $result_type:ty) => {
-        gen_expr_and_impls!($(#[$me])* $v $i(left: $first_type, right: $second_type) -> $result_type);
-    };
-    // Case: two unnamed parameters with unknown result type
-    ($(#[$me:meta])* $v:vis $i:ident($first_type:ty, $second_type:ty $(,)?) -> ?) => {
-        gen_expr_and_impls!($(#[$me])* $v $i(left: $first_type, right: $second_type) -> ?);
-    };
-    // Case: any number of named parameters with unknown result type
-    ($(#[$me:meta])* $v:vis $i:ident($($param_name:ident: $param_type:ty),* $(,)?) -> ?) => {
+    // Case: any number of named parameters
+    ($(#[$me:meta])* $v:vis $i:ident($($param_name:ident: $param_type:ty),* $(,)?) -> $($result:tt)*) => {
         gen_expr_and_impls!(impl_basic $(#[$me])* $v $i($($param_name: $param_type),*));
-    };
-    // Case: any number of named parameters with known result type
-    ($(#[$me:meta])* $v:vis $i:ident($($param_name:ident: $param_type:ty),* $(,)?) -> $result_type:ty) => {
-        gen_expr_and_impls!(impl_basic $(#[$me])* $v $i($($param_name: $param_type),*));
-        gen_expr_and_impls!(impl_extra_convert $i $result_type);
+        gen_expr_and_impls!(impl_extra_convert $i $($result)*);
     };
     // Internal usage: generate basic code for the expression
     (impl_basic $(#[$me:meta])* $v:vis $i:ident($($param_name:ident: $param_type:ty),* $(,)?)) => {
@@ -157,6 +145,9 @@ macro_rules! gen_expr_and_impls {
                 Expression::$i(expression).into()
             }
         }
+    };
+    // Internal usage: do nothing for expressions with unknown result type
+    (impl_extra_convert $i:ident ?) => {
     };
     // Internal usage: generate extra `From` impl for expressions with known result type
     (impl_extra_convert $i:ident $result_type:ty) => {

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -809,7 +809,7 @@ mod tests {
         otherwise: Option<Instruction>,
     ) -> Instruction {
         let condition: ExpressionBox = c.into();
-        let condition = condition.into();
+        let condition = EvaluatesTo::new_unchecked(condition);
         If {
             condition,
             then,

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -423,6 +423,16 @@ impl<'idbox> TryFrom<&'idbox IdentifiableBox> for &'idbox dyn HasMetadata {
     }
 }
 
+/// Create a [`Vec`] containing the arguments, which should satisfy `Into<Value>` bound.
+///
+/// Syntax is the same as [`vec`](macro@vec)
+#[macro_export]
+macro_rules! vec_of_values {
+    () => { Vec::new() };
+    ($elem:expr; $n:expr) => { vec![iroha_data_model::Value::from($elem); $n] };
+    ($($x:expr),+ $(,)?) => { vec![$(iroha_data_model::Value::from($x),)+] };
+}
+
 /// Boxed [`Value`].
 pub type ValueBox = Box<Value>;
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -427,7 +427,7 @@ impl<'idbox> TryFrom<&'idbox IdentifiableBox> for &'idbox dyn HasMetadata {
 ///
 /// Syntax is the same as [`vec`](macro@vec)
 #[macro_export]
-macro_rules! vec_of_values {
+macro_rules! val_vec {
     () => { Vec::new() };
     ($elem:expr; $n:expr) => { vec![iroha_data_model::Value::from($elem); $n] };
     ($($x:expr),+ $(,)?) => { vec![$(iroha_data_model::Value::from($x),)+] };

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -425,7 +425,7 @@ impl<'idbox> TryFrom<&'idbox IdentifiableBox> for &'idbox dyn HasMetadata {
 
 /// Create a [`Vec`] containing the arguments, which should satisfy `Into<Value>` bound.
 ///
-/// Syntax is the same as [`vec`](macro@vec)
+/// Syntax is the same as in [`vec`](macro@vec)
 #[macro_export]
 macro_rules! val_vec {
     () => { Vec::new() };

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -36,26 +36,32 @@ fn find_rate_and_make_exchange_isi_should_be_valid() {
     let _instruction = Pair::new(
         TransferBox::new(
             IdBox::AssetId(asset_id_new("btc", "crypto", "seller", "company")),
-            Expression::Query(
-                FindAssetQuantityById::new(asset_id_new(
-                    "btc2eth_rate",
-                    "exchange",
-                    "dex",
-                    "exchange",
-                ))
+            EvaluatesTo::new_evaluates_to_value(
+                Expression::Query(
+                    FindAssetQuantityById::new(asset_id_new(
+                        "btc2eth_rate",
+                        "exchange",
+                        "dex",
+                        "exchange",
+                    ))
+                    .into(),
+                )
                 .into(),
             ),
             IdBox::AssetId(asset_id_new("btc", "crypto", "buyer", "company")),
         ),
         TransferBox::new(
             IdBox::AssetId(asset_id_new("btc", "crypto", "buyer", "company")),
-            Expression::Query(
-                FindAssetQuantityById::new(asset_id_new(
-                    "btc2eth_rate",
-                    "exchange",
-                    "dex",
-                    "exchange",
-                ))
+            EvaluatesTo::new_evaluates_to_value(
+                Expression::Query(
+                    FindAssetQuantityById::new(asset_id_new(
+                        "btc2eth_rate",
+                        "exchange",
+                        "dex",
+                        "exchange",
+                    ))
+                    .into(),
+                )
                 .into(),
             ),
             IdBox::AssetId(asset_id_new("btc", "crypto", "seller", "company")),
@@ -67,12 +73,15 @@ fn find_rate_and_make_exchange_isi_should_be_valid() {
 fn find_rate_and_check_it_greater_than_value_isi_should_be_valid() {
     let _instruction = IfInstruction::new(
         Not::new(Greater::new(
-            QueryBox::from(FindAssetQuantityById::new(asset_id_new(
-                "btc2eth_rate",
-                "exchange",
-                "dex",
-                "exchange",
-            ))),
+            EvaluatesTo::new_unchecked(
+                QueryBox::from(FindAssetQuantityById::new(asset_id_new(
+                    "btc2eth_rate",
+                    "exchange",
+                    "dex",
+                    "exchange",
+                )))
+                .into(),
+            ),
             10_u32,
         )),
         FailBox::new("rate is less or equal to value"),
@@ -97,12 +106,15 @@ impl FindRateAndCheckItGreaterThanValue {
     pub fn into_isi(self) -> IfInstruction {
         IfInstruction::new(
             Not::new(Greater::new(
-                QueryBox::from(FindAssetQuantityById::new(AssetId::new(
-                    format!("{}2{}_rate#exchange", self.from_currency, self.to_currency)
-                        .parse()
-                        .expect("Valid"),
-                    AccountId::from_str("dex@exchange").expect("Valid"),
-                ))),
+                EvaluatesTo::new_unchecked(
+                    QueryBox::from(FindAssetQuantityById::new(AssetId::new(
+                        format!("{}2{}_rate#exchange", self.from_currency, self.to_currency)
+                            .parse()
+                            .expect("Valid"),
+                        AccountId::from_str("dex@exchange").expect("Valid"),
+                    )))
+                    .into(),
+                ),
                 self.value,
             )),
             FailBox::new("rate is less or equal to value"),
@@ -214,26 +226,32 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
             Pair::new(
                 TransferBox::new(
                     IdBox::AssetId(asset_id_new("btc", "crypto", "seller", "company")),
-                    Expression::Query(
-                        FindAssetQuantityById::new(asset_id_new(
-                            "btc2eth_rate",
-                            "exchange",
-                            "dex",
-                            "exchange",
-                        ))
+                    EvaluatesTo::new_evaluates_to_value(
+                        Expression::Query(
+                            FindAssetQuantityById::new(asset_id_new(
+                                "btc2eth_rate",
+                                "exchange",
+                                "dex",
+                                "exchange",
+                            ))
+                            .into(),
+                        )
                         .into(),
                     ),
                     IdBox::AssetId(asset_id_new("btc", "crypto", "buyer", "company")),
                 ),
                 TransferBox::new(
                     IdBox::AssetId(asset_id_new("eth", "crypto", "buyer", "company")),
-                    Expression::Query(
-                        FindAssetQuantityById::new(asset_id_new(
-                            "btc2eth_rate",
-                            "exchange",
-                            "dex",
-                            "exchange",
-                        ))
+                    EvaluatesTo::new_evaluates_to_value(
+                        Expression::Query(
+                            FindAssetQuantityById::new(asset_id_new(
+                                "btc2eth_rate",
+                                "exchange",
+                                "dex",
+                                "exchange",
+                            ))
+                            .into(),
+                        )
                         .into(),
                     ),
                     IdBox::AssetId(asset_id_new("eth", "crypto", "seller", "company")),

--- a/data_model/tests/ui.rs
+++ b/data_model/tests/ui.rs
@@ -1,0 +1,6 @@
+use trybuild::TestCases;
+
+#[test]
+fn ui() {
+    TestCases::new().compile_fail("tests/ui_fail/*.rs");
+}

--- a/data_model/tests/ui_fail/evaluates_to.rs
+++ b/data_model/tests/ui_fail/evaluates_to.rs
@@ -1,0 +1,12 @@
+//! This test ensures that [`EvaluatesTo`] provides compile-time strong typing
+
+use iroha_data_model::prelude::*;
+
+fn get_assets_by_account_id(_account_id: impl Into<EvaluatesTo<AccountId>>) -> Vec<Asset> {
+    Vec::new()
+}
+
+fn main() {
+    let asset_definition_id: <AssetDefinition as Identifiable>::Id = "rose#wonderland".parse().unwrap();
+    get_assets_by_account_id(asset_definition_id);
+}

--- a/data_model/tests/ui_fail/evaluates_to.stderr
+++ b/data_model/tests/ui_fail/evaluates_to.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `iroha_data_model::account::Id: From<DefinitionId>` is not satisfied
+  --> tests/ui_fail/evaluates_to.rs:11:30
+   |
+11 |     get_assets_by_account_id(asset_definition_id);
+   |     ------------------------ ^^^^^^^^^^^^^^^^^^^ the trait `From<DefinitionId>` is not implemented for `iroha_data_model::account::Id`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: required because of the requirements on the impl of `Into<iroha_data_model::account::Id>` for `DefinitionId`
+   = note: required because of the requirements on the impl of `From<DefinitionId>` for `iroha_data_model::expression::EvaluatesTo<iroha_data_model::account::Id>`
+   = note: 1 redundant requirement hidden
+   = note: required because of the requirements on the impl of `Into<iroha_data_model::expression::EvaluatesTo<iroha_data_model::account::Id>>` for `DefinitionId`
+note: required by a bound in `get_assets_by_account_id`
+  --> tests/ui_fail/evaluates_to.rs:5:47
+   |
+5  | fn get_assets_by_account_id(_account_id: impl Into<EvaluatesTo<AccountId>>) -> Vec<Asset> {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `get_assets_by_account_id`

--- a/permissions_validators/src/private_blockchain/tests/queries/account.rs
+++ b/permissions_validators/src/private_blockchain/tests/queries/account.rs
@@ -68,9 +68,10 @@ fn find_account_key_value_by_id_and_key() {
         ..
     } = TestEnv::new();
 
+    let name: Name = "name".parse().expect("Valid");
     let op = QueryBox::FindAccountKeyValueByIdAndKey(FindAccountKeyValueByIdAndKey::new(
         alice_id.clone(),
-        "name".to_owned(),
+        name,
     ));
 
     {
@@ -100,7 +101,8 @@ fn find_account_by_name() {
         ..
     } = TestEnv::new();
 
-    let op = QueryBox::FindAccountsByName(FindAccountsByName::new(alice_id.clone()));
+    let name: Name = "alice".parse().expect("Valid");
+    let op = QueryBox::FindAccountsByName(FindAccountsByName::new(name));
 
     {
         let only_accounts_domain = query::OnlyAccountsDomain;
@@ -204,7 +206,9 @@ fn find_accounts_with_asset() {
         ..
     } = TestEnv::new();
 
-    let op = QueryBox::FindAccountsWithAsset(FindAccountsWithAsset::new("xor".to_owned()));
+    let asset_definition_id: <AssetDefinition as Identifiable>::Id =
+        "xor#wonderland".parse().expect("Valid");
+    let op = QueryBox::FindAccountsWithAsset(FindAccountsWithAsset::new(asset_definition_id));
 
     {
         let only_accounts_domain = query::OnlyAccountsDomain;

--- a/permissions_validators/src/private_blockchain/tests/queries/asset.rs
+++ b/permissions_validators/src/private_blockchain/tests/queries/asset.rs
@@ -454,14 +454,15 @@ fn find_asset_key_value_by_id_and_key() {
         wsv,
         ..
     } = TestEnv::new();
+    let name: Name = "foo".parse().expect("Valid");
     let find_gold_key_value = QueryBox::FindAssetKeyValueByIdAndKey(
-        FindAssetKeyValueByIdAndKey::new(gold_asset_id, "foo".to_owned()),
+        FindAssetKeyValueByIdAndKey::new(gold_asset_id, name.clone()),
     );
     let find_silver_key_value = QueryBox::FindAssetKeyValueByIdAndKey(
-        FindAssetKeyValueByIdAndKey::new(silver_asset_id, "foo".to_owned()),
+        FindAssetKeyValueByIdAndKey::new(silver_asset_id, name.clone()),
     );
     let find_bronze_key_value = QueryBox::FindAssetKeyValueByIdAndKey(
-        FindAssetKeyValueByIdAndKey::new(bronze_asset_id, "foo".to_owned()),
+        FindAssetKeyValueByIdAndKey::new(bronze_asset_id, name),
     );
 
     {
@@ -523,14 +524,15 @@ fn find_asset_definition_key_value_by_id_and_key() {
         wsv,
         ..
     } = TestEnv::new();
+    let name: Name = "foo".parse().expect("Valid");
     let find_gold_key_value = QueryBox::FindAssetDefinitionKeyValueByIdAndKey(
-        FindAssetDefinitionKeyValueByIdAndKey::new(gold_asset_definition_id, "foo".to_owned()),
+        FindAssetDefinitionKeyValueByIdAndKey::new(gold_asset_definition_id, name.clone()),
     );
     let find_silver_key_value = QueryBox::FindAssetDefinitionKeyValueByIdAndKey(
-        FindAssetDefinitionKeyValueByIdAndKey::new(silver_asset_definition_id, "foo".to_owned()),
+        FindAssetDefinitionKeyValueByIdAndKey::new(silver_asset_definition_id, name.clone()),
     );
     let find_bronze_key_value = QueryBox::FindAssetDefinitionKeyValueByIdAndKey(
-        FindAssetDefinitionKeyValueByIdAndKey::new(bronze_asset_definition_id, "foo".to_owned()),
+        FindAssetDefinitionKeyValueByIdAndKey::new(bronze_asset_definition_id, name),
     );
     {
         let only_accounts_domain = query::OnlyAccountsDomain;

--- a/permissions_validators/src/private_blockchain/tests/queries/domain.rs
+++ b/permissions_validators/src/private_blockchain/tests/queries/domain.rs
@@ -94,8 +94,9 @@ fn find_domain_key_value_by_id_and_key() {
         ..
     } = TestEnv::new();
 
+    let name: Name = "foo".parse().expect("Valid");
     let find_wonderland_key_value = QueryBox::FindDomainKeyValueByIdAndKey(
-        FindDomainKeyValueByIdAndKey::new(wonderland_id, "foo".to_owned()),
+        FindDomainKeyValueByIdAndKey::new(wonderland_id, name),
     );
 
     {

--- a/permissions_validators/src/private_blockchain/tests/queries/role.rs
+++ b/permissions_validators/src/private_blockchain/tests/queries/role.rs
@@ -133,7 +133,8 @@ fn find_role_by_role_id() {
         ..
     } = TestEnv::new();
 
-    let find_by_admin = QueryBox::FindRoleByRoleId(FindRoleByRoleId::new("admin".to_owned()));
+    let role_id: <Role as Identifiable>::Id = "admin".parse().expect("Valid");
+    let find_by_admin = QueryBox::FindRoleByRoleId(FindRoleByRoleId::new(role_id));
 
     {
         let only_accounts_domain = query::OnlyAccountsDomain;

--- a/permissions_validators/src/private_blockchain/tests/queries/trigger.rs
+++ b/permissions_validators/src/private_blockchain/tests/queries/trigger.rs
@@ -98,9 +98,10 @@ fn find_trigger_key_value_by_id_and_key() {
         ..
     } = TestEnv::new();
 
+    let name: Name = "foo".parse().expect("Valid");
     let find_trigger = QueryBox::FindTriggerKeyValueByIdAndKey(FindTriggerKeyValueByIdAndKey {
         id: mintbox_gold_trigger_id.into(),
-        key: "foo".to_owned().into(),
+        key: name.into(),
     });
 
     {

--- a/permissions_validators/src/public_blockchain/mod.rs
+++ b/permissions_validators/src/public_blockchain/mod.rs
@@ -563,9 +563,10 @@ mod tests {
             AccountId::from_str("alice@test").expect("Valid"),
         );
         let wsv = WorldStateView::new(World::new());
+        let key: Name = "key".parse().expect("Valid");
         let set = Instruction::SetKeyValue(SetKeyValueBox::new(
             IdBox::AssetId(alice_xor_id),
-            Value::from("key".to_owned()),
+            key,
             Value::from("value".to_owned()),
         ));
         assert!(key_value::AssetSetOnlyForSignerAccount
@@ -585,10 +586,9 @@ mod tests {
             AccountId::from_str("alice@test").expect("Valid"),
         );
         let wsv = WorldStateView::new(World::new());
-        let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
-            IdBox::AssetId(alice_xor_id),
-            Value::from("key".to_owned()),
-        ));
+        let key: Name = "key".parse().expect("Valid");
+        let set =
+            Instruction::RemoveKeyValue(RemoveKeyValueBox::new(IdBox::AssetId(alice_xor_id), key));
         assert!(key_value::AssetRemoveOnlyForSignerAccount
             .check(&alice_id, &set, &wsv)
             .is_allow());
@@ -602,9 +602,10 @@ mod tests {
         let alice_id = AccountId::from_str("alice@test").expect("Valid");
         let bob_id = AccountId::from_str("bob@test").expect("Valid");
         let wsv = WorldStateView::new(World::new());
+        let key: Name = "key".parse().expect("Valid");
         let set = Instruction::SetKeyValue(SetKeyValueBox::new(
             IdBox::AccountId(alice_id.clone()),
-            Value::from("key".to_owned()),
+            key,
             Value::from("value".to_owned()),
         ));
         assert!(key_value::AccountSetOnlyForSignerAccount
@@ -620,9 +621,10 @@ mod tests {
         let alice_id = AccountId::from_str("alice@test").expect("Valid");
         let bob_id = AccountId::from_str("bob@test").expect("Valid");
         let wsv = WorldStateView::new(World::new());
+        let key: Name = "key".parse().expect("Valid");
         let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
             IdBox::AccountId(alice_id.clone()),
-            Value::from("key".to_owned()),
+            key,
         ));
         assert!(key_value::AccountRemoveOnlyForSignerAccount
             .check(&alice_id, &set, &wsv)
@@ -644,9 +646,10 @@ mod tests {
             .add_asset_definition(xor_definition, alice_id.clone())
             .is_none());
         let wsv = WorldStateView::new(World::with([domain], []));
+        let key: Name = "key".parse().expect("Valid");
         let set = Instruction::SetKeyValue(SetKeyValueBox::new(
             IdBox::AssetDefinitionId(xor_id),
-            Value::from("key".to_owned()),
+            key,
             Value::from("value".to_owned()),
         ));
         assert!(key_value::AssetDefinitionSetOnlyForSignerAccount
@@ -669,9 +672,10 @@ mod tests {
             .add_asset_definition(xor_definition, alice_id.clone())
             .is_none());
         let wsv = WorldStateView::new(World::with([domain], []));
+        let key: Name = "key".parse().expect("Valid");
         let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
             IdBox::AssetDefinitionId(xor_id),
-            Value::from("key".to_owned()),
+            key,
         ));
         assert!(key_value::AssetDefinitionRemoveOnlyForSignerAccount
             .check(&alice_id, &set, &wsv)

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.7", default-featur
 
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive"] }
 fixnum = { version = "0.6.1", default-features = false, features = ["serde", "parity", "i64"]}
-derive_more = { version = "0.99.16", default-features = false, features = ["display"] }
+derive_more = { version = "0.99.16", default-features = false, features = ["display", "as_ref", "as_mut", "deref"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 smallvec = { version = "1.8.0", default-features = false, features = ["serde", "union"] }
 smallstr = { version = "0.3.0", default-features = false, features = ["serde", "union"] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.7", default-featur
 
 parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive"] }
 fixnum = { version = "0.6.1", default-features = false, features = ["serde", "parity", "i64"]}
-derive_more = { version = "0.99.16", default-features = false, features = ["display", "as_ref", "as_mut", "deref"] }
+derive_more = { version = "0.99.16", default-features = false, features = ["display", "as_ref", "as_mut", "deref", "constructor"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 smallvec = { version = "1.8.0", default-features = false, features = ["serde", "union"] }
 smallstr = { version = "0.3.0", default-features = false, features = ["serde", "union"] }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 pub mod atomic;
 pub mod conststr;
 pub mod fixed;
+pub mod must_use;
 pub mod small;
 
 use fixed::prelude::*;

--- a/primitives/src/must_use.rs
+++ b/primitives/src/must_use.rs
@@ -44,23 +44,27 @@ use derive_more::{AsMut, AsRef, Constructor, Deref, Display};
     AsMut,
     Deref,
 )]
+#[repr(transparent)]
 #[must_use]
-pub struct MustUse<T>(T);
+pub struct MustUse<T>(pub T);
 
 impl<T> MustUse<T> {
     /// Get inner value
+    #[inline]
     pub fn into_inner(self) -> T {
         self.0
     }
 }
 
 impl<T> Borrow<T> for MustUse<T> {
+    #[inline]
     fn borrow(&self) -> &T {
         &self.0
     }
 }
 
 impl<T> BorrowMut<T> for MustUse<T> {
+    #[inline]
     fn borrow_mut(&mut self) -> &mut T {
         &mut self.0
     }

--- a/primitives/src/must_use.rs
+++ b/primitives/src/must_use.rs
@@ -1,0 +1,60 @@
+//! Contains wrapper type to annotate types with `must_use` attribute
+
+use core::borrow::{Borrow, BorrowMut};
+
+use derive_more::{AsMut, AsRef, Deref, Display};
+
+/// Wrapper type to annotate types with `must_use` attribute
+///
+/// # Example
+/// ```
+/// use iroha_primitives::must_use::MustUse;
+///
+/// fn is_odd(num: i32) -> Result<MustUse<bool>, String> {
+///     if num < 0 {
+///         return Err(String::from("Number must be positive"));
+///     }
+///
+///     if num % 2 == 0 {
+///         Ok(MustUse::new(true))
+///     } else {
+///         Ok(MustUse::new(false))
+///     }
+/// }
+///
+/// if *is_odd(2).unwrap() {
+///     println!("2 is odd");
+/// }
+///
+/// // Will produce a warning, case `#[warn(unused_must_use)]` on by default
+/// // is_odd(3).unwrap();
+/// ```
+#[derive(
+    Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, AsRef, AsMut, Deref,
+)]
+#[must_use]
+pub struct MustUse<T>(T);
+
+impl<T> MustUse<T> {
+    /// Construct new [`MustUse`] wrapper
+    pub fn new(value: T) -> Self {
+        MustUse(value)
+    }
+
+    /// Get inner value
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> Borrow<T> for MustUse<T> {
+    fn borrow(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> BorrowMut<T> for MustUse<T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}

--- a/primitives/src/must_use.rs
+++ b/primitives/src/must_use.rs
@@ -2,7 +2,7 @@
 
 use core::borrow::{Borrow, BorrowMut};
 
-use derive_more::{AsMut, AsRef, Deref, Display};
+use derive_more::{AsMut, AsRef, Constructor, Deref, Display};
 
 /// Wrapper type to annotate types with `must_use` attribute
 ///
@@ -30,17 +30,24 @@ use derive_more::{AsMut, AsRef, Deref, Display};
 /// // is_odd(3).unwrap();
 /// ```
 #[derive(
-    Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, AsRef, AsMut, Deref,
+    Constructor,
+    Debug,
+    Display,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    AsRef,
+    AsMut,
+    Deref,
 )]
 #[must_use]
 pub struct MustUse<T>(T);
 
 impl<T> MustUse<T> {
-    /// Construct new [`MustUse`] wrapper
-    pub fn new(value: T) -> Self {
-        MustUse(value)
-    }
-
     /// Get inner value
     pub fn into_inner(self) -> T {
         self.0

--- a/primitives/tests/ui_fail/must_use_not_used.rs
+++ b/primitives/tests/ui_fail/must_use_not_used.rs
@@ -1,0 +1,7 @@
+#![deny(unused_must_use)]
+
+use iroha_primitives::must_use::MustUse;
+
+fn main() {
+    MustUse::new(5);
+}

--- a/primitives/tests/ui_fail/must_use_not_used.stderr
+++ b/primitives/tests/ui_fail/must_use_not_used.stderr
@@ -1,0 +1,11 @@
+error: unused `MustUse` that must be used
+ --> tests/ui_fail/must_use_not_used.rs:6:5
+  |
+6 |     MustUse::new(5);
+  |     ^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui_fail/must_use_not_used.rs:1:9
+  |
+1 | #![deny(unused_must_use)]
+  |         ^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

#### EvaluatesTo (#2001)

* `Into EvaluatesTo<V>` conversion now has stricter bounds which provides static type checking
* For some cases there is no possibility to make a compile-time check (i.e. `Where`, `ContextValue` expressions and all queries) so we need a way to explicitly construct `EvaluatesTo<V>` omitting the type checking. That's why I've created `EvaluatedTo::<V>::new_unchecked()`
* Since all expressions and queries return `impl TryFrom<Value>` it's always safe to construct `EvaluatesTo<Value>`. That's why there is `EvaluatesTo::<Value>::new_evaluates_to_value()`
* Added ui test which ensures that there is no way to implicitly construct `EvaluatesTo` from uncompatible type

While doing that I've found a bug in `Queue` and fixed it. See next section.

#### Tx signature condition checking bug (#2580)

* Added `MustUse` type wrapper to `primitives`
* `MustUse` used for a checking function
* Added test which ensures that you get `unused_must_use` warning will be generated if `MustUse` type is unused
* Fixed actual bug

### Issue

* Closes #2001 
* Closes #2580 

After succesfull review I'll squash my commits into two -- one per resolved issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

#### EvaluatesTo (#2001)

* Now it's easier to write correct tests
* Found the important bug

#### Tx signature condition checking bug (#2580)

* Added helpful `MustUse` wrapper type
* Important bug fixed

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Harder to construct `EvaluatesTo` from types which require runtime check

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

You can run existing test, because a bunch of them where updated.

Also there are two new tests with `trybuild`:

#### `EvaluatesTo`

```bash
cargo test --package iroha_data_model --test ui -- ui --exact --nocapture 
```

#### `MustUse`

```bash
cargo test --package iroha_primitives --test ui -- ui --exact --nocapture
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs

@appetrosyan suggested to add `ok_or(err)` function to `MustUse` which should work something like this:

```rust
impl MustUse<bool> {
    pub fn ok_or<E>(err: E) -> Result<(), E> {
        if self.0 {
            Ok(())
        } else {
            Err(E)
        }
    }
}
```

But I have next the thoughts:

1. It's not that usable as it may look
2. [`std ok_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or) does not force you to return `()` as `Ok`
3. It does not follow the *Unix rule* and *Single-responsibility rule*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
