### PR TITLE
[ci]: Fix `iroha2:build` image build

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -24,6 +24,7 @@ jobs:
           tags: iroha2:build
           context: ${{ env.REPOSITORY_URL }}#iroha2-dev
           file: Dockerfile.build
+          build-args: TAG=dev
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/iroha2-lts.yml
+++ b/.github/workflows/iroha2-lts.yml
@@ -23,6 +23,7 @@ jobs:
           tags: iroha2:build
           context: ${{ env.REPOSITORY_URL }}#iroha2-lts
           file: Dockerfile.build
+          build-args: TAG=lts
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/iroha2-stable.yml
+++ b/.github/workflows/iroha2-stable.yml
@@ -23,6 +23,7 @@ jobs:
           tags: iroha2:build
           context: ${{ env.REPOSITORY_URL }}#iroha2-stable
           file: Dockerfile.build
+          build-args: TAG=stable
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
Add build-args corresponding tags values for workflows.

### Issue
The step of `iroha2:build` image building can not identify TAG value in `Dockerfile.base` ARG pointer,

### Benefits

Make CI step of `iroha2:base` image build workable.

### Possible Drawbacks

Should be none.