### PR TITLE
[fix] #2457: Forcibly shut down kura in tests

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -256,9 +256,7 @@ where
 
         Self::start_listening_signal(Arc::clone(&notify_shutdown))?;
 
-        if config.shutdown_on_panic {
-            Self::prepare_panic_hook(notify_shutdown);
-        }
+        Self::prepare_panic_hook(notify_shutdown);
 
         let torii = Some(torii);
         Ok(Self {

--- a/config/src/iroha.rs
+++ b/config/src/iroha.rs
@@ -25,8 +25,6 @@ view! {
         pub private_key: PrivateKey,
         /// Disable coloring of the backtrace and error report on panic
         pub disable_panic_terminal_colors: bool,
-        /// Iroha will shutdown on any panic if this option is set to `true`.
-        pub shutdown_on_panic: bool,
         /// `Kura` configuration
         #[config(inner)]
         pub kura: kura::Configuration,
@@ -71,7 +69,6 @@ impl Default for Configuration {
             public_key,
             private_key,
             disable_panic_terminal_colors: bool::default(),
-            shutdown_on_panic: true,
             kura: kura::Configuration::default(),
             sumeragi: sumeragi_configuration,
             torii: torii::Configuration::default(),

--- a/config/src/iroha.rs
+++ b/config/src/iroha.rs
@@ -71,7 +71,7 @@ impl Default for Configuration {
             public_key,
             private_key,
             disable_panic_terminal_colors: bool::default(),
-            shutdown_on_panic: false,
+            shutdown_on_panic: true,
             kura: kura::Configuration::default(),
             sumeragi: sumeragi_configuration,
             torii: torii::Configuration::default(),

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -433,6 +433,14 @@ where
             api_addr = %self.api_address,
             "Stopping peer",
         );
+
+        // We don't care about block storage, since this is
+        // a test peer that won't be run again.
+        if let Some(iroha) = &self.iroha {
+            iroha_logger::info!("Shutting down kura...");
+            iroha.kura.force_shutdown();
+        }
+
         if let Some(shutdown) = self.shutdown.take() {
             shutdown.abort();
             iroha_logger::info!("Shutting down peer...");

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -14,7 +14,6 @@ The following is the default configuration used by Iroha.
     "payload": "282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"
   },
   "DISABLE_PANIC_TERMINAL_COLORS": false,
-  "SHUTDOWN_ON_PANIC": true,
   "KURA": {
     "INIT_MODE": "strict",
     "BLOCK_STORE_PATH": "./blocks",
@@ -462,16 +461,6 @@ Has type `u64`. Can be configured via environment variable `QUEUE_TRANSACTION_TI
 
 ```json
 86400000
-```
-
-## `shutdown_on_panic`
-
-Iroha will shutdown on any panic if this option is set to `true`.
-
-Has type `bool`. Can be configured via environment variable `IROHA_SHUTDOWN_ON_PANIC`
-
-```json
-true
 ```
 
 ## `sumeragi`

--- a/docs/source/references/config.md
+++ b/docs/source/references/config.md
@@ -14,7 +14,7 @@ The following is the default configuration used by Iroha.
     "payload": "282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b"
   },
   "DISABLE_PANIC_TERMINAL_COLORS": false,
-  "SHUTDOWN_ON_PANIC": false,
+  "SHUTDOWN_ON_PANIC": true,
   "KURA": {
     "INIT_MODE": "strict",
     "BLOCK_STORE_PATH": "./blocks",
@@ -471,7 +471,7 @@ Iroha will shutdown on any panic if this option is set to `true`.
 Has type `bool`. Can be configured via environment variable `IROHA_SHUTDOWN_ON_PANIC`
 
 ```json
-false
+true
 ```
 
 ## `sumeragi`


### PR DESCRIPTION
Signed-off-by: Artemii Gerasimovich <gerasimovich@soramitsu.co.jp>

### Description of the Change

So I’ve been debugging #2457, and the problem there is as follows:

When we start a peer for tests, we [create](https://github.com/hyperledger/iroha/blob/a2b373d7fb21dc24f27cf83bf1c8cb9a6b187b98/core/test_network/src/lib.rs#L673) a [TempDir](https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html) for kura storage. It is then [held](https://github.com/hyperledger/iroha/blob/a2b373d7fb21dc24f27cf83bf1c8cb9a6b187b98/core/test_network/src/lib.rs#L502) until the peer is dropped to prevent its deletion. But kura thread receiving new blocks actually [lives on its own](https://github.com/hyperledger/iroha/blob/a2b373d7fb21dc24f27cf83bf1c8cb9a6b187b98/core/src/kura.rs#L77) and periodically [checks](https://github.com/hyperledger/iroha/blob/a2b373d7fb21dc24f27cf83bf1c8cb9a6b187b98/core/src/kura.rs#L182) if all other references to kura have been dropped and then returns. 

What happens is essentially a race condition, where after a test is finished, peer is dropped, dropping the tempdir, but kura is in process of writing a new block, so it's working directory is pulled from underneath it. This causes kura thread to panic, which wasn't a problem on its own, but is now caught by panic handler and leads to failure.

This PR is my shot of solving it by providing an ability to forcibly shut kura down and doing just that while dropping a test peer.

### Issue

#2457

### Benefits

Kura doesn't panic in tests.

### Possible Drawbacks

Not a particularly elegant solution.

### Alternate Designs

We can't hold tempdir for long enough, since there's no scope that's guaranteed to exceed kura threads lifetime.

We also can't provide a method to just _wait_ for kura to shut down without forcing it to with how it's currently implemented, since kura shuts down only when all strong references to it are dropped, and there is one in the same task that holds the tempdir.
