### PR TITLE
[ci]: Updates an expected error in ui_fail tests

### DIFF
--- a/primitives/tests/ui_fail/no_conversion.stderr
+++ b/primitives/tests/ui_fail/no_conversion.stderr
@@ -1,5 +1,13 @@
 error[E0308]: mismatched types
- --> tests/ui_fail/no_conversion.rs:4:17
-  |
-4 |     Fixed::from(-1_f64);
-  |                 ^^^^^^ expected struct `Fixed`, found `f64`
+   --> tests/ui_fail/no_conversion.rs:4:17
+    |
+4   |     Fixed::from(-1_f64);
+    |     ----------- ^^^^^^ expected struct `Fixed`, found `f64`
+    |     |
+    |     arguments to this function are incorrect
+    |
+note: associated function defined here
+   --> $RUST/core/src/convert/mod.rs
+    |
+    |     fn from(_: T) -> Self;
+    |        ^^^^


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This error appeared after switching from 1.61 to 1.62 because error messages are a mismatch.

### Issue

None

### Benefits

Fixes [this problem](https://github.com/hyperledger/iroha/runs/7793931336?check_suite_focus=true#step:7:1296)

### Possible Drawbacks

None

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
