### PR TITLE
[feature] #2511: Restrict FFI types on wasm

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -4,6 +4,9 @@ version = "2.0.0-pre-rc.7"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 edition = "2021"
 
+[features]
+wasm = []
+
 [dependencies]
 iroha_ffi_derive = { version = "=2.0.0-pre-rc.7", path = "derive" }
 

--- a/ffi/derive/src/convert.rs
+++ b/ffi/derive/src/convert.rs
@@ -86,7 +86,8 @@ fn variant_discriminants(enum_: &syn::DataEnum) -> Vec<syn::Expr> {
 }
 
 fn derive_try_from_repr_c_for_opaque_item_wrapper(name: &Ident) -> TokenStream2 {
-    let opaque_item_slice_try_from_repr_c_derive = derive_try_from_repr_c_for_opaque_item_slice(name);
+    let opaque_item_slice_try_from_repr_c_derive =
+        derive_try_from_repr_c_for_opaque_item_slice(name);
     let opaque_item_vec_try_from_repr_c_derive = derive_try_from_repr_c_for_opaque_item_vec(name);
 
     quote! {
@@ -146,7 +147,8 @@ fn derive_try_from_repr_c_for_opaque_item_wrapper(name: &Ident) -> TokenStream2 
 }
 
 fn derive_try_from_repr_c_for_opaque_item(name: &Ident) -> TokenStream2 {
-    let opaque_item_slice_try_from_repr_c_derive = derive_try_from_repr_c_for_opaque_item_slice(name);
+    let opaque_item_slice_try_from_repr_c_derive =
+        derive_try_from_repr_c_for_opaque_item_slice(name);
     let opaque_item_vec_try_from_repr_c_derive = derive_try_from_repr_c_for_opaque_item_vec(name);
 
     quote! {
@@ -460,7 +462,7 @@ fn derive_into_ffi_for_fieldless_enum(enum_name: &Ident, repr: &[syn::NestedMeta
     quote! {
         impl iroha_ffi::IntoFfi for #enum_name {
             type Target = <#ffi_type as iroha_ffi::IntoFfi>::Target;
-    
+
             fn into_ffi(self) -> Self::Target {
                 (self as #ffi_type).into_ffi()
             }

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -113,7 +113,7 @@ macro_rules! def_ffi_fn {
             handle_id: $crate::handle::Id,
             left_handle_ptr: *const core::ffi::c_void,
             right_handle_ptr: *const core::ffi::c_void,
-            output_ptr: *mut u8,
+            output_ptr: *mut <bool as $crate::IntoFfi>::Target,
         ) -> $crate::FfiReturn {
             $crate::def_ffi_fn!(@catch_unwind {
                 use core::borrow::Borrow;
@@ -152,7 +152,7 @@ macro_rules! def_ffi_fn {
             handle_id: $crate::handle::Id,
             left_handle_ptr: *const core::ffi::c_void,
             right_handle_ptr: *const core::ffi::c_void,
-            output_ptr: *mut i8,
+            output_ptr: *mut <core::cmp::Ordering as $crate::IntoFfi>::Target,
         ) -> $crate::FfiReturn {
             $crate::def_ffi_fn!(@catch_unwind {
                 use core::borrow::Borrow;

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -113,6 +113,7 @@ macro_rules! def_ffi_fn {
             handle_id: $crate::handle::Id,
             left_handle_ptr: *const core::ffi::c_void,
             right_handle_ptr: *const core::ffi::c_void,
+            // Pointer to FFI-safe representation of `bool` (u8 or u32 if `wasm` feature is active)
             output_ptr: *mut <bool as $crate::IntoFfi>::Target,
         ) -> $crate::FfiReturn {
             $crate::def_ffi_fn!(@catch_unwind {
@@ -152,6 +153,7 @@ macro_rules! def_ffi_fn {
             handle_id: $crate::handle::Id,
             left_handle_ptr: *const core::ffi::c_void,
             right_handle_ptr: *const core::ffi::c_void,
+            // Pointer to FFI-safe representation of `Ordering` (i8 or i32 if `wasm` feature is active)
             output_ptr: *mut <core::cmp::Ordering as $crate::IntoFfi>::Target,
         ) -> $crate::FfiReturn {
             $crate::def_ffi_fn!(@catch_unwind {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -7,6 +7,8 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
+
 pub use iroha_ffi_derive::*;
 use owned::Local;
 
@@ -313,6 +315,40 @@ macro_rules! impl_tuple {
             fn into_ffi(self) -> Self::Target {
                 let ($($ty,)+) = Clone::clone(self);
                 Local::new($ffi_ty($( <$ty as IntoFfi>::into_ffi($ty),)+))
+            }
+        }
+
+        impl<$($ty: IntoFfi),+> $crate::owned::IntoFfiVec for ($( $ty, )+) {
+            type Target = $crate::owned::LocalSlice<<Self as IntoFfi>::Target>;
+
+            fn into_ffi(source: Vec<Self>) -> Self::Target {
+                source.into_iter().map(IntoFfi::into_ffi).collect()
+            }
+        }
+
+        impl<'itm, $($ty: TryFromReprC<'itm>),+> $crate::owned::TryFromReprCVec<'itm> for ($( $ty, )+) {
+            type Source = $crate::slice::SliceRef<'itm, <Self as TryFromReprC<'itm>>::Source>;
+            type Store = Vec<<Self as TryFromReprC<'itm>>::Store>;
+
+            unsafe fn try_from_repr_c(
+                source: Self::Source,
+                store: &'itm mut Self::Store,
+            ) -> Result<Vec<Self>> {
+                let prev_store_len = store.len();
+                let slice = source.into_rust().ok_or(FfiReturn::ArgIsNull)?;
+                store.extend(core::iter::repeat_with(Default::default).take(slice.len()));
+
+                let mut substore = &mut store[prev_store_len..];
+                let mut res = Vec::with_capacity(slice.len());
+
+                let mut i = 0;
+                while let Some((first, rest)) = substore.split_first_mut() {
+                    res.push(TryFromReprC::try_from_repr_c(slice[i], first)?);
+                    substore = rest;
+                    i += 1;
+                }
+
+                Ok(res)
             }
         }
     };

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -109,6 +109,8 @@ pub trait Output: Sized {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i8)]
 pub enum FfiReturn {
+    /// The input argument provided to FFI function can't be converted into inner rust representation.
+    ConversionFailed = -7,
     /// The input argument provided to FFI function has a trap representation.
     TrapRepresentation = -6,
     /// FFI function execution panicked.

--- a/ffi/src/owned.rs
+++ b/ffi/src/owned.rs
@@ -5,7 +5,7 @@ use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 
 use crate::{
     slice::{OutBoxedSlice, SliceRef},
-    AsReprCRef, FfiReturn, IntoFfi, Output, ReprC, TryFromReprC, Result
+    AsReprCRef, FfiReturn, IntoFfi, Output, ReprC, Result, TryFromReprC,
 };
 
 /// Trait that facilitates the implementation of [`IntoFfi`] for vectors of foreign types
@@ -31,9 +31,9 @@ pub trait TryFromReprCVec<'slice>: Sized {
     ///
     /// # Errors
     ///
-    /// * [`FfiResult::ArgIsNull`]          - given pointer is null
-    /// * [`FfiResult::UnknownHandle`]      - given id doesn't identify any known handle
-    /// * [`FfiResult::TrapRepresentation`] - given value contains trap representation
+    /// * [`FfiReturn::ArgIsNull`]          - given pointer is null
+    /// * [`FfiReturn::UnknownHandle`]      - given id doesn't identify any known handle
+    /// * [`FfiReturn::TrapRepresentation`] - given value contains trap representation
     ///
     /// # Safety
     ///
@@ -192,10 +192,7 @@ impl<'itm> TryFromReprC<'itm> for String {
     type Source = <Vec<u8> as TryFromReprC<'itm>>::Source;
     type Store = ();
 
-    unsafe fn try_from_repr_c(
-        source: Self::Source,
-        _: &mut Self::Store,
-    ) -> Result<Self> {
+    unsafe fn try_from_repr_c(source: Self::Source, _: &mut Self::Store) -> Result<Self> {
         String::from_utf8(source.into_rust().ok_or(FfiReturn::ArgIsNull)?.to_owned())
             .map_err(|_e| FfiReturn::Utf8Error)
     }
@@ -204,10 +201,7 @@ impl<'itm> TryFromReprC<'itm> for &'itm str {
     type Source = <&'itm [u8] as TryFromReprC<'itm>>::Source;
     type Store = ();
 
-    unsafe fn try_from_repr_c(
-        source: Self::Source,
-        _: &mut Self::Store,
-    ) -> Result<Self> {
+    unsafe fn try_from_repr_c(source: Self::Source, _: &mut Self::Store) -> Result<Self> {
         core::str::from_utf8(source.into_rust().ok_or(FfiReturn::ArgIsNull)?)
             .map_err(|_e| FfiReturn::Utf8Error)
     }

--- a/ffi/src/primitives.rs
+++ b/ffi/src/primitives.rs
@@ -217,7 +217,7 @@ macro_rules! primitive_impls {
             type Store = ();
 
             unsafe fn try_from_repr_c(source: Self::Source, _: &mut Self::Store) -> Result<Self> {
-                source.try_into().map_err(|_| FfiReturn::TrapRepresentation)
+                source.try_into().map_err(|_| FfiReturn::ConversionFailed)
             }
         }
 

--- a/ffi/tests/ffi_export.rs
+++ b/ffi/tests/ffi_export.rs
@@ -286,12 +286,12 @@ fn return_result() {
     unsafe {
         assert_eq!(
             FfiReturn::ExecutionFail,
-            FfiStruct__fallible_int_output(u8::from(false), output.as_mut_ptr())
+            FfiStruct__fallible_int_output(From::from(false), output.as_mut_ptr())
         );
         assert_eq!(0, output.assume_init());
         assert_eq!(
             FfiReturn::Ok,
-            FfiStruct__fallible_int_output(u8::from(true), output.as_mut_ptr())
+            FfiStruct__fallible_int_output(From::from(true), output.as_mut_ptr())
         );
         assert_eq!(42, output.assume_init());
     }

--- a/ffi/tests/ffi_export.rs
+++ b/ffi/tests/ffi_export.rs
@@ -89,6 +89,12 @@ impl FfiStruct {
     }
 }
 
+#[ffi_export]
+/// Return byte
+pub fn simple(byte: u8) -> u8 {
+    byte
+}
+
 fn get_new_struct() -> FfiStruct {
     let name = Name(String::from("X"));
 
@@ -294,5 +300,19 @@ fn return_result() {
             FfiStruct__fallible_int_output(From::from(true), output.as_mut_ptr())
         );
         assert_eq!(42, output.assume_init());
+    }
+}
+
+#[cfg(feature = "wasm")]
+#[test]
+fn conversion_failed() {
+    let byte: u32 = u32::MAX;
+    let mut output = MaybeUninit::new(0);
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::ConversionFailed,
+            __simple(byte, output.as_mut_ptr())
+        )
     }
 }

--- a/ffi/tests/gen_shared_fns.rs
+++ b/ffi/tests/gen_shared_fns.rs
@@ -59,7 +59,7 @@ fn gen_shared_fns() {
             cloned
         };
 
-        let mut is_equal = MaybeUninit::<u8>::new(1);
+        let mut is_equal = MaybeUninit::new(1);
         let cloned_ptr = IntoFfi::into_ffi(&cloned);
 
         __eq(
@@ -73,7 +73,7 @@ fn gen_shared_fns() {
         assert!(is_equal);
 
         // TODO: Fix
-        let mut ordering = MaybeUninit::<i8>::new(1);
+        let mut ordering = MaybeUninit::new(1);
         __ord(
             FfiStruct1::ID,
             ffi_struct1.cast(),

--- a/ffi/tests/gen_shared_fns.rs
+++ b/ffi/tests/gen_shared_fns.rs
@@ -72,7 +72,6 @@ fn gen_shared_fns() {
             TryFromReprC::try_from_repr_c(is_equal.assume_init(), &mut ()).unwrap();
         assert!(is_equal);
 
-        // TODO: Fix
         let mut ordering = MaybeUninit::new(1);
         __ord(
             FfiStruct1::ID,


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Add `wasm` feature to `iroha_ffi` crate;
- Add `PrimitiveRepr` trait to substitute unsupported types with supported ones;
- Refactor `Vec`  transfer through ff-boundry.  

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2511.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Protect from various errors (when user can pass u32 where u8 supposed to be).

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

More complex implementation.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
